### PR TITLE
fix: remove mounting of host /tmp when running  argocd-test-(client|server) images (#24025) (#24028)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,6 @@ define run-in-test-client
 		-v ${GOPATH}/pkg/mod:/go/pkg/mod${VOLUME_MOUNT} \
 		-v ${GOCACHE}:/tmp/go-build-cache${VOLUME_MOUNT} \
 		-v ${HOME}/.kube:/home/user/.kube${VOLUME_MOUNT} \
-		-v /tmp:/tmp${VOLUME_MOUNT} \
 		-w ${DOCKER_WORKDIR} \
 		$(PODMAN_ARGS) \
 		$(TEST_TOOLS_PREFIX)$(TEST_TOOLS_IMAGE):$(TEST_TOOLS_TAG) \

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,6 @@ define run-in-test-server
 		-v ${GOPATH}/pkg/mod:/go/pkg/mod${VOLUME_MOUNT} \
 		-v ${GOCACHE}:/tmp/go-build-cache${VOLUME_MOUNT} \
 		-v ${HOME}/.kube:/home/user/.kube${VOLUME_MOUNT} \
-		-v /tmp:/tmp${VOLUME_MOUNT} \
 		-w ${DOCKER_WORKDIR} \
 		-p ${ARGOCD_E2E_APISERVER_PORT}:8080 \
 		-p 4000:4000 \

--- a/docs/developer-guide/toolchain-guide.md
+++ b/docs/developer-guide/toolchain-guide.md
@@ -23,7 +23,6 @@ The Docker container for the virtualized toolchain will use the following local 
 * `~/go/src` - Your Go workspace's source directory (modifications expected)
 * `~/.cache/go-build` - Your Go build cache (modifications expected)
 * `~/.kube` - Your Kubernetes client configuration (no modifications)
-* `/tmp` - Your system's temp directory (modifications expected)
 
 #### Known issues on macOS
 [Known issues](mac-users.md)


### PR DESCRIPTION
Fixes #24025
Fixes #24028

This change removes the mount of host /tmp directory from the invocations  
of the virtualized toolchain. It also changes the related documentation
accordingly.

This change fixes several issues that are caused by bugs and in Docker/Podman
implementation of the filesystems, which are used for cross-platform filesystem
access from containers (linux) to host (MacOS). It should also prevent potential
similar issues in the future. 

Additional advantages of this change:

- The temporary storage of the testing
  environments will always have sane linux semantics. While the `testdata`
  directories are still located on the host filesystem, when there is a test
  that relies on some tricky filesystem operation, it would be able
  to copy its files to the temporary filesystem.
- When running on MacOS, filesystem access inside a container is faster 
  than going out to the host, so it speeds up running the tests, on
  my machine (MacOS with Docker Desktop) `make test` finishes in 75 seconds
  instead of 180 without the change.

### List of known problems, which this patch fixes:

**Fixes the problem, which is described in comments of Issue #17251:**

Repo Server exits with the message "listen unix /tmp/reposerver-ask-pass.sock: bind: operation not supported" upon `make start` on MacOS.

This happens because the VirtioFS filesystem that Docker Desktop on MacOS by default uses for file sharing does not support unix domain sockets.

**Fixes failing  TestInit test (Issue #24025):**

The test creates a temporary directory in /tmp,
the sets its permissions to be 0300 (Write+Execute), then expects
an error to return from an attempt to read this directory. 

The error does not happen because handling of Write Only 
permissions is not implemented correctly in the filesystems
(both VirtioFS and GrpcFUSE) that Docker Desktop uses for sharing the 
mounted directories on MacOS.
 
**Fixes running containerized toolchain with Podman on Macos (issue #24028)**

In MacOS /tmp is not a real directory, but a symlink to /private/tmp`,
podman does not seem to handle symlink properly when doing mount, 
which causes the error.  

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [X] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [X] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
