### PR TITLE
feat(controller): add PostSyncHookError condition when PostSync hooks fail

### DIFF
--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -1798,6 +1798,8 @@ const (
 	ApplicationConditionSyncError = "SyncError"
 	// ApplicationConditionUnknownError indicates an unknown controller error
 	ApplicationConditionUnknownError = "UnknownError"
+	// ApplicationConditionPostSyncHookFailed indicates a PostSync hook (e.g., Job) failed
+	ApplicationConditionPostSyncHookError = "PostSyncHookError"
 	// ApplicationConditionSharedResourceWarning indicates that controller detected resources which belongs to more than one application
 	ApplicationConditionSharedResourceWarning = "SharedResourceWarning"
 	// ApplicationConditionRepeatedResourceWarning indicates that application source has resource with same Group, Kind, Name, Namespace multiple times


### PR DESCRIPTION
Closes  #23719

### Summary
Add PostSyncHookError Application condition.
On each sync, if any PostSync hook fails:

- SetHealth to Degraded
- Add/refresh PostSyncHookError with aggregated messages `(namespace/name: reason)`
When no PostSync failures remain, clear the condition.

This also surfaces in metrics via argocd_app_condition{condition="PostSyncHookError", ...} = 1.

### Motivation
Teams often run E2E/smoke tests in PostSync Jobs. When those tests fail (e.g., BackoffLimitExceeded), the failure is visible in the manifest, but not exposed as a dedicated condition/metric. This PR makes those failures observable and alertable.

### Changes
- controller/appcontroller.go: detect failed PostSync hooks in the latest sync and manage the PostSyncHookError condition; set Health to Degraded while failures exist; clear the condition when resolved.
- pkg/apis/application/v1alpha1/types.go: add ApplicationConditionPostSyncHookError (condition type) so it’s exported via metrics.

### Screenshots / Verification
1. UI—Health & Conditions
   - App health shows Degraded; 1 Error is displayed in App Conditions panel.
   - Screenshot: <img width="3008" height="1018" alt="image" src="https://github.com/user-attachments/assets/a6cda504-e7e5-411c-a4ce-a3bfffe1bbb4" />

2. Metrics—argocd_app_condition
    - `argocd_app_condition{condition="PostSyncHookError",name="test-post-job-failed-test",namespace="argo",project="default"} 1`
    - Screenshot: <img width="2004" height="184" alt="image" src="https://github.com/user-attachments/assets/d355e5b9-4e21-44df-8872-de88b8e0e178" />

3. Application conditions detail modal
    - Aggregated message like: 
        `PostSync hook failed: default/fail-postsync: Job has reached the specified backoff limit`
    - Screenshot: <img width="2412" height="412" alt="image" src="https://github.com/user-attachments/assets/08e50c2f-52a0-40ee-a694-c79d33697d9a" />


### Related
- Issue: https://github.com/argoproj/argo-cd/issues/23719
- Slack discussion: https://cloud-native.slack.com/archives/C01TSERG0KZ/p1752056389728489

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
