### PR TITLE
feat(cli): add 'get-resource' command (#23196)

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -95,6 +95,7 @@ func NewApplicationCommand(clientOpts *argocdclient.ClientOptions) *cobra.Comman
 	command.AddCommand(NewApplicationTerminateOpCommand(clientOpts))
 	command.AddCommand(NewApplicationEditCommand(clientOpts))
 	command.AddCommand(NewApplicationPatchCommand(clientOpts))
+	command.AddCommand(NewApplicationGetResourceCommand(clientOpts))
 	command.AddCommand(NewApplicationPatchResourceCommand(clientOpts))
 	command.AddCommand(NewApplicationDeleteResourceCommand(clientOpts))
 	command.AddCommand(NewApplicationResourceActionsCommand(clientOpts))

--- a/cmd/argocd/commands/app_resource_test.go
+++ b/cmd/argocd/commands/app_resource_test.go
@@ -242,13 +242,13 @@ spec:
 `
 
 	output, _ := captureOutput(func() error {
-		printManifests(&[]unstructured.Unstructured{obj}, false, "yaml")
+		printManifests(&[]unstructured.Unstructured{obj}, false, true, "yaml")
 		return nil
 	})
 	assert.Equal(t, expectedYAML+"\n", output, "Incorrect yaml output for printManifests")
 
 	output, _ = captureOutput(func() error {
-		printManifests(&[]unstructured.Unstructured{obj, obj}, false, "yaml")
+		printManifests(&[]unstructured.Unstructured{obj, obj}, false, true, "yaml")
 		return nil
 	})
 	assert.Equal(t, expectedYAML+"\n---\n"+expectedYAML+"\n", output, "Incorrect yaml output with multiple objs.")
@@ -265,19 +265,19 @@ spec:
 }`
 
 	output, _ = captureOutput(func() error {
-		printManifests(&[]unstructured.Unstructured{obj}, false, "json")
+		printManifests(&[]unstructured.Unstructured{obj}, false, true, "json")
 		return nil
 	})
 	assert.Equal(t, expectedJSON+"\n", output, "Incorrect json output.")
 
 	output, _ = captureOutput(func() error {
-		printManifests(&[]unstructured.Unstructured{obj, obj}, false, "json")
+		printManifests(&[]unstructured.Unstructured{obj, obj}, false, true, "json")
 		return nil
 	})
 	assert.Equal(t, expectedJSON+"\n---\n"+expectedJSON+"\n", output, "Incorrect json output with multiple objs.")
 
 	output, _ = captureOutput(func() error {
-		printManifests(&[]unstructured.Unstructured{obj}, true, "wide")
+		printManifests(&[]unstructured.Unstructured{obj}, true, true, "wide")
 		return nil
 	})
 	assert.Contains(t, output, "FIELD           RESOURCE NAME  VALUE", "Missing a line in the table")
@@ -285,4 +285,14 @@ spec:
 	assert.Contains(t, output, "kind            unit-test      test", "Missing a line in the table")
 	assert.Contains(t, output, "spec.testfield  unit-test      testvalue", "Missing a line in the table")
 	assert.NotContains(t, output, "metadata.name   unit-test      testvalue")
+
+	output, _ = captureOutput(func() error {
+		printManifests(&[]unstructured.Unstructured{obj}, true, false, "wide")
+		return nil
+	})
+	assert.Contains(t, output, "FIELD           VALUE", "Missing a line in the table")
+	assert.Contains(t, output, "apiVersion      vX", "Missing a line in the table")
+	assert.Contains(t, output, "kind            test", "Missing a line in the table")
+	assert.Contains(t, output, "spec.testfield  testvalue", "Missing a line in the table")
+	assert.NotContains(t, output, "metadata.name   testvalue")
 }

--- a/cmd/argocd/commands/app_resource_test.go
+++ b/cmd/argocd/commands/app_resource_test.go
@@ -280,19 +280,19 @@ spec:
 		printManifests(&[]unstructured.Unstructured{obj}, true, true, "wide")
 		return nil
 	})
-	assert.Contains(t, output, "FIELD           RESOURCE NAME  VALUE", "Missing a line in the table")
-	assert.Contains(t, output, "apiVersion      unit-test      vX", "Missing a line in the table")
-	assert.Contains(t, output, "kind            unit-test      test", "Missing a line in the table")
-	assert.Contains(t, output, "spec.testfield  unit-test      testvalue", "Missing a line in the table")
-	assert.NotContains(t, output, "metadata.name   unit-test      testvalue")
+	assert.Contains(t, output, "FIELD           RESOURCE NAME  VALUE", "Missing or incorrect header line for table print with showing names.")
+	assert.Contains(t, output, "apiVersion      unit-test      vX", "Missing or incorrect row in table related to apiVersion with showing names.")
+	assert.Contains(t, output, "kind            unit-test      test", "Missing or incorrect line in the table related to kind with showing names.")
+	assert.Contains(t, output, "spec.testfield  unit-test      testvalue", "Missing or incorrect line in the table related to spec.testfield with showing names.")
+	assert.NotContains(t, output, "metadata.name   unit-test      testvalue", "Missing or incorrect line in the table related to metadata.name with showing names.")
 
 	output, _ = captureOutput(func() error {
 		printManifests(&[]unstructured.Unstructured{obj}, true, false, "wide")
 		return nil
 	})
-	assert.Contains(t, output, "FIELD           VALUE", "Missing a line in the table")
-	assert.Contains(t, output, "apiVersion      vX", "Missing a line in the table")
-	assert.Contains(t, output, "kind            test", "Missing a line in the table")
-	assert.Contains(t, output, "spec.testfield  testvalue", "Missing a line in the table")
-	assert.NotContains(t, output, "metadata.name   testvalue")
+	assert.Contains(t, output, "FIELD           VALUE", "Missing or incorrect header line for table print with not showing names.")
+	assert.Contains(t, output, "apiVersion      vX", "Missing or incorrect row in table related to apiVersion with not showing names.")
+	assert.Contains(t, output, "kind            test", "Missing or incorrect row in the table related to kind with not showing names.")
+	assert.Contains(t, output, "spec.testfield  testvalue", "Missing or incorrect row in the table related to spec.testefield with not showing names.")
+	assert.NotContains(t, output, "metadata.name   testvalue", "Missing or incorrect row in the tbale related to metadata.name with not showing names.")
 }

--- a/cmd/argocd/commands/app_resources.go
+++ b/cmd/argocd/commands/app_resources.go
@@ -104,6 +104,7 @@ func NewApplicationGetResourceCommand(clientOpts *argocdclient.ClientOptions) *c
 			}
 
 			resources = append(resources, *obj)
+			log.Infof("Resource '%s' fetched", obj.GetName())
 		}
 		printManifests(&resources, len(filteredFields) > 0, output)
 	}
@@ -213,7 +214,6 @@ func printManifests(objs *[]unstructured.Unstructured, filteredFields bool, outp
 
 			printManifestAsTable(w, name, o.Object, "")
 		}
-		log.Infof("Resource '%s' fetched", o.GetName())
 	}
 
 	if output != "json" && output != "yaml" {

--- a/cmd/argocd/commands/app_resources.go
+++ b/cmd/argocd/commands/app_resources.go
@@ -75,13 +75,13 @@ func NewApplicationGetResourceCommand(clientOpts *argocdclient.ClientOptions) *c
 		// Search for resource to fill in potentially missing information
 		var version string
 		for _, r := range tree.Nodes {
-			if r.Name != resourceName {
+			if r.Name != resourceName || r.Kind != kind {
 				continue
 			}
 			version = r.Version
 			group = r.Group
-			kind = r.Kind
 			namespace = r.Namespace
+			break
 		}
 
 		resource, err := appIf.GetResource(ctx, &applicationpkg.ApplicationResourceRequest{

--- a/cmd/argocd/commands/app_resources.go
+++ b/cmd/argocd/commands/app_resources.go
@@ -39,9 +39,29 @@ func NewApplicationGetResourceCommand(clientOpts *argocdclient.ClientOptions) *c
 		output            string
 	)
 	command := &cobra.Command{
-		Use:     "get-resource APPNAME",
-		Short:   "Get details about the live Kubernetes manifests of a resource in an application. The filter-fields flag can be used to only display fields you want to see.",
-		Example: `  #`,
+		Use:   "get-resource APPNAME",
+		Short: "Get details about the live Kubernetes manifests of a resource in an application. The filter-fields flag can be used to only display fields you want to see.",
+		Example: `
+  # Get a specific resource, Pod my-app-pod, in 'my-app' by name in wide format
+    argocd app get-resource my-app --kind Pod --resource-name my-app-pod
+
+  # Get a specific resource, Pod my-app-pod, in 'my-app' by name in yaml format
+    argocd app get-resource my-app --kind Pod --resource-name my-app-pod -o yaml
+
+  # Get a specific resource, Pod my-app-pod, in 'my-app' by name in json format
+    argocd app get-resource my-app --kind Pod --resource-name my-app-pod -o json
+
+  # Get details about all Pods in the application
+    argocd app get-resource my-app --kind Pod
+
+  # Get a specific resource with managed fields, Pod my-app-pod, in 'my-app' by name in wide format
+    argocd app get-resource my-app --kind Pod --resource-name my-app-pod --showManagedFields
+
+  # Get the the details of a specific field in a resource in 'my-app' in the wide format
+    argocd app get-resource my-app --kind Pod --filter-fields status.podIP
+
+  # Get the details of multiple specific fields in a specific resource in 'my-app' in the wide format
+    argocd app get-resource my-app --kind Pod --resource-name my-app-pod --filter-fields status.podIP,status.hostIP`,
 	}
 
 	command.Flags().StringVar(&resourceName, "resource-name", "", "Name of resource, if none is included will output details of all resources with specified kind")
@@ -49,7 +69,7 @@ func NewApplicationGetResourceCommand(clientOpts *argocdclient.ClientOptions) *c
 	err := command.MarkFlagRequired("kind")
 	errors.CheckError(err)
 	command.Flags().StringVar(&project, "project", "", "Project of resource")
-	command.Flags().StringSliceVar(&filteredFields, "filter-fields", nil, "A comma separated list of fields to display, if empty will display entire manifest")
+	command.Flags().StringSliceVar(&filteredFields, "filter-fields", nil, "A comma separated list of fields to display, if not provided will output the entire manifest")
 	command.Flags().BoolVar(&showManagedFields, "show-managed-fields", false, "Show managed fields in the output manifest")
 	command.Flags().StringVarP(&output, "output", "o", "wide", "Format of the output, yaml or json")
 

--- a/cmd/argocd/commands/app_resources.go
+++ b/cmd/argocd/commands/app_resources.go
@@ -6,10 +6,11 @@ import (
 	"os"
 	"text/tabwriter"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/argoproj/argo-cd/v3/cmd/argocd/commands/utils"
 	"github.com/argoproj/argo-cd/v3/cmd/util"
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
-	"gopkg.in/yaml.v3"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -26,13 +27,15 @@ import (
 )
 
 func NewApplicationGetResourceCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
-	var resourceName string
-	var namespace string
-	var kind string
-	var group string
-	var project string
-	var output string
-	var showManagedFields bool
+	var (
+		resourceName      string
+		namespace         string
+		kind              string
+		group             string
+		project           string
+		output            string
+		showManagedFields bool
+	)
 	command := &cobra.Command{
 		Use:   "get-resource APPNAME",
 		Short: "Get live manifest of an application's resource",
@@ -72,13 +75,13 @@ func NewApplicationGetResourceCommand(clientOpts *argocdclient.ClientOptions) *c
 		// Search for resource to fill in potentially missing information
 		var version string
 		for _, r := range tree.Nodes {
-			if r.Name == resourceName {
-				version = r.Version
-				group = r.Group
-				kind = r.Kind
-				namespace = r.Namespace
-				break
+			if r.Name != resourceName {
+				continue
 			}
+			version = r.Version
+			group = r.Group
+			kind = r.Kind
+			namespace = r.Namespace
 		}
 
 		resource, err := appIf.GetResource(ctx, &applicationpkg.ApplicationResourceRequest{
@@ -117,20 +120,22 @@ func printManifest(obj *unstructured.Unstructured, showManagedFields bool, outpu
 		formattedManifest, err = yaml.Marshal(obj.Object)
 	}
 	errors.CheckError(err)
+
 	fmt.Println(string(formattedManifest))
 	log.Infof("Resource '%s' fetched", obj.GetName())
-
 }
 
 func NewApplicationPatchResourceCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
-	var patch string
-	var patchType string
-	var resourceName string
-	var namespace string
-	var kind string
-	var group string
-	var all bool
-	var project string
+	var (
+		patch        string
+		patchType    string
+		resourceName string
+		namespace    string
+		kind         string
+		group        string
+		all          bool
+		project      string
+	)
 	command := &cobra.Command{
 		Use:   "patch-resource APPNAME",
 		Short: "Patch resource in an application",
@@ -190,14 +195,16 @@ func NewApplicationPatchResourceCommand(clientOpts *argocdclient.ClientOptions) 
 }
 
 func NewApplicationDeleteResourceCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
-	var resourceName string
-	var namespace string
-	var kind string
-	var group string
-	var force bool
-	var orphan bool
-	var all bool
-	var project string
+	var (
+		resourceName string
+		namespace    string
+		kind         string
+		group        string
+		force        bool
+		orphan       bool
+		all          bool
+		project      string
+	)
 	command := &cobra.Command{
 		Use:   "delete-resource APPNAME",
 		Short: "Delete resource in an application",
@@ -357,9 +364,11 @@ func printResources(listAll bool, orphaned bool, appResourceTree *v1alpha1.Appli
 }
 
 func NewApplicationListResourcesCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
-	var orphaned bool
-	var output string
-	var project string
+	var (
+		orphaned bool
+		output   string
+		project  string
+	)
 	command := &cobra.Command{
 		Use:   "resources APPNAME",
 		Short: "List resource of application",

--- a/docs/user-guide/commands/argocd_app.md
+++ b/docs/user-guide/commands/argocd_app.md
@@ -89,7 +89,7 @@ argocd app [flags]
 * [argocd app diff](argocd_app_diff.md)	 - Perform a diff against the target and live state.
 * [argocd app edit](argocd_app_edit.md)	 - Edit application
 * [argocd app get](argocd_app_get.md)	 - Get application details
-* [argocd app get-resource](argocd_app_get-resource.md)	 - Get live manifest of an application's resource
+* [argocd app get-resource](argocd_app_get-resource.md)	 - Get details about the live Kubernetes manifests of a resource in an application. The filter-fields flag can be used to only display fields you want to see.
 * [argocd app history](argocd_app_history.md)	 - Show application deployment history
 * [argocd app list](argocd_app_list.md)	 - List applications
 * [argocd app logs](argocd_app_logs.md)	 - Get logs of application pods

--- a/docs/user-guide/commands/argocd_app.md
+++ b/docs/user-guide/commands/argocd_app.md
@@ -89,6 +89,7 @@ argocd app [flags]
 * [argocd app diff](argocd_app_diff.md)	 - Perform a diff against the target and live state.
 * [argocd app edit](argocd_app_edit.md)	 - Edit application
 * [argocd app get](argocd_app_get.md)	 - Get application details
+* [argocd app get-resource](argocd_app_get-resource.md)	 - Get live manifest of an application's resource
 * [argocd app history](argocd_app_history.md)	 - Show application deployment history
 * [argocd app list](argocd_app_list.md)	 - List applications
 * [argocd app logs](argocd_app_logs.md)	 - Get logs of application pods

--- a/docs/user-guide/commands/argocd_app_get-resource.md
+++ b/docs/user-guide/commands/argocd_app_get-resource.md
@@ -11,13 +11,33 @@ argocd app get-resource APPNAME [flags]
 ### Examples
 
 ```
-  #
+
+  # Get a specific resource, Pod my-app-pod, in 'my-app' by name in wide format
+    argocd app get-resource my-app --kind Pod --resource-name my-app-pod
+
+  # Get a specific resource, Pod my-app-pod, in 'my-app' by name in yaml format
+    argocd app get-resource my-app --kind Pod --resource-name my-app-pod -o yaml
+
+  # Get a specific resource, Pod my-app-pod, in 'my-app' by name in json format
+    argocd app get-resource my-app --kind Pod --resource-name my-app-pod -o json
+
+  # Get details about all Pods in the application
+    argocd app get-resource my-app --kind Pod
+
+  # Get a specific resource with managed fields, Pod my-app-pod, in 'my-app' by name in wide format
+    argocd app get-resource my-app --kind Pod --resource-name my-app-pod --showManagedFields
+
+  # Get the the details of a specific field in a resource in 'my-app' in the wide format
+    argocd app get-resource my-app --kind Pod --filter-fields status.podIP
+
+  # Get the details of multiple specific fields in a specific resource in 'my-app' in the wide format
+    argocd app get-resource my-app --kind Pod --resource-name my-app-pod --filter-fields status.podIP,status.hostIP
 ```
 
 ### Options
 
 ```
-      --filter-fields strings   A comma separated list of fields to display, if empty will display entire manifest
+      --filter-fields strings   A comma separated list of fields to display, if not provided will output the entire manifest
   -h, --help                    help for get-resource
       --kind string             Kind of resource [REQUIRED]
   -o, --output string           Format of the output, yaml or json (default "wide")

--- a/docs/user-guide/commands/argocd_app_get-resource.md
+++ b/docs/user-guide/commands/argocd_app_get-resource.md
@@ -25,7 +25,7 @@ argocd app get-resource APPNAME [flags]
     argocd app get-resource my-app --kind Pod
 
   # Get a specific resource with managed fields, Pod my-app-pod, in 'my-app' by name in wide format
-    argocd app get-resource my-app --kind Pod --resource-name my-app-pod --showManagedFields
+    argocd app get-resource my-app --kind Pod --resource-name my-app-pod --show-managed-fields
 
   # Get the the details of a specific field in a resource in 'my-app' in the wide format
     argocd app get-resource my-app --kind Pod --filter-fields status.podIP
@@ -40,7 +40,7 @@ argocd app get-resource APPNAME [flags]
       --filter-fields strings   A comma separated list of fields to display, if not provided will output the entire manifest
   -h, --help                    help for get-resource
       --kind string             Kind of resource [REQUIRED]
-  -o, --output string           Format of the output, yaml or json (default "wide")
+  -o, --output string           Format of the output, wide, yaml, or json (default "wide")
       --project string          Project of resource
       --resource-name string    Name of resource, if none is included will output details of all resources with specified kind
       --show-managed-fields     Show managed fields in the output manifest

--- a/docs/user-guide/commands/argocd_app_get-resource.md
+++ b/docs/user-guide/commands/argocd_app_get-resource.md
@@ -11,14 +11,13 @@ argocd app get-resource APPNAME [flags]
 ### Options
 
 ```
-      --group string           Group, if none is provided will default to nothing
-  -h, --help                   help for get-resource
-      --kind string            Kind of resource [REQUIRED]
-      --namespace string       Namespace, if none is provided will default to that of the resource
-      --output string          Format of the output, yaml or json (default "yaml")
-      --project string         Project of resource
-      --resource-name string   Name of resource [REQUIRED]
-      --show-managed-fields    Show managed fields in the output manifest
+      --filter-fields strings   A comma separated list of fields to display, if empty will display entire manifest
+  -h, --help                    help for get-resource
+      --kind string             Kind of resource [REQUIRED]
+  -o, --output string           Format of the output, yaml or json (default "wide")
+      --project string          Project of resource
+      --resource-name string    Name of resource, if none is included will output details of all resources with specified kind
+      --show-managed-fields     Show managed fields in the output manifest
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_app_get-resource.md
+++ b/docs/user-guide/commands/argocd_app_get-resource.md
@@ -1,0 +1,58 @@
+# `argocd app get-resource` Command Reference
+
+## argocd app get-resource
+
+Get live manifest of an application's resource
+
+```
+argocd app get-resource APPNAME [flags]
+```
+
+### Options
+
+```
+      --group string           Group, if none is provided will default to nothing
+  -h, --help                   help for get-resource
+      --kind string            Kind of resource [REQUIRED]
+      --namespace string       Namespace, if none is provided will default to that of the resource
+      --output string          Format of the output, yaml or json (default "yaml")
+      --project string         Project of resource
+      --resource-name string   Name of resource [REQUIRED]
+      --show-managed-fields    Show managed fields in the output manifest
+```
+
+### Options inherited from parent commands
+
+```
+      --argocd-context string           The name of the Argo-CD server context to use
+      --auth-token string               Authentication token; set this or the ARGOCD_AUTH_TOKEN environment variable
+      --client-crt string               Client certificate file
+      --client-crt-key string           Client certificate key file
+      --config string                   Path to Argo CD config (default "/home/user/.config/argocd/config")
+      --controller-name string          Name of the Argo CD Application controller; set this or the ARGOCD_APPLICATION_CONTROLLER_NAME environment variable when the controller's name label differs from the default, for example when installing via the Helm chart (default "argocd-application-controller")
+      --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
+      --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
+      --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
+  -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
+      --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
+      --insecure                        Skip server certificate and domain verification
+      --kube-context string             Directs the command to the given kube-context
+      --logformat string                Set the logging format. One of: json|text (default "json")
+      --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
+      --plaintext                       Disable TLS
+      --port-forward                    Connect to a random argocd-server port using port forwarding
+      --port-forward-namespace string   Namespace name which should be used for port forwarding
+      --prompts-enabled                 Force optional interactive prompts to be enabled or disabled, overriding local configuration. If not specified, the local configuration value will be used, which is false by default.
+      --redis-compress string           Enable this if the application controller is configured with redis compression enabled. (possible values: gzip, none) (default "gzip")
+      --redis-haproxy-name string       Name of the Redis HA Proxy; set this or the ARGOCD_REDIS_HAPROXY_NAME environment variable when the HA Proxy's name label differs from the default, for example when installing via the Helm chart (default "argocd-redis-ha-haproxy")
+      --redis-name string               Name of the Redis deployment; set this or the ARGOCD_REDIS_NAME environment variable when the Redis's name label differs from the default, for example when installing via the Helm chart (default "argocd-redis")
+      --repo-server-name string         Name of the Argo CD Repo server; set this or the ARGOCD_REPO_SERVER_NAME environment variable when the server's name label differs from the default, for example when installing via the Helm chart (default "argocd-repo-server")
+      --server string                   Argo CD server address
+      --server-crt string               Server certificate file
+      --server-name string              Name of the Argo CD API server; set this or the ARGOCD_SERVER_NAME environment variable when the server's name label differs from the default, for example when installing via the Helm chart (default "argocd-server")
+```
+
+### SEE ALSO
+
+* [argocd app](argocd_app.md)	 - Manage applications
+

--- a/docs/user-guide/commands/argocd_app_get-resource.md
+++ b/docs/user-guide/commands/argocd_app_get-resource.md
@@ -2,10 +2,16 @@
 
 ## argocd app get-resource
 
-Get live manifest of an application's resource
+Get details about the live Kubernetes manifests of a resource in an application. The filter-fields flag can be used to only display fields you want to see.
 
 ```
 argocd app get-resource APPNAME [flags]
+```
+
+### Examples
+
+```
+  #
 ```
 
 ### Options


### PR DESCRIPTION
Closes #22945 
Closes #23196 
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [X] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [X] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR. 
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [X] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [X] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->

## Purpose 
The purpose of this PR is to add the CLI command `app get-resource` that is discussed in the proposal in #23461. This first implementation allows you to output the manifest as a YAML or JSON and searches through the apps resources to fill in any information that might be missing. 

## Example
![Screenshot 2025-06-30 at 11 06 28 AM](https://github.com/user-attachments/assets/17387931-055b-491f-ac83-0faf1571fd95)

## Further Improvements
Below are some other ideas that I have thought of while working on the implementation that might be good to add to the command. 
- Filter fields, only display certain parts of the manifest that you would like to see.
- Specifying just a kind will bring up all the available options in the application and you can select one or return the manifests for multiple 

## Questions
- What type of tests need to be done for this feature? 
