### PR TITLE
feat: log a warning instead of debug when repository webhook does not match an application

### DIFF
--- a/applicationset/webhook/webhook.go
+++ b/applicationset/webhook/webhook.go
@@ -339,7 +339,7 @@ func genRevisionHasChanged(gen *v1alpha1.GitGenerator, revision string, touchedH
 
 func gitGeneratorUsesURL(gen *v1alpha1.GitGenerator, webURL string, repoRegexp *regexp.Regexp) bool {
 	if !repoRegexp.MatchString(gen.RepoURL) {
-		log.Debugf("%s does not match %s", gen.RepoURL, repoRegexp.String())
+		log.Warnf("%s does not match %s", gen.RepoURL, repoRegexp.String())
 		return false
 	}
 


### PR DESCRIPTION
This comes more as a suggestion. I spent longer than I'm proud of to notice that the reason the webhook was not triggering a refresh was a repository that was renamed in Github but its URL was not updated in the Argo CD's Application.

The sync was working, since Github redirects the requests, but the regex was not matching the configuration when a webhook was received, falling back to the 3 minute polling.

If I had this warning in the logs, the issue would have been fixed before and my debug time would be considerably smaller since it would not require me to change the log level to `debug` in order to see the issue.

It may generate false warnings if the webhook is configured at the organization level, so I understand if this just gets closed. Talking to my colleagues, it made sense for this to be a warning anyways, since it warns about why a certain action was prevented.

Another option is to make it an info log so we can state that the webhook did not trigger a refresh since no matching application was found.

Cheers!

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
