### PR TITLE
fix(server): infer resource status health for apps-in-any-ns (#22944)

### DIFF
--- a/server/application/application.go
+++ b/server/application/application.go
@@ -2679,7 +2679,7 @@ func (s *Server) GetApplicationSyncWindows(ctx context.Context, q *application.A
 func (s *Server) inferResourcesStatusHealth(app *v1alpha1.Application) {
 	if app.Status.ResourceHealthSource == v1alpha1.ResourceHealthLocationAppTree {
 		tree := &v1alpha1.ApplicationTree{}
-		if err := s.cache.GetAppResourcesTree(app.Name, tree); err == nil {
+		if err := s.cache.GetAppResourcesTree(app.InstanceName(s.ns), tree); err == nil {
 			healthByKey := map[kube.ResourceKey]*v1alpha1.HealthStatus{}
 			for _, node := range tree.Nodes {
 				if node.Health != nil {


### PR DESCRIPTION
Cherry-pick of https://github.com/argoproj/argo-cd/pull/22944