### PR TITLE
chore(ci): disable dependabot for ui-test

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,10 +22,11 @@ updates:
     schedule:
       interval: "daily"
 
-  - package-ecosystem: "npm"
-    directory: "/ui-test/"
-    schedule:
-      interval: "daily"
+# Disabled since this code is rarely used.
+#  - package-ecosystem: "npm"
+#    directory: "/ui-test/"
+#    schedule:
+#      interval: "daily"
 
   - package-ecosystem: "docker"
     directory: "/"
@@ -52,7 +53,8 @@ updates:
     schedule:
       interval: "daily"
 
-  - package-ecosystem: "docker"
-    directory: "/ui-test/"
-    schedule:
-      interval: "daily"
+# Disabled since this code is rarely used.
+#  - package-ecosystem: "docker"
+#    directory: "/ui-test/"
+#    schedule:
+#      interval: "daily"


### PR DESCRIPTION
ui-test isn't very frequently-used, but we get a lot of dependabot updates for it. Disabling for now until we start using those tests more heavily, ideally in CI.