### PR TITLE
fix: resolve argocd ui error for externalSecrets, fixes #23886

### DIFF
--- a/resource_customizations/external-secrets.io/ExternalSecret/actions/action_test.yaml
+++ b/resource_customizations/external-secrets.io/ExternalSecret/actions/action_test.yaml
@@ -2,3 +2,8 @@ actionTests:
   - action: refresh
     inputPath: testdata/external-secret.yaml
     expectedOutputPath: testdata/external-secret-updated.yaml
+
+discoveryTests:
+  - inputPath: testdata/external-secret.yaml
+    result:
+      - name: "refresh"

--- a/resource_customizations/external-secrets.io/ExternalSecret/actions/discovery.lua
+++ b/resource_customizations/external-secrets.io/ExternalSecret/actions/discovery.lua
@@ -3,11 +3,13 @@ local actions = {}
 local disable_refresh = false
 local time_units = {"ns", "us", "µs", "ms", "s", "m", "h"}
 local digits = obj.spec.refreshInterval
-for _, time_unit in ipairs(time_units) do
-  digits, _ = digits:gsub(time_unit, "")
-  if tonumber(digits) == 0 then
-    disable_refresh = true
-    break
+if digits ~= nil then
+  digits = tostring(digits)
+  for _, time_unit in ipairs(time_units) do
+    if digits == "0" or digits == "0" .. time_unit then
+      disable_refresh = true
+      break
+    end
   end
 end
 

--- a/resource_customizations/external-secrets.io/PushSecret/actions/action_test.yaml
+++ b/resource_customizations/external-secrets.io/PushSecret/actions/action_test.yaml
@@ -2,3 +2,8 @@ actionTests:
   - action: push
     inputPath: testdata/push-secret.yaml
     expectedOutputPath: testdata/push-secret-updated.yaml
+
+discoveryTests:
+  - inputPath: testdata/push-secret.yaml
+    result:
+      - name: "push"

--- a/resource_customizations/external-secrets.io/PushSecret/actions/discovery.lua
+++ b/resource_customizations/external-secrets.io/PushSecret/actions/discovery.lua
@@ -3,11 +3,13 @@ local actions = {}
 local disable_push = false
 local time_units = {"ns", "us", "µs", "ms", "s", "m", "h"}
 local digits = obj.spec.refreshInterval
-for _, time_unit in ipairs(time_units) do
-  digits, _ = digits:gsub(time_unit, "")
-  if tonumber(digits) == 0 then
-    disable_push = true
-    break
+if digits ~= nil then
+  digits = tostring(digits)
+  for _, time_unit in ipairs(time_units) do
+    if digits == "0" or digits == "0" .. time_unit then
+      disable_push = true
+      break
+    end
   end
 end
 


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->

### Summary
ArgoCD 3.1.0 introduced a Lua runtime error when viewing ExternalSecret resources in the UI:

Commit [4905876108409ae9016cf93cfcf18c689a40479f](https://github.com/argoproj/argo-cd/commit/4905876108409ae9016cf93cfcf18c689a40479f) added logic to disable refresh/push actions when refreshInterval is set to 0.

The newly introduced error `attempt to index a non-table object(string) with key 'gsub'` was caused by using string metatable methods (:gsub()) that aren't available in ArgoCD's restricted Lua environment for discovery scripts.

### Solution

1) Replaced `:gsub()` method calls with `tostring()` conversion and simple string comparisons
Applied the fix to both ExternalSecret and PushSecret discovery scripts
The fix maintains the same logical behavior while using only available Lua functions

2) Added Discovery Tests:
Tests validate that our discovery scripts correctly identify available actions
Tests pass in both restricted (production) and unrestricted (test) Lua environments

3) Verified the Solution:
All existing tests continue to pass
Our new discovery tests pass

### Changes:
- Replace `digits:gsub(time_unit, '')` with `tostring(digits)` and direct comparison
- Maintain same logical behavior while using only available Lua functions
- Apply fix to both ExternalSecret and PushSecret discovery scripts


### TODO: Check if the fix resolves the original UI error when clicking ExternalSecret/PushSecret resources
#### Disclaimer: I am not a lua expert, I am happy to get help to improve the approach of the fix.