### PR TITLE
feat(metrics): expose custom applicationLabels on argocd_app_info

### DIFF
--- a/controller/metrics/metrics_test.go
+++ b/controller/metrics/metrics_test.go
@@ -407,6 +407,18 @@ argocd_app_labels{label_non_existing="",name="my-app-3",namespace="argocd",proje
 `,
 			},
 		},
+		{
+			description:  "custom labels are present on argocd_app_info metric",
+			metricLabels: []string{"team-name", "team-bu"},
+			testCombination: testCombination{
+				applications: []string{fakeApp},
+				responseContains: `
+# HELP argocd_app_info Information about application.
+# TYPE argocd_app_info gauge
+argocd_app_info{autosync_enabled="false",dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Healthy",label_team_bu="bu-id",label_team_name="my-team",name="my-app",namespace="argocd",operation="",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_status="Synced"} 1
+`,
+			},
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
## What does this PR do?

Exposes custom `applicationLabels` on the `argocd_app_info` metric to support better filtering and observability in Prometheus.

##  How did you test it?

- Verified new label dimensions appear in the `/metrics` output
- Added unit tests to `metrics_test.go` to ensure the new labels are applied correctly

## Checklist

- [x] My code follows the coding style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have signed off my commit (`git commit -s`)

##  Related issue

Closes #23829
