### PR TITLE
fix: kustomize components + monorepos

### DIFF
--- a/util/kustomize/kustomize.go
+++ b/util/kustomize/kustomize.go
@@ -13,8 +13,9 @@ import (
 	"sync"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/argoproj/argo-cd/v3/util/io"
 	"sigs.k8s.io/yaml"
+
+	"github.com/argoproj/argo-cd/v3/util/io"
 
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	log "github.com/sirupsen/logrus"

--- a/util/kustomize/kustomize.go
+++ b/util/kustomize/kustomize.go
@@ -352,8 +352,7 @@ func (k *kustomize) Build(opts *v1alpha1.ApplicationSourceKustomize, kustomizeOp
 				for _, c := range opts.Components {
 					resolvedPath, err := filepath.Rel(k.repoRoot, filepath.Join(k.path, c))
 					if err != nil {
-						log.Debugf("failed to relativize path: %s", err)
-						continue
+						return nil, nil, nil, fmt.Errorf("kustomize components path failed: %w", err)
 					}
 					_, err = root.Stat(resolvedPath)
 					if err != nil {

--- a/util/kustomize/kustomize.go
+++ b/util/kustomize/kustomize.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/argoproj/argo-cd/v3/util/io"
 	"sigs.k8s.io/yaml"
 
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
@@ -345,6 +346,7 @@ func (k *kustomize) Build(opts *v1alpha1.ApplicationSourceKustomize, kustomizeOp
 			if opts.IgnoreMissingComponents {
 				foundComponents = make([]string, 0)
 				root, err := os.OpenRoot(k.repoRoot)
+				defer io.Close(root)
 				if err != nil {
 					return nil, nil, nil, fmt.Errorf("failed to open the repo folder: %w", err)
 				}

--- a/util/kustomize/kustomize_test.go
+++ b/util/kustomize/kustomize_test.go
@@ -533,7 +533,7 @@ func TestKustomizeBuildComponentsMonoRepo(t *testing.T) {
 	replicas, ok, err := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "tolerations")
 	require.NoError(t, err)
 	require.True(t, ok)
-	require.Equal(t, 1, len(replicas))
+	require.Len(t, replicas, 1)
 	require.Equal(t, "my-special-toleration", replicas[0].(map[string]any)["key"])
 	require.Equal(t, "Exists", replicas[0].(map[string]any)["operator"])
 }

--- a/util/kustomize/kustomize_test.go
+++ b/util/kustomize/kustomize_test.go
@@ -25,6 +25,7 @@ const (
 	kustomization6 = "kustomization_yaml_components"
 	kustomization7 = "label_without_selector"
 	kustomization8 = "kustomization_yaml_patches_empty"
+	kustomization9 = "kustomization_yaml_components_monorepo"
 )
 
 func testDataDir(tb testing.TB, testData string) (string, error) {
@@ -510,6 +511,31 @@ func TestKustomizeBuildComponents(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ok)
 	assert.Equal(t, int64(3), replicas)
+}
+
+func TestKustomizeBuildComponentsMonoRepo(t *testing.T) {
+	rootPath, err := testDataDir(t, kustomization9)
+	require.NoError(t, err)
+	appPath := path.Join(rootPath, "envs/inseng-pdx-egert-sandbox/namespaces/inst-system/apps/hello-world")
+	kustomize := NewKustomizeApp(rootPath, appPath, git.NopCreds{}, "", "", "", "")
+	kustomizeSource := v1alpha1.ApplicationSourceKustomize{
+		Components:              []string{"../../../../../../kustomize/components/all"},
+		IgnoreMissingComponents: true,
+	}
+	objs, _, _, err := kustomize.Build(&kustomizeSource, nil, nil, nil)
+	require.NoError(t, err)
+	obj := objs[2]
+	require.Equal(t, "hello-world-kustomize", obj.GetName())
+	require.Equal(t, map[string]string{
+		"app.kubernetes.io/name":  "hello-world-kustomize",
+		"app.kubernetes.io/owner": "fire-team",
+	}, obj.GetLabels())
+	replicas, ok, err := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "tolerations")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, 1, len(replicas))
+	require.Equal(t, "my-special-toleration", replicas[0].(map[string]any)["key"])
+	require.Equal(t, "Exists", replicas[0].(map[string]any)["operator"])
 }
 
 func TestKustomizeBuildPatches(t *testing.T) {

--- a/util/kustomize/testdata/kustomization_yaml_components_monorepo/envs/inseng-pdx-egert-sandbox/namespaces/inst-system/apps/hello-world/.argo-cd.yaml
+++ b/util/kustomize/testdata/kustomization_yaml_components_monorepo/envs/inseng-pdx-egert-sandbox/namespaces/inst-system/apps/hello-world/.argo-cd.yaml
@@ -1,0 +1,3 @@
+---
+kustomize:
+  componentsPath: ../../../../../../kustomize/components

--- a/util/kustomize/testdata/kustomization_yaml_components_monorepo/envs/inseng-pdx-egert-sandbox/namespaces/inst-system/apps/hello-world/kustomization.yaml
+++ b/util/kustomize/testdata/kustomization_yaml_components_monorepo/envs/inseng-pdx-egert-sandbox/namespaces/inst-system/apps/hello-world/kustomization.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# All the members of this group are meant be populated from the
+# same nonproduction overlay of the matching app
+resources:
+  - ../../../../../../kustomize/apps/hello-world/base
+
+nameSuffix: -kustomize
+
+labels:
+  - pairs:
+      app.kubernetes.io/name: hello-world-kustomize
+    includeSelectors: true
+    includeTemplates: true
+
+patches:
+  # Adjusting the serviceAccount ref
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: hello-world
+      spec:
+        template:
+          spec:
+            serviceAccountName: hello-world-kustomize
+
+# Container image versions across the members
+images:
+  - name: hello-world
+    newTag: 1.17.0

--- a/util/kustomize/testdata/kustomization_yaml_components_monorepo/kustomize/apps/hello-world/base/deployment.yaml
+++ b/util/kustomize/testdata/kustomization_yaml_components_monorepo/kustomize/apps/hello-world/base/deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-world
+  labels:
+    app.kubernetes.io/name: hello-world
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hello-world
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hello-world
+    spec:
+      serviceAccountName: hello-world
+      containers:
+        - name: hello-world
+          image: "nginx:1.16.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+      tolerations: []

--- a/util/kustomize/testdata/kustomization_yaml_components_monorepo/kustomize/apps/hello-world/base/kustomization.yaml
+++ b/util/kustomize/testdata/kustomization_yaml_components_monorepo/kustomize/apps/hello-world/base/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- deployment.yaml
+- service.yaml
+- serviceaccount.yaml

--- a/util/kustomize/testdata/kustomization_yaml_components_monorepo/kustomize/apps/hello-world/base/service.yaml
+++ b/util/kustomize/testdata/kustomization_yaml_components_monorepo/kustomize/apps/hello-world/base/service.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-world
+  labels:
+    app.kubernetes.io/name: hello-world
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: hello-world

--- a/util/kustomize/testdata/kustomization_yaml_components_monorepo/kustomize/apps/hello-world/base/serviceaccount.yaml
+++ b/util/kustomize/testdata/kustomization_yaml_components_monorepo/kustomize/apps/hello-world/base/serviceaccount.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hello-world
+  labels:
+    app.kubernetes.io/name: hello-world

--- a/util/kustomize/testdata/kustomization_yaml_components_monorepo/kustomize/components/all/kustomization.yaml
+++ b/util/kustomize/testdata/kustomization_yaml_components_monorepo/kustomize/components/all/kustomization.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+labels:
+  - pairs:
+      app.kubernetes.io/owner: fire-team
+    includeSelectors: false
+    includeTemplates: false
+
+patches:
+  - target:
+      kind: Deployment
+    patch: |-
+      - op: add
+        path: /spec/template/spec/tolerations/-
+        value:
+          key: my-special-toleration
+          operator: Exists


### PR DESCRIPTION
With #21674 the ability to ignore Kustomize component directories if they do not exist got introduced. This generally works fine, but the `securejoin` check is a bit too strict - we want to ensure that no-one can break out of the repo, but the current implementation doesn't allow for breaking outside the kustomization folder. This breaks the usage of this feature when using it for a monorepo.

This PR loosens the check to allow for traversals up to the repo root. We use the new `os.Root` functionality to ensure that users can't break outside the repo. Path traversals are still relative from the path where the kustomize source is located.

This should be cherry-picked for 3.0 and 3.1.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
