### PR TITLE
fix(hydrator): omit Argocd- trailers from hydrator.metadata

### DIFF
--- a/commitserver/commit/commit.go
+++ b/commitserver/commit/commit.go
@@ -220,6 +220,7 @@ type hydratorMetadataFile struct {
 	// Subject is the subject line of the DRY commit message, i.e. `git show --format=%s`.
 	Subject string `json:"subject,omitempty"`
 	// Body is the body of the DRY commit message, excluding the subject line, i.e. `git show --format=%b`.
+	// Known Argocd- trailers with valid values are removed, but all other trailers are kept.
 	Body       string                       `json:"body,omitempty"`
 	References []v1alpha1.RevisionReference `json:"references,omitempty"`
 }

--- a/commitserver/commit/hydratorhelper.go
+++ b/commitserver/commit/hydratorhelper.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/argoproj/argo-cd/v3/commitserver/apiclient"
 	appv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v3/util/git"
 	"github.com/argoproj/argo-cd/v3/util/io"
 )
 
@@ -48,8 +49,10 @@ func WriteForPaths(root *os.Root, repoUrl, drySha string, dryCommitMetadata *app
 
 	subject, body, _ := strings.Cut(message, "\n\n")
 
+	_, bodyMinusTrailers := git.GetReferences(log.WithFields(log.Fields{"repo": repoUrl, "revision": drySha}), body)
+
 	// Write the top-level readme.
-	err := writeMetadata(root, "", hydratorMetadataFile{DrySHA: drySha, RepoURL: repoUrl, Author: author, Subject: subject, Body: body, Date: date, References: references})
+	err := writeMetadata(root, "", hydratorMetadataFile{DrySHA: drySha, RepoURL: repoUrl, Author: author, Subject: subject, Body: bodyMinusTrailers, Date: date, References: references})
 	if err != nil {
 		return fmt.Errorf("failed to write top-level hydrator metadata: %w", err)
 	}

--- a/docs/user-guide/source-hydrator.md
+++ b/docs/user-guide/source-hydrator.md
@@ -232,7 +232,10 @@ The commit metadata will appear in the hydrated commit's root hydrator.metadata 
 {
   "author": "CI <ci@example.com>",
   "subject": "chore: bump image to b82add2",
+  "date": "2025-06-09T13:50:08-04:00",
   "body": "Signed-off-by: CI <ci@example.com>\n",
+  "drySha": "6cb951525937865dced818bbdd78c89b2d2b3045",
+  "repoURL": "https://git.example.com/owner/manifests-repo",
   "references": [
     {
       "commit": {

--- a/docs/user-guide/source-hydrator.md
+++ b/docs/user-guide/source-hydrator.md
@@ -230,6 +230,9 @@ The commit metadata will appear in the hydrated commit's root hydrator.metadata 
 
 ```json
 {
+  "author": "CI <ci@example.com>",
+  "subject": "chore: bump image to b82add2",
+  "body": "Signed-off-by: CI <ci@example.com>\n",
   "references": [
     {
       "commit": {
@@ -247,6 +250,10 @@ The commit metadata will appear in the hydrated commit's root hydrator.metadata 
   ]
 }
 ```
+
+The top-level "body" field contains the commit message of the DRY commit minus the subject line and any 
+`Argocd-reference-commit-*` trailers that were used in `references`. Unrecognized or invalid trailers are preserved in
+the body.
 
 Although `references` is an array, the source hydrator currently only supports a single related commit. If a trailer is
 specified more than once, the last one will be used.


### PR DESCRIPTION
The hydrator.metadata file currently duplicates a lot of information by having it stored both in the `references` structured block and in the top-level `body` field.

This change removes git trailers from the `body` field if there were used to populate a field in `references`, so we avoid duplicated information.