### PR TITLE
feat:(cli): add --password-stdin flag to read password securely

### DIFF
--- a/docs/user-guide/commands/argocd_login.md
+++ b/docs/user-guide/commands/argocd_login.md
@@ -18,6 +18,9 @@ argocd login SERVER [flags]
 # Login to Argo CD using a username and password
 argocd login cd.argoproj.io
 
+# Login to Argo CD using password-stdin
+echo "${PASSWORD}" | argocd login --username admin --password-stdin
+
 # Login to Argo CD using SSO
 argocd login cd.argoproj.io --sso
 
@@ -31,6 +34,7 @@ argocd login cd.argoproj.io --core
   -h, --help                 help for login
       --name string          Name to use for the context
       --password string      The password of an account to authenticate
+      --password-stdin       Get the password of an account to authenticate from stdin
       --skip-test-tls        Skip testing whether the server is configured with TLS (this can help when the command hangs for no apparent reason)
       --sso                  Perform SSO login
       --sso-launch-browser   Automatically launch the system default browser when performing SSO login (default true)


### PR DESCRIPTION
feat(login): add --password-stdin flag for secure password input

This change adds support for the `--password-stdin` flag in `argocd login`, allowing users to securely provide passwords via standard input instead of passing them directly as command-line arguments.

Our team encountered a security issue where the Argo CD password could be exposed through the `ps` command shortly after execution. For example:

```bash
$ ps -ef | grep argo
  501  1961 22939   0  2:33AM ttys013    0:00.10 argocd login localhost:9090 --plaintext --grpc-web --insecure --grpc-web-root-path /argocd --username admin --password argoargo
```
As shown above, the password(`argoargo`) is visible in ps command. While setting the password via environment variable is a possible workaround, i think it is more secure and user-friendly for the ArgoCD CLI to support reading
the password from stdin

This approach is similar to how 'docker login' handles passwords securely using `--password-stdin`:
```bash
$ ps -ef | grep argo
  501  2193 22939   0  2:33AM ttys013    0:00.11 argocd login localhost:9090 --plaintext --grpc-web --insecure --grpc-web-root-path /argocd --username admin --password-stdin
  501  2199 83183   0  2:33AM ttys014    0:00.00 grep argo
```

The new method allows easier integration with scripts
```bash
$ cat ./password.txt | argocd login localhost:9090 --plaintext --grpc-web --insecure --grpc-web-root-path /argocd --username admin --password-stdin
'admin:login' logged in successfully
Context 'localhost:9090/argocd' updated
```

Closes #23883

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
