### PR TITLE
docs: Update URL for HA manifests to stable.

### DIFF
--- a/docs/operator-manual/high_availability.md
+++ b/docs/operator-manual/high_availability.md
@@ -2,7 +2,7 @@
 
 Argo CD is largely stateless. All data is persisted as Kubernetes objects, which in turn is stored in Kubernetes' etcd. Redis is only used as a throw-away cache and can be lost. When lost, it will be rebuilt without loss of service.
 
-A set of [HA manifests](https://github.com/argoproj/argo-cd/tree/master/manifests/ha) are provided for users who wish to run Argo CD in a highly available manner. This runs more containers, and runs Redis in HA mode.
+A set of [HA manifests](https://github.com/argoproj/argo-cd/tree/stable/manifests/ha) are provided for users who wish to run Argo CD in a highly available manner. This runs more containers, and runs Redis in HA mode.
 
 > **NOTE:** The HA installation will require at least three different nodes due to pod anti-affinity roles in the
 > specs. Additionally, IPv6 only clusters are not supported.


### PR DESCRIPTION
Cherry-pick backport of #24049 for `release-3.0`.

@reggie-k 