### PR TITLE
feat: Implement Altinity clickhouse-operator CRD health checks

### DIFF
--- a/resource_customizations/clickhouse-keeper.altinity.com/ClickHouseKeeperInstallation/health.lua
+++ b/resource_customizations/clickhouse-keeper.altinity.com/ClickHouseKeeperInstallation/health.lua
@@ -1,0 +1,17 @@
+local hs = {}
+if obj.status ~= nil and obj.status.status ~= nil then
+  if obj.status.status == "Completed" then
+    hs.status = "Healthy"
+    hs.message = "ClickHouseKeeper installation completed successfully"
+  elseif obj.status.status == "InProgress" then
+    hs.status = "Progressing"
+    hs.message = "ClickHouseKeeper installation in progress"
+  else
+    hs.status = "Degraded"
+    hs.message = "ClickHouseKeeper status: " .. obj.status.status
+  end
+else
+  hs.status = "Progressing"
+  hs.message = "ClickHouseKeeper status not yet available"
+end
+return hs 

--- a/resource_customizations/clickhouse-keeper.altinity.com/ClickHouseKeeperInstallation/health_test.yaml
+++ b/resource_customizations/clickhouse-keeper.altinity.com/ClickHouseKeeperInstallation/health_test.yaml
@@ -1,0 +1,17 @@
+tests:
+- healthStatus:
+    status: Healthy
+    message: ClickHouseKeeper installation completed successfully
+  inputPath: testdata/healthy_completed.yaml
+- healthStatus:
+    status: Progressing
+    message: ClickHouseKeeper installation in progress
+  inputPath: testdata/progressing_inprogress.yaml
+- healthStatus:
+    status: Degraded
+    message: "ClickHouseKeeper status: Failed"
+  inputPath: testdata/degraded_failed.yaml
+- healthStatus:
+    status: Progressing
+    message: ClickHouseKeeper status not yet available
+  inputPath: testdata/progressing_nostatus.yaml

--- a/resource_customizations/clickhouse-keeper.altinity.com/ClickHouseKeeperInstallation/testdata/degraded_failed.yaml
+++ b/resource_customizations/clickhouse-keeper.altinity.com/ClickHouseKeeperInstallation/testdata/degraded_failed.yaml
@@ -1,0 +1,22 @@
+apiVersion: clickhouse-keeper.altinity.com/v1
+kind: ClickHouseKeeperInstallation
+metadata:
+  name: test-clickhouse-keeper
+  namespace: default
+spec:
+  configuration:
+    clusters:
+    - name: cluster
+      layout:
+        shards:
+        - name: shard
+          replicas:
+          - name: replica
+            port: 9181
+            template:
+              spec:
+                containers:
+                - name: clickhouse-keeper
+                  image: clickhouse/clickhouse-keeper:latest
+status:
+  status: Failed

--- a/resource_customizations/clickhouse-keeper.altinity.com/ClickHouseKeeperInstallation/testdata/healthy_completed.yaml
+++ b/resource_customizations/clickhouse-keeper.altinity.com/ClickHouseKeeperInstallation/testdata/healthy_completed.yaml
@@ -1,0 +1,22 @@
+apiVersion: clickhouse-keeper.altinity.com/v1
+kind: ClickHouseKeeperInstallation
+metadata:
+  name: test-clickhouse-keeper
+  namespace: default
+spec:
+  configuration:
+    clusters:
+    - name: cluster
+      layout:
+        shards:
+        - name: shard
+          replicas:
+          - name: replica
+            port: 9181
+            template:
+              spec:
+                containers:
+                - name: clickhouse-keeper
+                  image: clickhouse/clickhouse-keeper:latest
+status:
+  status: Completed

--- a/resource_customizations/clickhouse-keeper.altinity.com/ClickHouseKeeperInstallation/testdata/progressing_inprogress.yaml
+++ b/resource_customizations/clickhouse-keeper.altinity.com/ClickHouseKeeperInstallation/testdata/progressing_inprogress.yaml
@@ -1,0 +1,22 @@
+apiVersion: clickhouse-keeper.altinity.com/v1
+kind: ClickHouseKeeperInstallation
+metadata:
+  name: test-clickhouse-keeper
+  namespace: default
+spec:
+  configuration:
+    clusters:
+    - name: cluster
+      layout:
+        shards:
+        - name: shard
+          replicas:
+          - name: replica
+            port: 9181
+            template:
+              spec:
+                containers:
+                - name: clickhouse-keeper
+                  image: clickhouse/clickhouse-keeper:latest
+status:
+  status: InProgress

--- a/resource_customizations/clickhouse-keeper.altinity.com/ClickHouseKeeperInstallation/testdata/progressing_nostatus.yaml
+++ b/resource_customizations/clickhouse-keeper.altinity.com/ClickHouseKeeperInstallation/testdata/progressing_nostatus.yaml
@@ -1,0 +1,20 @@
+apiVersion: clickhouse-keeper.altinity.com/v1
+kind: ClickHouseKeeperInstallation
+metadata:
+  name: test-clickhouse-keeper
+  namespace: default
+spec:
+  configuration:
+    clusters:
+    - name: cluster
+      layout:
+        shards:
+        - name: shard
+          replicas:
+          - name: replica
+            port: 9181
+            template:
+              spec:
+                containers:
+                - name: clickhouse-keeper
+                  image: clickhouse/clickhouse-keeper:latest

--- a/resource_customizations/clickhouse.altinity.com/ClickHouseInstallation/health.lua
+++ b/resource_customizations/clickhouse.altinity.com/ClickHouseInstallation/health.lua
@@ -1,0 +1,17 @@
+local hs = {}
+if obj.status ~= nil and obj.status.status ~= nil then
+  if obj.status.status == "Completed" then
+    hs.status = "Healthy"
+    hs.message = "ClickHouse installation completed successfully"
+  elseif obj.status.status == "InProgress" then
+    hs.status = "Progressing"
+    hs.message = "ClickHouse installation in progress"
+  else
+    hs.status = "Degraded"
+    hs.message = "ClickHouse status: " .. obj.status.status
+  end
+else
+  hs.status = "Progressing"
+  hs.message = "ClickHouse status not yet available"
+end
+return hs 

--- a/resource_customizations/clickhouse.altinity.com/ClickHouseInstallation/health_test.yaml
+++ b/resource_customizations/clickhouse.altinity.com/ClickHouseInstallation/health_test.yaml
@@ -1,0 +1,17 @@
+tests:
+- healthStatus:
+    status: Healthy
+    message: ClickHouse installation completed successfully
+  inputPath: testdata/healthy_completed.yaml
+- healthStatus:
+    status: Progressing
+    message: ClickHouse installation in progress
+  inputPath: testdata/progressing_inprogress.yaml
+- healthStatus:
+    status: Degraded
+    message: "ClickHouse status: Failed"
+  inputPath: testdata/degraded_failed.yaml
+- healthStatus:
+    status: Progressing
+    message: ClickHouse status not yet available
+  inputPath: testdata/progressing_nostatus.yaml

--- a/resource_customizations/clickhouse.altinity.com/ClickHouseInstallation/testdata/degraded_failed.yaml
+++ b/resource_customizations/clickhouse.altinity.com/ClickHouseInstallation/testdata/degraded_failed.yaml
@@ -1,0 +1,22 @@
+apiVersion: clickhouse.altinity.com/v1
+kind: ClickHouseInstallation
+metadata:
+  name: test-clickhouse
+  namespace: default
+spec:
+  configuration:
+    clusters:
+    - name: cluster
+      layout:
+        shards:
+        - name: shard
+          replicas:
+          - name: replica
+            port: 9000
+            template:
+              spec:
+                containers:
+                - name: clickhouse
+                  image: clickhouse/clickhouse-server:latest
+status:
+  status: Failed

--- a/resource_customizations/clickhouse.altinity.com/ClickHouseInstallation/testdata/healthy_completed.yaml
+++ b/resource_customizations/clickhouse.altinity.com/ClickHouseInstallation/testdata/healthy_completed.yaml
@@ -1,0 +1,22 @@
+apiVersion: clickhouse.altinity.com/v1
+kind: ClickHouseInstallation
+metadata:
+  name: test-clickhouse
+  namespace: default
+spec:
+  configuration:
+    clusters:
+    - name: cluster
+      layout:
+        shards:
+        - name: shard
+          replicas:
+          - name: replica
+            port: 9000
+            template:
+              spec:
+                containers:
+                - name: clickhouse
+                  image: clickhouse/clickhouse-server:latest
+status:
+  status: Completed

--- a/resource_customizations/clickhouse.altinity.com/ClickHouseInstallation/testdata/progressing_inprogress.yaml
+++ b/resource_customizations/clickhouse.altinity.com/ClickHouseInstallation/testdata/progressing_inprogress.yaml
@@ -1,0 +1,22 @@
+apiVersion: clickhouse.altinity.com/v1
+kind: ClickHouseInstallation
+metadata:
+  name: test-clickhouse
+  namespace: default
+spec:
+  configuration:
+    clusters:
+    - name: cluster
+      layout:
+        shards:
+        - name: shard
+          replicas:
+          - name: replica
+            port: 9000
+            template:
+              spec:
+                containers:
+                - name: clickhouse
+                  image: clickhouse/clickhouse-server:latest
+status:
+  status: InProgress

--- a/resource_customizations/clickhouse.altinity.com/ClickHouseInstallation/testdata/progressing_nostatus.yaml
+++ b/resource_customizations/clickhouse.altinity.com/ClickHouseInstallation/testdata/progressing_nostatus.yaml
@@ -1,0 +1,20 @@
+apiVersion: clickhouse.altinity.com/v1
+kind: ClickHouseInstallation
+metadata:
+  name: test-clickhouse
+  namespace: default
+spec:
+  configuration:
+    clusters:
+    - name: cluster
+      layout:
+        shards:
+        - name: shard
+          replicas:
+          - name: replica
+            port: 9000
+            template:
+              spec:
+                containers:
+                - name: clickhouse
+                  image: clickhouse/clickhouse-server:latest


### PR DESCRIPTION
# Add custom health checks for ClickHouse and ClickHouseKeeper installations

## Description

This PR adds custom health checks for ClickHouse and ClickHouseKeeper installations from Altinity. These health checks will help Argo CD users better understand the status of their ClickHouse deployments and prevent race conditions by providing proper support for sync waves.

## Changes

### Added Health Checks

1. **clickhouse.altinity.com/ClickHouseInstallation**
   - Evaluates `status.status` field
   - Returns `Healthy` when status is `Completed`
   - Returns `Progressing` when status is `InProgress` or not yet available
   - Returns `Degraded` for any other status value

2. **clickhouse-keeper.altinity.com/ClickHouseKeeperInstallation**
   - Evaluates `status.status` field
   - Returns `Healthy` when status is `Completed`
   - Returns `Progressing` when status is `InProgress` or not yet available
   - Returns `Degraded` for any other status value

## Testing

Each health check includes comprehensive test cases covering:
- Healthy state (status: Completed)
- Progressing state (status: InProgress)
- Degraded state (status: Failed)
- Progressing state (no status field)

All health checks have been tested and validated to work correctly with the provided test data.

## Related Issues

Closes [ISSUE https://github.com/argoproj/argo-cd/issues/24015]
This addresses the need for proper health monitoring of ClickHouse installations in Argo CD applications and helps prevent race conditions during deployment by ensuring proper sync wave coordination.

## Notes

These health checks follow the same pattern as other custom health checks in the repository (e.g., cert-manager.io/Certificate) and use the standard Lua health check format. By providing accurate health status information, these checks enable Argo CD to properly coordinate sync waves and prevent race conditions during ClickHouse deployment and scaling operations.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
