### PR TITLE
fix(repo-server): sort images

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -72,7 +72,6 @@ linters:
         - rangeValCopy
         - regexpSimplify
         - sloppyReassign
-        - sortSlice
         - sprintfQuotedString
         - tooManyResultsChecker
         - typeAssertChain

--- a/controller/cache/info_test.go
+++ b/controller/cache/info_test.go
@@ -981,7 +981,7 @@ func TestGetIngressInfo(t *testing.T) {
 		populateNodeInfo(tc.Ingress, info, []string{})
 		assert.Empty(t, info.Info)
 		sort.Slice(info.NetworkingInfo.TargetRefs, func(i, j int) bool {
-			return info.NetworkingInfo.TargetRefs[j].Name < info.NetworkingInfo.TargetRefs[i].Name
+			return info.NetworkingInfo.TargetRefs[i].Name < info.NetworkingInfo.TargetRefs[j].Name
 		})
 		assert.Equal(t, &v1alpha1.ResourceNetworkingInfo{
 			Ingress: []corev1.LoadBalancerIngress{{IP: "107.178.210.11"}},
@@ -989,12 +989,12 @@ func TestGetIngressInfo(t *testing.T) {
 				Namespace: "default",
 				Group:     "",
 				Kind:      kube.ServiceKind,
-				Name:      "not-found-service",
+				Name:      "helm-guestbook",
 			}, {
 				Namespace: "default",
 				Group:     "",
 				Kind:      kube.ServiceKind,
-				Name:      "helm-guestbook",
+				Name:      "not-found-service",
 			}},
 			ExternalURLs: []string{"https://helm-guestbook.example.com/"},
 		}, info.NetworkingInfo)
@@ -1006,7 +1006,7 @@ func TestGetLinkAnnotatedIngressInfo(t *testing.T) {
 	populateNodeInfo(testLinkAnnotatedIngress, info, []string{})
 	assert.Empty(t, info.Info)
 	sort.Slice(info.NetworkingInfo.TargetRefs, func(i, j int) bool {
-		return info.NetworkingInfo.TargetRefs[j].Name < info.NetworkingInfo.TargetRefs[i].Name
+		return info.NetworkingInfo.TargetRefs[i].Name < info.NetworkingInfo.TargetRefs[j].Name
 	})
 	assert.Equal(t, &v1alpha1.ResourceNetworkingInfo{
 		Ingress: []corev1.LoadBalancerIngress{{IP: "107.178.210.11"}},
@@ -1014,12 +1014,12 @@ func TestGetLinkAnnotatedIngressInfo(t *testing.T) {
 			Namespace: "default",
 			Group:     "",
 			Kind:      kube.ServiceKind,
-			Name:      "not-found-service",
+			Name:      "helm-guestbook",
 		}, {
 			Namespace: "default",
 			Group:     "",
 			Kind:      kube.ServiceKind,
-			Name:      "helm-guestbook",
+			Name:      "not-found-service",
 		}},
 		ExternalURLs: []string{"http://my-grafana.example.com/ingress-link", "https://helm-guestbook.example.com/"},
 	}, info.NetworkingInfo)
@@ -1030,7 +1030,7 @@ func TestGetIngressInfoWildCardPath(t *testing.T) {
 	populateNodeInfo(testIngressWildCardPath, info, []string{})
 	assert.Empty(t, info.Info)
 	sort.Slice(info.NetworkingInfo.TargetRefs, func(i, j int) bool {
-		return info.NetworkingInfo.TargetRefs[j].Name < info.NetworkingInfo.TargetRefs[i].Name
+		return info.NetworkingInfo.TargetRefs[i].Name < info.NetworkingInfo.TargetRefs[j].Name
 	})
 	assert.Equal(t, &v1alpha1.ResourceNetworkingInfo{
 		Ingress: []corev1.LoadBalancerIngress{{IP: "107.178.210.11"}},
@@ -1038,12 +1038,12 @@ func TestGetIngressInfoWildCardPath(t *testing.T) {
 			Namespace: "default",
 			Group:     "",
 			Kind:      kube.ServiceKind,
-			Name:      "not-found-service",
+			Name:      "helm-guestbook",
 		}, {
 			Namespace: "default",
 			Group:     "",
 			Kind:      kube.ServiceKind,
-			Name:      "helm-guestbook",
+			Name:      "not-found-service",
 		}},
 		ExternalURLs: []string{"https://helm-guestbook.example.com/"},
 	}, info.NetworkingInfo)
@@ -1054,7 +1054,7 @@ func TestGetIngressInfoWithoutTls(t *testing.T) {
 	populateNodeInfo(testIngressWithoutTLS, info, []string{})
 	assert.Empty(t, info.Info)
 	sort.Slice(info.NetworkingInfo.TargetRefs, func(i, j int) bool {
-		return info.NetworkingInfo.TargetRefs[j].Name < info.NetworkingInfo.TargetRefs[i].Name
+		return info.NetworkingInfo.TargetRefs[i].Name < info.NetworkingInfo.TargetRefs[j].Name
 	})
 	assert.Equal(t, &v1alpha1.ResourceNetworkingInfo{
 		Ingress: []corev1.LoadBalancerIngress{{IP: "107.178.210.11"}},
@@ -1062,12 +1062,12 @@ func TestGetIngressInfoWithoutTls(t *testing.T) {
 			Namespace: "default",
 			Group:     "",
 			Kind:      kube.ServiceKind,
-			Name:      "not-found-service",
+			Name:      "helm-guestbook",
 		}, {
 			Namespace: "default",
 			Group:     "",
 			Kind:      kube.ServiceKind,
-			Name:      "helm-guestbook",
+			Name:      "not-found-service",
 		}},
 		ExternalURLs: []string{"http://helm-guestbook.example.com/"},
 	}, info.NetworkingInfo)

--- a/util/kustomize/kustomize.go
+++ b/util/kustomize/kustomize.go
@@ -499,9 +499,7 @@ func getImageParameters(objs []*unstructured.Unstructured) []Image {
 	for _, obj := range objs {
 		images = append(images, getImages(obj.Object)...)
 	}
-	sort.Slice(images, func(i, j int) bool {
-		return i < j
-	})
+	sort.Strings(images)
 	return images
 }
 

--- a/util/kustomize/kustomize_test.go
+++ b/util/kustomize/kustomize_test.go
@@ -588,3 +588,44 @@ func TestFailKustomizeBuildPatches(t *testing.T) {
 	_, _, _, err = kustomize.Build(&kustomizeSource, nil, nil, nil)
 	require.EqualError(t, err, "kustomization file not found in the path")
 }
+
+func Test_getImageParameters_sorted(t *testing.T) {
+	apps := []*unstructured.Unstructured{
+		{
+			Object: map[string]any{
+				"kind": "Deployment",
+				"spec": map[string]any{
+					"template": map[string]any{
+						"spec": map[string]any{
+							"containers": []any{
+								map[string]any{
+									"name":  "nginx",
+									"image": "nginx:1.15.6",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Object: map[string]any{
+				"kind": "Deployment",
+				"spec": map[string]any{
+					"template": map[string]any{
+						"spec": map[string]any{
+							"containers": []any{
+								map[string]any{
+									"name":  "nginx",
+									"image": "nginx:1.15.5",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	params := getImageParameters(apps)
+	assert.Equal(t, []string{"nginx:1.15.5", "nginx:1.15.6"}, params)
+}


### PR DESCRIPTION
Enabling the `sortSlice` linter revealed a bug in the Kustomize utility: a list of images, which was meant to be sorted, isn't actually sorted.

I fixed that and added a unit test.

The linter also reported that the order of some sorts in tests was unintuitive, so I just flipped the sort order. Those changes only affect tests, not user-facing code.