### PR TITLE
fix(discovery): add missing lua syntax and return to discovery (fixes #24257)

### DIFF
--- a/resource_customizations/numaflow.numaproj.io/InterStepBufferService/actions/discovery.lua
+++ b/resource_customizations/numaflow.numaproj.io/InterStepBufferService/actions/discovery.lua
@@ -16,3 +16,6 @@ if forcePromote then
   actions["force-promote"]["disabled"] = false
 else
   actions["force-promote"]["disabled"] = true
+end
+
+return actions

--- a/resource_customizations/numaflow.numaproj.io/MonoVertex/actions/action_test.yaml
+++ b/resource_customizations/numaflow.numaproj.io/MonoVertex/actions/action_test.yaml
@@ -11,3 +11,39 @@ actionTests:
 - action: force-promote
   inputPath: testdata/monovertex.yaml
   expectedOutputPath: testdata/monovertex-force-promote.yaml
+
+discoveryTests:
+  - inputPath: testdata/monovertex.yaml
+    result:
+      - name: pause
+        disabled: false
+        iconClass: 'fa-solid fa-fw fa-pause'
+      - name: unpause-gradual
+        disabled: true
+        iconClass: 'fa-solid fa-fw fa-play'
+        displayName: 'Unpause (gradual)'
+      - name: unpause-fast
+        disabled: true
+        iconClass: 'fa-solid fa-fw fa-play'
+        displayName: 'Unpause (fast)'
+      - name: force-promote
+        disabled: false
+        iconClass: 'fa-solid fa-fw fa-forward'
+        displayName: 'Force Promote'
+  - inputPath: testdata/monovertex-paused.yaml
+    result:
+      - name: pause
+        disabled: true
+        iconClass: 'fa-solid fa-fw fa-pause'
+      - name: unpause-gradual
+        disabled: false
+        iconClass: 'fa-solid fa-fw fa-play'
+        displayName: 'Unpause (gradual)'
+      - name: unpause-fast
+        disabled: true
+        iconClass: 'fa-solid fa-fw fa-play'
+        displayName: 'Unpause (fast)'
+      - name: force-promote
+        disabled: false
+        iconClass: 'fa-solid fa-fw fa-forward'
+        displayName: 'Force Promote'

--- a/resource_customizations/numaflow.numaproj.io/MonoVertex/actions/discovery.lua
+++ b/resource_customizations/numaflow.numaproj.io/MonoVertex/actions/discovery.lua
@@ -55,3 +55,6 @@ if forcePromote then
   actions["force-promote"]["disabled"] = false
 else
   actions["force-promote"]["disabled"] = true
+end
+
+return actions

--- a/resource_customizations/numaflow.numaproj.io/Pipeline/actions/action_test.yaml
+++ b/resource_customizations/numaflow.numaproj.io/Pipeline/actions/action_test.yaml
@@ -11,3 +11,39 @@ actionTests:
 - action: force-promote
   inputPath: testdata/pipeline.yaml
   expectedOutputPath: testdata/pipeline-force-promote.yaml
+
+discoveryTests:
+  - inputPath: testdata/pipeline.yaml
+    result:
+      - name: pause
+        disabled: false
+        iconClass: 'fa-solid fa-fw fa-pause'
+      - name: unpause-gradual
+        disabled: true
+        iconClass: 'fa-solid fa-fw fa-play'
+        displayName: 'Unpause (gradual)'
+      - name: unpause-fast
+        disabled: true
+        iconClass: 'fa-solid fa-fw fa-play'
+        displayName: 'Unpause (fast)'
+      - name: force-promote
+        disabled: false
+        iconClass: 'fa-solid fa-fw fa-forward'
+        displayName: 'Force Promote'
+  - inputPath: testdata/pipeline-paused.yaml
+    result:
+      - name: pause
+        disabled: true
+        iconClass: 'fa-solid fa-fw fa-pause'
+      - name: unpause-gradual
+        disabled: false
+        iconClass: 'fa-solid fa-fw fa-play'
+        displayName: 'Unpause (gradual)'
+      - name: unpause-fast
+        disabled: true
+        iconClass: 'fa-solid fa-fw fa-play'
+        displayName: 'Unpause (fast)'
+      - name: force-promote
+        disabled: false
+        iconClass: 'fa-solid fa-fw fa-forward'
+        displayName: 'Force Promote'

--- a/resource_customizations/numaflow.numaproj.io/Pipeline/actions/discovery.lua
+++ b/resource_customizations/numaflow.numaproj.io/Pipeline/actions/discovery.lua
@@ -55,3 +55,6 @@ if forcePromote then
   actions["force-promote"]["disabled"] = false
 else
   actions["force-promote"]["disabled"] = true
+end
+
+return actions


### PR DESCRIPTION
 of MonoVertex, Pipeline and InterStepBufferService. Added discovery tests

fixes #24257

PR https://github.com/argoproj/argo-cd/pull/22835 introduced broken lua code in the discovery of 
- numaflow.numaproj.io/InterStepBufferService
- numaflow.numaproj.io/MonoVertex
- numaflow.numaproj.io/Pipeline

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->

---

One open question that I came across is whether the `spec` is right here or should be removed:
Added by this PR https://github.com/argoproj/argo-cd/pull/24036
I'm talking about this line and some more around that: https://github.com/argoproj/argo-cd/blob/1c5d7f1f65909631d2c91fa791bac5269f56f5bb/resource_customizations/numaflow.numaproj.io/MonoVertex/actions/discovery.lua#L31
`obj.spec.metadata.annotations["numaflow.numaproj.io/allowed-resume-strategies"] == "fast"`
vs
`obj.metadata.annotations["numaflow.numaproj.io/allowed-resume-strategies"] == "fast"`

The spec of the resource actually defines `spec.metadata.annotations` [here](https://github.com/numaproj/numaflow/blob/630d6dd02a8ab166866d5e19c5d0b134ee04a2c6/config/base/crds/full/numaflow.numaproj.io_monovertices.yaml#L1682) but the tests have the `metadata.annotations` set and not `spec.metadata.annotations`: https://github.com/argoproj/argo-cd/blob/1c5d7f1f65909631d2c91fa791bac5269f56f5bb/resource_customizations/numaflow.numaproj.io/MonoVertex/actions/testdata/monovertex-paused.yaml#L12-L13