### PR TITLE
fix(cli): avoid panic in configure command when no local config exists (#23085)

### DIFF
--- a/cmd/argocd/commands/configure.go
+++ b/cmd/argocd/commands/configure.go
@@ -27,6 +27,10 @@ argocd configure --prompts-enabled=false`,
 		Run: func(_ *cobra.Command, _ []string) {
 			localCfg, err := localconfig.ReadLocalConfig(globalClientOpts.ConfigPath)
 			errors.CheckError(err)
+			if localCfg == nil {
+				fmt.Println("No local configuration found.")
+				return
+			}
 
 			localCfg.PromptsEnabled = promptsEnabled
 

--- a/cmd/argocd/commands/configure.go
+++ b/cmd/argocd/commands/configure.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 
 	"github.com/spf13/cobra"
@@ -28,8 +29,8 @@ argocd configure --prompts-enabled=false`,
 			localCfg, err := localconfig.ReadLocalConfig(globalClientOpts.ConfigPath)
 			errors.CheckError(err)
 			if localCfg == nil {
-				fmt.Println("No local configuration found.")
-				return
+				fmt.Println("No local configuration found")
+				os.Exit(1)
 			}
 
 			localCfg.PromptsEnabled = promptsEnabled

--- a/cmd/argocd/commands/configure_test.go
+++ b/cmd/argocd/commands/configure_test.go
@@ -95,15 +95,3 @@ func TestNewConfigureCommand_PromptsEnabled_False(t *testing.T) {
 
 	assert.False(t, localConfig.PromptsEnabled)
 }
-
-func TestNewConfigureCommand_NoLocalConfig(t *testing.T) {
-	// Ensure the test config file does not exist
-	err := os.Remove(testConfigFilePath)
-	require.Error(t, err)
-
-	cmd := NewConfigureCommand(&argocdclient.ClientOptions{ConfigPath: testConfigFilePath})
-	cmd.SetArgs([]string{"--prompts-enabled=true"})
-
-	err = cmd.Execute()
-	require.NoError(t, err)
-}

--- a/cmd/argocd/commands/configure_test.go
+++ b/cmd/argocd/commands/configure_test.go
@@ -95,3 +95,15 @@ func TestNewConfigureCommand_PromptsEnabled_False(t *testing.T) {
 
 	assert.False(t, localConfig.PromptsEnabled)
 }
+
+func TestNewConfigureCommand_NoLocalConfig(t *testing.T) {
+	// Ensure the test config file does not exist
+	err := os.Remove(testConfigFilePath)
+	require.Error(t, err)
+
+	cmd := NewConfigureCommand(&argocdclient.ClientOptions{ConfigPath: testConfigFilePath})
+	cmd.SetArgs([]string{"--prompts-enabled=true"})
+
+	err = cmd.Execute()
+	require.NoError(t, err)
+}


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Currently, the `argocd configure` command panics when no local config exists at the expected path. This is because `localconfig.ReadLocalConfig()` returns `nil` for both `LocalConfig` and `error`.

https://github.com/argoproj/argo-cd/blob/fe6aaad4f0a4eebcdf2722d75f5b0bc9a6c36b7e/util/localconfig/localconfig.go#L92-L95

As a result, `localCfg.PromptsEnabled` in `configure.go` triggers a panic due to a nil reference.

https://github.com/argoproj/argo-cd/blob/fe6aaad4f0a4eebcdf2722d75f5b0bc9a6c36b7e/cmd/argocd/commands/configure.go#L31

This PR adds a nil check for `localCfg` to prevent the CLI from panicking and to provide a clearer error message explaining why the command failed to execute, just like other commands like `context.go`.

https://github.com/argoproj/argo-cd/blob/fe6aaad4f0a4eebcdf2722d75f5b0bc9a6c36b7e/cmd/argocd/commands/context.go#L86-L90

Fixes #23085

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
