### PR TITLE
chore(refactor): move ignoreResourceUpdates defaults into code

### DIFF
--- a/cmd/argocd/commands/admin/settings_test.go
+++ b/cmd/argocd/commands/admin/settings_test.go
@@ -172,7 +172,8 @@ admissionregistration.k8s.io/MutatingWebhookConfiguration:
   jsonPointers:
   - /webhooks/0/clientConfig/caBundle`,
 			},
-			containsSummary: "2 resource overrides",
+			// The 8 default overrides + 1 configured above.
+			containsSummary: "9 resource overrides",
 		},
 	}
 	for name := range testCases {

--- a/docs/operator-manual/reconcile.md
+++ b/docs/operator-manual/reconcile.md
@@ -48,6 +48,18 @@ data:
     - /status
 ```
 
+The default configuration follows. Overriding the default configuration for one key will not affect the other defaults.
+Setting a key to any value, including an empty string, will override the default for that key.
+
+```yaml
+{!util/settings/default_ignore_resource_updates.yaml!}
+```
+
+It is also possible to configure `ignoreResourceUpdates` from within the top-level `resource.customizations` key. If
+an `ignoreResourceUpdates` configuration exists for a specific group and kind in both `resource.customizations` and
+`resource.customizations.ignoreResourceUpdates.<group>_<kind>`, the configuration in `resource.customizations.ignoreResourceUpdates.<group>_<kind>`
+takes precedence.
+
 ### Using ignoreDifferences to ignore reconcile
 
 By default, the existing system-level `ignoreDifferences` customizations will be added to ignore resource updates as well. This helps reduce config management by preventing you to copy all existing ignore differences configurations.

--- a/manifests/base/config/argocd-cm.yaml
+++ b/manifests/base/config/argocd-cm.yaml
@@ -6,56 +6,6 @@ metadata:
     app.kubernetes.io/name: argocd-cm
     app.kubernetes.io/part-of: argocd
 data:
-  ### Default configuration for ignoreResourceUpdates.
-  # The ignoreResourceUpdates list contains K8s resource's properties that are known to be frequently updated
-  # by controllers and operators. These resources, when watched by argo, will cause many unnecessary updates.
-  # Ignoring status for all resources. An update will still be sent if the status update causes the health to change.
-  resource.customizations.ignoreResourceUpdates.all: |
-    jsonPointers:
-      - /status
-  # Some Application fields are generated and not related to the application updates itself
-  # The Application itself is already watched by the controller lister, but this configuration is applied for apps of apps
-  resource.customizations.ignoreResourceUpdates.argoproj.io_Application: |
-    jqPathExpressions:
-      - '.metadata.annotations."notified.notifications.argoproj.io"'
-      - '.metadata.annotations."argocd.argoproj.io/refresh"'
-      - '.metadata.annotations."argocd.argoproj.io/hydrate"'
-      - '.operation'
-  resource.customizations.ignoreResourceUpdates.argoproj.io_Rollout: |
-    jqPathExpressions:
-      - '.metadata.annotations."notified.notifications.argoproj.io"'
-  # Legacy annotations used on HPA autoscaling/v1
-  resource.customizations.ignoreResourceUpdates.autoscaling_HorizontalPodAutoscaler: |
-    jqPathExpressions:
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/behavior"'
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/conditions"'
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/metrics"'
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/current-metrics"'
-  # Ignore the cluster-autoscaler status
-  resource.customizations.ignoreResourceUpdates.ConfigMap: |
-    jqPathExpressions:
-      # Ignore the cluster-autoscaler status
-      - '.metadata.annotations."cluster-autoscaler.kubernetes.io/last-updated"'
-      # Ignore the annotation of the legacy Leases election
-      - '.metadata.annotations."control-plane.alpha.kubernetes.io/leader"'
-  # Ignore the common scaling annotations
-  resource.customizations.ignoreResourceUpdates.apps_ReplicaSet: |
-    jqPathExpressions:
-      - '.metadata.annotations."deployment.kubernetes.io/desired-replicas"'
-      - '.metadata.annotations."deployment.kubernetes.io/max-replicas"'
-      - '.metadata.annotations."rollout.argoproj.io/desired-replicas"'
-  # Ignores update if EndpointSlice is not excluded globally
-  resource.customizations.ignoreResourceUpdates.discovery.k8s.io_EndpointSlice: |
-    jsonPointers:
-      - /metadata
-      - /endpoints
-      - /ports
-  # Ignores update if Endpoints is not excluded globally
-  resource.customizations.ignoreResourceUpdates.Endpoints: |
-    jsonPointers:
-      - /metadata
-      - /subsets
-
   ### Default configuration for exclusions.
   # The exclusion list are K8s resources that we assume will never be declared in Git,
   # and are never child objects of managed resources that need to be presented in the resource tree.

--- a/manifests/core-install-with-hydrator.yaml
+++ b/manifests/core-install-with-hydrator.yaml
@@ -24275,44 +24275,6 @@ subjects:
 ---
 apiVersion: v1
 data:
-  resource.customizations.ignoreResourceUpdates.ConfigMap: |
-    jqPathExpressions:
-      # Ignore the cluster-autoscaler status
-      - '.metadata.annotations."cluster-autoscaler.kubernetes.io/last-updated"'
-      # Ignore the annotation of the legacy Leases election
-      - '.metadata.annotations."control-plane.alpha.kubernetes.io/leader"'
-  resource.customizations.ignoreResourceUpdates.Endpoints: |
-    jsonPointers:
-      - /metadata
-      - /subsets
-  resource.customizations.ignoreResourceUpdates.all: |
-    jsonPointers:
-      - /status
-  resource.customizations.ignoreResourceUpdates.apps_ReplicaSet: |
-    jqPathExpressions:
-      - '.metadata.annotations."deployment.kubernetes.io/desired-replicas"'
-      - '.metadata.annotations."deployment.kubernetes.io/max-replicas"'
-      - '.metadata.annotations."rollout.argoproj.io/desired-replicas"'
-  resource.customizations.ignoreResourceUpdates.argoproj.io_Application: |
-    jqPathExpressions:
-      - '.metadata.annotations."notified.notifications.argoproj.io"'
-      - '.metadata.annotations."argocd.argoproj.io/refresh"'
-      - '.metadata.annotations."argocd.argoproj.io/hydrate"'
-      - '.operation'
-  resource.customizations.ignoreResourceUpdates.argoproj.io_Rollout: |
-    jqPathExpressions:
-      - '.metadata.annotations."notified.notifications.argoproj.io"'
-  resource.customizations.ignoreResourceUpdates.autoscaling_HorizontalPodAutoscaler: |
-    jqPathExpressions:
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/behavior"'
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/conditions"'
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/metrics"'
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/current-metrics"'
-  resource.customizations.ignoreResourceUpdates.discovery.k8s.io_EndpointSlice: |
-    jsonPointers:
-      - /metadata
-      - /endpoints
-      - /ports
   resource.exclusions: |
     ### Network resources created by the Kubernetes control plane and excluded to reduce the number of watched events and UI clutter
     - apiGroups:

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -24266,44 +24266,6 @@ subjects:
 ---
 apiVersion: v1
 data:
-  resource.customizations.ignoreResourceUpdates.ConfigMap: |
-    jqPathExpressions:
-      # Ignore the cluster-autoscaler status
-      - '.metadata.annotations."cluster-autoscaler.kubernetes.io/last-updated"'
-      # Ignore the annotation of the legacy Leases election
-      - '.metadata.annotations."control-plane.alpha.kubernetes.io/leader"'
-  resource.customizations.ignoreResourceUpdates.Endpoints: |
-    jsonPointers:
-      - /metadata
-      - /subsets
-  resource.customizations.ignoreResourceUpdates.all: |
-    jsonPointers:
-      - /status
-  resource.customizations.ignoreResourceUpdates.apps_ReplicaSet: |
-    jqPathExpressions:
-      - '.metadata.annotations."deployment.kubernetes.io/desired-replicas"'
-      - '.metadata.annotations."deployment.kubernetes.io/max-replicas"'
-      - '.metadata.annotations."rollout.argoproj.io/desired-replicas"'
-  resource.customizations.ignoreResourceUpdates.argoproj.io_Application: |
-    jqPathExpressions:
-      - '.metadata.annotations."notified.notifications.argoproj.io"'
-      - '.metadata.annotations."argocd.argoproj.io/refresh"'
-      - '.metadata.annotations."argocd.argoproj.io/hydrate"'
-      - '.operation'
-  resource.customizations.ignoreResourceUpdates.argoproj.io_Rollout: |
-    jqPathExpressions:
-      - '.metadata.annotations."notified.notifications.argoproj.io"'
-  resource.customizations.ignoreResourceUpdates.autoscaling_HorizontalPodAutoscaler: |
-    jqPathExpressions:
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/behavior"'
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/conditions"'
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/metrics"'
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/current-metrics"'
-  resource.customizations.ignoreResourceUpdates.discovery.k8s.io_EndpointSlice: |
-    jsonPointers:
-      - /metadata
-      - /endpoints
-      - /ports
   resource.exclusions: |
     ### Network resources created by the Kubernetes control plane and excluded to reduce the number of watched events and UI clutter
     - apiGroups:

--- a/manifests/ha/install-with-hydrator.yaml
+++ b/manifests/ha/install-with-hydrator.yaml
@@ -24668,44 +24668,6 @@ subjects:
 ---
 apiVersion: v1
 data:
-  resource.customizations.ignoreResourceUpdates.ConfigMap: |
-    jqPathExpressions:
-      # Ignore the cluster-autoscaler status
-      - '.metadata.annotations."cluster-autoscaler.kubernetes.io/last-updated"'
-      # Ignore the annotation of the legacy Leases election
-      - '.metadata.annotations."control-plane.alpha.kubernetes.io/leader"'
-  resource.customizations.ignoreResourceUpdates.Endpoints: |
-    jsonPointers:
-      - /metadata
-      - /subsets
-  resource.customizations.ignoreResourceUpdates.all: |
-    jsonPointers:
-      - /status
-  resource.customizations.ignoreResourceUpdates.apps_ReplicaSet: |
-    jqPathExpressions:
-      - '.metadata.annotations."deployment.kubernetes.io/desired-replicas"'
-      - '.metadata.annotations."deployment.kubernetes.io/max-replicas"'
-      - '.metadata.annotations."rollout.argoproj.io/desired-replicas"'
-  resource.customizations.ignoreResourceUpdates.argoproj.io_Application: |
-    jqPathExpressions:
-      - '.metadata.annotations."notified.notifications.argoproj.io"'
-      - '.metadata.annotations."argocd.argoproj.io/refresh"'
-      - '.metadata.annotations."argocd.argoproj.io/hydrate"'
-      - '.operation'
-  resource.customizations.ignoreResourceUpdates.argoproj.io_Rollout: |
-    jqPathExpressions:
-      - '.metadata.annotations."notified.notifications.argoproj.io"'
-  resource.customizations.ignoreResourceUpdates.autoscaling_HorizontalPodAutoscaler: |
-    jqPathExpressions:
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/behavior"'
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/conditions"'
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/metrics"'
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/current-metrics"'
-  resource.customizations.ignoreResourceUpdates.discovery.k8s.io_EndpointSlice: |
-    jsonPointers:
-      - /metadata
-      - /endpoints
-      - /ports
   resource.exclusions: |
     ### Network resources created by the Kubernetes control plane and excluded to reduce the number of watched events and UI clutter
     - apiGroups:

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -24659,44 +24659,6 @@ subjects:
 ---
 apiVersion: v1
 data:
-  resource.customizations.ignoreResourceUpdates.ConfigMap: |
-    jqPathExpressions:
-      # Ignore the cluster-autoscaler status
-      - '.metadata.annotations."cluster-autoscaler.kubernetes.io/last-updated"'
-      # Ignore the annotation of the legacy Leases election
-      - '.metadata.annotations."control-plane.alpha.kubernetes.io/leader"'
-  resource.customizations.ignoreResourceUpdates.Endpoints: |
-    jsonPointers:
-      - /metadata
-      - /subsets
-  resource.customizations.ignoreResourceUpdates.all: |
-    jsonPointers:
-      - /status
-  resource.customizations.ignoreResourceUpdates.apps_ReplicaSet: |
-    jqPathExpressions:
-      - '.metadata.annotations."deployment.kubernetes.io/desired-replicas"'
-      - '.metadata.annotations."deployment.kubernetes.io/max-replicas"'
-      - '.metadata.annotations."rollout.argoproj.io/desired-replicas"'
-  resource.customizations.ignoreResourceUpdates.argoproj.io_Application: |
-    jqPathExpressions:
-      - '.metadata.annotations."notified.notifications.argoproj.io"'
-      - '.metadata.annotations."argocd.argoproj.io/refresh"'
-      - '.metadata.annotations."argocd.argoproj.io/hydrate"'
-      - '.operation'
-  resource.customizations.ignoreResourceUpdates.argoproj.io_Rollout: |
-    jqPathExpressions:
-      - '.metadata.annotations."notified.notifications.argoproj.io"'
-  resource.customizations.ignoreResourceUpdates.autoscaling_HorizontalPodAutoscaler: |
-    jqPathExpressions:
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/behavior"'
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/conditions"'
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/metrics"'
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/current-metrics"'
-  resource.customizations.ignoreResourceUpdates.discovery.k8s.io_EndpointSlice: |
-    jsonPointers:
-      - /metadata
-      - /endpoints
-      - /ports
   resource.exclusions: |
     ### Network resources created by the Kubernetes control plane and excluded to reduce the number of watched events and UI clutter
     - apiGroups:

--- a/manifests/ha/namespace-install-with-hydrator.yaml
+++ b/manifests/ha/namespace-install-with-hydrator.yaml
@@ -473,44 +473,6 @@ subjects:
 ---
 apiVersion: v1
 data:
-  resource.customizations.ignoreResourceUpdates.ConfigMap: |
-    jqPathExpressions:
-      # Ignore the cluster-autoscaler status
-      - '.metadata.annotations."cluster-autoscaler.kubernetes.io/last-updated"'
-      # Ignore the annotation of the legacy Leases election
-      - '.metadata.annotations."control-plane.alpha.kubernetes.io/leader"'
-  resource.customizations.ignoreResourceUpdates.Endpoints: |
-    jsonPointers:
-      - /metadata
-      - /subsets
-  resource.customizations.ignoreResourceUpdates.all: |
-    jsonPointers:
-      - /status
-  resource.customizations.ignoreResourceUpdates.apps_ReplicaSet: |
-    jqPathExpressions:
-      - '.metadata.annotations."deployment.kubernetes.io/desired-replicas"'
-      - '.metadata.annotations."deployment.kubernetes.io/max-replicas"'
-      - '.metadata.annotations."rollout.argoproj.io/desired-replicas"'
-  resource.customizations.ignoreResourceUpdates.argoproj.io_Application: |
-    jqPathExpressions:
-      - '.metadata.annotations."notified.notifications.argoproj.io"'
-      - '.metadata.annotations."argocd.argoproj.io/refresh"'
-      - '.metadata.annotations."argocd.argoproj.io/hydrate"'
-      - '.operation'
-  resource.customizations.ignoreResourceUpdates.argoproj.io_Rollout: |
-    jqPathExpressions:
-      - '.metadata.annotations."notified.notifications.argoproj.io"'
-  resource.customizations.ignoreResourceUpdates.autoscaling_HorizontalPodAutoscaler: |
-    jqPathExpressions:
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/behavior"'
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/conditions"'
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/metrics"'
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/current-metrics"'
-  resource.customizations.ignoreResourceUpdates.discovery.k8s.io_EndpointSlice: |
-    jsonPointers:
-      - /metadata
-      - /endpoints
-      - /ports
   resource.exclusions: |
     ### Network resources created by the Kubernetes control plane and excluded to reduce the number of watched events and UI clutter
     - apiGroups:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -464,44 +464,6 @@ subjects:
 ---
 apiVersion: v1
 data:
-  resource.customizations.ignoreResourceUpdates.ConfigMap: |
-    jqPathExpressions:
-      # Ignore the cluster-autoscaler status
-      - '.metadata.annotations."cluster-autoscaler.kubernetes.io/last-updated"'
-      # Ignore the annotation of the legacy Leases election
-      - '.metadata.annotations."control-plane.alpha.kubernetes.io/leader"'
-  resource.customizations.ignoreResourceUpdates.Endpoints: |
-    jsonPointers:
-      - /metadata
-      - /subsets
-  resource.customizations.ignoreResourceUpdates.all: |
-    jsonPointers:
-      - /status
-  resource.customizations.ignoreResourceUpdates.apps_ReplicaSet: |
-    jqPathExpressions:
-      - '.metadata.annotations."deployment.kubernetes.io/desired-replicas"'
-      - '.metadata.annotations."deployment.kubernetes.io/max-replicas"'
-      - '.metadata.annotations."rollout.argoproj.io/desired-replicas"'
-  resource.customizations.ignoreResourceUpdates.argoproj.io_Application: |
-    jqPathExpressions:
-      - '.metadata.annotations."notified.notifications.argoproj.io"'
-      - '.metadata.annotations."argocd.argoproj.io/refresh"'
-      - '.metadata.annotations."argocd.argoproj.io/hydrate"'
-      - '.operation'
-  resource.customizations.ignoreResourceUpdates.argoproj.io_Rollout: |
-    jqPathExpressions:
-      - '.metadata.annotations."notified.notifications.argoproj.io"'
-  resource.customizations.ignoreResourceUpdates.autoscaling_HorizontalPodAutoscaler: |
-    jqPathExpressions:
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/behavior"'
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/conditions"'
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/metrics"'
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/current-metrics"'
-  resource.customizations.ignoreResourceUpdates.discovery.k8s.io_EndpointSlice: |
-    jsonPointers:
-      - /metadata
-      - /endpoints
-      - /ports
   resource.exclusions: |
     ### Network resources created by the Kubernetes control plane and excluded to reduce the number of watched events and UI clutter
     - apiGroups:

--- a/manifests/install-with-hydrator.yaml
+++ b/manifests/install-with-hydrator.yaml
@@ -24619,44 +24619,6 @@ subjects:
 ---
 apiVersion: v1
 data:
-  resource.customizations.ignoreResourceUpdates.ConfigMap: |
-    jqPathExpressions:
-      # Ignore the cluster-autoscaler status
-      - '.metadata.annotations."cluster-autoscaler.kubernetes.io/last-updated"'
-      # Ignore the annotation of the legacy Leases election
-      - '.metadata.annotations."control-plane.alpha.kubernetes.io/leader"'
-  resource.customizations.ignoreResourceUpdates.Endpoints: |
-    jsonPointers:
-      - /metadata
-      - /subsets
-  resource.customizations.ignoreResourceUpdates.all: |
-    jsonPointers:
-      - /status
-  resource.customizations.ignoreResourceUpdates.apps_ReplicaSet: |
-    jqPathExpressions:
-      - '.metadata.annotations."deployment.kubernetes.io/desired-replicas"'
-      - '.metadata.annotations."deployment.kubernetes.io/max-replicas"'
-      - '.metadata.annotations."rollout.argoproj.io/desired-replicas"'
-  resource.customizations.ignoreResourceUpdates.argoproj.io_Application: |
-    jqPathExpressions:
-      - '.metadata.annotations."notified.notifications.argoproj.io"'
-      - '.metadata.annotations."argocd.argoproj.io/refresh"'
-      - '.metadata.annotations."argocd.argoproj.io/hydrate"'
-      - '.operation'
-  resource.customizations.ignoreResourceUpdates.argoproj.io_Rollout: |
-    jqPathExpressions:
-      - '.metadata.annotations."notified.notifications.argoproj.io"'
-  resource.customizations.ignoreResourceUpdates.autoscaling_HorizontalPodAutoscaler: |
-    jqPathExpressions:
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/behavior"'
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/conditions"'
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/metrics"'
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/current-metrics"'
-  resource.customizations.ignoreResourceUpdates.discovery.k8s.io_EndpointSlice: |
-    jsonPointers:
-      - /metadata
-      - /endpoints
-      - /ports
   resource.exclusions: |
     ### Network resources created by the Kubernetes control plane and excluded to reduce the number of watched events and UI clutter
     - apiGroups:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -24610,44 +24610,6 @@ subjects:
 ---
 apiVersion: v1
 data:
-  resource.customizations.ignoreResourceUpdates.ConfigMap: |
-    jqPathExpressions:
-      # Ignore the cluster-autoscaler status
-      - '.metadata.annotations."cluster-autoscaler.kubernetes.io/last-updated"'
-      # Ignore the annotation of the legacy Leases election
-      - '.metadata.annotations."control-plane.alpha.kubernetes.io/leader"'
-  resource.customizations.ignoreResourceUpdates.Endpoints: |
-    jsonPointers:
-      - /metadata
-      - /subsets
-  resource.customizations.ignoreResourceUpdates.all: |
-    jsonPointers:
-      - /status
-  resource.customizations.ignoreResourceUpdates.apps_ReplicaSet: |
-    jqPathExpressions:
-      - '.metadata.annotations."deployment.kubernetes.io/desired-replicas"'
-      - '.metadata.annotations."deployment.kubernetes.io/max-replicas"'
-      - '.metadata.annotations."rollout.argoproj.io/desired-replicas"'
-  resource.customizations.ignoreResourceUpdates.argoproj.io_Application: |
-    jqPathExpressions:
-      - '.metadata.annotations."notified.notifications.argoproj.io"'
-      - '.metadata.annotations."argocd.argoproj.io/refresh"'
-      - '.metadata.annotations."argocd.argoproj.io/hydrate"'
-      - '.operation'
-  resource.customizations.ignoreResourceUpdates.argoproj.io_Rollout: |
-    jqPathExpressions:
-      - '.metadata.annotations."notified.notifications.argoproj.io"'
-  resource.customizations.ignoreResourceUpdates.autoscaling_HorizontalPodAutoscaler: |
-    jqPathExpressions:
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/behavior"'
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/conditions"'
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/metrics"'
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/current-metrics"'
-  resource.customizations.ignoreResourceUpdates.discovery.k8s.io_EndpointSlice: |
-    jsonPointers:
-      - /metadata
-      - /endpoints
-      - /ports
   resource.exclusions: |
     ### Network resources created by the Kubernetes control plane and excluded to reduce the number of watched events and UI clutter
     - apiGroups:

--- a/manifests/namespace-install-with-hydrator.yaml
+++ b/manifests/namespace-install-with-hydrator.yaml
@@ -424,44 +424,6 @@ subjects:
 ---
 apiVersion: v1
 data:
-  resource.customizations.ignoreResourceUpdates.ConfigMap: |
-    jqPathExpressions:
-      # Ignore the cluster-autoscaler status
-      - '.metadata.annotations."cluster-autoscaler.kubernetes.io/last-updated"'
-      # Ignore the annotation of the legacy Leases election
-      - '.metadata.annotations."control-plane.alpha.kubernetes.io/leader"'
-  resource.customizations.ignoreResourceUpdates.Endpoints: |
-    jsonPointers:
-      - /metadata
-      - /subsets
-  resource.customizations.ignoreResourceUpdates.all: |
-    jsonPointers:
-      - /status
-  resource.customizations.ignoreResourceUpdates.apps_ReplicaSet: |
-    jqPathExpressions:
-      - '.metadata.annotations."deployment.kubernetes.io/desired-replicas"'
-      - '.metadata.annotations."deployment.kubernetes.io/max-replicas"'
-      - '.metadata.annotations."rollout.argoproj.io/desired-replicas"'
-  resource.customizations.ignoreResourceUpdates.argoproj.io_Application: |
-    jqPathExpressions:
-      - '.metadata.annotations."notified.notifications.argoproj.io"'
-      - '.metadata.annotations."argocd.argoproj.io/refresh"'
-      - '.metadata.annotations."argocd.argoproj.io/hydrate"'
-      - '.operation'
-  resource.customizations.ignoreResourceUpdates.argoproj.io_Rollout: |
-    jqPathExpressions:
-      - '.metadata.annotations."notified.notifications.argoproj.io"'
-  resource.customizations.ignoreResourceUpdates.autoscaling_HorizontalPodAutoscaler: |
-    jqPathExpressions:
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/behavior"'
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/conditions"'
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/metrics"'
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/current-metrics"'
-  resource.customizations.ignoreResourceUpdates.discovery.k8s.io_EndpointSlice: |
-    jsonPointers:
-      - /metadata
-      - /endpoints
-      - /ports
   resource.exclusions: |
     ### Network resources created by the Kubernetes control plane and excluded to reduce the number of watched events and UI clutter
     - apiGroups:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -415,44 +415,6 @@ subjects:
 ---
 apiVersion: v1
 data:
-  resource.customizations.ignoreResourceUpdates.ConfigMap: |
-    jqPathExpressions:
-      # Ignore the cluster-autoscaler status
-      - '.metadata.annotations."cluster-autoscaler.kubernetes.io/last-updated"'
-      # Ignore the annotation of the legacy Leases election
-      - '.metadata.annotations."control-plane.alpha.kubernetes.io/leader"'
-  resource.customizations.ignoreResourceUpdates.Endpoints: |
-    jsonPointers:
-      - /metadata
-      - /subsets
-  resource.customizations.ignoreResourceUpdates.all: |
-    jsonPointers:
-      - /status
-  resource.customizations.ignoreResourceUpdates.apps_ReplicaSet: |
-    jqPathExpressions:
-      - '.metadata.annotations."deployment.kubernetes.io/desired-replicas"'
-      - '.metadata.annotations."deployment.kubernetes.io/max-replicas"'
-      - '.metadata.annotations."rollout.argoproj.io/desired-replicas"'
-  resource.customizations.ignoreResourceUpdates.argoproj.io_Application: |
-    jqPathExpressions:
-      - '.metadata.annotations."notified.notifications.argoproj.io"'
-      - '.metadata.annotations."argocd.argoproj.io/refresh"'
-      - '.metadata.annotations."argocd.argoproj.io/hydrate"'
-      - '.operation'
-  resource.customizations.ignoreResourceUpdates.argoproj.io_Rollout: |
-    jqPathExpressions:
-      - '.metadata.annotations."notified.notifications.argoproj.io"'
-  resource.customizations.ignoreResourceUpdates.autoscaling_HorizontalPodAutoscaler: |
-    jqPathExpressions:
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/behavior"'
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/conditions"'
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/metrics"'
-      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/current-metrics"'
-  resource.customizations.ignoreResourceUpdates.discovery.k8s.io_EndpointSlice: |
-    jsonPointers:
-      - /metadata
-      - /endpoints
-      - /ports
   resource.exclusions: |
     ### Network resources created by the Kubernetes control plane and excluded to reduce the number of watched events and UI clutter
     - apiGroups:

--- a/util/settings/default_ignore_resource_updates.go
+++ b/util/settings/default_ignore_resource_updates.go
@@ -1,0 +1,20 @@
+package settings
+
+import (
+	_ "embed"
+
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed default_ignore_resource_updates.yaml
+var defaultIgnoreResourceUpdatesYaml []byte
+
+// defaultIgnoreResourceUpdates holds the default map of resource-specific ignoreResourceUpdates configurations.
+var defaultIgnoreResourceUpdates map[string]string
+
+func init() {
+	err := yaml.Unmarshal(defaultIgnoreResourceUpdatesYaml, &defaultIgnoreResourceUpdates)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/util/settings/default_ignore_resource_updates.yaml
+++ b/util/settings/default_ignore_resource_updates.yaml
@@ -1,0 +1,49 @@
+### Default configuration for ignoreResourceUpdates.
+# The ignoreResourceUpdates list contains K8s resource's properties that are known to be frequently updated
+# by controllers and operators. These resources, when watched by argo, will cause many unnecessary updates.
+# Ignoring status for all resources. An update will still be sent if the status update causes the health to change.
+resource.customizations.ignoreResourceUpdates.all: |
+  jsonPointers:
+    - /status
+# Some Application fields are generated and not related to the application updates itself
+# The Application itself is already watched by the controller lister, but this configuration is applied for apps of apps
+resource.customizations.ignoreResourceUpdates.argoproj.io_Application: |
+  jqPathExpressions:
+    - '.metadata.annotations."notified.notifications.argoproj.io"'
+    - '.metadata.annotations."argocd.argoproj.io/refresh"'
+    - '.metadata.annotations."argocd.argoproj.io/hydrate"'
+    - '.operation'
+resource.customizations.ignoreResourceUpdates.argoproj.io_Rollout: |
+  jqPathExpressions:
+    - '.metadata.annotations."notified.notifications.argoproj.io"'
+# Legacy annotations used on HPA autoscaling/v1
+resource.customizations.ignoreResourceUpdates.autoscaling_HorizontalPodAutoscaler: |
+  jqPathExpressions:
+    - '.metadata.annotations."autoscaling.alpha.kubernetes.io/behavior"'
+    - '.metadata.annotations."autoscaling.alpha.kubernetes.io/conditions"'
+    - '.metadata.annotations."autoscaling.alpha.kubernetes.io/metrics"'
+    - '.metadata.annotations."autoscaling.alpha.kubernetes.io/current-metrics"'
+# Ignore the cluster-autoscaler status
+resource.customizations.ignoreResourceUpdates.ConfigMap: |
+  jqPathExpressions:
+    # Ignore the cluster-autoscaler status
+    - '.metadata.annotations."cluster-autoscaler.kubernetes.io/last-updated"'
+    # Ignore the annotation of the legacy Leases election
+    - '.metadata.annotations."control-plane.alpha.kubernetes.io/leader"'
+# Ignore the common scaling annotations
+resource.customizations.ignoreResourceUpdates.apps_ReplicaSet: |
+  jqPathExpressions:
+    - '.metadata.annotations."deployment.kubernetes.io/desired-replicas"'
+    - '.metadata.annotations."deployment.kubernetes.io/max-replicas"'
+    - '.metadata.annotations."rollout.argoproj.io/desired-replicas"'
+# Ignores update if EndpointSlice is not excluded globally
+resource.customizations.ignoreResourceUpdates.discovery.k8s.io_EndpointSlice: |
+  jsonPointers:
+    - /metadata
+    - /endpoints
+    - /ports
+# Ignores update if Endpoints is not excluded globally
+resource.customizations.ignoreResourceUpdates.Endpoints: |
+  jsonPointers:
+    - /metadata
+    - /subsets

--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -973,6 +973,10 @@ func (mgr *SettingsManager) GetResourceOverrides() (map[string]v1alpha1.Resource
 		}
 	}
 
+	err = mgr.appendResourceOverridesFromSplitKeys(defaultIgnoreResourceUpdates, resourceOverrides)
+	if err != nil {
+		return nil, fmt.Errorf("failed to apply default ignoreResourceUpdates: %w", err)
+	}
 	err = mgr.appendResourceOverridesFromSplitKeys(argoCDCM.Data, resourceOverrides)
 	if err != nil {
 		return nil, err

--- a/util/settings/settings_test.go
+++ b/util/settings/settings_test.go
@@ -294,9 +294,14 @@ func TestGetIsIgnoreResourceUpdatesEnabledFalse(t *testing.T) {
 }
 
 func TestGetResourceOverrides(t *testing.T) {
-	ignoreStatus := v1alpha1.ResourceOverride{IgnoreDifferences: v1alpha1.OverrideIgnoreDiff{
-		JSONPointers: []string{"/status"},
-	}}
+	ignoreStatus := v1alpha1.ResourceOverride{
+		IgnoreDifferences: v1alpha1.OverrideIgnoreDiff{
+			JSONPointers: []string{"/status"},
+		},
+		IgnoreResourceUpdates: v1alpha1.OverrideIgnoreDiff{
+			JSONPointers: []string{"/status"},
+		},
+	}
 	crdGK := "apiextensions.k8s.io/CustomResourceDefinition"
 
 	_, settingsManager := fixtures(map[string]string{
@@ -389,7 +394,9 @@ func TestGetResourceOverrides(t *testing.T) {
 	})
 	overrides, err = settingsManager.GetResourceOverrides()
 	require.NoError(t, err)
-	assert.Empty(t, overrides)
+	for _, o := range overrides {
+		assert.Empty(t, o.IgnoreDifferences)
+	}
 
 	// with value non-string false, status of no objects should be ignored
 	_, settingsManager = fixtures(map[string]string{
@@ -398,7 +405,9 @@ func TestGetResourceOverrides(t *testing.T) {
 	})
 	overrides, err = settingsManager.GetResourceOverrides()
 	require.NoError(t, err)
-	assert.Empty(t, overrides)
+	for _, o := range overrides {
+		assert.Empty(t, o.IgnoreDifferences)
+	}
 
 	// with value none, status of no objects should be ignored
 	_, settingsManager = fixtures(map[string]string{
@@ -407,7 +416,9 @@ func TestGetResourceOverrides(t *testing.T) {
 	})
 	overrides, err = settingsManager.GetResourceOverrides()
 	require.NoError(t, err)
-	assert.Empty(t, overrides)
+	for _, o := range overrides {
+		assert.Empty(t, o.IgnoreDifferences)
+	}
 }
 
 func TestGetResourceOverridesHealthWithWildcard(t *testing.T) {
@@ -423,7 +434,8 @@ func TestGetResourceOverridesHealthWithWildcard(t *testing.T) {
 
 		overrides, err := settingsManager.GetResourceOverrides()
 		require.NoError(t, err)
-		assert.Len(t, overrides, 2)
+		// Nine default overrides + one from the test
+		assert.Len(t, overrides, 9)
 		assert.Equal(t, "foo", overrides["*.aws.crossplane.io/*"].HealthLua)
 	})
 }
@@ -435,7 +447,7 @@ func TestSettingsManager_GetResourceOverrides_with_empty_string(t *testing.T) {
 	overrides, err := settingsManager.GetResourceOverrides()
 	require.NoError(t, err)
 
-	assert.Len(t, overrides, 1)
+	assert.Len(t, overrides, len(defaultIgnoreResourceUpdates))
 }
 
 func TestGetResourceOverrides_with_splitted_keys(t *testing.T) {
@@ -467,7 +479,7 @@ func TestGetResourceOverrides_with_splitted_keys(t *testing.T) {
 
 		overrides, err := settingsManager.GetResourceOverrides()
 		require.NoError(t, err)
-		assert.Len(t, overrides, 4)
+		assert.Len(t, overrides, len(defaultIgnoreResourceUpdates)+4)
 		assert.Len(t, overrides["admissionregistration.k8s.io/MutatingWebhookConfiguration"].IgnoreDifferences.JSONPointers, 1)
 		assert.Equal(t, "foo", overrides["admissionregistration.k8s.io/MutatingWebhookConfiguration"].IgnoreDifferences.JSONPointers[0])
 		assert.Len(t, overrides["admissionregistration.k8s.io/MutatingWebhookConfiguration"].IgnoreResourceUpdates.JSONPointers, 1)
@@ -516,7 +528,7 @@ func TestGetResourceOverrides_with_splitted_keys(t *testing.T) {
 
 		overrides, err := settingsManager.GetResourceOverrides()
 		require.NoError(t, err)
-		assert.Len(t, overrides, 8)
+		assert.Len(t, overrides, 15)
 		assert.Len(t, overrides["admissionregistration.k8s.io/MutatingWebhookConfiguration"].IgnoreDifferences.JSONPointers, 1)
 		assert.Equal(t, "bar", overrides["admissionregistration.k8s.io/MutatingWebhookConfiguration"].IgnoreDifferences.JSONPointers[0])
 		assert.Len(t, overrides["admissionregistration.k8s.io/MutatingWebhookConfiguration"].IgnoreResourceUpdates.JSONPointers, 1)
@@ -553,9 +565,8 @@ func mergemaps(mapA map[string]string, mapB map[string]string) map[string]string
 
 func TestGetIgnoreResourceUpdatesOverrides(t *testing.T) {
 	allDefault := v1alpha1.ResourceOverride{IgnoreDifferences: v1alpha1.OverrideIgnoreDiff{
-		JSONPointers: []string{"/metadata/resourceVersion", "/metadata/generation", "/metadata/managedFields"},
+		JSONPointers: []string{"/status", "/metadata/resourceVersion", "/metadata/generation", "/metadata/managedFields"},
 	}}
-	allGK := "*/*"
 
 	testCustomizations := map[string]string{
 		"resource.compareoptions": `
@@ -581,7 +592,7 @@ func TestGetIgnoreResourceUpdatesOverrides(t *testing.T) {
 	require.NoError(t, err)
 
 	// default overrides should always be present
-	allOverrides := overrides[allGK]
+	allOverrides := overrides["*/*"]
 	assert.NotNil(t, allOverrides)
 	assert.Equal(t, allDefault, allOverrides)
 


### PR DESCRIPTION
Partially fixes https://github.com/argoproj/argo-cd/issues/24394

This moves one of the groups of default configuration that currently resides in argocd-cm into code to align with how other config options work.

The defaults are published in the docs for easy reference: https://argo-cd--24330.org.readthedocs.build/en/24330/operator-manual/reconcile/#system-level-configuration

This is a minor breaking change. If someone has removed one or more of the default configs' keys from argocd-cm, this change will cause the defaults to start being used. The workaround would be for the user to set the key in argocd-cm but make the value an empty string.