### PR TITLE
feat: Add IsSelfReferencedObj field to ResourceStatus and update pruning logic

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -2182,7 +2182,7 @@ func (ctrl *ApplicationController) autoSync(app *appv1.Application, syncStatus *
 	if app.Spec.SyncPolicy.Automated.Prune && !app.Spec.SyncPolicy.Automated.AllowEmpty {
 		bAllNeedPrune := true
 		for _, r := range resources {
-			if !r.RequiresPruning {
+			if r.IsSelfReferencedObj && !r.RequiresPruning {
 				bAllNeedPrune = false
 			}
 		}

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -2792,3 +2792,116 @@ func TestSyncTimeout(t *testing.T) {
 		})
 	}
 }
+
+// TestAutoSyncPruneWithIsSelfReferencedObj tests the updated pruning logic that considers IsSelfReferencedObj
+func TestAutoSyncPruneWithIsSelfReferencedObj(t *testing.T) {
+	t.Run("Should trigger sync when all self-referenced resources don't require pruning", func(t *testing.T) {
+		app := newFakeApp()
+		app.Spec.SyncPolicy.Automated.Prune = true
+		app.Spec.SyncPolicy.Automated.AllowEmpty = false
+		ctrl := newFakeController(&fakeData{apps: []runtime.Object{app}}, nil)
+		syncStatus := v1alpha1.SyncStatus{
+			Status:   v1alpha1.SyncStatusCodeOutOfSync,
+			Revision: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		}
+
+		// All resources are self-referenced and don't require pruning
+		resources := []v1alpha1.ResourceStatus{
+			{
+				Name:                "resource1",
+				Kind:                kube.DeploymentKind,
+				Status:              v1alpha1.SyncStatusCodeOutOfSync,
+				IsSelfReferencedObj: true,
+				RequiresPruning:     false,
+			},
+			{
+				Name:                "resource2",
+				Kind:                kube.DeploymentKind,
+				Status:              v1alpha1.SyncStatusCodeOutOfSync,
+				IsSelfReferencedObj: true,
+				RequiresPruning:     false,
+			},
+		}
+
+		cond, _ := ctrl.autoSync(app, &syncStatus, resources, true)
+		assert.Nil(t, cond)
+
+		updatedApp, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(test.FakeArgoCDNamespace).Get(t.Context(), "my-app", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.NotNil(t, updatedApp.Operation)
+		assert.NotNil(t, updatedApp.Operation.Sync)
+		assert.True(t, updatedApp.Operation.Sync.Prune)
+	})
+
+	t.Run("Should trigger sync when some self-referenced resources require pruning", func(t *testing.T) {
+		app := newFakeApp()
+		app.Spec.SyncPolicy.Automated.Prune = true
+		app.Spec.SyncPolicy.Automated.AllowEmpty = false
+		ctrl := newFakeController(&fakeData{apps: []runtime.Object{app}}, nil)
+		syncStatus := v1alpha1.SyncStatus{
+			Status:   v1alpha1.SyncStatusCodeOutOfSync,
+			Revision: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		}
+
+		// Mix of resources: some self-referenced requiring pruning, some not
+		resources := []v1alpha1.ResourceStatus{
+			{
+				Name:                "resource1",
+				Kind:                kube.DeploymentKind,
+				Status:              v1alpha1.SyncStatusCodeOutOfSync,
+				IsSelfReferencedObj: true,
+				RequiresPruning:     true,
+			},
+			{
+				Name:                "resource2",
+				Kind:                kube.DeploymentKind,
+				Status:              v1alpha1.SyncStatusCodeOutOfSync,
+				IsSelfReferencedObj: true,
+				RequiresPruning:     false,
+			},
+		}
+
+		cond, _ := ctrl.autoSync(app, &syncStatus, resources, true)
+		assert.Nil(t, cond)
+
+		updatedApp, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(test.FakeArgoCDNamespace).Get(t.Context(), "my-app", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.NotNil(t, updatedApp.Operation)
+		assert.NotNil(t, updatedApp.Operation.Sync)
+		assert.True(t, updatedApp.Operation.Sync.Prune)
+	})
+
+	t.Run("Should skip sync when non-self-referenced resources don't require pruning", func(t *testing.T) {
+		app := newFakeApp()
+		app.Spec.SyncPolicy.Automated.Prune = true
+		app.Spec.SyncPolicy.Automated.AllowEmpty = false
+		ctrl := newFakeController(&fakeData{apps: []runtime.Object{app}}, nil)
+		syncStatus := v1alpha1.SyncStatus{
+			Status:   v1alpha1.SyncStatusCodeOutOfSync,
+			Revision: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		}
+
+		// Non-self-referenced resources that don't require pruning
+		resources := []v1alpha1.ResourceStatus{
+			{
+				Name:                "resource1",
+				Kind:                kube.DeploymentKind,
+				Status:              v1alpha1.SyncStatusCodeOutOfSync,
+				IsSelfReferencedObj: false,
+				RequiresPruning:     false,
+			},
+			{
+				Name:                "resource2",
+				Kind:                kube.DeploymentKind,
+				Status:              v1alpha1.SyncStatusCodeOutOfSync,
+				IsSelfReferencedObj: false,
+				RequiresPruning:     false,
+			},
+		}
+
+		cond, _ := ctrl.autoSync(app, &syncStatus, resources, true)
+		assert.NotNil(t, cond)
+		assert.Equal(t, v1alpha1.ApplicationConditionSyncError, cond.Type)
+		assert.Contains(t, cond.Message, "auto-sync will wipe out all resources")
+	})
+}

--- a/controller/state.go
+++ b/controller/state.go
@@ -860,13 +860,14 @@ func (m *appStateManager) CompareAppState(app *v1alpha1.Application, project *v1
 		isSelfReferencedObj := m.isSelfReferencedObj(liveObj, targetObj, app.GetName(), v1alpha1.TrackingMethod(trackingMethod), installationID)
 
 		resState := v1alpha1.ResourceStatus{
-			Namespace:       obj.GetNamespace(),
-			Name:            obj.GetName(),
-			Kind:            gvk.Kind,
-			Version:         gvk.Version,
-			Group:           gvk.Group,
-			Hook:            isHook(obj),
-			RequiresPruning: targetObj == nil && liveObj != nil && isSelfReferencedObj,
+			Namespace:           obj.GetNamespace(),
+			Name:                obj.GetName(),
+			Kind:                gvk.Kind,
+			Version:             gvk.Version,
+			Group:               gvk.Group,
+			Hook:                isHook(obj),
+			IsSelfReferencedObj: isSelfReferencedObj,
+			RequiresPruning:     targetObj == nil && liveObj != nil && isSelfReferencedObj,
 			RequiresDeletionConfirmation: targetObj != nil && resourceutil.HasAnnotationOption(targetObj, synccommon.AnnotationSyncOptions, synccommon.SyncOptionDeleteRequireConfirm) ||
 				liveObj != nil && resourceutil.HasAnnotationOption(liveObj, synccommon.AnnotationSyncOptions, synccommon.SyncOptionDeleteRequireConfirm),
 		}

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -2133,6 +2133,8 @@ type ResourceStatus struct {
 	SyncWave int64 `json:"syncWave,omitempty" protobuf:"bytes,10,opt,name=syncWave"`
 	// RequiresDeletionConfirmation is true if the resource requires explicit user confirmation before deletion.
 	RequiresDeletionConfirmation bool `json:"requiresDeletionConfirmation,omitempty" protobuf:"bytes,11,opt,name=requiresDeletionConfirmation"`
+	// IsSelfReferencedObj is true if the resource is managed by the application.
+	IsSelfReferencedObj bool `json:"isSelfReferencedObj,omitempty" protobuf:"bytes,12,opt,name=isSelfReferencedObj"`
 }
 
 // GroupVersionKind returns the GVK schema type for given resource status

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -4543,3 +4543,92 @@ func TestCluster_ParseProxyUrl(t *testing.T) {
 		}
 	}
 }
+
+// TestResourceStatus_IsSelfReferencedObj tests the IsSelfReferencedObj field serialization and deserialization
+func TestResourceStatus_IsSelfReferencedObj(t *testing.T) {
+	t.Run("IsSelfReferencedObj field serialization", func(t *testing.T) {
+		resourceStatus := ResourceStatus{
+			Namespace:           "test-namespace",
+			Name:                "test-resource",
+			Kind:                "Deployment",
+			Version:             "v1",
+			Group:               "apps",
+			IsSelfReferencedObj: true,
+			RequiresPruning:     true,
+		}
+
+		jsonData, err := json.Marshal(resourceStatus)
+		require.NoError(t, err)
+
+		var unmarshaledResourceStatus ResourceStatus
+		err = json.Unmarshal(jsonData, &unmarshaledResourceStatus)
+		require.NoError(t, err)
+
+		assert.Equal(t, resourceStatus.Namespace, unmarshaledResourceStatus.Namespace)
+		assert.Equal(t, resourceStatus.Name, unmarshaledResourceStatus.Name)
+		assert.Equal(t, resourceStatus.Kind, unmarshaledResourceStatus.Kind)
+		assert.Equal(t, resourceStatus.Version, unmarshaledResourceStatus.Version)
+		assert.Equal(t, resourceStatus.Group, unmarshaledResourceStatus.Group)
+		assert.Equal(t, resourceStatus.IsSelfReferencedObj, unmarshaledResourceStatus.IsSelfReferencedObj)
+		assert.Equal(t, resourceStatus.RequiresPruning, unmarshaledResourceStatus.RequiresPruning)
+	})
+
+	t.Run("IsSelfReferencedObj field defaults to false", func(t *testing.T) {
+		resourceStatus := ResourceStatus{
+			Namespace:       "test-namespace",
+			Name:            "test-resource",
+			Kind:            "Deployment",
+			Version:         "v1",
+			Group:           "apps",
+			RequiresPruning: false,
+		}
+
+		jsonData, err := json.Marshal(resourceStatus)
+		require.NoError(t, err)
+
+		var unmarshaledResourceStatus ResourceStatus
+		err = json.Unmarshal(jsonData, &unmarshaledResourceStatus)
+		require.NoError(t, err)
+
+		assert.False(t, unmarshaledResourceStatus.IsSelfReferencedObj)
+	})
+
+	t.Run("IsSelfReferencedObj field with JSON omitempty", func(t *testing.T) {
+		resourceStatus := ResourceStatus{
+			Namespace:           "test-namespace",
+			Name:                "test-resource",
+			Kind:                "Deployment",
+			Version:             "v1",
+			Group:               "apps",
+			IsSelfReferencedObj: false,
+			RequiresPruning:     false,
+		}
+
+		jsonData, err := json.Marshal(resourceStatus)
+		require.NoError(t, err)
+
+		// Verify that the field is not included in JSON when false due to omitempty
+		jsonStr := string(jsonData)
+		assert.NotContains(t, jsonStr, "isSelfReferencedObj")
+	})
+
+	t.Run("IsSelfReferencedObj field with true value", func(t *testing.T) {
+		resourceStatus := ResourceStatus{
+			Namespace:           "test-namespace",
+			Name:                "test-resource",
+			Kind:                "Deployment",
+			Version:             "v1",
+			Group:               "apps",
+			IsSelfReferencedObj: true,
+			RequiresPruning:     false,
+		}
+
+		jsonData, err := json.Marshal(resourceStatus)
+		require.NoError(t, err)
+
+		// Verify that the field is included in JSON when true
+		jsonStr := string(jsonData)
+		assert.Contains(t, jsonStr, "isSelfReferencedObj")
+		assert.Contains(t, jsonStr, "true")
+	})
+}


### PR DESCRIPTION
- Introduced IsSelfReferencedObj field in ResourceStatus to indicate if a r
esource is managed by the application.
- Updated pruning logic in autoSync method to account for self-referenced o
bjects.
- Enhance tests for IsSelfReferencedObj field and pruning logic
