### PR TITLE
feat: add repo-server metric for upstream repository requests

### DIFF
--- a/docs/operator-manual/metrics.md
+++ b/docs/operator-manual/metrics.md
@@ -255,14 +255,22 @@ Metrics about the Repo Server. The gRPC metrics are not exposed by default.  Met
 Scraped at the `argocd-repo-server:8084/metrics` endpoint.
 
 
-| Metric                                  |   Type    | Description                                                               |
-| --------------------------------------- | :-------: | ------------------------------------------------------------------------- |
-| `argocd_git_request_duration_seconds`   | histogram | Git requests duration seconds.                                            |
-| `argocd_git_request_total`              |  counter  | Number of git requests performed by repo server                           |
-| `argocd_git_fetch_fail_total`           |  counter  | Number of git fetch requests failures by repo server                      |
-| `argocd_redis_request_duration_seconds` | histogram | Redis requests duration seconds.                                          |
-| `argocd_redis_request_total`            |  counter  | Number of Kubernetes requests executed during application reconciliation. |
-| `argocd_repo_pending_request_total`     |   gauge   | Number of pending requests requiring repository lock                      |
+| Metric                                  |   Type    | Description                                                                        |
+|-----------------------------------------|:---------:|------------------------------------------------------------------------------------|
+| `argocd_git_request_duration_seconds`   | histogram | Git requests duration seconds.                                                     |
+| `argocd_git_request_total`              |  counter  | Number of git requests performed by repo server                                    |
+| `argocd_git_fetch_fail_total`           |  counter  | Number of git fetch requests failures by repo server                               |
+| `argocd_redis_request_duration_seconds` | histogram | Redis requests duration seconds.                                                   |
+| `argocd_redis_request_total`            |  counter  | Number of Kubernetes requests executed during application reconciliation.          |
+| `argocd_repo_pending_request_total`     |   gauge   | Number of pending requests requiring repository lock                               |
+| `argocd_repo_upstream_requests_total`   |  counter  | Number of upstream repository requests by type and status performed by repo server. |
+
+### Labels
+
+| Label Name  | Example Value | Description                                                                                                                                |
+| ----------- |---------------| -------------------------------------------------------------------- |
+| repo_type | git           | Type of repository being accessed (e.g., git, helm, etc.) |
+| failed    | false         | Indicates if the upstream request failed. Possible values: true, false |
 
 ## Commit Server Metrics
 

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -2772,6 +2772,7 @@ func (s *Service) TestRepository(ctx context.Context, q *apiclient.TestRepositor
 	check := checks[repo.Type]
 	apiResp := &apiclient.TestRepositoryResponse{VerifiedRepository: false}
 	err := check()
+	s.metricsServer.IncUpstreamRepoRequest(repo.Type, err != nil)
 	if err != nil {
 		return apiResp, fmt.Errorf("error testing repository connectivity: %w", err)
 	}


### PR DESCRIPTION
### Description

This metric was added to address a real-world issue where chartmuseum was down for a helm repo, causing the repo-server to fail in making requests to it. At the time, there was no existing metric in Argo CD to identify upstream errors. As a result, external metrics, such as Istio metrics, had to be used to set up alerts for upstream failures. This new metric argocd_repo_upstream_requests_total provides visibility into such errors, enabling operators to monitor and respond to upstream issues directly within Argo CD.

### Changes
1. Added the `argocd_repo_upstream_requests_total` metric in `reposerver/metrics/metrics.go`. No tests to modify, as none of the unit tests verify metrics.
2. Implemented the `IncUpstreamRepoRequest` method in the `MetricsServer` struct to increment the counter.
3. Updated the documentation in `docs/operator-manual/metrics.md` to include the new metric and its labels.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
