### PR TITLE
chore(refactor): replace trivial function w/ standard lib

### DIFF
--- a/applicationset/generators/merge.go
+++ b/applicationset/generators/merge.go
@@ -4,12 +4,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"time"
 
 	"dario.cat/mergo"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/argoproj/argo-cd/v3/applicationset/utils"
 	argoprojiov1alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 )
 
@@ -83,11 +83,8 @@ func (m *MergeGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.Appl
 					}
 					baseParamSetsByMergeKey[mergeKeyValue] = baseParamSet
 				} else {
-					overriddenParamSet, err := utils.CombineStringMapsAllowDuplicates(baseParamSet, overrideParamSet)
-					if err != nil {
-						return nil, fmt.Errorf("error combining string maps: %w", err)
-					}
-					baseParamSetsByMergeKey[mergeKeyValue] = utils.ConvertToMapStringInterface(overriddenParamSet)
+					maps.Copy(baseParamSet, overrideParamSet)
+					baseParamSetsByMergeKey[mergeKeyValue] = baseParamSet
 				}
 			}
 		}

--- a/applicationset/utils/map.go
+++ b/applicationset/utils/map.go
@@ -42,21 +42,3 @@ func CombineStringMaps(aSI map[string]any, bSI map[string]any) (map[string]strin
 
 	return res, nil
 }
-
-// CombineStringMapsAllowDuplicates merges two maps. Where there are duplicates, take the latter map's value.
-func CombineStringMapsAllowDuplicates(aSI map[string]any, bSI map[string]any) (map[string]string, error) {
-	a := ConvertToMapStringString(aSI)
-	b := ConvertToMapStringString(bSI)
-
-	res := map[string]string{}
-
-	for k, v := range a {
-		res[k] = v
-	}
-
-	for k, v := range b {
-		res[k] = v
-	}
-
-	return res, nil
-}


### PR DESCRIPTION
maps.Copy behaves the same way as the util function, just modifying the map in place.

Based on reading and tests, I believe mutating the map in-place is fine.