### PR TITLE
feat(cli): add bcrypt password verification with --compare flag

### DIFF
--- a/cmd/argocd/commands/bcrypt.go
+++ b/cmd/argocd/commands/bcrypt.go
@@ -4,9 +4,10 @@ import (
 	stderrors "errors"
 	"fmt"
 
-	"github.com/argoproj/argo-cd/v3/util/errors"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/bcrypt"
+
+	"github.com/argoproj/argo-cd/v3/util/errors"
 )
 
 type bcryptCmdOpt struct {
@@ -53,7 +54,7 @@ func runBcryptCommand(opt bcryptCmdOpt) (string, error) {
 			if stderrors.Is(err, bcrypt.ErrMismatchedHashAndPassword) {
 				return "no", nil
 			}
-			return "", fmt.Errorf("Failed to compare password: %v", err)
+			return "", fmt.Errorf("failed to compare password: %w", err)
 		}
 		return "yes", nil
 	}
@@ -61,7 +62,7 @@ func runBcryptCommand(opt bcryptCmdOpt) (string, error) {
 	// Hash password
 	hash, err := bcrypt.GenerateFromPassword(bytePassword, bcrypt.DefaultCost)
 	if err != nil {
-		return "", fmt.Errorf("Failed to generate bcrypt hash: %v", err)
+		return "", fmt.Errorf("failed to generate bcrypt hash: %w", err)
 	}
 	return string(hash), nil
 }

--- a/cmd/argocd/commands/bcrypt_test.go
+++ b/cmd/argocd/commands/bcrypt_test.go
@@ -39,7 +39,7 @@ func TestComparePassword(t *testing.T) {
 		return
 	}
 
-	assert.Equal(t, output.String(), "yes")
+	assert.Equal(t, "yes", output.String())
 }
 
 func TestComparePasswordFailureCase(t *testing.T) {
@@ -60,5 +60,5 @@ func TestComparePasswordFailureCase(t *testing.T) {
 		return
 	}
 
-	assert.Equal(t, output.String(), "no")
+	assert.Equal(t, "no", output.String())
 }

--- a/cmd/argocd/commands/bcrypt_test.go
+++ b/cmd/argocd/commands/bcrypt_test.go
@@ -20,3 +20,45 @@ func TestGeneratePassword(t *testing.T) {
 	err = bcrypt.CompareHashAndPassword(output.Bytes(), []byte("abc"))
 	assert.NoError(t, err)
 }
+
+func TestComparePassword(t *testing.T) {
+	bcryptCmd := NewBcryptCmd()
+	bcryptCmd.SetArgs([]string{"--password", "abc"})
+	output := new(bytes.Buffer)
+	bcryptCmd.SetOut(output)
+	err := bcryptCmd.Execute()
+	if err != nil {
+		return
+	}
+
+	bcryptCmd.SetArgs([]string{"--password", "abc", "--compare", output.String()})
+	output.Reset()
+
+	err = bcryptCmd.Execute()
+	if err != nil {
+		return
+	}
+
+	assert.Equal(t, output.String(), "yes")
+}
+
+func TestComparePasswordFailureCase(t *testing.T) {
+	bcryptCmd := NewBcryptCmd()
+	bcryptCmd.SetArgs([]string{"--password", "a"})
+	output := new(bytes.Buffer)
+	bcryptCmd.SetOut(output)
+	err := bcryptCmd.Execute()
+	if err != nil {
+		return
+	}
+
+	bcryptCmd.SetArgs([]string{"--password", "abc", "--compare", output.String()})
+	output.Reset()
+
+	err = bcryptCmd.Execute()
+	if err != nil {
+		return
+	}
+
+	assert.Equal(t, output.String(), "no")
+}

--- a/docs/user-guide/commands/argocd_account_bcrypt.md
+++ b/docs/user-guide/commands/argocd_account_bcrypt.md
@@ -13,11 +13,13 @@ argocd account bcrypt [flags]
 ```
 # Generate bcrypt hash for any password 
 argocd account bcrypt --password YOUR_PASSWORD
+argocd account bcrypt --password YOUR_PASSWORD --compare 'YOUR_HASH_PASSWORD'
 ```
 
 ### Options
 
 ```
+      --compare string    Existing bcrypt hash to compare with password
   -h, --help              help for bcrypt
       --password string   Password for which bcrypt hash is generated
 ```


### PR DESCRIPTION
This PR enhances the argocd account bcrypt CLI command by introducing a --compare flag. This flag allows users to verify if a plaintext password matches an existing bcrypt hash.

In addition, corresponding unit tests have been added to verify both the hash generation and password comparison functionalities.

Closes #23866

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
