### PR TITLE
fix(hydrator): increase max msg size

### DIFF
--- a/commitserver/apiclient/clientset.go
+++ b/commitserver/apiclient/clientset.go
@@ -2,6 +2,10 @@ package apiclient
 
 import (
 	"fmt"
+	"math"
+
+	"github.com/argoproj/argo-cd/v3/common"
+	"github.com/argoproj/argo-cd/v3/util/env"
 
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
@@ -9,6 +13,9 @@ import (
 
 	utilio "github.com/argoproj/argo-cd/v3/util/io"
 )
+
+// MaxGRPCMessageSize contains max grpc message size
+var MaxGRPCMessageSize = env.ParseNumFromEnv(common.EnvGRPCMaxSizeMB, 100, 0, math.MaxInt32) * 1024 * 1024
 
 // Clientset represents commit server api clients
 type Clientset interface {

--- a/commitserver/server.go
+++ b/commitserver/server.go
@@ -25,7 +25,7 @@ func NewServer(gitCredsStore git.CredsStore, metricsServer *metrics.Server) *Arg
 
 // CreateGRPC creates a new gRPC server.
 func (a *ArgoCDCommitServer) CreateGRPC() *grpc.Server {
-	server := grpc.NewServer()
+	server := grpc.NewServer(grpc.MaxRecvMsgSize(apiclient.MaxGRPCMessageSize))
 	versionpkg.RegisterVersionServiceServer(server, version.NewServer(nil, func() (bool, error) {
 		return true, nil
 	}))


### PR DESCRIPTION
I was getting this error:

```
failed to hydrate apps: failed to commit hydrated manifests: rpc error: code = ResourceExhausted desc = grpc: received message larger than max (4216716 vs. 4194304)
```

Added a const to align with apiserver, reposerver, and cmpserver. This effectively bumps the receive limit to 200MB.