### PR TITLE
feat(health-check): add resource_customizations for ocs.openshift.io

### DIFF
--- a/resource_customizations/ocs.openshift.io/StorageCluster/health.lua
+++ b/resource_customizations/ocs.openshift.io/StorageCluster/health.lua
@@ -1,0 +1,28 @@
+local hs = {}
+if obj.status ~= nil then
+    if obj.status.conditions ~= nil then
+        for _, condition in pairs(obj.status.conditions) do
+            if condition.type == "Degraded" and condition.status == "True" then 
+                hs.status = "Degraded"
+                hs.message = condition.message
+                return hs
+            elseif condition.type == "Progressing" and condition.status == "False" then
+                hs.status = "Progressing"
+                hs.message = condition.message
+                return hs
+            elseif condition.type == "Upgradeable" and condition.status == "True" then
+                hs.status = "Healthy"
+                hs.message = condition.message
+                return hs
+            elseif condition.type == "Available" and condition.status == "True" then
+                hs.status = "Healthy"
+                hs.message = condition.message
+                return hs
+            end
+        end
+    end
+end
+
+hs.status = "Progressing"
+hs.message = "StorageCluster is still being initialized or is in an unknown state."
+return hs

--- a/resource_customizations/ocs.openshift.io/StorageCluster/health_test.yaml
+++ b/resource_customizations/ocs.openshift.io/StorageCluster/health_test.yaml
@@ -1,0 +1,17 @@
+tests:
+- healthStatus:
+    status: Degraded
+    message: "StorageCluster is degraded"
+  inputPath: testdata/degraded.yaml
+- healthStatus:
+    status: Progressing
+    message: "StorageCluster is progressing"
+  inputPath: testdata/progressing.yaml
+- healthStatus:
+    status: Healthy
+    message: "Reconcile completed successfully"
+  inputPath: testdata/healthy_available.yaml
+- healthStatus:
+    status: Healthy
+    message: "StorageCluster is healthy and upgradeable"
+  inputPath: testdata/healthy_upgradeable.yaml

--- a/resource_customizations/ocs.openshift.io/StorageCluster/testdata/degraded.yaml
+++ b/resource_customizations/ocs.openshift.io/StorageCluster/testdata/degraded.yaml
@@ -1,0 +1,34 @@
+apiVersion: ocs.openshift.io/v1
+kind: StorageCluster
+metadata:
+  name: test-storagecluster
+  namespace: argocd
+spec:
+  manageNodes: false
+  monDataDirHostPath: /var/lib/rook
+  storageDeviceSets:
+  - name: test-storagecluster-device-set
+    count: 1
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: "1"
+        memory: 2Gi
+    portable: true
+    dataPVCTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi
+    placement: {}
+status:
+  conditions:
+  - lastHeartBeatTime: "2023-10-01T12:00:00Z"
+    lastTransitionTime: "2023-10-01T12:00:00Z"
+    message: "StorageCluster is degraded"
+    status: "True"
+    type: Degraded

--- a/resource_customizations/ocs.openshift.io/StorageCluster/testdata/healthy_available.yaml
+++ b/resource_customizations/ocs.openshift.io/StorageCluster/testdata/healthy_available.yaml
@@ -1,0 +1,35 @@
+apiVersion: ocs.openshift.io/v1
+kind: StorageCluster
+metadata:
+  name: test-storagecluster
+  namespace: argocd
+spec:
+  manageNodes: false
+  monDataDirHostPath: /var/lib/rook
+  storageDeviceSets:
+  - name: test-storagecluster-device-set
+    count: 1
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: "1"
+        memory: 2Gi
+    portable: true
+    dataPVCTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi
+    placement: {}
+status:
+  conditions:
+  - lastHeartBeatTime: "2023-10-01T12:00:00Z"
+    lastTransitionTime: "2023-10-01T12:00:00Z"
+    message: Reconcile completed successfully
+    reason: ReconcileCompleted
+    status: "True"
+    type: Available

--- a/resource_customizations/ocs.openshift.io/StorageCluster/testdata/healthy_upgradeable.yaml
+++ b/resource_customizations/ocs.openshift.io/StorageCluster/testdata/healthy_upgradeable.yaml
@@ -1,0 +1,34 @@
+apiVersion: ocs.openshift.io/v1
+kind: StorageCluster
+metadata:
+  name: test-storagecluster
+  namespace: argocd
+spec:
+  manageNodes: false
+  monDataDirHostPath: /var/lib/rook
+  storageDeviceSets:
+  - name: test-storagecluster-device-set
+    count: 1
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: "1"
+        memory: 2Gi
+    portable: true
+    dataPVCTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi
+    placement: {}
+status:
+  conditions:
+  - lastHeartBeatTime: "2023-10-01T12:00:00Z"
+    lastTransitionTime: "2023-10-01T12:00:00Z"
+    message: "StorageCluster is healthy and upgradeable"
+    status: "True"
+    type: Upgradeable

--- a/resource_customizations/ocs.openshift.io/StorageCluster/testdata/progressing.yaml
+++ b/resource_customizations/ocs.openshift.io/StorageCluster/testdata/progressing.yaml
@@ -1,0 +1,34 @@
+apiVersion: ocs.openshift.io/v1
+kind: StorageCluster
+metadata:
+  name: test-storagecluster
+  namespace: argocd
+spec:
+  manageNodes: false
+  monDataDirHostPath: /var/lib/rook
+  storageDeviceSets:
+  - name: test-storagecluster-device-set
+    count: 1
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: "1"
+        memory: 2Gi
+    portable: true
+    dataPVCTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi
+    placement: {}
+status:
+  conditions:
+  - lastHeartBeatTime: "2023-10-01T12:00:00Z"
+    lastTransitionTime: "2023-10-01T12:00:00Z"
+    message: "StorageCluster is progressing"
+    status: "False"
+    type: Progressing


### PR DESCRIPTION
Adds a custom health check for `StorageCluster` resource in the `ocs.openshift.io` api so a `StorageCluster` that is progressing shows to be in the "Progressing" state instead of presenting itself as "synced".

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [X] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [X] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [X] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
