### PR TITLE
fix: `kustomize edit add component` check

### DIFF
--- a/util/kustomize/kustomize.go
+++ b/util/kustomize/kustomize.go
@@ -365,15 +365,18 @@ func (k *kustomize) Build(opts *v1alpha1.ApplicationSourceKustomize, kustomizeOp
 					foundComponents = append(foundComponents, c)
 				}
 			}
-			args := []string{"edit", "add", "component"}
-			args = append(args, foundComponents...)
-			cmd := exec.Command(k.getBinaryPath(), args...)
-			cmd.Dir = k.path
-			cmd.Env = env
-			commands = append(commands, executil.GetCommandArgsToLog(cmd))
-			_, err := executil.Run(cmd)
-			if err != nil {
-				return nil, nil, nil, err
+
+			if len(foundComponents) > 0 {
+				args := []string{"edit", "add", "component"}
+				args = append(args, foundComponents...)
+				cmd := exec.Command(k.getBinaryPath(), args...)
+				cmd.Dir = k.path
+				cmd.Env = env
+				commands = append(commands, executil.GetCommandArgsToLog(cmd))
+				_, err := executil.Run(cmd)
+				if err != nil {
+					return nil, nil, nil, err
+				}
 			}
 		}
 	}

--- a/util/kustomize/kustomize_test.go
+++ b/util/kustomize/kustomize_test.go
@@ -628,7 +628,7 @@ func TestKustomizeBuildComponentsNoFoundComponents(t *testing.T) {
 	}
 	_, _, commands, err := kustomize.Build(&kustomizeSource, nil, nil, nil)
 	require.NoError(t, err)
-	
+
 	// Verify that no "edit add component" command was executed
 	for _, cmd := range commands {
 		assert.NotContains(t, cmd, "edit add component", "kustomize edit add component should not be invoked when foundComponents is empty")

--- a/util/kustomize/kustomize_test.go
+++ b/util/kustomize/kustomize_test.go
@@ -615,6 +615,26 @@ func TestFailKustomizeBuildPatches(t *testing.T) {
 	require.EqualError(t, err, "kustomization file not found in the path")
 }
 
+func TestKustomizeBuildComponentsNoFoundComponents(t *testing.T) {
+	appPath, err := testDataDir(t, kustomization6)
+	require.NoError(t, err)
+	kustomize := NewKustomizeApp(appPath, appPath, git.NopCreds{}, "", "", "", "")
+
+	// Test with non-existent components and IgnoreMissingComponents = true
+	// This should result in foundComponents being empty, so no "edit add component" command should be executed
+	kustomizeSource := v1alpha1.ApplicationSourceKustomize{
+		Components:              []string{"./non-existent-component1", "./non-existent-component2"},
+		IgnoreMissingComponents: true,
+	}
+	_, _, commands, err := kustomize.Build(&kustomizeSource, nil, nil, nil)
+	require.NoError(t, err)
+	
+	// Verify that no "edit add component" command was executed
+	for _, cmd := range commands {
+		assert.NotContains(t, cmd, "edit add component", "kustomize edit add component should not be invoked when foundComponents is empty")
+	}
+}
+
 func Test_getImageParameters_sorted(t *testing.T) {
 	apps := []*unstructured.Unstructured{
 		{


### PR DESCRIPTION
Ensure that `foundComponents` > 0 before running `kustomize edit add component`, otherwise kustomize will error out in case no components are found.

Should be cherry-picked for 3.0 + 3.1.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
