### PR TITLE
fix(applicationset): Git generator: Don't append default object to literal empty json array (#23500)

### DIFF
--- a/applicationset/generators/git_test.go
+++ b/applicationset/generators/git_test.go
@@ -825,7 +825,7 @@ func TestGitGenerateParamsFromFiles(t *testing.T) {
 			},
 			repoPathsError: nil,
 			expected:       []map[string]any{},
-			expectedError:  errors.New("error generating params from git: unable to process file 'cluster-config/production/config.json': unable to parse file: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type map[string]interface {}"),
+			expectedError:  errors.New("error generating params from git: unable to process file 'cluster-config/production/config.json': unable to parse file: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type []map[string]interface {}"),
 		},
 		{
 			name:  "test JSON array",
@@ -981,6 +981,16 @@ cluster:
 				},
 			},
 			expectedError: nil,
+		},
+		{
+			name:  "test empty YAML array",
+			files: []v1alpha1.GitFileGeneratorItem{{Path: "**/config.yaml"}},
+			repoFileContents: map[string][]byte{
+				"cluster-config/production/config.yaml": []byte(`[]`),
+			},
+			repoPathsError: nil,
+			expected:       []map[string]any{},
+			expectedError:  nil,
 		},
 	}
 
@@ -2060,7 +2070,7 @@ func TestGitGenerateParamsFromFilesGoTemplate(t *testing.T) {
 			},
 			repoPathsError: nil,
 			expected:       []map[string]any{},
-			expectedError:  errors.New("error generating params from git: unable to process file 'cluster-config/production/config.json': unable to parse file: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type map[string]interface {}"),
+			expectedError:  errors.New("error generating params from git: unable to process file 'cluster-config/production/config.json': unable to parse file: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type []map[string]interface {}"),
 		},
 		{
 			name:  "test JSON array",


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

This is basically an improved version of https://github.com/argoproj/argo-cd/pull/15661. That PR fixed the case where an empty yaml file wasn't distinguished from a *missing* file, which could easily lead to deleted applications when a user commented out all entries from their yaml file.

Unfortunately, that PR didn't distinguish between an empty yaml file from yaml files containing a literal empty json array (`[]`) as the root element. Using arrays as the top-level structure for yaml files has long been supported by the git generator, but it seems to be an undocumented feature (or at least I couldn't find any documentation).

If a yaml file contains an array as the top level element, the Git generator outputs a separate params-object for each element of the array. In other words, this feature can be used to easily template multiple applications from a single yaml file without the use of a matrix generator, as a user does this here:

* https://github.com/argoproj/argo-cd/issues/23500

Since this is a supported use-case, it stands to reason that an empty array (`[]`) should result in an empty slice of objects returned by the git generator. But this has been broken since v2.10 due to https://github.com/argoproj/argo-cd/pull/15661 failing to distinguish between an empty file (or `{}`) from an empty array, because the code previously tried to unmarshal the data into a slice, which even succeeds for empty files.

To fix this I've just reversed the order of parsing attempts: This PR first tries to unmarshal the data into a `map`, which even succeeds for empty files! This also makes the code a bit cleaner, since there is no need for constructing a dummy slice entry anymore. Only if parsing as a map fails (which is also the case for `[]`) we fall back to trying to unmarshal the data into a slice. 

I think it's also nice that the most common use case (yaml containing an object) is now tried first, while arrays are only attempted as a fallback. This slightly changed the returned error messsages, but no tests needed to be adjusted aside from that. I've added a unit test that fails with the previous implementation.

Kindly pinging @agaudreault because this builds on his previous PR.

Please see the comments of the linked issue for more details about the use-case and the cause of this issue.

Closes #23500
