### PR TITLE
chore: upgrade mockery

### DIFF
--- a/applicationset/generators/mocks/Generator.go
+++ b/applicationset/generators/mocks/Generator.go
@@ -73,16 +73,32 @@ type Generator_GenerateParams_Call struct {
 }
 
 // GenerateParams is a helper method to define mock.On call
-//   - appSetGenerator
-//   - applicationSetInfo
-//   - client1
+//   - appSetGenerator *v1alpha1.ApplicationSetGenerator
+//   - applicationSetInfo *v1alpha1.ApplicationSet
+//   - client1 client.Client
 func (_e *Generator_Expecter) GenerateParams(appSetGenerator interface{}, applicationSetInfo interface{}, client1 interface{}) *Generator_GenerateParams_Call {
 	return &Generator_GenerateParams_Call{Call: _e.mock.On("GenerateParams", appSetGenerator, applicationSetInfo, client1)}
 }
 
 func (_c *Generator_GenerateParams_Call) Run(run func(appSetGenerator *v1alpha1.ApplicationSetGenerator, applicationSetInfo *v1alpha1.ApplicationSet, client1 client.Client)) *Generator_GenerateParams_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*v1alpha1.ApplicationSetGenerator), args[1].(*v1alpha1.ApplicationSet), args[2].(client.Client))
+		var arg0 *v1alpha1.ApplicationSetGenerator
+		if args[0] != nil {
+			arg0 = args[0].(*v1alpha1.ApplicationSetGenerator)
+		}
+		var arg1 *v1alpha1.ApplicationSet
+		if args[1] != nil {
+			arg1 = args[1].(*v1alpha1.ApplicationSet)
+		}
+		var arg2 client.Client
+		if args[2] != nil {
+			arg2 = args[2].(client.Client)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
 	})
 	return _c
 }
@@ -120,14 +136,20 @@ type Generator_GetRequeueAfter_Call struct {
 }
 
 // GetRequeueAfter is a helper method to define mock.On call
-//   - appSetGenerator
+//   - appSetGenerator *v1alpha1.ApplicationSetGenerator
 func (_e *Generator_Expecter) GetRequeueAfter(appSetGenerator interface{}) *Generator_GetRequeueAfter_Call {
 	return &Generator_GetRequeueAfter_Call{Call: _e.mock.On("GetRequeueAfter", appSetGenerator)}
 }
 
 func (_c *Generator_GetRequeueAfter_Call) Run(run func(appSetGenerator *v1alpha1.ApplicationSetGenerator)) *Generator_GetRequeueAfter_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*v1alpha1.ApplicationSetGenerator))
+		var arg0 *v1alpha1.ApplicationSetGenerator
+		if args[0] != nil {
+			arg0 = args[0].(*v1alpha1.ApplicationSetGenerator)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -167,14 +189,20 @@ type Generator_GetTemplate_Call struct {
 }
 
 // GetTemplate is a helper method to define mock.On call
-//   - appSetGenerator
+//   - appSetGenerator *v1alpha1.ApplicationSetGenerator
 func (_e *Generator_Expecter) GetTemplate(appSetGenerator interface{}) *Generator_GetTemplate_Call {
 	return &Generator_GetTemplate_Call{Call: _e.mock.On("GetTemplate", appSetGenerator)}
 }
 
 func (_c *Generator_GetTemplate_Call) Run(run func(appSetGenerator *v1alpha1.ApplicationSetGenerator)) *Generator_GetTemplate_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*v1alpha1.ApplicationSetGenerator))
+		var arg0 *v1alpha1.ApplicationSetGenerator
+		if args[0] != nil {
+			arg0 = args[0].(*v1alpha1.ApplicationSetGenerator)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }

--- a/applicationset/services/mocks/Repos.go
+++ b/applicationset/services/mocks/Repos.go
@@ -71,19 +71,50 @@ type Repos_GetDirectories_Call struct {
 }
 
 // GetDirectories is a helper method to define mock.On call
-//   - ctx
-//   - repoURL
-//   - revision
-//   - project
-//   - noRevisionCache
-//   - verifyCommit
+//   - ctx context.Context
+//   - repoURL string
+//   - revision string
+//   - project string
+//   - noRevisionCache bool
+//   - verifyCommit bool
 func (_e *Repos_Expecter) GetDirectories(ctx interface{}, repoURL interface{}, revision interface{}, project interface{}, noRevisionCache interface{}, verifyCommit interface{}) *Repos_GetDirectories_Call {
 	return &Repos_GetDirectories_Call{Call: _e.mock.On("GetDirectories", ctx, repoURL, revision, project, noRevisionCache, verifyCommit)}
 }
 
 func (_c *Repos_GetDirectories_Call) Run(run func(ctx context.Context, repoURL string, revision string, project string, noRevisionCache bool, verifyCommit bool)) *Repos_GetDirectories_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].(bool), args[5].(bool))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
+		var arg4 bool
+		if args[4] != nil {
+			arg4 = args[4].(bool)
+		}
+		var arg5 bool
+		if args[5] != nil {
+			arg5 = args[5].(bool)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+			arg5,
+		)
 	})
 	return _c
 }
@@ -132,20 +163,56 @@ type Repos_GetFiles_Call struct {
 }
 
 // GetFiles is a helper method to define mock.On call
-//   - ctx
-//   - repoURL
-//   - revision
-//   - project
-//   - pattern
-//   - noRevisionCache
-//   - verifyCommit
+//   - ctx context.Context
+//   - repoURL string
+//   - revision string
+//   - project string
+//   - pattern string
+//   - noRevisionCache bool
+//   - verifyCommit bool
 func (_e *Repos_Expecter) GetFiles(ctx interface{}, repoURL interface{}, revision interface{}, project interface{}, pattern interface{}, noRevisionCache interface{}, verifyCommit interface{}) *Repos_GetFiles_Call {
 	return &Repos_GetFiles_Call{Call: _e.mock.On("GetFiles", ctx, repoURL, revision, project, pattern, noRevisionCache, verifyCommit)}
 }
 
 func (_c *Repos_GetFiles_Call) Run(run func(ctx context.Context, repoURL string, revision string, project string, pattern string, noRevisionCache bool, verifyCommit bool)) *Repos_GetFiles_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].(string), args[5].(bool), args[6].(bool))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
+		var arg4 string
+		if args[4] != nil {
+			arg4 = args[4].(string)
+		}
+		var arg5 bool
+		if args[5] != nil {
+			arg5 = args[5].(bool)
+		}
+		var arg6 bool
+		if args[6] != nil {
+			arg6 = args[6].(bool)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+			arg5,
+			arg6,
+		)
 	})
 	return _c
 }

--- a/applicationset/services/scm_provider/aws_codecommit/mocks/AWSCodeCommitClient.go
+++ b/applicationset/services/scm_provider/aws_codecommit/mocks/AWSCodeCommitClient.go
@@ -80,9 +80,9 @@ type AWSCodeCommitClient_GetFolderWithContext_Call struct {
 }
 
 // GetFolderWithContext is a helper method to define mock.On call
-//   - v
-//   - getFolderInput
-//   - options
+//   - v aws.Context
+//   - getFolderInput *codecommit.GetFolderInput
+//   - options ...request.Option
 func (_e *AWSCodeCommitClient_Expecter) GetFolderWithContext(v interface{}, getFolderInput interface{}, options ...interface{}) *AWSCodeCommitClient_GetFolderWithContext_Call {
 	return &AWSCodeCommitClient_GetFolderWithContext_Call{Call: _e.mock.On("GetFolderWithContext",
 		append([]interface{}{v, getFolderInput}, options...)...)}
@@ -90,13 +90,27 @@ func (_e *AWSCodeCommitClient_Expecter) GetFolderWithContext(v interface{}, getF
 
 func (_c *AWSCodeCommitClient_GetFolderWithContext_Call) Run(run func(v aws.Context, getFolderInput *codecommit.GetFolderInput, options ...request.Option)) *AWSCodeCommitClient_GetFolderWithContext_Call {
 	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 aws.Context
+		if args[0] != nil {
+			arg0 = args[0].(aws.Context)
+		}
+		var arg1 *codecommit.GetFolderInput
+		if args[1] != nil {
+			arg1 = args[1].(*codecommit.GetFolderInput)
+		}
+		var arg2 []request.Option
 		variadicArgs := make([]request.Option, len(args)-2)
 		for i, a := range args[2:] {
 			if a != nil {
 				variadicArgs[i] = a.(request.Option)
 			}
 		}
-		run(args[0].(aws.Context), args[1].(*codecommit.GetFolderInput), variadicArgs...)
+		arg2 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2...,
+		)
 	})
 	return _c
 }
@@ -153,9 +167,9 @@ type AWSCodeCommitClient_GetRepositoryWithContext_Call struct {
 }
 
 // GetRepositoryWithContext is a helper method to define mock.On call
-//   - v
-//   - getRepositoryInput
-//   - options
+//   - v aws.Context
+//   - getRepositoryInput *codecommit.GetRepositoryInput
+//   - options ...request.Option
 func (_e *AWSCodeCommitClient_Expecter) GetRepositoryWithContext(v interface{}, getRepositoryInput interface{}, options ...interface{}) *AWSCodeCommitClient_GetRepositoryWithContext_Call {
 	return &AWSCodeCommitClient_GetRepositoryWithContext_Call{Call: _e.mock.On("GetRepositoryWithContext",
 		append([]interface{}{v, getRepositoryInput}, options...)...)}
@@ -163,13 +177,27 @@ func (_e *AWSCodeCommitClient_Expecter) GetRepositoryWithContext(v interface{}, 
 
 func (_c *AWSCodeCommitClient_GetRepositoryWithContext_Call) Run(run func(v aws.Context, getRepositoryInput *codecommit.GetRepositoryInput, options ...request.Option)) *AWSCodeCommitClient_GetRepositoryWithContext_Call {
 	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 aws.Context
+		if args[0] != nil {
+			arg0 = args[0].(aws.Context)
+		}
+		var arg1 *codecommit.GetRepositoryInput
+		if args[1] != nil {
+			arg1 = args[1].(*codecommit.GetRepositoryInput)
+		}
+		var arg2 []request.Option
 		variadicArgs := make([]request.Option, len(args)-2)
 		for i, a := range args[2:] {
 			if a != nil {
 				variadicArgs[i] = a.(request.Option)
 			}
 		}
-		run(args[0].(aws.Context), args[1].(*codecommit.GetRepositoryInput), variadicArgs...)
+		arg2 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2...,
+		)
 	})
 	return _c
 }
@@ -226,9 +254,9 @@ type AWSCodeCommitClient_ListBranchesWithContext_Call struct {
 }
 
 // ListBranchesWithContext is a helper method to define mock.On call
-//   - v
-//   - listBranchesInput
-//   - options
+//   - v aws.Context
+//   - listBranchesInput *codecommit.ListBranchesInput
+//   - options ...request.Option
 func (_e *AWSCodeCommitClient_Expecter) ListBranchesWithContext(v interface{}, listBranchesInput interface{}, options ...interface{}) *AWSCodeCommitClient_ListBranchesWithContext_Call {
 	return &AWSCodeCommitClient_ListBranchesWithContext_Call{Call: _e.mock.On("ListBranchesWithContext",
 		append([]interface{}{v, listBranchesInput}, options...)...)}
@@ -236,13 +264,27 @@ func (_e *AWSCodeCommitClient_Expecter) ListBranchesWithContext(v interface{}, l
 
 func (_c *AWSCodeCommitClient_ListBranchesWithContext_Call) Run(run func(v aws.Context, listBranchesInput *codecommit.ListBranchesInput, options ...request.Option)) *AWSCodeCommitClient_ListBranchesWithContext_Call {
 	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 aws.Context
+		if args[0] != nil {
+			arg0 = args[0].(aws.Context)
+		}
+		var arg1 *codecommit.ListBranchesInput
+		if args[1] != nil {
+			arg1 = args[1].(*codecommit.ListBranchesInput)
+		}
+		var arg2 []request.Option
 		variadicArgs := make([]request.Option, len(args)-2)
 		for i, a := range args[2:] {
 			if a != nil {
 				variadicArgs[i] = a.(request.Option)
 			}
 		}
-		run(args[0].(aws.Context), args[1].(*codecommit.ListBranchesInput), variadicArgs...)
+		arg2 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2...,
+		)
 	})
 	return _c
 }
@@ -299,9 +341,9 @@ type AWSCodeCommitClient_ListRepositoriesWithContext_Call struct {
 }
 
 // ListRepositoriesWithContext is a helper method to define mock.On call
-//   - v
-//   - listRepositoriesInput
-//   - options
+//   - v aws.Context
+//   - listRepositoriesInput *codecommit.ListRepositoriesInput
+//   - options ...request.Option
 func (_e *AWSCodeCommitClient_Expecter) ListRepositoriesWithContext(v interface{}, listRepositoriesInput interface{}, options ...interface{}) *AWSCodeCommitClient_ListRepositoriesWithContext_Call {
 	return &AWSCodeCommitClient_ListRepositoriesWithContext_Call{Call: _e.mock.On("ListRepositoriesWithContext",
 		append([]interface{}{v, listRepositoriesInput}, options...)...)}
@@ -309,13 +351,27 @@ func (_e *AWSCodeCommitClient_Expecter) ListRepositoriesWithContext(v interface{
 
 func (_c *AWSCodeCommitClient_ListRepositoriesWithContext_Call) Run(run func(v aws.Context, listRepositoriesInput *codecommit.ListRepositoriesInput, options ...request.Option)) *AWSCodeCommitClient_ListRepositoriesWithContext_Call {
 	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 aws.Context
+		if args[0] != nil {
+			arg0 = args[0].(aws.Context)
+		}
+		var arg1 *codecommit.ListRepositoriesInput
+		if args[1] != nil {
+			arg1 = args[1].(*codecommit.ListRepositoriesInput)
+		}
+		var arg2 []request.Option
 		variadicArgs := make([]request.Option, len(args)-2)
 		for i, a := range args[2:] {
 			if a != nil {
 				variadicArgs[i] = a.(request.Option)
 			}
 		}
-		run(args[0].(aws.Context), args[1].(*codecommit.ListRepositoriesInput), variadicArgs...)
+		arg2 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2...,
+		)
 	})
 	return _c
 }

--- a/applicationset/services/scm_provider/aws_codecommit/mocks/AWSTaggingClient.go
+++ b/applicationset/services/scm_provider/aws_codecommit/mocks/AWSTaggingClient.go
@@ -80,9 +80,9 @@ type AWSTaggingClient_GetResourcesWithContext_Call struct {
 }
 
 // GetResourcesWithContext is a helper method to define mock.On call
-//   - v
-//   - getResourcesInput
-//   - options
+//   - v aws.Context
+//   - getResourcesInput *resourcegroupstaggingapi.GetResourcesInput
+//   - options ...request.Option
 func (_e *AWSTaggingClient_Expecter) GetResourcesWithContext(v interface{}, getResourcesInput interface{}, options ...interface{}) *AWSTaggingClient_GetResourcesWithContext_Call {
 	return &AWSTaggingClient_GetResourcesWithContext_Call{Call: _e.mock.On("GetResourcesWithContext",
 		append([]interface{}{v, getResourcesInput}, options...)...)}
@@ -90,13 +90,27 @@ func (_e *AWSTaggingClient_Expecter) GetResourcesWithContext(v interface{}, getR
 
 func (_c *AWSTaggingClient_GetResourcesWithContext_Call) Run(run func(v aws.Context, getResourcesInput *resourcegroupstaggingapi.GetResourcesInput, options ...request.Option)) *AWSTaggingClient_GetResourcesWithContext_Call {
 	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 aws.Context
+		if args[0] != nil {
+			arg0 = args[0].(aws.Context)
+		}
+		var arg1 *resourcegroupstaggingapi.GetResourcesInput
+		if args[1] != nil {
+			arg1 = args[1].(*resourcegroupstaggingapi.GetResourcesInput)
+		}
+		var arg2 []request.Option
 		variadicArgs := make([]request.Option, len(args)-2)
 		for i, a := range args[2:] {
 			if a != nil {
 				variadicArgs[i] = a.(request.Option)
 			}
 		}
-		run(args[0].(aws.Context), args[1].(*resourcegroupstaggingapi.GetResourcesInput), variadicArgs...)
+		arg2 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2...,
+		)
 	})
 	return _c
 }

--- a/applicationset/services/scm_provider/azure_devops/git/mocks/Client.go
+++ b/applicationset/services/scm_provider/azure_devops/git/mocks/Client.go
@@ -75,15 +75,26 @@ type Client_CreateAnnotatedTag_Call struct {
 }
 
 // CreateAnnotatedTag is a helper method to define mock.On call
-//   - context1
-//   - createAnnotatedTagArgs
+//   - context1 context.Context
+//   - createAnnotatedTagArgs git.CreateAnnotatedTagArgs
 func (_e *Client_Expecter) CreateAnnotatedTag(context1 interface{}, createAnnotatedTagArgs interface{}) *Client_CreateAnnotatedTag_Call {
 	return &Client_CreateAnnotatedTag_Call{Call: _e.mock.On("CreateAnnotatedTag", context1, createAnnotatedTagArgs)}
 }
 
 func (_c *Client_CreateAnnotatedTag_Call) Run(run func(context1 context.Context, createAnnotatedTagArgs git.CreateAnnotatedTagArgs)) *Client_CreateAnnotatedTag_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.CreateAnnotatedTagArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.CreateAnnotatedTagArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.CreateAnnotatedTagArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -132,15 +143,26 @@ type Client_CreateAttachment_Call struct {
 }
 
 // CreateAttachment is a helper method to define mock.On call
-//   - context1
-//   - createAttachmentArgs
+//   - context1 context.Context
+//   - createAttachmentArgs git.CreateAttachmentArgs
 func (_e *Client_Expecter) CreateAttachment(context1 interface{}, createAttachmentArgs interface{}) *Client_CreateAttachment_Call {
 	return &Client_CreateAttachment_Call{Call: _e.mock.On("CreateAttachment", context1, createAttachmentArgs)}
 }
 
 func (_c *Client_CreateAttachment_Call) Run(run func(context1 context.Context, createAttachmentArgs git.CreateAttachmentArgs)) *Client_CreateAttachment_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.CreateAttachmentArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.CreateAttachmentArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.CreateAttachmentArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -189,15 +211,26 @@ type Client_CreateCherryPick_Call struct {
 }
 
 // CreateCherryPick is a helper method to define mock.On call
-//   - context1
-//   - createCherryPickArgs
+//   - context1 context.Context
+//   - createCherryPickArgs git.CreateCherryPickArgs
 func (_e *Client_Expecter) CreateCherryPick(context1 interface{}, createCherryPickArgs interface{}) *Client_CreateCherryPick_Call {
 	return &Client_CreateCherryPick_Call{Call: _e.mock.On("CreateCherryPick", context1, createCherryPickArgs)}
 }
 
 func (_c *Client_CreateCherryPick_Call) Run(run func(context1 context.Context, createCherryPickArgs git.CreateCherryPickArgs)) *Client_CreateCherryPick_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.CreateCherryPickArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.CreateCherryPickArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.CreateCherryPickArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -246,15 +279,26 @@ type Client_CreateComment_Call struct {
 }
 
 // CreateComment is a helper method to define mock.On call
-//   - context1
-//   - createCommentArgs
+//   - context1 context.Context
+//   - createCommentArgs git.CreateCommentArgs
 func (_e *Client_Expecter) CreateComment(context1 interface{}, createCommentArgs interface{}) *Client_CreateComment_Call {
 	return &Client_CreateComment_Call{Call: _e.mock.On("CreateComment", context1, createCommentArgs)}
 }
 
 func (_c *Client_CreateComment_Call) Run(run func(context1 context.Context, createCommentArgs git.CreateCommentArgs)) *Client_CreateComment_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.CreateCommentArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.CreateCommentArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.CreateCommentArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -303,15 +347,26 @@ type Client_CreateCommitStatus_Call struct {
 }
 
 // CreateCommitStatus is a helper method to define mock.On call
-//   - context1
-//   - createCommitStatusArgs
+//   - context1 context.Context
+//   - createCommitStatusArgs git.CreateCommitStatusArgs
 func (_e *Client_Expecter) CreateCommitStatus(context1 interface{}, createCommitStatusArgs interface{}) *Client_CreateCommitStatus_Call {
 	return &Client_CreateCommitStatus_Call{Call: _e.mock.On("CreateCommitStatus", context1, createCommitStatusArgs)}
 }
 
 func (_c *Client_CreateCommitStatus_Call) Run(run func(context1 context.Context, createCommitStatusArgs git.CreateCommitStatusArgs)) *Client_CreateCommitStatus_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.CreateCommitStatusArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.CreateCommitStatusArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.CreateCommitStatusArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -360,15 +415,26 @@ type Client_CreateFavorite_Call struct {
 }
 
 // CreateFavorite is a helper method to define mock.On call
-//   - context1
-//   - createFavoriteArgs
+//   - context1 context.Context
+//   - createFavoriteArgs git.CreateFavoriteArgs
 func (_e *Client_Expecter) CreateFavorite(context1 interface{}, createFavoriteArgs interface{}) *Client_CreateFavorite_Call {
 	return &Client_CreateFavorite_Call{Call: _e.mock.On("CreateFavorite", context1, createFavoriteArgs)}
 }
 
 func (_c *Client_CreateFavorite_Call) Run(run func(context1 context.Context, createFavoriteArgs git.CreateFavoriteArgs)) *Client_CreateFavorite_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.CreateFavoriteArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.CreateFavoriteArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.CreateFavoriteArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -417,15 +483,26 @@ type Client_CreateForkSyncRequest_Call struct {
 }
 
 // CreateForkSyncRequest is a helper method to define mock.On call
-//   - context1
-//   - createForkSyncRequestArgs
+//   - context1 context.Context
+//   - createForkSyncRequestArgs git.CreateForkSyncRequestArgs
 func (_e *Client_Expecter) CreateForkSyncRequest(context1 interface{}, createForkSyncRequestArgs interface{}) *Client_CreateForkSyncRequest_Call {
 	return &Client_CreateForkSyncRequest_Call{Call: _e.mock.On("CreateForkSyncRequest", context1, createForkSyncRequestArgs)}
 }
 
 func (_c *Client_CreateForkSyncRequest_Call) Run(run func(context1 context.Context, createForkSyncRequestArgs git.CreateForkSyncRequestArgs)) *Client_CreateForkSyncRequest_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.CreateForkSyncRequestArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.CreateForkSyncRequestArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.CreateForkSyncRequestArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -474,15 +551,26 @@ type Client_CreateImportRequest_Call struct {
 }
 
 // CreateImportRequest is a helper method to define mock.On call
-//   - context1
-//   - createImportRequestArgs
+//   - context1 context.Context
+//   - createImportRequestArgs git.CreateImportRequestArgs
 func (_e *Client_Expecter) CreateImportRequest(context1 interface{}, createImportRequestArgs interface{}) *Client_CreateImportRequest_Call {
 	return &Client_CreateImportRequest_Call{Call: _e.mock.On("CreateImportRequest", context1, createImportRequestArgs)}
 }
 
 func (_c *Client_CreateImportRequest_Call) Run(run func(context1 context.Context, createImportRequestArgs git.CreateImportRequestArgs)) *Client_CreateImportRequest_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.CreateImportRequestArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.CreateImportRequestArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.CreateImportRequestArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -520,15 +608,26 @@ type Client_CreateLike_Call struct {
 }
 
 // CreateLike is a helper method to define mock.On call
-//   - context1
-//   - createLikeArgs
+//   - context1 context.Context
+//   - createLikeArgs git.CreateLikeArgs
 func (_e *Client_Expecter) CreateLike(context1 interface{}, createLikeArgs interface{}) *Client_CreateLike_Call {
 	return &Client_CreateLike_Call{Call: _e.mock.On("CreateLike", context1, createLikeArgs)}
 }
 
 func (_c *Client_CreateLike_Call) Run(run func(context1 context.Context, createLikeArgs git.CreateLikeArgs)) *Client_CreateLike_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.CreateLikeArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.CreateLikeArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.CreateLikeArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -577,15 +676,26 @@ type Client_CreateMergeRequest_Call struct {
 }
 
 // CreateMergeRequest is a helper method to define mock.On call
-//   - context1
-//   - createMergeRequestArgs
+//   - context1 context.Context
+//   - createMergeRequestArgs git.CreateMergeRequestArgs
 func (_e *Client_Expecter) CreateMergeRequest(context1 interface{}, createMergeRequestArgs interface{}) *Client_CreateMergeRequest_Call {
 	return &Client_CreateMergeRequest_Call{Call: _e.mock.On("CreateMergeRequest", context1, createMergeRequestArgs)}
 }
 
 func (_c *Client_CreateMergeRequest_Call) Run(run func(context1 context.Context, createMergeRequestArgs git.CreateMergeRequestArgs)) *Client_CreateMergeRequest_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.CreateMergeRequestArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.CreateMergeRequestArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.CreateMergeRequestArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -634,15 +744,26 @@ type Client_CreatePullRequest_Call struct {
 }
 
 // CreatePullRequest is a helper method to define mock.On call
-//   - context1
-//   - createPullRequestArgs
+//   - context1 context.Context
+//   - createPullRequestArgs git.CreatePullRequestArgs
 func (_e *Client_Expecter) CreatePullRequest(context1 interface{}, createPullRequestArgs interface{}) *Client_CreatePullRequest_Call {
 	return &Client_CreatePullRequest_Call{Call: _e.mock.On("CreatePullRequest", context1, createPullRequestArgs)}
 }
 
 func (_c *Client_CreatePullRequest_Call) Run(run func(context1 context.Context, createPullRequestArgs git.CreatePullRequestArgs)) *Client_CreatePullRequest_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.CreatePullRequestArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.CreatePullRequestArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.CreatePullRequestArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -691,15 +812,26 @@ type Client_CreatePullRequestIterationStatus_Call struct {
 }
 
 // CreatePullRequestIterationStatus is a helper method to define mock.On call
-//   - context1
-//   - createPullRequestIterationStatusArgs
+//   - context1 context.Context
+//   - createPullRequestIterationStatusArgs git.CreatePullRequestIterationStatusArgs
 func (_e *Client_Expecter) CreatePullRequestIterationStatus(context1 interface{}, createPullRequestIterationStatusArgs interface{}) *Client_CreatePullRequestIterationStatus_Call {
 	return &Client_CreatePullRequestIterationStatus_Call{Call: _e.mock.On("CreatePullRequestIterationStatus", context1, createPullRequestIterationStatusArgs)}
 }
 
 func (_c *Client_CreatePullRequestIterationStatus_Call) Run(run func(context1 context.Context, createPullRequestIterationStatusArgs git.CreatePullRequestIterationStatusArgs)) *Client_CreatePullRequestIterationStatus_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.CreatePullRequestIterationStatusArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.CreatePullRequestIterationStatusArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.CreatePullRequestIterationStatusArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -748,15 +880,26 @@ type Client_CreatePullRequestLabel_Call struct {
 }
 
 // CreatePullRequestLabel is a helper method to define mock.On call
-//   - context1
-//   - createPullRequestLabelArgs
+//   - context1 context.Context
+//   - createPullRequestLabelArgs git.CreatePullRequestLabelArgs
 func (_e *Client_Expecter) CreatePullRequestLabel(context1 interface{}, createPullRequestLabelArgs interface{}) *Client_CreatePullRequestLabel_Call {
 	return &Client_CreatePullRequestLabel_Call{Call: _e.mock.On("CreatePullRequestLabel", context1, createPullRequestLabelArgs)}
 }
 
 func (_c *Client_CreatePullRequestLabel_Call) Run(run func(context1 context.Context, createPullRequestLabelArgs git.CreatePullRequestLabelArgs)) *Client_CreatePullRequestLabel_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.CreatePullRequestLabelArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.CreatePullRequestLabelArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.CreatePullRequestLabelArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -805,15 +948,26 @@ type Client_CreatePullRequestReviewer_Call struct {
 }
 
 // CreatePullRequestReviewer is a helper method to define mock.On call
-//   - context1
-//   - createPullRequestReviewerArgs
+//   - context1 context.Context
+//   - createPullRequestReviewerArgs git.CreatePullRequestReviewerArgs
 func (_e *Client_Expecter) CreatePullRequestReviewer(context1 interface{}, createPullRequestReviewerArgs interface{}) *Client_CreatePullRequestReviewer_Call {
 	return &Client_CreatePullRequestReviewer_Call{Call: _e.mock.On("CreatePullRequestReviewer", context1, createPullRequestReviewerArgs)}
 }
 
 func (_c *Client_CreatePullRequestReviewer_Call) Run(run func(context1 context.Context, createPullRequestReviewerArgs git.CreatePullRequestReviewerArgs)) *Client_CreatePullRequestReviewer_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.CreatePullRequestReviewerArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.CreatePullRequestReviewerArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.CreatePullRequestReviewerArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -862,15 +1016,26 @@ type Client_CreatePullRequestReviewers_Call struct {
 }
 
 // CreatePullRequestReviewers is a helper method to define mock.On call
-//   - context1
-//   - createPullRequestReviewersArgs
+//   - context1 context.Context
+//   - createPullRequestReviewersArgs git.CreatePullRequestReviewersArgs
 func (_e *Client_Expecter) CreatePullRequestReviewers(context1 interface{}, createPullRequestReviewersArgs interface{}) *Client_CreatePullRequestReviewers_Call {
 	return &Client_CreatePullRequestReviewers_Call{Call: _e.mock.On("CreatePullRequestReviewers", context1, createPullRequestReviewersArgs)}
 }
 
 func (_c *Client_CreatePullRequestReviewers_Call) Run(run func(context1 context.Context, createPullRequestReviewersArgs git.CreatePullRequestReviewersArgs)) *Client_CreatePullRequestReviewers_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.CreatePullRequestReviewersArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.CreatePullRequestReviewersArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.CreatePullRequestReviewersArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -919,15 +1084,26 @@ type Client_CreatePullRequestStatus_Call struct {
 }
 
 // CreatePullRequestStatus is a helper method to define mock.On call
-//   - context1
-//   - createPullRequestStatusArgs
+//   - context1 context.Context
+//   - createPullRequestStatusArgs git.CreatePullRequestStatusArgs
 func (_e *Client_Expecter) CreatePullRequestStatus(context1 interface{}, createPullRequestStatusArgs interface{}) *Client_CreatePullRequestStatus_Call {
 	return &Client_CreatePullRequestStatus_Call{Call: _e.mock.On("CreatePullRequestStatus", context1, createPullRequestStatusArgs)}
 }
 
 func (_c *Client_CreatePullRequestStatus_Call) Run(run func(context1 context.Context, createPullRequestStatusArgs git.CreatePullRequestStatusArgs)) *Client_CreatePullRequestStatus_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.CreatePullRequestStatusArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.CreatePullRequestStatusArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.CreatePullRequestStatusArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -976,15 +1152,26 @@ type Client_CreatePush_Call struct {
 }
 
 // CreatePush is a helper method to define mock.On call
-//   - context1
-//   - createPushArgs
+//   - context1 context.Context
+//   - createPushArgs git.CreatePushArgs
 func (_e *Client_Expecter) CreatePush(context1 interface{}, createPushArgs interface{}) *Client_CreatePush_Call {
 	return &Client_CreatePush_Call{Call: _e.mock.On("CreatePush", context1, createPushArgs)}
 }
 
 func (_c *Client_CreatePush_Call) Run(run func(context1 context.Context, createPushArgs git.CreatePushArgs)) *Client_CreatePush_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.CreatePushArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.CreatePushArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.CreatePushArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -1033,15 +1220,26 @@ type Client_CreateRepository_Call struct {
 }
 
 // CreateRepository is a helper method to define mock.On call
-//   - context1
-//   - createRepositoryArgs
+//   - context1 context.Context
+//   - createRepositoryArgs git.CreateRepositoryArgs
 func (_e *Client_Expecter) CreateRepository(context1 interface{}, createRepositoryArgs interface{}) *Client_CreateRepository_Call {
 	return &Client_CreateRepository_Call{Call: _e.mock.On("CreateRepository", context1, createRepositoryArgs)}
 }
 
 func (_c *Client_CreateRepository_Call) Run(run func(context1 context.Context, createRepositoryArgs git.CreateRepositoryArgs)) *Client_CreateRepository_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.CreateRepositoryArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.CreateRepositoryArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.CreateRepositoryArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -1090,15 +1288,26 @@ type Client_CreateRevert_Call struct {
 }
 
 // CreateRevert is a helper method to define mock.On call
-//   - context1
-//   - createRevertArgs
+//   - context1 context.Context
+//   - createRevertArgs git.CreateRevertArgs
 func (_e *Client_Expecter) CreateRevert(context1 interface{}, createRevertArgs interface{}) *Client_CreateRevert_Call {
 	return &Client_CreateRevert_Call{Call: _e.mock.On("CreateRevert", context1, createRevertArgs)}
 }
 
 func (_c *Client_CreateRevert_Call) Run(run func(context1 context.Context, createRevertArgs git.CreateRevertArgs)) *Client_CreateRevert_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.CreateRevertArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.CreateRevertArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.CreateRevertArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -1147,15 +1356,26 @@ type Client_CreateThread_Call struct {
 }
 
 // CreateThread is a helper method to define mock.On call
-//   - context1
-//   - createThreadArgs
+//   - context1 context.Context
+//   - createThreadArgs git.CreateThreadArgs
 func (_e *Client_Expecter) CreateThread(context1 interface{}, createThreadArgs interface{}) *Client_CreateThread_Call {
 	return &Client_CreateThread_Call{Call: _e.mock.On("CreateThread", context1, createThreadArgs)}
 }
 
 func (_c *Client_CreateThread_Call) Run(run func(context1 context.Context, createThreadArgs git.CreateThreadArgs)) *Client_CreateThread_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.CreateThreadArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.CreateThreadArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.CreateThreadArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -1204,15 +1424,26 @@ type Client_CreateUnmaterializedPullRequestReviewer_Call struct {
 }
 
 // CreateUnmaterializedPullRequestReviewer is a helper method to define mock.On call
-//   - context1
-//   - createUnmaterializedPullRequestReviewerArgs
+//   - context1 context.Context
+//   - createUnmaterializedPullRequestReviewerArgs git.CreateUnmaterializedPullRequestReviewerArgs
 func (_e *Client_Expecter) CreateUnmaterializedPullRequestReviewer(context1 interface{}, createUnmaterializedPullRequestReviewerArgs interface{}) *Client_CreateUnmaterializedPullRequestReviewer_Call {
 	return &Client_CreateUnmaterializedPullRequestReviewer_Call{Call: _e.mock.On("CreateUnmaterializedPullRequestReviewer", context1, createUnmaterializedPullRequestReviewerArgs)}
 }
 
 func (_c *Client_CreateUnmaterializedPullRequestReviewer_Call) Run(run func(context1 context.Context, createUnmaterializedPullRequestReviewerArgs git.CreateUnmaterializedPullRequestReviewerArgs)) *Client_CreateUnmaterializedPullRequestReviewer_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.CreateUnmaterializedPullRequestReviewerArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.CreateUnmaterializedPullRequestReviewerArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.CreateUnmaterializedPullRequestReviewerArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -1250,15 +1481,26 @@ type Client_DeleteAttachment_Call struct {
 }
 
 // DeleteAttachment is a helper method to define mock.On call
-//   - context1
-//   - deleteAttachmentArgs
+//   - context1 context.Context
+//   - deleteAttachmentArgs git.DeleteAttachmentArgs
 func (_e *Client_Expecter) DeleteAttachment(context1 interface{}, deleteAttachmentArgs interface{}) *Client_DeleteAttachment_Call {
 	return &Client_DeleteAttachment_Call{Call: _e.mock.On("DeleteAttachment", context1, deleteAttachmentArgs)}
 }
 
 func (_c *Client_DeleteAttachment_Call) Run(run func(context1 context.Context, deleteAttachmentArgs git.DeleteAttachmentArgs)) *Client_DeleteAttachment_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.DeleteAttachmentArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.DeleteAttachmentArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.DeleteAttachmentArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -1296,15 +1538,26 @@ type Client_DeleteComment_Call struct {
 }
 
 // DeleteComment is a helper method to define mock.On call
-//   - context1
-//   - deleteCommentArgs
+//   - context1 context.Context
+//   - deleteCommentArgs git.DeleteCommentArgs
 func (_e *Client_Expecter) DeleteComment(context1 interface{}, deleteCommentArgs interface{}) *Client_DeleteComment_Call {
 	return &Client_DeleteComment_Call{Call: _e.mock.On("DeleteComment", context1, deleteCommentArgs)}
 }
 
 func (_c *Client_DeleteComment_Call) Run(run func(context1 context.Context, deleteCommentArgs git.DeleteCommentArgs)) *Client_DeleteComment_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.DeleteCommentArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.DeleteCommentArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.DeleteCommentArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -1342,15 +1595,26 @@ type Client_DeleteLike_Call struct {
 }
 
 // DeleteLike is a helper method to define mock.On call
-//   - context1
-//   - deleteLikeArgs
+//   - context1 context.Context
+//   - deleteLikeArgs git.DeleteLikeArgs
 func (_e *Client_Expecter) DeleteLike(context1 interface{}, deleteLikeArgs interface{}) *Client_DeleteLike_Call {
 	return &Client_DeleteLike_Call{Call: _e.mock.On("DeleteLike", context1, deleteLikeArgs)}
 }
 
 func (_c *Client_DeleteLike_Call) Run(run func(context1 context.Context, deleteLikeArgs git.DeleteLikeArgs)) *Client_DeleteLike_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.DeleteLikeArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.DeleteLikeArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.DeleteLikeArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -1388,15 +1652,26 @@ type Client_DeletePullRequestIterationStatus_Call struct {
 }
 
 // DeletePullRequestIterationStatus is a helper method to define mock.On call
-//   - context1
-//   - deletePullRequestIterationStatusArgs
+//   - context1 context.Context
+//   - deletePullRequestIterationStatusArgs git.DeletePullRequestIterationStatusArgs
 func (_e *Client_Expecter) DeletePullRequestIterationStatus(context1 interface{}, deletePullRequestIterationStatusArgs interface{}) *Client_DeletePullRequestIterationStatus_Call {
 	return &Client_DeletePullRequestIterationStatus_Call{Call: _e.mock.On("DeletePullRequestIterationStatus", context1, deletePullRequestIterationStatusArgs)}
 }
 
 func (_c *Client_DeletePullRequestIterationStatus_Call) Run(run func(context1 context.Context, deletePullRequestIterationStatusArgs git.DeletePullRequestIterationStatusArgs)) *Client_DeletePullRequestIterationStatus_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.DeletePullRequestIterationStatusArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.DeletePullRequestIterationStatusArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.DeletePullRequestIterationStatusArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -1434,15 +1709,26 @@ type Client_DeletePullRequestLabels_Call struct {
 }
 
 // DeletePullRequestLabels is a helper method to define mock.On call
-//   - context1
-//   - deletePullRequestLabelsArgs
+//   - context1 context.Context
+//   - deletePullRequestLabelsArgs git.DeletePullRequestLabelsArgs
 func (_e *Client_Expecter) DeletePullRequestLabels(context1 interface{}, deletePullRequestLabelsArgs interface{}) *Client_DeletePullRequestLabels_Call {
 	return &Client_DeletePullRequestLabels_Call{Call: _e.mock.On("DeletePullRequestLabels", context1, deletePullRequestLabelsArgs)}
 }
 
 func (_c *Client_DeletePullRequestLabels_Call) Run(run func(context1 context.Context, deletePullRequestLabelsArgs git.DeletePullRequestLabelsArgs)) *Client_DeletePullRequestLabels_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.DeletePullRequestLabelsArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.DeletePullRequestLabelsArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.DeletePullRequestLabelsArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -1480,15 +1766,26 @@ type Client_DeletePullRequestReviewer_Call struct {
 }
 
 // DeletePullRequestReviewer is a helper method to define mock.On call
-//   - context1
-//   - deletePullRequestReviewerArgs
+//   - context1 context.Context
+//   - deletePullRequestReviewerArgs git.DeletePullRequestReviewerArgs
 func (_e *Client_Expecter) DeletePullRequestReviewer(context1 interface{}, deletePullRequestReviewerArgs interface{}) *Client_DeletePullRequestReviewer_Call {
 	return &Client_DeletePullRequestReviewer_Call{Call: _e.mock.On("DeletePullRequestReviewer", context1, deletePullRequestReviewerArgs)}
 }
 
 func (_c *Client_DeletePullRequestReviewer_Call) Run(run func(context1 context.Context, deletePullRequestReviewerArgs git.DeletePullRequestReviewerArgs)) *Client_DeletePullRequestReviewer_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.DeletePullRequestReviewerArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.DeletePullRequestReviewerArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.DeletePullRequestReviewerArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -1526,15 +1823,26 @@ type Client_DeletePullRequestStatus_Call struct {
 }
 
 // DeletePullRequestStatus is a helper method to define mock.On call
-//   - context1
-//   - deletePullRequestStatusArgs
+//   - context1 context.Context
+//   - deletePullRequestStatusArgs git.DeletePullRequestStatusArgs
 func (_e *Client_Expecter) DeletePullRequestStatus(context1 interface{}, deletePullRequestStatusArgs interface{}) *Client_DeletePullRequestStatus_Call {
 	return &Client_DeletePullRequestStatus_Call{Call: _e.mock.On("DeletePullRequestStatus", context1, deletePullRequestStatusArgs)}
 }
 
 func (_c *Client_DeletePullRequestStatus_Call) Run(run func(context1 context.Context, deletePullRequestStatusArgs git.DeletePullRequestStatusArgs)) *Client_DeletePullRequestStatus_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.DeletePullRequestStatusArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.DeletePullRequestStatusArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.DeletePullRequestStatusArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -1572,15 +1880,26 @@ type Client_DeleteRefFavorite_Call struct {
 }
 
 // DeleteRefFavorite is a helper method to define mock.On call
-//   - context1
-//   - deleteRefFavoriteArgs
+//   - context1 context.Context
+//   - deleteRefFavoriteArgs git.DeleteRefFavoriteArgs
 func (_e *Client_Expecter) DeleteRefFavorite(context1 interface{}, deleteRefFavoriteArgs interface{}) *Client_DeleteRefFavorite_Call {
 	return &Client_DeleteRefFavorite_Call{Call: _e.mock.On("DeleteRefFavorite", context1, deleteRefFavoriteArgs)}
 }
 
 func (_c *Client_DeleteRefFavorite_Call) Run(run func(context1 context.Context, deleteRefFavoriteArgs git.DeleteRefFavoriteArgs)) *Client_DeleteRefFavorite_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.DeleteRefFavoriteArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.DeleteRefFavoriteArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.DeleteRefFavoriteArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -1618,15 +1937,26 @@ type Client_DeleteRepository_Call struct {
 }
 
 // DeleteRepository is a helper method to define mock.On call
-//   - context1
-//   - deleteRepositoryArgs
+//   - context1 context.Context
+//   - deleteRepositoryArgs git.DeleteRepositoryArgs
 func (_e *Client_Expecter) DeleteRepository(context1 interface{}, deleteRepositoryArgs interface{}) *Client_DeleteRepository_Call {
 	return &Client_DeleteRepository_Call{Call: _e.mock.On("DeleteRepository", context1, deleteRepositoryArgs)}
 }
 
 func (_c *Client_DeleteRepository_Call) Run(run func(context1 context.Context, deleteRepositoryArgs git.DeleteRepositoryArgs)) *Client_DeleteRepository_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.DeleteRepositoryArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.DeleteRepositoryArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.DeleteRepositoryArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -1664,15 +1994,26 @@ type Client_DeleteRepositoryFromRecycleBin_Call struct {
 }
 
 // DeleteRepositoryFromRecycleBin is a helper method to define mock.On call
-//   - context1
-//   - deleteRepositoryFromRecycleBinArgs
+//   - context1 context.Context
+//   - deleteRepositoryFromRecycleBinArgs git.DeleteRepositoryFromRecycleBinArgs
 func (_e *Client_Expecter) DeleteRepositoryFromRecycleBin(context1 interface{}, deleteRepositoryFromRecycleBinArgs interface{}) *Client_DeleteRepositoryFromRecycleBin_Call {
 	return &Client_DeleteRepositoryFromRecycleBin_Call{Call: _e.mock.On("DeleteRepositoryFromRecycleBin", context1, deleteRepositoryFromRecycleBinArgs)}
 }
 
 func (_c *Client_DeleteRepositoryFromRecycleBin_Call) Run(run func(context1 context.Context, deleteRepositoryFromRecycleBinArgs git.DeleteRepositoryFromRecycleBinArgs)) *Client_DeleteRepositoryFromRecycleBin_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.DeleteRepositoryFromRecycleBinArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.DeleteRepositoryFromRecycleBinArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.DeleteRepositoryFromRecycleBinArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -1721,15 +2062,26 @@ type Client_GetAnnotatedTag_Call struct {
 }
 
 // GetAnnotatedTag is a helper method to define mock.On call
-//   - context1
-//   - getAnnotatedTagArgs
+//   - context1 context.Context
+//   - getAnnotatedTagArgs git.GetAnnotatedTagArgs
 func (_e *Client_Expecter) GetAnnotatedTag(context1 interface{}, getAnnotatedTagArgs interface{}) *Client_GetAnnotatedTag_Call {
 	return &Client_GetAnnotatedTag_Call{Call: _e.mock.On("GetAnnotatedTag", context1, getAnnotatedTagArgs)}
 }
 
 func (_c *Client_GetAnnotatedTag_Call) Run(run func(context1 context.Context, getAnnotatedTagArgs git.GetAnnotatedTagArgs)) *Client_GetAnnotatedTag_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetAnnotatedTagArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetAnnotatedTagArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetAnnotatedTagArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -1778,15 +2130,26 @@ type Client_GetAttachmentContent_Call struct {
 }
 
 // GetAttachmentContent is a helper method to define mock.On call
-//   - context1
-//   - getAttachmentContentArgs
+//   - context1 context.Context
+//   - getAttachmentContentArgs git.GetAttachmentContentArgs
 func (_e *Client_Expecter) GetAttachmentContent(context1 interface{}, getAttachmentContentArgs interface{}) *Client_GetAttachmentContent_Call {
 	return &Client_GetAttachmentContent_Call{Call: _e.mock.On("GetAttachmentContent", context1, getAttachmentContentArgs)}
 }
 
 func (_c *Client_GetAttachmentContent_Call) Run(run func(context1 context.Context, getAttachmentContentArgs git.GetAttachmentContentArgs)) *Client_GetAttachmentContent_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetAttachmentContentArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetAttachmentContentArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetAttachmentContentArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -1835,15 +2198,26 @@ type Client_GetAttachmentZip_Call struct {
 }
 
 // GetAttachmentZip is a helper method to define mock.On call
-//   - context1
-//   - getAttachmentZipArgs
+//   - context1 context.Context
+//   - getAttachmentZipArgs git.GetAttachmentZipArgs
 func (_e *Client_Expecter) GetAttachmentZip(context1 interface{}, getAttachmentZipArgs interface{}) *Client_GetAttachmentZip_Call {
 	return &Client_GetAttachmentZip_Call{Call: _e.mock.On("GetAttachmentZip", context1, getAttachmentZipArgs)}
 }
 
 func (_c *Client_GetAttachmentZip_Call) Run(run func(context1 context.Context, getAttachmentZipArgs git.GetAttachmentZipArgs)) *Client_GetAttachmentZip_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetAttachmentZipArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetAttachmentZipArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetAttachmentZipArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -1892,15 +2266,26 @@ type Client_GetAttachments_Call struct {
 }
 
 // GetAttachments is a helper method to define mock.On call
-//   - context1
-//   - getAttachmentsArgs
+//   - context1 context.Context
+//   - getAttachmentsArgs git.GetAttachmentsArgs
 func (_e *Client_Expecter) GetAttachments(context1 interface{}, getAttachmentsArgs interface{}) *Client_GetAttachments_Call {
 	return &Client_GetAttachments_Call{Call: _e.mock.On("GetAttachments", context1, getAttachmentsArgs)}
 }
 
 func (_c *Client_GetAttachments_Call) Run(run func(context1 context.Context, getAttachmentsArgs git.GetAttachmentsArgs)) *Client_GetAttachments_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetAttachmentsArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetAttachmentsArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetAttachmentsArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -1949,15 +2334,26 @@ type Client_GetBlob_Call struct {
 }
 
 // GetBlob is a helper method to define mock.On call
-//   - context1
-//   - getBlobArgs
+//   - context1 context.Context
+//   - getBlobArgs git.GetBlobArgs
 func (_e *Client_Expecter) GetBlob(context1 interface{}, getBlobArgs interface{}) *Client_GetBlob_Call {
 	return &Client_GetBlob_Call{Call: _e.mock.On("GetBlob", context1, getBlobArgs)}
 }
 
 func (_c *Client_GetBlob_Call) Run(run func(context1 context.Context, getBlobArgs git.GetBlobArgs)) *Client_GetBlob_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetBlobArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetBlobArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetBlobArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -2006,15 +2402,26 @@ type Client_GetBlobContent_Call struct {
 }
 
 // GetBlobContent is a helper method to define mock.On call
-//   - context1
-//   - getBlobContentArgs
+//   - context1 context.Context
+//   - getBlobContentArgs git.GetBlobContentArgs
 func (_e *Client_Expecter) GetBlobContent(context1 interface{}, getBlobContentArgs interface{}) *Client_GetBlobContent_Call {
 	return &Client_GetBlobContent_Call{Call: _e.mock.On("GetBlobContent", context1, getBlobContentArgs)}
 }
 
 func (_c *Client_GetBlobContent_Call) Run(run func(context1 context.Context, getBlobContentArgs git.GetBlobContentArgs)) *Client_GetBlobContent_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetBlobContentArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetBlobContentArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetBlobContentArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -2063,15 +2470,26 @@ type Client_GetBlobZip_Call struct {
 }
 
 // GetBlobZip is a helper method to define mock.On call
-//   - context1
-//   - getBlobZipArgs
+//   - context1 context.Context
+//   - getBlobZipArgs git.GetBlobZipArgs
 func (_e *Client_Expecter) GetBlobZip(context1 interface{}, getBlobZipArgs interface{}) *Client_GetBlobZip_Call {
 	return &Client_GetBlobZip_Call{Call: _e.mock.On("GetBlobZip", context1, getBlobZipArgs)}
 }
 
 func (_c *Client_GetBlobZip_Call) Run(run func(context1 context.Context, getBlobZipArgs git.GetBlobZipArgs)) *Client_GetBlobZip_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetBlobZipArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetBlobZipArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetBlobZipArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -2120,15 +2538,26 @@ type Client_GetBlobsZip_Call struct {
 }
 
 // GetBlobsZip is a helper method to define mock.On call
-//   - context1
-//   - getBlobsZipArgs
+//   - context1 context.Context
+//   - getBlobsZipArgs git.GetBlobsZipArgs
 func (_e *Client_Expecter) GetBlobsZip(context1 interface{}, getBlobsZipArgs interface{}) *Client_GetBlobsZip_Call {
 	return &Client_GetBlobsZip_Call{Call: _e.mock.On("GetBlobsZip", context1, getBlobsZipArgs)}
 }
 
 func (_c *Client_GetBlobsZip_Call) Run(run func(context1 context.Context, getBlobsZipArgs git.GetBlobsZipArgs)) *Client_GetBlobsZip_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetBlobsZipArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetBlobsZipArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetBlobsZipArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -2177,15 +2606,26 @@ type Client_GetBranch_Call struct {
 }
 
 // GetBranch is a helper method to define mock.On call
-//   - context1
-//   - getBranchArgs
+//   - context1 context.Context
+//   - getBranchArgs git.GetBranchArgs
 func (_e *Client_Expecter) GetBranch(context1 interface{}, getBranchArgs interface{}) *Client_GetBranch_Call {
 	return &Client_GetBranch_Call{Call: _e.mock.On("GetBranch", context1, getBranchArgs)}
 }
 
 func (_c *Client_GetBranch_Call) Run(run func(context1 context.Context, getBranchArgs git.GetBranchArgs)) *Client_GetBranch_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetBranchArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetBranchArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetBranchArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -2234,15 +2674,26 @@ type Client_GetBranches_Call struct {
 }
 
 // GetBranches is a helper method to define mock.On call
-//   - context1
-//   - getBranchesArgs
+//   - context1 context.Context
+//   - getBranchesArgs git.GetBranchesArgs
 func (_e *Client_Expecter) GetBranches(context1 interface{}, getBranchesArgs interface{}) *Client_GetBranches_Call {
 	return &Client_GetBranches_Call{Call: _e.mock.On("GetBranches", context1, getBranchesArgs)}
 }
 
 func (_c *Client_GetBranches_Call) Run(run func(context1 context.Context, getBranchesArgs git.GetBranchesArgs)) *Client_GetBranches_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetBranchesArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetBranchesArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetBranchesArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -2291,15 +2742,26 @@ type Client_GetChanges_Call struct {
 }
 
 // GetChanges is a helper method to define mock.On call
-//   - context1
-//   - getChangesArgs
+//   - context1 context.Context
+//   - getChangesArgs git.GetChangesArgs
 func (_e *Client_Expecter) GetChanges(context1 interface{}, getChangesArgs interface{}) *Client_GetChanges_Call {
 	return &Client_GetChanges_Call{Call: _e.mock.On("GetChanges", context1, getChangesArgs)}
 }
 
 func (_c *Client_GetChanges_Call) Run(run func(context1 context.Context, getChangesArgs git.GetChangesArgs)) *Client_GetChanges_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetChangesArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetChangesArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetChangesArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -2348,15 +2810,26 @@ type Client_GetCherryPick_Call struct {
 }
 
 // GetCherryPick is a helper method to define mock.On call
-//   - context1
-//   - getCherryPickArgs
+//   - context1 context.Context
+//   - getCherryPickArgs git.GetCherryPickArgs
 func (_e *Client_Expecter) GetCherryPick(context1 interface{}, getCherryPickArgs interface{}) *Client_GetCherryPick_Call {
 	return &Client_GetCherryPick_Call{Call: _e.mock.On("GetCherryPick", context1, getCherryPickArgs)}
 }
 
 func (_c *Client_GetCherryPick_Call) Run(run func(context1 context.Context, getCherryPickArgs git.GetCherryPickArgs)) *Client_GetCherryPick_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetCherryPickArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetCherryPickArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetCherryPickArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -2405,15 +2878,26 @@ type Client_GetCherryPickForRefName_Call struct {
 }
 
 // GetCherryPickForRefName is a helper method to define mock.On call
-//   - context1
-//   - getCherryPickForRefNameArgs
+//   - context1 context.Context
+//   - getCherryPickForRefNameArgs git.GetCherryPickForRefNameArgs
 func (_e *Client_Expecter) GetCherryPickForRefName(context1 interface{}, getCherryPickForRefNameArgs interface{}) *Client_GetCherryPickForRefName_Call {
 	return &Client_GetCherryPickForRefName_Call{Call: _e.mock.On("GetCherryPickForRefName", context1, getCherryPickForRefNameArgs)}
 }
 
 func (_c *Client_GetCherryPickForRefName_Call) Run(run func(context1 context.Context, getCherryPickForRefNameArgs git.GetCherryPickForRefNameArgs)) *Client_GetCherryPickForRefName_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetCherryPickForRefNameArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetCherryPickForRefNameArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetCherryPickForRefNameArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -2462,15 +2946,26 @@ type Client_GetComment_Call struct {
 }
 
 // GetComment is a helper method to define mock.On call
-//   - context1
-//   - getCommentArgs
+//   - context1 context.Context
+//   - getCommentArgs git.GetCommentArgs
 func (_e *Client_Expecter) GetComment(context1 interface{}, getCommentArgs interface{}) *Client_GetComment_Call {
 	return &Client_GetComment_Call{Call: _e.mock.On("GetComment", context1, getCommentArgs)}
 }
 
 func (_c *Client_GetComment_Call) Run(run func(context1 context.Context, getCommentArgs git.GetCommentArgs)) *Client_GetComment_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetCommentArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetCommentArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetCommentArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -2519,15 +3014,26 @@ type Client_GetComments_Call struct {
 }
 
 // GetComments is a helper method to define mock.On call
-//   - context1
-//   - getCommentsArgs
+//   - context1 context.Context
+//   - getCommentsArgs git.GetCommentsArgs
 func (_e *Client_Expecter) GetComments(context1 interface{}, getCommentsArgs interface{}) *Client_GetComments_Call {
 	return &Client_GetComments_Call{Call: _e.mock.On("GetComments", context1, getCommentsArgs)}
 }
 
 func (_c *Client_GetComments_Call) Run(run func(context1 context.Context, getCommentsArgs git.GetCommentsArgs)) *Client_GetComments_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetCommentsArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetCommentsArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetCommentsArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -2576,15 +3082,26 @@ type Client_GetCommit_Call struct {
 }
 
 // GetCommit is a helper method to define mock.On call
-//   - context1
-//   - getCommitArgs
+//   - context1 context.Context
+//   - getCommitArgs git.GetCommitArgs
 func (_e *Client_Expecter) GetCommit(context1 interface{}, getCommitArgs interface{}) *Client_GetCommit_Call {
 	return &Client_GetCommit_Call{Call: _e.mock.On("GetCommit", context1, getCommitArgs)}
 }
 
 func (_c *Client_GetCommit_Call) Run(run func(context1 context.Context, getCommitArgs git.GetCommitArgs)) *Client_GetCommit_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetCommitArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetCommitArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetCommitArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -2633,15 +3150,26 @@ type Client_GetCommitDiffs_Call struct {
 }
 
 // GetCommitDiffs is a helper method to define mock.On call
-//   - context1
-//   - getCommitDiffsArgs
+//   - context1 context.Context
+//   - getCommitDiffsArgs git.GetCommitDiffsArgs
 func (_e *Client_Expecter) GetCommitDiffs(context1 interface{}, getCommitDiffsArgs interface{}) *Client_GetCommitDiffs_Call {
 	return &Client_GetCommitDiffs_Call{Call: _e.mock.On("GetCommitDiffs", context1, getCommitDiffsArgs)}
 }
 
 func (_c *Client_GetCommitDiffs_Call) Run(run func(context1 context.Context, getCommitDiffsArgs git.GetCommitDiffsArgs)) *Client_GetCommitDiffs_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetCommitDiffsArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetCommitDiffsArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetCommitDiffsArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -2690,15 +3218,26 @@ type Client_GetCommits_Call struct {
 }
 
 // GetCommits is a helper method to define mock.On call
-//   - context1
-//   - getCommitsArgs
+//   - context1 context.Context
+//   - getCommitsArgs git.GetCommitsArgs
 func (_e *Client_Expecter) GetCommits(context1 interface{}, getCommitsArgs interface{}) *Client_GetCommits_Call {
 	return &Client_GetCommits_Call{Call: _e.mock.On("GetCommits", context1, getCommitsArgs)}
 }
 
 func (_c *Client_GetCommits_Call) Run(run func(context1 context.Context, getCommitsArgs git.GetCommitsArgs)) *Client_GetCommits_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetCommitsArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetCommitsArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetCommitsArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -2747,15 +3286,26 @@ type Client_GetCommitsBatch_Call struct {
 }
 
 // GetCommitsBatch is a helper method to define mock.On call
-//   - context1
-//   - getCommitsBatchArgs
+//   - context1 context.Context
+//   - getCommitsBatchArgs git.GetCommitsBatchArgs
 func (_e *Client_Expecter) GetCommitsBatch(context1 interface{}, getCommitsBatchArgs interface{}) *Client_GetCommitsBatch_Call {
 	return &Client_GetCommitsBatch_Call{Call: _e.mock.On("GetCommitsBatch", context1, getCommitsBatchArgs)}
 }
 
 func (_c *Client_GetCommitsBatch_Call) Run(run func(context1 context.Context, getCommitsBatchArgs git.GetCommitsBatchArgs)) *Client_GetCommitsBatch_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetCommitsBatchArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetCommitsBatchArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetCommitsBatchArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -2804,15 +3354,26 @@ type Client_GetDeletedRepositories_Call struct {
 }
 
 // GetDeletedRepositories is a helper method to define mock.On call
-//   - context1
-//   - getDeletedRepositoriesArgs
+//   - context1 context.Context
+//   - getDeletedRepositoriesArgs git.GetDeletedRepositoriesArgs
 func (_e *Client_Expecter) GetDeletedRepositories(context1 interface{}, getDeletedRepositoriesArgs interface{}) *Client_GetDeletedRepositories_Call {
 	return &Client_GetDeletedRepositories_Call{Call: _e.mock.On("GetDeletedRepositories", context1, getDeletedRepositoriesArgs)}
 }
 
 func (_c *Client_GetDeletedRepositories_Call) Run(run func(context1 context.Context, getDeletedRepositoriesArgs git.GetDeletedRepositoriesArgs)) *Client_GetDeletedRepositories_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetDeletedRepositoriesArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetDeletedRepositoriesArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetDeletedRepositoriesArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -2861,15 +3422,26 @@ type Client_GetForkSyncRequest_Call struct {
 }
 
 // GetForkSyncRequest is a helper method to define mock.On call
-//   - context1
-//   - getForkSyncRequestArgs
+//   - context1 context.Context
+//   - getForkSyncRequestArgs git.GetForkSyncRequestArgs
 func (_e *Client_Expecter) GetForkSyncRequest(context1 interface{}, getForkSyncRequestArgs interface{}) *Client_GetForkSyncRequest_Call {
 	return &Client_GetForkSyncRequest_Call{Call: _e.mock.On("GetForkSyncRequest", context1, getForkSyncRequestArgs)}
 }
 
 func (_c *Client_GetForkSyncRequest_Call) Run(run func(context1 context.Context, getForkSyncRequestArgs git.GetForkSyncRequestArgs)) *Client_GetForkSyncRequest_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetForkSyncRequestArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetForkSyncRequestArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetForkSyncRequestArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -2918,15 +3490,26 @@ type Client_GetForkSyncRequests_Call struct {
 }
 
 // GetForkSyncRequests is a helper method to define mock.On call
-//   - context1
-//   - getForkSyncRequestsArgs
+//   - context1 context.Context
+//   - getForkSyncRequestsArgs git.GetForkSyncRequestsArgs
 func (_e *Client_Expecter) GetForkSyncRequests(context1 interface{}, getForkSyncRequestsArgs interface{}) *Client_GetForkSyncRequests_Call {
 	return &Client_GetForkSyncRequests_Call{Call: _e.mock.On("GetForkSyncRequests", context1, getForkSyncRequestsArgs)}
 }
 
 func (_c *Client_GetForkSyncRequests_Call) Run(run func(context1 context.Context, getForkSyncRequestsArgs git.GetForkSyncRequestsArgs)) *Client_GetForkSyncRequests_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetForkSyncRequestsArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetForkSyncRequestsArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetForkSyncRequestsArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -2975,15 +3558,26 @@ type Client_GetForks_Call struct {
 }
 
 // GetForks is a helper method to define mock.On call
-//   - context1
-//   - getForksArgs
+//   - context1 context.Context
+//   - getForksArgs git.GetForksArgs
 func (_e *Client_Expecter) GetForks(context1 interface{}, getForksArgs interface{}) *Client_GetForks_Call {
 	return &Client_GetForks_Call{Call: _e.mock.On("GetForks", context1, getForksArgs)}
 }
 
 func (_c *Client_GetForks_Call) Run(run func(context1 context.Context, getForksArgs git.GetForksArgs)) *Client_GetForks_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetForksArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetForksArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetForksArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -3032,15 +3626,26 @@ type Client_GetImportRequest_Call struct {
 }
 
 // GetImportRequest is a helper method to define mock.On call
-//   - context1
-//   - getImportRequestArgs
+//   - context1 context.Context
+//   - getImportRequestArgs git.GetImportRequestArgs
 func (_e *Client_Expecter) GetImportRequest(context1 interface{}, getImportRequestArgs interface{}) *Client_GetImportRequest_Call {
 	return &Client_GetImportRequest_Call{Call: _e.mock.On("GetImportRequest", context1, getImportRequestArgs)}
 }
 
 func (_c *Client_GetImportRequest_Call) Run(run func(context1 context.Context, getImportRequestArgs git.GetImportRequestArgs)) *Client_GetImportRequest_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetImportRequestArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetImportRequestArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetImportRequestArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -3089,15 +3694,26 @@ type Client_GetItem_Call struct {
 }
 
 // GetItem is a helper method to define mock.On call
-//   - context1
-//   - getItemArgs
+//   - context1 context.Context
+//   - getItemArgs git.GetItemArgs
 func (_e *Client_Expecter) GetItem(context1 interface{}, getItemArgs interface{}) *Client_GetItem_Call {
 	return &Client_GetItem_Call{Call: _e.mock.On("GetItem", context1, getItemArgs)}
 }
 
 func (_c *Client_GetItem_Call) Run(run func(context1 context.Context, getItemArgs git.GetItemArgs)) *Client_GetItem_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetItemArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetItemArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetItemArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -3146,15 +3762,26 @@ type Client_GetItemContent_Call struct {
 }
 
 // GetItemContent is a helper method to define mock.On call
-//   - context1
-//   - getItemContentArgs
+//   - context1 context.Context
+//   - getItemContentArgs git.GetItemContentArgs
 func (_e *Client_Expecter) GetItemContent(context1 interface{}, getItemContentArgs interface{}) *Client_GetItemContent_Call {
 	return &Client_GetItemContent_Call{Call: _e.mock.On("GetItemContent", context1, getItemContentArgs)}
 }
 
 func (_c *Client_GetItemContent_Call) Run(run func(context1 context.Context, getItemContentArgs git.GetItemContentArgs)) *Client_GetItemContent_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetItemContentArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetItemContentArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetItemContentArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -3203,15 +3830,26 @@ type Client_GetItemText_Call struct {
 }
 
 // GetItemText is a helper method to define mock.On call
-//   - context1
-//   - getItemTextArgs
+//   - context1 context.Context
+//   - getItemTextArgs git.GetItemTextArgs
 func (_e *Client_Expecter) GetItemText(context1 interface{}, getItemTextArgs interface{}) *Client_GetItemText_Call {
 	return &Client_GetItemText_Call{Call: _e.mock.On("GetItemText", context1, getItemTextArgs)}
 }
 
 func (_c *Client_GetItemText_Call) Run(run func(context1 context.Context, getItemTextArgs git.GetItemTextArgs)) *Client_GetItemText_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetItemTextArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetItemTextArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetItemTextArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -3260,15 +3898,26 @@ type Client_GetItemZip_Call struct {
 }
 
 // GetItemZip is a helper method to define mock.On call
-//   - context1
-//   - getItemZipArgs
+//   - context1 context.Context
+//   - getItemZipArgs git.GetItemZipArgs
 func (_e *Client_Expecter) GetItemZip(context1 interface{}, getItemZipArgs interface{}) *Client_GetItemZip_Call {
 	return &Client_GetItemZip_Call{Call: _e.mock.On("GetItemZip", context1, getItemZipArgs)}
 }
 
 func (_c *Client_GetItemZip_Call) Run(run func(context1 context.Context, getItemZipArgs git.GetItemZipArgs)) *Client_GetItemZip_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetItemZipArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetItemZipArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetItemZipArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -3317,15 +3966,26 @@ type Client_GetItems_Call struct {
 }
 
 // GetItems is a helper method to define mock.On call
-//   - context1
-//   - getItemsArgs
+//   - context1 context.Context
+//   - getItemsArgs git.GetItemsArgs
 func (_e *Client_Expecter) GetItems(context1 interface{}, getItemsArgs interface{}) *Client_GetItems_Call {
 	return &Client_GetItems_Call{Call: _e.mock.On("GetItems", context1, getItemsArgs)}
 }
 
 func (_c *Client_GetItems_Call) Run(run func(context1 context.Context, getItemsArgs git.GetItemsArgs)) *Client_GetItems_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetItemsArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetItemsArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetItemsArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -3374,15 +4034,26 @@ type Client_GetItemsBatch_Call struct {
 }
 
 // GetItemsBatch is a helper method to define mock.On call
-//   - context1
-//   - getItemsBatchArgs
+//   - context1 context.Context
+//   - getItemsBatchArgs git.GetItemsBatchArgs
 func (_e *Client_Expecter) GetItemsBatch(context1 interface{}, getItemsBatchArgs interface{}) *Client_GetItemsBatch_Call {
 	return &Client_GetItemsBatch_Call{Call: _e.mock.On("GetItemsBatch", context1, getItemsBatchArgs)}
 }
 
 func (_c *Client_GetItemsBatch_Call) Run(run func(context1 context.Context, getItemsBatchArgs git.GetItemsBatchArgs)) *Client_GetItemsBatch_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetItemsBatchArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetItemsBatchArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetItemsBatchArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -3431,15 +4102,26 @@ type Client_GetLikes_Call struct {
 }
 
 // GetLikes is a helper method to define mock.On call
-//   - context1
-//   - getLikesArgs
+//   - context1 context.Context
+//   - getLikesArgs git.GetLikesArgs
 func (_e *Client_Expecter) GetLikes(context1 interface{}, getLikesArgs interface{}) *Client_GetLikes_Call {
 	return &Client_GetLikes_Call{Call: _e.mock.On("GetLikes", context1, getLikesArgs)}
 }
 
 func (_c *Client_GetLikes_Call) Run(run func(context1 context.Context, getLikesArgs git.GetLikesArgs)) *Client_GetLikes_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetLikesArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetLikesArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetLikesArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -3488,15 +4170,26 @@ type Client_GetMergeBases_Call struct {
 }
 
 // GetMergeBases is a helper method to define mock.On call
-//   - context1
-//   - getMergeBasesArgs
+//   - context1 context.Context
+//   - getMergeBasesArgs git.GetMergeBasesArgs
 func (_e *Client_Expecter) GetMergeBases(context1 interface{}, getMergeBasesArgs interface{}) *Client_GetMergeBases_Call {
 	return &Client_GetMergeBases_Call{Call: _e.mock.On("GetMergeBases", context1, getMergeBasesArgs)}
 }
 
 func (_c *Client_GetMergeBases_Call) Run(run func(context1 context.Context, getMergeBasesArgs git.GetMergeBasesArgs)) *Client_GetMergeBases_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetMergeBasesArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetMergeBasesArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetMergeBasesArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -3545,15 +4238,26 @@ type Client_GetMergeRequest_Call struct {
 }
 
 // GetMergeRequest is a helper method to define mock.On call
-//   - context1
-//   - getMergeRequestArgs
+//   - context1 context.Context
+//   - getMergeRequestArgs git.GetMergeRequestArgs
 func (_e *Client_Expecter) GetMergeRequest(context1 interface{}, getMergeRequestArgs interface{}) *Client_GetMergeRequest_Call {
 	return &Client_GetMergeRequest_Call{Call: _e.mock.On("GetMergeRequest", context1, getMergeRequestArgs)}
 }
 
 func (_c *Client_GetMergeRequest_Call) Run(run func(context1 context.Context, getMergeRequestArgs git.GetMergeRequestArgs)) *Client_GetMergeRequest_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetMergeRequestArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetMergeRequestArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetMergeRequestArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -3602,15 +4306,26 @@ type Client_GetPermission_Call struct {
 }
 
 // GetPermission is a helper method to define mock.On call
-//   - context1
-//   - getPermissionArgs
+//   - context1 context.Context
+//   - getPermissionArgs git.GetPermissionArgs
 func (_e *Client_Expecter) GetPermission(context1 interface{}, getPermissionArgs interface{}) *Client_GetPermission_Call {
 	return &Client_GetPermission_Call{Call: _e.mock.On("GetPermission", context1, getPermissionArgs)}
 }
 
 func (_c *Client_GetPermission_Call) Run(run func(context1 context.Context, getPermissionArgs git.GetPermissionArgs)) *Client_GetPermission_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetPermissionArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetPermissionArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetPermissionArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -3659,15 +4374,26 @@ type Client_GetPolicyConfigurations_Call struct {
 }
 
 // GetPolicyConfigurations is a helper method to define mock.On call
-//   - context1
-//   - getPolicyConfigurationsArgs
+//   - context1 context.Context
+//   - getPolicyConfigurationsArgs git.GetPolicyConfigurationsArgs
 func (_e *Client_Expecter) GetPolicyConfigurations(context1 interface{}, getPolicyConfigurationsArgs interface{}) *Client_GetPolicyConfigurations_Call {
 	return &Client_GetPolicyConfigurations_Call{Call: _e.mock.On("GetPolicyConfigurations", context1, getPolicyConfigurationsArgs)}
 }
 
 func (_c *Client_GetPolicyConfigurations_Call) Run(run func(context1 context.Context, getPolicyConfigurationsArgs git.GetPolicyConfigurationsArgs)) *Client_GetPolicyConfigurations_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetPolicyConfigurationsArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetPolicyConfigurationsArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetPolicyConfigurationsArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -3716,15 +4442,26 @@ type Client_GetPullRequest_Call struct {
 }
 
 // GetPullRequest is a helper method to define mock.On call
-//   - context1
-//   - getPullRequestArgs
+//   - context1 context.Context
+//   - getPullRequestArgs git.GetPullRequestArgs
 func (_e *Client_Expecter) GetPullRequest(context1 interface{}, getPullRequestArgs interface{}) *Client_GetPullRequest_Call {
 	return &Client_GetPullRequest_Call{Call: _e.mock.On("GetPullRequest", context1, getPullRequestArgs)}
 }
 
 func (_c *Client_GetPullRequest_Call) Run(run func(context1 context.Context, getPullRequestArgs git.GetPullRequestArgs)) *Client_GetPullRequest_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetPullRequestArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetPullRequestArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetPullRequestArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -3773,15 +4510,26 @@ type Client_GetPullRequestById_Call struct {
 }
 
 // GetPullRequestById is a helper method to define mock.On call
-//   - context1
-//   - getPullRequestByIdArgs
+//   - context1 context.Context
+//   - getPullRequestByIdArgs git.GetPullRequestByIdArgs
 func (_e *Client_Expecter) GetPullRequestById(context1 interface{}, getPullRequestByIdArgs interface{}) *Client_GetPullRequestById_Call {
 	return &Client_GetPullRequestById_Call{Call: _e.mock.On("GetPullRequestById", context1, getPullRequestByIdArgs)}
 }
 
 func (_c *Client_GetPullRequestById_Call) Run(run func(context1 context.Context, getPullRequestByIdArgs git.GetPullRequestByIdArgs)) *Client_GetPullRequestById_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetPullRequestByIdArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetPullRequestByIdArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetPullRequestByIdArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -3830,15 +4578,26 @@ type Client_GetPullRequestCommits_Call struct {
 }
 
 // GetPullRequestCommits is a helper method to define mock.On call
-//   - context1
-//   - getPullRequestCommitsArgs
+//   - context1 context.Context
+//   - getPullRequestCommitsArgs git.GetPullRequestCommitsArgs
 func (_e *Client_Expecter) GetPullRequestCommits(context1 interface{}, getPullRequestCommitsArgs interface{}) *Client_GetPullRequestCommits_Call {
 	return &Client_GetPullRequestCommits_Call{Call: _e.mock.On("GetPullRequestCommits", context1, getPullRequestCommitsArgs)}
 }
 
 func (_c *Client_GetPullRequestCommits_Call) Run(run func(context1 context.Context, getPullRequestCommitsArgs git.GetPullRequestCommitsArgs)) *Client_GetPullRequestCommits_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetPullRequestCommitsArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetPullRequestCommitsArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetPullRequestCommitsArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -3887,15 +4646,26 @@ type Client_GetPullRequestIteration_Call struct {
 }
 
 // GetPullRequestIteration is a helper method to define mock.On call
-//   - context1
-//   - getPullRequestIterationArgs
+//   - context1 context.Context
+//   - getPullRequestIterationArgs git.GetPullRequestIterationArgs
 func (_e *Client_Expecter) GetPullRequestIteration(context1 interface{}, getPullRequestIterationArgs interface{}) *Client_GetPullRequestIteration_Call {
 	return &Client_GetPullRequestIteration_Call{Call: _e.mock.On("GetPullRequestIteration", context1, getPullRequestIterationArgs)}
 }
 
 func (_c *Client_GetPullRequestIteration_Call) Run(run func(context1 context.Context, getPullRequestIterationArgs git.GetPullRequestIterationArgs)) *Client_GetPullRequestIteration_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetPullRequestIterationArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetPullRequestIterationArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetPullRequestIterationArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -3944,15 +4714,26 @@ type Client_GetPullRequestIterationChanges_Call struct {
 }
 
 // GetPullRequestIterationChanges is a helper method to define mock.On call
-//   - context1
-//   - getPullRequestIterationChangesArgs
+//   - context1 context.Context
+//   - getPullRequestIterationChangesArgs git.GetPullRequestIterationChangesArgs
 func (_e *Client_Expecter) GetPullRequestIterationChanges(context1 interface{}, getPullRequestIterationChangesArgs interface{}) *Client_GetPullRequestIterationChanges_Call {
 	return &Client_GetPullRequestIterationChanges_Call{Call: _e.mock.On("GetPullRequestIterationChanges", context1, getPullRequestIterationChangesArgs)}
 }
 
 func (_c *Client_GetPullRequestIterationChanges_Call) Run(run func(context1 context.Context, getPullRequestIterationChangesArgs git.GetPullRequestIterationChangesArgs)) *Client_GetPullRequestIterationChanges_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetPullRequestIterationChangesArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetPullRequestIterationChangesArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetPullRequestIterationChangesArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -4001,15 +4782,26 @@ type Client_GetPullRequestIterationCommits_Call struct {
 }
 
 // GetPullRequestIterationCommits is a helper method to define mock.On call
-//   - context1
-//   - getPullRequestIterationCommitsArgs
+//   - context1 context.Context
+//   - getPullRequestIterationCommitsArgs git.GetPullRequestIterationCommitsArgs
 func (_e *Client_Expecter) GetPullRequestIterationCommits(context1 interface{}, getPullRequestIterationCommitsArgs interface{}) *Client_GetPullRequestIterationCommits_Call {
 	return &Client_GetPullRequestIterationCommits_Call{Call: _e.mock.On("GetPullRequestIterationCommits", context1, getPullRequestIterationCommitsArgs)}
 }
 
 func (_c *Client_GetPullRequestIterationCommits_Call) Run(run func(context1 context.Context, getPullRequestIterationCommitsArgs git.GetPullRequestIterationCommitsArgs)) *Client_GetPullRequestIterationCommits_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetPullRequestIterationCommitsArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetPullRequestIterationCommitsArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetPullRequestIterationCommitsArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -4058,15 +4850,26 @@ type Client_GetPullRequestIterationStatus_Call struct {
 }
 
 // GetPullRequestIterationStatus is a helper method to define mock.On call
-//   - context1
-//   - getPullRequestIterationStatusArgs
+//   - context1 context.Context
+//   - getPullRequestIterationStatusArgs git.GetPullRequestIterationStatusArgs
 func (_e *Client_Expecter) GetPullRequestIterationStatus(context1 interface{}, getPullRequestIterationStatusArgs interface{}) *Client_GetPullRequestIterationStatus_Call {
 	return &Client_GetPullRequestIterationStatus_Call{Call: _e.mock.On("GetPullRequestIterationStatus", context1, getPullRequestIterationStatusArgs)}
 }
 
 func (_c *Client_GetPullRequestIterationStatus_Call) Run(run func(context1 context.Context, getPullRequestIterationStatusArgs git.GetPullRequestIterationStatusArgs)) *Client_GetPullRequestIterationStatus_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetPullRequestIterationStatusArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetPullRequestIterationStatusArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetPullRequestIterationStatusArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -4115,15 +4918,26 @@ type Client_GetPullRequestIterationStatuses_Call struct {
 }
 
 // GetPullRequestIterationStatuses is a helper method to define mock.On call
-//   - context1
-//   - getPullRequestIterationStatusesArgs
+//   - context1 context.Context
+//   - getPullRequestIterationStatusesArgs git.GetPullRequestIterationStatusesArgs
 func (_e *Client_Expecter) GetPullRequestIterationStatuses(context1 interface{}, getPullRequestIterationStatusesArgs interface{}) *Client_GetPullRequestIterationStatuses_Call {
 	return &Client_GetPullRequestIterationStatuses_Call{Call: _e.mock.On("GetPullRequestIterationStatuses", context1, getPullRequestIterationStatusesArgs)}
 }
 
 func (_c *Client_GetPullRequestIterationStatuses_Call) Run(run func(context1 context.Context, getPullRequestIterationStatusesArgs git.GetPullRequestIterationStatusesArgs)) *Client_GetPullRequestIterationStatuses_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetPullRequestIterationStatusesArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetPullRequestIterationStatusesArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetPullRequestIterationStatusesArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -4172,15 +4986,26 @@ type Client_GetPullRequestIterations_Call struct {
 }
 
 // GetPullRequestIterations is a helper method to define mock.On call
-//   - context1
-//   - getPullRequestIterationsArgs
+//   - context1 context.Context
+//   - getPullRequestIterationsArgs git.GetPullRequestIterationsArgs
 func (_e *Client_Expecter) GetPullRequestIterations(context1 interface{}, getPullRequestIterationsArgs interface{}) *Client_GetPullRequestIterations_Call {
 	return &Client_GetPullRequestIterations_Call{Call: _e.mock.On("GetPullRequestIterations", context1, getPullRequestIterationsArgs)}
 }
 
 func (_c *Client_GetPullRequestIterations_Call) Run(run func(context1 context.Context, getPullRequestIterationsArgs git.GetPullRequestIterationsArgs)) *Client_GetPullRequestIterations_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetPullRequestIterationsArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetPullRequestIterationsArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetPullRequestIterationsArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -4229,15 +5054,26 @@ type Client_GetPullRequestLabel_Call struct {
 }
 
 // GetPullRequestLabel is a helper method to define mock.On call
-//   - context1
-//   - getPullRequestLabelArgs
+//   - context1 context.Context
+//   - getPullRequestLabelArgs git.GetPullRequestLabelArgs
 func (_e *Client_Expecter) GetPullRequestLabel(context1 interface{}, getPullRequestLabelArgs interface{}) *Client_GetPullRequestLabel_Call {
 	return &Client_GetPullRequestLabel_Call{Call: _e.mock.On("GetPullRequestLabel", context1, getPullRequestLabelArgs)}
 }
 
 func (_c *Client_GetPullRequestLabel_Call) Run(run func(context1 context.Context, getPullRequestLabelArgs git.GetPullRequestLabelArgs)) *Client_GetPullRequestLabel_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetPullRequestLabelArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetPullRequestLabelArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetPullRequestLabelArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -4286,15 +5122,26 @@ type Client_GetPullRequestLabels_Call struct {
 }
 
 // GetPullRequestLabels is a helper method to define mock.On call
-//   - context1
-//   - getPullRequestLabelsArgs
+//   - context1 context.Context
+//   - getPullRequestLabelsArgs git.GetPullRequestLabelsArgs
 func (_e *Client_Expecter) GetPullRequestLabels(context1 interface{}, getPullRequestLabelsArgs interface{}) *Client_GetPullRequestLabels_Call {
 	return &Client_GetPullRequestLabels_Call{Call: _e.mock.On("GetPullRequestLabels", context1, getPullRequestLabelsArgs)}
 }
 
 func (_c *Client_GetPullRequestLabels_Call) Run(run func(context1 context.Context, getPullRequestLabelsArgs git.GetPullRequestLabelsArgs)) *Client_GetPullRequestLabels_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetPullRequestLabelsArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetPullRequestLabelsArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetPullRequestLabelsArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -4343,15 +5190,26 @@ type Client_GetPullRequestProperties_Call struct {
 }
 
 // GetPullRequestProperties is a helper method to define mock.On call
-//   - context1
-//   - getPullRequestPropertiesArgs
+//   - context1 context.Context
+//   - getPullRequestPropertiesArgs git.GetPullRequestPropertiesArgs
 func (_e *Client_Expecter) GetPullRequestProperties(context1 interface{}, getPullRequestPropertiesArgs interface{}) *Client_GetPullRequestProperties_Call {
 	return &Client_GetPullRequestProperties_Call{Call: _e.mock.On("GetPullRequestProperties", context1, getPullRequestPropertiesArgs)}
 }
 
 func (_c *Client_GetPullRequestProperties_Call) Run(run func(context1 context.Context, getPullRequestPropertiesArgs git.GetPullRequestPropertiesArgs)) *Client_GetPullRequestProperties_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetPullRequestPropertiesArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetPullRequestPropertiesArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetPullRequestPropertiesArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -4400,15 +5258,26 @@ type Client_GetPullRequestQuery_Call struct {
 }
 
 // GetPullRequestQuery is a helper method to define mock.On call
-//   - context1
-//   - getPullRequestQueryArgs
+//   - context1 context.Context
+//   - getPullRequestQueryArgs git.GetPullRequestQueryArgs
 func (_e *Client_Expecter) GetPullRequestQuery(context1 interface{}, getPullRequestQueryArgs interface{}) *Client_GetPullRequestQuery_Call {
 	return &Client_GetPullRequestQuery_Call{Call: _e.mock.On("GetPullRequestQuery", context1, getPullRequestQueryArgs)}
 }
 
 func (_c *Client_GetPullRequestQuery_Call) Run(run func(context1 context.Context, getPullRequestQueryArgs git.GetPullRequestQueryArgs)) *Client_GetPullRequestQuery_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetPullRequestQueryArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetPullRequestQueryArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetPullRequestQueryArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -4457,15 +5326,26 @@ type Client_GetPullRequestReviewer_Call struct {
 }
 
 // GetPullRequestReviewer is a helper method to define mock.On call
-//   - context1
-//   - getPullRequestReviewerArgs
+//   - context1 context.Context
+//   - getPullRequestReviewerArgs git.GetPullRequestReviewerArgs
 func (_e *Client_Expecter) GetPullRequestReviewer(context1 interface{}, getPullRequestReviewerArgs interface{}) *Client_GetPullRequestReviewer_Call {
 	return &Client_GetPullRequestReviewer_Call{Call: _e.mock.On("GetPullRequestReviewer", context1, getPullRequestReviewerArgs)}
 }
 
 func (_c *Client_GetPullRequestReviewer_Call) Run(run func(context1 context.Context, getPullRequestReviewerArgs git.GetPullRequestReviewerArgs)) *Client_GetPullRequestReviewer_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetPullRequestReviewerArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetPullRequestReviewerArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetPullRequestReviewerArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -4514,15 +5394,26 @@ type Client_GetPullRequestReviewers_Call struct {
 }
 
 // GetPullRequestReviewers is a helper method to define mock.On call
-//   - context1
-//   - getPullRequestReviewersArgs
+//   - context1 context.Context
+//   - getPullRequestReviewersArgs git.GetPullRequestReviewersArgs
 func (_e *Client_Expecter) GetPullRequestReviewers(context1 interface{}, getPullRequestReviewersArgs interface{}) *Client_GetPullRequestReviewers_Call {
 	return &Client_GetPullRequestReviewers_Call{Call: _e.mock.On("GetPullRequestReviewers", context1, getPullRequestReviewersArgs)}
 }
 
 func (_c *Client_GetPullRequestReviewers_Call) Run(run func(context1 context.Context, getPullRequestReviewersArgs git.GetPullRequestReviewersArgs)) *Client_GetPullRequestReviewers_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetPullRequestReviewersArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetPullRequestReviewersArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetPullRequestReviewersArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -4571,15 +5462,26 @@ type Client_GetPullRequestStatus_Call struct {
 }
 
 // GetPullRequestStatus is a helper method to define mock.On call
-//   - context1
-//   - getPullRequestStatusArgs
+//   - context1 context.Context
+//   - getPullRequestStatusArgs git.GetPullRequestStatusArgs
 func (_e *Client_Expecter) GetPullRequestStatus(context1 interface{}, getPullRequestStatusArgs interface{}) *Client_GetPullRequestStatus_Call {
 	return &Client_GetPullRequestStatus_Call{Call: _e.mock.On("GetPullRequestStatus", context1, getPullRequestStatusArgs)}
 }
 
 func (_c *Client_GetPullRequestStatus_Call) Run(run func(context1 context.Context, getPullRequestStatusArgs git.GetPullRequestStatusArgs)) *Client_GetPullRequestStatus_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetPullRequestStatusArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetPullRequestStatusArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetPullRequestStatusArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -4628,15 +5530,26 @@ type Client_GetPullRequestStatuses_Call struct {
 }
 
 // GetPullRequestStatuses is a helper method to define mock.On call
-//   - context1
-//   - getPullRequestStatusesArgs
+//   - context1 context.Context
+//   - getPullRequestStatusesArgs git.GetPullRequestStatusesArgs
 func (_e *Client_Expecter) GetPullRequestStatuses(context1 interface{}, getPullRequestStatusesArgs interface{}) *Client_GetPullRequestStatuses_Call {
 	return &Client_GetPullRequestStatuses_Call{Call: _e.mock.On("GetPullRequestStatuses", context1, getPullRequestStatusesArgs)}
 }
 
 func (_c *Client_GetPullRequestStatuses_Call) Run(run func(context1 context.Context, getPullRequestStatusesArgs git.GetPullRequestStatusesArgs)) *Client_GetPullRequestStatuses_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetPullRequestStatusesArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetPullRequestStatusesArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetPullRequestStatusesArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -4685,15 +5598,26 @@ type Client_GetPullRequestThread_Call struct {
 }
 
 // GetPullRequestThread is a helper method to define mock.On call
-//   - context1
-//   - getPullRequestThreadArgs
+//   - context1 context.Context
+//   - getPullRequestThreadArgs git.GetPullRequestThreadArgs
 func (_e *Client_Expecter) GetPullRequestThread(context1 interface{}, getPullRequestThreadArgs interface{}) *Client_GetPullRequestThread_Call {
 	return &Client_GetPullRequestThread_Call{Call: _e.mock.On("GetPullRequestThread", context1, getPullRequestThreadArgs)}
 }
 
 func (_c *Client_GetPullRequestThread_Call) Run(run func(context1 context.Context, getPullRequestThreadArgs git.GetPullRequestThreadArgs)) *Client_GetPullRequestThread_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetPullRequestThreadArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetPullRequestThreadArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetPullRequestThreadArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -4742,15 +5666,26 @@ type Client_GetPullRequestWorkItemRefs_Call struct {
 }
 
 // GetPullRequestWorkItemRefs is a helper method to define mock.On call
-//   - context1
-//   - getPullRequestWorkItemRefsArgs
+//   - context1 context.Context
+//   - getPullRequestWorkItemRefsArgs git.GetPullRequestWorkItemRefsArgs
 func (_e *Client_Expecter) GetPullRequestWorkItemRefs(context1 interface{}, getPullRequestWorkItemRefsArgs interface{}) *Client_GetPullRequestWorkItemRefs_Call {
 	return &Client_GetPullRequestWorkItemRefs_Call{Call: _e.mock.On("GetPullRequestWorkItemRefs", context1, getPullRequestWorkItemRefsArgs)}
 }
 
 func (_c *Client_GetPullRequestWorkItemRefs_Call) Run(run func(context1 context.Context, getPullRequestWorkItemRefsArgs git.GetPullRequestWorkItemRefsArgs)) *Client_GetPullRequestWorkItemRefs_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetPullRequestWorkItemRefsArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetPullRequestWorkItemRefsArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetPullRequestWorkItemRefsArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -4799,15 +5734,26 @@ type Client_GetPullRequests_Call struct {
 }
 
 // GetPullRequests is a helper method to define mock.On call
-//   - context1
-//   - getPullRequestsArgs
+//   - context1 context.Context
+//   - getPullRequestsArgs git.GetPullRequestsArgs
 func (_e *Client_Expecter) GetPullRequests(context1 interface{}, getPullRequestsArgs interface{}) *Client_GetPullRequests_Call {
 	return &Client_GetPullRequests_Call{Call: _e.mock.On("GetPullRequests", context1, getPullRequestsArgs)}
 }
 
 func (_c *Client_GetPullRequests_Call) Run(run func(context1 context.Context, getPullRequestsArgs git.GetPullRequestsArgs)) *Client_GetPullRequests_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetPullRequestsArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetPullRequestsArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetPullRequestsArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -4856,15 +5802,26 @@ type Client_GetPullRequestsByProject_Call struct {
 }
 
 // GetPullRequestsByProject is a helper method to define mock.On call
-//   - context1
-//   - getPullRequestsByProjectArgs
+//   - context1 context.Context
+//   - getPullRequestsByProjectArgs git.GetPullRequestsByProjectArgs
 func (_e *Client_Expecter) GetPullRequestsByProject(context1 interface{}, getPullRequestsByProjectArgs interface{}) *Client_GetPullRequestsByProject_Call {
 	return &Client_GetPullRequestsByProject_Call{Call: _e.mock.On("GetPullRequestsByProject", context1, getPullRequestsByProjectArgs)}
 }
 
 func (_c *Client_GetPullRequestsByProject_Call) Run(run func(context1 context.Context, getPullRequestsByProjectArgs git.GetPullRequestsByProjectArgs)) *Client_GetPullRequestsByProject_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetPullRequestsByProjectArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetPullRequestsByProjectArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetPullRequestsByProjectArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -4913,15 +5870,26 @@ type Client_GetPush_Call struct {
 }
 
 // GetPush is a helper method to define mock.On call
-//   - context1
-//   - getPushArgs
+//   - context1 context.Context
+//   - getPushArgs git.GetPushArgs
 func (_e *Client_Expecter) GetPush(context1 interface{}, getPushArgs interface{}) *Client_GetPush_Call {
 	return &Client_GetPush_Call{Call: _e.mock.On("GetPush", context1, getPushArgs)}
 }
 
 func (_c *Client_GetPush_Call) Run(run func(context1 context.Context, getPushArgs git.GetPushArgs)) *Client_GetPush_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetPushArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetPushArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetPushArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -4970,15 +5938,26 @@ type Client_GetPushCommits_Call struct {
 }
 
 // GetPushCommits is a helper method to define mock.On call
-//   - context1
-//   - getPushCommitsArgs
+//   - context1 context.Context
+//   - getPushCommitsArgs git.GetPushCommitsArgs
 func (_e *Client_Expecter) GetPushCommits(context1 interface{}, getPushCommitsArgs interface{}) *Client_GetPushCommits_Call {
 	return &Client_GetPushCommits_Call{Call: _e.mock.On("GetPushCommits", context1, getPushCommitsArgs)}
 }
 
 func (_c *Client_GetPushCommits_Call) Run(run func(context1 context.Context, getPushCommitsArgs git.GetPushCommitsArgs)) *Client_GetPushCommits_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetPushCommitsArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetPushCommitsArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetPushCommitsArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -5027,15 +6006,26 @@ type Client_GetPushes_Call struct {
 }
 
 // GetPushes is a helper method to define mock.On call
-//   - context1
-//   - getPushesArgs
+//   - context1 context.Context
+//   - getPushesArgs git.GetPushesArgs
 func (_e *Client_Expecter) GetPushes(context1 interface{}, getPushesArgs interface{}) *Client_GetPushes_Call {
 	return &Client_GetPushes_Call{Call: _e.mock.On("GetPushes", context1, getPushesArgs)}
 }
 
 func (_c *Client_GetPushes_Call) Run(run func(context1 context.Context, getPushesArgs git.GetPushesArgs)) *Client_GetPushes_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetPushesArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetPushesArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetPushesArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -5084,15 +6074,26 @@ type Client_GetRecycleBinRepositories_Call struct {
 }
 
 // GetRecycleBinRepositories is a helper method to define mock.On call
-//   - context1
-//   - getRecycleBinRepositoriesArgs
+//   - context1 context.Context
+//   - getRecycleBinRepositoriesArgs git.GetRecycleBinRepositoriesArgs
 func (_e *Client_Expecter) GetRecycleBinRepositories(context1 interface{}, getRecycleBinRepositoriesArgs interface{}) *Client_GetRecycleBinRepositories_Call {
 	return &Client_GetRecycleBinRepositories_Call{Call: _e.mock.On("GetRecycleBinRepositories", context1, getRecycleBinRepositoriesArgs)}
 }
 
 func (_c *Client_GetRecycleBinRepositories_Call) Run(run func(context1 context.Context, getRecycleBinRepositoriesArgs git.GetRecycleBinRepositoriesArgs)) *Client_GetRecycleBinRepositories_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetRecycleBinRepositoriesArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetRecycleBinRepositoriesArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetRecycleBinRepositoriesArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -5141,15 +6142,26 @@ type Client_GetRefFavorite_Call struct {
 }
 
 // GetRefFavorite is a helper method to define mock.On call
-//   - context1
-//   - getRefFavoriteArgs
+//   - context1 context.Context
+//   - getRefFavoriteArgs git.GetRefFavoriteArgs
 func (_e *Client_Expecter) GetRefFavorite(context1 interface{}, getRefFavoriteArgs interface{}) *Client_GetRefFavorite_Call {
 	return &Client_GetRefFavorite_Call{Call: _e.mock.On("GetRefFavorite", context1, getRefFavoriteArgs)}
 }
 
 func (_c *Client_GetRefFavorite_Call) Run(run func(context1 context.Context, getRefFavoriteArgs git.GetRefFavoriteArgs)) *Client_GetRefFavorite_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetRefFavoriteArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetRefFavoriteArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetRefFavoriteArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -5198,15 +6210,26 @@ type Client_GetRefFavorites_Call struct {
 }
 
 // GetRefFavorites is a helper method to define mock.On call
-//   - context1
-//   - getRefFavoritesArgs
+//   - context1 context.Context
+//   - getRefFavoritesArgs git.GetRefFavoritesArgs
 func (_e *Client_Expecter) GetRefFavorites(context1 interface{}, getRefFavoritesArgs interface{}) *Client_GetRefFavorites_Call {
 	return &Client_GetRefFavorites_Call{Call: _e.mock.On("GetRefFavorites", context1, getRefFavoritesArgs)}
 }
 
 func (_c *Client_GetRefFavorites_Call) Run(run func(context1 context.Context, getRefFavoritesArgs git.GetRefFavoritesArgs)) *Client_GetRefFavorites_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetRefFavoritesArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetRefFavoritesArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetRefFavoritesArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -5255,15 +6278,26 @@ type Client_GetRefs_Call struct {
 }
 
 // GetRefs is a helper method to define mock.On call
-//   - context1
-//   - getRefsArgs
+//   - context1 context.Context
+//   - getRefsArgs git.GetRefsArgs
 func (_e *Client_Expecter) GetRefs(context1 interface{}, getRefsArgs interface{}) *Client_GetRefs_Call {
 	return &Client_GetRefs_Call{Call: _e.mock.On("GetRefs", context1, getRefsArgs)}
 }
 
 func (_c *Client_GetRefs_Call) Run(run func(context1 context.Context, getRefsArgs git.GetRefsArgs)) *Client_GetRefs_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetRefsArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetRefsArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetRefsArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -5312,15 +6346,26 @@ type Client_GetRepositories_Call struct {
 }
 
 // GetRepositories is a helper method to define mock.On call
-//   - context1
-//   - getRepositoriesArgs
+//   - context1 context.Context
+//   - getRepositoriesArgs git.GetRepositoriesArgs
 func (_e *Client_Expecter) GetRepositories(context1 interface{}, getRepositoriesArgs interface{}) *Client_GetRepositories_Call {
 	return &Client_GetRepositories_Call{Call: _e.mock.On("GetRepositories", context1, getRepositoriesArgs)}
 }
 
 func (_c *Client_GetRepositories_Call) Run(run func(context1 context.Context, getRepositoriesArgs git.GetRepositoriesArgs)) *Client_GetRepositories_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetRepositoriesArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetRepositoriesArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetRepositoriesArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -5369,15 +6414,26 @@ type Client_GetRepository_Call struct {
 }
 
 // GetRepository is a helper method to define mock.On call
-//   - context1
-//   - getRepositoryArgs
+//   - context1 context.Context
+//   - getRepositoryArgs git.GetRepositoryArgs
 func (_e *Client_Expecter) GetRepository(context1 interface{}, getRepositoryArgs interface{}) *Client_GetRepository_Call {
 	return &Client_GetRepository_Call{Call: _e.mock.On("GetRepository", context1, getRepositoryArgs)}
 }
 
 func (_c *Client_GetRepository_Call) Run(run func(context1 context.Context, getRepositoryArgs git.GetRepositoryArgs)) *Client_GetRepository_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetRepositoryArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetRepositoryArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetRepositoryArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -5426,15 +6482,26 @@ type Client_GetRepositoryWithParent_Call struct {
 }
 
 // GetRepositoryWithParent is a helper method to define mock.On call
-//   - context1
-//   - getRepositoryWithParentArgs
+//   - context1 context.Context
+//   - getRepositoryWithParentArgs git.GetRepositoryWithParentArgs
 func (_e *Client_Expecter) GetRepositoryWithParent(context1 interface{}, getRepositoryWithParentArgs interface{}) *Client_GetRepositoryWithParent_Call {
 	return &Client_GetRepositoryWithParent_Call{Call: _e.mock.On("GetRepositoryWithParent", context1, getRepositoryWithParentArgs)}
 }
 
 func (_c *Client_GetRepositoryWithParent_Call) Run(run func(context1 context.Context, getRepositoryWithParentArgs git.GetRepositoryWithParentArgs)) *Client_GetRepositoryWithParent_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetRepositoryWithParentArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetRepositoryWithParentArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetRepositoryWithParentArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -5483,15 +6550,26 @@ type Client_GetRevert_Call struct {
 }
 
 // GetRevert is a helper method to define mock.On call
-//   - context1
-//   - getRevertArgs
+//   - context1 context.Context
+//   - getRevertArgs git.GetRevertArgs
 func (_e *Client_Expecter) GetRevert(context1 interface{}, getRevertArgs interface{}) *Client_GetRevert_Call {
 	return &Client_GetRevert_Call{Call: _e.mock.On("GetRevert", context1, getRevertArgs)}
 }
 
 func (_c *Client_GetRevert_Call) Run(run func(context1 context.Context, getRevertArgs git.GetRevertArgs)) *Client_GetRevert_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetRevertArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetRevertArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetRevertArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -5540,15 +6618,26 @@ type Client_GetRevertForRefName_Call struct {
 }
 
 // GetRevertForRefName is a helper method to define mock.On call
-//   - context1
-//   - getRevertForRefNameArgs
+//   - context1 context.Context
+//   - getRevertForRefNameArgs git.GetRevertForRefNameArgs
 func (_e *Client_Expecter) GetRevertForRefName(context1 interface{}, getRevertForRefNameArgs interface{}) *Client_GetRevertForRefName_Call {
 	return &Client_GetRevertForRefName_Call{Call: _e.mock.On("GetRevertForRefName", context1, getRevertForRefNameArgs)}
 }
 
 func (_c *Client_GetRevertForRefName_Call) Run(run func(context1 context.Context, getRevertForRefNameArgs git.GetRevertForRefNameArgs)) *Client_GetRevertForRefName_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetRevertForRefNameArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetRevertForRefNameArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetRevertForRefNameArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -5597,15 +6686,26 @@ type Client_GetStatuses_Call struct {
 }
 
 // GetStatuses is a helper method to define mock.On call
-//   - context1
-//   - getStatusesArgs
+//   - context1 context.Context
+//   - getStatusesArgs git.GetStatusesArgs
 func (_e *Client_Expecter) GetStatuses(context1 interface{}, getStatusesArgs interface{}) *Client_GetStatuses_Call {
 	return &Client_GetStatuses_Call{Call: _e.mock.On("GetStatuses", context1, getStatusesArgs)}
 }
 
 func (_c *Client_GetStatuses_Call) Run(run func(context1 context.Context, getStatusesArgs git.GetStatusesArgs)) *Client_GetStatuses_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetStatusesArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetStatusesArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetStatusesArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -5654,15 +6754,26 @@ type Client_GetSuggestions_Call struct {
 }
 
 // GetSuggestions is a helper method to define mock.On call
-//   - context1
-//   - getSuggestionsArgs
+//   - context1 context.Context
+//   - getSuggestionsArgs git.GetSuggestionsArgs
 func (_e *Client_Expecter) GetSuggestions(context1 interface{}, getSuggestionsArgs interface{}) *Client_GetSuggestions_Call {
 	return &Client_GetSuggestions_Call{Call: _e.mock.On("GetSuggestions", context1, getSuggestionsArgs)}
 }
 
 func (_c *Client_GetSuggestions_Call) Run(run func(context1 context.Context, getSuggestionsArgs git.GetSuggestionsArgs)) *Client_GetSuggestions_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetSuggestionsArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetSuggestionsArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetSuggestionsArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -5711,15 +6822,26 @@ type Client_GetThreads_Call struct {
 }
 
 // GetThreads is a helper method to define mock.On call
-//   - context1
-//   - getThreadsArgs
+//   - context1 context.Context
+//   - getThreadsArgs git.GetThreadsArgs
 func (_e *Client_Expecter) GetThreads(context1 interface{}, getThreadsArgs interface{}) *Client_GetThreads_Call {
 	return &Client_GetThreads_Call{Call: _e.mock.On("GetThreads", context1, getThreadsArgs)}
 }
 
 func (_c *Client_GetThreads_Call) Run(run func(context1 context.Context, getThreadsArgs git.GetThreadsArgs)) *Client_GetThreads_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetThreadsArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetThreadsArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetThreadsArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -5768,15 +6890,26 @@ type Client_GetTree_Call struct {
 }
 
 // GetTree is a helper method to define mock.On call
-//   - context1
-//   - getTreeArgs
+//   - context1 context.Context
+//   - getTreeArgs git.GetTreeArgs
 func (_e *Client_Expecter) GetTree(context1 interface{}, getTreeArgs interface{}) *Client_GetTree_Call {
 	return &Client_GetTree_Call{Call: _e.mock.On("GetTree", context1, getTreeArgs)}
 }
 
 func (_c *Client_GetTree_Call) Run(run func(context1 context.Context, getTreeArgs git.GetTreeArgs)) *Client_GetTree_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetTreeArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetTreeArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetTreeArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -5825,15 +6958,26 @@ type Client_GetTreeZip_Call struct {
 }
 
 // GetTreeZip is a helper method to define mock.On call
-//   - context1
-//   - getTreeZipArgs
+//   - context1 context.Context
+//   - getTreeZipArgs git.GetTreeZipArgs
 func (_e *Client_Expecter) GetTreeZip(context1 interface{}, getTreeZipArgs interface{}) *Client_GetTreeZip_Call {
 	return &Client_GetTreeZip_Call{Call: _e.mock.On("GetTreeZip", context1, getTreeZipArgs)}
 }
 
 func (_c *Client_GetTreeZip_Call) Run(run func(context1 context.Context, getTreeZipArgs git.GetTreeZipArgs)) *Client_GetTreeZip_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.GetTreeZipArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.GetTreeZipArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.GetTreeZipArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -5882,15 +7026,26 @@ type Client_QueryImportRequests_Call struct {
 }
 
 // QueryImportRequests is a helper method to define mock.On call
-//   - context1
-//   - queryImportRequestsArgs
+//   - context1 context.Context
+//   - queryImportRequestsArgs git.QueryImportRequestsArgs
 func (_e *Client_Expecter) QueryImportRequests(context1 interface{}, queryImportRequestsArgs interface{}) *Client_QueryImportRequests_Call {
 	return &Client_QueryImportRequests_Call{Call: _e.mock.On("QueryImportRequests", context1, queryImportRequestsArgs)}
 }
 
 func (_c *Client_QueryImportRequests_Call) Run(run func(context1 context.Context, queryImportRequestsArgs git.QueryImportRequestsArgs)) *Client_QueryImportRequests_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.QueryImportRequestsArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.QueryImportRequestsArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.QueryImportRequestsArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -5939,15 +7094,26 @@ type Client_RestoreRepositoryFromRecycleBin_Call struct {
 }
 
 // RestoreRepositoryFromRecycleBin is a helper method to define mock.On call
-//   - context1
-//   - restoreRepositoryFromRecycleBinArgs
+//   - context1 context.Context
+//   - restoreRepositoryFromRecycleBinArgs git.RestoreRepositoryFromRecycleBinArgs
 func (_e *Client_Expecter) RestoreRepositoryFromRecycleBin(context1 interface{}, restoreRepositoryFromRecycleBinArgs interface{}) *Client_RestoreRepositoryFromRecycleBin_Call {
 	return &Client_RestoreRepositoryFromRecycleBin_Call{Call: _e.mock.On("RestoreRepositoryFromRecycleBin", context1, restoreRepositoryFromRecycleBinArgs)}
 }
 
 func (_c *Client_RestoreRepositoryFromRecycleBin_Call) Run(run func(context1 context.Context, restoreRepositoryFromRecycleBinArgs git.RestoreRepositoryFromRecycleBinArgs)) *Client_RestoreRepositoryFromRecycleBin_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.RestoreRepositoryFromRecycleBinArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.RestoreRepositoryFromRecycleBinArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.RestoreRepositoryFromRecycleBinArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -5985,15 +7151,26 @@ type Client_SharePullRequest_Call struct {
 }
 
 // SharePullRequest is a helper method to define mock.On call
-//   - context1
-//   - sharePullRequestArgs
+//   - context1 context.Context
+//   - sharePullRequestArgs git.SharePullRequestArgs
 func (_e *Client_Expecter) SharePullRequest(context1 interface{}, sharePullRequestArgs interface{}) *Client_SharePullRequest_Call {
 	return &Client_SharePullRequest_Call{Call: _e.mock.On("SharePullRequest", context1, sharePullRequestArgs)}
 }
 
 func (_c *Client_SharePullRequest_Call) Run(run func(context1 context.Context, sharePullRequestArgs git.SharePullRequestArgs)) *Client_SharePullRequest_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.SharePullRequestArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.SharePullRequestArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.SharePullRequestArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -6042,15 +7219,26 @@ type Client_UpdateComment_Call struct {
 }
 
 // UpdateComment is a helper method to define mock.On call
-//   - context1
-//   - updateCommentArgs
+//   - context1 context.Context
+//   - updateCommentArgs git.UpdateCommentArgs
 func (_e *Client_Expecter) UpdateComment(context1 interface{}, updateCommentArgs interface{}) *Client_UpdateComment_Call {
 	return &Client_UpdateComment_Call{Call: _e.mock.On("UpdateComment", context1, updateCommentArgs)}
 }
 
 func (_c *Client_UpdateComment_Call) Run(run func(context1 context.Context, updateCommentArgs git.UpdateCommentArgs)) *Client_UpdateComment_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.UpdateCommentArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.UpdateCommentArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.UpdateCommentArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -6099,15 +7287,26 @@ type Client_UpdateImportRequest_Call struct {
 }
 
 // UpdateImportRequest is a helper method to define mock.On call
-//   - context1
-//   - updateImportRequestArgs
+//   - context1 context.Context
+//   - updateImportRequestArgs git.UpdateImportRequestArgs
 func (_e *Client_Expecter) UpdateImportRequest(context1 interface{}, updateImportRequestArgs interface{}) *Client_UpdateImportRequest_Call {
 	return &Client_UpdateImportRequest_Call{Call: _e.mock.On("UpdateImportRequest", context1, updateImportRequestArgs)}
 }
 
 func (_c *Client_UpdateImportRequest_Call) Run(run func(context1 context.Context, updateImportRequestArgs git.UpdateImportRequestArgs)) *Client_UpdateImportRequest_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.UpdateImportRequestArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.UpdateImportRequestArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.UpdateImportRequestArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -6156,15 +7355,26 @@ type Client_UpdatePullRequest_Call struct {
 }
 
 // UpdatePullRequest is a helper method to define mock.On call
-//   - context1
-//   - updatePullRequestArgs
+//   - context1 context.Context
+//   - updatePullRequestArgs git.UpdatePullRequestArgs
 func (_e *Client_Expecter) UpdatePullRequest(context1 interface{}, updatePullRequestArgs interface{}) *Client_UpdatePullRequest_Call {
 	return &Client_UpdatePullRequest_Call{Call: _e.mock.On("UpdatePullRequest", context1, updatePullRequestArgs)}
 }
 
 func (_c *Client_UpdatePullRequest_Call) Run(run func(context1 context.Context, updatePullRequestArgs git.UpdatePullRequestArgs)) *Client_UpdatePullRequest_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.UpdatePullRequestArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.UpdatePullRequestArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.UpdatePullRequestArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -6202,15 +7412,26 @@ type Client_UpdatePullRequestIterationStatuses_Call struct {
 }
 
 // UpdatePullRequestIterationStatuses is a helper method to define mock.On call
-//   - context1
-//   - updatePullRequestIterationStatusesArgs
+//   - context1 context.Context
+//   - updatePullRequestIterationStatusesArgs git.UpdatePullRequestIterationStatusesArgs
 func (_e *Client_Expecter) UpdatePullRequestIterationStatuses(context1 interface{}, updatePullRequestIterationStatusesArgs interface{}) *Client_UpdatePullRequestIterationStatuses_Call {
 	return &Client_UpdatePullRequestIterationStatuses_Call{Call: _e.mock.On("UpdatePullRequestIterationStatuses", context1, updatePullRequestIterationStatusesArgs)}
 }
 
 func (_c *Client_UpdatePullRequestIterationStatuses_Call) Run(run func(context1 context.Context, updatePullRequestIterationStatusesArgs git.UpdatePullRequestIterationStatusesArgs)) *Client_UpdatePullRequestIterationStatuses_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.UpdatePullRequestIterationStatusesArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.UpdatePullRequestIterationStatusesArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.UpdatePullRequestIterationStatusesArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -6259,15 +7480,26 @@ type Client_UpdatePullRequestProperties_Call struct {
 }
 
 // UpdatePullRequestProperties is a helper method to define mock.On call
-//   - context1
-//   - updatePullRequestPropertiesArgs
+//   - context1 context.Context
+//   - updatePullRequestPropertiesArgs git.UpdatePullRequestPropertiesArgs
 func (_e *Client_Expecter) UpdatePullRequestProperties(context1 interface{}, updatePullRequestPropertiesArgs interface{}) *Client_UpdatePullRequestProperties_Call {
 	return &Client_UpdatePullRequestProperties_Call{Call: _e.mock.On("UpdatePullRequestProperties", context1, updatePullRequestPropertiesArgs)}
 }
 
 func (_c *Client_UpdatePullRequestProperties_Call) Run(run func(context1 context.Context, updatePullRequestPropertiesArgs git.UpdatePullRequestPropertiesArgs)) *Client_UpdatePullRequestProperties_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.UpdatePullRequestPropertiesArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.UpdatePullRequestPropertiesArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.UpdatePullRequestPropertiesArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -6316,15 +7548,26 @@ type Client_UpdatePullRequestReviewer_Call struct {
 }
 
 // UpdatePullRequestReviewer is a helper method to define mock.On call
-//   - context1
-//   - updatePullRequestReviewerArgs
+//   - context1 context.Context
+//   - updatePullRequestReviewerArgs git.UpdatePullRequestReviewerArgs
 func (_e *Client_Expecter) UpdatePullRequestReviewer(context1 interface{}, updatePullRequestReviewerArgs interface{}) *Client_UpdatePullRequestReviewer_Call {
 	return &Client_UpdatePullRequestReviewer_Call{Call: _e.mock.On("UpdatePullRequestReviewer", context1, updatePullRequestReviewerArgs)}
 }
 
 func (_c *Client_UpdatePullRequestReviewer_Call) Run(run func(context1 context.Context, updatePullRequestReviewerArgs git.UpdatePullRequestReviewerArgs)) *Client_UpdatePullRequestReviewer_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.UpdatePullRequestReviewerArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.UpdatePullRequestReviewerArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.UpdatePullRequestReviewerArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -6362,15 +7605,26 @@ type Client_UpdatePullRequestReviewers_Call struct {
 }
 
 // UpdatePullRequestReviewers is a helper method to define mock.On call
-//   - context1
-//   - updatePullRequestReviewersArgs
+//   - context1 context.Context
+//   - updatePullRequestReviewersArgs git.UpdatePullRequestReviewersArgs
 func (_e *Client_Expecter) UpdatePullRequestReviewers(context1 interface{}, updatePullRequestReviewersArgs interface{}) *Client_UpdatePullRequestReviewers_Call {
 	return &Client_UpdatePullRequestReviewers_Call{Call: _e.mock.On("UpdatePullRequestReviewers", context1, updatePullRequestReviewersArgs)}
 }
 
 func (_c *Client_UpdatePullRequestReviewers_Call) Run(run func(context1 context.Context, updatePullRequestReviewersArgs git.UpdatePullRequestReviewersArgs)) *Client_UpdatePullRequestReviewers_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.UpdatePullRequestReviewersArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.UpdatePullRequestReviewersArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.UpdatePullRequestReviewersArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -6408,15 +7662,26 @@ type Client_UpdatePullRequestStatuses_Call struct {
 }
 
 // UpdatePullRequestStatuses is a helper method to define mock.On call
-//   - context1
-//   - updatePullRequestStatusesArgs
+//   - context1 context.Context
+//   - updatePullRequestStatusesArgs git.UpdatePullRequestStatusesArgs
 func (_e *Client_Expecter) UpdatePullRequestStatuses(context1 interface{}, updatePullRequestStatusesArgs interface{}) *Client_UpdatePullRequestStatuses_Call {
 	return &Client_UpdatePullRequestStatuses_Call{Call: _e.mock.On("UpdatePullRequestStatuses", context1, updatePullRequestStatusesArgs)}
 }
 
 func (_c *Client_UpdatePullRequestStatuses_Call) Run(run func(context1 context.Context, updatePullRequestStatusesArgs git.UpdatePullRequestStatusesArgs)) *Client_UpdatePullRequestStatuses_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.UpdatePullRequestStatusesArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.UpdatePullRequestStatusesArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.UpdatePullRequestStatusesArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -6465,15 +7730,26 @@ type Client_UpdateRef_Call struct {
 }
 
 // UpdateRef is a helper method to define mock.On call
-//   - context1
-//   - updateRefArgs
+//   - context1 context.Context
+//   - updateRefArgs git.UpdateRefArgs
 func (_e *Client_Expecter) UpdateRef(context1 interface{}, updateRefArgs interface{}) *Client_UpdateRef_Call {
 	return &Client_UpdateRef_Call{Call: _e.mock.On("UpdateRef", context1, updateRefArgs)}
 }
 
 func (_c *Client_UpdateRef_Call) Run(run func(context1 context.Context, updateRefArgs git.UpdateRefArgs)) *Client_UpdateRef_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.UpdateRefArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.UpdateRefArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.UpdateRefArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -6522,15 +7798,26 @@ type Client_UpdateRefs_Call struct {
 }
 
 // UpdateRefs is a helper method to define mock.On call
-//   - context1
-//   - updateRefsArgs
+//   - context1 context.Context
+//   - updateRefsArgs git.UpdateRefsArgs
 func (_e *Client_Expecter) UpdateRefs(context1 interface{}, updateRefsArgs interface{}) *Client_UpdateRefs_Call {
 	return &Client_UpdateRefs_Call{Call: _e.mock.On("UpdateRefs", context1, updateRefsArgs)}
 }
 
 func (_c *Client_UpdateRefs_Call) Run(run func(context1 context.Context, updateRefsArgs git.UpdateRefsArgs)) *Client_UpdateRefs_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.UpdateRefsArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.UpdateRefsArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.UpdateRefsArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -6579,15 +7866,26 @@ type Client_UpdateRepository_Call struct {
 }
 
 // UpdateRepository is a helper method to define mock.On call
-//   - context1
-//   - updateRepositoryArgs
+//   - context1 context.Context
+//   - updateRepositoryArgs git.UpdateRepositoryArgs
 func (_e *Client_Expecter) UpdateRepository(context1 interface{}, updateRepositoryArgs interface{}) *Client_UpdateRepository_Call {
 	return &Client_UpdateRepository_Call{Call: _e.mock.On("UpdateRepository", context1, updateRepositoryArgs)}
 }
 
 func (_c *Client_UpdateRepository_Call) Run(run func(context1 context.Context, updateRepositoryArgs git.UpdateRepositoryArgs)) *Client_UpdateRepository_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.UpdateRepositoryArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.UpdateRepositoryArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.UpdateRepositoryArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -6636,15 +7934,26 @@ type Client_UpdateThread_Call struct {
 }
 
 // UpdateThread is a helper method to define mock.On call
-//   - context1
-//   - updateThreadArgs
+//   - context1 context.Context
+//   - updateThreadArgs git.UpdateThreadArgs
 func (_e *Client_Expecter) UpdateThread(context1 interface{}, updateThreadArgs interface{}) *Client_UpdateThread_Call {
 	return &Client_UpdateThread_Call{Call: _e.mock.On("UpdateThread", context1, updateThreadArgs)}
 }
 
 func (_c *Client_UpdateThread_Call) Run(run func(context1 context.Context, updateThreadArgs git.UpdateThreadArgs)) *Client_UpdateThread_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(git.UpdateThreadArgs))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 git.UpdateThreadArgs
+		if args[1] != nil {
+			arg1 = args[1].(git.UpdateThreadArgs)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }

--- a/applicationset/utils/mocks/Renderer.go
+++ b/applicationset/utils/mocks/Renderer.go
@@ -70,18 +70,44 @@ type Renderer_RenderTemplateParams_Call struct {
 }
 
 // RenderTemplateParams is a helper method to define mock.On call
-//   - tmpl
-//   - syncPolicy
-//   - params
-//   - useGoTemplate
-//   - goTemplateOptions
+//   - tmpl *v1alpha1.Application
+//   - syncPolicy *v1alpha1.ApplicationSetSyncPolicy
+//   - params map[string]any
+//   - useGoTemplate bool
+//   - goTemplateOptions []string
 func (_e *Renderer_Expecter) RenderTemplateParams(tmpl interface{}, syncPolicy interface{}, params interface{}, useGoTemplate interface{}, goTemplateOptions interface{}) *Renderer_RenderTemplateParams_Call {
 	return &Renderer_RenderTemplateParams_Call{Call: _e.mock.On("RenderTemplateParams", tmpl, syncPolicy, params, useGoTemplate, goTemplateOptions)}
 }
 
 func (_c *Renderer_RenderTemplateParams_Call) Run(run func(tmpl *v1alpha1.Application, syncPolicy *v1alpha1.ApplicationSetSyncPolicy, params map[string]any, useGoTemplate bool, goTemplateOptions []string)) *Renderer_RenderTemplateParams_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*v1alpha1.Application), args[1].(*v1alpha1.ApplicationSetSyncPolicy), args[2].(map[string]any), args[3].(bool), args[4].([]string))
+		var arg0 *v1alpha1.Application
+		if args[0] != nil {
+			arg0 = args[0].(*v1alpha1.Application)
+		}
+		var arg1 *v1alpha1.ApplicationSetSyncPolicy
+		if args[1] != nil {
+			arg1 = args[1].(*v1alpha1.ApplicationSetSyncPolicy)
+		}
+		var arg2 map[string]any
+		if args[2] != nil {
+			arg2 = args[2].(map[string]any)
+		}
+		var arg3 bool
+		if args[3] != nil {
+			arg3 = args[3].(bool)
+		}
+		var arg4 []string
+		if args[4] != nil {
+			arg4 = args[4].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+		)
 	})
 	return _c
 }
@@ -128,17 +154,38 @@ type Renderer_Replace_Call struct {
 }
 
 // Replace is a helper method to define mock.On call
-//   - tmpl
-//   - replaceMap
-//   - useGoTemplate
-//   - goTemplateOptions
+//   - tmpl string
+//   - replaceMap map[string]any
+//   - useGoTemplate bool
+//   - goTemplateOptions []string
 func (_e *Renderer_Expecter) Replace(tmpl interface{}, replaceMap interface{}, useGoTemplate interface{}, goTemplateOptions interface{}) *Renderer_Replace_Call {
 	return &Renderer_Replace_Call{Call: _e.mock.On("Replace", tmpl, replaceMap, useGoTemplate, goTemplateOptions)}
 }
 
 func (_c *Renderer_Replace_Call) Run(run func(tmpl string, replaceMap map[string]any, useGoTemplate bool, goTemplateOptions []string)) *Renderer_Replace_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(map[string]any), args[2].(bool), args[3].([]string))
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 map[string]any
+		if args[1] != nil {
+			arg1 = args[1].(map[string]any)
+		}
+		var arg2 bool
+		if args[2] != nil {
+			arg2 = args[2].(bool)
+		}
+		var arg3 []string
+		if args[3] != nil {
+			arg3 = args[3].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
 	})
 	return _c
 }

--- a/commitserver/apiclient/mocks/CommitServiceClient.go
+++ b/commitserver/apiclient/mocks/CommitServiceClient.go
@@ -81,9 +81,9 @@ type CommitServiceClient_CommitHydratedManifests_Call struct {
 }
 
 // CommitHydratedManifests is a helper method to define mock.On call
-//   - ctx
-//   - in
-//   - opts
+//   - ctx context.Context
+//   - in *apiclient.CommitHydratedManifestsRequest
+//   - opts ...grpc.CallOption
 func (_e *CommitServiceClient_Expecter) CommitHydratedManifests(ctx interface{}, in interface{}, opts ...interface{}) *CommitServiceClient_CommitHydratedManifests_Call {
 	return &CommitServiceClient_CommitHydratedManifests_Call{Call: _e.mock.On("CommitHydratedManifests",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -91,13 +91,27 @@ func (_e *CommitServiceClient_Expecter) CommitHydratedManifests(ctx interface{},
 
 func (_c *CommitServiceClient_CommitHydratedManifests_Call) Run(run func(ctx context.Context, in *apiclient.CommitHydratedManifestsRequest, opts ...grpc.CallOption)) *CommitServiceClient_CommitHydratedManifests_Call {
 	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *apiclient.CommitHydratedManifestsRequest
+		if args[1] != nil {
+			arg1 = args[1].(*apiclient.CommitHydratedManifestsRequest)
+		}
+		var arg2 []grpc.CallOption
 		variadicArgs := make([]grpc.CallOption, len(args)-2)
 		for i, a := range args[2:] {
 			if a != nil {
 				variadicArgs[i] = a.(grpc.CallOption)
 			}
 		}
-		run(args[0].(context.Context), args[1].(*apiclient.CommitHydratedManifestsRequest), variadicArgs...)
+		arg2 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2...,
+		)
 	})
 	return _c
 }

--- a/commitserver/commit/mocks/RepoClientFactory.go
+++ b/commitserver/commit/mocks/RepoClientFactory.go
@@ -71,15 +71,26 @@ type RepoClientFactory_NewClient_Call struct {
 }
 
 // NewClient is a helper method to define mock.On call
-//   - repo
-//   - rootPath
+//   - repo *v1alpha1.Repository
+//   - rootPath string
 func (_e *RepoClientFactory_Expecter) NewClient(repo interface{}, rootPath interface{}) *RepoClientFactory_NewClient_Call {
 	return &RepoClientFactory_NewClient_Call{Call: _e.mock.On("NewClient", repo, rootPath)}
 }
 
 func (_c *RepoClientFactory_NewClient_Call) Run(run func(repo *v1alpha1.Repository, rootPath string)) *RepoClientFactory_NewClient_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*v1alpha1.Repository), args[1].(string))
+		var arg0 *v1alpha1.Repository
+		if args[0] != nil {
+			arg0 = args[0].(*v1alpha1.Repository)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }

--- a/controller/cache/mocks/LiveStateCache.go
+++ b/controller/cache/mocks/LiveStateCache.go
@@ -77,14 +77,20 @@ type LiveStateCache_GetClusterCache_Call struct {
 }
 
 // GetClusterCache is a helper method to define mock.On call
-//   - server
+//   - server *v1alpha1.Cluster
 func (_e *LiveStateCache_Expecter) GetClusterCache(server interface{}) *LiveStateCache_GetClusterCache_Call {
 	return &LiveStateCache_GetClusterCache_Call{Call: _e.mock.On("GetClusterCache", server)}
 }
 
 func (_c *LiveStateCache_GetClusterCache_Call) Run(run func(server *v1alpha1.Cluster)) *LiveStateCache_GetClusterCache_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*v1alpha1.Cluster))
+		var arg0 *v1alpha1.Cluster
+		if args[0] != nil {
+			arg0 = args[0].(*v1alpha1.Cluster)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -179,16 +185,32 @@ type LiveStateCache_GetManagedLiveObjs_Call struct {
 }
 
 // GetManagedLiveObjs is a helper method to define mock.On call
-//   - destCluster
-//   - a
-//   - targetObjs
+//   - destCluster *v1alpha1.Cluster
+//   - a *v1alpha1.Application
+//   - targetObjs []*unstructured.Unstructured
 func (_e *LiveStateCache_Expecter) GetManagedLiveObjs(destCluster interface{}, a interface{}, targetObjs interface{}) *LiveStateCache_GetManagedLiveObjs_Call {
 	return &LiveStateCache_GetManagedLiveObjs_Call{Call: _e.mock.On("GetManagedLiveObjs", destCluster, a, targetObjs)}
 }
 
 func (_c *LiveStateCache_GetManagedLiveObjs_Call) Run(run func(destCluster *v1alpha1.Cluster, a *v1alpha1.Application, targetObjs []*unstructured.Unstructured)) *LiveStateCache_GetManagedLiveObjs_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*v1alpha1.Cluster), args[1].(*v1alpha1.Application), args[2].([]*unstructured.Unstructured))
+		var arg0 *v1alpha1.Cluster
+		if args[0] != nil {
+			arg0 = args[0].(*v1alpha1.Cluster)
+		}
+		var arg1 *v1alpha1.Application
+		if args[1] != nil {
+			arg1 = args[1].(*v1alpha1.Application)
+		}
+		var arg2 []*unstructured.Unstructured
+		if args[2] != nil {
+			arg2 = args[2].([]*unstructured.Unstructured)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
 	})
 	return _c
 }
@@ -237,15 +259,26 @@ type LiveStateCache_GetNamespaceTopLevelResources_Call struct {
 }
 
 // GetNamespaceTopLevelResources is a helper method to define mock.On call
-//   - server
-//   - namespace
+//   - server *v1alpha1.Cluster
+//   - namespace string
 func (_e *LiveStateCache_Expecter) GetNamespaceTopLevelResources(server interface{}, namespace interface{}) *LiveStateCache_GetNamespaceTopLevelResources_Call {
 	return &LiveStateCache_GetNamespaceTopLevelResources_Call{Call: _e.mock.On("GetNamespaceTopLevelResources", server, namespace)}
 }
 
 func (_c *LiveStateCache_GetNamespaceTopLevelResources_Call) Run(run func(server *v1alpha1.Cluster, namespace string)) *LiveStateCache_GetNamespaceTopLevelResources_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*v1alpha1.Cluster), args[1].(string))
+		var arg0 *v1alpha1.Cluster
+		if args[0] != nil {
+			arg0 = args[0].(*v1alpha1.Cluster)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -300,14 +333,20 @@ type LiveStateCache_GetVersionsInfo_Call struct {
 }
 
 // GetVersionsInfo is a helper method to define mock.On call
-//   - server
+//   - server *v1alpha1.Cluster
 func (_e *LiveStateCache_Expecter) GetVersionsInfo(server interface{}) *LiveStateCache_GetVersionsInfo_Call {
 	return &LiveStateCache_GetVersionsInfo_Call{Call: _e.mock.On("GetVersionsInfo", server)}
 }
 
 func (_c *LiveStateCache_GetVersionsInfo_Call) Run(run func(server *v1alpha1.Cluster)) *LiveStateCache_GetVersionsInfo_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*v1alpha1.Cluster))
+		var arg0 *v1alpha1.Cluster
+		if args[0] != nil {
+			arg0 = args[0].(*v1alpha1.Cluster)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -398,15 +437,26 @@ type LiveStateCache_IsNamespaced_Call struct {
 }
 
 // IsNamespaced is a helper method to define mock.On call
-//   - server
-//   - gk
+//   - server *v1alpha1.Cluster
+//   - gk schema.GroupKind
 func (_e *LiveStateCache_Expecter) IsNamespaced(server interface{}, gk interface{}) *LiveStateCache_IsNamespaced_Call {
 	return &LiveStateCache_IsNamespaced_Call{Call: _e.mock.On("IsNamespaced", server, gk)}
 }
 
 func (_c *LiveStateCache_IsNamespaced_Call) Run(run func(server *v1alpha1.Cluster, gk schema.GroupKind)) *LiveStateCache_IsNamespaced_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*v1alpha1.Cluster), args[1].(schema.GroupKind))
+		var arg0 *v1alpha1.Cluster
+		if args[0] != nil {
+			arg0 = args[0].(*v1alpha1.Cluster)
+		}
+		var arg1 schema.GroupKind
+		if args[1] != nil {
+			arg1 = args[1].(schema.GroupKind)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -444,16 +494,32 @@ type LiveStateCache_IterateHierarchy_Call struct {
 }
 
 // IterateHierarchy is a helper method to define mock.On call
-//   - server
-//   - key
-//   - action
+//   - server *v1alpha1.Cluster
+//   - key kube.ResourceKey
+//   - action func(child v1alpha1.ResourceNode, appName string) bool
 func (_e *LiveStateCache_Expecter) IterateHierarchy(server interface{}, key interface{}, action interface{}) *LiveStateCache_IterateHierarchy_Call {
 	return &LiveStateCache_IterateHierarchy_Call{Call: _e.mock.On("IterateHierarchy", server, key, action)}
 }
 
 func (_c *LiveStateCache_IterateHierarchy_Call) Run(run func(server *v1alpha1.Cluster, key kube.ResourceKey, action func(child v1alpha1.ResourceNode, appName string) bool)) *LiveStateCache_IterateHierarchy_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*v1alpha1.Cluster), args[1].(kube.ResourceKey), args[2].(func(child v1alpha1.ResourceNode, appName string) bool))
+		var arg0 *v1alpha1.Cluster
+		if args[0] != nil {
+			arg0 = args[0].(*v1alpha1.Cluster)
+		}
+		var arg1 kube.ResourceKey
+		if args[1] != nil {
+			arg1 = args[1].(kube.ResourceKey)
+		}
+		var arg2 func(child v1alpha1.ResourceNode, appName string) bool
+		if args[2] != nil {
+			arg2 = args[2].(func(child v1alpha1.ResourceNode, appName string) bool)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
 	})
 	return _c
 }
@@ -491,16 +557,32 @@ type LiveStateCache_IterateHierarchyV2_Call struct {
 }
 
 // IterateHierarchyV2 is a helper method to define mock.On call
-//   - server
-//   - keys
-//   - action
+//   - server *v1alpha1.Cluster
+//   - keys []kube.ResourceKey
+//   - action func(child v1alpha1.ResourceNode, appName string) bool
 func (_e *LiveStateCache_Expecter) IterateHierarchyV2(server interface{}, keys interface{}, action interface{}) *LiveStateCache_IterateHierarchyV2_Call {
 	return &LiveStateCache_IterateHierarchyV2_Call{Call: _e.mock.On("IterateHierarchyV2", server, keys, action)}
 }
 
 func (_c *LiveStateCache_IterateHierarchyV2_Call) Run(run func(server *v1alpha1.Cluster, keys []kube.ResourceKey, action func(child v1alpha1.ResourceNode, appName string) bool)) *LiveStateCache_IterateHierarchyV2_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*v1alpha1.Cluster), args[1].([]kube.ResourceKey), args[2].(func(child v1alpha1.ResourceNode, appName string) bool))
+		var arg0 *v1alpha1.Cluster
+		if args[0] != nil {
+			arg0 = args[0].(*v1alpha1.Cluster)
+		}
+		var arg1 []kube.ResourceKey
+		if args[1] != nil {
+			arg1 = args[1].([]kube.ResourceKey)
+		}
+		var arg2 func(child v1alpha1.ResourceNode, appName string) bool
+		if args[2] != nil {
+			arg2 = args[2].(func(child v1alpha1.ResourceNode, appName string) bool)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
 	})
 	return _c
 }
@@ -538,15 +620,26 @@ type LiveStateCache_IterateResources_Call struct {
 }
 
 // IterateResources is a helper method to define mock.On call
-//   - server
-//   - callback
+//   - server *v1alpha1.Cluster
+//   - callback func(res *cache.Resource, info *cache0.ResourceInfo)
 func (_e *LiveStateCache_Expecter) IterateResources(server interface{}, callback interface{}) *LiveStateCache_IterateResources_Call {
 	return &LiveStateCache_IterateResources_Call{Call: _e.mock.On("IterateResources", server, callback)}
 }
 
 func (_c *LiveStateCache_IterateResources_Call) Run(run func(server *v1alpha1.Cluster, callback func(res *cache.Resource, info *cache0.ResourceInfo))) *LiveStateCache_IterateResources_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*v1alpha1.Cluster), args[1].(func(res *cache.Resource, info *cache0.ResourceInfo)))
+		var arg0 *v1alpha1.Cluster
+		if args[0] != nil {
+			arg0 = args[0].(*v1alpha1.Cluster)
+		}
+		var arg1 func(res *cache.Resource, info *cache0.ResourceInfo)
+		if args[1] != nil {
+			arg1 = args[1].(func(res *cache.Resource, info *cache0.ResourceInfo))
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -584,14 +677,20 @@ type LiveStateCache_Run_Call struct {
 }
 
 // Run is a helper method to define mock.On call
-//   - ctx
+//   - ctx context.Context
 func (_e *LiveStateCache_Expecter) Run(ctx interface{}) *LiveStateCache_Run_Call {
 	return &LiveStateCache_Run_Call{Call: _e.mock.On("Run", ctx)}
 }
 
 func (_c *LiveStateCache_Run_Call) Run(run func(ctx context.Context)) *LiveStateCache_Run_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -629,14 +728,20 @@ type LiveStateCache_UpdateShard_Call struct {
 }
 
 // UpdateShard is a helper method to define mock.On call
-//   - shard
+//   - shard int
 func (_e *LiveStateCache_Expecter) UpdateShard(shard interface{}) *LiveStateCache_UpdateShard_Call {
 	return &LiveStateCache_UpdateShard_Call{Call: _e.mock.On("UpdateShard", shard)}
 }
 
 func (_c *LiveStateCache_UpdateShard_Call) Run(run func(shard int)) *LiveStateCache_UpdateShard_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(int))
+		var arg0 int
+		if args[0] != nil {
+			arg0 = args[0].(int)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }

--- a/hack/installers/install-codegen-go-tools.sh
+++ b/hack/installers/install-codegen-go-tools.sh
@@ -54,4 +54,4 @@ go install github.com/go-swagger/go-swagger/cmd/swagger@v0.28.0
 go install golang.org/x/tools/cmd/goimports@v0.1.8
 
 # mockery is used to generate mock
-go install github.com/vektra/mockery/v3@v3.2.5
+go install github.com/vektra/mockery/v3@v3.3.6

--- a/pkg/apiclient/cluster/mocks/ClusterServiceServer.go
+++ b/pkg/apiclient/cluster/mocks/ClusterServiceServer.go
@@ -73,15 +73,26 @@ type ClusterServiceServer_Create_Call struct {
 }
 
 // Create is a helper method to define mock.On call
-//   - context1
-//   - clusterCreateRequest
+//   - context1 context.Context
+//   - clusterCreateRequest *cluster.ClusterCreateRequest
 func (_e *ClusterServiceServer_Expecter) Create(context1 interface{}, clusterCreateRequest interface{}) *ClusterServiceServer_Create_Call {
 	return &ClusterServiceServer_Create_Call{Call: _e.mock.On("Create", context1, clusterCreateRequest)}
 }
 
 func (_c *ClusterServiceServer_Create_Call) Run(run func(context1 context.Context, clusterCreateRequest *cluster.ClusterCreateRequest)) *ClusterServiceServer_Create_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*cluster.ClusterCreateRequest))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *cluster.ClusterCreateRequest
+		if args[1] != nil {
+			arg1 = args[1].(*cluster.ClusterCreateRequest)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -130,15 +141,26 @@ type ClusterServiceServer_Delete_Call struct {
 }
 
 // Delete is a helper method to define mock.On call
-//   - context1
-//   - clusterQuery
+//   - context1 context.Context
+//   - clusterQuery *cluster.ClusterQuery
 func (_e *ClusterServiceServer_Expecter) Delete(context1 interface{}, clusterQuery interface{}) *ClusterServiceServer_Delete_Call {
 	return &ClusterServiceServer_Delete_Call{Call: _e.mock.On("Delete", context1, clusterQuery)}
 }
 
 func (_c *ClusterServiceServer_Delete_Call) Run(run func(context1 context.Context, clusterQuery *cluster.ClusterQuery)) *ClusterServiceServer_Delete_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*cluster.ClusterQuery))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *cluster.ClusterQuery
+		if args[1] != nil {
+			arg1 = args[1].(*cluster.ClusterQuery)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -187,15 +209,26 @@ type ClusterServiceServer_Get_Call struct {
 }
 
 // Get is a helper method to define mock.On call
-//   - context1
-//   - clusterQuery
+//   - context1 context.Context
+//   - clusterQuery *cluster.ClusterQuery
 func (_e *ClusterServiceServer_Expecter) Get(context1 interface{}, clusterQuery interface{}) *ClusterServiceServer_Get_Call {
 	return &ClusterServiceServer_Get_Call{Call: _e.mock.On("Get", context1, clusterQuery)}
 }
 
 func (_c *ClusterServiceServer_Get_Call) Run(run func(context1 context.Context, clusterQuery *cluster.ClusterQuery)) *ClusterServiceServer_Get_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*cluster.ClusterQuery))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *cluster.ClusterQuery
+		if args[1] != nil {
+			arg1 = args[1].(*cluster.ClusterQuery)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -244,15 +277,26 @@ type ClusterServiceServer_InvalidateCache_Call struct {
 }
 
 // InvalidateCache is a helper method to define mock.On call
-//   - context1
-//   - clusterQuery
+//   - context1 context.Context
+//   - clusterQuery *cluster.ClusterQuery
 func (_e *ClusterServiceServer_Expecter) InvalidateCache(context1 interface{}, clusterQuery interface{}) *ClusterServiceServer_InvalidateCache_Call {
 	return &ClusterServiceServer_InvalidateCache_Call{Call: _e.mock.On("InvalidateCache", context1, clusterQuery)}
 }
 
 func (_c *ClusterServiceServer_InvalidateCache_Call) Run(run func(context1 context.Context, clusterQuery *cluster.ClusterQuery)) *ClusterServiceServer_InvalidateCache_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*cluster.ClusterQuery))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *cluster.ClusterQuery
+		if args[1] != nil {
+			arg1 = args[1].(*cluster.ClusterQuery)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -301,15 +345,26 @@ type ClusterServiceServer_List_Call struct {
 }
 
 // List is a helper method to define mock.On call
-//   - context1
-//   - clusterQuery
+//   - context1 context.Context
+//   - clusterQuery *cluster.ClusterQuery
 func (_e *ClusterServiceServer_Expecter) List(context1 interface{}, clusterQuery interface{}) *ClusterServiceServer_List_Call {
 	return &ClusterServiceServer_List_Call{Call: _e.mock.On("List", context1, clusterQuery)}
 }
 
 func (_c *ClusterServiceServer_List_Call) Run(run func(context1 context.Context, clusterQuery *cluster.ClusterQuery)) *ClusterServiceServer_List_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*cluster.ClusterQuery))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *cluster.ClusterQuery
+		if args[1] != nil {
+			arg1 = args[1].(*cluster.ClusterQuery)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -358,15 +413,26 @@ type ClusterServiceServer_RotateAuth_Call struct {
 }
 
 // RotateAuth is a helper method to define mock.On call
-//   - context1
-//   - clusterQuery
+//   - context1 context.Context
+//   - clusterQuery *cluster.ClusterQuery
 func (_e *ClusterServiceServer_Expecter) RotateAuth(context1 interface{}, clusterQuery interface{}) *ClusterServiceServer_RotateAuth_Call {
 	return &ClusterServiceServer_RotateAuth_Call{Call: _e.mock.On("RotateAuth", context1, clusterQuery)}
 }
 
 func (_c *ClusterServiceServer_RotateAuth_Call) Run(run func(context1 context.Context, clusterQuery *cluster.ClusterQuery)) *ClusterServiceServer_RotateAuth_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*cluster.ClusterQuery))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *cluster.ClusterQuery
+		if args[1] != nil {
+			arg1 = args[1].(*cluster.ClusterQuery)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -415,15 +481,26 @@ type ClusterServiceServer_Update_Call struct {
 }
 
 // Update is a helper method to define mock.On call
-//   - context1
-//   - clusterUpdateRequest
+//   - context1 context.Context
+//   - clusterUpdateRequest *cluster.ClusterUpdateRequest
 func (_e *ClusterServiceServer_Expecter) Update(context1 interface{}, clusterUpdateRequest interface{}) *ClusterServiceServer_Update_Call {
 	return &ClusterServiceServer_Update_Call{Call: _e.mock.On("Update", context1, clusterUpdateRequest)}
 }
 
 func (_c *ClusterServiceServer_Update_Call) Run(run func(context1 context.Context, clusterUpdateRequest *cluster.ClusterUpdateRequest)) *ClusterServiceServer_Update_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*cluster.ClusterUpdateRequest))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *cluster.ClusterUpdateRequest
+		if args[1] != nil {
+			arg1 = args[1].(*cluster.ClusterUpdateRequest)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }

--- a/pkg/apiclient/session/mocks/SessionServiceClient.go
+++ b/pkg/apiclient/session/mocks/SessionServiceClient.go
@@ -81,9 +81,9 @@ type SessionServiceClient_Create_Call struct {
 }
 
 // Create is a helper method to define mock.On call
-//   - ctx
-//   - in
-//   - opts
+//   - ctx context.Context
+//   - in *session.SessionCreateRequest
+//   - opts ...grpc.CallOption
 func (_e *SessionServiceClient_Expecter) Create(ctx interface{}, in interface{}, opts ...interface{}) *SessionServiceClient_Create_Call {
 	return &SessionServiceClient_Create_Call{Call: _e.mock.On("Create",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -91,13 +91,27 @@ func (_e *SessionServiceClient_Expecter) Create(ctx interface{}, in interface{},
 
 func (_c *SessionServiceClient_Create_Call) Run(run func(ctx context.Context, in *session.SessionCreateRequest, opts ...grpc.CallOption)) *SessionServiceClient_Create_Call {
 	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *session.SessionCreateRequest
+		if args[1] != nil {
+			arg1 = args[1].(*session.SessionCreateRequest)
+		}
+		var arg2 []grpc.CallOption
 		variadicArgs := make([]grpc.CallOption, len(args)-2)
 		for i, a := range args[2:] {
 			if a != nil {
 				variadicArgs[i] = a.(grpc.CallOption)
 			}
 		}
-		run(args[0].(context.Context), args[1].(*session.SessionCreateRequest), variadicArgs...)
+		arg2 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2...,
+		)
 	})
 	return _c
 }
@@ -154,9 +168,9 @@ type SessionServiceClient_Delete_Call struct {
 }
 
 // Delete is a helper method to define mock.On call
-//   - ctx
-//   - in
-//   - opts
+//   - ctx context.Context
+//   - in *session.SessionDeleteRequest
+//   - opts ...grpc.CallOption
 func (_e *SessionServiceClient_Expecter) Delete(ctx interface{}, in interface{}, opts ...interface{}) *SessionServiceClient_Delete_Call {
 	return &SessionServiceClient_Delete_Call{Call: _e.mock.On("Delete",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -164,13 +178,27 @@ func (_e *SessionServiceClient_Expecter) Delete(ctx interface{}, in interface{},
 
 func (_c *SessionServiceClient_Delete_Call) Run(run func(ctx context.Context, in *session.SessionDeleteRequest, opts ...grpc.CallOption)) *SessionServiceClient_Delete_Call {
 	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *session.SessionDeleteRequest
+		if args[1] != nil {
+			arg1 = args[1].(*session.SessionDeleteRequest)
+		}
+		var arg2 []grpc.CallOption
 		variadicArgs := make([]grpc.CallOption, len(args)-2)
 		for i, a := range args[2:] {
 			if a != nil {
 				variadicArgs[i] = a.(grpc.CallOption)
 			}
 		}
-		run(args[0].(context.Context), args[1].(*session.SessionDeleteRequest), variadicArgs...)
+		arg2 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2...,
+		)
 	})
 	return _c
 }
@@ -227,9 +255,9 @@ type SessionServiceClient_GetUserInfo_Call struct {
 }
 
 // GetUserInfo is a helper method to define mock.On call
-//   - ctx
-//   - in
-//   - opts
+//   - ctx context.Context
+//   - in *session.GetUserInfoRequest
+//   - opts ...grpc.CallOption
 func (_e *SessionServiceClient_Expecter) GetUserInfo(ctx interface{}, in interface{}, opts ...interface{}) *SessionServiceClient_GetUserInfo_Call {
 	return &SessionServiceClient_GetUserInfo_Call{Call: _e.mock.On("GetUserInfo",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -237,13 +265,27 @@ func (_e *SessionServiceClient_Expecter) GetUserInfo(ctx interface{}, in interfa
 
 func (_c *SessionServiceClient_GetUserInfo_Call) Run(run func(ctx context.Context, in *session.GetUserInfoRequest, opts ...grpc.CallOption)) *SessionServiceClient_GetUserInfo_Call {
 	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *session.GetUserInfoRequest
+		if args[1] != nil {
+			arg1 = args[1].(*session.GetUserInfoRequest)
+		}
+		var arg2 []grpc.CallOption
 		variadicArgs := make([]grpc.CallOption, len(args)-2)
 		for i, a := range args[2:] {
 			if a != nil {
 				variadicArgs[i] = a.(grpc.CallOption)
 			}
 		}
-		run(args[0].(context.Context), args[1].(*session.GetUserInfoRequest), variadicArgs...)
+		arg2 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2...,
+		)
 	})
 	return _c
 }

--- a/pkg/apiclient/session/mocks/SessionServiceServer.go
+++ b/pkg/apiclient/session/mocks/SessionServiceServer.go
@@ -72,15 +72,26 @@ type SessionServiceServer_Create_Call struct {
 }
 
 // Create is a helper method to define mock.On call
-//   - context1
-//   - sessionCreateRequest
+//   - context1 context.Context
+//   - sessionCreateRequest *session.SessionCreateRequest
 func (_e *SessionServiceServer_Expecter) Create(context1 interface{}, sessionCreateRequest interface{}) *SessionServiceServer_Create_Call {
 	return &SessionServiceServer_Create_Call{Call: _e.mock.On("Create", context1, sessionCreateRequest)}
 }
 
 func (_c *SessionServiceServer_Create_Call) Run(run func(context1 context.Context, sessionCreateRequest *session.SessionCreateRequest)) *SessionServiceServer_Create_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*session.SessionCreateRequest))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *session.SessionCreateRequest
+		if args[1] != nil {
+			arg1 = args[1].(*session.SessionCreateRequest)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -129,15 +140,26 @@ type SessionServiceServer_Delete_Call struct {
 }
 
 // Delete is a helper method to define mock.On call
-//   - context1
-//   - sessionDeleteRequest
+//   - context1 context.Context
+//   - sessionDeleteRequest *session.SessionDeleteRequest
 func (_e *SessionServiceServer_Expecter) Delete(context1 interface{}, sessionDeleteRequest interface{}) *SessionServiceServer_Delete_Call {
 	return &SessionServiceServer_Delete_Call{Call: _e.mock.On("Delete", context1, sessionDeleteRequest)}
 }
 
 func (_c *SessionServiceServer_Delete_Call) Run(run func(context1 context.Context, sessionDeleteRequest *session.SessionDeleteRequest)) *SessionServiceServer_Delete_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*session.SessionDeleteRequest))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *session.SessionDeleteRequest
+		if args[1] != nil {
+			arg1 = args[1].(*session.SessionDeleteRequest)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -186,15 +208,26 @@ type SessionServiceServer_GetUserInfo_Call struct {
 }
 
 // GetUserInfo is a helper method to define mock.On call
-//   - context1
-//   - getUserInfoRequest
+//   - context1 context.Context
+//   - getUserInfoRequest *session.GetUserInfoRequest
 func (_e *SessionServiceServer_Expecter) GetUserInfo(context1 interface{}, getUserInfoRequest interface{}) *SessionServiceServer_GetUserInfo_Call {
 	return &SessionServiceServer_GetUserInfo_Call{Call: _e.mock.On("GetUserInfo", context1, getUserInfoRequest)}
 }
 
 func (_c *SessionServiceServer_GetUserInfo_Call) Run(run func(context1 context.Context, getUserInfoRequest *session.GetUserInfoRequest)) *SessionServiceServer_GetUserInfo_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*session.GetUserInfoRequest))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *session.GetUserInfoRequest
+		if args[1] != nil {
+			arg1 = args[1].(*session.GetUserInfoRequest)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }

--- a/pkg/client/clientset/versioned/typed/application/v1alpha1/mocks/AppProjectInterface.go
+++ b/pkg/client/clientset/versioned/typed/application/v1alpha1/mocks/AppProjectInterface.go
@@ -75,16 +75,32 @@ type AppProjectInterface_Create_Call struct {
 }
 
 // Create is a helper method to define mock.On call
-//   - ctx
-//   - appProject
-//   - opts
+//   - ctx context.Context
+//   - appProject *v1alpha1.AppProject
+//   - opts v1.CreateOptions
 func (_e *AppProjectInterface_Expecter) Create(ctx interface{}, appProject interface{}, opts interface{}) *AppProjectInterface_Create_Call {
 	return &AppProjectInterface_Create_Call{Call: _e.mock.On("Create", ctx, appProject, opts)}
 }
 
 func (_c *AppProjectInterface_Create_Call) Run(run func(ctx context.Context, appProject *v1alpha1.AppProject, opts v1.CreateOptions)) *AppProjectInterface_Create_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*v1alpha1.AppProject), args[2].(v1.CreateOptions))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *v1alpha1.AppProject
+		if args[1] != nil {
+			arg1 = args[1].(*v1alpha1.AppProject)
+		}
+		var arg2 v1.CreateOptions
+		if args[2] != nil {
+			arg2 = args[2].(v1.CreateOptions)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
 	})
 	return _c
 }
@@ -122,16 +138,32 @@ type AppProjectInterface_Delete_Call struct {
 }
 
 // Delete is a helper method to define mock.On call
-//   - ctx
-//   - name
-//   - opts
+//   - ctx context.Context
+//   - name string
+//   - opts v1.DeleteOptions
 func (_e *AppProjectInterface_Expecter) Delete(ctx interface{}, name interface{}, opts interface{}) *AppProjectInterface_Delete_Call {
 	return &AppProjectInterface_Delete_Call{Call: _e.mock.On("Delete", ctx, name, opts)}
 }
 
 func (_c *AppProjectInterface_Delete_Call) Run(run func(ctx context.Context, name string, opts v1.DeleteOptions)) *AppProjectInterface_Delete_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(v1.DeleteOptions))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 v1.DeleteOptions
+		if args[2] != nil {
+			arg2 = args[2].(v1.DeleteOptions)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
 	})
 	return _c
 }
@@ -169,16 +201,32 @@ type AppProjectInterface_DeleteCollection_Call struct {
 }
 
 // DeleteCollection is a helper method to define mock.On call
-//   - ctx
-//   - opts
-//   - listOpts
+//   - ctx context.Context
+//   - opts v1.DeleteOptions
+//   - listOpts v1.ListOptions
 func (_e *AppProjectInterface_Expecter) DeleteCollection(ctx interface{}, opts interface{}, listOpts interface{}) *AppProjectInterface_DeleteCollection_Call {
 	return &AppProjectInterface_DeleteCollection_Call{Call: _e.mock.On("DeleteCollection", ctx, opts, listOpts)}
 }
 
 func (_c *AppProjectInterface_DeleteCollection_Call) Run(run func(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions)) *AppProjectInterface_DeleteCollection_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(v1.DeleteOptions), args[2].(v1.ListOptions))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 v1.DeleteOptions
+		if args[1] != nil {
+			arg1 = args[1].(v1.DeleteOptions)
+		}
+		var arg2 v1.ListOptions
+		if args[2] != nil {
+			arg2 = args[2].(v1.ListOptions)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
 	})
 	return _c
 }
@@ -227,16 +275,32 @@ type AppProjectInterface_Get_Call struct {
 }
 
 // Get is a helper method to define mock.On call
-//   - ctx
-//   - name
-//   - opts
+//   - ctx context.Context
+//   - name string
+//   - opts v1.GetOptions
 func (_e *AppProjectInterface_Expecter) Get(ctx interface{}, name interface{}, opts interface{}) *AppProjectInterface_Get_Call {
 	return &AppProjectInterface_Get_Call{Call: _e.mock.On("Get", ctx, name, opts)}
 }
 
 func (_c *AppProjectInterface_Get_Call) Run(run func(ctx context.Context, name string, opts v1.GetOptions)) *AppProjectInterface_Get_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(v1.GetOptions))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 v1.GetOptions
+		if args[2] != nil {
+			arg2 = args[2].(v1.GetOptions)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
 	})
 	return _c
 }
@@ -285,15 +349,26 @@ type AppProjectInterface_List_Call struct {
 }
 
 // List is a helper method to define mock.On call
-//   - ctx
-//   - opts
+//   - ctx context.Context
+//   - opts v1.ListOptions
 func (_e *AppProjectInterface_Expecter) List(ctx interface{}, opts interface{}) *AppProjectInterface_List_Call {
 	return &AppProjectInterface_List_Call{Call: _e.mock.On("List", ctx, opts)}
 }
 
 func (_c *AppProjectInterface_List_Call) Run(run func(ctx context.Context, opts v1.ListOptions)) *AppProjectInterface_List_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(v1.ListOptions))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 v1.ListOptions
+		if args[1] != nil {
+			arg1 = args[1].(v1.ListOptions)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -350,12 +425,12 @@ type AppProjectInterface_Patch_Call struct {
 }
 
 // Patch is a helper method to define mock.On call
-//   - ctx
-//   - name
-//   - pt
-//   - data
-//   - opts
-//   - subresources
+//   - ctx context.Context
+//   - name string
+//   - pt types.PatchType
+//   - data []byte
+//   - opts v1.PatchOptions
+//   - subresources ...string
 func (_e *AppProjectInterface_Expecter) Patch(ctx interface{}, name interface{}, pt interface{}, data interface{}, opts interface{}, subresources ...interface{}) *AppProjectInterface_Patch_Call {
 	return &AppProjectInterface_Patch_Call{Call: _e.mock.On("Patch",
 		append([]interface{}{ctx, name, pt, data, opts}, subresources...)...)}
@@ -363,13 +438,42 @@ func (_e *AppProjectInterface_Expecter) Patch(ctx interface{}, name interface{},
 
 func (_c *AppProjectInterface_Patch_Call) Run(run func(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string)) *AppProjectInterface_Patch_Call {
 	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 types.PatchType
+		if args[2] != nil {
+			arg2 = args[2].(types.PatchType)
+		}
+		var arg3 []byte
+		if args[3] != nil {
+			arg3 = args[3].([]byte)
+		}
+		var arg4 v1.PatchOptions
+		if args[4] != nil {
+			arg4 = args[4].(v1.PatchOptions)
+		}
+		var arg5 []string
 		variadicArgs := make([]string, len(args)-5)
 		for i, a := range args[5:] {
 			if a != nil {
 				variadicArgs[i] = a.(string)
 			}
 		}
-		run(args[0].(context.Context), args[1].(string), args[2].(types.PatchType), args[3].([]byte), args[4].(v1.PatchOptions), variadicArgs...)
+		arg5 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+			arg5...,
+		)
 	})
 	return _c
 }
@@ -418,16 +522,32 @@ type AppProjectInterface_Update_Call struct {
 }
 
 // Update is a helper method to define mock.On call
-//   - ctx
-//   - appProject
-//   - opts
+//   - ctx context.Context
+//   - appProject *v1alpha1.AppProject
+//   - opts v1.UpdateOptions
 func (_e *AppProjectInterface_Expecter) Update(ctx interface{}, appProject interface{}, opts interface{}) *AppProjectInterface_Update_Call {
 	return &AppProjectInterface_Update_Call{Call: _e.mock.On("Update", ctx, appProject, opts)}
 }
 
 func (_c *AppProjectInterface_Update_Call) Run(run func(ctx context.Context, appProject *v1alpha1.AppProject, opts v1.UpdateOptions)) *AppProjectInterface_Update_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*v1alpha1.AppProject), args[2].(v1.UpdateOptions))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *v1alpha1.AppProject
+		if args[1] != nil {
+			arg1 = args[1].(*v1alpha1.AppProject)
+		}
+		var arg2 v1.UpdateOptions
+		if args[2] != nil {
+			arg2 = args[2].(v1.UpdateOptions)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
 	})
 	return _c
 }
@@ -476,15 +596,26 @@ type AppProjectInterface_Watch_Call struct {
 }
 
 // Watch is a helper method to define mock.On call
-//   - ctx
-//   - opts
+//   - ctx context.Context
+//   - opts v1.ListOptions
 func (_e *AppProjectInterface_Expecter) Watch(ctx interface{}, opts interface{}) *AppProjectInterface_Watch_Call {
 	return &AppProjectInterface_Watch_Call{Call: _e.mock.On("Watch", ctx, opts)}
 }
 
 func (_c *AppProjectInterface_Watch_Call) Run(run func(ctx context.Context, opts v1.ListOptions)) *AppProjectInterface_Watch_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(v1.ListOptions))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 v1.ListOptions
+		if args[1] != nil {
+			arg1 = args[1].(v1.ListOptions)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }

--- a/reposerver/apiclient/mocks/RepoServerServiceClient.go
+++ b/reposerver/apiclient/mocks/RepoServerServiceClient.go
@@ -83,9 +83,9 @@ type RepoServerServiceClient_GenerateManifest_Call struct {
 }
 
 // GenerateManifest is a helper method to define mock.On call
-//   - ctx
-//   - in
-//   - opts
+//   - ctx context.Context
+//   - in *apiclient.ManifestRequest
+//   - opts ...grpc.CallOption
 func (_e *RepoServerServiceClient_Expecter) GenerateManifest(ctx interface{}, in interface{}, opts ...interface{}) *RepoServerServiceClient_GenerateManifest_Call {
 	return &RepoServerServiceClient_GenerateManifest_Call{Call: _e.mock.On("GenerateManifest",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -93,13 +93,27 @@ func (_e *RepoServerServiceClient_Expecter) GenerateManifest(ctx interface{}, in
 
 func (_c *RepoServerServiceClient_GenerateManifest_Call) Run(run func(ctx context.Context, in *apiclient.ManifestRequest, opts ...grpc.CallOption)) *RepoServerServiceClient_GenerateManifest_Call {
 	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *apiclient.ManifestRequest
+		if args[1] != nil {
+			arg1 = args[1].(*apiclient.ManifestRequest)
+		}
+		var arg2 []grpc.CallOption
 		variadicArgs := make([]grpc.CallOption, len(args)-2)
 		for i, a := range args[2:] {
 			if a != nil {
 				variadicArgs[i] = a.(grpc.CallOption)
 			}
 		}
-		run(args[0].(context.Context), args[1].(*apiclient.ManifestRequest), variadicArgs...)
+		arg2 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2...,
+		)
 	})
 	return _c
 }
@@ -156,8 +170,8 @@ type RepoServerServiceClient_GenerateManifestWithFiles_Call struct {
 }
 
 // GenerateManifestWithFiles is a helper method to define mock.On call
-//   - ctx
-//   - opts
+//   - ctx context.Context
+//   - opts ...grpc.CallOption
 func (_e *RepoServerServiceClient_Expecter) GenerateManifestWithFiles(ctx interface{}, opts ...interface{}) *RepoServerServiceClient_GenerateManifestWithFiles_Call {
 	return &RepoServerServiceClient_GenerateManifestWithFiles_Call{Call: _e.mock.On("GenerateManifestWithFiles",
 		append([]interface{}{ctx}, opts...)...)}
@@ -165,13 +179,22 @@ func (_e *RepoServerServiceClient_Expecter) GenerateManifestWithFiles(ctx interf
 
 func (_c *RepoServerServiceClient_GenerateManifestWithFiles_Call) Run(run func(ctx context.Context, opts ...grpc.CallOption)) *RepoServerServiceClient_GenerateManifestWithFiles_Call {
 	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []grpc.CallOption
 		variadicArgs := make([]grpc.CallOption, len(args)-1)
 		for i, a := range args[1:] {
 			if a != nil {
 				variadicArgs[i] = a.(grpc.CallOption)
 			}
 		}
-		run(args[0].(context.Context), variadicArgs...)
+		arg1 = variadicArgs
+		run(
+			arg0,
+			arg1...,
+		)
 	})
 	return _c
 }
@@ -228,9 +251,9 @@ type RepoServerServiceClient_GetAppDetails_Call struct {
 }
 
 // GetAppDetails is a helper method to define mock.On call
-//   - ctx
-//   - in
-//   - opts
+//   - ctx context.Context
+//   - in *apiclient.RepoServerAppDetailsQuery
+//   - opts ...grpc.CallOption
 func (_e *RepoServerServiceClient_Expecter) GetAppDetails(ctx interface{}, in interface{}, opts ...interface{}) *RepoServerServiceClient_GetAppDetails_Call {
 	return &RepoServerServiceClient_GetAppDetails_Call{Call: _e.mock.On("GetAppDetails",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -238,13 +261,27 @@ func (_e *RepoServerServiceClient_Expecter) GetAppDetails(ctx interface{}, in in
 
 func (_c *RepoServerServiceClient_GetAppDetails_Call) Run(run func(ctx context.Context, in *apiclient.RepoServerAppDetailsQuery, opts ...grpc.CallOption)) *RepoServerServiceClient_GetAppDetails_Call {
 	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *apiclient.RepoServerAppDetailsQuery
+		if args[1] != nil {
+			arg1 = args[1].(*apiclient.RepoServerAppDetailsQuery)
+		}
+		var arg2 []grpc.CallOption
 		variadicArgs := make([]grpc.CallOption, len(args)-2)
 		for i, a := range args[2:] {
 			if a != nil {
 				variadicArgs[i] = a.(grpc.CallOption)
 			}
 		}
-		run(args[0].(context.Context), args[1].(*apiclient.RepoServerAppDetailsQuery), variadicArgs...)
+		arg2 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2...,
+		)
 	})
 	return _c
 }
@@ -301,9 +338,9 @@ type RepoServerServiceClient_GetGitDirectories_Call struct {
 }
 
 // GetGitDirectories is a helper method to define mock.On call
-//   - ctx
-//   - in
-//   - opts
+//   - ctx context.Context
+//   - in *apiclient.GitDirectoriesRequest
+//   - opts ...grpc.CallOption
 func (_e *RepoServerServiceClient_Expecter) GetGitDirectories(ctx interface{}, in interface{}, opts ...interface{}) *RepoServerServiceClient_GetGitDirectories_Call {
 	return &RepoServerServiceClient_GetGitDirectories_Call{Call: _e.mock.On("GetGitDirectories",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -311,13 +348,27 @@ func (_e *RepoServerServiceClient_Expecter) GetGitDirectories(ctx interface{}, i
 
 func (_c *RepoServerServiceClient_GetGitDirectories_Call) Run(run func(ctx context.Context, in *apiclient.GitDirectoriesRequest, opts ...grpc.CallOption)) *RepoServerServiceClient_GetGitDirectories_Call {
 	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *apiclient.GitDirectoriesRequest
+		if args[1] != nil {
+			arg1 = args[1].(*apiclient.GitDirectoriesRequest)
+		}
+		var arg2 []grpc.CallOption
 		variadicArgs := make([]grpc.CallOption, len(args)-2)
 		for i, a := range args[2:] {
 			if a != nil {
 				variadicArgs[i] = a.(grpc.CallOption)
 			}
 		}
-		run(args[0].(context.Context), args[1].(*apiclient.GitDirectoriesRequest), variadicArgs...)
+		arg2 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2...,
+		)
 	})
 	return _c
 }
@@ -374,9 +425,9 @@ type RepoServerServiceClient_GetGitFiles_Call struct {
 }
 
 // GetGitFiles is a helper method to define mock.On call
-//   - ctx
-//   - in
-//   - opts
+//   - ctx context.Context
+//   - in *apiclient.GitFilesRequest
+//   - opts ...grpc.CallOption
 func (_e *RepoServerServiceClient_Expecter) GetGitFiles(ctx interface{}, in interface{}, opts ...interface{}) *RepoServerServiceClient_GetGitFiles_Call {
 	return &RepoServerServiceClient_GetGitFiles_Call{Call: _e.mock.On("GetGitFiles",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -384,13 +435,27 @@ func (_e *RepoServerServiceClient_Expecter) GetGitFiles(ctx interface{}, in inte
 
 func (_c *RepoServerServiceClient_GetGitFiles_Call) Run(run func(ctx context.Context, in *apiclient.GitFilesRequest, opts ...grpc.CallOption)) *RepoServerServiceClient_GetGitFiles_Call {
 	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *apiclient.GitFilesRequest
+		if args[1] != nil {
+			arg1 = args[1].(*apiclient.GitFilesRequest)
+		}
+		var arg2 []grpc.CallOption
 		variadicArgs := make([]grpc.CallOption, len(args)-2)
 		for i, a := range args[2:] {
 			if a != nil {
 				variadicArgs[i] = a.(grpc.CallOption)
 			}
 		}
-		run(args[0].(context.Context), args[1].(*apiclient.GitFilesRequest), variadicArgs...)
+		arg2 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2...,
+		)
 	})
 	return _c
 }
@@ -447,9 +512,9 @@ type RepoServerServiceClient_GetHelmCharts_Call struct {
 }
 
 // GetHelmCharts is a helper method to define mock.On call
-//   - ctx
-//   - in
-//   - opts
+//   - ctx context.Context
+//   - in *apiclient.HelmChartsRequest
+//   - opts ...grpc.CallOption
 func (_e *RepoServerServiceClient_Expecter) GetHelmCharts(ctx interface{}, in interface{}, opts ...interface{}) *RepoServerServiceClient_GetHelmCharts_Call {
 	return &RepoServerServiceClient_GetHelmCharts_Call{Call: _e.mock.On("GetHelmCharts",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -457,13 +522,27 @@ func (_e *RepoServerServiceClient_Expecter) GetHelmCharts(ctx interface{}, in in
 
 func (_c *RepoServerServiceClient_GetHelmCharts_Call) Run(run func(ctx context.Context, in *apiclient.HelmChartsRequest, opts ...grpc.CallOption)) *RepoServerServiceClient_GetHelmCharts_Call {
 	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *apiclient.HelmChartsRequest
+		if args[1] != nil {
+			arg1 = args[1].(*apiclient.HelmChartsRequest)
+		}
+		var arg2 []grpc.CallOption
 		variadicArgs := make([]grpc.CallOption, len(args)-2)
 		for i, a := range args[2:] {
 			if a != nil {
 				variadicArgs[i] = a.(grpc.CallOption)
 			}
 		}
-		run(args[0].(context.Context), args[1].(*apiclient.HelmChartsRequest), variadicArgs...)
+		arg2 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2...,
+		)
 	})
 	return _c
 }
@@ -520,9 +599,9 @@ type RepoServerServiceClient_GetOCIMetadata_Call struct {
 }
 
 // GetOCIMetadata is a helper method to define mock.On call
-//   - ctx
-//   - in
-//   - opts
+//   - ctx context.Context
+//   - in *apiclient.RepoServerRevisionChartDetailsRequest
+//   - opts ...grpc.CallOption
 func (_e *RepoServerServiceClient_Expecter) GetOCIMetadata(ctx interface{}, in interface{}, opts ...interface{}) *RepoServerServiceClient_GetOCIMetadata_Call {
 	return &RepoServerServiceClient_GetOCIMetadata_Call{Call: _e.mock.On("GetOCIMetadata",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -530,13 +609,27 @@ func (_e *RepoServerServiceClient_Expecter) GetOCIMetadata(ctx interface{}, in i
 
 func (_c *RepoServerServiceClient_GetOCIMetadata_Call) Run(run func(ctx context.Context, in *apiclient.RepoServerRevisionChartDetailsRequest, opts ...grpc.CallOption)) *RepoServerServiceClient_GetOCIMetadata_Call {
 	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *apiclient.RepoServerRevisionChartDetailsRequest
+		if args[1] != nil {
+			arg1 = args[1].(*apiclient.RepoServerRevisionChartDetailsRequest)
+		}
+		var arg2 []grpc.CallOption
 		variadicArgs := make([]grpc.CallOption, len(args)-2)
 		for i, a := range args[2:] {
 			if a != nil {
 				variadicArgs[i] = a.(grpc.CallOption)
 			}
 		}
-		run(args[0].(context.Context), args[1].(*apiclient.RepoServerRevisionChartDetailsRequest), variadicArgs...)
+		arg2 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2...,
+		)
 	})
 	return _c
 }
@@ -593,9 +686,9 @@ type RepoServerServiceClient_GetRevisionChartDetails_Call struct {
 }
 
 // GetRevisionChartDetails is a helper method to define mock.On call
-//   - ctx
-//   - in
-//   - opts
+//   - ctx context.Context
+//   - in *apiclient.RepoServerRevisionChartDetailsRequest
+//   - opts ...grpc.CallOption
 func (_e *RepoServerServiceClient_Expecter) GetRevisionChartDetails(ctx interface{}, in interface{}, opts ...interface{}) *RepoServerServiceClient_GetRevisionChartDetails_Call {
 	return &RepoServerServiceClient_GetRevisionChartDetails_Call{Call: _e.mock.On("GetRevisionChartDetails",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -603,13 +696,27 @@ func (_e *RepoServerServiceClient_Expecter) GetRevisionChartDetails(ctx interfac
 
 func (_c *RepoServerServiceClient_GetRevisionChartDetails_Call) Run(run func(ctx context.Context, in *apiclient.RepoServerRevisionChartDetailsRequest, opts ...grpc.CallOption)) *RepoServerServiceClient_GetRevisionChartDetails_Call {
 	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *apiclient.RepoServerRevisionChartDetailsRequest
+		if args[1] != nil {
+			arg1 = args[1].(*apiclient.RepoServerRevisionChartDetailsRequest)
+		}
+		var arg2 []grpc.CallOption
 		variadicArgs := make([]grpc.CallOption, len(args)-2)
 		for i, a := range args[2:] {
 			if a != nil {
 				variadicArgs[i] = a.(grpc.CallOption)
 			}
 		}
-		run(args[0].(context.Context), args[1].(*apiclient.RepoServerRevisionChartDetailsRequest), variadicArgs...)
+		arg2 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2...,
+		)
 	})
 	return _c
 }
@@ -666,9 +773,9 @@ type RepoServerServiceClient_GetRevisionMetadata_Call struct {
 }
 
 // GetRevisionMetadata is a helper method to define mock.On call
-//   - ctx
-//   - in
-//   - opts
+//   - ctx context.Context
+//   - in *apiclient.RepoServerRevisionMetadataRequest
+//   - opts ...grpc.CallOption
 func (_e *RepoServerServiceClient_Expecter) GetRevisionMetadata(ctx interface{}, in interface{}, opts ...interface{}) *RepoServerServiceClient_GetRevisionMetadata_Call {
 	return &RepoServerServiceClient_GetRevisionMetadata_Call{Call: _e.mock.On("GetRevisionMetadata",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -676,13 +783,27 @@ func (_e *RepoServerServiceClient_Expecter) GetRevisionMetadata(ctx interface{},
 
 func (_c *RepoServerServiceClient_GetRevisionMetadata_Call) Run(run func(ctx context.Context, in *apiclient.RepoServerRevisionMetadataRequest, opts ...grpc.CallOption)) *RepoServerServiceClient_GetRevisionMetadata_Call {
 	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *apiclient.RepoServerRevisionMetadataRequest
+		if args[1] != nil {
+			arg1 = args[1].(*apiclient.RepoServerRevisionMetadataRequest)
+		}
+		var arg2 []grpc.CallOption
 		variadicArgs := make([]grpc.CallOption, len(args)-2)
 		for i, a := range args[2:] {
 			if a != nil {
 				variadicArgs[i] = a.(grpc.CallOption)
 			}
 		}
-		run(args[0].(context.Context), args[1].(*apiclient.RepoServerRevisionMetadataRequest), variadicArgs...)
+		arg2 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2...,
+		)
 	})
 	return _c
 }
@@ -739,9 +860,9 @@ type RepoServerServiceClient_ListApps_Call struct {
 }
 
 // ListApps is a helper method to define mock.On call
-//   - ctx
-//   - in
-//   - opts
+//   - ctx context.Context
+//   - in *apiclient.ListAppsRequest
+//   - opts ...grpc.CallOption
 func (_e *RepoServerServiceClient_Expecter) ListApps(ctx interface{}, in interface{}, opts ...interface{}) *RepoServerServiceClient_ListApps_Call {
 	return &RepoServerServiceClient_ListApps_Call{Call: _e.mock.On("ListApps",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -749,13 +870,27 @@ func (_e *RepoServerServiceClient_Expecter) ListApps(ctx interface{}, in interfa
 
 func (_c *RepoServerServiceClient_ListApps_Call) Run(run func(ctx context.Context, in *apiclient.ListAppsRequest, opts ...grpc.CallOption)) *RepoServerServiceClient_ListApps_Call {
 	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *apiclient.ListAppsRequest
+		if args[1] != nil {
+			arg1 = args[1].(*apiclient.ListAppsRequest)
+		}
+		var arg2 []grpc.CallOption
 		variadicArgs := make([]grpc.CallOption, len(args)-2)
 		for i, a := range args[2:] {
 			if a != nil {
 				variadicArgs[i] = a.(grpc.CallOption)
 			}
 		}
-		run(args[0].(context.Context), args[1].(*apiclient.ListAppsRequest), variadicArgs...)
+		arg2 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2...,
+		)
 	})
 	return _c
 }
@@ -812,9 +947,9 @@ type RepoServerServiceClient_ListOCITags_Call struct {
 }
 
 // ListOCITags is a helper method to define mock.On call
-//   - ctx
-//   - in
-//   - opts
+//   - ctx context.Context
+//   - in *apiclient.ListRefsRequest
+//   - opts ...grpc.CallOption
 func (_e *RepoServerServiceClient_Expecter) ListOCITags(ctx interface{}, in interface{}, opts ...interface{}) *RepoServerServiceClient_ListOCITags_Call {
 	return &RepoServerServiceClient_ListOCITags_Call{Call: _e.mock.On("ListOCITags",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -822,13 +957,27 @@ func (_e *RepoServerServiceClient_Expecter) ListOCITags(ctx interface{}, in inte
 
 func (_c *RepoServerServiceClient_ListOCITags_Call) Run(run func(ctx context.Context, in *apiclient.ListRefsRequest, opts ...grpc.CallOption)) *RepoServerServiceClient_ListOCITags_Call {
 	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *apiclient.ListRefsRequest
+		if args[1] != nil {
+			arg1 = args[1].(*apiclient.ListRefsRequest)
+		}
+		var arg2 []grpc.CallOption
 		variadicArgs := make([]grpc.CallOption, len(args)-2)
 		for i, a := range args[2:] {
 			if a != nil {
 				variadicArgs[i] = a.(grpc.CallOption)
 			}
 		}
-		run(args[0].(context.Context), args[1].(*apiclient.ListRefsRequest), variadicArgs...)
+		arg2 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2...,
+		)
 	})
 	return _c
 }
@@ -885,9 +1034,9 @@ type RepoServerServiceClient_ListPlugins_Call struct {
 }
 
 // ListPlugins is a helper method to define mock.On call
-//   - ctx
-//   - in
-//   - opts
+//   - ctx context.Context
+//   - in *emptypb.Empty
+//   - opts ...grpc.CallOption
 func (_e *RepoServerServiceClient_Expecter) ListPlugins(ctx interface{}, in interface{}, opts ...interface{}) *RepoServerServiceClient_ListPlugins_Call {
 	return &RepoServerServiceClient_ListPlugins_Call{Call: _e.mock.On("ListPlugins",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -895,13 +1044,27 @@ func (_e *RepoServerServiceClient_Expecter) ListPlugins(ctx interface{}, in inte
 
 func (_c *RepoServerServiceClient_ListPlugins_Call) Run(run func(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption)) *RepoServerServiceClient_ListPlugins_Call {
 	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *emptypb.Empty
+		if args[1] != nil {
+			arg1 = args[1].(*emptypb.Empty)
+		}
+		var arg2 []grpc.CallOption
 		variadicArgs := make([]grpc.CallOption, len(args)-2)
 		for i, a := range args[2:] {
 			if a != nil {
 				variadicArgs[i] = a.(grpc.CallOption)
 			}
 		}
-		run(args[0].(context.Context), args[1].(*emptypb.Empty), variadicArgs...)
+		arg2 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2...,
+		)
 	})
 	return _c
 }
@@ -958,9 +1121,9 @@ type RepoServerServiceClient_ListRefs_Call struct {
 }
 
 // ListRefs is a helper method to define mock.On call
-//   - ctx
-//   - in
-//   - opts
+//   - ctx context.Context
+//   - in *apiclient.ListRefsRequest
+//   - opts ...grpc.CallOption
 func (_e *RepoServerServiceClient_Expecter) ListRefs(ctx interface{}, in interface{}, opts ...interface{}) *RepoServerServiceClient_ListRefs_Call {
 	return &RepoServerServiceClient_ListRefs_Call{Call: _e.mock.On("ListRefs",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -968,13 +1131,27 @@ func (_e *RepoServerServiceClient_Expecter) ListRefs(ctx interface{}, in interfa
 
 func (_c *RepoServerServiceClient_ListRefs_Call) Run(run func(ctx context.Context, in *apiclient.ListRefsRequest, opts ...grpc.CallOption)) *RepoServerServiceClient_ListRefs_Call {
 	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *apiclient.ListRefsRequest
+		if args[1] != nil {
+			arg1 = args[1].(*apiclient.ListRefsRequest)
+		}
+		var arg2 []grpc.CallOption
 		variadicArgs := make([]grpc.CallOption, len(args)-2)
 		for i, a := range args[2:] {
 			if a != nil {
 				variadicArgs[i] = a.(grpc.CallOption)
 			}
 		}
-		run(args[0].(context.Context), args[1].(*apiclient.ListRefsRequest), variadicArgs...)
+		arg2 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2...,
+		)
 	})
 	return _c
 }
@@ -1031,9 +1208,9 @@ type RepoServerServiceClient_ResolveRevision_Call struct {
 }
 
 // ResolveRevision is a helper method to define mock.On call
-//   - ctx
-//   - in
-//   - opts
+//   - ctx context.Context
+//   - in *apiclient.ResolveRevisionRequest
+//   - opts ...grpc.CallOption
 func (_e *RepoServerServiceClient_Expecter) ResolveRevision(ctx interface{}, in interface{}, opts ...interface{}) *RepoServerServiceClient_ResolveRevision_Call {
 	return &RepoServerServiceClient_ResolveRevision_Call{Call: _e.mock.On("ResolveRevision",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1041,13 +1218,27 @@ func (_e *RepoServerServiceClient_Expecter) ResolveRevision(ctx interface{}, in 
 
 func (_c *RepoServerServiceClient_ResolveRevision_Call) Run(run func(ctx context.Context, in *apiclient.ResolveRevisionRequest, opts ...grpc.CallOption)) *RepoServerServiceClient_ResolveRevision_Call {
 	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *apiclient.ResolveRevisionRequest
+		if args[1] != nil {
+			arg1 = args[1].(*apiclient.ResolveRevisionRequest)
+		}
+		var arg2 []grpc.CallOption
 		variadicArgs := make([]grpc.CallOption, len(args)-2)
 		for i, a := range args[2:] {
 			if a != nil {
 				variadicArgs[i] = a.(grpc.CallOption)
 			}
 		}
-		run(args[0].(context.Context), args[1].(*apiclient.ResolveRevisionRequest), variadicArgs...)
+		arg2 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2...,
+		)
 	})
 	return _c
 }
@@ -1104,9 +1295,9 @@ type RepoServerServiceClient_TestRepository_Call struct {
 }
 
 // TestRepository is a helper method to define mock.On call
-//   - ctx
-//   - in
-//   - opts
+//   - ctx context.Context
+//   - in *apiclient.TestRepositoryRequest
+//   - opts ...grpc.CallOption
 func (_e *RepoServerServiceClient_Expecter) TestRepository(ctx interface{}, in interface{}, opts ...interface{}) *RepoServerServiceClient_TestRepository_Call {
 	return &RepoServerServiceClient_TestRepository_Call{Call: _e.mock.On("TestRepository",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1114,13 +1305,27 @@ func (_e *RepoServerServiceClient_Expecter) TestRepository(ctx interface{}, in i
 
 func (_c *RepoServerServiceClient_TestRepository_Call) Run(run func(ctx context.Context, in *apiclient.TestRepositoryRequest, opts ...grpc.CallOption)) *RepoServerServiceClient_TestRepository_Call {
 	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *apiclient.TestRepositoryRequest
+		if args[1] != nil {
+			arg1 = args[1].(*apiclient.TestRepositoryRequest)
+		}
+		var arg2 []grpc.CallOption
 		variadicArgs := make([]grpc.CallOption, len(args)-2)
 		for i, a := range args[2:] {
 			if a != nil {
 				variadicArgs[i] = a.(grpc.CallOption)
 			}
 		}
-		run(args[0].(context.Context), args[1].(*apiclient.TestRepositoryRequest), variadicArgs...)
+		arg2 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2...,
+		)
 	})
 	return _c
 }
@@ -1177,9 +1382,9 @@ type RepoServerServiceClient_UpdateRevisionForPaths_Call struct {
 }
 
 // UpdateRevisionForPaths is a helper method to define mock.On call
-//   - ctx
-//   - in
-//   - opts
+//   - ctx context.Context
+//   - in *apiclient.UpdateRevisionForPathsRequest
+//   - opts ...grpc.CallOption
 func (_e *RepoServerServiceClient_Expecter) UpdateRevisionForPaths(ctx interface{}, in interface{}, opts ...interface{}) *RepoServerServiceClient_UpdateRevisionForPaths_Call {
 	return &RepoServerServiceClient_UpdateRevisionForPaths_Call{Call: _e.mock.On("UpdateRevisionForPaths",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1187,13 +1392,27 @@ func (_e *RepoServerServiceClient_Expecter) UpdateRevisionForPaths(ctx interface
 
 func (_c *RepoServerServiceClient_UpdateRevisionForPaths_Call) Run(run func(ctx context.Context, in *apiclient.UpdateRevisionForPathsRequest, opts ...grpc.CallOption)) *RepoServerServiceClient_UpdateRevisionForPaths_Call {
 	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *apiclient.UpdateRevisionForPathsRequest
+		if args[1] != nil {
+			arg1 = args[1].(*apiclient.UpdateRevisionForPathsRequest)
+		}
+		var arg2 []grpc.CallOption
 		variadicArgs := make([]grpc.CallOption, len(args)-2)
 		for i, a := range args[2:] {
 			if a != nil {
 				variadicArgs[i] = a.(grpc.CallOption)
 			}
 		}
-		run(args[0].(context.Context), args[1].(*apiclient.UpdateRevisionForPathsRequest), variadicArgs...)
+		arg2 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2...,
+		)
 	})
 	return _c
 }

--- a/reposerver/apiclient/mocks/RepoServerService_GenerateManifestWithFilesClient.go
+++ b/reposerver/apiclient/mocks/RepoServerService_GenerateManifestWithFilesClient.go
@@ -262,14 +262,20 @@ type RepoServerService_GenerateManifestWithFilesClient_RecvMsg_Call struct {
 }
 
 // RecvMsg is a helper method to define mock.On call
-//   - m
+//   - m any
 func (_e *RepoServerService_GenerateManifestWithFilesClient_Expecter) RecvMsg(m interface{}) *RepoServerService_GenerateManifestWithFilesClient_RecvMsg_Call {
 	return &RepoServerService_GenerateManifestWithFilesClient_RecvMsg_Call{Call: _e.mock.On("RecvMsg", m)}
 }
 
 func (_c *RepoServerService_GenerateManifestWithFilesClient_RecvMsg_Call) Run(run func(m any)) *RepoServerService_GenerateManifestWithFilesClient_RecvMsg_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(any))
+		var arg0 any
+		if args[0] != nil {
+			arg0 = args[0].(any)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -307,14 +313,20 @@ type RepoServerService_GenerateManifestWithFilesClient_Send_Call struct {
 }
 
 // Send is a helper method to define mock.On call
-//   - manifestRequestWithFiles
+//   - manifestRequestWithFiles *apiclient.ManifestRequestWithFiles
 func (_e *RepoServerService_GenerateManifestWithFilesClient_Expecter) Send(manifestRequestWithFiles interface{}) *RepoServerService_GenerateManifestWithFilesClient_Send_Call {
 	return &RepoServerService_GenerateManifestWithFilesClient_Send_Call{Call: _e.mock.On("Send", manifestRequestWithFiles)}
 }
 
 func (_c *RepoServerService_GenerateManifestWithFilesClient_Send_Call) Run(run func(manifestRequestWithFiles *apiclient.ManifestRequestWithFiles)) *RepoServerService_GenerateManifestWithFilesClient_Send_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*apiclient.ManifestRequestWithFiles))
+		var arg0 *apiclient.ManifestRequestWithFiles
+		if args[0] != nil {
+			arg0 = args[0].(*apiclient.ManifestRequestWithFiles)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -352,14 +364,20 @@ type RepoServerService_GenerateManifestWithFilesClient_SendMsg_Call struct {
 }
 
 // SendMsg is a helper method to define mock.On call
-//   - m
+//   - m any
 func (_e *RepoServerService_GenerateManifestWithFilesClient_Expecter) SendMsg(m interface{}) *RepoServerService_GenerateManifestWithFilesClient_SendMsg_Call {
 	return &RepoServerService_GenerateManifestWithFilesClient_SendMsg_Call{Call: _e.mock.On("SendMsg", m)}
 }
 
 func (_c *RepoServerService_GenerateManifestWithFilesClient_SendMsg_Call) Run(run func(m any)) *RepoServerService_GenerateManifestWithFilesClient_SendMsg_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(any))
+		var arg0 any
+		if args[0] != nil {
+			arg0 = args[0].(any)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }

--- a/server/application/mocks/Broadcaster.go
+++ b/server/application/mocks/Broadcaster.go
@@ -48,15 +48,26 @@ type Broadcaster_OnAdd_Call struct {
 }
 
 // OnAdd is a helper method to define mock.On call
-//   - v
-//   - b
+//   - v any
+//   - b bool
 func (_e *Broadcaster_Expecter) OnAdd(v interface{}, b interface{}) *Broadcaster_OnAdd_Call {
 	return &Broadcaster_OnAdd_Call{Call: _e.mock.On("OnAdd", v, b)}
 }
 
 func (_c *Broadcaster_OnAdd_Call) Run(run func(v any, b bool)) *Broadcaster_OnAdd_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(any), args[1].(bool))
+		var arg0 any
+		if args[0] != nil {
+			arg0 = args[0].(any)
+		}
+		var arg1 bool
+		if args[1] != nil {
+			arg1 = args[1].(bool)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -83,14 +94,20 @@ type Broadcaster_OnDelete_Call struct {
 }
 
 // OnDelete is a helper method to define mock.On call
-//   - v
+//   - v any
 func (_e *Broadcaster_Expecter) OnDelete(v interface{}) *Broadcaster_OnDelete_Call {
 	return &Broadcaster_OnDelete_Call{Call: _e.mock.On("OnDelete", v)}
 }
 
 func (_c *Broadcaster_OnDelete_Call) Run(run func(v any)) *Broadcaster_OnDelete_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(any))
+		var arg0 any
+		if args[0] != nil {
+			arg0 = args[0].(any)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -117,15 +134,26 @@ type Broadcaster_OnUpdate_Call struct {
 }
 
 // OnUpdate is a helper method to define mock.On call
-//   - v
-//   - v1
+//   - v any
+//   - v1 any
 func (_e *Broadcaster_Expecter) OnUpdate(v interface{}, v1 interface{}) *Broadcaster_OnUpdate_Call {
 	return &Broadcaster_OnUpdate_Call{Call: _e.mock.On("OnUpdate", v, v1)}
 }
 
 func (_c *Broadcaster_OnUpdate_Call) Run(run func(v any, v1 any)) *Broadcaster_OnUpdate_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(any), args[1].(any))
+		var arg0 any
+		if args[0] != nil {
+			arg0 = args[0].(any)
+		}
+		var arg1 any
+		if args[1] != nil {
+			arg1 = args[1].(any)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -173,8 +201,8 @@ type Broadcaster_Subscribe_Call struct {
 }
 
 // Subscribe is a helper method to define mock.On call
-//   - ch
-//   - filters
+//   - ch chan *v1alpha1.ApplicationWatchEvent
+//   - filters ...func(event *v1alpha1.ApplicationWatchEvent) bool
 func (_e *Broadcaster_Expecter) Subscribe(ch interface{}, filters ...interface{}) *Broadcaster_Subscribe_Call {
 	return &Broadcaster_Subscribe_Call{Call: _e.mock.On("Subscribe",
 		append([]interface{}{ch}, filters...)...)}
@@ -182,13 +210,22 @@ func (_e *Broadcaster_Expecter) Subscribe(ch interface{}, filters ...interface{}
 
 func (_c *Broadcaster_Subscribe_Call) Run(run func(ch chan *v1alpha1.ApplicationWatchEvent, filters ...func(event *v1alpha1.ApplicationWatchEvent) bool)) *Broadcaster_Subscribe_Call {
 	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 chan *v1alpha1.ApplicationWatchEvent
+		if args[0] != nil {
+			arg0 = args[0].(chan *v1alpha1.ApplicationWatchEvent)
+		}
+		var arg1 []func(event *v1alpha1.ApplicationWatchEvent) bool
 		variadicArgs := make([]func(event *v1alpha1.ApplicationWatchEvent) bool, len(args)-1)
 		for i, a := range args[1:] {
 			if a != nil {
 				variadicArgs[i] = a.(func(event *v1alpha1.ApplicationWatchEvent) bool)
 			}
 		}
-		run(args[0].(chan *v1alpha1.ApplicationWatchEvent), variadicArgs...)
+		arg1 = variadicArgs
+		run(
+			arg0,
+			arg1...,
+		)
 	})
 	return _c
 }

--- a/server/extension/mocks/ApplicationGetter.go
+++ b/server/extension/mocks/ApplicationGetter.go
@@ -70,15 +70,26 @@ type ApplicationGetter_Get_Call struct {
 }
 
 // Get is a helper method to define mock.On call
-//   - ns
-//   - name
+//   - ns string
+//   - name string
 func (_e *ApplicationGetter_Expecter) Get(ns interface{}, name interface{}) *ApplicationGetter_Get_Call {
 	return &ApplicationGetter_Get_Call{Call: _e.mock.On("Get", ns, name)}
 }
 
 func (_c *ApplicationGetter_Get_Call) Run(run func(ns string, name string)) *ApplicationGetter_Get_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string))
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }

--- a/server/extension/mocks/ExtensionMetricsRegistry.go
+++ b/server/extension/mocks/ExtensionMetricsRegistry.go
@@ -49,15 +49,26 @@ type ExtensionMetricsRegistry_IncExtensionRequestCounter_Call struct {
 }
 
 // IncExtensionRequestCounter is a helper method to define mock.On call
-//   - extension
-//   - status
+//   - extension string
+//   - status int
 func (_e *ExtensionMetricsRegistry_Expecter) IncExtensionRequestCounter(extension interface{}, status interface{}) *ExtensionMetricsRegistry_IncExtensionRequestCounter_Call {
 	return &ExtensionMetricsRegistry_IncExtensionRequestCounter_Call{Call: _e.mock.On("IncExtensionRequestCounter", extension, status)}
 }
 
 func (_c *ExtensionMetricsRegistry_IncExtensionRequestCounter_Call) Run(run func(extension string, status int)) *ExtensionMetricsRegistry_IncExtensionRequestCounter_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(int))
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 int
+		if args[1] != nil {
+			arg1 = args[1].(int)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -84,15 +95,26 @@ type ExtensionMetricsRegistry_ObserveExtensionRequestDuration_Call struct {
 }
 
 // ObserveExtensionRequestDuration is a helper method to define mock.On call
-//   - extension
-//   - duration
+//   - extension string
+//   - duration time.Duration
 func (_e *ExtensionMetricsRegistry_Expecter) ObserveExtensionRequestDuration(extension interface{}, duration interface{}) *ExtensionMetricsRegistry_ObserveExtensionRequestDuration_Call {
 	return &ExtensionMetricsRegistry_ObserveExtensionRequestDuration_Call{Call: _e.mock.On("ObserveExtensionRequestDuration", extension, duration)}
 }
 
 func (_c *ExtensionMetricsRegistry_ObserveExtensionRequestDuration_Call) Run(run func(extension string, duration time.Duration)) *ExtensionMetricsRegistry_ObserveExtensionRequestDuration_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(time.Duration))
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 time.Duration
+		if args[1] != nil {
+			arg1 = args[1].(time.Duration)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }

--- a/server/extension/mocks/ProjectGetter.go
+++ b/server/extension/mocks/ProjectGetter.go
@@ -70,14 +70,20 @@ type ProjectGetter_Get_Call struct {
 }
 
 // Get is a helper method to define mock.On call
-//   - name
+//   - name string
 func (_e *ProjectGetter_Expecter) Get(name interface{}) *ProjectGetter_Get_Call {
 	return &ProjectGetter_Get_Call{Call: _e.mock.On("Get", name)}
 }
 
 func (_c *ProjectGetter_Get_Call) Run(run func(name string)) *ProjectGetter_Get_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -126,14 +132,20 @@ type ProjectGetter_GetClusters_Call struct {
 }
 
 // GetClusters is a helper method to define mock.On call
-//   - project
+//   - project string
 func (_e *ProjectGetter_Expecter) GetClusters(project interface{}) *ProjectGetter_GetClusters_Call {
 	return &ProjectGetter_GetClusters_Call{Call: _e.mock.On("GetClusters", project)}
 }
 
 func (_c *ProjectGetter_GetClusters_Call) Run(run func(project string)) *ProjectGetter_GetClusters_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }

--- a/server/extension/mocks/RbacEnforcer.go
+++ b/server/extension/mocks/RbacEnforcer.go
@@ -60,7 +60,7 @@ type RbacEnforcer_EnforceErr_Call struct {
 }
 
 // EnforceErr is a helper method to define mock.On call
-//   - rvals
+//   - rvals ...any
 func (_e *RbacEnforcer_Expecter) EnforceErr(rvals ...interface{}) *RbacEnforcer_EnforceErr_Call {
 	return &RbacEnforcer_EnforceErr_Call{Call: _e.mock.On("EnforceErr",
 		append([]interface{}{}, rvals...)...)}
@@ -68,13 +68,17 @@ func (_e *RbacEnforcer_Expecter) EnforceErr(rvals ...interface{}) *RbacEnforcer_
 
 func (_c *RbacEnforcer_EnforceErr_Call) Run(run func(rvals ...any)) *RbacEnforcer_EnforceErr_Call {
 	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 []any
 		variadicArgs := make([]any, len(args)-0)
 		for i, a := range args[0:] {
 			if a != nil {
 				variadicArgs[i] = a.(any)
 			}
 		}
-		run(variadicArgs...)
+		arg0 = variadicArgs
+		run(
+			arg0...,
+		)
 	})
 	return _c
 }

--- a/server/extension/mocks/UserGetter.go
+++ b/server/extension/mocks/UserGetter.go
@@ -62,14 +62,20 @@ type UserGetter_GetGroups_Call struct {
 }
 
 // GetGroups is a helper method to define mock.On call
-//   - ctx
+//   - ctx context.Context
 func (_e *UserGetter_Expecter) GetGroups(ctx interface{}) *UserGetter_GetGroups_Call {
 	return &UserGetter_GetGroups_Call{Call: _e.mock.On("GetGroups", ctx)}
 }
 
 func (_c *UserGetter_GetGroups_Call) Run(run func(ctx context.Context)) *UserGetter_GetGroups_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -107,14 +113,20 @@ type UserGetter_GetUser_Call struct {
 }
 
 // GetUser is a helper method to define mock.On call
-//   - ctx
+//   - ctx context.Context
 func (_e *UserGetter_Expecter) GetUser(ctx interface{}) *UserGetter_GetUser_Call {
 	return &UserGetter_GetUser_Call{Call: _e.mock.On("GetUser", ctx)}
 }
 
 func (_c *UserGetter_GetUser_Call) Run(run func(ctx context.Context)) *UserGetter_GetUser_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }

--- a/util/db/mocks/ArgoDB.go
+++ b/util/db/mocks/ArgoDB.go
@@ -81,15 +81,26 @@ type ArgoDB_AddGPGPublicKey_Call struct {
 }
 
 // AddGPGPublicKey is a helper method to define mock.On call
-//   - ctx
-//   - keyData
+//   - ctx context.Context
+//   - keyData string
 func (_e *ArgoDB_Expecter) AddGPGPublicKey(ctx interface{}, keyData interface{}) *ArgoDB_AddGPGPublicKey_Call {
 	return &ArgoDB_AddGPGPublicKey_Call{Call: _e.mock.On("AddGPGPublicKey", ctx, keyData)}
 }
 
 func (_c *ArgoDB_AddGPGPublicKey_Call) Run(run func(ctx context.Context, keyData string)) *ArgoDB_AddGPGPublicKey_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -138,15 +149,26 @@ type ArgoDB_CreateCluster_Call struct {
 }
 
 // CreateCluster is a helper method to define mock.On call
-//   - ctx
-//   - c
+//   - ctx context.Context
+//   - c *v1alpha1.Cluster
 func (_e *ArgoDB_Expecter) CreateCluster(ctx interface{}, c interface{}) *ArgoDB_CreateCluster_Call {
 	return &ArgoDB_CreateCluster_Call{Call: _e.mock.On("CreateCluster", ctx, c)}
 }
 
 func (_c *ArgoDB_CreateCluster_Call) Run(run func(ctx context.Context, c *v1alpha1.Cluster)) *ArgoDB_CreateCluster_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*v1alpha1.Cluster))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *v1alpha1.Cluster
+		if args[1] != nil {
+			arg1 = args[1].(*v1alpha1.Cluster)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -195,16 +217,32 @@ type ArgoDB_CreateRepoCertificate_Call struct {
 }
 
 // CreateRepoCertificate is a helper method to define mock.On call
-//   - ctx
-//   - certificate
-//   - upsert
+//   - ctx context.Context
+//   - certificate *v1alpha1.RepositoryCertificateList
+//   - upsert bool
 func (_e *ArgoDB_Expecter) CreateRepoCertificate(ctx interface{}, certificate interface{}, upsert interface{}) *ArgoDB_CreateRepoCertificate_Call {
 	return &ArgoDB_CreateRepoCertificate_Call{Call: _e.mock.On("CreateRepoCertificate", ctx, certificate, upsert)}
 }
 
 func (_c *ArgoDB_CreateRepoCertificate_Call) Run(run func(ctx context.Context, certificate *v1alpha1.RepositoryCertificateList, upsert bool)) *ArgoDB_CreateRepoCertificate_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*v1alpha1.RepositoryCertificateList), args[2].(bool))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *v1alpha1.RepositoryCertificateList
+		if args[1] != nil {
+			arg1 = args[1].(*v1alpha1.RepositoryCertificateList)
+		}
+		var arg2 bool
+		if args[2] != nil {
+			arg2 = args[2].(bool)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
 	})
 	return _c
 }
@@ -253,15 +291,26 @@ type ArgoDB_CreateRepository_Call struct {
 }
 
 // CreateRepository is a helper method to define mock.On call
-//   - ctx
-//   - r
+//   - ctx context.Context
+//   - r *v1alpha1.Repository
 func (_e *ArgoDB_Expecter) CreateRepository(ctx interface{}, r interface{}) *ArgoDB_CreateRepository_Call {
 	return &ArgoDB_CreateRepository_Call{Call: _e.mock.On("CreateRepository", ctx, r)}
 }
 
 func (_c *ArgoDB_CreateRepository_Call) Run(run func(ctx context.Context, r *v1alpha1.Repository)) *ArgoDB_CreateRepository_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*v1alpha1.Repository))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *v1alpha1.Repository
+		if args[1] != nil {
+			arg1 = args[1].(*v1alpha1.Repository)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -310,15 +359,26 @@ type ArgoDB_CreateRepositoryCredentials_Call struct {
 }
 
 // CreateRepositoryCredentials is a helper method to define mock.On call
-//   - ctx
-//   - r
+//   - ctx context.Context
+//   - r *v1alpha1.RepoCreds
 func (_e *ArgoDB_Expecter) CreateRepositoryCredentials(ctx interface{}, r interface{}) *ArgoDB_CreateRepositoryCredentials_Call {
 	return &ArgoDB_CreateRepositoryCredentials_Call{Call: _e.mock.On("CreateRepositoryCredentials", ctx, r)}
 }
 
 func (_c *ArgoDB_CreateRepositoryCredentials_Call) Run(run func(ctx context.Context, r *v1alpha1.RepoCreds)) *ArgoDB_CreateRepositoryCredentials_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*v1alpha1.RepoCreds))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *v1alpha1.RepoCreds
+		if args[1] != nil {
+			arg1 = args[1].(*v1alpha1.RepoCreds)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -367,15 +427,26 @@ type ArgoDB_CreateWriteRepository_Call struct {
 }
 
 // CreateWriteRepository is a helper method to define mock.On call
-//   - ctx
-//   - r
+//   - ctx context.Context
+//   - r *v1alpha1.Repository
 func (_e *ArgoDB_Expecter) CreateWriteRepository(ctx interface{}, r interface{}) *ArgoDB_CreateWriteRepository_Call {
 	return &ArgoDB_CreateWriteRepository_Call{Call: _e.mock.On("CreateWriteRepository", ctx, r)}
 }
 
 func (_c *ArgoDB_CreateWriteRepository_Call) Run(run func(ctx context.Context, r *v1alpha1.Repository)) *ArgoDB_CreateWriteRepository_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*v1alpha1.Repository))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *v1alpha1.Repository
+		if args[1] != nil {
+			arg1 = args[1].(*v1alpha1.Repository)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -424,15 +495,26 @@ type ArgoDB_CreateWriteRepositoryCredentials_Call struct {
 }
 
 // CreateWriteRepositoryCredentials is a helper method to define mock.On call
-//   - ctx
-//   - r
+//   - ctx context.Context
+//   - r *v1alpha1.RepoCreds
 func (_e *ArgoDB_Expecter) CreateWriteRepositoryCredentials(ctx interface{}, r interface{}) *ArgoDB_CreateWriteRepositoryCredentials_Call {
 	return &ArgoDB_CreateWriteRepositoryCredentials_Call{Call: _e.mock.On("CreateWriteRepositoryCredentials", ctx, r)}
 }
 
 func (_c *ArgoDB_CreateWriteRepositoryCredentials_Call) Run(run func(ctx context.Context, r *v1alpha1.RepoCreds)) *ArgoDB_CreateWriteRepositoryCredentials_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*v1alpha1.RepoCreds))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *v1alpha1.RepoCreds
+		if args[1] != nil {
+			arg1 = args[1].(*v1alpha1.RepoCreds)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -470,15 +552,26 @@ type ArgoDB_DeleteCluster_Call struct {
 }
 
 // DeleteCluster is a helper method to define mock.On call
-//   - ctx
-//   - server
+//   - ctx context.Context
+//   - server string
 func (_e *ArgoDB_Expecter) DeleteCluster(ctx interface{}, server interface{}) *ArgoDB_DeleteCluster_Call {
 	return &ArgoDB_DeleteCluster_Call{Call: _e.mock.On("DeleteCluster", ctx, server)}
 }
 
 func (_c *ArgoDB_DeleteCluster_Call) Run(run func(ctx context.Context, server string)) *ArgoDB_DeleteCluster_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -516,15 +609,26 @@ type ArgoDB_DeleteGPGPublicKey_Call struct {
 }
 
 // DeleteGPGPublicKey is a helper method to define mock.On call
-//   - ctx
-//   - keyID
+//   - ctx context.Context
+//   - keyID string
 func (_e *ArgoDB_Expecter) DeleteGPGPublicKey(ctx interface{}, keyID interface{}) *ArgoDB_DeleteGPGPublicKey_Call {
 	return &ArgoDB_DeleteGPGPublicKey_Call{Call: _e.mock.On("DeleteGPGPublicKey", ctx, keyID)}
 }
 
 func (_c *ArgoDB_DeleteGPGPublicKey_Call) Run(run func(ctx context.Context, keyID string)) *ArgoDB_DeleteGPGPublicKey_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -562,16 +666,32 @@ type ArgoDB_DeleteRepository_Call struct {
 }
 
 // DeleteRepository is a helper method to define mock.On call
-//   - ctx
-//   - name
-//   - project
+//   - ctx context.Context
+//   - name string
+//   - project string
 func (_e *ArgoDB_Expecter) DeleteRepository(ctx interface{}, name interface{}, project interface{}) *ArgoDB_DeleteRepository_Call {
 	return &ArgoDB_DeleteRepository_Call{Call: _e.mock.On("DeleteRepository", ctx, name, project)}
 }
 
 func (_c *ArgoDB_DeleteRepository_Call) Run(run func(ctx context.Context, name string, project string)) *ArgoDB_DeleteRepository_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
 	})
 	return _c
 }
@@ -609,15 +729,26 @@ type ArgoDB_DeleteRepositoryCredentials_Call struct {
 }
 
 // DeleteRepositoryCredentials is a helper method to define mock.On call
-//   - ctx
-//   - name
+//   - ctx context.Context
+//   - name string
 func (_e *ArgoDB_Expecter) DeleteRepositoryCredentials(ctx interface{}, name interface{}) *ArgoDB_DeleteRepositoryCredentials_Call {
 	return &ArgoDB_DeleteRepositoryCredentials_Call{Call: _e.mock.On("DeleteRepositoryCredentials", ctx, name)}
 }
 
 func (_c *ArgoDB_DeleteRepositoryCredentials_Call) Run(run func(ctx context.Context, name string)) *ArgoDB_DeleteRepositoryCredentials_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -655,16 +786,32 @@ type ArgoDB_DeleteWriteRepository_Call struct {
 }
 
 // DeleteWriteRepository is a helper method to define mock.On call
-//   - ctx
-//   - name
-//   - project
+//   - ctx context.Context
+//   - name string
+//   - project string
 func (_e *ArgoDB_Expecter) DeleteWriteRepository(ctx interface{}, name interface{}, project interface{}) *ArgoDB_DeleteWriteRepository_Call {
 	return &ArgoDB_DeleteWriteRepository_Call{Call: _e.mock.On("DeleteWriteRepository", ctx, name, project)}
 }
 
 func (_c *ArgoDB_DeleteWriteRepository_Call) Run(run func(ctx context.Context, name string, project string)) *ArgoDB_DeleteWriteRepository_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
 	})
 	return _c
 }
@@ -702,15 +849,26 @@ type ArgoDB_DeleteWriteRepositoryCredentials_Call struct {
 }
 
 // DeleteWriteRepositoryCredentials is a helper method to define mock.On call
-//   - ctx
-//   - name
+//   - ctx context.Context
+//   - name string
 func (_e *ArgoDB_Expecter) DeleteWriteRepositoryCredentials(ctx interface{}, name interface{}) *ArgoDB_DeleteWriteRepositoryCredentials_Call {
 	return &ArgoDB_DeleteWriteRepositoryCredentials_Call{Call: _e.mock.On("DeleteWriteRepositoryCredentials", ctx, name)}
 }
 
 func (_c *ArgoDB_DeleteWriteRepositoryCredentials_Call) Run(run func(ctx context.Context, name string)) *ArgoDB_DeleteWriteRepositoryCredentials_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -759,14 +917,20 @@ type ArgoDB_GetAllHelmRepositoryCredentials_Call struct {
 }
 
 // GetAllHelmRepositoryCredentials is a helper method to define mock.On call
-//   - ctx
+//   - ctx context.Context
 func (_e *ArgoDB_Expecter) GetAllHelmRepositoryCredentials(ctx interface{}) *ArgoDB_GetAllHelmRepositoryCredentials_Call {
 	return &ArgoDB_GetAllHelmRepositoryCredentials_Call{Call: _e.mock.On("GetAllHelmRepositoryCredentials", ctx)}
 }
 
 func (_c *ArgoDB_GetAllHelmRepositoryCredentials_Call) Run(run func(ctx context.Context)) *ArgoDB_GetAllHelmRepositoryCredentials_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -815,14 +979,20 @@ type ArgoDB_GetAllOCIRepositoryCredentials_Call struct {
 }
 
 // GetAllOCIRepositoryCredentials is a helper method to define mock.On call
-//   - ctx
+//   - ctx context.Context
 func (_e *ArgoDB_Expecter) GetAllOCIRepositoryCredentials(ctx interface{}) *ArgoDB_GetAllOCIRepositoryCredentials_Call {
 	return &ArgoDB_GetAllOCIRepositoryCredentials_Call{Call: _e.mock.On("GetAllOCIRepositoryCredentials", ctx)}
 }
 
 func (_c *ArgoDB_GetAllOCIRepositoryCredentials_Call) Run(run func(ctx context.Context)) *ArgoDB_GetAllOCIRepositoryCredentials_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -915,15 +1085,26 @@ type ArgoDB_GetCluster_Call struct {
 }
 
 // GetCluster is a helper method to define mock.On call
-//   - ctx
-//   - server
+//   - ctx context.Context
+//   - server string
 func (_e *ArgoDB_Expecter) GetCluster(ctx interface{}, server interface{}) *ArgoDB_GetCluster_Call {
 	return &ArgoDB_GetCluster_Call{Call: _e.mock.On("GetCluster", ctx, server)}
 }
 
 func (_c *ArgoDB_GetCluster_Call) Run(run func(ctx context.Context, server string)) *ArgoDB_GetCluster_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -972,15 +1153,26 @@ type ArgoDB_GetClusterServersByName_Call struct {
 }
 
 // GetClusterServersByName is a helper method to define mock.On call
-//   - ctx
-//   - name
+//   - ctx context.Context
+//   - name string
 func (_e *ArgoDB_Expecter) GetClusterServersByName(ctx interface{}, name interface{}) *ArgoDB_GetClusterServersByName_Call {
 	return &ArgoDB_GetClusterServersByName_Call{Call: _e.mock.On("GetClusterServersByName", ctx, name)}
 }
 
 func (_c *ArgoDB_GetClusterServersByName_Call) Run(run func(ctx context.Context, name string)) *ArgoDB_GetClusterServersByName_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -1029,15 +1221,26 @@ type ArgoDB_GetProjectClusters_Call struct {
 }
 
 // GetProjectClusters is a helper method to define mock.On call
-//   - ctx
-//   - project
+//   - ctx context.Context
+//   - project string
 func (_e *ArgoDB_Expecter) GetProjectClusters(ctx interface{}, project interface{}) *ArgoDB_GetProjectClusters_Call {
 	return &ArgoDB_GetProjectClusters_Call{Call: _e.mock.On("GetProjectClusters", ctx, project)}
 }
 
 func (_c *ArgoDB_GetProjectClusters_Call) Run(run func(ctx context.Context, project string)) *ArgoDB_GetProjectClusters_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -1086,14 +1289,20 @@ type ArgoDB_GetProjectRepositories_Call struct {
 }
 
 // GetProjectRepositories is a helper method to define mock.On call
-//   - project
+//   - project string
 func (_e *ArgoDB_Expecter) GetProjectRepositories(project interface{}) *ArgoDB_GetProjectRepositories_Call {
 	return &ArgoDB_GetProjectRepositories_Call{Call: _e.mock.On("GetProjectRepositories", project)}
 }
 
 func (_c *ArgoDB_GetProjectRepositories_Call) Run(run func(project string)) *ArgoDB_GetProjectRepositories_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -1142,14 +1351,20 @@ type ArgoDB_GetProjectWriteRepositories_Call struct {
 }
 
 // GetProjectWriteRepositories is a helper method to define mock.On call
-//   - project
+//   - project string
 func (_e *ArgoDB_Expecter) GetProjectWriteRepositories(project interface{}) *ArgoDB_GetProjectWriteRepositories_Call {
 	return &ArgoDB_GetProjectWriteRepositories_Call{Call: _e.mock.On("GetProjectWriteRepositories", project)}
 }
 
 func (_c *ArgoDB_GetProjectWriteRepositories_Call) Run(run func(project string)) *ArgoDB_GetProjectWriteRepositories_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -1198,16 +1413,32 @@ type ArgoDB_GetRepository_Call struct {
 }
 
 // GetRepository is a helper method to define mock.On call
-//   - ctx
-//   - url
-//   - project
+//   - ctx context.Context
+//   - url string
+//   - project string
 func (_e *ArgoDB_Expecter) GetRepository(ctx interface{}, url interface{}, project interface{}) *ArgoDB_GetRepository_Call {
 	return &ArgoDB_GetRepository_Call{Call: _e.mock.On("GetRepository", ctx, url, project)}
 }
 
 func (_c *ArgoDB_GetRepository_Call) Run(run func(ctx context.Context, url string, project string)) *ArgoDB_GetRepository_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
 	})
 	return _c
 }
@@ -1256,15 +1487,26 @@ type ArgoDB_GetRepositoryCredentials_Call struct {
 }
 
 // GetRepositoryCredentials is a helper method to define mock.On call
-//   - ctx
-//   - name
+//   - ctx context.Context
+//   - name string
 func (_e *ArgoDB_Expecter) GetRepositoryCredentials(ctx interface{}, name interface{}) *ArgoDB_GetRepositoryCredentials_Call {
 	return &ArgoDB_GetRepositoryCredentials_Call{Call: _e.mock.On("GetRepositoryCredentials", ctx, name)}
 }
 
 func (_c *ArgoDB_GetRepositoryCredentials_Call) Run(run func(ctx context.Context, name string)) *ArgoDB_GetRepositoryCredentials_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -1313,16 +1555,32 @@ type ArgoDB_GetWriteRepository_Call struct {
 }
 
 // GetWriteRepository is a helper method to define mock.On call
-//   - ctx
-//   - url
-//   - project
+//   - ctx context.Context
+//   - url string
+//   - project string
 func (_e *ArgoDB_Expecter) GetWriteRepository(ctx interface{}, url interface{}, project interface{}) *ArgoDB_GetWriteRepository_Call {
 	return &ArgoDB_GetWriteRepository_Call{Call: _e.mock.On("GetWriteRepository", ctx, url, project)}
 }
 
 func (_c *ArgoDB_GetWriteRepository_Call) Run(run func(ctx context.Context, url string, project string)) *ArgoDB_GetWriteRepository_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
 	})
 	return _c
 }
@@ -1371,15 +1629,26 @@ type ArgoDB_GetWriteRepositoryCredentials_Call struct {
 }
 
 // GetWriteRepositoryCredentials is a helper method to define mock.On call
-//   - ctx
-//   - name
+//   - ctx context.Context
+//   - name string
 func (_e *ArgoDB_Expecter) GetWriteRepositoryCredentials(ctx interface{}, name interface{}) *ArgoDB_GetWriteRepositoryCredentials_Call {
 	return &ArgoDB_GetWriteRepositoryCredentials_Call{Call: _e.mock.On("GetWriteRepositoryCredentials", ctx, name)}
 }
 
 func (_c *ArgoDB_GetWriteRepositoryCredentials_Call) Run(run func(ctx context.Context, name string)) *ArgoDB_GetWriteRepositoryCredentials_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -1428,14 +1697,20 @@ type ArgoDB_ListClusters_Call struct {
 }
 
 // ListClusters is a helper method to define mock.On call
-//   - ctx
+//   - ctx context.Context
 func (_e *ArgoDB_Expecter) ListClusters(ctx interface{}) *ArgoDB_ListClusters_Call {
 	return &ArgoDB_ListClusters_Call{Call: _e.mock.On("ListClusters", ctx)}
 }
 
 func (_c *ArgoDB_ListClusters_Call) Run(run func(ctx context.Context)) *ArgoDB_ListClusters_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -1484,14 +1759,20 @@ type ArgoDB_ListConfiguredGPGPublicKeys_Call struct {
 }
 
 // ListConfiguredGPGPublicKeys is a helper method to define mock.On call
-//   - ctx
+//   - ctx context.Context
 func (_e *ArgoDB_Expecter) ListConfiguredGPGPublicKeys(ctx interface{}) *ArgoDB_ListConfiguredGPGPublicKeys_Call {
 	return &ArgoDB_ListConfiguredGPGPublicKeys_Call{Call: _e.mock.On("ListConfiguredGPGPublicKeys", ctx)}
 }
 
 func (_c *ArgoDB_ListConfiguredGPGPublicKeys_Call) Run(run func(ctx context.Context)) *ArgoDB_ListConfiguredGPGPublicKeys_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -1540,14 +1821,20 @@ type ArgoDB_ListHelmRepositories_Call struct {
 }
 
 // ListHelmRepositories is a helper method to define mock.On call
-//   - ctx
+//   - ctx context.Context
 func (_e *ArgoDB_Expecter) ListHelmRepositories(ctx interface{}) *ArgoDB_ListHelmRepositories_Call {
 	return &ArgoDB_ListHelmRepositories_Call{Call: _e.mock.On("ListHelmRepositories", ctx)}
 }
 
 func (_c *ArgoDB_ListHelmRepositories_Call) Run(run func(ctx context.Context)) *ArgoDB_ListHelmRepositories_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -1596,14 +1883,20 @@ type ArgoDB_ListOCIRepositories_Call struct {
 }
 
 // ListOCIRepositories is a helper method to define mock.On call
-//   - ctx
+//   - ctx context.Context
 func (_e *ArgoDB_Expecter) ListOCIRepositories(ctx interface{}) *ArgoDB_ListOCIRepositories_Call {
 	return &ArgoDB_ListOCIRepositories_Call{Call: _e.mock.On("ListOCIRepositories", ctx)}
 }
 
 func (_c *ArgoDB_ListOCIRepositories_Call) Run(run func(ctx context.Context)) *ArgoDB_ListOCIRepositories_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -1652,15 +1945,26 @@ type ArgoDB_ListRepoCertificates_Call struct {
 }
 
 // ListRepoCertificates is a helper method to define mock.On call
-//   - ctx
-//   - selector
+//   - ctx context.Context
+//   - selector *db.CertificateListSelector
 func (_e *ArgoDB_Expecter) ListRepoCertificates(ctx interface{}, selector interface{}) *ArgoDB_ListRepoCertificates_Call {
 	return &ArgoDB_ListRepoCertificates_Call{Call: _e.mock.On("ListRepoCertificates", ctx, selector)}
 }
 
 func (_c *ArgoDB_ListRepoCertificates_Call) Run(run func(ctx context.Context, selector *db.CertificateListSelector)) *ArgoDB_ListRepoCertificates_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*db.CertificateListSelector))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *db.CertificateListSelector
+		if args[1] != nil {
+			arg1 = args[1].(*db.CertificateListSelector)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -1709,14 +2013,20 @@ type ArgoDB_ListRepositories_Call struct {
 }
 
 // ListRepositories is a helper method to define mock.On call
-//   - ctx
+//   - ctx context.Context
 func (_e *ArgoDB_Expecter) ListRepositories(ctx interface{}) *ArgoDB_ListRepositories_Call {
 	return &ArgoDB_ListRepositories_Call{Call: _e.mock.On("ListRepositories", ctx)}
 }
 
 func (_c *ArgoDB_ListRepositories_Call) Run(run func(ctx context.Context)) *ArgoDB_ListRepositories_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -1765,14 +2075,20 @@ type ArgoDB_ListRepositoryCredentials_Call struct {
 }
 
 // ListRepositoryCredentials is a helper method to define mock.On call
-//   - ctx
+//   - ctx context.Context
 func (_e *ArgoDB_Expecter) ListRepositoryCredentials(ctx interface{}) *ArgoDB_ListRepositoryCredentials_Call {
 	return &ArgoDB_ListRepositoryCredentials_Call{Call: _e.mock.On("ListRepositoryCredentials", ctx)}
 }
 
 func (_c *ArgoDB_ListRepositoryCredentials_Call) Run(run func(ctx context.Context)) *ArgoDB_ListRepositoryCredentials_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -1821,14 +2137,20 @@ type ArgoDB_ListWriteRepositories_Call struct {
 }
 
 // ListWriteRepositories is a helper method to define mock.On call
-//   - ctx
+//   - ctx context.Context
 func (_e *ArgoDB_Expecter) ListWriteRepositories(ctx interface{}) *ArgoDB_ListWriteRepositories_Call {
 	return &ArgoDB_ListWriteRepositories_Call{Call: _e.mock.On("ListWriteRepositories", ctx)}
 }
 
 func (_c *ArgoDB_ListWriteRepositories_Call) Run(run func(ctx context.Context)) *ArgoDB_ListWriteRepositories_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -1877,14 +2199,20 @@ type ArgoDB_ListWriteRepositoryCredentials_Call struct {
 }
 
 // ListWriteRepositoryCredentials is a helper method to define mock.On call
-//   - ctx
+//   - ctx context.Context
 func (_e *ArgoDB_Expecter) ListWriteRepositoryCredentials(ctx interface{}) *ArgoDB_ListWriteRepositoryCredentials_Call {
 	return &ArgoDB_ListWriteRepositoryCredentials_Call{Call: _e.mock.On("ListWriteRepositoryCredentials", ctx)}
 }
 
 func (_c *ArgoDB_ListWriteRepositoryCredentials_Call) Run(run func(ctx context.Context)) *ArgoDB_ListWriteRepositoryCredentials_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -1933,15 +2261,26 @@ type ArgoDB_RemoveRepoCertificates_Call struct {
 }
 
 // RemoveRepoCertificates is a helper method to define mock.On call
-//   - ctx
-//   - selector
+//   - ctx context.Context
+//   - selector *db.CertificateListSelector
 func (_e *ArgoDB_Expecter) RemoveRepoCertificates(ctx interface{}, selector interface{}) *ArgoDB_RemoveRepoCertificates_Call {
 	return &ArgoDB_RemoveRepoCertificates_Call{Call: _e.mock.On("RemoveRepoCertificates", ctx, selector)}
 }
 
 func (_c *ArgoDB_RemoveRepoCertificates_Call) Run(run func(ctx context.Context, selector *db.CertificateListSelector)) *ArgoDB_RemoveRepoCertificates_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*db.CertificateListSelector))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *db.CertificateListSelector
+		if args[1] != nil {
+			arg1 = args[1].(*db.CertificateListSelector)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -1988,16 +2327,32 @@ type ArgoDB_RepositoryExists_Call struct {
 }
 
 // RepositoryExists is a helper method to define mock.On call
-//   - ctx
-//   - repoURL
-//   - project
+//   - ctx context.Context
+//   - repoURL string
+//   - project string
 func (_e *ArgoDB_Expecter) RepositoryExists(ctx interface{}, repoURL interface{}, project interface{}) *ArgoDB_RepositoryExists_Call {
 	return &ArgoDB_RepositoryExists_Call{Call: _e.mock.On("RepositoryExists", ctx, repoURL, project)}
 }
 
 func (_c *ArgoDB_RepositoryExists_Call) Run(run func(ctx context.Context, repoURL string, project string)) *ArgoDB_RepositoryExists_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
 	})
 	return _c
 }
@@ -2046,15 +2401,26 @@ type ArgoDB_UpdateCluster_Call struct {
 }
 
 // UpdateCluster is a helper method to define mock.On call
-//   - ctx
-//   - c
+//   - ctx context.Context
+//   - c *v1alpha1.Cluster
 func (_e *ArgoDB_Expecter) UpdateCluster(ctx interface{}, c interface{}) *ArgoDB_UpdateCluster_Call {
 	return &ArgoDB_UpdateCluster_Call{Call: _e.mock.On("UpdateCluster", ctx, c)}
 }
 
 func (_c *ArgoDB_UpdateCluster_Call) Run(run func(ctx context.Context, c *v1alpha1.Cluster)) *ArgoDB_UpdateCluster_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*v1alpha1.Cluster))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *v1alpha1.Cluster
+		if args[1] != nil {
+			arg1 = args[1].(*v1alpha1.Cluster)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -2103,15 +2469,26 @@ type ArgoDB_UpdateRepository_Call struct {
 }
 
 // UpdateRepository is a helper method to define mock.On call
-//   - ctx
-//   - r
+//   - ctx context.Context
+//   - r *v1alpha1.Repository
 func (_e *ArgoDB_Expecter) UpdateRepository(ctx interface{}, r interface{}) *ArgoDB_UpdateRepository_Call {
 	return &ArgoDB_UpdateRepository_Call{Call: _e.mock.On("UpdateRepository", ctx, r)}
 }
 
 func (_c *ArgoDB_UpdateRepository_Call) Run(run func(ctx context.Context, r *v1alpha1.Repository)) *ArgoDB_UpdateRepository_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*v1alpha1.Repository))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *v1alpha1.Repository
+		if args[1] != nil {
+			arg1 = args[1].(*v1alpha1.Repository)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -2160,15 +2537,26 @@ type ArgoDB_UpdateRepositoryCredentials_Call struct {
 }
 
 // UpdateRepositoryCredentials is a helper method to define mock.On call
-//   - ctx
-//   - r
+//   - ctx context.Context
+//   - r *v1alpha1.RepoCreds
 func (_e *ArgoDB_Expecter) UpdateRepositoryCredentials(ctx interface{}, r interface{}) *ArgoDB_UpdateRepositoryCredentials_Call {
 	return &ArgoDB_UpdateRepositoryCredentials_Call{Call: _e.mock.On("UpdateRepositoryCredentials", ctx, r)}
 }
 
 func (_c *ArgoDB_UpdateRepositoryCredentials_Call) Run(run func(ctx context.Context, r *v1alpha1.RepoCreds)) *ArgoDB_UpdateRepositoryCredentials_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*v1alpha1.RepoCreds))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *v1alpha1.RepoCreds
+		if args[1] != nil {
+			arg1 = args[1].(*v1alpha1.RepoCreds)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -2217,15 +2605,26 @@ type ArgoDB_UpdateWriteRepository_Call struct {
 }
 
 // UpdateWriteRepository is a helper method to define mock.On call
-//   - ctx
-//   - r
+//   - ctx context.Context
+//   - r *v1alpha1.Repository
 func (_e *ArgoDB_Expecter) UpdateWriteRepository(ctx interface{}, r interface{}) *ArgoDB_UpdateWriteRepository_Call {
 	return &ArgoDB_UpdateWriteRepository_Call{Call: _e.mock.On("UpdateWriteRepository", ctx, r)}
 }
 
 func (_c *ArgoDB_UpdateWriteRepository_Call) Run(run func(ctx context.Context, r *v1alpha1.Repository)) *ArgoDB_UpdateWriteRepository_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*v1alpha1.Repository))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *v1alpha1.Repository
+		if args[1] != nil {
+			arg1 = args[1].(*v1alpha1.Repository)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -2274,15 +2673,26 @@ type ArgoDB_UpdateWriteRepositoryCredentials_Call struct {
 }
 
 // UpdateWriteRepositoryCredentials is a helper method to define mock.On call
-//   - ctx
-//   - r
+//   - ctx context.Context
+//   - r *v1alpha1.RepoCreds
 func (_e *ArgoDB_Expecter) UpdateWriteRepositoryCredentials(ctx interface{}, r interface{}) *ArgoDB_UpdateWriteRepositoryCredentials_Call {
 	return &ArgoDB_UpdateWriteRepositoryCredentials_Call{Call: _e.mock.On("UpdateWriteRepositoryCredentials", ctx, r)}
 }
 
 func (_c *ArgoDB_UpdateWriteRepositoryCredentials_Call) Run(run func(ctx context.Context, r *v1alpha1.RepoCreds)) *ArgoDB_UpdateWriteRepositoryCredentials_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*v1alpha1.RepoCreds))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *v1alpha1.RepoCreds
+		if args[1] != nil {
+			arg1 = args[1].(*v1alpha1.RepoCreds)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -2320,17 +2730,38 @@ type ArgoDB_WatchClusters_Call struct {
 }
 
 // WatchClusters is a helper method to define mock.On call
-//   - ctx
-//   - handleAddEvent
-//   - handleModEvent
-//   - handleDeleteEvent
+//   - ctx context.Context
+//   - handleAddEvent func(cluster *v1alpha1.Cluster)
+//   - handleModEvent func(oldCluster *v1alpha1.Cluster, newCluster *v1alpha1.Cluster)
+//   - handleDeleteEvent func(clusterServer string)
 func (_e *ArgoDB_Expecter) WatchClusters(ctx interface{}, handleAddEvent interface{}, handleModEvent interface{}, handleDeleteEvent interface{}) *ArgoDB_WatchClusters_Call {
 	return &ArgoDB_WatchClusters_Call{Call: _e.mock.On("WatchClusters", ctx, handleAddEvent, handleModEvent, handleDeleteEvent)}
 }
 
 func (_c *ArgoDB_WatchClusters_Call) Run(run func(ctx context.Context, handleAddEvent func(cluster *v1alpha1.Cluster), handleModEvent func(oldCluster *v1alpha1.Cluster, newCluster *v1alpha1.Cluster), handleDeleteEvent func(clusterServer string))) *ArgoDB_WatchClusters_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(func(cluster *v1alpha1.Cluster)), args[2].(func(oldCluster *v1alpha1.Cluster, newCluster *v1alpha1.Cluster)), args[3].(func(clusterServer string)))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 func(cluster *v1alpha1.Cluster)
+		if args[1] != nil {
+			arg1 = args[1].(func(cluster *v1alpha1.Cluster))
+		}
+		var arg2 func(oldCluster *v1alpha1.Cluster, newCluster *v1alpha1.Cluster)
+		if args[2] != nil {
+			arg2 = args[2].(func(oldCluster *v1alpha1.Cluster, newCluster *v1alpha1.Cluster))
+		}
+		var arg3 func(clusterServer string)
+		if args[3] != nil {
+			arg3 = args[3].(func(clusterServer string))
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
 	})
 	return _c
 }
@@ -2377,16 +2808,32 @@ type ArgoDB_WriteRepositoryExists_Call struct {
 }
 
 // WriteRepositoryExists is a helper method to define mock.On call
-//   - ctx
-//   - repoURL
-//   - project
+//   - ctx context.Context
+//   - repoURL string
+//   - project string
 func (_e *ArgoDB_Expecter) WriteRepositoryExists(ctx interface{}, repoURL interface{}, project interface{}) *ArgoDB_WriteRepositoryExists_Call {
 	return &ArgoDB_WriteRepositoryExists_Call{Call: _e.mock.On("WriteRepositoryExists", ctx, repoURL, project)}
 }
 
 func (_c *ArgoDB_WriteRepositoryExists_Call) Run(run func(ctx context.Context, repoURL string, project string)) *ArgoDB_WriteRepositoryExists_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
 	})
 	return _c
 }

--- a/util/git/mocks/Client.go
+++ b/util/git/mocks/Client.go
@@ -70,15 +70,26 @@ type Client_ChangedFiles_Call struct {
 }
 
 // ChangedFiles is a helper method to define mock.On call
-//   - revision
-//   - targetRevision
+//   - revision string
+//   - targetRevision string
 func (_e *Client_Expecter) ChangedFiles(revision interface{}, targetRevision interface{}) *Client_ChangedFiles_Call {
 	return &Client_ChangedFiles_Call{Call: _e.mock.On("ChangedFiles", revision, targetRevision)}
 }
 
 func (_c *Client_ChangedFiles_Call) Run(run func(revision string, targetRevision string)) *Client_ChangedFiles_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string))
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -125,15 +136,26 @@ type Client_Checkout_Call struct {
 }
 
 // Checkout is a helper method to define mock.On call
-//   - revision
-//   - submoduleEnabled
+//   - revision string
+//   - submoduleEnabled bool
 func (_e *Client_Expecter) Checkout(revision interface{}, submoduleEnabled interface{}) *Client_Checkout_Call {
 	return &Client_Checkout_Call{Call: _e.mock.On("Checkout", revision, submoduleEnabled)}
 }
 
 func (_c *Client_Checkout_Call) Run(run func(revision string, submoduleEnabled bool)) *Client_Checkout_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(bool))
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 bool
+		if args[1] != nil {
+			arg1 = args[1].(bool)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -180,16 +202,32 @@ type Client_CheckoutOrNew_Call struct {
 }
 
 // CheckoutOrNew is a helper method to define mock.On call
-//   - branch
-//   - base
-//   - submoduleEnabled
+//   - branch string
+//   - base string
+//   - submoduleEnabled bool
 func (_e *Client_Expecter) CheckoutOrNew(branch interface{}, base interface{}, submoduleEnabled interface{}) *Client_CheckoutOrNew_Call {
 	return &Client_CheckoutOrNew_Call{Call: _e.mock.On("CheckoutOrNew", branch, base, submoduleEnabled)}
 }
 
 func (_c *Client_CheckoutOrNew_Call) Run(run func(branch string, base string, submoduleEnabled bool)) *Client_CheckoutOrNew_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string), args[2].(bool))
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 bool
+		if args[2] != nil {
+			arg2 = args[2].(bool)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
 	})
 	return _c
 }
@@ -236,15 +274,26 @@ type Client_CheckoutOrOrphan_Call struct {
 }
 
 // CheckoutOrOrphan is a helper method to define mock.On call
-//   - branch
-//   - submoduleEnabled
+//   - branch string
+//   - submoduleEnabled bool
 func (_e *Client_Expecter) CheckoutOrOrphan(branch interface{}, submoduleEnabled interface{}) *Client_CheckoutOrOrphan_Call {
 	return &Client_CheckoutOrOrphan_Call{Call: _e.mock.On("CheckoutOrOrphan", branch, submoduleEnabled)}
 }
 
 func (_c *Client_CheckoutOrOrphan_Call) Run(run func(branch string, submoduleEnabled bool)) *Client_CheckoutOrOrphan_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(bool))
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 bool
+		if args[1] != nil {
+			arg1 = args[1].(bool)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -291,15 +340,26 @@ type Client_CommitAndPush_Call struct {
 }
 
 // CommitAndPush is a helper method to define mock.On call
-//   - branch
-//   - message
+//   - branch string
+//   - message string
 func (_e *Client_Expecter) CommitAndPush(branch interface{}, message interface{}) *Client_CommitAndPush_Call {
 	return &Client_CommitAndPush_Call{Call: _e.mock.On("CommitAndPush", branch, message)}
 }
 
 func (_c *Client_CommitAndPush_Call) Run(run func(branch string, message string)) *Client_CommitAndPush_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string))
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -390,14 +450,20 @@ type Client_Fetch_Call struct {
 }
 
 // Fetch is a helper method to define mock.On call
-//   - revision
+//   - revision string
 func (_e *Client_Expecter) Fetch(revision interface{}) *Client_Fetch_Call {
 	return &Client_Fetch_Call{Call: _e.mock.On("Fetch", revision)}
 }
 
 func (_c *Client_Fetch_Call) Run(run func(revision string)) *Client_Fetch_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -479,14 +545,20 @@ type Client_IsAnnotatedTag_Call struct {
 }
 
 // IsAnnotatedTag is a helper method to define mock.On call
-//   - s
+//   - s string
 func (_e *Client_Expecter) IsAnnotatedTag(s interface{}) *Client_IsAnnotatedTag_Call {
 	return &Client_IsAnnotatedTag_Call{Call: _e.mock.On("IsAnnotatedTag", s)}
 }
 
 func (_c *Client_IsAnnotatedTag_Call) Run(run func(s string)) *Client_IsAnnotatedTag_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -524,14 +596,20 @@ type Client_IsRevisionPresent_Call struct {
 }
 
 // IsRevisionPresent is a helper method to define mock.On call
-//   - revision
+//   - revision string
 func (_e *Client_Expecter) IsRevisionPresent(revision interface{}) *Client_IsRevisionPresent_Call {
 	return &Client_IsRevisionPresent_Call{Call: _e.mock.On("IsRevisionPresent", revision)}
 }
 
 func (_c *Client_IsRevisionPresent_Call) Run(run func(revision string)) *Client_IsRevisionPresent_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -580,15 +658,26 @@ type Client_LsFiles_Call struct {
 }
 
 // LsFiles is a helper method to define mock.On call
-//   - path
-//   - enableNewGitFileGlobbing
+//   - path string
+//   - enableNewGitFileGlobbing bool
 func (_e *Client_Expecter) LsFiles(path interface{}, enableNewGitFileGlobbing interface{}) *Client_LsFiles_Call {
 	return &Client_LsFiles_Call{Call: _e.mock.On("LsFiles", path, enableNewGitFileGlobbing)}
 }
 
 func (_c *Client_LsFiles_Call) Run(run func(path string, enableNewGitFileGlobbing bool)) *Client_LsFiles_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(bool))
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 bool
+		if args[1] != nil {
+			arg1 = args[1].(bool)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -745,14 +834,20 @@ type Client_LsRemote_Call struct {
 }
 
 // LsRemote is a helper method to define mock.On call
-//   - revision
+//   - revision string
 func (_e *Client_Expecter) LsRemote(revision interface{}) *Client_LsRemote_Call {
 	return &Client_LsRemote_Call{Call: _e.mock.On("LsRemote", revision)}
 }
 
 func (_c *Client_LsRemote_Call) Run(run func(revision string)) *Client_LsRemote_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -854,14 +949,20 @@ type Client_RevisionMetadata_Call struct {
 }
 
 // RevisionMetadata is a helper method to define mock.On call
-//   - revision
+//   - revision string
 func (_e *Client_Expecter) RevisionMetadata(revision interface{}) *Client_RevisionMetadata_Call {
 	return &Client_RevisionMetadata_Call{Call: _e.mock.On("RevisionMetadata", revision)}
 }
 
 func (_c *Client_RevisionMetadata_Call) Run(run func(revision string)) *Client_RevisionMetadata_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -952,15 +1053,26 @@ type Client_SetAuthor_Call struct {
 }
 
 // SetAuthor is a helper method to define mock.On call
-//   - name
-//   - email
+//   - name string
+//   - email string
 func (_e *Client_Expecter) SetAuthor(name interface{}, email interface{}) *Client_SetAuthor_Call {
 	return &Client_SetAuthor_Call{Call: _e.mock.On("SetAuthor", name, email)}
 }
 
 func (_c *Client_SetAuthor_Call) Run(run func(name string, email string)) *Client_SetAuthor_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string))
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -1051,14 +1163,20 @@ type Client_VerifyCommitSignature_Call struct {
 }
 
 // VerifyCommitSignature is a helper method to define mock.On call
-//   - s
+//   - s string
 func (_e *Client_Expecter) VerifyCommitSignature(s interface{}) *Client_VerifyCommitSignature_Call {
 	return &Client_VerifyCommitSignature_Call{Call: _e.mock.On("VerifyCommitSignature", s)}
 }
 
 func (_c *Client_VerifyCommitSignature_Call) Run(run func(s string)) *Client_VerifyCommitSignature_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }

--- a/util/helm/mocks/Client.go
+++ b/util/helm/mocks/Client.go
@@ -60,15 +60,26 @@ type Client_CleanChartCache_Call struct {
 }
 
 // CleanChartCache is a helper method to define mock.On call
-//   - chart
-//   - version
+//   - chart string
+//   - version string
 func (_e *Client_Expecter) CleanChartCache(chart interface{}, version interface{}) *Client_CleanChartCache_Call {
 	return &Client_CleanChartCache_Call{Call: _e.mock.On("CleanChartCache", chart, version)}
 }
 
 func (_c *Client_CleanChartCache_Call) Run(run func(chart string, version string)) *Client_CleanChartCache_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string))
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -123,18 +134,44 @@ type Client_ExtractChart_Call struct {
 }
 
 // ExtractChart is a helper method to define mock.On call
-//   - chart
-//   - version
-//   - passCredentials
-//   - manifestMaxExtractedSize
-//   - disableManifestMaxExtractedSize
+//   - chart string
+//   - version string
+//   - passCredentials bool
+//   - manifestMaxExtractedSize int64
+//   - disableManifestMaxExtractedSize bool
 func (_e *Client_Expecter) ExtractChart(chart interface{}, version interface{}, passCredentials interface{}, manifestMaxExtractedSize interface{}, disableManifestMaxExtractedSize interface{}) *Client_ExtractChart_Call {
 	return &Client_ExtractChart_Call{Call: _e.mock.On("ExtractChart", chart, version, passCredentials, manifestMaxExtractedSize, disableManifestMaxExtractedSize)}
 }
 
 func (_c *Client_ExtractChart_Call) Run(run func(chart string, version string, passCredentials bool, manifestMaxExtractedSize int64, disableManifestMaxExtractedSize bool)) *Client_ExtractChart_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string), args[2].(bool), args[3].(int64), args[4].(bool))
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 bool
+		if args[2] != nil {
+			arg2 = args[2].(bool)
+		}
+		var arg3 int64
+		if args[3] != nil {
+			arg3 = args[3].(int64)
+		}
+		var arg4 bool
+		if args[4] != nil {
+			arg4 = args[4].(bool)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+		)
 	})
 	return _c
 }
@@ -183,15 +220,26 @@ type Client_GetIndex_Call struct {
 }
 
 // GetIndex is a helper method to define mock.On call
-//   - noCache
-//   - maxIndexSize
+//   - noCache bool
+//   - maxIndexSize int64
 func (_e *Client_Expecter) GetIndex(noCache interface{}, maxIndexSize interface{}) *Client_GetIndex_Call {
 	return &Client_GetIndex_Call{Call: _e.mock.On("GetIndex", noCache, maxIndexSize)}
 }
 
 func (_c *Client_GetIndex_Call) Run(run func(noCache bool, maxIndexSize int64)) *Client_GetIndex_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(bool), args[1].(int64))
+		var arg0 bool
+		if args[0] != nil {
+			arg0 = args[0].(bool)
+		}
+		var arg1 int64
+		if args[1] != nil {
+			arg1 = args[1].(int64)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -240,15 +288,26 @@ type Client_GetTags_Call struct {
 }
 
 // GetTags is a helper method to define mock.On call
-//   - chart
-//   - noCache
+//   - chart string
+//   - noCache bool
 func (_e *Client_Expecter) GetTags(chart interface{}, noCache interface{}) *Client_GetTags_Call {
 	return &Client_GetTags_Call{Call: _e.mock.On("GetTags", chart, noCache)}
 }
 
 func (_c *Client_GetTags_Call) Run(run func(chart string, noCache bool)) *Client_GetTags_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(bool))
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 bool
+		if args[1] != nil {
+			arg1 = args[1].(bool)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }

--- a/util/io/mocks/TempPaths.go
+++ b/util/io/mocks/TempPaths.go
@@ -47,15 +47,26 @@ type TempPaths_Add_Call struct {
 }
 
 // Add is a helper method to define mock.On call
-//   - key
-//   - value
+//   - key string
+//   - value string
 func (_e *TempPaths_Expecter) Add(key interface{}, value interface{}) *TempPaths_Add_Call {
 	return &TempPaths_Add_Call{Call: _e.mock.On("Add", key, value)}
 }
 
 func (_c *TempPaths_Add_Call) Run(run func(key string, value string)) *TempPaths_Add_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string))
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -102,14 +113,20 @@ type TempPaths_GetPath_Call struct {
 }
 
 // GetPath is a helper method to define mock.On call
-//   - key
+//   - key string
 func (_e *TempPaths_Expecter) GetPath(key interface{}) *TempPaths_GetPath_Call {
 	return &TempPaths_GetPath_Call{Call: _e.mock.On("GetPath", key)}
 }
 
 func (_c *TempPaths_GetPath_Call) Run(run func(key string)) *TempPaths_GetPath_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -147,14 +164,20 @@ type TempPaths_GetPathIfExists_Call struct {
 }
 
 // GetPathIfExists is a helper method to define mock.On call
-//   - key
+//   - key string
 func (_e *TempPaths_Expecter) GetPathIfExists(key interface{}) *TempPaths_GetPathIfExists_Call {
 	return &TempPaths_GetPathIfExists_Call{Call: _e.mock.On("GetPathIfExists", key)}
 }
 
 func (_c *TempPaths_GetPathIfExists_Call) Run(run func(key string)) *TempPaths_GetPathIfExists_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }

--- a/util/notification/argocd/mocks/Service.go
+++ b/util/notification/argocd/mocks/Service.go
@@ -73,15 +73,26 @@ type Service_GetAppDetails_Call struct {
 }
 
 // GetAppDetails is a helper method to define mock.On call
-//   - ctx
-//   - app
+//   - ctx context.Context
+//   - app *v1alpha1.Application
 func (_e *Service_Expecter) GetAppDetails(ctx interface{}, app interface{}) *Service_GetAppDetails_Call {
 	return &Service_GetAppDetails_Call{Call: _e.mock.On("GetAppDetails", ctx, app)}
 }
 
 func (_c *Service_GetAppDetails_Call) Run(run func(ctx context.Context, app *v1alpha1.Application)) *Service_GetAppDetails_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*v1alpha1.Application))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *v1alpha1.Application
+		if args[1] != nil {
+			arg1 = args[1].(*v1alpha1.Application)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -130,17 +141,38 @@ type Service_GetCommitMetadata_Call struct {
 }
 
 // GetCommitMetadata is a helper method to define mock.On call
-//   - ctx
-//   - repoURL
-//   - commitSHA
-//   - project
+//   - ctx context.Context
+//   - repoURL string
+//   - commitSHA string
+//   - project string
 func (_e *Service_Expecter) GetCommitMetadata(ctx interface{}, repoURL interface{}, commitSHA interface{}, project interface{}) *Service_GetCommitMetadata_Call {
 	return &Service_GetCommitMetadata_Call{Call: _e.mock.On("GetCommitMetadata", ctx, repoURL, commitSHA, project)}
 }
 
 func (_c *Service_GetCommitMetadata_Call) Run(run func(ctx context.Context, repoURL string, commitSHA string, project string)) *Service_GetCommitMetadata_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
 	})
 	return _c
 }

--- a/util/workloadidentity/mocks/TokenProvider.go
+++ b/util/workloadidentity/mocks/TokenProvider.go
@@ -70,14 +70,20 @@ type TokenProvider_GetToken_Call struct {
 }
 
 // GetToken is a helper method to define mock.On call
-//   - scope
+//   - scope string
 func (_e *TokenProvider_Expecter) GetToken(scope interface{}) *TokenProvider_GetToken_Call {
 	return &TokenProvider_GetToken_Call{Call: _e.mock.On("GetToken", scope)}
 }
 
 func (_c *TokenProvider_GetToken_Call) Run(run func(scope string)) *TokenProvider_GetToken_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
