### PR TITLE
fix(sync): auto-sync loop when FailOnSharedResource

### DIFF
--- a/controller/sync_test.go
+++ b/controller/sync_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/argoproj/gitops-engine/pkg/sync"
 	"github.com/argoproj/gitops-engine/pkg/sync/common"
-	synccommon "github.com/argoproj/gitops-engine/pkg/sync/common"
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	argocommon "github.com/argoproj/argo-cd/v2/common"
 	"github.com/argoproj/argo-cd/v2/controller/testdata"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/reposerver/apiclient"
@@ -256,7 +256,7 @@ func TestAppStateManager_SyncAppState(t *testing.T) {
 				Name:      "configmap1",
 				Namespace: "default",
 				Annotations: map[string]string{
-					common.AnnotationKeyAppInstance: "guestbook:/ConfigMap:default/configmap1",
+					argocommon.AnnotationKeyAppInstance: "guestbook:/ConfigMap:default/configmap1",
 				},
 			},
 		})
@@ -273,10 +273,10 @@ func TestAppStateManager_SyncAppState(t *testing.T) {
 		}}
 
 		// when
-		f.controller.appStateManager.SyncAppState(f.application, f.project, opState)
+		f.controller.appStateManager.SyncAppState(f.application, opState)
 
 		// then
-		assert.Equal(t, synccommon.OperationFailed, opState.Phase)
+		assert.Equal(t, common.OperationFailed, opState.Phase)
 		assert.Contains(t, opState.Message, "ConfigMap/configmap1 is part of applications fake-argocd-ns/my-app and guestbook")
 	})
 }

--- a/controller/sync_test.go
+++ b/controller/sync_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -210,7 +209,7 @@ func TestAppStateManager_SyncAppState(t *testing.T) {
 		}
 
 		project := &v1alpha1.AppProject{
-			ObjectMeta: metav1.ObjectMeta{
+			ObjectMeta: v1.ObjectMeta{
 				Namespace: test.FakeArgoCDNamespace,
 				Name:      "default",
 			},
@@ -248,11 +247,11 @@ func TestAppStateManager_SyncAppState(t *testing.T) {
 		t.Parallel()
 
 		sharedObject := kube.MustToUnstructured(&corev1.ConfigMap{
-			TypeMeta: metav1.TypeMeta{
+			TypeMeta: v1.TypeMeta{
 				APIVersion: "v1",
 				Kind:       "ConfigMap",
 			},
-			ObjectMeta: metav1.ObjectMeta{
+			ObjectMeta: v1.ObjectMeta{
 				Name:      "configmap1",
 				Namespace: "default",
 				Annotations: map[string]string{

--- a/controller/sync_test.go
+++ b/controller/sync_test.go
@@ -254,8 +254,8 @@ func TestAppStateManager_SyncAppState(t *testing.T) {
 			ObjectMeta: v1.ObjectMeta{
 				Name:      "configmap1",
 				Namespace: "default",
-				Annotations: map[string]string{
-					argocommon.AnnotationKeyAppInstance: "guestbook:/ConfigMap:default/configmap1",
+				Labels: map[string]string{
+					argocommon.LabelKeyAppInstance: "another-app",
 				},
 			},
 		})
@@ -276,7 +276,7 @@ func TestAppStateManager_SyncAppState(t *testing.T) {
 
 		// then
 		assert.Equal(t, common.OperationFailed, opState.Phase)
-		assert.Contains(t, opState.Message, "ConfigMap/configmap1 is part of applications fake-argocd-ns/my-app and guestbook")
+		assert.Contains(t, opState.Message, "ConfigMap/configmap1 is part of applications fake-argocd-ns/my-app and another-app")
 	})
 }
 


### PR DESCRIPTION
This PR fixes a loop when auto-sync is on and the application is configured to `FailOnSharedResource`.

Auto-sync will try to compare the revisions in the sync results. However, the syncResult is not initialized on errors returned this early in SyncAppState.

In general, the errors happening early are validation also performed before auto-sync runs, but not in this case.


The real fix to prevent this from happening is https://github.com/argoproj/argo-cd/pull/23356