### PR TITLE
fix(server): race condition in revoked token logic (#23311)

### DIFF
--- a/util/session/state.go
+++ b/util/session/state.go
@@ -38,6 +38,8 @@ func NewUserStateStorage(redis *redis.Client) *userStateStorage {
 	}
 }
 
+// Init sets up watches on the revoked tokens and starts a ticker to periodically resync the revoked tokens from Redis.
+// Don't call this until after setting up all hooks on the Redis client, or you might encounter race conditions.
 func (storage *userStateStorage) Init(ctx context.Context) {
 	go storage.watchRevokedTokens(ctx)
 	ticker := time.NewTicker(storage.resyncDuration)


### PR DESCRIPTION
Fixes #23311

Reproduced this by adding a 100x loop to TestGracefulShutdown, but I reverted that to avoid slow tests.

I considered expanding the lock in `loadRevokedTokens` to include the Redis Scan call. But that would be a significant performance downside for something that's easily solved by just doing things in the correct order.