### PR TITLE
chore(deps): bump slsa-framework/slsa-github-generator from 2.0.0 to 2.1.0 (#23166)

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -86,7 +86,7 @@ jobs:
       packages: write # for uploading attestations. (https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#known-issues)
     if: ${{ github.repository == 'argoproj/argo-cd' && github.event_name == 'push' }}
     # Must be refernced by a tag. https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#referencing-the-slsa-generator
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.10.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
     with:
       image: ghcr.io/argoproj/argo-cd/argocd
       digest: ${{ needs.build-and-publish.outputs.image-digest }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,20 +31,20 @@ jobs:
       quay_password: ${{ secrets.RELEASE_QUAY_TOKEN }}
 
   argocd-image-provenance:
-      needs: [argocd-image]
-      permissions:
-        actions: read # for detecting the Github Actions environment.
-        id-token: write # for creating OIDC tokens for signing.
-        packages: write # for uploading attestations. (https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#known-issues)
-      # Must be refernced by a tag. https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#referencing-the-slsa-generator
-      if: github.repository == 'argoproj/argo-cd'
-      uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.10.0
-      with:
-        image: quay.io/argoproj/argocd
-        digest: ${{ needs.argocd-image.outputs.image-digest }}
-      secrets:
-        registry-username: ${{ secrets.RELEASE_QUAY_USERNAME }}
-        registry-password: ${{ secrets.RELEASE_QUAY_TOKEN }}
+    needs: [argocd-image]
+    permissions:
+      actions: read # for detecting the Github Actions environment.
+      id-token: write # for creating OIDC tokens for signing.
+      packages: write # for uploading attestations. (https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#known-issues)
+    # Must be refernced by a tag. https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#referencing-the-slsa-generator
+    if: github.repository == 'argoproj/argo-cd'
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    with:
+      image: quay.io/argoproj/argocd
+      digest: ${{ needs.argocd-image.outputs.image-digest }}
+    secrets:
+      registry-username: ${{ secrets.RELEASE_QUAY_USERNAME }}
+      registry-password: ${{ secrets.RELEASE_QUAY_TOKEN }}
 
   goreleaser:
     needs:
@@ -128,7 +128,7 @@ jobs:
       contents: write #  Needed for release uploads
     if: github.repository == 'argoproj/argo-cd'
     # Must be refernced by a tag. https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#referencing-the-slsa-generator
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.10.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
       provenance-name: "argocd-cli.intoto.jsonl"
@@ -211,8 +211,8 @@ jobs:
       id-token: write # Needed for provenance signing and ID
       contents: write #  Needed for release uploads
     if: github.repository == 'argoproj/argo-cd'
-    # Must be refernced by a tag. https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#referencing-the-slsa-generator
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.10.0
+    # Must be referenced by a tag. https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#referencing-the-slsa-generator
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.generate-sbom.outputs.hashes }}"
       provenance-name: "argocd-sbom.intoto.jsonl"


### PR DESCRIPTION
PR cherry-picks https://github.com/argoproj/argo-cd/pull/23166 (bump slsa-framework/slsa-github-generator from 2.0.0 to 2.1.0)