### PR TITLE
chore(ci): use existing label standard

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -11,8 +11,8 @@ jobs:
     name: Cherry Pick
     if: |
       github.event.pull_request.merged == true && (
-        (github.event.action == 'labeled' && startsWith(github.event.label.name, 'cherry-pick-')) ||
-        (github.event.action == 'closed' && contains(toJSON(github.event.pull_request.labels.*.name), 'cherry-pick-'))
+        (github.event.action == 'labeled' && startsWith(github.event.label.name, 'cherry-pick/')) ||
+        (github.event.action == 'closed' && contains(toJSON(github.event.pull_request.labels.*.name), 'cherry-pick/'))
       )
     runs-on: ubuntu-latest
     steps:
@@ -48,10 +48,12 @@ jobs:
             CHERRY_PICK_LABEL="${{ github.event.label.name }}"
           else
             # PR was closed - find cherry-pick label from all labels
-            CHERRY_PICK_LABEL=$(echo '${{ toJSON(github.event.pull_request.labels) }}' | jq -r '.[] | select(.name | startswith("cherry-pick-")) | .name' | head -1)
+            CHERRY_PICK_LABEL=$(echo '${{ toJSON(github.event.pull_request.labels) }}' | jq -r '.[] | select(.name | startswith("cherry-pick/")) | .name' | head -1)
           fi
           
-          TARGET_BRANCH="release-${CHERRY_PICK_LABEL#cherry-pick-}"  # Remove 'cherry-pick-' prefix with `release-` prefix
+          VERSION_NUMBER="${CHERRY_PICK_LABEL#cherry-pick/}"
+          echo "version_number=$VERSION_NUMBER" >> "$GITHUB_OUTPUT"
+          TARGET_BRANCH="release-$VERSION_NUMBER"  # Remove 'cherry-pick/' prefix with `release-` prefix
           
           echo "🍒 Cherry-picking commit $MERGE_COMMIT to branch $TARGET_BRANCH"
           
@@ -89,7 +91,7 @@ jobs:
         run: |
           # Create cherry-pick PR
           gh pr create \
-            --title "${{ github.event.pull_request.title }} (cherry-pick #${{ github.event.pull_request.number }})" \
+            --title "${{ github.event.pull_request.title }} (cherry-pick #${{ github.event.pull_request.number }} for ${{ steps.cherry-pick.outputs.version_number }})" \
             --body "Cherry-picked ${{ github.event.pull_request.title }} (#${{ github.event.pull_request.number }})
 
           ${{ steps.cherry-pick.outputs.signoff }}" \

--- a/docs/developer-guide/submit-your-pr.md
+++ b/docs/developer-guide/submit-your-pr.md
@@ -84,3 +84,13 @@ If you want to see how much coverage just a specific module (i.e. your new one) 
 ...
 ok      github.com/argoproj/argo-cd/server/cache        0.029s  coverage: 89.3% of statements
 ```
+
+## Cherry-picking fixes
+
+If your PR contains a bug fix, and you want to have that fix backported to a previous release branch, please label your
+PR with `cherry-pick/x.y` (example: `cherry-pick/3.1`). If you do not have access to add labels, ask a maintainer to add
+them for you.
+
+If you add labels before the PR is merged, the cherry-pick bot will open the backport PRs when your PR is merged.
+
+Adding a label after the PR is merged will also cause the bot to open the backport PR.


### PR DESCRIPTION
We had already been using labels like `cherry-pick/x.y`, so let's stick with that if possible.