### PR TITLE
fix(health): CRD health check message (#23690)

### DIFF
--- a/resource_customizations/apiextensions.k8s.io/CustomResourceDefinition/testdata/crd-v1-non-structual-degraded.yaml
+++ b/resource_customizations/apiextensions.k8s.io/CustomResourceDefinition/testdata/crd-v1-non-structual-degraded.yaml
@@ -47,15 +47,15 @@ status:
       reason: NoConflicts
       status: 'True'
       type: NamesAccepted
-    - lastTransitionTime: '2024-05-19T23:35:28Z'
-      message: the initial names have been accepted
-      reason: InitialNamesAccepted
-      status: 'True'
-      type: Established
     - lastTransitionTime: '2024-10-26T19:44:57Z'
       message: 'spec.preserveUnknownFields: Invalid value: true: must be false'
       reason: Violations
       status: 'True'
       type: NonStructuralSchema
+    - lastTransitionTime: '2024-05-19T23:35:28Z'
+      message: the initial names have been accepted
+      reason: InitialNamesAccepted
+      status: 'True'
+      type: Established
   storedVersions:
     - v1alpha1


### PR DESCRIPTION
The health check message currently is the message of "whatever condition was observed last," even if the condition health is based on some other condition.

I've changed the health check to quit early if it observes a condition which would make the resource Degraded or Progressing. As a result, it always returns the message most relevant to that condition.

I've updated the test to change the condition order in a way that triggers the bug.