### PR TITLE
feat(server): pass authenticated userId as header to extensions

### DIFF
--- a/docs/developer-guide/extensions/proxy-extensions.md
+++ b/docs/developer-guide/extensions/proxy-extensions.md
@@ -311,7 +311,8 @@ section for more details.
 
 #### `Argocd-Username`
 
-Will be populated with the username logged in Argo CD.
+Will be populated with the username logged in Argo CD. This is primarily useful for display purposes. 
+To identify a user for programmatic needs, `Argocd-User-Id` is probably a better choice.
 
 #### `Argocd-User-Id`
 

--- a/docs/developer-guide/extensions/proxy-extensions.md
+++ b/docs/developer-guide/extensions/proxy-extensions.md
@@ -1,7 +1,8 @@
 # Proxy Extensions
 
 !!! warning "Beta Feature (Since 2.7.0)"
-    This feature is in the [Beta](https://github.com/argoproj/argoproj/blob/main/community/feature-status.md#beta) stage. 
+
+    This feature is in the [Beta](https://github.com/argoproj/argoproj/blob/main/community/feature-status.md#beta) stage.
     It is generally considered stable, but there may be unhandled edge cases.
 
 ## Overview
@@ -29,7 +30,7 @@ metadata:
   name: argocd-cmd-params-cm
   namespace: argocd
 data:
-  server.enable.proxy.extension: "true"
+  server.enable.proxy.extension: 'true'
 ```
 
 Once the proxy extension is enabled, it can be configured in the main
@@ -102,11 +103,12 @@ respect the new configuration.
 
 Every configuration entry is explained below:
 
-#### `extensions` (*list*)
+#### `extensions` (_list_)
 
 Defines configurations for all extensions enabled.
 
-#### `extensions.name` (*string*)
+#### `extensions.name` (_string_)
+
 (mandatory)
 
 Defines the endpoint that will be used to register the extension
@@ -116,54 +118,61 @@ following url:
 
     <argocd-host>/extensions/my-extension
 
-#### `extensions.backend.connectionTimeout` (*duration string*)
+#### `extensions.backend.connectionTimeout` (_duration string_)
+
 (optional. Default: 2s)
 
 Is the maximum amount of time a dial to the extension server will wait
-for a connect to complete. 
+for a connect to complete.
 
-#### `extensions.backend.keepAlive` (*duration string*)
+#### `extensions.backend.keepAlive` (_duration string_)
+
 (optional. Default: 15s)
 
 Specifies the interval between keep-alive probes for an active network
 connection between the API server and the extension server.
 
-#### `extensions.backend.idleConnectionTimeout` (*duration string*)
+#### `extensions.backend.idleConnectionTimeout` (_duration string_)
+
 (optional. Default: 60s)
 
 Is the maximum amount of time an idle (keep-alive) connection between
 the API server and the extension server will remain idle before
 closing itself.
 
-#### `extensions.backend.maxIdleConnections` (*int*)
+#### `extensions.backend.maxIdleConnections` (_int_)
+
 (optional. Default: 30)
 
 Controls the maximum number of idle (keep-alive) connections between
 the API server and the extension server.
 
-#### `extensions.backend.services` (*list*)
+#### `extensions.backend.services` (_list_)
 
 Defines a list with backend url by cluster.
 
-#### `extensions.backend.services.url` (*string*)
+#### `extensions.backend.services.url` (_string_)
+
 (mandatory)
 
 Is the address where the extension backend must be available.
 
-#### `extensions.backend.services.headers` (*list*)
+#### `extensions.backend.services.headers` (_list_)
 
 If provided, the headers list will be added on all outgoing requests
 for this service config. Existing headers in the incoming request with
 the same name will be overridden by the one in this list. Reserved header
 names will be ignored (see the [headers](#incoming-request-headers) below).
 
-#### `extensions.backend.services.headers.name` (*string*)
+#### `extensions.backend.services.headers.name` (_string_)
+
 (mandatory)
 
 Defines the name of the header. It is a mandatory field if a header is
 provided.
 
-#### `extensions.backend.services.headers.value` (*string*)
+#### `extensions.backend.services.headers.value` (_string_)
+
 (mandatory)
 
 Defines the value of the header. It is a mandatory field if a header is
@@ -178,7 +187,8 @@ Example:
 In the example above, the value will be replaced with the one from
 the argocd-secret with key 'some.argocd.secret.key'.
 
-#### `extensions.backend.services.cluster` (*object*)
+#### `extensions.backend.services.cluster` (_object_)
+
 (optional)
 
 If provided, and multiple services are configured, will have to match
@@ -190,17 +200,19 @@ send requests to the proper backend service. If only one backend
 service is configured, this field is ignored, and all requests are
 forwarded to the configured one.
 
-#### `extensions.backend.services.cluster.name` (*string*)
+#### `extensions.backend.services.cluster.name` (_string_)
+
 (optional)
 
 It will be matched with the value from
 `Application.Spec.Destination.Name`
 
-#### `extensions.backend.services.cluster.server` (*string*)
+#### `extensions.backend.services.cluster.server` (_string_)
+
 (optional)
 
 It will be matched with the value from
-`Application.Spec.Destination.Server`. 
+`Application.Spec.Destination.Server`.
 
 ## Usage
 
@@ -245,7 +257,7 @@ Argo CD UI keeps the authentication token stored in a cookie
 (`argocd.token`). This value needs to be sent in the `Cookie` header
 so the API server can validate its authenticity.
 
-Example: 
+Example:
 
     Cookie: argocd.token=eyJhbGciOiJIUzI1Ni...
 
@@ -301,9 +313,13 @@ section for more details.
 
 Will be populated with the username logged in Argo CD.
 
+#### `Argocd-User-Id`
+
+Will be populated with the internal user id, most often defined by the `sub` claim, logged in Argo CD.
+
 #### `Argocd-User-Groups`
 
-Will be populated with the 'groups' claim from the user logged in Argo CD.
+Will be populated with the configured RBAC scopes, most often the `groups` claim, from the user logged in Argo CD.
 
 ### Multi Backend Use-Case
 

--- a/server/extension/mocks/UserGetter.go
+++ b/server/extension/mocks/UserGetter.go
@@ -90,12 +90,12 @@ func (_c *UserGetter_GetGroups_Call) RunAndReturn(run func(ctx context.Context) 
 	return _c
 }
 
-// GetUser provides a mock function for the type UserGetter
-func (_mock *UserGetter) GetUser(ctx context.Context) string {
+// GetUserId provides a mock function for the type UserGetter
+func (_mock *UserGetter) GetUserId(ctx context.Context) string {
 	ret := _mock.Called(ctx)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetUser")
+		panic("no return value specified for GetUserId")
 	}
 
 	var r0 string
@@ -107,18 +107,18 @@ func (_mock *UserGetter) GetUser(ctx context.Context) string {
 	return r0
 }
 
-// UserGetter_GetUser_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUser'
-type UserGetter_GetUser_Call struct {
+// UserGetter_GetUserId_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUserId'
+type UserGetter_GetUserId_Call struct {
 	*mock.Call
 }
 
-// GetUser is a helper method to define mock.On call
+// GetUserId is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *UserGetter_Expecter) GetUser(ctx interface{}) *UserGetter_GetUser_Call {
-	return &UserGetter_GetUser_Call{Call: _e.mock.On("GetUser", ctx)}
+func (_e *UserGetter_Expecter) GetUserId(ctx interface{}) *UserGetter_GetUserId_Call {
+	return &UserGetter_GetUserId_Call{Call: _e.mock.On("GetUserId", ctx)}
 }
 
-func (_c *UserGetter_GetUser_Call) Run(run func(ctx context.Context)) *UserGetter_GetUser_Call {
+func (_c *UserGetter_GetUserId_Call) Run(run func(ctx context.Context)) *UserGetter_GetUserId_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -131,12 +131,63 @@ func (_c *UserGetter_GetUser_Call) Run(run func(ctx context.Context)) *UserGette
 	return _c
 }
 
-func (_c *UserGetter_GetUser_Call) Return(s string) *UserGetter_GetUser_Call {
+func (_c *UserGetter_GetUserId_Call) Return(s string) *UserGetter_GetUserId_Call {
 	_c.Call.Return(s)
 	return _c
 }
 
-func (_c *UserGetter_GetUser_Call) RunAndReturn(run func(ctx context.Context) string) *UserGetter_GetUser_Call {
+func (_c *UserGetter_GetUserId_Call) RunAndReturn(run func(ctx context.Context) string) *UserGetter_GetUserId_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetUsername provides a mock function for the type UserGetter
+func (_mock *UserGetter) GetUsername(ctx context.Context) string {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUsername")
+	}
+
+	var r0 string
+	if returnFunc, ok := ret.Get(0).(func(context.Context) string); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	return r0
+}
+
+// UserGetter_GetUsername_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUsername'
+type UserGetter_GetUsername_Call struct {
+	*mock.Call
+}
+
+// GetUsername is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *UserGetter_Expecter) GetUsername(ctx interface{}) *UserGetter_GetUsername_Call {
+	return &UserGetter_GetUsername_Call{Call: _e.mock.On("GetUsername", ctx)}
+}
+
+func (_c *UserGetter_GetUsername_Call) Run(run func(ctx context.Context)) *UserGetter_GetUsername_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *UserGetter_GetUsername_Call) Return(s string) *UserGetter_GetUsername_Call {
+	_c.Call.Return(s)
+	return _c
+}
+
+func (_c *UserGetter_GetUsername_Call) RunAndReturn(run func(ctx context.Context) string) *UserGetter_GetUsername_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
The proxy extension currently receive 2 headers that are retrieved from the current user active session: the username and the groups. While the groups correctly reflect the information used by Argo CD to make RBAC decision, it is not the case for the username. The username is not used for RBAC decision, it is the "user identifier" that is used.

This PR adds a `Argocd-User-Id` header that will contain the actual information user to identify the user.

The username header is unmodified and contains the "displayed" username information for the logged in user. 

This change is forward compatible if the `preferred_username` claim is eventually used to configure the username https://github.com/argoproj/argo-cd/issues/6390