### PR TITLE
chore: simplify symlink check

### DIFF
--- a/util/app/path/path.go
+++ b/util/app/path/path.go
@@ -3,11 +3,13 @@ package path
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v3/util/io"
 	"github.com/argoproj/argo-cd/v3/util/io/files"
 	"github.com/argoproj/argo-cd/v3/util/security"
 )
@@ -43,13 +45,20 @@ func (e *OutOfBoundsSymlinkError) Error() string {
 }
 
 // CheckOutOfBoundsSymlinks determines if basePath contains any symlinks that
-// are absolute or point to a path outside of the basePath. If found, an
+// are absolute or point to a path outside the basePath. If found, an
 // OutOfBoundsSymlinkError is returned.
 func CheckOutOfBoundsSymlinks(basePath string) error {
 	absBasePath, err := filepath.Abs(basePath)
 	if err != nil {
 		return fmt.Errorf("failed to get absolute path: %w", err)
 	}
+
+	root, err := os.OpenRoot(absBasePath)
+	if err != nil {
+		return fmt.Errorf("failed to open dir: %w", err)
+	}
+	defer io.Close(root)
+
 	return filepath.Walk(absBasePath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			// Ignore "no such file or directory" errors than can happen with
@@ -75,22 +84,14 @@ func CheckOutOfBoundsSymlinks(basePath string) error {
 			if filepath.IsAbs(linkTarget) {
 				return &OutOfBoundsSymlinkError{File: linkRelPath}
 			}
-			// get the parent directory of the symlink
-			currentDir := filepath.Dir(path)
 
-			// walk each part of the symlink target to make sure it never leaves basePath
-			parts := strings.Split(linkTarget, string(os.PathSeparator))
-			for _, part := range parts {
-				newDir := filepath.Join(currentDir, part)
-				rel, err := filepath.Rel(absBasePath, newDir)
-				if err != nil {
-					return fmt.Errorf("failed to get relative path for symlink target: %w", err)
-				}
-				if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
-					// return an error so we don't keep traversing the tree
+			_, err = root.Stat(linkRelPath)
+			if err != nil {
+				var pathErr *fs.PathError
+				if errors.As(err, &pathErr) {
 					return &OutOfBoundsSymlinkError{File: linkRelPath}
 				}
-				currentDir = newDir
+				return fmt.Errorf("failed to stat %s: %w", path, err)
 			}
 		}
 		return nil


### PR DESCRIPTION
We can just use `os.Root`

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
