### PR TITLE
chore(ci): Use default TARGETPLATFORM for base ArgoCD image to fix multi-platform builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN ./install.sh helm && \
 ####################################################################################################
 # Argo CD Base - used as the base for both the release and dev argocd images
 ####################################################################################################
-FROM --platform=$BUILDPLATFORM $BASE_IMAGE AS argocd-base
+FROM --platform=$TARGETPLATFORM $BASE_IMAGE AS argocd-base
 
 LABEL org.opencontainers.image.source="https://github.com/argoproj/argo-cd"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG BASE_IMAGE=docker.io/library/ubuntu:25.04@sha256:10bb10bb062de665d4dc3e0ea36
 # Initial stage which pulls prepares build dependencies and CLI tooling we need for our final image
 # Also used as the image in CI jobs so needs all dependencies
 ####################################################################################################
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.24.4@sha256:db5d0afbfb4ab648af2393b92e87eaae9ad5e01132803d80caef91b5752d289c AS builder
+FROM --platform=$TARGETPLATFORM docker.io/library/golang:1.24.4@sha256:db5d0afbfb4ab648af2393b92e87eaae9ad5e01132803d80caef91b5752d289c AS builder
 
 WORKDIR /tmp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG BASE_IMAGE=docker.io/library/ubuntu:25.04@sha256:10bb10bb062de665d4dc3e0ea36
 # Initial stage which pulls prepares build dependencies and CLI tooling we need for our final image
 # Also used as the image in CI jobs so needs all dependencies
 ####################################################################################################
-FROM --platform=$TARGETPLATFORM docker.io/library/golang:1.24.4@sha256:db5d0afbfb4ab648af2393b92e87eaae9ad5e01132803d80caef91b5752d289c AS builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.24.4@sha256:db5d0afbfb4ab648af2393b92e87eaae9ad5e01132803d80caef91b5752d289c AS builder
 
 WORKDIR /tmp
 
@@ -34,7 +34,7 @@ RUN ./install.sh helm && \
 ####################################################################################################
 # Argo CD Base - used as the base for both the release and dev argocd images
 ####################################################################################################
-FROM --platform=$TARGETPLATFORM $BASE_IMAGE AS argocd-base
+FROM $BASE_IMAGE AS argocd-base
 
 LABEL org.opencontainers.image.source="https://github.com/argoproj/argo-cd"
 


### PR DESCRIPTION
https://github.com/argoproj/argo-cd/pull/23993 added `--platform=$BUILDPLATFORM` to the `FROM` lines in the `Dockerfile` which breaks multi-platform builds resulting in the `arm64` image containing `x86_64` binaries.

This is because `BUILDPLATFORM` contains the platform of the _build_ host -- which, in this case, is a `x86_64` GitHub Actions runner.  In this case, Go will still produce an `arm64` binary but it is packaged in an `amd64` image.

To fix, use the default `TARGETPLATFORM` when building the ArgoCD base image.