### PR TITLE
chore(cli): print groups when retrieving roles info

### DIFF
--- a/cmd/argocd/commands/project_role.go
+++ b/cmd/argocd/commands/project_role.go
@@ -605,8 +605,17 @@ ID          ISSUED-AT                                  EXPIRES-AT
 			fmt.Printf(printRoleFmtStr, "Description:", role.Description)
 			fmt.Printf("Policies:\n")
 			fmt.Printf("%s\n", proj.ProjectPoliciesString())
+			fmt.Printf("Groups:\n")
+			// if the group exists in the role
+			// range over each group and print it
+			if v1alpha1.RoleGroupExists(role) {
+				for _, group := range role.Groups {
+					fmt.Printf("  - %s\n", group)
+				}
+			} else {
+				fmt.Println("<none>")
+			}
 			fmt.Printf("JWT Tokens:\n")
-			// TODO(jessesuen): print groups
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 			fmt.Fprintf(w, "ID\tISSUED-AT\tEXPIRES-AT\n")
 			for _, token := range proj.Status.JWTTokensByRole[roleName].Items {

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -925,6 +925,42 @@ func TestAppProject_ValidPolicyRules(t *testing.T) {
 	}
 }
 
+// TestRoleGroupExists tests if a group has been defined in the Project role
+func TestRoleGroupExists(t *testing.T) {
+	tests := []struct {
+		name     string
+		role     *ProjectRole
+		expected bool
+	}{
+		{
+			name: "Project role group exists",
+			role: &ProjectRole{
+				Name:        "custom-project-role",
+				Description: "The \"custom-project-role\" will be applied to the `some-user` group.",
+				Groups:      []string{"some-user"},
+				Policies:    []string{"roj:sample-test-project:custom-project-role, applications, *, *, allow"},
+			},
+			expected: true,
+		},
+		{
+			name: "Project role group doesn't exist",
+			role: &ProjectRole{
+				Name:        "custom-project-role",
+				Description: "The \"custom-project-role\" will be applied to the `some-user` group.",
+				Policies:    []string{"roj:sample-test-project:custom-project-role, applications, *, *, allow"},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := RoleGroupExists(tt.role)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
 func TestExplicitType(t *testing.T) {
 	src := ApplicationSource{
 		Kustomize: &ApplicationSourceKustomize{


### PR DESCRIPTION
Currently `argocd proj role get` command retrieves the entire information about a role defined except printing the groups. This PR lets your print the groups too when using the above command. It also documents some of the methods that were missing the documentation along with a unit test.

## After

```
> argocd proj role get sample-test-project custom-project-role
Role Name:     custom-project-role
Description:   The "custom-project-role" will be applied to the `some-user` group.
Policies:
p, proj:sample-test-project:custom-project-role, projects, get, sample-test-project, allow
p, proj:sample-test-project:custom-project-role, applications, *, *, allow
g, some-user, proj:sample-test-project:custom-project-role
Groups:
  - some-user
JWT Tokens:
ID  ISSUED-AT  EXPIRES-AT
```

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
