### PR TITLE
fix(server): infer resource status health for apps-in-any-ns (#22944)

### DIFF
--- a/server/application/application.go
+++ b/server/application/application.go
@@ -2646,7 +2646,7 @@ func (s *Server) GetApplicationSyncWindows(ctx context.Context, q *application.A
 func (s *Server) inferResourcesStatusHealth(app *appv1.Application) {
 	if app.Status.ResourceHealthSource == appv1.ResourceHealthLocationAppTree {
 		tree := &appv1.ApplicationTree{}
-		if err := s.cache.GetAppResourcesTree(app.Name, tree); err == nil {
+		if err := s.cache.GetAppResourcesTree(app.InstanceName(s.ns), tree); err == nil {
 			healthByKey := map[kube.ResourceKey]*appv1.HealthStatus{}
 			for _, node := range tree.Nodes {
 				healthByKey[kube.NewResourceKey(node.Group, node.Kind, node.Namespace, node.Name)] = node.Health


### PR DESCRIPTION
Cherry-pick of https://github.com/argoproj/argo-cd/pull/22944