### PR TITLE
chore(ci): pin tj-actions/changed-files to v46.0.5

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -32,7 +32,7 @@ jobs:
       docs: ${{ steps.filter.outputs.docs_any_changed }}
     steps:
       - uses: actions/checkout@8410ad0602e1e429cee44a835ae9f77f654a6694 # v4.0.0
-      - uses: tj-actions/changed-files@c6634ca281a9fc05b03bee224ba00910cb78ab6e # v46.0.5
+      - uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
         id: filter
         with:
           # Any file which is not under docs/, ui/ or is not a markdown file is counted as a backend file


### PR DESCRIPTION
I think I messed up the hash at some point, because it doesn't match the release tag. Hopefully this gets dependabot back in the habit of keeping the hash in sync with the version.