### PR TITLE
fix(test): race condition in kubectl metrics (#23382)

### DIFF
--- a/applicationset/metrics/metrics.go
+++ b/applicationset/metrics/metrics.go
@@ -58,8 +58,7 @@ func NewApplicationsetMetrics(appsetLister applisters.ApplicationSetLister, apps
 	metrics.Registry.MustRegister(reconcileHistogram)
 	metrics.Registry.MustRegister(appsetCollector)
 
-	kubectlMetricsServer := kubectl.NewKubectlMetrics()
-	kubectlMetricsServer.RegisterWithClientGo()
+	kubectl.RegisterWithClientGo()
 	kubectl.RegisterWithPrometheus(metrics.Registry)
 
 	return ApplicationsetMetrics{

--- a/controller/metrics/metrics.go
+++ b/controller/metrics/metrics.go
@@ -199,8 +199,7 @@ func NewMetricsServer(addr string, appLister applister.ApplicationLister, appFil
 	registry.MustRegister(resourceEventsProcessingHistogram)
 	registry.MustRegister(resourceEventsNumberGauge)
 
-	kubectlMetricsServer := kubectl.NewKubectlMetrics()
-	kubectlMetricsServer.RegisterWithClientGo()
+	kubectl.RegisterWithClientGo()
 	kubectl.RegisterWithPrometheus(registry)
 
 	metricsServer := &MetricsServer{

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -80,8 +80,7 @@ func NewMetricsServer(host string, port int) *MetricsServer {
 	registry.MustRegister(extensionRequestDuration)
 	registry.MustRegister(argoVersion)
 
-	kubectlMetricsServer := kubectl.NewKubectlMetrics()
-	kubectlMetricsServer.RegisterWithClientGo()
+	kubectl.RegisterWithClientGo()
 	kubectl.RegisterWithPrometheus(registry)
 
 	return &MetricsServer{

--- a/util/metrics/kubectl/kubectl_metrics_test.go
+++ b/util/metrics/kubectl/kubectl_metrics_test.go
@@ -1,0 +1,11 @@
+package kubectl
+
+import (
+	"testing"
+)
+
+func Test_RegisterWithClientGo_race(_ *testing.T) {
+	// This test ensures that the RegisterWithClientGo function can be called concurrently without causing a data race.
+	go RegisterWithClientGo()
+	go RegisterWithClientGo()
+}


### PR DESCRIPTION
My initial implementation was overly complicated, because I thought I needed a `initiator` field on the metrics struct.

Instead, I can just deal directly with global variables.

This test refactors for simplicity and protects the global var initialization with a sync.Once.

Closes #23382