### PR TITLE
feat(ci): don't cancel-in-progress on master

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -18,7 +18,7 @@ env:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
The history of the master branch is littered with incomplete CI runs. That has a couple downsides:

1) It's more difficult to determine which commit broke the build
2) Codecov reports don't always get sent to Codecov, so coverage reports for PRs often just say "no HEAD to compare"

Now that we're on the CNCF enterprise account and are allotted an absurd number of parallel runners, I think we can afford to run all CI jobs on every commit to master.

If we have trouble, we can always revisit.