### PR TITLE
fix(ui): fix misleading pointer cursor and animation click-block issue

### DIFF
--- a/ui/src/app/applications/components/application-resource-tree/application-resource-tree.scss
+++ b/ui/src/app/applications/components/application-resource-tree/application-resource-tree.scss
@@ -328,6 +328,7 @@
         top: 0;
         bottom: 0;
         animation: shadow-pulse 1s 1;
+        pointer-events: none;
     }
 
     @keyframes shadow-pulse {

--- a/ui/src/app/applications/components/application-resource-tree/application-resource-tree.scss
+++ b/ui/src/app/applications/components/application-resource-tree/application-resource-tree.scss
@@ -107,6 +107,14 @@
             }
         }
 
+        &--grouped-node {
+            cursor: default;
+        }
+
+        &__top-part {
+            cursor: pointer;
+        }
+
         &--load-balancer {
             cursor: default;
             background-color: $argo-color-teal-2;

--- a/ui/src/app/applications/components/application-resource-tree/application-resource-tree.tsx
+++ b/ui/src/app/applications/components/application-resource-tree/application-resource-tree.tsx
@@ -446,7 +446,8 @@ function renderPodGroup(props: ApplicationResourceTreeProps, id: string, node: R
         <div
             className={classNames('application-resource-tree__node', {
                 'active': fullName === props.selectedNodeFullName,
-                'application-resource-tree__node--orphaned': node.orphaned
+                'application-resource-tree__node--orphaned': node.orphaned,
+                'application-resource-tree__node--grouped-node': !showPodGroupByStatus
             })}
             title={describeNode(node)}
             style={{


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Fixes two UI issues:
- Replaced incorrect `cursor: pointer` applied to all application resource tree elements.
Introduced a new `&--grouped-node` class to apply `cursor: default` to non-clickable parts of pod group nodes,
while restricting `cursor: pointer` to only the `&__top-part` element that handles actual interaction.
#### `cursor: pointer` with no click event
<img width="484" alt="pointer cursor with no click event" src="https://github.com/user-attachments/assets/c0a82006-81e5-4dee-838e-66bb3f77aacb" />

#### fix - `cursor: default` with no click event
<img width="520" alt="pointer default with no click event" src="https://github.com/user-attachments/assets/58ae480c-ab22-43c1-b132-a880800ad401" />  

<br>  
<br>
  
- Added `pointer-events: none` to the shadow animation to prevent it from blocking clicks.
#### after `<NodeUpdateAnimation />` generated content is non-clickable
<img width="508" alt="after animation - nonclickable" src="https://github.com/user-attachments/assets/0fbf8161-f762-4f41-b8bb-02a241dc8c9f" />

#### fix - after `<NodeUpdateAnimation />` generated content is clickable
<img width="554" alt="after animation - clickable" src="https://github.com/user-attachments/assets/259ee642-f227-48da-9f68-3067eae71c8e" />



Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
