### PR TITLE
docs: remove incorrect ignoreDifferences example

### DIFF
--- a/docs/operator-manual/application.yaml
+++ b/docs/operator-manual/application.yaml
@@ -266,7 +266,7 @@ spec:
     - /spec/replicas
   - kind: ConfigMap
     jqPathExpressions:
-    - '.data["config.yaml"].auth'
+    - '.data["config.yaml"]'
   # for the specified managedFields managers
   - group: "*"
     kind: "*"

--- a/docs/operator-manual/application.yaml
+++ b/docs/operator-manual/application.yaml
@@ -266,6 +266,7 @@ spec:
     - /spec/replicas
   - kind: ConfigMap
     jqPathExpressions:
+    # Example: Ignore changes to a specific key inside a ConfigMap
     - '.data["config.yaml"]'
   # for the specified managedFields managers
   - group: "*"


### PR DESCRIPTION
ConfigMap field values are strings, so it doesn't make sense to index within a ConfigMap data value.