### PR TITLE
chore(ci): run e2e tests on CNCF runner

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -407,7 +407,7 @@ jobs:
   test-e2e:
     name: Run end-to-end tests
     if: ${{ needs.changes.outputs.backend == 'true' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest-16-cores
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
At last test, this ran in ~29min instead of ~36min.

It's not much, but it adds up.