### PR TITLE
feat(helm): upgrade to 3.18.3

### DIFF
--- a/docs/operator-manual/upgrading/3.0-3.1.md
+++ b/docs/operator-manual/upgrading/3.0-3.1.md
@@ -37,3 +37,8 @@ If it returns `"enablePKCEAuthentication": true`, then PKCE is used.
 ### Remediation
 
 On your identity provider, ensure that the OIDC client used for Argo CD has the `/auth/callback` endpoint of your Argo CD URL (e.g. https://argocd.example.com/auth/callback) in the redirect URIs.
+
+## Helm Upgraded to 3.18.3
+
+Argo CD v3.1 upgrades the bundled Helm version to 3.18.3. There are no breaking changes in Helm 3.18 according to the
+[release notes](https://github.com/helm/helm/releases/tag/v3.18.0).

--- a/hack/installers/checksums/helm-v3.18.3-darwin-amd64.tar.gz.sha256
+++ b/hack/installers/checksums/helm-v3.18.3-darwin-amd64.tar.gz.sha256
@@ -1,0 +1,1 @@
+d186851d40b1999c5d75696bc0b754e4d29e860c8d0cf4c132ac1b1940c5cffc  helm-v3.18.3-darwin-amd64.tar.gz

--- a/hack/installers/checksums/helm-v3.18.3-darwin-arm64.tar.gz.sha256
+++ b/hack/installers/checksums/helm-v3.18.3-darwin-arm64.tar.gz.sha256
@@ -1,0 +1,1 @@
+3fe3e9739ab3c75d88bfe13e464a79a2a7a804fc692c3258fa6a9d185d53e377  helm-v3.18.3-darwin-arm64.tar.gz

--- a/hack/installers/checksums/helm-v3.18.3-linux-amd64.tar.gz.sha256
+++ b/hack/installers/checksums/helm-v3.18.3-linux-amd64.tar.gz.sha256
@@ -1,0 +1,1 @@
+6ec85f306dd8fe9eb05c61ba4593182b2afcfefb52f21add3fe043ebbdc48e39  helm-v3.18.3-linux-amd64.tar.gz

--- a/hack/installers/checksums/helm-v3.18.3-linux-arm64.tar.gz.sha256
+++ b/hack/installers/checksums/helm-v3.18.3-linux-arm64.tar.gz.sha256
@@ -1,0 +1,1 @@
+3382ebdc6d6e027371551a63fc6e0a3073a1aec1061e346692932da61cfd8d24  helm-v3.18.3-linux-arm64.tar.gz

--- a/hack/installers/checksums/helm-v3.18.3-linux-ppc64le.tar.gz.sha256
+++ b/hack/installers/checksums/helm-v3.18.3-linux-ppc64le.tar.gz.sha256
@@ -1,0 +1,1 @@
+ca5ab0bb205488276095881f04b72bfed5c0ddb92f715940dde6a7ccae72818c  helm-v3.18.3-linux-ppc64le.tar.gz

--- a/hack/installers/checksums/helm-v3.18.3-linux-s390x.tar.gz.sha256
+++ b/hack/installers/checksums/helm-v3.18.3-linux-s390x.tar.gz.sha256
@@ -1,0 +1,1 @@
+be261f040b59c04ad4f1ce6fc2f976e500167475cadb468bf78cb9772300fb5d  helm-v3.18.3-linux-s390x.tar.gz

--- a/hack/tool-versions.sh
+++ b/hack/tool-versions.sh
@@ -11,7 +11,7 @@
 # Use ./hack/installers/checksums/add-helm-checksums.sh and
 # add-kustomize-checksums.sh to help download checksums.
 ###############################################################################
-helm3_version=3.17.1
+helm3_version=3.18.3
 kustomize5_version=5.6.0
 protoc_version=29.3
 oras_version=1.2.0


### PR DESCRIPTION
I think we should cherry-pick this into 3.1.0. Getting stuck on old Helm versions is terrible for security upgrades.