### PR TITLE
fix(hydrator): handle empty path

### DIFF
--- a/commitserver/commit/hydratorhelper.go
+++ b/commitserver/commit/hydratorhelper.go
@@ -71,9 +71,12 @@ func WriteForPaths(root *os.Root, repoUrl, drySha string, dryCommitMetadata *app
 			hydratePath = ""
 		}
 
-		err = root.MkdirAll(hydratePath, 0o755)
-		if err != nil {
-			return fmt.Errorf("failed to create path: %w", err)
+		// Only create directory if path is not empty (root directory case)
+		if hydratePath != "" {
+			err = root.MkdirAll(hydratePath, 0o755)
+			if err != nil {
+				return fmt.Errorf("failed to create path: %w", err)
+			}
 		}
 
 		// Write the manifests


### PR DESCRIPTION
Reopening since there were DCO issues: https://github.com/argoproj/argo-cd/pull/24333

Not including unit tests, because I'm going to open another PR to entirely disallow hydrating to the root of the destination branch.