### PR TITLE
fix(api): user with global access should get `NotFound` instead of `PermissionDenied`

### DIFF
--- a/docs/operator-manual/upgrading/3.2-3.3.md
+++ b/docs/operator-manual/upgrading/3.2-3.3.md
@@ -1,0 +1,15 @@
+# v3.2 to 3.3
+
+## ApplicationService API return code
+
+The Application Service API used to return a `PermissionDenied` error instead of `NotFound` when the optional `project` parameter was
+not provided in the query. This was to ensure that users have the necessary permissions to access the requested resources and
+prevent a possible application enumeration.
+
+This made it impossible for a user to determine whether a specific application existed, without having to LIST all applications. To remediate this,
+the API now returns a `NotFound` error when the `project` parameter is not provided **AND** the user has explicit permissions to _ALL_ Applications.
+
+This allows users with a permission such as `p, role:all-app-access, applications, get, */*, allow` to determine the existence of an application
+without needing to know the specific project it belongs to, and without needing to list all applications.
+
+_Note_: If the RBAC `policy.matchMode` is set to `regex` (default is `glob`), the permission's object will need to match the value of `*/*`.

--- a/docs/operator-manual/upgrading/overview.md
+++ b/docs/operator-manual/upgrading/overview.md
@@ -38,6 +38,7 @@ kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/<v
 
 <hr/>
 
+- [v3.2 to v3.3](./3.2-3.3.md)
 - [v3.1 to v3.2](./3.1-3.2.md)
 - [v3.0 to v3.1](./3.0-3.1.md)
 - [v2.14 to v3.0](./2.14-3.0.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -131,6 +131,7 @@ nav:
     - operator-manual/server-commands/additional-configuration-method.md
   - Upgrading:
     - operator-manual/upgrading/overview.md
+    - operator-manual/upgrading/3.2-3.3.md
     - operator-manual/upgrading/3.1-3.2.md
     - operator-manual/upgrading/3.0-3.1.md
     - operator-manual/upgrading/2.14-3.0.md

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -168,6 +168,7 @@ func (s *Server) getAppEnforceRBAC(ctx context.Context, action, project, namespa
 		"application": name,
 		"namespace":   namespace,
 	})
+	globalAccess := false
 	if project != "" {
 		// The user has provided everything we need to perform an initial RBAC check.
 		givenRBACName := security.RBACName(s.ns, project, namespace, name)
@@ -182,14 +183,24 @@ func (s *Server) getAppEnforceRBAC(ctx context.Context, action, project, namespa
 			_, _ = getApp()
 			return nil, nil, argocommon.PermissionDeniedAPIError
 		}
+	} else {
+		// The user did not provide a project in the request. We can only guarantee that the user would have access to
+		// an application in a specific project if the user has access to all projects. For that,
+		// we assume that the application requested is '*/*'.
+		givenRBACName := security.RBACName(s.ns, "*", namespace, "*")
+		if err := s.enf.EnforceErr(ctx.Value("claims"), rbac.ResourceApplications, action, givenRBACName); err == nil {
+			globalAccess = true
+		}
 	}
+
 	a, err := getApp()
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			if project != "" {
+			if project != "" || globalAccess {
 				// We know that the user was allowed to get the Application, but the Application does not exist. Return 404.
 				return nil, nil, status.Error(codes.NotFound, apierrors.NewNotFound(schema.GroupResource{Group: "argoproj.io", Resource: "applications"}, name).Error())
 			}
+
 			// We don't know if the user was allowed to get the Application, and we don't want to leak information about
 			// the Application's existence. Return 403.
 			logCtx.Warn("application does not exist")
@@ -198,6 +209,7 @@ func (s *Server) getAppEnforceRBAC(ctx context.Context, action, project, namespa
 		logCtx.Errorf("failed to get application: %s", err)
 		return nil, nil, argocommon.PermissionDeniedAPIError
 	}
+
 	// Even if we performed an initial RBAC check (because the request was fully parameterized), we still need to
 	// perform a second RBAC check to ensure that the user has access to the actual Application's project (not just the
 	// project they specified in the request).


### PR DESCRIPTION
The current behavior, while functional, is a usability bug. If a user, for instance users with the `role:admin` permissions have access to all applications, then they should not be getting a `PermissionDenied` if they do not provide an optional `project` on the API call. 

It is wrong to return `PermissionDenied`, because the user has permissions. This prevent a user to know if an application exist. The workaround is to use `kubectl` to  get the application by name, or use the Argo API LIST to get all the applications and filter by name. While filtering by name is possible and not too expensive, it is a very surprising usage of the API.

Since the RBAC enforcement is always project scoped in the case of applications, and that `*` is not a valid character in k8s object name, we can safely determine a global access by looking at the `*/*` object name. In that case, a user with global access will receive a`NotFound` result if the app does not exist.