### PR TITLE
fix: RunResourceAction: error getting Lua resource action: built-in script does not exist #24490 

### DIFF
--- a/manifests/cluster-rbac/server/argocd-server-clusterrole.yaml
+++ b/manifests/cluster-rbac/server/argocd-server-clusterrole.yaml
@@ -21,7 +21,6 @@ rules:
   - events
   verbs:
   - list    # supports listing events in UI
-  - create # supports creating events on resource actions
 - apiGroups:
   - ""
   resources:

--- a/manifests/cluster-rbac/server/argocd-server-clusterrole.yaml
+++ b/manifests/cluster-rbac/server/argocd-server-clusterrole.yaml
@@ -21,6 +21,7 @@ rules:
   - events
   verbs:
   - list    # supports listing events in UI
+  - create # supports creating events on resource actions
 - apiGroups:
   - ""
   resources:

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -2516,6 +2516,7 @@ func (s *Server) RunResourceAction(ctx context.Context, q *application.ResourceA
 		Kind:         q.Kind,
 		Version:      q.Version,
 		Group:        q.Group,
+		Action:       q.Action,
 		Project:      q.Project,
 	}
 	return s.RunResourceActionV2(ctx, qV2)


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->

Fixes #24490 RunResourceAction: `error getting Lua resource action: built-in script does not exist`

Should be cherry picked to `v3.1`

Also includes added rbac cluster role for auditing RunResourceAction, which gives error like:
```shell
{"level":"error","msg":"Unable to create audit event: events is forbidden: User \"system:serviceaccount:argocd:argocd-server\" cannot create resource \"events\" in API group \"\" in the namespace \"dev-next\"","name":"nginx","reason":"ResourceActionRan","time":"2025-09-09T19:05:28Z","type":"Normal","user":"admin"}
```
