### PR TITLE
fix: the specified namespace is not taking effect in argocd-notifications

### DIFF
--- a/cmd/argocd-notification/commands/controller.go
+++ b/cmd/argocd-notification/commands/controller.go
@@ -50,7 +50,6 @@ func NewCommand() *cobra.Command {
 	var (
 		clientConfig                   clientcmd.ClientConfig
 		processorsCount                int
-		namespace                      string
 		appLabelSelector               string
 		logLevel                       string
 		logFormat                      string
@@ -178,7 +177,6 @@ func NewCommand() *cobra.Command {
 	clientConfig = addK8SFlagsToCmd(&command)
 	command.Flags().IntVar(&processorsCount, "processors-count", 1, "Processors count.")
 	command.Flags().StringVar(&appLabelSelector, "app-label-selector", "", "App label selector.")
-	command.Flags().StringVar(&namespace, "namespace", "", "Namespace which controller handles. Current namespace if empty.")
 	command.Flags().StringVar(&logLevel, "loglevel", env.StringFromEnv("ARGOCD_NOTIFICATIONS_CONTROLLER_LOGLEVEL", "info"), "Set the logging level. One of: debug|info|warn|error")
 	command.Flags().StringVar(&logFormat, "logformat", env.StringFromEnv("ARGOCD_NOTIFICATIONS_CONTROLLER_LOGFORMAT", "json"), "Set the logging format. One of: json|text")
 	command.Flags().IntVar(&metricsPort, "metrics-port", defaultMetricsPort, "Metrics port")


### PR DESCRIPTION
I'm trying to run argocd-notifications out-of-cluster and specify it's namespace by:

```
argocd-notifications --kubeconfig /path --namespace testns
```

However, the provided namespace was not being respected. After some debugging, I identified the root cause: the argocd-notifications command redundantly defines its own `--namespace` flag:

https://github.com/argoproj/argo-cd/blob/908c73255e80b6e56ae7abdcf45ea2468bb628af/cmd/argocd-notification/commands/controller.go#L181

This conflict with the [`ContextOverrideFlags`](https://github.com/kubernetes/client-go/blob/be36413bbca77ccb084601be239952e1fb091fa1/tools/clientcmd/overrides.go#L208-L214) provided by `clientcmd.RecommendedConfigOverrideFlags`.

This conflict causes the namespace field within the `ContextOverride` struct to be an empty string. As a result, when the namespace is retrieved via `clientConfig.Namespace()`, it consistently falls back to the default namespace, ignoring the user's intended value:

<img width="552" height="222" alt="Screenshot 2025-07-18 at 10 35 40" src="https://github.com/user-attachments/assets/38960ef6-61c4-474f-9da0-18e5b47ce003" />


after this patch:
<img width="550" height="220" alt="Screenshot 2025-07-18 at 10 57 24" src="https://github.com/user-attachments/assets/72cf98bd-1f0c-4ef2-90ef-d1b82bb87f82" />


Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
