### PR TITLE
chore: local docker build on MAC with amd64 target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG BASE_IMAGE=docker.io/library/ubuntu:25.04@sha256:10bb10bb062de665d4dc3e0ea36
 # Initial stage which pulls prepares build dependencies and CLI tooling we need for our final image
 # Also used as the image in CI jobs so needs all dependencies
 ####################################################################################################
-FROM docker.io/library/golang:1.24.4@sha256:db5d0afbfb4ab648af2393b92e87eaae9ad5e01132803d80caef91b5752d289c AS builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.24.4@sha256:db5d0afbfb4ab648af2393b92e87eaae9ad5e01132803d80caef91b5752d289c AS builder
 
 WORKDIR /tmp
 
@@ -34,7 +34,7 @@ RUN ./install.sh helm && \
 ####################################################################################################
 # Argo CD Base - used as the base for both the release and dev argocd images
 ####################################################################################################
-FROM $BASE_IMAGE AS argocd-base
+FROM --platform=$BUILDPLATFORM $BASE_IMAGE AS argocd-base
 
 LABEL org.opencontainers.image.source="https://github.com/argoproj/argo-cd"
 


### PR DESCRIPTION
When running `TARGET_ARCH=linux/arm64 make image` locally on Mac OS arm64 arch, I was getting errors like the following preventing the ability to build a container for the linux/arm64 arch. 

```
128.9 Errors were encountered while processing:
128.9  git-lfs
129.1 E: Sub-process /usr/bin/dpkg returned an error code (1)
```

```
15.25 + helm version --client
15.78 runtime: lfstack.push invalid packing: node=0xffff5a24be40 cnt=0x1 packed=0xffff5a24be400001 -> node=0xffffffff5a24be40
15.78 fatal error: lfstack.push
```