### PR TITLE
fix: custom resource health for flux helm repository of type oci

### DIFF
--- a/resource_customizations/source.toolkit.fluxcd.io/HelmRepository/health.lua
+++ b/resource_customizations/source.toolkit.fluxcd.io/HelmRepository/health.lua
@@ -4,6 +4,13 @@ if obj.spec.suspend ~= nil and obj.spec.suspend == true then
   hs.status = "Suspended"
   return hs
 end
+-- Helm repositories of type "oci" do not contain any information in the status
+-- https://fluxcd.io/flux/components/source/helmrepositories/#helmrepository-status
+if obj.spec.type ~= nil and obj.spec.type == "oci" then
+  hs.message = "Helm repositories of type 'oci' do not contain any information in the status."
+  hs.status = "Healthy"
+  return hs
+end
 if obj.status ~= nil then
   if obj.status.conditions ~= nil then
     local numProgressing = 0

--- a/resource_customizations/source.toolkit.fluxcd.io/HelmRepository/health_test.yaml
+++ b/resource_customizations/source.toolkit.fluxcd.io/HelmRepository/health_test.yaml
@@ -11,3 +11,7 @@ tests:
       status: Healthy
       message: Succeeded
     inputPath: testdata/healthy.yaml
+  - healthStatus:
+      status: Healthy
+      message: "Helm repositories of type 'oci' do not contain any information in the status."
+    inputPath: testdata/oci.yaml

--- a/resource_customizations/source.toolkit.fluxcd.io/HelmRepository/testdata/oci.yaml
+++ b/resource_customizations/source.toolkit.fluxcd.io/HelmRepository/testdata/oci.yaml
@@ -1,0 +1,10 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: podinfo
+  namespace: default
+spec:
+  type: "oci"
+  interval: 5m0s
+  url: oci://ghcr.io/stefanprodan/charts
+status: {}


### PR DESCRIPTION
According to https://fluxcd.io/flux/components/source/helmrepositories/#helm-oci-repository a HelmRepository of type oci doesn't emit any status information.
Therefore the health of such a resource is always in status "Progressing" with the message "Status unknown".

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
