### PR TITLE
chore: enable lint for unused private fields

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -221,6 +221,10 @@ linters:
       disable:
         - go-require
 
+    unused:
+      field-writes-are-uses: false
+      exported-fields-are-used: false
+
     usetesting:
       os-mkdir-temp: false
 

--- a/applicationset/generators/cluster.go
+++ b/applicationset/generators/cluster.go
@@ -7,8 +7,6 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/argoproj/argo-cd/v3/util/settings"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -27,21 +25,17 @@ type ClusterGenerator struct {
 	ctx       context.Context
 	clientset kubernetes.Interface
 	// namespace is the Argo CD namespace
-	namespace       string
-	settingsManager *settings.SettingsManager
+	namespace string
 }
 
 var render = &utils.Render{}
 
 func NewClusterGenerator(ctx context.Context, c client.Client, clientset kubernetes.Interface, namespace string) Generator {
-	settingsManager := settings.NewSettingsManager(ctx, clientset, namespace)
-
 	g := &ClusterGenerator{
-		Client:          c,
-		ctx:             ctx,
-		clientset:       clientset,
-		namespace:       namespace,
-		settingsManager: settingsManager,
+		Client:    c,
+		ctx:       ctx,
+		clientset: clientset,
+		namespace: namespace,
 	}
 	return g
 }

--- a/applicationset/generators/duck_type.go
+++ b/applicationset/generators/duck_type.go
@@ -10,8 +10,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/argoproj/argo-cd/v3/util/settings"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -26,22 +24,18 @@ var _ Generator = (*DuckTypeGenerator)(nil)
 
 // DuckTypeGenerator generates Applications for some or all clusters registered with ArgoCD.
 type DuckTypeGenerator struct {
-	ctx             context.Context
-	dynClient       dynamic.Interface
-	clientset       kubernetes.Interface
-	namespace       string // namespace is the Argo CD namespace
-	settingsManager *settings.SettingsManager
+	ctx       context.Context
+	dynClient dynamic.Interface
+	clientset kubernetes.Interface
+	namespace string // namespace is the Argo CD namespace
 }
 
 func NewDuckTypeGenerator(ctx context.Context, dynClient dynamic.Interface, clientset kubernetes.Interface, namespace string) Generator {
-	settingsManager := settings.NewSettingsManager(ctx, clientset, namespace)
-
 	g := &DuckTypeGenerator{
-		ctx:             ctx,
-		dynClient:       dynClient,
-		clientset:       clientset,
-		namespace:       namespace,
-		settingsManager: settingsManager,
+		ctx:       ctx,
+		dynClient: dynClient,
+		clientset: clientset,
+		namespace: namespace,
 	}
 	return g
 }

--- a/applicationset/generators/plugin.go
+++ b/applicationset/generators/plugin.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/jeremywohl/flatten"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	argoprojiov1alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
@@ -27,16 +26,12 @@ var _ Generator = (*PluginGenerator)(nil)
 
 type PluginGenerator struct {
 	client    client.Client
-	ctx       context.Context
-	clientset kubernetes.Interface
 	namespace string
 }
 
-func NewPluginGenerator(ctx context.Context, client client.Client, clientset kubernetes.Interface, namespace string) Generator {
+func NewPluginGenerator(client client.Client, namespace string) Generator {
 	g := &PluginGenerator{
 		client:    client,
-		ctx:       ctx,
-		clientset: clientset,
 		namespace: namespace,
 	}
 	return g

--- a/applicationset/generators/plugin_test.go
+++ b/applicationset/generators/plugin_test.go
@@ -14,8 +14,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	kubefake "k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -628,8 +626,6 @@ func TestPluginGenerateParams(t *testing.T) {
 		},
 	}
 
-	ctx := t.Context()
-
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			generatorConfig := argoprojiov1alpha1.ApplicationSetGenerator{
@@ -666,11 +662,9 @@ func TestPluginGenerateParams(t *testing.T) {
 				testCase.configmap.Data["baseUrl"] = fakeServer.URL
 			}
 
-			fakeClient := kubefake.NewSimpleClientset(append([]runtime.Object{}, testCase.configmap, testCase.secret)...)
-
 			fakeClientWithCache := fake.NewClientBuilder().WithObjects([]client.Object{testCase.configmap, testCase.secret}...).Build()
 
-			pluginGenerator := NewPluginGenerator(ctx, fakeClientWithCache, fakeClient, "default")
+			pluginGenerator := NewPluginGenerator(fakeClientWithCache, "default")
 
 			applicationSetInfo := argoprojiov1alpha1.ApplicationSet{
 				ObjectMeta: metav1.ObjectMeta{

--- a/applicationset/generators/utils.go
+++ b/applicationset/generators/utils.go
@@ -18,7 +18,7 @@ func GetGenerators(ctx context.Context, c client.Client, k8sClient kubernetes.In
 		"SCMProvider":             NewSCMProviderGenerator(c, scmConfig),
 		"ClusterDecisionResource": NewDuckTypeGenerator(ctx, dynamicClient, k8sClient, namespace),
 		"PullRequest":             NewPullRequestGenerator(c, scmConfig),
-		"Plugin":                  NewPluginGenerator(ctx, c, k8sClient, namespace),
+		"Plugin":                  NewPluginGenerator(c, namespace),
 	}
 
 	nestedGenerators := map[string]Generator{

--- a/applicationset/services/scm_provider/azure_devops.go
+++ b/applicationset/services/scm_provider/azure_devops.go
@@ -47,7 +47,6 @@ func (factory *devopsFactoryImpl) GetClient(ctx context.Context) (azureGit.Clien
 type AzureDevOpsProvider struct {
 	organization  string
 	teamProject   string
-	accessToken   string
 	clientFactory AzureDevOpsClientFactory
 	allBranches   bool
 }
@@ -69,7 +68,7 @@ func NewAzureDevOpsProvider(accessToken string, org string, url string, project 
 
 	connection := azuredevops.NewPatConnection(devOpsURL, accessToken)
 
-	return &AzureDevOpsProvider{organization: org, teamProject: project, accessToken: accessToken, clientFactory: &devopsFactoryImpl{connection: connection}, allBranches: allBranches}, nil
+	return &AzureDevOpsProvider{organization: org, teamProject: project, clientFactory: &devopsFactoryImpl{connection: connection}, allBranches: allBranches}, nil
 }
 
 func (g *AzureDevOpsProvider) ListRepos(ctx context.Context, _ string) ([]*Repository, error) {

--- a/applicationset/webhook/webhook.go
+++ b/applicationset/webhook/webhook.go
@@ -32,7 +32,6 @@ const payloadQueueSize = 50000
 
 type WebhookHandler struct {
 	sync.WaitGroup // for testing
-	namespace      string
 	github         *github.Webhook
 	gitlab         *gitlab.Webhook
 	azuredevops    *azuredevops.Webhook
@@ -69,7 +68,7 @@ type prGeneratorGitlabInfo struct {
 	APIHostname string
 }
 
-func NewWebhookHandler(namespace string, webhookParallelism int, argocdSettingsMgr *argosettings.SettingsManager, client client.Client, generators map[string]generators.Generator) (*WebhookHandler, error) {
+func NewWebhookHandler(webhookParallelism int, argocdSettingsMgr *argosettings.SettingsManager, client client.Client, generators map[string]generators.Generator) (*WebhookHandler, error) {
 	// register the webhook secrets stored under "argocd-secret" for verifying incoming payloads
 	argocdSettings, err := argocdSettingsMgr.GetSettings()
 	if err != nil {
@@ -89,7 +88,6 @@ func NewWebhookHandler(namespace string, webhookParallelism int, argocdSettingsM
 	}
 
 	webhookHandler := &WebhookHandler{
-		namespace:   namespace,
 		github:      githubHandler,
 		gitlab:      gitlabHandler,
 		azuredevops: azuredevopsHandler,

--- a/applicationset/webhook/webhook_test.go
+++ b/applicationset/webhook/webhook_test.go
@@ -230,7 +230,7 @@ func TestWebhookHandler(t *testing.T) {
 				fakeAppWithMergeAndNestedGitGenerator("merge-nested-git-github", namespace, "https://github.com/org/repo"),
 			).Build()
 			set := argosettings.NewSettingsManager(t.Context(), fakeClient, namespace)
-			h, err := NewWebhookHandler(namespace, webhookParallelism, set, fc, mockGenerators())
+			h, err := NewWebhookHandler(webhookParallelism, set, fc, mockGenerators())
 			require.NoError(t, err)
 
 			req := httptest.NewRequest(http.MethodPost, "/api/webhook", nil)

--- a/cmd/argocd-applicationset-controller/commands/applicationset_controller.go
+++ b/cmd/argocd-applicationset-controller/commands/applicationset_controller.go
@@ -198,7 +198,7 @@ func NewCommand() *cobra.Command {
 			topLevelGenerators := generators.GetGenerators(ctx, mgr.GetClient(), k8sClient, namespace, argoCDService, dynamicClient, scmConfig)
 
 			// start a webhook server that listens to incoming webhook payloads
-			webhookHandler, err := webhook.NewWebhookHandler(namespace, webhookParallelism, argoSettingsMgr, mgr.GetClient(), topLevelGenerators)
+			webhookHandler, err := webhook.NewWebhookHandler(webhookParallelism, argoSettingsMgr, mgr.GetClient(), topLevelGenerators)
 			if err != nil {
 				log.Error(err, "failed to create webhook handler")
 			}

--- a/cmd/argocd/commands/admin/app.go
+++ b/cmd/argocd/commands/admin/app.go
@@ -479,5 +479,5 @@ func reconcileApplications(
 }
 
 func newLiveStateCache(argoDB db.ArgoDB, appInformer kubecache.SharedIndexInformer, settingsMgr *settings.SettingsManager, server *metrics.MetricsServer) cache.LiveStateCache {
-	return cache.NewLiveStateCache(argoDB, appInformer, settingsMgr, kubeutil.NewKubectl(), server, func(_ map[string]bool, _ corev1.ObjectReference) {}, &sharding.ClusterSharding{}, argo.NewResourceTracking())
+	return cache.NewLiveStateCache(argoDB, appInformer, settingsMgr, server, func(_ map[string]bool, _ corev1.ObjectReference) {}, &sharding.ClusterSharding{}, argo.NewResourceTracking())
 }

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -1362,7 +1362,6 @@ func NewApplicationDiffCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 
 				diffOption.res = res
 				diffOption.revisions = revisions
-				diffOption.sourcePositions = sourcePositions
 			case revision != "":
 				q := application.ApplicationManifestQuery{
 					Name:         &appName,
@@ -1423,14 +1422,13 @@ func NewApplicationDiffCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 
 // DifferenceOption struct to store diff options
 type DifferenceOption struct {
-	local           string
-	localRepoRoot   string
-	revision        string
-	cluster         *argoappv1.Cluster
-	res             *repoapiclient.ManifestResponse
-	serversideRes   *repoapiclient.ManifestResponse
-	revisions       []string
-	sourcePositions []int64
+	local         string
+	localRepoRoot string
+	revision      string
+	cluster       *argoappv1.Cluster
+	res           *repoapiclient.ManifestResponse
+	serversideRes *repoapiclient.ManifestResponse
+	revisions     []string
 }
 
 // findandPrintDiff ... Prints difference between application current state and state stored in git or locally, returns boolean as true if difference is found else returns false

--- a/cmd/argocd/commands/headless/headless.go
+++ b/cmd/argocd/commands/headless/headless.go
@@ -278,7 +278,7 @@ func MaybeStartLocalServer(ctx context.Context, clientOpts *apiclient.ClientOpti
 		AppClientset:            appClientset,
 		DisableAuth:             true,
 		RedisClient:             redis.NewClient(redisOptions),
-		Cache:                   servercache.NewCache(appstateCache, 0, 0, 0),
+		Cache:                   servercache.NewCache(appstateCache, 0, 0),
 		KubeClientset:           kubeClientset,
 		DynamicClientset:        dynamicClientset,
 		KubeControllerClientset: controllerClientset,

--- a/cmpserver/server.go
+++ b/cmpserver/server.go
@@ -30,7 +30,6 @@ import (
 
 // ArgoCDCMPServer is the config management plugin server implementation
 type ArgoCDCMPServer struct {
-	log           *log.Entry
 	opts          []grpc.ServerOption
 	initConstants plugin.CMPServerInitConstants
 	stopCh        chan os.Signal
@@ -75,7 +74,6 @@ func NewServer(initConstants plugin.CMPServerInitConstants) (*ArgoCDCMPServer, e
 	}
 
 	return &ArgoCDCMPServer{
-		log:           serverLog,
 		opts:          serverOpts,
 		stopCh:        make(chan os.Signal),
 		doneCh:        make(chan any),

--- a/commitserver/commit/commit.go
+++ b/commitserver/commit/commit.go
@@ -17,7 +17,6 @@ import (
 
 // Service is the service that handles commit requests.
 type Service struct {
-	gitCredsStore     git.CredsStore
 	metricsServer     *metrics.Server
 	repoClientFactory RepoClientFactory
 }
@@ -25,7 +24,6 @@ type Service struct {
 // NewService returns a new instance of the commit service.
 func NewService(gitCredsStore git.CredsStore, metricsServer *metrics.Server) *Service {
 	return &Service{
-		gitCredsStore:     gitCredsStore,
 		metricsServer:     metricsServer,
 		repoClientFactory: NewRepoClientFactory(gitCredsStore, metricsServer),
 	}

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -205,7 +205,7 @@ func NewApplicationController(
 		statusRefreshJitter:               appResyncJitter,
 		refreshRequestedApps:              make(map[string]CompareWith),
 		refreshRequestedAppsMutex:         &sync.Mutex{},
-		auditLogger:                       argo.NewAuditLogger(namespace, kubeClientset, common.ApplicationController, enableK8sEvent),
+		auditLogger:                       argo.NewAuditLogger(kubeClientset, common.ApplicationController, enableK8sEvent),
 		settingsMgr:                       settingsMgr,
 		selfHealTimeout:                   selfHealTimeout,
 		selfHealBackOff:                   selfHealBackoff,
@@ -327,7 +327,7 @@ func NewApplicationController(
 			return nil, err
 		}
 	}
-	stateCache := statecache.NewLiveStateCache(db, appInformer, ctrl.settingsMgr, kubectl, ctrl.metricsServer, ctrl.handleObjectUpdated, clusterSharding, argo.NewResourceTracking())
+	stateCache := statecache.NewLiveStateCache(db, appInformer, ctrl.settingsMgr, ctrl.metricsServer, ctrl.handleObjectUpdated, clusterSharding, argo.NewResourceTracking())
 	appStateManager := NewAppStateManager(db, applicationClientset, repoClientset, namespace, kubectl, ctrl.onKubectlRun, ctrl.settingsMgr, stateCache, projInformer, ctrl.metricsServer, argoCache, ctrl.statusRefreshTimeout, argo.NewResourceTracking(), persistResourceHealth, repoErrorGracePeriod, serverSideDiff, ignoreNormalizerOpts)
 	ctrl.appInformer = appInformer
 	ctrl.appLister = appLister

--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -186,7 +186,15 @@ type ResourceInfo struct {
 	manifestHash string
 }
 
-func NewLiveStateCache(db db.ArgoDB, appInformer cache.SharedIndexInformer, settingsMgr *settings.SettingsManager, metricsServer *metrics.MetricsServer, onObjectUpdated ObjectUpdatedHandler, clusterSharding sharding.ClusterShardingCache, resourceTracking argo.ResourceTracking) LiveStateCache {
+func NewLiveStateCache(
+	db db.ArgoDB,
+	appInformer cache.SharedIndexInformer,
+	settingsMgr *settings.SettingsManager,
+	metricsServer *metrics.MetricsServer,
+	onObjectUpdated ObjectUpdatedHandler,
+	clusterSharding sharding.ClusterShardingCache,
+	resourceTracking argo.ResourceTracking,
+) LiveStateCache {
 	return &liveStateCache{
 		appInformer:      appInformer,
 		db:               db,

--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -186,22 +186,12 @@ type ResourceInfo struct {
 	manifestHash string
 }
 
-func NewLiveStateCache(
-	db db.ArgoDB,
-	appInformer cache.SharedIndexInformer,
-	settingsMgr *settings.SettingsManager,
-	kubectl kube.Kubectl,
-	metricsServer *metrics.MetricsServer,
-	onObjectUpdated ObjectUpdatedHandler,
-	clusterSharding sharding.ClusterShardingCache,
-	resourceTracking argo.ResourceTracking,
-) LiveStateCache {
+func NewLiveStateCache(db db.ArgoDB, appInformer cache.SharedIndexInformer, settingsMgr *settings.SettingsManager, metricsServer *metrics.MetricsServer, onObjectUpdated ObjectUpdatedHandler, clusterSharding sharding.ClusterShardingCache, resourceTracking argo.ResourceTracking) LiveStateCache {
 	return &liveStateCache{
 		appInformer:      appInformer,
 		db:               db,
 		clusters:         make(map[string]clustercache.ClusterCache),
 		onObjectUpdated:  onObjectUpdated,
-		kubectl:          kubectl,
 		settingsMgr:      settingsMgr,
 		metricsServer:    metricsServer,
 		clusterSharding:  clusterSharding,
@@ -225,7 +215,6 @@ type liveStateCache struct {
 	db                   db.ArgoDB
 	appInformer          cache.SharedIndexInformer
 	onObjectUpdated      ObjectUpdatedHandler
-	kubectl              kube.Kubectl
 	settingsMgr          *settings.SettingsManager
 	metricsServer        *metrics.MetricsServer
 	clusterSharding      sharding.ClusterShardingCache

--- a/controller/cache/cache_test.go
+++ b/controller/cache/cache_test.go
@@ -73,7 +73,6 @@ func TestHandleModEvent_ClusterExcluded(t *testing.T) {
 		appInformer: nil,
 		onObjectUpdated: func(_ map[string]bool, _ corev1.ObjectReference) {
 		},
-		kubectl:       nil,
 		settingsMgr:   &argosettings.SettingsManager{},
 		metricsServer: &metrics.MetricsServer{},
 		// returns a shard that never process any cluster

--- a/controller/hydrator/hydrator.go
+++ b/controller/hydrator/hydrator.go
@@ -101,10 +101,14 @@ type HydrationQueueKey struct {
 
 // uniqueHydrationDestination is used to detect duplicate hydrate destinations.
 type uniqueHydrationDestination struct {
-	sourceRepoURL        string
+	//nolint:unused // used as part of a map key
+	sourceRepoURL string
+	//nolint:unused // used as part of a map key
 	sourceTargetRevision string
-	destinationBranch    string
-	destinationPath      string
+	//nolint:unused // used as part of a map key
+	destinationBranch string
+	//nolint:unused // used as part of a map key
+	destinationPath string
 }
 
 func (h *Hydrator) ProcessHydrationQueueItem(hydrationKey HydrationQueueKey) (processNext bool) {

--- a/controller/sync_test.go
+++ b/controller/sync_test.go
@@ -190,7 +190,6 @@ func TestSyncComparisonError(t *testing.T) {
 
 func TestAppStateManager_SyncAppState(t *testing.T) {
 	type fixture struct {
-		project     *v1alpha1.AppProject
 		application *v1alpha1.Application
 		controller  *ApplicationController
 	}
@@ -222,7 +221,6 @@ func TestAppStateManager_SyncAppState(t *testing.T) {
 		ctrl := newFakeController(&data, nil)
 
 		return &fixture{
-			project:     project,
 			application: app,
 			controller:  ctrl,
 		}
@@ -258,7 +256,6 @@ func TestAppStateManager_SyncAppState(t *testing.T) {
 
 func TestSyncWindowDeniesSync(t *testing.T) {
 	type fixture struct {
-		project     *v1alpha1.AppProject
 		application *v1alpha1.Application
 		controller  *ApplicationController
 	}
@@ -297,7 +294,6 @@ func TestSyncWindowDeniesSync(t *testing.T) {
 		ctrl := newFakeController(&data, nil)
 
 		return &fixture{
-			project:     project,
 			application: app,
 			controller:  ctrl,
 		}
@@ -1268,7 +1264,6 @@ func TestDeriveServiceAccountMatchingServers(t *testing.T) {
 
 func TestSyncWithImpersonate(t *testing.T) {
 	type fixture struct {
-		project     *v1alpha1.AppProject
 		application *v1alpha1.Application
 		controller  *ApplicationController
 	}
@@ -1319,7 +1314,6 @@ func TestSyncWithImpersonate(t *testing.T) {
 		}
 		ctrl := newFakeController(&data, nil)
 		return &fixture{
-			project:     project,
 			application: app,
 			controller:  ctrl,
 		}

--- a/docs/operator-manual/argocd-cmd-params-cm.yaml
+++ b/docs/operator-manual/argocd-cmd-params-cm.yaml
@@ -156,8 +156,6 @@ data:
   server.connection.status.cache.expiration: "1h0m0s"
   # Cache expiration for OIDC state (default 3m0s)
   server.oidc.cache.expiration: "3m0s"
-  # Cache expiration for failed login attempts (default 24h0m0s)
-  server.login.attempts.expiration: "24h0m0s"
   # Cache expiration for app state (default 1h0m0s)
   server.app.state.cache.expiration: "1h0m0s"
   # Cache expiration default (default 24h0m0s)

--- a/docs/operator-manual/server-commands/argocd-server.md
+++ b/docs/operator-manual/server-commands/argocd-server.md
@@ -60,7 +60,7 @@ argocd-server [flags]
       --insecure-skip-tls-verify                        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string                               Path to a kube config. Only required if out-of-cluster
       --logformat string                                Set the logging format. One of: json|text (default "json")
-      --login-attempts-expiration duration              Cache expiration for failed login attempts (default 24h0m0s)
+      --login-attempts-expiration duration              Cache expiration for failed login attempts. DEPRECATED: this flag is unused and will be removed in a future version. (default 24h0m0s)
       --loglevel string                                 Set the logging level. One of: debug|info|warn|error (default "info")
       --metrics-address string                          Listen for metrics on given address (default "0.0.0.0")
       --metrics-port int                                Start metrics on given port (default 8083)

--- a/hack/gen-resources/cmd/commands/cmd.go
+++ b/hack/gen-resources/cmd/commands/cmd.go
@@ -66,7 +66,7 @@ func NewGenerateCommand(opts *util.GenerateOpts) *cobra.Command {
 			argoDB := db.NewDB(opts.Namespace, settingsMgr, clientSet)
 
 			pg := generator.NewProjectGenerator(argoClientSet)
-			ag := generator.NewApplicationGenerator(argoClientSet, clientSet, argoDB)
+			ag := generator.NewApplicationGenerator(argoClientSet, clientSet)
 			rg := generator.NewRepoGenerator(util.ConnectToK8sClientSet())
 			cg := generator.NewClusterGenerator(argoDB, util.ConnectToK8sClientSet(), util.ConnectToK8sConfig())
 
@@ -104,7 +104,7 @@ func NewCleanCommand(opts *util.GenerateOpts) *cobra.Command {
 			argoDB := db.NewDB(opts.Namespace, settingsMgr, clientSet)
 
 			pg := generator.NewProjectGenerator(argoClientSet)
-			ag := generator.NewApplicationGenerator(argoClientSet, clientSet, argoDB)
+			ag := generator.NewApplicationGenerator(argoClientSet, clientSet)
 			cg := generator.NewClusterGenerator(argoDB, clientSet, util.ConnectToK8sConfig())
 			rg := generator.NewRepoGenerator(clientSet)
 

--- a/hack/gen-resources/generators/application_generator.go
+++ b/hack/gen-resources/generators/application_generator.go
@@ -22,11 +22,10 @@ import (
 type ApplicationGenerator struct {
 	argoClientSet *appclientset.Clientset
 	clientSet     *kubernetes.Clientset
-	db            db.ArgoDB
 }
 
-func NewApplicationGenerator(argoClientSet *appclientset.Clientset, clientSet *kubernetes.Clientset, db db.ArgoDB) Generator {
-	return &ApplicationGenerator{argoClientSet, clientSet, db}
+func NewApplicationGenerator(argoClientSet *appclientset.Clientset, clientSet *kubernetes.Clientset) Generator {
+	return &ApplicationGenerator{argoClientSet, clientSet}
 }
 
 func (generator *ApplicationGenerator) buildRandomSource(repositories []*v1alpha1.Repository) (*v1alpha1.ApplicationSource, error) {

--- a/manifests/base/server/argocd-server-deployment.yaml
+++ b/manifests/base/server/argocd-server-deployment.yaml
@@ -154,12 +154,6 @@ spec:
                   name: argocd-cmd-params-cm
                   key: server.oidc.cache.expiration
                   optional: true
-            - name: ARGOCD_SERVER_LOGIN_ATTEMPTS_EXPIRATION
-              valueFrom:
-                configMapKeyRef:
-                  name: argocd-cmd-params-cm
-                  key: server.login.attempts.expiration
-                  optional: true
             - name: ARGOCD_SERVER_STATIC_ASSETS
               valueFrom:
                 configMapKeyRef:

--- a/manifests/ha/install-with-hydrator.yaml
+++ b/manifests/ha/install-with-hydrator.yaml
@@ -27125,12 +27125,6 @@ spec:
               key: server.oidc.cache.expiration
               name: argocd-cmd-params-cm
               optional: true
-        - name: ARGOCD_SERVER_LOGIN_ATTEMPTS_EXPIRATION
-          valueFrom:
-            configMapKeyRef:
-              key: server.login.attempts.expiration
-              name: argocd-cmd-params-cm
-              optional: true
         - name: ARGOCD_SERVER_STATIC_ASSETS
           valueFrom:
             configMapKeyRef:

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -26961,12 +26961,6 @@ spec:
               key: server.oidc.cache.expiration
               name: argocd-cmd-params-cm
               optional: true
-        - name: ARGOCD_SERVER_LOGIN_ATTEMPTS_EXPIRATION
-          valueFrom:
-            configMapKeyRef:
-              key: server.login.attempts.expiration
-              name: argocd-cmd-params-cm
-              optional: true
         - name: ARGOCD_SERVER_STATIC_ASSETS
           valueFrom:
             configMapKeyRef:

--- a/manifests/ha/namespace-install-with-hydrator.yaml
+++ b/manifests/ha/namespace-install-with-hydrator.yaml
@@ -2928,12 +2928,6 @@ spec:
               key: server.oidc.cache.expiration
               name: argocd-cmd-params-cm
               optional: true
-        - name: ARGOCD_SERVER_LOGIN_ATTEMPTS_EXPIRATION
-          valueFrom:
-            configMapKeyRef:
-              key: server.login.attempts.expiration
-              name: argocd-cmd-params-cm
-              optional: true
         - name: ARGOCD_SERVER_STATIC_ASSETS
           valueFrom:
             configMapKeyRef:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -2764,12 +2764,6 @@ spec:
               key: server.oidc.cache.expiration
               name: argocd-cmd-params-cm
               optional: true
-        - name: ARGOCD_SERVER_LOGIN_ATTEMPTS_EXPIRATION
-          valueFrom:
-            configMapKeyRef:
-              key: server.login.attempts.expiration
-              name: argocd-cmd-params-cm
-              optional: true
         - name: ARGOCD_SERVER_STATIC_ASSETS
           valueFrom:
             configMapKeyRef:

--- a/manifests/install-with-hydrator.yaml
+++ b/manifests/install-with-hydrator.yaml
@@ -26169,12 +26169,6 @@ spec:
               key: server.oidc.cache.expiration
               name: argocd-cmd-params-cm
               optional: true
-        - name: ARGOCD_SERVER_LOGIN_ATTEMPTS_EXPIRATION
-          valueFrom:
-            configMapKeyRef:
-              key: server.login.attempts.expiration
-              name: argocd-cmd-params-cm
-              optional: true
         - name: ARGOCD_SERVER_STATIC_ASSETS
           valueFrom:
             configMapKeyRef:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -26003,12 +26003,6 @@ spec:
               key: server.oidc.cache.expiration
               name: argocd-cmd-params-cm
               optional: true
-        - name: ARGOCD_SERVER_LOGIN_ATTEMPTS_EXPIRATION
-          valueFrom:
-            configMapKeyRef:
-              key: server.login.attempts.expiration
-              name: argocd-cmd-params-cm
-              optional: true
         - name: ARGOCD_SERVER_STATIC_ASSETS
           valueFrom:
             configMapKeyRef:

--- a/manifests/namespace-install-with-hydrator.yaml
+++ b/manifests/namespace-install-with-hydrator.yaml
@@ -1972,12 +1972,6 @@ spec:
               key: server.oidc.cache.expiration
               name: argocd-cmd-params-cm
               optional: true
-        - name: ARGOCD_SERVER_LOGIN_ATTEMPTS_EXPIRATION
-          valueFrom:
-            configMapKeyRef:
-              key: server.login.attempts.expiration
-              name: argocd-cmd-params-cm
-              optional: true
         - name: ARGOCD_SERVER_STATIC_ASSETS
           valueFrom:
             configMapKeyRef:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -1806,12 +1806,6 @@ spec:
               key: server.oidc.cache.expiration
               name: argocd-cmd-params-cm
               optional: true
-        - name: ARGOCD_SERVER_LOGIN_ATTEMPTS_EXPIRATION
-          valueFrom:
-            configMapKeyRef:
-              key: server.login.attempts.expiration
-              name: argocd-cmd-params-cm
-              optional: true
         - name: ARGOCD_SERVER_STATIC_ASSETS
           valueFrom:
             configMapKeyRef:

--- a/notification_controller/controller/controller.go
+++ b/notification_controller/controller/controller.go
@@ -91,7 +91,6 @@ func NewController(
 		configMapInformer: configMapInformer,
 		appInformer:       appInformer,
 		appProjInformer:   appProjInformer,
-		apiFactory:        apiFactory,
 	}
 	skipProcessingOpt := controller.WithSkipProcessing(func(obj metav1.Object) (bool, string) {
 		app, ok := (obj).(*unstructured.Unstructured)
@@ -173,7 +172,6 @@ func newInformer(resClient dynamic.ResourceInterface, controllerNamespace string
 }
 
 type notificationController struct {
-	apiFactory        api.Factory
 	ctrl              controller.NotificationController
 	appInformer       cache.SharedIndexInformer
 	appProjInformer   cache.SharedIndexInformer

--- a/pkg/apis/application/v1alpha1/repository_types.go
+++ b/pkg/apis/application/v1alpha1/repository_types.go
@@ -219,13 +219,13 @@ func (repo *Repository) GetGitCreds(store git.CredsStore) git.Creds {
 		return git.NopCreds{}
 	}
 	if repo.Password != "" || repo.BearerToken != "" {
-		return git.NewHTTPSCreds(repo.Username, repo.Password, repo.BearerToken, repo.TLSClientCertData, repo.TLSClientCertKey, repo.IsInsecure(), repo.Proxy, repo.NoProxy, store, repo.ForceHttpBasicAuth)
+		return git.NewHTTPSCreds(repo.Username, repo.Password, repo.BearerToken, repo.TLSClientCertData, repo.TLSClientCertKey, repo.IsInsecure(), store, repo.ForceHttpBasicAuth)
 	}
 	if repo.SSHPrivateKey != "" {
-		return git.NewSSHCreds(repo.SSHPrivateKey, getCAPath(repo.Repo), repo.IsInsecure(), store, repo.Proxy, repo.NoProxy)
+		return git.NewSSHCreds(repo.SSHPrivateKey, getCAPath(repo.Repo), repo.IsInsecure(), repo.Proxy)
 	}
 	if repo.GithubAppPrivateKey != "" && repo.GithubAppId != 0 && repo.GithubAppInstallationId != 0 {
-		return git.NewGitHubAppCreds(repo.GithubAppId, repo.GithubAppInstallationId, repo.GithubAppPrivateKey, repo.GitHubAppEnterpriseBaseURL, repo.Repo, repo.TLSClientCertData, repo.TLSClientCertKey, repo.IsInsecure(), repo.Proxy, repo.NoProxy, store)
+		return git.NewGitHubAppCreds(repo.GithubAppId, repo.GithubAppInstallationId, repo.GithubAppPrivateKey, repo.GitHubAppEnterpriseBaseURL, repo.TLSClientCertData, repo.TLSClientCertKey, repo.IsInsecure(), repo.Proxy, repo.NoProxy, store)
 	}
 	if repo.GCPServiceAccountKey != "" {
 		return git.NewGoogleCloudCreds(repo.GCPServiceAccountKey, store)

--- a/pkg/apis/application/v1alpha1/repository_types_test.go
+++ b/pkg/apis/application/v1alpha1/repository_types_test.go
@@ -54,21 +54,21 @@ func TestGetGitCreds(t *testing.T) {
 				Username: "user",
 				Password: "pass",
 			},
-			expected: git.NewHTTPSCreds("user", "pass", "", "", "", false, "", "", nil, false),
+			expected: git.NewHTTPSCreds("user", "pass", "", "", "", false, nil, false),
 		},
 		{
 			name: "Bearer token credentials",
 			repo: &Repository{
 				BearerToken: "token",
 			},
-			expected: git.NewHTTPSCreds("", "", "token", "", "", false, "", "", nil, false),
+			expected: git.NewHTTPSCreds("", "", "token", "", "", false, nil, false),
 		},
 		{
 			name: "SSH credentials",
 			repo: &Repository{
 				SSHPrivateKey: "ssh-key",
 			},
-			expected: git.NewSSHCreds("ssh-key", "", false, nil, "", ""),
+			expected: git.NewSSHCreds("ssh-key", "", false, ""),
 		},
 		{
 			name: "GitHub App credentials",
@@ -77,7 +77,7 @@ func TestGetGitCreds(t *testing.T) {
 				GithubAppId:             123,
 				GithubAppInstallationId: 456,
 			},
-			expected: git.NewGitHubAppCreds(123, 456, "github-key", "", "", "", "", false, "", "", nil),
+			expected: git.NewGitHubAppCreds(123, 456, "github-key", "", "", "", false, "", "", nil),
 		},
 		{
 			name: "Google Cloud credentials",

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -82,7 +82,6 @@ type Service struct {
 	cache                     *cache.Cache
 	parallelismLimitSemaphore *semaphore.Weighted
 	metricsServer             *metrics.MetricsServer
-	resourceTracking          argo.ResourceTracking
 	newGitClient              func(rawRepoURL string, root string, creds git.Creds, insecure bool, enableLfs bool, proxy string, noProxy string, opts ...git.ClientOpts) (git.Client, error)
 	newHelmClient             func(repoURL string, creds helm.Creds, enableOci bool, proxy string, noProxy string, opts ...helm.ClientOpts) helm.Client
 	initConstants             RepoServerInitConstants
@@ -111,7 +110,7 @@ type RepoServerInitConstants struct {
 var manifestGenerateLock = sync.NewKeyLock()
 
 // NewService returns a new instance of the Manifest service
-func NewService(metricsServer *metrics.MetricsServer, cache *cache.Cache, initConstants RepoServerInitConstants, resourceTracking argo.ResourceTracking, gitCredsStore git.CredsStore, rootDir string) *Service {
+func NewService(metricsServer *metrics.MetricsServer, cache *cache.Cache, initConstants RepoServerInitConstants, gitCredsStore git.CredsStore, rootDir string) *Service {
 	var parallelismLimitSemaphore *semaphore.Weighted
 	if initConstants.ParallelismLimit > 0 {
 		parallelismLimitSemaphore = semaphore.NewWeighted(initConstants.ParallelismLimit)
@@ -125,7 +124,6 @@ func NewService(metricsServer *metrics.MetricsServer, cache *cache.Cache, initCo
 		cache:                     cache,
 		metricsServer:             metricsServer,
 		newGitClient:              git.NewClientExt,
-		resourceTracking:          resourceTracking,
 		newHelmClient: func(repoURL string, creds helm.Creds, enableOci bool, proxy string, noProxy string, opts ...helm.ClientOpts) helm.Client {
 			return helm.NewClientWithLock(repoURL, creds, sync.NewKeyLock(), enableOci, proxy, noProxy, opts...)
 		},

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -65,8 +65,7 @@ type repoCacheMocks struct {
 }
 
 type newGitRepoHelmChartOptions struct {
-	chartName    string
-	chartVersion string
+	chartName string
 	// valuesFiles is a map of the values file name to the key/value pairs to be written to the file
 	valuesFiles map[string]map[string]string
 }
@@ -148,7 +147,7 @@ func newServiceWithOpt(t *testing.T, cf clientFunc, root string) (*Service, *git
 	cf(gitClient, helmClient, paths)
 	cacheMocks := newCacheMocks()
 	t.Cleanup(cacheMocks.mockCache.StopRedisCallback)
-	service := NewService(metrics.NewMetricsServer(), cacheMocks.cache, RepoServerInitConstants{ParallelismLimit: 1}, argo.NewResourceTracking(), &git.NoopCredsStore{}, root)
+	service := NewService(metrics.NewMetricsServer(), cacheMocks.cache, RepoServerInitConstants{ParallelismLimit: 1}, &git.NoopCredsStore{}, root)
 
 	service.newGitClient = func(_ string, _ string, _ git.Creds, _ bool, _ bool, _ string, _ string, _ ...git.ClientOpts) (client git.Client, e error) {
 		return gitClient, nil
@@ -367,7 +366,7 @@ func TestGenerateManifest_RefOnlyShortCircuit(t *testing.T) {
 	repoRemote := "file://" + repopath
 	cacheMocks := newCacheMocks()
 	t.Cleanup(cacheMocks.mockCache.StopRedisCallback)
-	service := NewService(metrics.NewMetricsServer(), cacheMocks.cache, RepoServerInitConstants{ParallelismLimit: 1}, argo.NewResourceTracking(), &git.NoopCredsStore{}, repopath)
+	service := NewService(metrics.NewMetricsServer(), cacheMocks.cache, RepoServerInitConstants{ParallelismLimit: 1}, &git.NoopCredsStore{}, repopath)
 	service.newGitClient = func(rawRepoURL string, root string, creds git.Creds, insecure bool, enableLfs bool, proxy string, noProxy string, opts ...git.ClientOpts) (client git.Client, e error) {
 		opts = append(opts, git.WithEventHandlers(git.EventHandlers{
 			// Primary check, we want to make sure ls-remote is not called when the item is in cache
@@ -431,7 +430,7 @@ func TestGenerateManifestsHelmWithRefs_CachedNoLsRemote(t *testing.T) {
 			})
 		require.NoError(t, err)
 	})
-	service := NewService(metrics.NewMetricsServer(), cacheMocks.cache, RepoServerInitConstants{ParallelismLimit: 1}, argo.NewResourceTracking(), &git.NoopCredsStore{}, repopath)
+	service := NewService(metrics.NewMetricsServer(), cacheMocks.cache, RepoServerInitConstants{ParallelismLimit: 1}, &git.NoopCredsStore{}, repopath)
 	var gitClient git.Client
 	var err error
 	service.newGitClient = func(rawRepoURL string, root string, creds git.Creds, insecure bool, enableLfs bool, proxy string, noProxy string, opts ...git.ClientOpts) (client git.Client, e error) {
@@ -452,9 +451,8 @@ func TestGenerateManifestsHelmWithRefs_CachedNoLsRemote(t *testing.T) {
 		createPath: true,
 		remote:     repoRemote,
 		helmChartOptions: newGitRepoHelmChartOptions{
-			chartName:    "my-chart",
-			chartVersion: "v1.0.0",
-			valuesFiles:  map[string]map[string]string{"test.yaml": {"testval": "test"}},
+			chartName:   "my-chart",
+			valuesFiles: map[string]map[string]string{"test.yaml": {"testval": "test"}},
 		},
 	})
 	src := v1alpha1.ApplicationSource{RepoURL: repoRemote, Path: ".", TargetRevision: "HEAD", Helm: &v1alpha1.ApplicationSourceHelm{

--- a/reposerver/server.go
+++ b/reposerver/server.go
@@ -26,7 +26,6 @@ import (
 	"github.com/argoproj/argo-cd/v3/reposerver/metrics"
 	"github.com/argoproj/argo-cd/v3/reposerver/repository"
 	"github.com/argoproj/argo-cd/v3/server/version"
-	"github.com/argoproj/argo-cd/v3/util/argo"
 	"github.com/argoproj/argo-cd/v3/util/env"
 	"github.com/argoproj/argo-cd/v3/util/git"
 	grpc_util "github.com/argoproj/argo-cd/v3/util/grpc"
@@ -35,13 +34,8 @@ import (
 
 // ArgoCDRepoServer is the repo server implementation
 type ArgoCDRepoServer struct {
-	log           *log.Entry
-	repoService   *repository.Service
-	metricsServer *metrics.MetricsServer
-	gitCredsStore git.CredsStore
-	cache         *reposervercache.Cache
-	opts          []grpc.ServerOption
-	initConstants repository.RepoServerInitConstants
+	repoService *repository.Service
+	opts        []grpc.ServerOption
 }
 
 // The hostnames to generate self-signed issues with
@@ -104,19 +98,14 @@ func NewServer(metricsServer *metrics.MetricsServer, cache *reposervercache.Cach
 	if tlsConfig != nil {
 		serverOpts = append(serverOpts, grpc.Creds(credentials.NewTLS(tlsConfig)))
 	}
-	repoService := repository.NewService(metricsServer, cache, initConstants, argo.NewResourceTracking(), gitCredsStore, filepath.Join(os.TempDir(), "_argocd-repo"))
+	repoService := repository.NewService(metricsServer, cache, initConstants, gitCredsStore, filepath.Join(os.TempDir(), "_argocd-repo"))
 	if err := repoService.Init(); err != nil {
 		return nil, fmt.Errorf("failed to initialize the repo service: %w", err)
 	}
 
 	return &ArgoCDRepoServer{
-		log:           serverLog,
-		metricsServer: metricsServer,
-		cache:         cache,
-		initConstants: initConstants,
-		opts:          serverOpts,
-		gitCredsStore: gitCredsStore,
-		repoService:   repoService,
+		opts:        serverOpts,
+		repoService: repoService,
 	}, nil
 }
 

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -138,7 +138,7 @@ func NewServer(
 		kubectl:                kubectl,
 		enf:                    enf,
 		projectLock:            projectLock,
-		auditLogger:            argo.NewAuditLogger(namespace, kubeclientset, "argocd-server", enableK8sEvent),
+		auditLogger:            argo.NewAuditLogger(kubeclientset, "argocd-server", enableK8sEvent),
 		settingsMgr:            settingsMgr,
 		projInformer:           projInformer,
 		enabledNamespaces:      enabledNamespaces,

--- a/server/application/application_test.go
+++ b/server/application/application_test.go
@@ -285,7 +285,7 @@ func newTestAppServerWithEnforcerConfigure(t *testing.T, f func(*rbac.Enforcer),
 			require.NoError(t, err)
 		}
 	}
-	appCache := servercache.NewCache(appStateCache, time.Hour, time.Hour, time.Hour)
+	appCache := servercache.NewCache(appStateCache, time.Hour, time.Hour)
 
 	kubectl := &kubetest.MockKubectlCmd{}
 	kubectl = kubectl.WithGetResourceFunc(func(_ context.Context, _ *rest.Config, gvk schema.GroupVersionKind, name string, namespace string) (*unstructured.Unstructured, error) {
@@ -448,7 +448,7 @@ func newTestAppServerWithEnforcerConfigureWithBenchmark(b *testing.B, f func(*rb
 			require.NoError(b, err)
 		}
 	}
-	appCache := servercache.NewCache(appStateCache, time.Hour, time.Hour, time.Hour)
+	appCache := servercache.NewCache(appStateCache, time.Hour, time.Hour)
 
 	kubectl := &kubetest.MockKubectlCmd{}
 	kubectl = kubectl.WithGetResourceFunc(func(_ context.Context, _ *rest.Config, gvk schema.GroupVersionKind, name string, namespace string) (*unstructured.Unstructured, error) {
@@ -2443,7 +2443,7 @@ func TestInferResourcesStatusHealth(t *testing.T) {
 
 	require.NoError(t, err)
 
-	appServer.cache = servercache.NewCache(appStateCache, time.Minute, time.Minute, time.Minute)
+	appServer.cache = servercache.NewCache(appStateCache, time.Minute, time.Minute)
 
 	appServer.inferResourcesStatusHealth(testApp)
 
@@ -2533,7 +2533,7 @@ func TestRunNewStyleResourceAction(t *testing.T) {
 		testApp.Status.Resources = resources
 
 		appServer := newTestAppServer(t, testApp, createJobDenyingProj, kube.MustToUnstructured(&cronJob))
-		appServer.cache = servercache.NewCache(appStateCache, time.Minute, time.Minute, time.Minute)
+		appServer.cache = servercache.NewCache(appStateCache, time.Minute, time.Minute)
 
 		err := appStateCache.SetAppResourcesTree(testApp.Name, &v1alpha1.ApplicationTree{Nodes: nodes})
 		require.NoError(t, err)
@@ -2559,7 +2559,7 @@ func TestRunNewStyleResourceAction(t *testing.T) {
 		testApp.Status.Resources = resources
 
 		appServer := newTestAppServer(t, testApp, kube.MustToUnstructured(&cronJob))
-		appServer.cache = servercache.NewCache(appStateCache, time.Minute, time.Minute, time.Minute)
+		appServer.cache = servercache.NewCache(appStateCache, time.Minute, time.Minute)
 
 		err := appStateCache.SetAppResourcesTree(testApp.Name, &v1alpha1.ApplicationTree{Nodes: nodes})
 		require.NoError(t, err)
@@ -2630,7 +2630,7 @@ func TestRunOldStyleResourceAction(t *testing.T) {
 
 		// appServer := newTestAppServer(t, testApp, returnDeployment())
 		appServer := newTestAppServer(t, testApp, kube.MustToUnstructured(&deployment))
-		appServer.cache = servercache.NewCache(appStateCache, time.Minute, time.Minute, time.Minute)
+		appServer.cache = servercache.NewCache(appStateCache, time.Minute, time.Minute)
 
 		err := appStateCache.SetAppResourcesTree(testApp.Name, &v1alpha1.ApplicationTree{Nodes: nodes})
 		require.NoError(t, err)

--- a/server/application/terminal.go
+++ b/server/application/terminal.go
@@ -20,7 +20,6 @@ import (
 
 	appv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	applisters "github.com/argoproj/argo-cd/v3/pkg/client/listers/application/v1alpha1"
-	servercache "github.com/argoproj/argo-cd/v3/server/cache"
 	"github.com/argoproj/argo-cd/v3/util/argo"
 	"github.com/argoproj/argo-cd/v3/util/db"
 	"github.com/argoproj/argo-cd/v3/util/rbac"
@@ -32,7 +31,6 @@ import (
 type terminalHandler struct {
 	appLister         applisters.ApplicationLister
 	db                db.ArgoDB
-	cache             *servercache.Cache
 	appResourceTreeFn func(ctx context.Context, app *appv1.Application) (*appv1.ApplicationTree, error)
 	allowedShells     []string
 	namespace         string
@@ -47,11 +45,10 @@ type TerminalOptions struct {
 }
 
 // NewHandler returns a new terminal handler.
-func NewHandler(appLister applisters.ApplicationLister, namespace string, enabledNamespaces []string, db db.ArgoDB, cache *servercache.Cache, appResourceTree AppResourceTreeFn, allowedShells []string, sessionManager *util_session.SessionManager, terminalOptions *TerminalOptions) *terminalHandler {
+func NewHandler(appLister applisters.ApplicationLister, namespace string, enabledNamespaces []string, db db.ArgoDB, appResourceTree AppResourceTreeFn, allowedShells []string, sessionManager *util_session.SessionManager, terminalOptions *TerminalOptions) *terminalHandler {
 	return &terminalHandler{
 		appLister:         appLister,
 		db:                db,
-		cache:             cache,
 		appResourceTreeFn: appResourceTree,
 		allowedShells:     allowedShells,
 		namespace:         namespace,

--- a/server/application/websocket.go
+++ b/server/application/websocket.go
@@ -38,7 +38,6 @@ type terminalSession struct {
 	wsConn         *websocket.Conn
 	sizeChan       chan remotecommand.TerminalSize
 	doneChan       chan struct{}
-	tty            bool
 	readLock       sync.Mutex
 	writeLock      sync.Mutex
 	sessionManager *util_session.SessionManager
@@ -67,7 +66,6 @@ func newTerminalSession(ctx context.Context, w http.ResponseWriter, r *http.Requ
 	session := &terminalSession{
 		ctx:            ctx,
 		wsConn:         conn,
-		tty:            true,
 		sizeChan:       make(chan remotecommand.TerminalSize),
 		doneChan:       make(chan struct{}),
 		sessionManager: sessionManager,

--- a/server/applicationset/applicationset.go
+++ b/server/applicationset/applicationset.go
@@ -41,7 +41,6 @@ import (
 	"github.com/argoproj/argo-cd/v3/util/rbac"
 	"github.com/argoproj/argo-cd/v3/util/security"
 	"github.com/argoproj/argo-cd/v3/util/session"
-	"github.com/argoproj/argo-cd/v3/util/settings"
 )
 
 type Server struct {
@@ -55,9 +54,7 @@ type Server struct {
 	appclientset             appclientset.Interface
 	appsetInformer           cache.SharedIndexInformer
 	appsetLister             applisters.ApplicationSetLister
-	projLister               applisters.AppProjectNamespaceLister
 	auditLogger              *argo.AuditLogger
-	settings                 *settings.SettingsManager
 	projectLock              sync.KeyLock
 	enabledNamespaces        []string
 	GitSubmoduleEnabled      bool
@@ -78,8 +75,6 @@ func NewServer(
 	appclientset appclientset.Interface,
 	appsetInformer cache.SharedIndexInformer,
 	appsetLister applisters.ApplicationSetLister,
-	projLister applisters.AppProjectNamespaceLister,
-	settings *settings.SettingsManager,
 	namespace string,
 	projectLock sync.KeyLock,
 	enabledNamespaces []string,
@@ -101,10 +96,8 @@ func NewServer(
 		appclientset:             appclientset,
 		appsetInformer:           appsetInformer,
 		appsetLister:             appsetLister,
-		projLister:               projLister,
-		settings:                 settings,
 		projectLock:              projectLock,
-		auditLogger:              argo.NewAuditLogger(namespace, kubeclientset, "argocd-server", enableK8sEvent),
+		auditLogger:              argo.NewAuditLogger(kubeclientset, "argocd-server", enableK8sEvent),
 		enabledNamespaces:        enabledNamespaces,
 		GitSubmoduleEnabled:      gitSubmoduleEnabled,
 		EnableNewGitFileGlobbing: enableNewGitFileGlobbing,

--- a/server/applicationset/applicationset_test.go
+++ b/server/applicationset/applicationset_test.go
@@ -123,8 +123,6 @@ func newTestAppSetServerWithEnforcerConfigure(t *testing.T, f func(*rbac.Enforce
 	f(enforcer)
 	enforcer.SetClaimsEnforcerFunc(rbacpolicy.NewRBACPolicyEnforcer(enforcer, fakeProjLister).EnforceClaims)
 
-	settingsMgr := settings.NewSettingsManager(ctx, kubeclientset, testNamespace)
-
 	// populate the app informer with the fake objects
 	appInformer := factory.Argoproj().V1alpha1().Applications().Informer()
 	// TODO(jessesuen): probably should return cancel function so tests can stop background informer
@@ -156,8 +154,6 @@ func newTestAppSetServerWithEnforcerConfigure(t *testing.T, f func(*rbac.Enforce
 		fakeAppsClientset,
 		appInformer,
 		factory.Argoproj().V1alpha1().ApplicationSets().Lister(),
-		fakeProjLister,
-		settingsMgr,
 		testNamespace,
 		sync.NewKeyLock(),
 		[]string{testNamespace, "external-namespace"},

--- a/server/cache/cache.go
+++ b/server/cache/cache.go
@@ -20,16 +20,14 @@ type Cache struct {
 	cache                           *appstatecache.Cache
 	connectionStatusCacheExpiration time.Duration
 	oidcCacheExpiration             time.Duration
-	loginAttemptsExpiration         time.Duration
 }
 
 func NewCache(
 	cache *appstatecache.Cache,
 	connectionStatusCacheExpiration time.Duration,
 	oidcCacheExpiration time.Duration,
-	loginAttemptsExpiration time.Duration,
 ) *Cache {
-	return &Cache{cache, connectionStatusCacheExpiration, oidcCacheExpiration, loginAttemptsExpiration}
+	return &Cache{cache, connectionStatusCacheExpiration, oidcCacheExpiration}
 }
 
 func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...cacheutil.Options) func() (*Cache, error) {
@@ -39,7 +37,7 @@ func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...cacheutil.Options) func() (*
 
 	cmd.Flags().DurationVar(&connectionStatusCacheExpiration, "connection-status-cache-expiration", env.ParseDurationFromEnv("ARGOCD_SERVER_CONNECTION_STATUS_CACHE_EXPIRATION", 1*time.Hour, 0, math.MaxInt64), "Cache expiration for cluster/repo connection status")
 	cmd.Flags().DurationVar(&oidcCacheExpiration, "oidc-cache-expiration", env.ParseDurationFromEnv("ARGOCD_SERVER_OIDC_CACHE_EXPIRATION", 3*time.Minute, 0, math.MaxInt64), "Cache expiration for OIDC state")
-	cmd.Flags().DurationVar(&loginAttemptsExpiration, "login-attempts-expiration", env.ParseDurationFromEnv("ARGOCD_SERVER_LOGIN_ATTEMPTS_EXPIRATION", 24*time.Hour, 0, math.MaxInt64), "Cache expiration for failed login attempts")
+	cmd.Flags().DurationVar(&loginAttemptsExpiration, "login-attempts-expiration", env.ParseDurationFromEnv("ARGOCD_SERVER_LOGIN_ATTEMPTS_EXPIRATION", 24*time.Hour, 0, math.MaxInt64), "Cache expiration for failed login attempts. DEPRECATED: this flag is unused and will be removed in a future version.")
 
 	fn := appstatecache.AddCacheFlagsToCmd(cmd, opts...)
 
@@ -49,7 +47,7 @@ func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...cacheutil.Options) func() (*
 			return nil, err
 		}
 
-		return NewCache(cache, connectionStatusCacheExpiration, oidcCacheExpiration, loginAttemptsExpiration), nil
+		return NewCache(cache, connectionStatusCacheExpiration, oidcCacheExpiration), nil
 	}
 }
 

--- a/server/cache/cache_test.go
+++ b/server/cache/cache_test.go
@@ -25,7 +25,6 @@ func newFixtures() *fixtures {
 		),
 		1*time.Minute,
 		1*time.Minute,
-		1*time.Minute,
 	)}
 }
 

--- a/server/certificate/certificate.go
+++ b/server/certificate/certificate.go
@@ -5,28 +5,21 @@ import (
 
 	certificatepkg "github.com/argoproj/argo-cd/v3/pkg/apiclient/certificate"
 	appsv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
-	"github.com/argoproj/argo-cd/v3/reposerver/apiclient"
 	"github.com/argoproj/argo-cd/v3/util/db"
 	"github.com/argoproj/argo-cd/v3/util/rbac"
 )
 
 // Server provides a Certificate service
 type Server struct {
-	db            db.ArgoDB
-	repoClientset apiclient.Clientset
-	enf           *rbac.Enforcer
+	db  db.ArgoDB
+	enf *rbac.Enforcer
 }
 
 // NewServer returns a new instance of the Certificate service
-func NewServer(
-	repoClientset apiclient.Clientset,
-	db db.ArgoDB,
-	enf *rbac.Enforcer,
-) *Server {
+func NewServer(db db.ArgoDB, enf *rbac.Enforcer) *Server {
 	return &Server{
-		db:            db,
-		repoClientset: repoClientset,
-		enf:           enf,
+		db:  db,
+		enf: enf,
 	}
 }
 

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -111,7 +111,6 @@ func newServerInMemoryCache() *servercache.Cache {
 		),
 		1*time.Minute,
 		1*time.Minute,
-		1*time.Minute,
 	)
 }
 

--- a/server/extension/extension.go
+++ b/server/extension/extension.go
@@ -398,8 +398,11 @@ func NewProxyRegistry() ProxyRegistry {
 // ProxyKey defines the struct used as a key in the proxy registry
 // map (ProxyRegistry).
 type ProxyKey struct {
+	//nolint:unused // used as part of a map kay
 	extensionName string
-	clusterName   string
+	//nolint:unused // used as part of a map kay
+	clusterName string
+	//nolint:unused // used as part of a map kay
 	clusterServer string
 }
 

--- a/server/gpgkey/gpgkey.go
+++ b/server/gpgkey/gpgkey.go
@@ -8,7 +8,6 @@ import (
 
 	gpgkeypkg "github.com/argoproj/argo-cd/v3/pkg/apiclient/gpgkey"
 	appsv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
-	"github.com/argoproj/argo-cd/v3/reposerver/apiclient"
 	"github.com/argoproj/argo-cd/v3/util/db"
 	"github.com/argoproj/argo-cd/v3/util/gpg"
 	"github.com/argoproj/argo-cd/v3/util/rbac"
@@ -16,21 +15,15 @@ import (
 
 // Server provides a service of type GPGKeyService
 type Server struct {
-	db            db.ArgoDB
-	repoClientset apiclient.Clientset
-	enf           *rbac.Enforcer
+	db  db.ArgoDB
+	enf *rbac.Enforcer
 }
 
 // NewServer returns a new instance of the service with type GPGKeyService
-func NewServer(
-	repoClientset apiclient.Clientset,
-	db db.ArgoDB,
-	enf *rbac.Enforcer,
-) *Server {
+func NewServer(db db.ArgoDB, enf *rbac.Enforcer) *Server {
 	return &Server{
-		db:            db,
-		repoClientset: repoClientset,
-		enf:           enf,
+		db:  db,
+		enf: enf,
 	}
 }
 

--- a/server/logout/logout.go
+++ b/server/logout/logout.go
@@ -11,7 +11,6 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/argoproj/argo-cd/v3/common"
-	"github.com/argoproj/argo-cd/v3/pkg/client/clientset/versioned"
 	httputil "github.com/argoproj/argo-cd/v3/util/http"
 	jwtutil "github.com/argoproj/argo-cd/v3/util/jwt"
 	"github.com/argoproj/argo-cd/v3/util/session"
@@ -19,26 +18,22 @@ import (
 )
 
 // NewHandler creates handler serving to do api/logout endpoint
-func NewHandler(appClientset versioned.Interface, settingsMrg *settings.SettingsManager, sessionMgr *session.SessionManager, rootPath, baseHRef, namespace string) *Handler {
+func NewHandler(settingsMrg *settings.SettingsManager, sessionMgr *session.SessionManager, rootPath, baseHRef string) *Handler {
 	return &Handler{
-		appClientset: appClientset,
-		namespace:    namespace,
-		settingsMgr:  settingsMrg,
-		rootPath:     rootPath,
-		baseHRef:     baseHRef,
-		verifyToken:  sessionMgr.VerifyToken,
-		revokeToken:  sessionMgr.RevokeToken,
+		settingsMgr: settingsMrg,
+		rootPath:    rootPath,
+		baseHRef:    baseHRef,
+		verifyToken: sessionMgr.VerifyToken,
+		revokeToken: sessionMgr.RevokeToken,
 	}
 }
 
 type Handler struct {
-	namespace    string
-	appClientset versioned.Interface
-	settingsMgr  *settings.SettingsManager
-	rootPath     string
-	verifyToken  func(tokenString string) (jwt.Claims, string, error)
-	revokeToken  func(ctx context.Context, id string, expiringAt time.Duration) error
-	baseHRef     string
+	settingsMgr *settings.SettingsManager
+	rootPath    string
+	verifyToken func(tokenString string) (jwt.Claims, string, error)
+	revokeToken func(ctx context.Context, id string, expiringAt time.Duration) error
+	baseHRef    string
 }
 
 var (

--- a/server/logout/logout_test.go
+++ b/server/logout/logout_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/argoproj/argo-cd/v3/common"
-	appclientset "github.com/argoproj/argo-cd/v3/pkg/client/clientset/versioned/fake"
 	"github.com/argoproj/argo-cd/v3/test"
 	"github.com/argoproj/argo-cd/v3/util/session"
 	"github.com/argoproj/argo-cd/v3/util/settings"
@@ -245,28 +244,28 @@ func TestHandlerConstructLogoutURL(t *testing.T) {
 
 	sessionManager := session.NewSessionManager(settingsManagerWithOIDCConfig, test.NewFakeProjLister(), "", nil, session.NewUserStateStorage(nil))
 
-	oidcHandler := NewHandler(appclientset.NewSimpleClientset(), settingsManagerWithOIDCConfig, sessionManager, rootPath, baseHRef, "default")
+	oidcHandler := NewHandler(settingsManagerWithOIDCConfig, sessionManager, rootPath, baseHRef)
 	oidcHandler.verifyToken = func(tokenString string) (jwt.Claims, string, error) {
 		if !validJWTPattern.MatchString(tokenString) {
 			return nil, "", errors.New("invalid jwt")
 		}
 		return &jwt.RegisteredClaims{Issuer: "okta"}, "", nil
 	}
-	nonoidcHandler := NewHandler(appclientset.NewSimpleClientset(), settingsManagerWithoutOIDCConfig, sessionManager, "", baseHRef, "default")
+	nonoidcHandler := NewHandler(settingsManagerWithoutOIDCConfig, sessionManager, "", baseHRef)
 	nonoidcHandler.verifyToken = func(tokenString string) (jwt.Claims, string, error) {
 		if !validJWTPattern.MatchString(tokenString) {
 			return nil, "", errors.New("invalid jwt")
 		}
 		return &jwt.RegisteredClaims{Issuer: session.SessionManagerClaimsIssuer}, "", nil
 	}
-	oidcHandlerWithoutLogoutURL := NewHandler(appclientset.NewSimpleClientset(), settingsManagerWithOIDCConfigButNoLogoutURL, sessionManager, "", baseHRef, "default")
+	oidcHandlerWithoutLogoutURL := NewHandler(settingsManagerWithOIDCConfigButNoLogoutURL, sessionManager, "", baseHRef)
 	oidcHandlerWithoutLogoutURL.verifyToken = func(tokenString string) (jwt.Claims, string, error) {
 		if !validJWTPattern.MatchString(tokenString) {
 			return nil, "", errors.New("invalid jwt")
 		}
 		return &jwt.RegisteredClaims{Issuer: "okta"}, "", nil
 	}
-	nonoidcHandlerWithMultipleURLs := NewHandler(appclientset.NewSimpleClientset(), settingsManagerWithoutOIDCAndMultipleURLs, sessionManager, "", baseHRef, "default")
+	nonoidcHandlerWithMultipleURLs := NewHandler(settingsManagerWithoutOIDCAndMultipleURLs, sessionManager, "", baseHRef)
 	nonoidcHandlerWithMultipleURLs.verifyToken = func(tokenString string) (jwt.Claims, string, error) {
 		if !validJWTPattern.MatchString(tokenString) {
 			return nil, "", errors.New("invalid jwt")
@@ -274,7 +273,7 @@ func TestHandlerConstructLogoutURL(t *testing.T) {
 		return &jwt.RegisteredClaims{Issuer: "okta"}, "", nil
 	}
 
-	oidcHandlerWithoutBaseURL := NewHandler(appclientset.NewSimpleClientset(), settingsManagerWithOIDCConfigButNoURL, sessionManager, "argocd", baseHRef, "default")
+	oidcHandlerWithoutBaseURL := NewHandler(settingsManagerWithOIDCConfigButNoURL, sessionManager, "argocd", baseHRef)
 	oidcHandlerWithoutBaseURL.verifyToken = func(tokenString string) (jwt.Claims, string, error) {
 		if !validJWTPattern.MatchString(tokenString) {
 			return nil, "", errors.New("invalid jwt")

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -20,7 +20,6 @@ type MetricsServer struct {
 	redisRequestHistogram    *prometheus.HistogramVec
 	extensionRequestCounter  *prometheus.CounterVec
 	extensionRequestDuration *prometheus.HistogramVec
-	argoVersion              *prometheus.GaugeVec
 }
 
 var (
@@ -94,7 +93,6 @@ func NewMetricsServer(host string, port int) *MetricsServer {
 		redisRequestHistogram:    redisRequestHistogram,
 		extensionRequestCounter:  extensionRequestCounter,
 		extensionRequestDuration: extensionRequestDuration,
-		argoVersion:              argoVersion,
 	}
 }
 

--- a/server/project/project.go
+++ b/server/project/project.go
@@ -60,7 +60,7 @@ type Server struct {
 func NewServer(ns string, kubeclientset kubernetes.Interface, appclientset appclientset.Interface, enf *rbac.Enforcer, projectLock sync.KeyLock, sessionMgr *session.SessionManager, policyEnf *rbacpolicy.RBACPolicyEnforcer,
 	projInformer cache.SharedIndexInformer, settingsMgr *settings.SettingsManager, db db.ArgoDB, enableK8sEvent []string,
 ) *Server {
-	auditLogger := argo.NewAuditLogger(ns, kubeclientset, "argocd-server", enableK8sEvent)
+	auditLogger := argo.NewAuditLogger(kubeclientset, "argocd-server", enableK8sEvent)
 	return &Server{
 		enf: enf, policyEnf: policyEnf, appclientset: appclientset, kubeclientset: kubeclientset, ns: ns, projectLock: projectLock, auditLogger: auditLogger, sessionMgr: sessionMgr,
 		projInformer: projInformer, settingsMgr: settingsMgr, db: db,

--- a/server/repocreds/repocreds.go
+++ b/server/repocreds/repocreds.go
@@ -11,32 +11,24 @@ import (
 
 	repocredspkg "github.com/argoproj/argo-cd/v3/pkg/apiclient/repocreds"
 	appsv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
-	"github.com/argoproj/argo-cd/v3/reposerver/apiclient"
 	"github.com/argoproj/argo-cd/v3/util/db"
 	"github.com/argoproj/argo-cd/v3/util/rbac"
-	"github.com/argoproj/argo-cd/v3/util/settings"
 )
 
 // Server provides a Repository service
 type Server struct {
-	db            db.ArgoDB
-	repoClientset apiclient.Clientset
-	enf           *rbac.Enforcer
-	settings      *settings.SettingsManager
+	db  db.ArgoDB
+	enf *rbac.Enforcer
 }
 
 // NewServer returns a new instance of the Repository service
 func NewServer(
-	repoClientset apiclient.Clientset,
 	db db.ArgoDB,
 	enf *rbac.Enforcer,
-	settings *settings.SettingsManager,
 ) *Server {
 	return &Server{
-		db:            db,
-		repoClientset: repoClientset,
-		enf:           enf,
-		settings:      settings,
+		db:  db,
+		enf: enf,
 	}
 }
 

--- a/server/repository/repository_test.go
+++ b/server/repository/repository_test.go
@@ -955,7 +955,6 @@ func newFixtures() *fixtures {
 		),
 		1*time.Minute,
 		1*time.Minute,
-		1*time.Minute,
 	)}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -182,7 +182,6 @@ type ArgoCDServer struct {
 	settingsMgr    *settings_util.SettingsManager
 	enf            *rbac.Enforcer
 	projInformer   cache.SharedIndexInformer
-	projLister     applisters.AppProjectNamespaceLister
 	policyEnforcer *rbacpolicy.RBACPolicyEnforcer
 	appInformer    cache.SharedIndexInformer
 	appLister      applisters.ApplicationLister
@@ -371,7 +370,6 @@ func NewServer(ctx context.Context, opts ArgoCDServerOpts, appsetOpts Applicatio
 		settingsMgr:        settingsMgr,
 		enf:                enf,
 		projInformer:       projInformer,
-		projLister:         projLister,
 		appInformer:        appInformer,
 		appLister:          appLister,
 		appsetInformer:     appsetInformer,
@@ -1011,7 +1009,7 @@ func newArgoCDServiceSet(a *ArgoCDServer) *ArgoCDServiceSet {
 	kubectl := kubeutil.NewKubectl()
 	clusterService := cluster.NewServer(a.db, a.enf, a.Cache, kubectl)
 	repoService := repository.NewServer(a.RepoClientset, a.db, a.enf, a.Cache, a.appLister, a.projInformer, a.Namespace, a.settingsMgr, a.HydratorEnabled)
-	repoCredsService := repocreds.NewServer(a.RepoClientset, a.db, a.enf, a.settingsMgr)
+	repoCredsService := repocreds.NewServer(a.db, a.enf)
 	var loginRateLimiter func() (utilio.Closer, error)
 	if maxConcurrentLoginRequestsCount > 0 {
 		loginRateLimiter = session.NewLoginRateLimiter(maxConcurrentLoginRequestsCount)
@@ -1048,8 +1046,6 @@ func newArgoCDServiceSet(a *ArgoCDServer) *ArgoCDServiceSet {
 		a.AppClientset,
 		a.appsetInformer,
 		a.appsetLister,
-		a.projLister,
-		a.settingsMgr,
 		a.Namespace,
 		projectLock,
 		a.ApplicationNamespaces,
@@ -1067,8 +1063,8 @@ func newArgoCDServiceSet(a *ArgoCDServer) *ArgoCDServiceSet {
 	accountService := account.NewServer(a.sessionMgr, a.settingsMgr, a.enf)
 
 	notificationService := notification.NewServer(a.apiFactory)
-	certificateService := certificate.NewServer(a.RepoClientset, a.db, a.enf)
-	gpgkeyService := gpgkey.NewServer(a.RepoClientset, a.db, a.enf)
+	certificateService := certificate.NewServer(a.db, a.enf)
+	gpgkeyService := gpgkey.NewServer(a.db, a.enf)
 	versionService := version.NewServer(a, func() (bool, error) {
 		if a.DisableAuth {
 			return true, nil
@@ -1171,7 +1167,7 @@ func (server *ArgoCDServer) newHTTPServer(ctx context.Context, port int, grpcWeb
 			handler: mux,
 			urlToHandler: map[string]http.Handler{
 				"/api/badge":          badge.NewHandler(server.AppClientset, server.settingsMgr, server.Namespace, server.ApplicationNamespaces),
-				common.LogoutEndpoint: logout.NewHandler(server.AppClientset, server.settingsMgr, server.sessionMgr, server.RootPath, server.BaseHRef, server.Namespace),
+				common.LogoutEndpoint: logout.NewHandler(server.settingsMgr, server.sessionMgr, server.RootPath, server.BaseHRef),
 			},
 			contentTypeToHandler: map[string]http.Handler{
 				"application/grpc-web+proto": grpcWebHandler,
@@ -1202,7 +1198,7 @@ func (server *ArgoCDServer) newHTTPServer(ctx context.Context, port int, grpcWeb
 
 	terminalOpts := application.TerminalOptions{DisableAuth: server.DisableAuth, Enf: server.enf}
 
-	terminal := application.NewHandler(server.appLister, server.Namespace, server.ApplicationNamespaces, server.db, server.Cache, appResourceTreeFn, server.settings.ExecShells, server.sessionMgr, &terminalOpts).
+	terminal := application.NewHandler(server.appLister, server.Namespace, server.ApplicationNamespaces, server.db, appResourceTreeFn, server.settings.ExecShells, server.sessionMgr, &terminalOpts).
 		WithFeatureFlagMiddleware(server.settingsMgr.GetSettings)
 	th := util_session.WithAuthMiddleware(server.DisableAuth, server.sessionMgr, terminal)
 	mux.Handle("/terminal", th)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -84,7 +84,6 @@ func fakeServer(t *testing.T) (*FakeArgoCDServer, func()) {
 			),
 			1*time.Minute,
 			1*time.Minute,
-			1*time.Minute,
 		),
 		RedisClient:             redis,
 		RepoClientset:           mockRepoClient,

--- a/test/e2e/applicationset_git_generator_test.go
+++ b/test/e2e/applicationset_git_generator_test.go
@@ -304,7 +304,6 @@ func TestSimpleGitDirectoryGeneratorGPGEnabledUnsignedCommits(t *testing.T) {
 	project := "gpg"
 
 	Given(t).
-		Project(project).
 		When().
 		// Create a GitGenerator-based ApplicationSet
 		Create(v1alpha1.ApplicationSet{
@@ -404,7 +403,6 @@ func TestSimpleGitDirectoryGeneratorGPGEnabledWithoutKnownKeys(t *testing.T) {
 	project := "gpg"
 
 	Given(t).
-		Project(project).
 		Path(guestbookPath).
 		When().
 		AddSignedFile("test.yaml", randStr(t)).IgnoreErrors().
@@ -620,7 +618,6 @@ func TestSimpleGitFilesGeneratorGPGEnabledUnsignedCommits(t *testing.T) {
 	}
 
 	Given(t).
-		Project(project).
 		When().
 		// Create a GitGenerator-based ApplicationSet
 		Create(v1alpha1.ApplicationSet{
@@ -719,7 +716,6 @@ func TestSimpleGitFilesGeneratorGPGEnabledWithoutKnownKeys(t *testing.T) {
 	}
 
 	Given(t).
-		Project(project).
 		Path(guestbookPath).
 		When().
 		AddSignedFile("test.yaml", randStr(t)).IgnoreErrors().

--- a/test/e2e/fixture/account/actions.go
+++ b/test/e2e/fixture/account/actions.go
@@ -13,10 +13,9 @@ import (
 // none of the func implement error checks, and that is complete intended, you should check for errors
 // using the Then()
 type Actions struct {
-	context      *Context
-	ignoreErrors bool
-	lastOutput   string
-	lastError    error
+	context    *Context
+	lastOutput string
+	lastError  error
 }
 
 func (a *Actions) prepareCanIGetLogsArgs() []string {
@@ -29,16 +28,6 @@ func (a *Actions) prepareCanIGetLogsArgs() []string {
 func (a *Actions) CanIGetLogs() *Actions {
 	a.context.t.Helper()
 	a.runCli(a.prepareCanIGetLogsArgs()...)
-	return a
-}
-
-func (a *Actions) IgnoreErrors() *Actions {
-	a.ignoreErrors = true
-	return a
-}
-
-func (a *Actions) DoNotIgnoreErrors() *Actions {
-	a.ignoreErrors = false
 	return a
 }
 

--- a/test/e2e/fixture/account/context.go
+++ b/test/e2e/fixture/account/context.go
@@ -5,14 +5,12 @@ import (
 	"time"
 
 	"github.com/argoproj/argo-cd/v3/test/e2e/fixture"
-	"github.com/argoproj/argo-cd/v3/util/env"
 )
 
 // this implements the "given" part of given/when/then
 type Context struct {
 	t *testing.T
 	// seconds
-	timeout int
 	name    string
 	project string
 }
@@ -20,10 +18,7 @@ type Context struct {
 func Given(t *testing.T) *Context {
 	t.Helper()
 	fixture.EnsureCleanState(t)
-	// ARGOCE_E2E_DEFAULT_TIMEOUT can be used to override the default timeout
-	// for any context.
-	timeout := env.ParseNumFromEnv("ARGOCD_E2E_DEFAULT_TIMEOUT", 10, 0, 180)
-	return &Context{t: t, name: fixture.Name(), timeout: timeout}
+	return &Context{t: t, name: fixture.Name()}
 }
 
 func (c *Context) Project(project string) *Context {

--- a/test/e2e/fixture/admin/actions.go
+++ b/test/e2e/fixture/admin/actions.go
@@ -11,10 +11,9 @@ import (
 // none of the func implement error checks, and that is complete intended, you should check for errors
 // using the Then()
 type Actions struct {
-	context      *Context
-	ignoreErrors bool
-	lastOutput   string
-	lastError    error
+	context    *Context
+	lastOutput string
+	lastError  error
 }
 
 func (a *Actions) prepareExportCommand() []string {
@@ -40,16 +39,6 @@ func (a *Actions) RunExport() *Actions {
 func (a *Actions) RunImport(stdin string) *Actions {
 	a.context.t.Helper()
 	a.runCliWithStdin(stdin, a.prepareImportCommand()...)
-	return a
-}
-
-func (a *Actions) IgnoreErrors() *Actions {
-	a.ignoreErrors = true
-	return a
-}
-
-func (a *Actions) DoNotIgnoreErrors() *Actions {
-	a.ignoreErrors = false
 	return a
 }
 

--- a/test/e2e/fixture/admin/context.go
+++ b/test/e2e/fixture/admin/context.go
@@ -5,15 +5,11 @@ import (
 	"time"
 
 	"github.com/argoproj/argo-cd/v3/test/e2e/fixture"
-	"github.com/argoproj/argo-cd/v3/util/env"
 )
 
 // this implements the "given" part of given/when/then
 type Context struct {
 	t *testing.T
-	// seconds
-	timeout int
-	name    string
 }
 
 func Given(t *testing.T) *Context {
@@ -24,14 +20,7 @@ func Given(t *testing.T) *Context {
 
 func GivenWithSameState(t *testing.T) *Context {
 	t.Helper()
-	// ARGOCE_E2E_DEFAULT_TIMEOUT can be used to override the default timeout
-	// for any context.
-	timeout := env.ParseNumFromEnv("ARGOCD_E2E_DEFAULT_TIMEOUT", 20, 0, 180)
-	return &Context{
-		t:       t,
-		name:    fixture.Name(),
-		timeout: timeout,
-	}
+	return &Context{t}
 }
 
 func (c *Context) And(block func()) *Context {

--- a/test/e2e/fixture/applicationsets/context.go
+++ b/test/e2e/fixture/applicationsets/context.go
@@ -18,7 +18,6 @@ type Context struct {
 	name              string
 	namespace         string
 	switchToNamespace utils.ExternalNamespace
-	project           string
 	path              string
 }
 
@@ -40,11 +39,6 @@ func (c *Context) Sleep(seconds time.Duration) *Context {
 
 func (c *Context) And(block func()) *Context {
 	block()
-	return c
-}
-
-func (c *Context) Project(project string) *Context {
-	c.project = project
 	return c
 }
 

--- a/test/e2e/fixture/cluster/context.go
+++ b/test/e2e/fixture/cluster/context.go
@@ -5,14 +5,11 @@ import (
 	"time"
 
 	"github.com/argoproj/argo-cd/v3/test/e2e/fixture"
-	"github.com/argoproj/argo-cd/v3/util/env"
 )
 
 // this implements the "given" part of given/when/then
 type Context struct {
-	t *testing.T
-	// seconds
-	timeout     int
+	t           *testing.T
 	name        string
 	project     string
 	server      string
@@ -29,10 +26,7 @@ func Given(t *testing.T) *Context {
 
 func GivenWithSameState(t *testing.T) *Context {
 	t.Helper()
-	// ARGOCE_E2E_DEFAULT_TIMEOUT can be used to override the default timeout
-	// for any context.
-	timeout := env.ParseNumFromEnv("ARGOCD_E2E_DEFAULT_TIMEOUT", 10, 0, 180)
-	return &Context{t: t, name: fixture.Name(), timeout: timeout, project: "default"}
+	return &Context{t: t, name: fixture.Name(), project: "default"}
 }
 
 func (c *Context) GetName() string {

--- a/test/e2e/fixture/project/actions.go
+++ b/test/e2e/fixture/project/actions.go
@@ -18,7 +18,6 @@ import (
 // using the Then()
 type Actions struct {
 	context      *Context
-	lastOutput   string
 	lastError    error
 	ignoreErrors bool
 }
@@ -119,7 +118,7 @@ func (a *Actions) Then() *Consequences {
 
 func (a *Actions) runCli(args ...string) {
 	a.context.t.Helper()
-	a.lastOutput, a.lastError = fixture.RunCli(args...)
+	_, a.lastError = fixture.RunCli(args...)
 	if !a.ignoreErrors {
 		require.NoError(a.context.t, a.lastError)
 	}

--- a/test/e2e/fixture/project/context.go
+++ b/test/e2e/fixture/project/context.go
@@ -5,14 +5,11 @@ import (
 	"time"
 
 	"github.com/argoproj/argo-cd/v3/test/e2e/fixture"
-	"github.com/argoproj/argo-cd/v3/util/env"
 )
 
 // this implements the "given" part of given/when/then
 type Context struct {
-	t *testing.T
-	// seconds
-	timeout                    int
+	t                          *testing.T
 	name                       string
 	destination                string
 	destinationServiceAccounts []string
@@ -28,10 +25,7 @@ func Given(t *testing.T) *Context {
 
 func GivenWithSameState(t *testing.T) *Context {
 	t.Helper()
-	// ARGOCE_E2E_DEFAULT_TIMEOUT can be used to override the default timeout
-	// for any context.
-	timeout := env.ParseNumFromEnv("ARGOCD_E2E_DEFAULT_TIMEOUT", 10, 0, 180)
-	return &Context{t: t, name: fixture.Name(), timeout: timeout}
+	return &Context{t: t, name: fixture.Name()}
 }
 
 func (c *Context) GetName() string {

--- a/test/e2e/fixture/repos/context.go
+++ b/test/e2e/fixture/repos/context.go
@@ -5,16 +5,12 @@ import (
 	"time"
 
 	"github.com/argoproj/argo-cd/v3/test/e2e/fixture"
-	"github.com/argoproj/argo-cd/v3/util/env"
 )
 
 // this implements the "given" part of given/when/then
 type Context struct {
-	t           *testing.T
-	path        string
-	repoURLType fixture.RepoURLType
-	// seconds
-	timeout int
+	t       *testing.T
+	path    string
 	name    string
 	project string
 }
@@ -29,15 +25,7 @@ func Given(t *testing.T) *Context {
 // state in your test setup don't want to waste time by doing so again.
 func GivenWithSameState(t *testing.T) *Context {
 	t.Helper()
-	// ARGOCE_E2E_DEFAULT_TIMEOUT can be used to override the default timeout
-	// for any context.
-	timeout := env.ParseNumFromEnv("ARGOCD_E2E_DEFAULT_TIMEOUT", 10, 0, 180)
-	return &Context{t: t, repoURLType: fixture.RepoURLTypeFile, name: fixture.Name(), timeout: timeout, project: "default"}
-}
-
-func (c *Context) RepoURLType(urlType fixture.RepoURLType) *Context {
-	c.repoURLType = urlType
-	return c
+	return &Context{t: t, name: fixture.Name(), project: "default"}
 }
 
 func (c *Context) GetName() string {

--- a/util/argo/audit_logger.go
+++ b/util/argo/audit_logger.go
@@ -20,7 +20,6 @@ import (
 type AuditLogger struct {
 	kIf            kubernetes.Interface
 	component      string
-	ns             string
 	enableEventLog map[string]bool
 }
 
@@ -179,9 +178,8 @@ func (l *AuditLogger) LogAppProjEvent(proj *v1alpha1.AppProject, info EventInfo,
 	l.logEvent(objectMeta, v1alpha1.AppProjectSchemaGroupVersionKind, info, message, nil, nil)
 }
 
-func NewAuditLogger(ns string, kIf kubernetes.Interface, component string, enableK8sEvent []string) *AuditLogger {
+func NewAuditLogger(kIf kubernetes.Interface, component string, enableK8sEvent []string) *AuditLogger {
 	return &AuditLogger{
-		ns:             ns,
 		kIf:            kIf,
 		component:      component,
 		enableEventLog: setK8sEventList(enableK8sEvent),

--- a/util/argo/audit_logger_test.go
+++ b/util/argo/audit_logger_test.go
@@ -36,12 +36,12 @@ func captureLogEntries(run func()) string {
 }
 
 func TestNewAuditLogger(t *testing.T) {
-	logger := NewAuditLogger("default", fake.NewClientset(), _somecomponent, testEnableEventLog)
+	logger := NewAuditLogger(fake.NewClientset(), _somecomponent, testEnableEventLog)
 	assert.NotNil(t, logger)
 }
 
 func TestLogAppProjEvent(t *testing.T) {
-	logger := NewAuditLogger("default", fake.NewClientset(), _somecomponent, testEnableEventLog)
+	logger := NewAuditLogger(fake.NewClientset(), _somecomponent, testEnableEventLog)
 	assert.NotNil(t, logger)
 
 	proj := argoappv1.AppProject{
@@ -82,7 +82,7 @@ func TestLogAppProjEvent(t *testing.T) {
 }
 
 func TestLogAppEvent(t *testing.T) {
-	logger := NewAuditLogger("default", fake.NewClientset(), _somecomponent, testEnableEventLog)
+	logger := NewAuditLogger(fake.NewClientset(), _somecomponent, testEnableEventLog)
 	assert.NotNil(t, logger)
 
 	app := argoappv1.Application{
@@ -128,7 +128,7 @@ func TestLogAppEvent(t *testing.T) {
 }
 
 func TestLogResourceEvent(t *testing.T) {
-	logger := NewAuditLogger("default", fake.NewClientset(), _somecomponent, testEnableEventLog)
+	logger := NewAuditLogger(fake.NewClientset(), _somecomponent, testEnableEventLog)
 	assert.NotNil(t, logger)
 
 	res := argoappv1.ResourceNode{

--- a/util/argo/diff/diff_test.go
+++ b/util/argo/diff/diff_test.go
@@ -21,10 +21,7 @@ func TestStateDiff(t *testing.T) {
 		overrides      map[string]v1alpha1.ResourceOverride
 		label          string
 		trackingMethod string
-		noCache        bool
 		ignoreRoles    bool
-		appName        string
-		stateCache     *appstatecache.Cache
 	}
 	defaultDiffConfigParams := func() *diffConfigParams {
 		return &diffConfigParams{
@@ -32,10 +29,7 @@ func TestStateDiff(t *testing.T) {
 			overrides:      map[string]v1alpha1.ResourceOverride{},
 			label:          "",
 			trackingMethod: "",
-			noCache:        true,
 			ignoreRoles:    true,
-			appName:        "",
-			stateCache:     &appstatecache.Cache{},
 		}
 	}
 	diffConfig := func(t *testing.T, params *diffConfigParams) argo.DiffConfig {
@@ -166,7 +160,6 @@ func TestDiffConfigBuilder(t *testing.T) {
 		noCache        bool
 		ignoreRoles    bool
 		appName        string
-		stateCache     *appstatecache.Cache
 	}
 	setup := func() *fixture {
 		return &fixture{
@@ -177,7 +170,6 @@ func TestDiffConfigBuilder(t *testing.T) {
 			noCache:        true,
 			ignoreRoles:    false,
 			appName:        "application-name",
-			stateCache:     &appstatecache.Cache{},
 		}
 	}
 	t.Run("will build diff config successfully", func(t *testing.T) {

--- a/util/cache/redis_test.go
+++ b/util/cache/redis_test.go
@@ -33,7 +33,6 @@ var (
 )
 
 type MockMetricsServer struct {
-	registry              *prometheus.Registry
 	redisRequestCounter   *prometheus.CounterVec
 	redisRequestHistogram *prometheus.HistogramVec
 }
@@ -43,7 +42,6 @@ func NewMockMetricsServer() *MockMetricsServer {
 	registry.MustRegister(redisRequestCounter)
 	registry.MustRegister(redisRequestHistogram)
 	return &MockMetricsServer{
-		registry:              registry,
 		redisRequestCounter:   redisRequestCounter,
 		redisRequestHistogram: redisRequestHistogram,
 	}

--- a/util/git/creds.go
+++ b/util/git/creds.go
@@ -142,17 +142,13 @@ type HTTPSCreds struct {
 	clientCertData string
 	// Client certificate key to use
 	clientCertKey string
-	// HTTP/HTTPS proxy used to access repository
-	proxy string
-	// list of targets that shouldn't use the proxy, applies only if the proxy is set
-	noProxy string
 	// temporal credentials store
 	store CredsStore
 	// whether to force usage of basic auth
 	forceBasicAuth bool
 }
 
-func NewHTTPSCreds(username string, password string, bearerToken string, clientCertData string, clientCertKey string, insecure bool, proxy string, noProxy string, store CredsStore, forceBasicAuth bool) GenericHTTPSCreds {
+func NewHTTPSCreds(username string, password string, bearerToken string, clientCertData string, clientCertKey string, insecure bool, store CredsStore, forceBasicAuth bool) GenericHTTPSCreds {
 	return HTTPSCreds{
 		username,
 		password,
@@ -160,8 +156,6 @@ func NewHTTPSCreds(username string, password string, bearerToken string, clientC
 		insecure,
 		clientCertData,
 		clientCertKey,
-		proxy,
-		noProxy,
 		store,
 		forceBasicAuth,
 	}
@@ -277,13 +271,11 @@ type SSHCreds struct {
 	sshPrivateKey string
 	caPath        string
 	insecure      bool
-	store         CredsStore
 	proxy         string
-	noProxy       string
 }
 
-func NewSSHCreds(sshPrivateKey string, caPath string, insecureIgnoreHostKey bool, store CredsStore, proxy string, noProxy string) SSHCreds {
-	return SSHCreds{sshPrivateKey, caPath, insecureIgnoreHostKey, store, proxy, noProxy}
+func NewSSHCreds(sshPrivateKey string, caPath string, insecureIgnoreHostKey bool, proxy string) SSHCreds {
+	return SSHCreds{sshPrivateKey, caPath, insecureIgnoreHostKey, proxy}
 }
 
 // GetUserInfo returns empty strings for user info.
@@ -382,7 +374,6 @@ type GitHubAppCreds struct {
 	appInstallId   int64
 	privateKey     string
 	baseURL        string
-	repoURL        string
 	clientCertData string
 	clientCertKey  string
 	insecure       bool
@@ -392,8 +383,8 @@ type GitHubAppCreds struct {
 }
 
 // NewGitHubAppCreds provide github app credentials
-func NewGitHubAppCreds(appID int64, appInstallId int64, privateKey string, baseURL string, repoURL string, clientCertData string, clientCertKey string, insecure bool, proxy string, noProxy string, store CredsStore) GenericHTTPSCreds {
-	return GitHubAppCreds{appID: appID, appInstallId: appInstallId, privateKey: privateKey, baseURL: baseURL, repoURL: repoURL, clientCertData: clientCertData, clientCertKey: clientCertKey, insecure: insecure, proxy: proxy, noProxy: noProxy, store: store}
+func NewGitHubAppCreds(appID int64, appInstallId int64, privateKey string, baseURL string, clientCertData string, clientCertKey string, insecure bool, proxy string, noProxy string, store CredsStore) GenericHTTPSCreds {
+	return GitHubAppCreds{appID: appID, appInstallId: appInstallId, privateKey: privateKey, baseURL: baseURL, clientCertData: clientCertData, clientCertKey: clientCertKey, insecure: insecure, proxy: proxy, noProxy: noProxy, store: store}
 }
 
 func (g GitHubAppCreds) Environ() (io.Closer, []string, error) {

--- a/util/git/creds_test.go
+++ b/util/git/creds_test.go
@@ -53,7 +53,7 @@ func (s *memoryCredsStore) Environ(_ string) []string {
 
 func TestHTTPSCreds_Environ_no_cert_cleanup(t *testing.T) {
 	store := &memoryCredsStore{creds: make(map[string]cred)}
-	creds := NewHTTPSCreds("", "", "", "", "", true, "", "", store, false)
+	creds := NewHTTPSCreds("", "", "", "", "", true, store, false)
 	closer, _, err := creds.Environ()
 	require.NoError(t, err)
 	credsLenBefore := len(store.creds)
@@ -62,7 +62,7 @@ func TestHTTPSCreds_Environ_no_cert_cleanup(t *testing.T) {
 }
 
 func TestHTTPSCreds_Environ_insecure_true(t *testing.T) {
-	creds := NewHTTPSCreds("", "", "", "", "", true, "", "", &NoopCredsStore{}, false)
+	creds := NewHTTPSCreds("", "", "", "", "", true, &NoopCredsStore{}, false)
 	closer, env, err := creds.Environ()
 	t.Cleanup(func() {
 		utilio.Close(closer)
@@ -79,7 +79,7 @@ func TestHTTPSCreds_Environ_insecure_true(t *testing.T) {
 }
 
 func TestHTTPSCreds_Environ_insecure_false(t *testing.T) {
-	creds := NewHTTPSCreds("", "", "", "", "", false, "", "", &NoopCredsStore{}, false)
+	creds := NewHTTPSCreds("", "", "", "", "", false, &NoopCredsStore{}, false)
 	closer, env, err := creds.Environ()
 	t.Cleanup(func() {
 		utilio.Close(closer)
@@ -98,7 +98,7 @@ func TestHTTPSCreds_Environ_insecure_false(t *testing.T) {
 func TestHTTPSCreds_Environ_forceBasicAuth(t *testing.T) {
 	t.Run("Enabled and credentials set", func(t *testing.T) {
 		store := &memoryCredsStore{creds: make(map[string]cred)}
-		creds := NewHTTPSCreds("username", "password", "", "", "", false, "", "", store, true)
+		creds := NewHTTPSCreds("username", "password", "", "", "", false, store, true)
 		closer, env, err := creds.Environ()
 		require.NoError(t, err)
 		defer closer.Close()
@@ -116,7 +116,7 @@ func TestHTTPSCreds_Environ_forceBasicAuth(t *testing.T) {
 	})
 	t.Run("Enabled but credentials not set", func(t *testing.T) {
 		store := &memoryCredsStore{creds: make(map[string]cred)}
-		creds := NewHTTPSCreds("", "", "", "", "", false, "", "", store, true)
+		creds := NewHTTPSCreds("", "", "", "", "", false, store, true)
 		closer, env, err := creds.Environ()
 		require.NoError(t, err)
 		defer closer.Close()
@@ -133,7 +133,7 @@ func TestHTTPSCreds_Environ_forceBasicAuth(t *testing.T) {
 	})
 	t.Run("Disabled with credentials set", func(t *testing.T) {
 		store := &memoryCredsStore{creds: make(map[string]cred)}
-		creds := NewHTTPSCreds("username", "password", "", "", "", false, "", "", store, false)
+		creds := NewHTTPSCreds("username", "password", "", "", "", false, store, false)
 		closer, env, err := creds.Environ()
 		require.NoError(t, err)
 		defer closer.Close()
@@ -151,7 +151,7 @@ func TestHTTPSCreds_Environ_forceBasicAuth(t *testing.T) {
 
 	t.Run("Disabled with credentials not set", func(t *testing.T) {
 		store := &memoryCredsStore{creds: make(map[string]cred)}
-		creds := NewHTTPSCreds("", "", "", "", "", false, "", "", store, false)
+		creds := NewHTTPSCreds("", "", "", "", "", false, store, false)
 		closer, env, err := creds.Environ()
 		require.NoError(t, err)
 		defer closer.Close()
@@ -171,7 +171,7 @@ func TestHTTPSCreds_Environ_forceBasicAuth(t *testing.T) {
 func TestHTTPSCreds_Environ_bearerTokenAuth(t *testing.T) {
 	t.Run("Enabled and credentials set", func(t *testing.T) {
 		store := &memoryCredsStore{creds: make(map[string]cred)}
-		creds := NewHTTPSCreds("", "", "token", "", "", false, "", "", store, false)
+		creds := NewHTTPSCreds("", "", "token", "", "", false, store, false)
 		closer, env, err := creds.Environ()
 		require.NoError(t, err)
 		defer closer.Close()
@@ -190,7 +190,7 @@ func TestHTTPSCreds_Environ_bearerTokenAuth(t *testing.T) {
 
 func TestHTTPSCreds_Environ_clientCert(t *testing.T) {
 	store := &memoryCredsStore{creds: make(map[string]cred)}
-	creds := NewHTTPSCreds("", "", "", "clientCertData", "clientCertKey", false, "", "", store, false)
+	creds := NewHTTPSCreds("", "", "", "clientCertData", "clientCertKey", false, store, false)
 	closer, env, err := creds.Environ()
 	require.NoError(t, err)
 	var cert, key string
@@ -228,7 +228,7 @@ func Test_SSHCreds_Environ(t *testing.T) {
 		caFile := path.Join(tempDir, "caFile")
 		err := os.WriteFile(caFile, []byte(""), os.FileMode(0o600))
 		require.NoError(t, err)
-		creds := NewSSHCreds("sshPrivateKey", caFile, insecureIgnoreHostKey, &NoopCredsStore{}, "", "")
+		creds := NewSSHCreds("sshPrivateKey", caFile, insecureIgnoreHostKey, "")
 		closer, env, err := creds.Environ()
 		require.NoError(t, err)
 		require.Len(t, env, 2)
@@ -261,7 +261,7 @@ func Test_SSHCreds_Environ_WithProxy(t *testing.T) {
 		caFile := path.Join(tempDir, "caFile")
 		err := os.WriteFile(caFile, []byte(""), os.FileMode(0o600))
 		require.NoError(t, err)
-		creds := NewSSHCreds("sshPrivateKey", caFile, insecureIgnoreHostKey, &NoopCredsStore{}, "socks5://127.0.0.1:1080", "")
+		creds := NewSSHCreds("sshPrivateKey", caFile, insecureIgnoreHostKey, "socks5://127.0.0.1:1080")
 		closer, env, err := creds.Environ()
 		require.NoError(t, err)
 		require.Len(t, env, 2)
@@ -295,7 +295,7 @@ func Test_SSHCreds_Environ_WithProxyUserNamePassword(t *testing.T) {
 		caFile := path.Join(tempDir, "caFile")
 		err := os.WriteFile(caFile, []byte(""), os.FileMode(0o600))
 		require.NoError(t, err)
-		creds := NewSSHCreds("sshPrivateKey", caFile, insecureIgnoreHostKey, &NoopCredsStore{}, "socks5://user:password@127.0.0.1:1080", "")
+		creds := NewSSHCreds("sshPrivateKey", caFile, insecureIgnoreHostKey, "socks5://user:password@127.0.0.1:1080")
 		closer, env, err := creds.Environ()
 		require.NoError(t, err)
 		require.Len(t, env, 4)
@@ -341,7 +341,7 @@ func Test_SSHCreds_Environ_TempFileCleanupOnInvalidProxyURL(t *testing.T) {
 		caFile := path.Join(tempDir, "caFile")
 		err := os.WriteFile(caFile, []byte(""), os.FileMode(0o600))
 		require.NoError(t, err)
-		creds := NewSSHCreds("sshPrivateKey", caFile, insecureIgnoreHostKey, &NoopCredsStore{}, ":invalid-proxy-url", "")
+		creds := NewSSHCreds("sshPrivateKey", caFile, insecureIgnoreHostKey, ":invalid-proxy-url")
 
 		filesInDevShmBeforeInvocation := countFilesInDevShm()
 

--- a/util/git/git_test.go
+++ b/util/git/git_test.go
@@ -134,7 +134,7 @@ func TestCustomHTTPClient(t *testing.T) {
 	assert.NotEmpty(t, string(keyData))
 
 	// Get HTTPSCreds with client cert creds specified, and insecure connection
-	creds := NewHTTPSCreds("test", "test", "", string(certData), string(keyData), false, "http://proxy:5000", "", &NoopCredsStore{}, false)
+	creds := NewHTTPSCreds("test", "test", "", string(certData), string(keyData), false, &NoopCredsStore{}, false)
 	client := GetRepoHTTPClient("https://localhost:9443/foo/bar", false, creds, "http://proxy:5000", "")
 	assert.NotNil(t, client)
 	assert.NotNil(t, client.Transport)
@@ -163,7 +163,7 @@ func TestCustomHTTPClient(t *testing.T) {
 	t.Setenv("http_proxy", "http://proxy-from-env:7878")
 
 	// Get HTTPSCreds without client cert creds, but insecure connection
-	creds = NewHTTPSCreds("test", "test", "", "", "", true, "", "", &NoopCredsStore{}, false)
+	creds = NewHTTPSCreds("test", "test", "", "", "", true, &NoopCredsStore{}, false)
 	client = GetRepoHTTPClient("https://localhost:9443/foo/bar", true, creds, "", "")
 	assert.NotNil(t, client)
 	assert.NotNil(t, client.Transport)

--- a/util/oidc/oidc.go
+++ b/util/oidc/oidc.go
@@ -68,8 +68,6 @@ type ClientApp struct {
 	redirectURI string
 	// URL of the issuer (e.g. https://argocd.example.com/api/dex)
 	issuerURL string
-	// the path where the issuer providers user information (e.g /user-info for okta)
-	userInfoPath string
 	// The URL endpoint at which the ArgoCD server is accessed.
 	baseHRef string
 	// client is the HTTP client which is used to query the IDp
@@ -122,7 +120,6 @@ func NewClientApp(settings *settings.ArgoCDSettings, dexServerAddr string, dexTL
 		useAzureWorkloadIdentity: settings.UseAzureWorkloadIdentity(),
 		redirectURI:              redirectURL,
 		issuerURL:                settings.IssuerURL(),
-		userInfoPath:             settings.UserInfoPath(),
 		baseHRef:                 baseHRef,
 		encryptionKey:            encryptionKey,
 		clientCache:              cacheClient,

--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -567,8 +567,6 @@ type SettingsManager struct {
 	// mutex protects concurrency sensitive parts of settings manager: access to subscribers list and initialization flag
 	mutex                 *sync.Mutex
 	initContextCancel     func()
-	reposCache            []Repository
-	repoCredsCache        []RepositoryCredentials
 	reposOrClusterChanged func()
 }
 
@@ -1276,9 +1274,6 @@ func (mgr *SettingsManager) GetSettings() (*ArgoCDSettings, error) {
 func (mgr *SettingsManager) invalidateCache() {
 	mgr.mutex.Lock()
 	defer mgr.mutex.Unlock()
-
-	mgr.reposCache = nil
-	mgr.repoCredsCache = nil
 }
 
 func (mgr *SettingsManager) initialize(ctx context.Context) error {

--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -712,8 +712,6 @@ func (mgr *SettingsManager) updateConfigMap(callback func(*corev1.ConfigMap) err
 		return err
 	}
 
-	mgr.invalidateCache()
-
 	return mgr.ResyncInformers()
 }
 
@@ -1270,12 +1268,6 @@ func (mgr *SettingsManager) GetSettings() (*ArgoCDSettings, error) {
 	return &settings, nil
 }
 
-// Clears cached settings on configmap/secret change
-func (mgr *SettingsManager) invalidateCache() {
-	mgr.mutex.Lock()
-	defer mgr.mutex.Unlock()
-}
-
 func (mgr *SettingsManager) initialize(ctx context.Context) error {
 	tweakConfigMap := func(options *metav1.ListOptions) {
 		cmLabelSelector := fields.ParseSelectorOrDie(partOfArgoCDSelector)
@@ -1284,7 +1276,6 @@ func (mgr *SettingsManager) initialize(ctx context.Context) error {
 
 	eventHandler := cache.ResourceEventHandlerFuncs{
 		UpdateFunc: func(_, _ any) {
-			mgr.invalidateCache()
 			mgr.onRepoOrClusterChanged()
 		},
 		AddFunc: func(_ any) {

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -115,7 +115,7 @@ func newMockHandler(reactor *reactorDef, applicationNamespaces []string, maxPayl
 		1*time.Minute,
 		1*time.Minute,
 		10*time.Second,
-	), servercache.NewCache(appstate.NewCache(cacheClient, time.Minute), time.Minute, time.Minute, time.Minute), argoDB, maxPayloadSize)
+	), servercache.NewCache(appstate.NewCache(cacheClient, time.Minute), time.Minute, time.Minute), argoDB, maxPayloadSize)
 }
 
 func TestGitHubCommitEvent(t *testing.T) {


### PR DESCRIPTION
This lint rule seems mostly very good. It found a bunch of unnecessary code.

The only false positives were two structs that have fields that are being used to make unique map keys.