### PR TITLE
fix(ui): enable natural sort ordering for resources, add autocomplete attributes to login form #22853

### DIFF
--- a/ui/src/app/applications/components/application-details/application-resource-list.tsx
+++ b/ui/src/app/applications/components/application-details/application-resource-list.tsx
@@ -69,7 +69,7 @@ export const ApplicationResourceList = (props: ApplicationResourceListProps) => 
                         </div>
                     </div>
                     {props.resources
-                        .sort((first, second) => -createdOrNodeKey(first).localeCompare(createdOrNodeKey(second)))
+                        .sort((first, second) => -createdOrNodeKey(first).localeCompare(createdOrNodeKey(second), undefined, {numeric: true}))
                         .map(res => {
                             const groupkindjoin = [res.group, res.kind].filter(item => !!item).join('/');
                             return (

--- a/ui/src/app/applications/components/application-pod-view/pod-view.tsx
+++ b/ui/src/app/applications/components/application-pod-view/pod-view.tsx
@@ -427,7 +427,7 @@ export class PodView extends React.Component<PodViewProps> {
             }
         });
 
-        Object.values(groupRefs).forEach(group => group.pods.sort((first, second) => nodeKey(first).localeCompare(nodeKey(second))));
+        Object.values(groupRefs).forEach(group => group.pods.sort((first, second) => nodeKey(first).localeCompare(nodeKey(second), undefined, {numeric: true})));
 
         return Object.values(groupRefs)
             .sort((a, b) => (a.name > b.name ? 1 : a.name === b.name ? 0 : -1)) // sort by name

--- a/ui/src/app/applications/components/application-resource-tree/application-resource-tree.tsx
+++ b/ui/src/app/applications/components/application-resource-tree/application-resource-tree.tsx
@@ -210,7 +210,7 @@ export function compareNodes(first: ResourceTreeNode, second: ResourceTreeNode) 
         const numberA = Number(a);
         const numberB = Number(b);
         if (isNaN(numberA) || isNaN(numberB)) {
-            return a.localeCompare(b);
+            return a.localeCompare(b, undefined, {numeric: true});
         }
         return Math.sign(numberA - numberB);
     }
@@ -229,13 +229,13 @@ export function compareNodes(first: ResourceTreeNode, second: ResourceTreeNode) 
         return (
             orphanedToInt(first.orphaned) - orphanedToInt(second.orphaned) ||
             compareRevision(getRevision(second), getRevision(first)) ||
-            nodeKey(first).localeCompare(nodeKey(second)) ||
+            nodeKey(first).localeCompare(nodeKey(second), undefined, {numeric: true}) ||
             0
         );
     }
     return (
         orphanedToInt(first.orphaned) - orphanedToInt(second.orphaned) ||
-        nodeKey(first).localeCompare(nodeKey(second)) ||
+        nodeKey(first).localeCompare(nodeKey(second), undefined, {numeric: true}) ||
         compareRevision(getRevision(first), getRevision(second)) ||
         0
     );

--- a/ui/src/app/applications/components/application-sync-panel/application-sync-panel.tsx
+++ b/ui/src/app/applications/components/application-sync-panel/application-sync-panel.tsx
@@ -23,7 +23,7 @@ export const ApplicationSyncPanel = ({application, selectedResource, hide}: {app
     const [form, setForm] = React.useState<FormApi>(null);
     const isVisible = !!(selectedResource && application);
     const appResources = ((application && selectedResource && application.status && application.status.resources) || [])
-        .sort((first, second) => nodeKey(first).localeCompare(nodeKey(second)))
+        .sort((first, second) => nodeKey(first).localeCompare(nodeKey(second), undefined, {numeric: true}))
         .filter(item => !item.hook);
     const syncResIndex = appResources.findIndex(item => nodeKey(item) === selectedResource);
     const syncStrategy = {} as models.SyncStrategy;

--- a/ui/src/app/applications/components/applications-list/applications-list.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-list.tsx
@@ -534,7 +534,10 @@ export const ApplicationsList = (props: RouteComponentProps<{}>) => {
                                                                             </EmptyState>
                                                                         )}
                                                                         sortOptions={[
-                                                                            {title: 'Name', compare: (a, b) => a.metadata.name.localeCompare(b.metadata.name)},
+                                                                            {
+                                                                                title: 'Name',
+                                                                                compare: (a, b) => a.metadata.name.localeCompare(b.metadata.name, undefined, {numeric: true})
+                                                                            },
                                                                             {
                                                                                 title: 'Created At',
                                                                                 compare: (b, a) => a.metadata.creationTimestamp.localeCompare(b.metadata.creationTimestamp)

--- a/ui/src/app/login/components/login.tsx
+++ b/ui/src/app/login/components/login.tsx
@@ -87,10 +87,10 @@ export class Login extends React.Component<RouteComponentProps<{}>, State> {
                             {formApi => (
                                 <form role='form' className='width-control' onSubmit={formApi.submitForm}>
                                     <div className='argo-form-row'>
-                                        <FormField formApi={formApi} label='Username' field='username' component={Text} componentProps={{autoCapitalize: 'none'}} />
+                                        <FormField formApi={formApi} label='Username' field='username' component={Text} componentProps={{name: 'username', autoCapitalize: 'none', autoComplete: 'username'}} />
                                     </div>
                                     <div className='argo-form-row'>
-                                        <FormField formApi={formApi} label='Password' field='password' component={Text} componentProps={{type: 'password'}} />
+                                        <FormField formApi={formApi} label='Password' field='password' component={Text} componentProps={{name: 'password', type: 'password', autoComplete: 'password'}} />
                                         {this.state.loginError && <div className='argo-form-row__error-msg'>{this.state.loginError}</div>}
                                     </div>
                                     <div className='login__form-row'>

--- a/ui/src/app/login/components/login.tsx
+++ b/ui/src/app/login/components/login.tsx
@@ -87,10 +87,22 @@ export class Login extends React.Component<RouteComponentProps<{}>, State> {
                             {formApi => (
                                 <form role='form' className='width-control' onSubmit={formApi.submitForm}>
                                     <div className='argo-form-row'>
-                                        <FormField formApi={formApi} label='Username' field='username' component={Text} componentProps={{name: 'username', autoCapitalize: 'none', autoComplete: 'username'}} />
+                                        <FormField
+                                            formApi={formApi}
+                                            label='Username'
+                                            field='username'
+                                            component={Text}
+                                            componentProps={{name: 'username', autoCapitalize: 'none', autoComplete: 'username'}}
+                                        />
                                     </div>
                                     <div className='argo-form-row'>
-                                        <FormField formApi={formApi} label='Password' field='password' component={Text} componentProps={{name: 'password', type: 'password', autoComplete: 'password'}} />
+                                        <FormField
+                                            formApi={formApi}
+                                            label='Password'
+                                            field='password'
+                                            component={Text}
+                                            componentProps={{name: 'password', type: 'password', autoComplete: 'password'}}
+                                        />
                                         {this.state.loginError && <div className='argo-form-row__error-msg'>{this.state.loginError}</div>}
                                     </div>
                                     <div className='login__form-row'>


### PR DESCRIPTION
Closes #22853 [ISSUE #22853]

This PR does 2 things:
1. Enables natural sort order for application resources and applications themselves instead of lexicographic order. The change applies to application details UI, sync panels and application list. Some image examples:

*Resource tree*
|Before|After|
|--------|-------|
| ![pods-order-old](https://github.com/user-attachments/assets/4104f688-f14f-4310-8306-3c200c4559f6) | ![pods-order-new](https://github.com/user-attachments/assets/cc3f3481-5c08-46a6-b755-0a23bed3db88) |

*Sync panel*
|Before|After|
|--------|-------|
| ![sync-panel-old](https://github.com/user-attachments/assets/20c86d21-fd59-4a3a-8c4d-5b37089729af) | ![sync-panel-new](https://github.com/user-attachments/assets/ebce8dd7-7eb3-46b0-a8a0-767f2ca2e8f9) |

*Application list*
|Before|After|
|--------|-------|
| ![app-list-old](https://github.com/user-attachments/assets/bdd3c7df-8567-4eb1-9576-28ef7deb9f8f) | ![app-list-new](https://github.com/user-attachments/assets/068fdcdc-aa3a-46a1-bc15-e2584137c46b)|

2. Adds attributes `name` and `autocomplete` to login fields (necessary for some password managers to identify "username" field).

![login-with-autocomplete](https://github.com/user-attachments/assets/864ad84f-9767-40c2-9f2d-b855bc154b21)

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [X] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [X] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [X] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [X] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).