### PR TITLE
fix: avoid unnecessary `GetSettings` calls (#17277) (#23965)

### DIFF
--- a/util/db/cluster.go
+++ b/util/db/cluster.go
@@ -65,11 +65,7 @@ func (db *db) ListClusters(_ context.Context) (*appv1.ClusterList, error) {
 	clusterList := appv1.ClusterList{
 		Items: make([]appv1.Cluster, 0),
 	}
-	settings, err := db.settingsMgr.GetSettings()
-	if err != nil {
-		return nil, err
-	}
-	inClusterEnabled := settings.InClusterEnabled
+	var inClusterEnabled *bool
 	hasInClusterCredentials := false
 	for _, clusterSecret := range clusterSecrets {
 		cluster, err := SecretToCluster(clusterSecret)
@@ -78,7 +74,17 @@ func (db *db) ListClusters(_ context.Context) (*appv1.ClusterList, error) {
 			continue
 		}
 		if cluster.Server == appv1.KubernetesInternalAPIServerAddr {
-			if inClusterEnabled {
+			if inClusterEnabled == nil {
+				settings, err := db.settingsMgr.GetSettings()
+
+				if err != nil {
+					return nil, err
+				}
+
+				inClusterEnabled = &settings.InClusterEnabled
+			}
+
+			if *inClusterEnabled {
 				hasInClusterCredentials = true
 				clusterList.Items = append(clusterList.Items, *cluster)
 			}
@@ -86,20 +92,34 @@ func (db *db) ListClusters(_ context.Context) (*appv1.ClusterList, error) {
 			clusterList.Items = append(clusterList.Items, *cluster)
 		}
 	}
-	if inClusterEnabled && !hasInClusterCredentials {
-		clusterList.Items = append(clusterList.Items, *db.getLocalCluster())
+	if !hasInClusterCredentials {
+		if inClusterEnabled == nil {
+			settings, err := db.settingsMgr.GetSettings()
+
+			if err != nil {
+				return nil, err
+			}
+
+			inClusterEnabled = &settings.InClusterEnabled
+		}
+
+		if *inClusterEnabled {
+			clusterList.Items = append(clusterList.Items, *db.getLocalCluster())
+		}
 	}
 	return &clusterList, nil
 }
 
 // CreateCluster creates a cluster
 func (db *db) CreateCluster(ctx context.Context, c *appv1.Cluster) (*appv1.Cluster, error) {
-	settings, err := db.settingsMgr.GetSettings()
-	if err != nil {
-		return nil, err
-	}
-	if c.Server == appv1.KubernetesInternalAPIServerAddr && !settings.InClusterEnabled {
-		return nil, status.Errorf(codes.InvalidArgument, "cannot register cluster: in-cluster has been disabled")
+	if c.Server == appv1.KubernetesInternalAPIServerAddr {
+		settings, err := db.settingsMgr.GetSettings()
+		if err != nil {
+			return nil, err
+		}
+		if !settings.InClusterEnabled {
+			return nil, status.Errorf(codes.InvalidArgument, "cannot register cluster: in-cluster has been disabled")
+		}
 	}
 	secName, err := URIToSecretName("cluster", c.Server)
 	if err != nil {
@@ -226,12 +246,14 @@ func (db *db) getClusterSecret(server string) (*corev1.Secret, error) {
 
 // GetCluster returns a cluster from a query
 func (db *db) GetCluster(_ context.Context, server string) (*appv1.Cluster, error) {
-	argoSettings, err := db.settingsMgr.GetSettings()
-	if err != nil {
-		return nil, err
-	}
-	if server == appv1.KubernetesInternalAPIServerAddr && !argoSettings.InClusterEnabled {
-		return nil, status.Errorf(codes.NotFound, "cluster %q is disabled", server)
+	if server == appv1.KubernetesInternalAPIServerAddr {
+		argoSettings, err := db.settingsMgr.GetSettings()
+		if err != nil {
+			return nil, err
+		}
+		if !argoSettings.InClusterEnabled {
+			return nil, status.Errorf(codes.NotFound, "cluster %q is disabled", server)
+		}
 	}
 
 	informer, err := db.settingsMgr.GetSecretsInformer()
@@ -275,10 +297,6 @@ func (db *db) GetProjectClusters(_ context.Context, project string) ([]*appv1.Cl
 }
 
 func (db *db) GetClusterServersByName(_ context.Context, name string) ([]string, error) {
-	argoSettings, err := db.settingsMgr.GetSettings()
-	if err != nil {
-		return nil, err
-	}
 	informer, err := db.settingsMgr.GetSecretsInformer()
 	if err != nil {
 		return nil, err
@@ -290,8 +308,22 @@ func (db *db) GetClusterServersByName(_ context.Context, name string) ([]string,
 		return nil, err
 	}
 
-	if len(localClusterSecrets) == 0 && db.getLocalCluster().Name == name && argoSettings.InClusterEnabled {
-		return []string{appv1.KubernetesInternalAPIServerAddr}, nil
+	var inClusterEnabled *bool
+
+	if len(localClusterSecrets) == 0 && db.getLocalCluster().Name == name {
+		if inClusterEnabled == nil {
+			settings, err := db.settingsMgr.GetSettings()
+
+			if err != nil {
+				return nil, err
+			}
+
+			inClusterEnabled = &settings.InClusterEnabled
+		}
+
+		if *inClusterEnabled {
+			return []string{appv1.KubernetesInternalAPIServerAddr}, nil
+		}
 	}
 
 	secrets, err := informer.GetIndexer().ByIndex(settings.ByClusterNameIndexer, name)
@@ -302,8 +334,20 @@ func (db *db) GetClusterServersByName(_ context.Context, name string) ([]string,
 	for i := range secrets {
 		s := secrets[i].(*corev1.Secret)
 		server := strings.TrimRight(string(s.Data["server"]), "/")
-		if !argoSettings.InClusterEnabled && server == appv1.KubernetesInternalAPIServerAddr {
-			continue
+		if server == appv1.KubernetesInternalAPIServerAddr {
+			if inClusterEnabled == nil {
+				settings, err := db.settingsMgr.GetSettings()
+
+				if err != nil {
+					return nil, err
+				}
+
+				inClusterEnabled = &settings.InClusterEnabled
+			}
+
+			if !*inClusterEnabled {
+				continue
+			}
 		}
 		res = append(res, server)
 	}

--- a/util/db/cluster.go
+++ b/util/db/cluster.go
@@ -76,14 +76,12 @@ func (db *db) ListClusters(_ context.Context) (*appv1.ClusterList, error) {
 		if cluster.Server == appv1.KubernetesInternalAPIServerAddr {
 			if inClusterEnabled == nil {
 				settings, err := db.settingsMgr.GetSettings()
-
 				if err != nil {
 					return nil, err
 				}
 
 				inClusterEnabled = &settings.InClusterEnabled
 			}
-
 			if *inClusterEnabled {
 				hasInClusterCredentials = true
 				clusterList.Items = append(clusterList.Items, *cluster)
@@ -95,14 +93,12 @@ func (db *db) ListClusters(_ context.Context) (*appv1.ClusterList, error) {
 	if !hasInClusterCredentials {
 		if inClusterEnabled == nil {
 			settings, err := db.settingsMgr.GetSettings()
-
 			if err != nil {
 				return nil, err
 			}
 
 			inClusterEnabled = &settings.InClusterEnabled
 		}
-
 		if *inClusterEnabled {
 			clusterList.Items = append(clusterList.Items, *db.getLocalCluster())
 		}
@@ -309,18 +305,13 @@ func (db *db) GetClusterServersByName(_ context.Context, name string) ([]string,
 	}
 
 	var inClusterEnabled *bool
-
 	if len(localClusterSecrets) == 0 && db.getLocalCluster().Name == name {
-		if inClusterEnabled == nil {
-			settings, err := db.settingsMgr.GetSettings()
-
-			if err != nil {
-				return nil, err
-			}
-
-			inClusterEnabled = &settings.InClusterEnabled
+		settings, err := db.settingsMgr.GetSettings()
+		if err != nil {
+			return nil, err
 		}
 
+		inClusterEnabled = &settings.InClusterEnabled
 		if *inClusterEnabled {
 			return []string{appv1.KubernetesInternalAPIServerAddr}, nil
 		}
@@ -337,7 +328,6 @@ func (db *db) GetClusterServersByName(_ context.Context, name string) ([]string,
 		if server == appv1.KubernetesInternalAPIServerAddr {
 			if inClusterEnabled == nil {
 				settings, err := db.settingsMgr.GetSettings()
-
 				if err != nil {
 					return nil, err
 				}

--- a/util/db/cluster_test.go
+++ b/util/db/cluster_test.go
@@ -276,6 +276,7 @@ func TestCreateCluster(t *testing.T) {
 		settingsManager := settingsMocks.NewGetSettingsCounterMock(fakeNamespace, kubeclientset)
 		db := NewDB(fakeNamespace, settingsManager, kubeclientset)
 
+		//nolint:errcheck
 		db.CreateCluster(t.Context(), &v1alpha1.Cluster{
 			Server: v1alpha1.KubernetesInternalAPIServerAddr,
 		})
@@ -288,6 +289,7 @@ func TestCreateCluster(t *testing.T) {
 		settingsManager := settingsMocks.NewGetSettingsCounterMock(fakeNamespace, kubeclientset)
 		db := NewDB(fakeNamespace, settingsManager, kubeclientset)
 
+		//nolint:errcheck
 		db.CreateCluster(t.Context(), &v1alpha1.Cluster{
 			Server: "http://mycluster",
 		})
@@ -416,6 +418,7 @@ func TestGetCluster(t *testing.T) {
 		settingsManager := settingsMocks.NewGetSettingsCounterMock(fakeNamespace, kubeclientset)
 		db := NewDB(fakeNamespace, settingsManager, kubeclientset)
 
+		//nolint:errcheck
 		db.GetCluster(t.Context(), v1alpha1.KubernetesInternalAPIServerAddr)
 
 		assert.Equal(t, 1, settingsManager.GetGetSettingsCallCount())
@@ -426,6 +429,7 @@ func TestGetCluster(t *testing.T) {
 		settingsManager := settingsMocks.NewGetSettingsCounterMock(fakeNamespace, kubeclientset)
 		db := NewDB(fakeNamespace, settingsManager, kubeclientset)
 
+		//nolint:errcheck
 		db.GetCluster(t.Context(), string(secretForServerWithExternalClusterAddr.Data["server"]))
 
 		assert.Equal(t, 0, settingsManager.GetGetSettingsCallCount())
@@ -726,6 +730,7 @@ func TestGetClusterServersByName(t *testing.T) {
 		settingsManager := settingsMocks.NewGetSettingsCounterMock(fakeNamespace, kubeclientset)
 		db := NewDB(fakeNamespace, settingsManager, kubeclientset)
 
+		//nolint:errcheck
 		db.GetClusterServersByName(t.Context(), "in-cluster")
 
 		assert.Equal(t, 1, settingsManager.GetGetSettingsCallCount())
@@ -735,6 +740,7 @@ func TestGetClusterServersByName(t *testing.T) {
 		settingsManager := settingsMocks.NewGetSettingsCounterMock(fakeNamespace, kubeclientset)
 		db := NewDB(fakeNamespace, settingsManager, kubeclientset)
 
+		//nolint:errcheck
 		db.GetClusterServersByName(t.Context(), "my-cluster-name")
 
 		assert.Equal(t, 0, settingsManager.GetGetSettingsCallCount())

--- a/util/settings/mocks/GetSettingsCounterMock.go
+++ b/util/settings/mocks/GetSettingsCounterMock.go
@@ -1,0 +1,88 @@
+package mocks
+
+import (
+	"context"
+	"errors"
+
+	"github.com/argoproj/argo-cd/v3/util/settings"
+
+	corev1 "k8s.io/api/core/v1"
+	informersv1 "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes"
+	v1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+// This mocks just enough of ArgoDBSettingsSource to test whether or not the DB
+// cluster methods call GetSettings or not.
+
+type GetSettingsCounterMock struct {
+	ns string
+	clientset kubernetes.Interface
+	getSettingsCallCount int
+}
+
+func NewGetSettingsCounterMock(ns string, clientset kubernetes.Interface) *GetSettingsCounterMock {
+	return &GetSettingsCounterMock {
+		ns: ns,
+		clientset: clientset,
+	}
+}
+
+func (mgr *GetSettingsCounterMock) GetGetSettingsCallCount() int {
+	return mgr.getSettingsCallCount
+}
+
+func (mgr *GetSettingsCounterMock) GetSettings() (*settings.ArgoCDSettings, error) {
+	mgr.getSettingsCallCount++
+
+	return nil, errors.New("not implemented")
+}
+
+func (mgr *GetSettingsCounterMock) SaveSSHKnownHostsData(context.Context, []string) error {
+	return errors.New("not implemented")
+}
+
+func (mgr *GetSettingsCounterMock) SaveTLSCertificateData(context.Context, map[string]string) error {
+	return errors.New("not implemented")
+}
+
+func (mgr *GetSettingsCounterMock) GetConfigMapByName(string) (*corev1.ConfigMap, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (mgr *GetSettingsCounterMock) ResyncInformers() error {
+	return errors.New("not implemented")
+}
+
+func (mgr *GetSettingsCounterMock) GetSecretsInformer() (cache.SharedIndexInformer, error) {
+	nilIndexer := func(obj any) ([]string, error) {
+		return nil, nil
+	}
+
+	indexers := cache.Indexers{
+		"byClusterURL": nilIndexer,
+		"byClusterName": nilIndexer,
+		"byProjectCluster": nilIndexer,
+		"byProjectRepo": nilIndexer,
+		"byProjectRepoWrite": nilIndexer,
+	}
+
+	return informersv1.NewSecretInformer(mgr.clientset, mgr.ns, 0, indexers), nil
+}
+
+func (mgr *GetSettingsCounterMock) GetSecretByName(string) (*corev1.Secret, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (mgr *GetSettingsCounterMock) GetNamespace() string {
+	return mgr.ns
+}
+
+func (mgr *GetSettingsCounterMock) SaveGPGPublicKeyData(context.Context, map[string]string) error {
+	return errors.New("not implemented")
+}
+
+func (mgr *GetSettingsCounterMock) GetSecretsLister() (v1listers.SecretLister, error) {
+	return nil, errors.New("not implemented")
+}

--- a/util/settings/mocks/GetSettingsCounterMock.go
+++ b/util/settings/mocks/GetSettingsCounterMock.go
@@ -17,15 +17,16 @@ import (
 // cluster methods call GetSettings or not.
 
 type GetSettingsCounterMock struct {
-	namespace string
-	clientset kubernetes.Interface
+	namespace            string
+	clientset            kubernetes.Interface
 	getSettingsCallCount int
 }
 
 func NewGetSettingsCounterMock(namespace string, clientset kubernetes.Interface) *GetSettingsCounterMock {
-	return &GetSettingsCounterMock {
-		namespace: namespace,
-		clientset: clientset,
+	return &GetSettingsCounterMock{
+		namespace:            namespace,
+		clientset:            clientset,
+		getSettingsCallCount: 0,
 	}
 }
 
@@ -61,10 +62,10 @@ func (mgr *GetSettingsCounterMock) GetSecretsInformer() (cache.SharedIndexInform
 	}
 
 	indexers := cache.Indexers{
-		"byClusterURL": nilIndexer,
-		"byClusterName": nilIndexer,
-		"byProjectCluster": nilIndexer,
-		"byProjectRepo": nilIndexer,
+		"byClusterURL":       nilIndexer,
+		"byClusterName":      nilIndexer,
+		"byProjectCluster":   nilIndexer,
+		"byProjectRepo":      nilIndexer,
 		"byProjectRepoWrite": nilIndexer,
 	}
 

--- a/util/settings/mocks/GetSettingsCounterMock.go
+++ b/util/settings/mocks/GetSettingsCounterMock.go
@@ -17,14 +17,14 @@ import (
 // cluster methods call GetSettings or not.
 
 type GetSettingsCounterMock struct {
-	ns string
+	namespace string
 	clientset kubernetes.Interface
 	getSettingsCallCount int
 }
 
-func NewGetSettingsCounterMock(ns string, clientset kubernetes.Interface) *GetSettingsCounterMock {
+func NewGetSettingsCounterMock(namespace string, clientset kubernetes.Interface) *GetSettingsCounterMock {
 	return &GetSettingsCounterMock {
-		ns: ns,
+		namespace: namespace,
 		clientset: clientset,
 	}
 }
@@ -56,7 +56,7 @@ func (mgr *GetSettingsCounterMock) ResyncInformers() error {
 }
 
 func (mgr *GetSettingsCounterMock) GetSecretsInformer() (cache.SharedIndexInformer, error) {
-	nilIndexer := func(obj any) ([]string, error) {
+	nilIndexer := func(_ any) ([]string, error) {
 		return nil, nil
 	}
 
@@ -68,7 +68,7 @@ func (mgr *GetSettingsCounterMock) GetSecretsInformer() (cache.SharedIndexInform
 		"byProjectRepoWrite": nilIndexer,
 	}
 
-	return informersv1.NewSecretInformer(mgr.clientset, mgr.ns, 0, indexers), nil
+	return informersv1.NewSecretInformer(mgr.clientset, mgr.namespace, 0, indexers), nil
 }
 
 func (mgr *GetSettingsCounterMock) GetSecretByName(string) (*corev1.Secret, error) {
@@ -76,7 +76,7 @@ func (mgr *GetSettingsCounterMock) GetSecretByName(string) (*corev1.Secret, erro
 }
 
 func (mgr *GetSettingsCounterMock) GetNamespace() string {
-	return mgr.ns
+	return mgr.namespace
 }
 
 func (mgr *GetSettingsCounterMock) SaveGPGPublicKeyData(context.Context, map[string]string) error {


### PR DESCRIPTION
Fixes #17277, #23965.

Every reconciliation performed by our application set controller prints 2 `Loading TLS configuration from secret` messages per app (and we have hundreds of apps). Tracked it down to the fact that multiple cluster DB methods (`GetCluster`, specifically in our case) call `GetSettings()` unconditionally but only end up referencing the settings if the cluster in question is the current k8s cluster (`appv1.KubernetesInternalAPIServerAddr`).

This updates `GetCluster`, `GetClusterServersByName`, and `CreateCluster` to only call `GetSettings` if considering the current cluster.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* ~[ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.~
* ~[ ] Does this PR require documentation updates?~
* ~[ ] I've updated documentation as required by this PR.~
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* ~[ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.~
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
