### PR TITLE
chore(refactor): use contexts in hydration operations

### DIFF
--- a/controller/hook.go
+++ b/controller/hook.go
@@ -51,7 +51,7 @@ func (ctrl *ApplicationController) executePostDeleteHooks(app *v1alpha1.Applicat
 		revisions = append(revisions, src.TargetRevision)
 	}
 
-	targets, _, _, err := ctrl.appStateManager.GetRepoObjs(app, app.Spec.GetSources(), appLabelKey, revisions, false, false, false, proj, true)
+	targets, _, _, err := ctrl.appStateManager.GetRepoObjs(context.Background(), app, app.Spec.GetSources(), appLabelKey, revisions, false, false, false, proj, true)
 	if err != nil {
 		return false, err
 	}

--- a/controller/hydrator/hydrator.go
+++ b/controller/hydrator/hydrator.go
@@ -44,7 +44,7 @@ type Dependencies interface {
 
 	// GetRepoObjs returns the repository objects for the given application, source, and revision. It calls the repo-
 	// server and gets the manifests (objects).
-	GetRepoObjs(app *appv1.Application, source appv1.ApplicationSource, revision string, project *appv1.AppProject) ([]*unstructured.Unstructured, *apiclient.ManifestResponse, error)
+	GetRepoObjs(ctx context.Context, app *appv1.Application, source appv1.ApplicationSource, revision string, project *appv1.AppProject) ([]*unstructured.Unstructured, *apiclient.ManifestResponse, error)
 
 	// GetWriteCredentials returns the repository credentials for the given repository URL and project. These are to be
 	// sent to the commit server to write the hydrated manifests.
@@ -292,7 +292,7 @@ func (h *Hydrator) hydrate(logCtx *log.Entry, apps []*appv1.Application) (string
 		}
 
 		// TODO: enable signature verification
-		objs, resp, err := h.dependencies.GetRepoObjs(app, drySource, targetRevision, project)
+		objs, resp, err := h.dependencies.GetRepoObjs(context.Background(), app, drySource, targetRevision, project)
 		if err != nil {
 			return "", "", fmt.Errorf("failed to get repo objects for app %q: %w", app.QualifiedName(), err)
 		}

--- a/controller/hydrator/mocks/Dependencies.go
+++ b/controller/hydrator/mocks/Dependencies.go
@@ -252,7 +252,7 @@ func (_c *Dependencies_GetProcessableApps_Call) RunAndReturn(run func() (*v1alph
 }
 
 // GetRepoObjs provides a mock function for the type Dependencies
-func (_mock *Dependencies) GetRepoObjs(app *v1alpha1.Application, source v1alpha1.ApplicationSource, revision string, project *v1alpha1.AppProject) ([]*unstructured.Unstructured, *apiclient.ManifestResponse, error) {
+func (_mock *Dependencies) GetRepoObjs(ctx context.Context, app *v1alpha1.Application, source v1alpha1.ApplicationSource, revision string, project *v1alpha1.AppProject) ([]*unstructured.Unstructured, *apiclient.ManifestResponse, error) {
 	ret := _mock.Called(app, source, revision, project)
 
 	if len(ret) == 0 {

--- a/controller/hydrator/mocks/Dependencies.go
+++ b/controller/hydrator/mocks/Dependencies.go
@@ -253,7 +253,7 @@ func (_c *Dependencies_GetProcessableApps_Call) RunAndReturn(run func() (*v1alph
 
 // GetRepoObjs provides a mock function for the type Dependencies
 func (_mock *Dependencies) GetRepoObjs(ctx context.Context, app *v1alpha1.Application, source v1alpha1.ApplicationSource, revision string, project *v1alpha1.AppProject) ([]*unstructured.Unstructured, *apiclient.ManifestResponse, error) {
-	ret := _mock.Called(app, source, revision, project)
+	ret := _mock.Called(ctx, app, source, revision, project)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetRepoObjs")
@@ -262,25 +262,25 @@ func (_mock *Dependencies) GetRepoObjs(ctx context.Context, app *v1alpha1.Applic
 	var r0 []*unstructured.Unstructured
 	var r1 *apiclient.ManifestResponse
 	var r2 error
-	if returnFunc, ok := ret.Get(0).(func(*v1alpha1.Application, v1alpha1.ApplicationSource, string, *v1alpha1.AppProject) ([]*unstructured.Unstructured, *apiclient.ManifestResponse, error)); ok {
-		return returnFunc(app, source, revision, project)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *v1alpha1.Application, v1alpha1.ApplicationSource, string, *v1alpha1.AppProject) ([]*unstructured.Unstructured, *apiclient.ManifestResponse, error)); ok {
+		return returnFunc(ctx, app, source, revision, project)
 	}
-	if returnFunc, ok := ret.Get(0).(func(*v1alpha1.Application, v1alpha1.ApplicationSource, string, *v1alpha1.AppProject) []*unstructured.Unstructured); ok {
-		r0 = returnFunc(app, source, revision, project)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *v1alpha1.Application, v1alpha1.ApplicationSource, string, *v1alpha1.AppProject) []*unstructured.Unstructured); ok {
+		r0 = returnFunc(ctx, app, source, revision, project)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*unstructured.Unstructured)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(*v1alpha1.Application, v1alpha1.ApplicationSource, string, *v1alpha1.AppProject) *apiclient.ManifestResponse); ok {
-		r1 = returnFunc(app, source, revision, project)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *v1alpha1.Application, v1alpha1.ApplicationSource, string, *v1alpha1.AppProject) *apiclient.ManifestResponse); ok {
+		r1 = returnFunc(ctx, app, source, revision, project)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*apiclient.ManifestResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(2).(func(*v1alpha1.Application, v1alpha1.ApplicationSource, string, *v1alpha1.AppProject) error); ok {
-		r2 = returnFunc(app, source, revision, project)
+	if returnFunc, ok := ret.Get(2).(func(context.Context, *v1alpha1.Application, v1alpha1.ApplicationSource, string, *v1alpha1.AppProject) error); ok {
+		r2 = returnFunc(ctx, app, source, revision, project)
 	} else {
 		r2 = ret.Error(2)
 	}
@@ -293,37 +293,43 @@ type Dependencies_GetRepoObjs_Call struct {
 }
 
 // GetRepoObjs is a helper method to define mock.On call
+//   - ctx context.Context
 //   - app *v1alpha1.Application
 //   - source v1alpha1.ApplicationSource
 //   - revision string
 //   - project *v1alpha1.AppProject
-func (_e *Dependencies_Expecter) GetRepoObjs(app interface{}, source interface{}, revision interface{}, project interface{}) *Dependencies_GetRepoObjs_Call {
-	return &Dependencies_GetRepoObjs_Call{Call: _e.mock.On("GetRepoObjs", app, source, revision, project)}
+func (_e *Dependencies_Expecter) GetRepoObjs(ctx interface{}, app interface{}, source interface{}, revision interface{}, project interface{}) *Dependencies_GetRepoObjs_Call {
+	return &Dependencies_GetRepoObjs_Call{Call: _e.mock.On("GetRepoObjs", ctx, app, source, revision, project)}
 }
 
-func (_c *Dependencies_GetRepoObjs_Call) Run(run func(app *v1alpha1.Application, source v1alpha1.ApplicationSource, revision string, project *v1alpha1.AppProject)) *Dependencies_GetRepoObjs_Call {
+func (_c *Dependencies_GetRepoObjs_Call) Run(run func(ctx context.Context, app *v1alpha1.Application, source v1alpha1.ApplicationSource, revision string, project *v1alpha1.AppProject)) *Dependencies_GetRepoObjs_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 *v1alpha1.Application
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(*v1alpha1.Application)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 v1alpha1.ApplicationSource
+		var arg1 *v1alpha1.Application
 		if args[1] != nil {
-			arg1 = args[1].(v1alpha1.ApplicationSource)
+			arg1 = args[1].(*v1alpha1.Application)
 		}
-		var arg2 string
+		var arg2 v1alpha1.ApplicationSource
 		if args[2] != nil {
-			arg2 = args[2].(string)
+			arg2 = args[2].(v1alpha1.ApplicationSource)
 		}
-		var arg3 *v1alpha1.AppProject
+		var arg3 string
 		if args[3] != nil {
-			arg3 = args[3].(*v1alpha1.AppProject)
+			arg3 = args[3].(string)
+		}
+		var arg4 *v1alpha1.AppProject
+		if args[4] != nil {
+			arg4 = args[4].(*v1alpha1.AppProject)
 		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
+			arg4,
 		)
 	})
 	return _c
@@ -334,7 +340,7 @@ func (_c *Dependencies_GetRepoObjs_Call) Return(unstructureds []*unstructured.Un
 	return _c
 }
 
-func (_c *Dependencies_GetRepoObjs_Call) RunAndReturn(run func(app *v1alpha1.Application, source v1alpha1.ApplicationSource, revision string, project *v1alpha1.AppProject) ([]*unstructured.Unstructured, *apiclient.ManifestResponse, error)) *Dependencies_GetRepoObjs_Call {
+func (_c *Dependencies_GetRepoObjs_Call) RunAndReturn(run func(ctx context.Context, app *v1alpha1.Application, source v1alpha1.ApplicationSource, revision string, project *v1alpha1.AppProject) ([]*unstructured.Unstructured, *apiclient.ManifestResponse, error)) *Dependencies_GetRepoObjs_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/controller/hydrator_dependencies.go
+++ b/controller/hydrator_dependencies.go
@@ -31,7 +31,7 @@ func (ctrl *ApplicationController) GetProcessableApps() (*appv1.ApplicationList,
 	return ctrl.getAppList(metav1.ListOptions{})
 }
 
-func (ctrl *ApplicationController) GetRepoObjs(origApp *appv1.Application, drySource appv1.ApplicationSource, revision string, project *appv1.AppProject) ([]*unstructured.Unstructured, *apiclient.ManifestResponse, error) {
+func (ctrl *ApplicationController) GetRepoObjs(ctx context.Context, origApp *appv1.Application, drySource appv1.ApplicationSource, revision string, project *appv1.AppProject) ([]*unstructured.Unstructured, *apiclient.ManifestResponse, error) {
 	drySources := []appv1.ApplicationSource{drySource}
 	dryRevisions := []string{revision}
 
@@ -50,7 +50,7 @@ func (ctrl *ApplicationController) GetRepoObjs(origApp *appv1.Application, drySo
 	delete(app.Annotations, appv1.AnnotationKeyManifestGeneratePaths)
 
 	// FIXME: use cache and revision cache
-	objs, resp, _, err := ctrl.appStateManager.GetRepoObjs(app, drySources, appLabelKey, dryRevisions, true, true, false, project, false)
+	objs, resp, _, err := ctrl.appStateManager.GetRepoObjs(ctx, app, drySources, appLabelKey, dryRevisions, true, true, false, project, false)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get repo objects: %w", err)
 	}

--- a/controller/hydrator_dependencies_test.go
+++ b/controller/hydrator_dependencies_test.go
@@ -47,7 +47,7 @@ func TestGetRepoObjs(t *testing.T) {
 	source := app.Spec.GetSource()
 	source.RepoURL = "oci://example.com/argo/argo-cd"
 
-	objs, resp, err := ctrl.GetRepoObjs(app, source, "abc123", &v1alpha1.AppProject{
+	objs, resp, err := ctrl.GetRepoObjs(t.Context(), app, source, "abc123", &v1alpha1.AppProject{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "default",
 			Namespace: test.FakeArgoCDNamespace,

--- a/controller/state_test.go
+++ b/controller/state_test.go
@@ -1845,6 +1845,6 @@ func TestCompareAppState_DoesNotCallUpdateRevisionForPaths_ForOCI(t *testing.T) 
 	sources := make([]v1alpha1.ApplicationSource, 0)
 	sources = append(sources, source)
 
-	_, _, _, err := ctrl.appStateManager.GetRepoObjs(app, sources, "abc123", []string{"123456"}, false, false, false, &defaultProj, false)
+	_, _, _, err := ctrl.appStateManager.GetRepoObjs(t.Context(), app, sources, "abc123", []string{"123456"}, false, false, false, &defaultProj, false)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
`GetRepoObjs` is the controller's way of calling repo-server to get manifests.

Getting manifests is a long-ish-running operation. We should really be using contexts through all this code so that timeouts can be easily implemented.

This PR is purely a refactor to centralize the `context.Background()` in a few key places so that we can introduce timeouts and short-circuiting later.

My immediate motivation is using an errgroup context to short-circuit parallel calls to repo-server in Source Hydrator when one of those calls fails. No need to wait for all the other calls to finish when one has already failed. I'll open a follow-up PR to introduce that parallelization.