### PR TITLE
docs: update declarative-setup.md (azure auth)

### DIFF
--- a/docs/operator-manual/declarative-setup.md
+++ b/docs/operator-manual/declarative-setup.md
@@ -1007,15 +1007,15 @@ Azure cluster secret example using argocd-k8s-auth and [kubelogin](https://githu
 |Variable Name|Description|
 |-------------|-----------|
 |AAD_LOGIN_METHOD|One of devicecode, spn, ropc, msi, azurecli, or workloadidentity|
-|AAD_SERVICE_PRINCIPAL_CLIENT_CERTIFICATE|AAD client cert in pfx.  Used in spn login|
-|AAD_SERVICE_PRINCIPAL_CLIENT_ID|AAD client application ID|
-|AAD_SERVICE_PRINCIPAL_CLIENT_SECRET|AAD client application secret|
+|AZURE_CLIENT_CERTIFICATE_PATH|Path to AAD client cert in pfx.  Used in spn login and WorkloadIdentityLogin flow|
+|AZURE_CLIENT_CERTIFICATE_PASSWORD|Password for the client cert in pfx.  Used in spn login|
+|AZURE_CLIENT_ID|AAD client application ID|
+|AZURE_CLIENT_SECRET|AAD client application secret|
 |AAD_USER_PRINCIPAL_NAME|Used in the ropc flow|
 |AAD_USER_PRINCIPAL_PASSWORD|Used in the ropc flow|
 |AZURE_TENANT_ID|The AAD tenant ID.|
 |AZURE_AUTHORITY_HOST|Used in the WorkloadIdentityLogin flow|
 |AZURE_FEDERATED_TOKEN_FILE|Used in the WorkloadIdentityLogin flow|
-|AZURE_CLIENT_ID|Used in the WorkloadIdentityLogin flow|
 
 In addition to the environment variables above, argocd-k8s-auth accepts two extra environment variables to set the AAD environment, and to set the AAD server application ID.  The AAD server application ID will default to 6dae42f8-4368-4678-94ff-3960e28e3630 if not specified.  See [here](https://github.com/azure/kubelogin#exec-plugin-format) for details.
 
@@ -1089,9 +1089,9 @@ stringData:
         "command": "argocd-k8s-auth",
         "env": {
           "AAD_ENVIRONMENT_NAME": "AzurePublicCloud",
-          "AAD_SERVICE_PRINCIPAL_CLIENT_SECRET": "fill in your service principal client secret",
+          "AZURE_CLIENT_SECRET": "fill in your service principal client secret",
           "AZURE_TENANT_ID": "fill in tenant id",
-          "AAD_SERVICE_PRINCIPAL_CLIENT_ID": "fill in your service principal client id",
+          "AZURE_CLIENT_ID": "fill in your service principal client id",
           "AAD_LOGIN_METHOD": "spn"
         },
         "args": ["azure"],


### PR DESCRIPTION
### Context

The Azure authentication implementation from argocd to an external cluster has been broken for a while. As far as I understand, the following two issues are not directly related:

1. The `workloadidentity` is broken since argo-cd 3.0 and should be soon fixed (source: #22884) 
2. The `spn` login method is broken since argocd 2.14 and the issue is stalled (#22318)


While issue 1 is to be fixed in the next release (according to comments in the issue thread), issue 2 has remained a mystery.

After investigating, I found that the change was most likely due to the upgrade from `kubelogin` `v0.0.20` to `v0.2.8` (complete rewrite).

In the [previous implementation](hhttps://github.com/argoproj/argo-cd/blob/v2.13.8/cmd/argocd-k8s-auth/commands/azure.go#L29), argocd would call `token.New` and then `o.UpdateFromEnv`. 
[Now](https://github.com/argoproj/argo-cd/blob/master/cmd/argocd-k8s-auth/commands/azure.go#L26C1-L26C31) we use the `token.OptionsWithEnv` method which essentially seems to overwrite the `AAD_SERVICE_PRINCIPAL*` auth variables with `AZURE_CLIENT_*` instead (see [source code](https://github.com/Azure/kubelogin/blob/main/pkg/token/options_ctor.go#L11)).

### Fix
In my setup, modifying the k8s secret config to the following format solved the issue:

```yaml
config: |
  {
    "execProviderConfig": {
      "command": "argocd-k8s-auth",
      "env": {
        "AAD_ENVIRONMENT_NAME": "AzurePublicCloud",
        "AZURE_CLIENT_SECRET": "xxx", # instead of AAD_SERVICE_PRINCIPAL_CLIENT_SECRET
        "AZURE_CLIENT_ID": "xxx", # instead of AAD_SERVICE_PRINCIPAL_CLIENT_ID
        "AZURE_TENANT_ID": "xxx",
        "AAD_LOGIN_METHOD": "spn"
      },
      "args": ["azure"],
      "apiVersion": "client.authentication.k8s.io/v1beta1"
    },
    "tlsClientConfig": {
      "insecure": false,
      "caData": "xxx"
    }
  }
name: cluster-name
server: https://cluster-url.hcp.westeurope.azmk8s.io:443
```

This PR updates the documentation to reflect the current situation (we no longer need to use the AAD_SERVICE_PRINCIPAL variables and can use the AZURE_CLIENT_* ones for both the `spn` and `workloadidentity` methods )