### PR TITLE
feat(kustomize): multiple base support via multi-source references (#23872)

### DIFF
--- a/docs/user-guide/multiple_sources.md
+++ b/docs/user-guide/multiple_sources.md
@@ -86,3 +86,29 @@ at that URL. If the `path` field is not set, Argo CD will use the repository sol
 
 > [!NOTE]
 > Even when the `ref` field is configured with the `path` field, `$value` still represents the root of sources with the `ref` field. Consequently, `valueFiles` must be specified as relative paths from the root of sources.
+
+## Kustomize components from external Git repository
+
+Similar to Helm value files, Kustomize components can also reference external Git repositories. This allows you to use components from other repositories in your Kustomize configurations.
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+spec:
+  sources:
+  - repoURL: 'https://github.com/mycompany/main-app.git'
+    path: kustomize-app
+    targetRevision: main
+    kustomize:
+      components:
+      - $components/common/monitoring
+      - $components/common/logging
+  - repoURL: 'https://github.com/mycompany/kustomize-components.git'
+    targetRevision: main
+    ref: components
+```
+
+In the above example, the Kustomize application will use components from the `github.com/mycompany/kustomize-components.git` repository. The `ref: components` parameter maps to the variable `$components`, which resolves to the root of the components repository.
+
+Components with ref prefixes work the same way as Helm value files with ref prefixes. The component path must be specified relative to the root of the referenced repository.
+

--- a/util/kustomize/kustomize.go
+++ b/util/kustomize/kustomize.go
@@ -341,10 +341,10 @@ func (k *kustomize) Build(opts *v1alpha1.ApplicationSourceKustomize, kustomizeOp
 				return nil, nil, nil, errors.New("kustomize components require kustomize v3.7.0 and above")
 			}
 
-			// add components
-			foundComponents := opts.Components
+			// add components - components are now pre-resolved by the repository server
+			foundComponents := make([]string, 0)
+
 			if opts.IgnoreMissingComponents {
-				foundComponents = make([]string, 0)
 				root, err := os.OpenRoot(k.repoRoot)
 				defer io.Close(root)
 				if err != nil {
@@ -352,16 +352,44 @@ func (k *kustomize) Build(opts *v1alpha1.ApplicationSourceKustomize, kustomizeOp
 				}
 
 				for _, c := range opts.Components {
-					resolvedPath, err := filepath.Rel(k.repoRoot, filepath.Join(k.path, c))
-					if err != nil {
-						return nil, nil, nil, fmt.Errorf("kustomize components path failed: %w", err)
+					// For components with ref prefix that have been resolved to absolute paths,
+					// we need to use them directly rather than joining with k.path
+					var resolvedPath string
+					var componentPath string
+					if filepath.IsAbs(c) {
+						resolvedPath = c
+						// Convert absolute path to relative path from repo root for kustomize command
+						componentPath, err = filepath.Rel(k.repoRoot, c)
+						if err != nil {
+							return nil, nil, nil, fmt.Errorf("kustomize components path failed: %w", err)
+						}
+					} else {
+						resolvedPath, err = filepath.Rel(k.repoRoot, filepath.Join(k.path, c))
+						if err != nil {
+							return nil, nil, nil, fmt.Errorf("kustomize components path failed: %w", err)
+						}
+						componentPath = c
 					}
 					_, err = root.Stat(resolvedPath)
 					if err != nil {
 						log.Debugf("%s component directory does not exist", resolvedPath)
 						continue
 					}
-					foundComponents = append(foundComponents, c)
+					foundComponents = append(foundComponents, componentPath)
+				}
+			} else {
+				// When not ignoring missing components, still need to convert absolute paths to relative
+				for _, c := range opts.Components {
+					if filepath.IsAbs(c) {
+						// Convert absolute path to relative path from repo root for kustomize command
+						componentPath, err := filepath.Rel(k.repoRoot, c)
+						if err != nil {
+							return nil, nil, nil, fmt.Errorf("kustomize components path failed: %w", err)
+						}
+						foundComponents = append(foundComponents, componentPath)
+					} else {
+						foundComponents = append(foundComponents, c)
+					}
 				}
 			}
 


### PR DESCRIPTION
Following #21674 which allowed ignoring components and #23486 which allowed having components specified in a monorepo, this allows specifying components by reference the same way that helm values files can be specified. This is useful for people that store components in branches or are doing testing by using branches against the main application components. Fixes #23872.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
