### PR TITLE
feat(health-check): Add resource_customizations for game.kruise.io

### DIFF
--- a/resource_customizations/game.kruise.io/GameServer/health.lua
+++ b/resource_customizations/game.kruise.io/GameServer/health.lua
@@ -4,14 +4,14 @@ if obj.status then
     local cur  = obj.status.currentState
     local dest = obj.status.desiredState
 
-    -- 1) 当前状态与期望状态不一致 → Progressing
+    -- 1) Check cur and dest status: Progressing
     if cur ~= dest then
     hs.status = "Progressing"
     hs.message = "State change: " .. (cur or "Unknown") .. " → " .. (dest or "Unknown")
     return hs
     end
 
-    -- 2) Pod 级别检查：关注 KruisePodReady
+    -- 2) Check pod: KruisePodReady
     local podCond = obj.status.podStatus or {}
     for _, c in ipairs(podCond.conditions or {}) do
         if c.type == "KruisePodReady" and c.status ~= "True" then
@@ -21,7 +21,7 @@ if obj.status then
         end
     end
 
-    -- 3) 当前状态与期望均为 Ready → Healthy
+    -- 3) Both ready: Healthy
     if cur == "Ready" and dest == "Ready" then
     hs.status = "Healthy"
     hs.message = "GameServer is Ready"

--- a/resource_customizations/game.kruise.io/GameServer/health.lua
+++ b/resource_customizations/game.kruise.io/GameServer/health.lua
@@ -1,0 +1,32 @@
+hs = {status="Unknown", message="Waiting for GameServer to be ready"}
+
+if obj.status then
+    local cur  = obj.status.currentState
+    local dest = obj.status.desiredState
+
+    -- 1) 当前状态与期望状态不一致 → Progressing
+    if cur ~= dest then
+    hs.status = "Progressing"
+    hs.message = "State change: " .. (cur or "Unknown") .. " → " .. (dest or "Unknown")
+    return hs
+    end
+
+    -- 2) Pod 级别检查：关注 KruisePodReady
+    local podCond = obj.status.podStatus or {}
+    for _, c in ipairs(podCond.conditions or {}) do
+        if c.type == "KruisePodReady" and c.status ~= "True" then
+            hs.status = "Degraded"
+            hs.message = "Pod is not ready: " .. c.type
+            return hs
+        end
+    end
+
+    -- 3) 当前状态与期望均为 Ready → Healthy
+    if cur == "Ready" and dest == "Ready" then
+    hs.status = "Healthy"
+    hs.message = "GameServer is Ready"
+    return hs
+    end
+end
+
+return hs

--- a/resource_customizations/game.kruise.io/GameServer/health_test.yaml
+++ b/resource_customizations/game.kruise.io/GameServer/health_test.yaml
@@ -1,0 +1,20 @@
+tests:
+- healthStatus:
+    status: Healthy
+    message: GameServer is Ready
+  inputPath: testdata/healthy.yaml
+
+- healthStatus:
+    status: Progressing
+    message: 'State change: Creating → Ready'
+  inputPath: testdata/progressing.yaml
+
+- healthStatus:
+    status: Degraded
+    message: 'Pod is not ready: KruisePodReady'
+  inputPath: testdata/degraded.yaml
+
+- healthStatus:
+    status: Unknown
+    message: Waiting for GameServer to be ready
+  inputPath: testdata/unknown.yaml

--- a/resource_customizations/game.kruise.io/GameServer/testdata/degraded.yaml
+++ b/resource_customizations/game.kruise.io/GameServer/testdata/degraded.yaml
@@ -1,0 +1,13 @@
+apiVersion: game.kruise.io/v1alpha1
+kind: GameServer
+metadata:
+  name: gs-degraded
+status:
+  currentState: "Ready"
+  desiredState: "Ready"
+  podStatus:
+    conditions:
+    - type: "Ready"
+      status: "True"
+    - type: "KruisePodReady"
+      status: "False"

--- a/resource_customizations/game.kruise.io/GameServer/testdata/healthy.yaml
+++ b/resource_customizations/game.kruise.io/GameServer/testdata/healthy.yaml
@@ -1,0 +1,12 @@
+apiVersion: game.kruise.io/v1alpha1
+kind: GameServer
+metadata:
+  name: gs-healthy
+status:
+  currentState: Ready
+  desiredState: Ready
+  conditions:
+  - type: PodNormal
+    status: "True"
+  - type: NodeNormal
+    status: "True"

--- a/resource_customizations/game.kruise.io/GameServer/testdata/progressing.yaml
+++ b/resource_customizations/game.kruise.io/GameServer/testdata/progressing.yaml
@@ -1,0 +1,7 @@
+apiVersion: game.kruise.io/v1alpha1
+kind: GameServer
+metadata:
+  name: gs-progressing
+status:
+  currentState: "Creating"
+  desiredState: "Ready"

--- a/resource_customizations/game.kruise.io/GameServer/testdata/unknown.yaml
+++ b/resource_customizations/game.kruise.io/GameServer/testdata/unknown.yaml
@@ -1,0 +1,5 @@
+apiVersion: game.kruise.io/v1alpha1
+kind: GameServer
+metadata:
+  name: gs-unknown
+spec: {}

--- a/resource_customizations/game.kruise.io/GameServerSet/health.lua
+++ b/resource_customizations/game.kruise.io/GameServerSet/health.lua
@@ -27,7 +27,7 @@ if obj.status and obj.metadata.generation == obj.status.observedGeneration then
 
   -- 4) 就绪不足
   if (obj.status.readyReplicas or 0) < (obj.status.replicas or 0) then
-    hs.status  = "Degraded"
+    hs.status  = "Progressing"
     hs.message = "ReadyReplicas " ..
                  (obj.status.readyReplicas or 0) .. "/" ..
                  (obj.status.replicas or 0) .. ", still progressing"

--- a/resource_customizations/game.kruise.io/GameServerSet/health.lua
+++ b/resource_customizations/game.kruise.io/GameServerSet/health.lua
@@ -1,0 +1,38 @@
+hs = {status="Progressing", message="Waiting for GameServerSet initialization"}
+
+if obj.status and obj.metadata.generation == obj.status.observedGeneration then
+  local ru = obj.spec.updateStrategy and obj.spec.updateStrategy.rollingUpdate or {}
+
+  -- 1) Pause
+  if ru.paused == true then
+    hs.status  = "Suspended"
+    hs.message = "GameServerSet is paused"
+    return hs
+  end
+
+  -- 2) Partition 灰度
+  local partition = ru.partition or 0
+  if partition ~= 0 and (obj.status.updatedReplicas or 0) >= (obj.status.replicas or 0) - partition then
+    hs.status  = "Suspended"
+    hs.message = "Partition=" .. partition .. ", waiting for manual intervention"
+    return hs
+  end
+
+  -- 3) 全量就绪（用 updatedReadyReplicas）
+  if (obj.status.updatedReadyReplicas or 0) == (obj.status.replicas or 0) then
+    hs.status  = "Healthy"
+    hs.message = "All GameServerSet replicas are updated and ready"
+    return hs
+  end
+
+  -- 4) 就绪不足
+  if (obj.status.readyReplicas or 0) < (obj.status.replicas or 0) then
+    hs.status  = "Degraded"
+    hs.message = "ReadyReplicas " ..
+                 (obj.status.readyReplicas or 0) .. "/" ..
+                 (obj.status.replicas or 0) .. ", still progressing"
+    return hs
+  end
+end
+
+return hs

--- a/resource_customizations/game.kruise.io/GameServerSet/health.lua
+++ b/resource_customizations/game.kruise.io/GameServerSet/health.lua
@@ -10,7 +10,7 @@ if obj.status and obj.metadata.generation == obj.status.observedGeneration then
     return hs
   end
 
-  -- 2) Partition 灰度
+  -- 2) Partition
   local partition = ru.partition or 0
   if partition ~= 0 and (obj.status.updatedReplicas or 0) >= (obj.status.replicas or 0) - partition then
     hs.status  = "Suspended"
@@ -18,14 +18,14 @@ if obj.status and obj.metadata.generation == obj.status.observedGeneration then
     return hs
   end
 
-  -- 3) 全量就绪（用 updatedReadyReplicas）
+  -- 3) All updated and ready
   if (obj.status.updatedReadyReplicas or 0) == (obj.status.replicas or 0) then
     hs.status  = "Healthy"
     hs.message = "All GameServerSet replicas are updated and ready"
     return hs
   end
 
-  -- 4) 就绪不足
+  -- 4) ReadyRelicas not enough
   if (obj.status.readyReplicas or 0) < (obj.status.replicas or 0) then
     hs.status  = "Progressing"
     hs.message = "ReadyReplicas " ..

--- a/resource_customizations/game.kruise.io/GameServerSet/health_test.yaml
+++ b/resource_customizations/game.kruise.io/GameServerSet/health_test.yaml
@@ -15,11 +15,11 @@ tests:
   inputPath: testdata/suspended-partition.yaml
 
 - healthStatus:
-    status: Degraded
+    status: Progressing
     message: 'ReadyReplicas 2/3, still progressing'
-  inputPath: testdata/degraded.yaml
+  inputPath: testdata/progressing.yaml
 
 - healthStatus:
     status: Progressing
     message: Waiting for GameServerSet initialization
-  inputPath: testdata/progressing.yaml
+  inputPath: testdata/progressing-init.yaml

--- a/resource_customizations/game.kruise.io/GameServerSet/health_test.yaml
+++ b/resource_customizations/game.kruise.io/GameServerSet/health_test.yaml
@@ -1,0 +1,25 @@
+tests:
+- healthStatus:
+    status: Healthy
+    message: All GameServerSet replicas are updated and ready
+  inputPath: testdata/healthy.yaml
+
+- healthStatus:
+    status: Suspended
+    message: GameServerSet is paused
+  inputPath: testdata/suspended-paused.yaml
+
+- healthStatus:
+    status: Suspended
+    message: Partition=2, waiting for manual intervention
+  inputPath: testdata/suspended-partition.yaml
+
+- healthStatus:
+    status: Degraded
+    message: 'ReadyReplicas 2/3, still progressing'
+  inputPath: testdata/degraded.yaml
+
+- healthStatus:
+    status: Progressing
+    message: Waiting for GameServerSet initialization
+  inputPath: testdata/progressing.yaml

--- a/resource_customizations/game.kruise.io/GameServerSet/testdata/degraded.yaml
+++ b/resource_customizations/game.kruise.io/GameServerSet/testdata/degraded.yaml
@@ -1,0 +1,11 @@
+apiVersion: game.kruise.io/v1alpha1
+kind: GameServerSet
+metadata:
+  generation: 1
+spec:
+  replicas: 3
+status:
+  observedGeneration: 1
+  replicas: 3
+  readyReplicas: 2
+  updatedReadyReplicas: 2

--- a/resource_customizations/game.kruise.io/GameServerSet/testdata/healthy.yaml
+++ b/resource_customizations/game.kruise.io/GameServerSet/testdata/healthy.yaml
@@ -1,0 +1,11 @@
+apiVersion: game.kruise.io/v1alpha1
+kind: GameServerSet
+metadata:
+  generation: 1
+spec:
+  replicas: 3
+status:
+  observedGeneration: 1
+  replicas: 3
+  readyReplicas: 3
+  updatedReadyReplicas: 3

--- a/resource_customizations/game.kruise.io/GameServerSet/testdata/progressing-init.yaml
+++ b/resource_customizations/game.kruise.io/GameServerSet/testdata/progressing-init.yaml
@@ -1,11 +1,9 @@
 apiVersion: game.kruise.io/v1alpha1
 kind: GameServerSet
 metadata:
-  generation: 1
+  generation: 2
 spec:
   replicas: 3
 status:
   observedGeneration: 1
   replicas: 3
-  readyReplicas: 2
-  updatedReadyReplicas: 2

--- a/resource_customizations/game.kruise.io/GameServerSet/testdata/progressing.yaml
+++ b/resource_customizations/game.kruise.io/GameServerSet/testdata/progressing.yaml
@@ -1,0 +1,9 @@
+apiVersion: game.kruise.io/v1alpha1
+kind: GameServerSet
+metadata:
+  generation: 2
+spec:
+  replicas: 3
+status:
+  observedGeneration: 1
+  replicas: 3

--- a/resource_customizations/game.kruise.io/GameServerSet/testdata/progressing.yaml
+++ b/resource_customizations/game.kruise.io/GameServerSet/testdata/progressing.yaml
@@ -1,9 +1,11 @@
 apiVersion: game.kruise.io/v1alpha1
 kind: GameServerSet
 metadata:
-  generation: 2
+  generation: 1
 spec:
   replicas: 3
 status:
   observedGeneration: 1
   replicas: 3
+  readyReplicas: 2
+  updatedReadyReplicas: 2

--- a/resource_customizations/game.kruise.io/GameServerSet/testdata/suspended-partition.yaml
+++ b/resource_customizations/game.kruise.io/GameServerSet/testdata/suspended-partition.yaml
@@ -1,0 +1,13 @@
+apiVersion: game.kruise.io/v1alpha1
+kind: GameServerSet
+metadata:
+  generation: 1
+spec:
+  replicas: 5
+  updateStrategy:
+    rollingUpdate:
+      partition: 2
+status:
+  observedGeneration: 1
+  replicas: 5
+  updatedReplicas: 3

--- a/resource_customizations/game.kruise.io/GameServerSet/testdata/suspended-paused.yaml
+++ b/resource_customizations/game.kruise.io/GameServerSet/testdata/suspended-paused.yaml
@@ -1,0 +1,12 @@
+apiVersion: game.kruise.io/v1alpha1
+kind: GameServerSet
+metadata:
+  generation: 1
+spec:
+  replicas: 3
+  updateStrategy:
+    rollingUpdate:
+      paused: true
+status:
+  observedGeneration: 1
+  replicas: 3


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Adds custom health check for `GameServer` and `GameServerSet` resources in `game.kurise.io`.

I have written unit and/or e2e tests for my changes, and have already tested it in a real cluster.

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
