### PR TITLE
fix(security): repository.GetDetailedProject exposes repo secrets

### DIFF
--- a/docs/operator-manual/upgrading/2.13-2.14.md
+++ b/docs/operator-manual/upgrading/2.13-2.14.md
@@ -17,5 +17,6 @@ the [CLI and Application CR](https://argo-cd.readthedocs.io/en/latest/user-guide
 
 ## Sanitized project API response
 
-Due to security reasons, the project API response was sanitized to remove sensitive information. This includes
+Due to security reasons ([GHSA-786q-9hcg-v9ff](https://github.com/argoproj/argo-cd/security/advisories/GHSA-786q-9hcg-v9ff)),
+the project API response was sanitized to remove sensitive information. This includes
 credentials of project-scoped repositories and clusters.

--- a/docs/operator-manual/upgrading/2.13-2.14.md
+++ b/docs/operator-manual/upgrading/2.13-2.14.md
@@ -12,3 +12,10 @@ Eg, `https://github.com/argoproj/argo-cd/manifests/ha/cluster-install?ref=v2.14.
 
 Helm was upgraded to 3.16.2 and the skipSchemaValidation Flag was added to
 the [CLI and Application CR](https://argo-cd.readthedocs.io/en/latest/user-guide/helm/#helm-skip-schema-validation). 
+
+## Breaking Changes
+
+## Sanitized project API response
+
+Due to security reasons, the project API response was sanitized to remove sensitive information. This includes
+credentials of project-scoped repositories and clusters.

--- a/docs/operator-manual/upgrading/2.14-3.0.md
+++ b/docs/operator-manual/upgrading/2.14-3.0.md
@@ -492,3 +492,8 @@ resource.customizations.ignoreDifferences.apiextensions.k8s.io_CustomResourceDef
 ```
 
 More details for ignored resource updates in the [Diffing customization](../../user-guide/diffing.md) documentation.
+
+### Sanitized project API response
+
+Due to security reasons, the project API response was sanitized to remove sensitive information. This includes
+credentials of project-scoped repositories and clusters.

--- a/docs/operator-manual/upgrading/2.14-3.0.md
+++ b/docs/operator-manual/upgrading/2.14-3.0.md
@@ -495,5 +495,6 @@ More details for ignored resource updates in the [Diffing customization](../../u
 
 ### Sanitized project API response
 
-Due to security reasons, the project API response was sanitized to remove sensitive information. This includes
+Due to security reasons ([GHSA-786q-9hcg-v9ff](https://github.com/argoproj/argo-cd/security/advisories/GHSA-786q-9hcg-v9ff)),
+the project API response was sanitized to remove sensitive information. This includes
 credentials of project-scoped repositories and clusters.

--- a/docs/operator-manual/upgrading/3.0-3.1.md
+++ b/docs/operator-manual/upgrading/3.0-3.1.md
@@ -55,3 +55,10 @@ Argo CD v3.1 upgrades the bundled Helm version to 3.18.4. There are no breaking 
 
 Argo CD v3.1 upgrades the bundled Kustomize version to 5.7.0. There are no breaking changes in Kustomize 5.7 according
 to the [release notes](https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv5.7.0).
+
+## Breaking Changes
+
+## Sanitized project API response
+
+Due to security reasons, the project API response was sanitized to remove sensitive information. This includes
+credentials of project-scoped repositories and clusters.

--- a/docs/operator-manual/upgrading/3.0-3.1.md
+++ b/docs/operator-manual/upgrading/3.0-3.1.md
@@ -60,5 +60,6 @@ to the [release notes](https://github.com/kubernetes-sigs/kustomize/releases/tag
 
 ## Sanitized project API response
 
-Due to security reasons, the project API response was sanitized to remove sensitive information. This includes
+Due to security reasons ([GHSA-786q-9hcg-v9ff](https://github.com/argoproj/argo-cd/security/advisories/GHSA-786q-9hcg-v9ff)),
+the project API response was sanitized to remove sensitive information. This includes
 credentials of project-scoped repositories and clusters.

--- a/docs/operator-manual/upgrading/3.1-3.2.md
+++ b/docs/operator-manual/upgrading/3.1-3.2.md
@@ -52,3 +52,10 @@ If you do not want your CronJob to affect the Application's aggregated Health, y
 `argocd.argoproj.io/ignore-healthcheck: "true"` on the CronJob resource.
 
 The health can also be configured globally using the `resource.customizations.health.batch_CronJob` configuration to change the default behaviour.
+
+## Breaking Changes
+
+## Sanitized project API response
+
+Due to security reasons, the project API response was sanitized to remove sensitive information. This includes
+credentials of project-scoped repositories and clusters.

--- a/docs/operator-manual/upgrading/3.1-3.2.md
+++ b/docs/operator-manual/upgrading/3.1-3.2.md
@@ -57,5 +57,6 @@ The health can also be configured globally using the `resource.customizations.he
 
 ## Sanitized project API response
 
-Due to security reasons, the project API response was sanitized to remove sensitive information. This includes
+Due to security reasons ([GHSA-786q-9hcg-v9ff](https://github.com/argoproj/argo-cd/security/advisories/GHSA-786q-9hcg-v9ff)),
+the project API response was sanitized to remove sensitive information. This includes
 credentials of project-scoped repositories and clusters.

--- a/pkg/apis/application/v1alpha1/repository_types.go
+++ b/pkg/apis/application/v1alpha1/repository_types.go
@@ -347,7 +347,6 @@ func (repo *Repository) Sanitized() *Repository {
 		Repo:                       repo.Repo,
 		Type:                       repo.Type,
 		Name:                       repo.Name,
-		Username:                   repo.Username,
 		Insecure:                   repo.IsInsecure(),
 		EnableLFS:                  repo.EnableLFS,
 		EnableOCI:                  repo.EnableOCI,

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -2257,7 +2257,7 @@ func (c *Cluster) Sanitized() *Cluster {
 			ProxyUrl:           c.Config.ProxyUrl,
 			DisableCompression: c.Config.DisableCompression,
 			TLSClientConfig: TLSClientConfig{
-				Insecure: c.Config.TLSClientConfig.Insecure,
+				Insecure: c.Config.Insecure,
 			},
 		},
 	}

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -2237,6 +2237,23 @@ type Cluster struct {
 	Annotations map[string]string `json:"annotations,omitempty" protobuf:"bytes,13,opt,name=annotations"`
 }
 
+func (c *Cluster) Sanitized() *Cluster {
+	clust := *c
+	clust.Config.Username = ""
+	clust.Config.Password = ""
+	clust.Config.BearerToken = ""
+	clust.Config.KeyData = nil
+	if clust.Config.ExecProviderConfig != nil {
+		// We can't know what the user has put into args or
+		// env vars on the exec provider that might be sensitive
+		// (e.g. --private-key=XXX, PASSWORD=XXX)
+		// Implicitly assumes the command executable name is non-sensitive
+		clust.Config.ExecProviderConfig.Env = make(map[string]string)
+		clust.Config.ExecProviderConfig.Args = nil
+	}
+	return &clust
+}
+
 // Equals returns true if two cluster objects are considered to be equal
 func (c *Cluster) Equals(other *Cluster) bool {
 	if c.Server != other.Server {

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -2238,20 +2238,38 @@ type Cluster struct {
 }
 
 func (c *Cluster) Sanitized() *Cluster {
-	clust := *c
-	clust.Config.Username = ""
-	clust.Config.Password = ""
-	clust.Config.BearerToken = ""
-	clust.Config.KeyData = nil
-	if clust.Config.ExecProviderConfig != nil {
-		// We can't know what the user has put into args or
-		// env vars on the exec provider that might be sensitive
-		// (e.g. --private-key=XXX, PASSWORD=XXX)
-		// Implicitly assumes the command executable name is non-sensitive
-		clust.Config.ExecProviderConfig.Env = make(map[string]string)
-		clust.Config.ExecProviderConfig.Args = nil
+	var execProviderConfig *ExecProviderConfig
+	if c.Config.ExecProviderConfig != nil {
+		execProviderConfig = &ExecProviderConfig{
+			Command:     c.Config.ExecProviderConfig.Command,
+			APIVersion:  c.Config.ExecProviderConfig.APIVersion,
+			InstallHint: c.Config.ExecProviderConfig.InstallHint,
+		}
 	}
-	return &clust
+	return &Cluster{
+		ID:                 c.ID,
+		Server:             c.Server,
+		Name:               c.Name,
+		Project:            c.Project,
+		Namespaces:         c.Namespaces,
+		Shard:              c.Shard,
+		Labels:             c.Labels,
+		Annotations:        c.Annotations,
+		ClusterResources:   c.ClusterResources,
+		ConnectionState:    c.ConnectionState,
+		ServerVersion:      c.ServerVersion,
+		Info:               c.Info,
+		RefreshRequestedAt: c.RefreshRequestedAt,
+		Config: ClusterConfig{
+			ExecProviderConfig: execProviderConfig,
+			AWSAuthConfig:      c.Config.AWSAuthConfig,
+			ProxyUrl:           c.Config.ProxyUrl,
+			DisableCompression: c.Config.DisableCompression,
+			TLSClientConfig: TLSClientConfig{
+				Insecure: c.Config.TLSClientConfig.Insecure,
+			},
+		},
+	}
 }
 
 // Equals returns true if two cluster objects are considered to be equal

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -2238,14 +2238,6 @@ type Cluster struct {
 }
 
 func (c *Cluster) Sanitized() *Cluster {
-	var execProviderConfig *ExecProviderConfig
-	if c.Config.ExecProviderConfig != nil {
-		execProviderConfig = &ExecProviderConfig{
-			Command:     c.Config.ExecProviderConfig.Command,
-			APIVersion:  c.Config.ExecProviderConfig.APIVersion,
-			InstallHint: c.Config.ExecProviderConfig.InstallHint,
-		}
-	}
 	return &Cluster{
 		ID:                 c.ID,
 		Server:             c.Server,
@@ -2261,7 +2253,6 @@ func (c *Cluster) Sanitized() *Cluster {
 		Info:               c.Info,
 		RefreshRequestedAt: c.RefreshRequestedAt,
 		Config: ClusterConfig{
-			ExecProviderConfig: execProviderConfig,
 			AWSAuthConfig:      c.Config.AWSAuthConfig,
 			ProxyUrl:           c.Config.ProxyUrl,
 			DisableCompression: c.Config.DisableCompression,

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -4705,3 +4705,55 @@ func TestSyncWindow_Hash(t *testing.T) {
 		require.Equal(t, hash1, hash2, "windows with same core identity but different metadata should produce same hash")
 	})
 }
+
+func TestSanitized(t *testing.T) {
+	now := metav1.Now()
+	cluster := &Cluster{
+		ID:            "123",
+		Server:        "https://example.com",
+		Name:          "example",
+		ServerVersion: "v1.0.0",
+		Namespaces:    []string{"default", "kube-system"},
+		Project:       "default",
+		Labels: map[string]string{
+			"env": "production",
+		},
+		Annotations: map[string]string{
+			"annotation-key": "annotation-value",
+		},
+		ConnectionState: ConnectionState{
+			Status:     ConnectionStatusSuccessful,
+			Message:    "Connection successful",
+			ModifiedAt: &now,
+		},
+		Config: ClusterConfig{
+			Username:    "admin",
+			Password:    "password123",
+			BearerToken: "abc",
+			TLSClientConfig: TLSClientConfig{
+				Insecure: true,
+			},
+		},
+	}
+
+	assert.Equal(t, &Cluster{
+		ID:            "123",
+		Server:        "https://example.com",
+		Name:          "example",
+		ServerVersion: "v1.0.0",
+		Namespaces:    []string{"default", "kube-system"},
+		Project:       "default",
+		Labels:        map[string]string{"env": "production"},
+		Annotations:   map[string]string{"annotation-key": "annotation-value"},
+		ConnectionState: ConnectionState{
+			Status:     ConnectionStatusSuccessful,
+			Message:    "Connection successful",
+			ModifiedAt: &now,
+		},
+		Config: ClusterConfig{
+			TLSClientConfig: TLSClientConfig{
+				Insecure: true,
+			},
+		},
+	}, cluster.Sanitized())
+}

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -4733,6 +4733,9 @@ func TestSanitized(t *testing.T) {
 			TLSClientConfig: TLSClientConfig{
 				Insecure: true,
 			},
+			ExecProviderConfig: &ExecProviderConfig{
+				Command: "test",
+			},
 		},
 	}
 

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -471,19 +471,8 @@ func (s *Server) RotateAuth(ctx context.Context, q *cluster.ClusterQuery) (*clus
 }
 
 func (s *Server) toAPIResponse(clust *appv1.Cluster) *appv1.Cluster {
+	clust = clust.Sanitized()
 	_ = s.cache.GetClusterInfo(clust.Server, &clust.Info)
-
-	clust.Config.Password = ""
-	clust.Config.BearerToken = ""
-	clust.Config.KeyData = nil
-	if clust.Config.ExecProviderConfig != nil {
-		// We can't know what the user has put into args or
-		// env vars on the exec provider that might be sensitive
-		// (e.g. --private-key=XXX, PASSWORD=XXX)
-		// Implicitly assumes the command executable name is non-sensitive
-		clust.Config.ExecProviderConfig.Env = make(map[string]string)
-		clust.Config.ExecProviderConfig.Args = nil
-	}
 	// populate deprecated fields for backward compatibility
 	//nolint:staticcheck
 	clust.ServerVersion = clust.Info.ServerVersion

--- a/server/project/project.go
+++ b/server/project/project.go
@@ -310,12 +310,20 @@ func (s *Server) GetDetailedProject(ctx context.Context, q *project.ProjectQuery
 	}
 	proj.NormalizeJWTTokens()
 	globalProjects := argo.GetGlobalProjects(proj, listersv1alpha1.NewAppProjectLister(s.projInformer.GetIndexer()), s.settingsMgr)
+	var apiRepos []*v1alpha1.Repository
+	for _, repo := range repositories {
+		apiRepos = append(apiRepos, repo.Normalize().Sanitized())
+	}
+	var apiClusters []*v1alpha1.Cluster
+	for _, cluster := range clusters {
+		apiClusters = append(apiClusters, cluster.Sanitized())
+	}
 
 	return &project.DetailedProjectsResponse{
 		GlobalProjects: globalProjects,
 		Project:        proj,
-		Repositories:   repositories,
-		Clusters:       clusters,
+		Repositories:   apiRepos,
+		Clusters:       apiClusters,
 	}, err
 }
 

--- a/server/repository/repository_test.go
+++ b/server/repository/repository_test.go
@@ -313,7 +313,7 @@ func TestRepositoryServer(t *testing.T) {
 		testRepo := &appsv1.Repository{
 			Repo:           url,
 			Type:           "git",
-			Username:       "foo",
+			Username:       "",
 			InheritedCreds: true,
 		}
 		db.On("ListRepositories", t.Context()).Return([]*appsv1.Repository{testRepo}, nil)


### PR DESCRIPTION
This was properly handled in a to-be-published GHSA, but GHSA is infuriatingly difficult to work with, particularly in merging these PRs. So manually opening PRs.

Will publish the GHSA shortly.