### PR TITLE
docs: Update rbac.md

### DIFF
--- a/docs/operator-manual/rbac.md
+++ b/docs/operator-manual/rbac.md
@@ -341,7 +341,7 @@ spec:
     - name: admin
       description: Admin privileges to team-beta
       policies:
-        - p, proj:team-beta-project:admin, applications, *, *, allow
+        - p, proj:team-beta-project:admin, applications, *, team-beta-project/*, allow
       groups:
         - user@example.org # Value from the email scope
         - my-org:team-beta # Value from the groups scope


### PR DESCRIPTION
In the "Using SSO Users/Groups" section, in the AppProject definition, the RBAC policy in invalid. Trying to apply such policy would return the following error:

```
Unable to edit project: invalid policy rule 'p, proj:team-beta-project:admin, applications, get, *, *': object must be of form 'team-beta-project/*', 'team-beta-project[/<NAMESPACE>]/<APPNAME>' or 'team-beta-project/<APPNAME>', not '*'
```
