### PR TITLE
fix(api): `app create --upsert` should not error on invalid current destination

### DIFF
--- a/server/application/application.go
+++ b/server/application/application.go
@@ -380,10 +380,6 @@ func (s *Server) Create(ctx context.Context, q *application.ApplicationCreateReq
 		return nil, status.Errorf(codes.Internal, "unable to check existing application details (%s): %v", appNs, err)
 	}
 
-	if _, err := argo.GetDestinationCluster(ctx, existing.Spec.Destination, s.db); err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "application destination spec for %s is invalid: %s", existing.Name, err.Error())
-	}
-
 	equalSpecs := reflect.DeepEqual(existing.Spec.Destination, a.Spec.Destination) &&
 		reflect.DeepEqual(existing.Spec, a.Spec) &&
 		reflect.DeepEqual(existing.Labels, a.Labels) &&


### PR DESCRIPTION
The current destination validation does not provide any value and prevent an application to be updated via `create --upsert` when it is invalid.

This validation is most likely a leftover from the removed destination inference code.

Before:
```
--- FAIL: TestCreateAppUpsert (0.00s)
    --- FAIL: TestCreateAppUpsert/Invalid_existing_app_can_be_updated (0.67s)
            	Error Trace: server/application/application_test.go:1564
            	Error:      	Received unexpected error:
            	            	rpc error: code = InvalidArgument desc = application destination spec for test-app is invalid: error getting cluster by server "https://invalid-cluster": rpc error: code = NotFound desc = cluster "https://invalid-cluster" not found
            	Test:       	TestCreateAppUpsert/Invalid_existing_app_can_be_updated
```