### PR TITLE
fix: Cast uint32 type to int explicitly in secure_mkdir_linux.go

### DIFF
--- a/util/io/files/secure_mkdir_linux.go
+++ b/util/io/files/secure_mkdir_linux.go
@@ -13,7 +13,7 @@ import (
 // directory traversal attacks by ensuring the path is within the root directory. The path is constructed as if the
 // given root is the root of the filesystem. So anything traversing outside the root is simply removed from the path.
 func SecureMkdirAll(root, unsafePath string, mode os.FileMode) (string, error) {
-	err := securejoin.MkdirAll(root, unsafePath, mode)
+	err := securejoin.MkdirAll(root, unsafePath, int(mode))
 	if err != nil {
 		return "", fmt.Errorf("failed to make directory: %w", err)
 	}


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

`external/gazelle++go_deps+com_github_argoproj_argo_cd_v3/util/io/files/secure_mkdir_linux.go:16:47: cannot use mode (variable of uint32 type os.FileMode) as int value in argument to securejoin.MkdirAll` 

[This issue is fixed in ](https://github.com/argoproj/argo-cd/blob/v2.14.15/util/io/files/secure_mkdir_linux.go)`v2.14.15`, and just needs to be carried over to `3.X.X`. 

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
