### PR TITLE
feat(ui): search filter by target revision

### DIFF
--- a/ui/src/app/applications/components/applications-list/applications-filter.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-filter.tsx
@@ -38,6 +38,7 @@ export interface ApplicationSetFilterResult {
     health: boolean;
     favourite: boolean;
     labels: boolean;
+    targetRevision: boolean;
 }
 
 export interface FilteredApp extends Application {
@@ -408,7 +409,6 @@ const TargetRevisionFilter = (props: AppFilterProps) => {
         () => optionsFrom(Array.from(new Set(props.apps.flatMap(app => getAppTargetRevisions(app)).filter(item => !!item))), props.pref.targetRevisionFilter),
         [props.apps, props.pref.targetRevisionFilter]
     );
-
     return (
         <Filter
             label='TARGET REVISION'

--- a/ui/src/app/applications/components/applications-list/applications-filter.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-filter.tsx
@@ -27,6 +27,7 @@ export interface FilterResult {
     health: boolean;
     clusters: boolean;
     namespaces: boolean;
+    targetRevision: boolean;
     operation: boolean;
     annotations: boolean;
     favourite: boolean;
@@ -55,35 +56,76 @@ export function getAutoSyncStatus(syncPolicy?: SyncPolicy) {
     return 'Enabled';
 }
 
+function getAppTargetRevisions(app: Application): string[] {
+    const revisions = new Set<string>();
+
+    if (app.spec.sourceHydrator) {
+        const drySourceRevision = app.spec.sourceHydrator.drySource?.targetRevision;
+        const syncSourceRevision = app.spec.sourceHydrator.syncSource?.targetBranch;
+
+        if (drySourceRevision) {
+            revisions.add(drySourceRevision);
+        }
+        if (syncSourceRevision) {
+            revisions.add(syncSourceRevision);
+        }
+
+        return Array.from(revisions);
+    }
+
+    if (app.spec.sources?.length) {
+        app.spec.sources.forEach(source => {
+            if (source.targetRevision) {
+                revisions.add(source.targetRevision);
+            }
+        });
+
+        return Array.from(revisions);
+    }
+
+    if (app.spec.source?.targetRevision) {
+        revisions.add(app.spec.source.targetRevision);
+    }
+
+    return Array.from(revisions);
+}
+
 export function getAppFilterResults(applications: Application[], pref: AppsListPreferences): FilteredApp[] {
     const labelSelector = createMetadataSelector(pref.labelsFilter || []);
     const annotationSelector = createMetadataSelector(pref.annotationsFilter || []);
 
-    return applications.map(app => ({
-        ...app,
-        filterResult: {
-            sync: pref.syncFilter.length === 0 || pref.syncFilter.includes(app.status.sync.status),
-            autosync: pref.autoSyncFilter.length === 0 || pref.autoSyncFilter.includes(getAutoSyncStatus(app.spec.syncPolicy)),
-            health: pref.healthFilter.length === 0 || pref.healthFilter.includes(app.status.health.status),
-            namespaces: pref.namespacesFilter.length === 0 || pref.namespacesFilter.some(ns => app.spec.destination.namespace && minimatch(app.spec.destination.namespace, ns)),
-            favourite: !pref.showFavorites || (pref.favoritesAppList && pref.favoritesAppList.includes(app.metadata.name)),
-            clusters:
-                pref.clustersFilter.length === 0 ||
-                pref.clustersFilter.some(filterString => {
-                    const match = filterString.match('^(.*) [(](http.*)[)]$');
-                    if (match?.length === 3) {
-                        const [, name, url] = match;
-                        return url === app.spec.destination.server || name === app.spec.destination.name;
-                    } else {
-                        const inputMatch = filterString.match('^http.*$');
-                        return (inputMatch && inputMatch[0] === app.spec.destination.server) || (app.spec.destination.name && minimatch(app.spec.destination.name, filterString));
-                    }
-                }),
-            labels: pref.labelsFilter.length === 0 || labelSelector(app.metadata.labels),
-            annotations: pref.annotationsFilter.length === 0 || annotationSelector(app.metadata.annotations),
-            operation: pref.operationFilter.length === 0 || pref.operationFilter.includes(getOperationStateTitle(app))
-        }
-    }));
+    return applications.map(app => {
+        const targetRevisions = getAppTargetRevisions(app);
+
+        return {
+            ...app,
+            filterResult: {
+                sync: pref.syncFilter.length === 0 || pref.syncFilter.includes(app.status.sync.status),
+                autosync: pref.autoSyncFilter.length === 0 || pref.autoSyncFilter.includes(getAutoSyncStatus(app.spec.syncPolicy)),
+                health: pref.healthFilter.length === 0 || pref.healthFilter.includes(app.status.health.status),
+                namespaces: pref.namespacesFilter.length === 0 || pref.namespacesFilter.some(ns => app.spec.destination.namespace && minimatch(app.spec.destination.namespace, ns)),
+                favourite: !pref.showFavorites || (pref.favoritesAppList && pref.favoritesAppList.includes(app.metadata.name)),
+                clusters:
+                    pref.clustersFilter.length === 0 ||
+                    pref.clustersFilter.some(filterString => {
+                        const match = filterString.match('^(.*) [(](http.*)[)]$');
+                        if (match?.length === 3) {
+                            const [, name, url] = match;
+                            return url === app.spec.destination.server || name === app.spec.destination.name;
+                        } else {
+                            const inputMatch = filterString.match('^http.*$');
+                            return (inputMatch && inputMatch[0] === app.spec.destination.server) || (app.spec.destination.name && minimatch(app.spec.destination.name, filterString));
+                        }
+                    }),
+                targetRevision:
+                    pref.targetRevisionFilter.length === 0 ||
+                    pref.targetRevisionFilter.some(filter => targetRevisions.some(targetRevision => minimatch(targetRevision, filter))),
+                labels: pref.labelsFilter.length === 0 || labelSelector(app.metadata.labels),
+                annotations: pref.annotationsFilter.length === 0 || annotationSelector(app.metadata.annotations),
+                operation: pref.operationFilter.length === 0 || pref.operationFilter.includes(getOperationStateTitle(app))
+            }
+        };
+    });
 }
 
 export function getAppSetFilterResults(appSets: ApplicationSet[], pref: AppSetsListPreferences): ApplicationSetFilteredApp[] {
@@ -361,6 +403,23 @@ const NamespaceFilter = React.memo((props: AppFilterProps) => {
     );
 });
 
+const TargetRevisionFilter = (props: AppFilterProps) => {
+    const targetRevisionOptions = React.useMemo(
+        () => optionsFrom(Array.from(new Set(props.apps.flatMap(app => getAppTargetRevisions(app)).filter(item => !!item))), props.pref.targetRevisionFilter),
+        [props.apps, props.pref.targetRevisionFilter]
+    );
+
+    return (
+        <Filter
+            label='TARGET REVISION'
+            selected={props.pref.targetRevisionFilter}
+            setSelected={s => props.onChange({...props.pref, targetRevisionFilter: s})}
+            field={true}
+            options={targetRevisionOptions}
+        />
+    );
+};
+
 const FavoriteFilter = (props: {value: boolean; onChange: (showFavorites: boolean) => void}) => {
     const onChange = (val: boolean) => {
         props.onChange(val);
@@ -471,6 +530,7 @@ export const ApplicationsFilter = (props: AppFilterProps) => {
         ...(props.pref.projectsFilter || []),
         ...(props.pref.clustersFilter || []),
         ...(props.pref.namespacesFilter || []),
+        ...(props.pref.targetRevisionFilter || []),
         ...(props.pref.autoSyncFilter || []),
         ...(props.pref.showFavorites ? ['favorites'] : [])
     ];
@@ -492,6 +552,7 @@ export const ApplicationsFilter = (props: AppFilterProps) => {
             <ProjectFilter {...props} />
             <ClusterFilter {...props} />
             <NamespaceFilter {...props} />
+            <TargetRevisionFilter {...props} />
             <AutoSyncFilter {...props} collapsed={true} />
         </FiltersGroup>
     );

--- a/ui/src/app/applications/components/applications-list/applications-filter.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-filter.tsx
@@ -38,7 +38,6 @@ export interface ApplicationSetFilterResult {
     health: boolean;
     favourite: boolean;
     labels: boolean;
-    targetRevision: boolean;
 }
 
 export interface FilteredApp extends Application {
@@ -83,12 +82,13 @@ export function getAppFilterResults(applications: Application[], pref: AppsListP
                             return url === app.spec.destination.server || name === app.spec.destination.name;
                         } else {
                             const inputMatch = filterString.match('^http.*$');
-                            return (inputMatch && inputMatch[0] === app.spec.destination.server) || (app.spec.destination.name && minimatch(app.spec.destination.name, filterString));
+                            return (
+                                (inputMatch && inputMatch[0] === app.spec.destination.server) || (app.spec.destination.name && minimatch(app.spec.destination.name, filterString))
+                            );
                         }
                     }),
                 targetRevision:
-                    pref.targetRevisionFilter.length === 0 ||
-                    pref.targetRevisionFilter.some(filter => targetRevisions.some(targetRevision => minimatch(targetRevision, filter))),
+                    pref.targetRevisionFilter.length === 0 || pref.targetRevisionFilter.some(filter => targetRevisions.some(targetRevision => minimatch(targetRevision, filter))),
                 labels: pref.labelsFilter.length === 0 || labelSelector(app.metadata.labels),
                 annotations: pref.annotationsFilter.length === 0 || annotationSelector(app.metadata.annotations),
                 operation: pref.operationFilter.length === 0 || pref.operationFilter.includes(getOperationStateTitle(app))
@@ -376,13 +376,7 @@ const TargetRevisionFilter = (props: AppFilterProps) => {
     const targetRevisionOptions = React.useMemo(
         () =>
             optionsFrom(
-                Array.from(
-                    new Set(
-                        props.apps
-                            .flatMap(app => getAppAllSources(app).map(source => source.targetRevision))
-                            .filter((item): item is string => !!item)
-                    )
-                ),
+                Array.from(new Set(props.apps.flatMap(app => getAppAllSources(app).map(source => source.targetRevision)).filter((item): item is string => !!item))),
                 props.pref.targetRevisionFilter
             ),
         [props.apps, props.pref.targetRevisionFilter]

--- a/ui/src/app/applications/components/applications-list/applications-filter.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-filter.tsx
@@ -17,7 +17,7 @@ import {
 import {AppsListPreferences, AppSetsListPreferences, services} from '../../../shared/services';
 import {Filter, FiltersGroup} from '../filter/filter';
 import {createMetadataSelector} from '../selectors';
-import {ComparisonStatusIcon, getAppSetHealthStatus, HealthStatusIcon, getOperationStateTitle} from '../utils';
+import {ComparisonStatusIcon, getAppAllSources, getAppSetHealthStatus, HealthStatusIcon, getOperationStateTitle} from '../utils';
 import {formatClusterQueryParam} from '../../../shared/utils';
 import {COLORS} from '../../../shared/components/colors';
 
@@ -57,46 +57,14 @@ export function getAutoSyncStatus(syncPolicy?: SyncPolicy) {
     return 'Enabled';
 }
 
-function getAppTargetRevisions(app: Application): string[] {
-    const revisions = new Set<string>();
-
-    if (app.spec.sourceHydrator) {
-        const drySourceRevision = app.spec.sourceHydrator.drySource?.targetRevision;
-        const syncSourceRevision = app.spec.sourceHydrator.syncSource?.targetBranch;
-
-        if (drySourceRevision) {
-            revisions.add(drySourceRevision);
-        }
-        if (syncSourceRevision) {
-            revisions.add(syncSourceRevision);
-        }
-
-        return Array.from(revisions);
-    }
-
-    if (app.spec.sources?.length) {
-        app.spec.sources.forEach(source => {
-            if (source.targetRevision) {
-                revisions.add(source.targetRevision);
-            }
-        });
-
-        return Array.from(revisions);
-    }
-
-    if (app.spec.source?.targetRevision) {
-        revisions.add(app.spec.source.targetRevision);
-    }
-
-    return Array.from(revisions);
-}
-
 export function getAppFilterResults(applications: Application[], pref: AppsListPreferences): FilteredApp[] {
     const labelSelector = createMetadataSelector(pref.labelsFilter || []);
     const annotationSelector = createMetadataSelector(pref.annotationsFilter || []);
 
     return applications.map(app => {
-        const targetRevisions = getAppTargetRevisions(app);
+        const targetRevisions = getAppAllSources(app)
+            .map(source => source.targetRevision)
+            .filter((item): item is string => !!item);
 
         return {
             ...app,
@@ -406,7 +374,17 @@ const NamespaceFilter = React.memo((props: AppFilterProps) => {
 
 const TargetRevisionFilter = (props: AppFilterProps) => {
     const targetRevisionOptions = React.useMemo(
-        () => optionsFrom(Array.from(new Set(props.apps.flatMap(app => getAppTargetRevisions(app)).filter(item => !!item))), props.pref.targetRevisionFilter),
+        () =>
+            optionsFrom(
+                Array.from(
+                    new Set(
+                        props.apps
+                            .flatMap(app => getAppAllSources(app).map(source => source.targetRevision))
+                            .filter((item): item is string => !!item)
+                    )
+                ),
+                props.pref.targetRevisionFilter
+            ),
         [props.apps, props.pref.targetRevisionFilter]
     );
     return (

--- a/ui/src/app/applications/components/applications-list/applications-list.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-list.tsx
@@ -160,6 +160,13 @@ const ViewPref = ({children}: {children: (pref: AppsListPreferences & {page: num
                                 .split(',')
                                 .filter(item => !!item);
                         }
+                        if (params.get('targetRevision') != null) {
+                            viewPref.targetRevisionFilter = params
+                                .get('targetRevision')
+                                .split(',')
+                                .map(decodeURIComponent)
+                                .filter(item => !!item);
+                        }
                         if (params.get('cluster') != null) {
                             viewPref.clustersFilter = params
                                 .get('cluster')
@@ -473,6 +480,7 @@ export const ApplicationsList = (props: RouteComponentProps<any> & {objectListKi
                 autoSync: newPref.autoSyncFilter.join(','),
                 health: newPref.healthFilter.join(','),
                 namespace: newPref.namespacesFilter.join(','),
+                targetRevision: newPref.targetRevisionFilter.map(encodeURIComponent).join(','),
                 cluster: newPref.clustersFilter.join(','),
                 labels: newPref.labelsFilter.map(encodeURIComponent).join(','),
                 annotations: newPref.annotationsFilter.map(encodeURIComponent).join(','),

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -1479,6 +1479,34 @@ export function getAppDrySource(app?: appModels.Application): appModels.Applicat
     return {repoURL, targetRevision, path};
 }
 
+// getAppAllSources gets all app sources as an array. For single source apps, returns [source].
+// For multi-source apps, returns the sources array. For sourceHydrator apps, returns a single synthesized source.
+export function getAppAllSources(app?: appModels.Application): appModels.ApplicationSource[] {
+    if (!app) {
+        return [];
+    }
+
+    if (app.spec.sourceHydrator) {
+        return [
+            {
+                repoURL: app.spec.sourceHydrator.drySource.repoURL,
+                targetRevision: app.spec.sourceHydrator.syncSource.targetBranch,
+                path: app.spec.sourceHydrator.syncSource.path
+            } as appModels.ApplicationSource
+        ];
+    }
+
+    if (app.spec.sources && app.spec.sources.length > 0) {
+        return app.spec.sources;
+    }
+
+    if (app.spec.source) {
+        return [app.spec.source];
+    }
+
+    return [];
+}
+
 // getAppDefaultSyncRevision gets the first app revisions from `status.sync.revisions` or, if that list is missing or empty, the `revision`
 // field.
 export function getAppDefaultSyncRevision(app?: appModels.Application) {

--- a/ui/src/app/shared/services/view-preferences-service.ts
+++ b/ui/src/app/shared/services/view-preferences-service.ts
@@ -72,16 +72,12 @@ export class AbstractAppsListPreferences {
         pref.healthFilter = [];
         pref.labelsFilter = [];
         pref.annotationsFilter = [];
-        pref.targetRevisionFilter = [];
         pref.showFavorites = false;
     }
 
     public labelsFilter: string[];
     public annotationsFilter: string[];
     public healthFilter: string[];
-    public namespacesFilter: string[];
-    public targetRevisionFilter: string[];
-    public clustersFilter: string[];
     public view: AppsListViewType;
     public hideFilters: boolean;
     public statusBarView: HealthStatusBarPreferences;
@@ -90,28 +86,12 @@ export class AbstractAppsListPreferences {
 }
 
 export class AppsListPreferences extends AbstractAppsListPreferences {
-    public static countEnabledFilters(pref: AppsListPreferences) {
-        const enabledFilterGroups = [
-            pref.clustersFilter,
-            pref.healthFilter,
-            pref.labelsFilter,
-            pref.annotationsFilter,
-            pref.namespacesFilter,
-            pref.projectsFilter,
-            pref.syncFilter,
-            pref.targetRevisionFilter,
-            pref.autoSyncFilter,
-            pref.operationFilter
-        ];
-
-        return enabledFilterGroups.reduce((count, filter) => count + (filter && filter.length > 0 ? 1 : 0), pref.showFavorites ? 1 : 0);
-    }
-
     public static clearFilters(pref: AppsListPreferences) {
         super.clearFilters(pref);
 
         pref.clustersFilter = [];
         pref.namespacesFilter = [];
+        pref.targetRevisionFilter = [];
         pref.projectsFilter = [];
         pref.syncFilter = [];
         pref.autoSyncFilter = [];

--- a/ui/src/app/shared/services/view-preferences-service.ts
+++ b/ui/src/app/shared/services/view-preferences-service.ts
@@ -72,12 +72,16 @@ export class AbstractAppsListPreferences {
         pref.healthFilter = [];
         pref.labelsFilter = [];
         pref.annotationsFilter = [];
+        pref.targetRevisionFilter = [];
         pref.showFavorites = false;
     }
 
     public labelsFilter: string[];
     public annotationsFilter: string[];
     public healthFilter: string[];
+    public namespacesFilter: string[];
+    public targetRevisionFilter: string[];
+    public clustersFilter: string[];
     public view: AppsListViewType;
     public hideFilters: boolean;
     public statusBarView: HealthStatusBarPreferences;
@@ -86,6 +90,23 @@ export class AbstractAppsListPreferences {
 }
 
 export class AppsListPreferences extends AbstractAppsListPreferences {
+    public static countEnabledFilters(pref: AppsListPreferences) {
+        const enabledFilterGroups = [
+            pref.clustersFilter,
+            pref.healthFilter,
+            pref.labelsFilter,
+            pref.annotationsFilter,
+            pref.namespacesFilter,
+            pref.projectsFilter,
+            pref.syncFilter,
+            pref.targetRevisionFilter,
+            pref.autoSyncFilter,
+            pref.operationFilter
+        ];
+
+        return enabledFilterGroups.reduce((count, filter) => count + (filter && filter.length > 0 ? 1 : 0), pref.showFavorites ? 1 : 0);
+    }
+
     public static clearFilters(pref: AppsListPreferences) {
         super.clearFilters(pref);
 
@@ -102,6 +123,7 @@ export class AppsListPreferences extends AbstractAppsListPreferences {
     public autoSyncFilter: string[];
     public namespacesFilter: string[];
     public clustersFilter: string[];
+    public targetRevisionFilter: string[];
     public operationFilter: string[];
 }
 
@@ -156,6 +178,7 @@ const DEFAULT_PREFERENCES: ViewPreferences = {
         annotationsFilter: new Array<string>(),
         projectsFilter: new Array<string>(),
         namespacesFilter: new Array<string>(),
+        targetRevisionFilter: new Array<string>(),
         clustersFilter: new Array<string>(),
         syncFilter: new Array<string>(),
         autoSyncFilter: new Array<string>(),
@@ -228,6 +251,7 @@ export class ViewPreferencesService {
         appList.annotationsFilter = appList.annotationsFilter || [];
         appList.projectsFilter = appList.projectsFilter || [];
         appList.namespacesFilter = appList.namespacesFilter || [];
+        appList.targetRevisionFilter = appList.targetRevisionFilter || [];
         appList.clustersFilter = appList.clustersFilter || [];
         appList.syncFilter = appList.syncFilter || [];
         appList.autoSyncFilter = appList.autoSyncFilter || [];


### PR DESCRIPTION
Closes #23704 

Hi,
As you can see from the issue link, I implemented a feature that allows filtering by target revision in the Argo CD Application dashboard.
To support both multi-source and single-source Applications, I created a utility function that handles both cases.
I designed the utility function to return the appropriate source based on priority.
If a `sourceHydrator` exists, it takes precedence over all others. (as list)
If not, it falls back to `multi-source` first, and then to `single-source`.

I've attached a short video and some screenshots to demonstrate how it works.
Please take a look and review the code when you have a moment.
Thanks!

```
# multi source application manifest example

project: default
destination:
  server: https://kubernetes.default.svc
  namespace: default
sources:
  - repoURL: https://github.com/argoproj/argocd-example-apps
    path: kustomize-guestbook
    targetRevision: agaudreault-patch-1 # or HEAD in test
  - repoURL: https://github.com/argoproj/argocd-example-apps
    path: jsonnet-guestbook
    targetRevision: HEAD # or agaudreault-patch-1 in test
```

### Demo video

https://github.com/user-attachments/assets/fecf1525-a8cc-4f5b-84aa-7069f3f5902e

### Demo screenshots
<img width="1631" height="1142" alt="target revision filter" src="https://github.com/user-attachments/assets/4cb753bf-a2fe-4e82-88d3-2db16cf2a6f6" />
<img width="1269" height="1192" alt="target revision filter 1" src="https://github.com/user-attachments/assets/d584fabd-d85b-4c47-aade-80afaea024d5" />
<img width="1720" height="1160" alt="target revision filter 2" src="https://github.com/user-attachments/assets/650b9966-aec1-407b-abce-ea435473981c" />
<img width="1626" height="1207" alt="target revision filter 3" src="https://github.com/user-attachments/assets/0f2ef370-038b-41b1-aff5-a14c164b2108" />
<img width="1740" height="1204" alt="search with target revision filter" src="https://github.com/user-attachments/assets/4ad335a2-9bda-4956-82d4-4227a9a1e319" />
<img width="1337" height="1176" alt="target revision multi source" src="https://github.com/user-attachments/assets/d2d66680-eee8-4221-8193-8c35ec8dd335" />



<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
