### PR TITLE
docs: clarify `timeout.reconciliation` values

### DIFF
--- a/docs/operator-manual/high_availability.md
+++ b/docs/operator-manual/high_availability.md
@@ -63,7 +63,7 @@ performance. For performance reasons the controller monitors and caches only the
 preferred version into a version of the resource stored in Git. If `kubectl convert` fails because the conversion is not supported then the controller falls back to Kubernetes API query which slows down
 reconciliation. In this case, we advise to use the preferred resource version in Git.
 
-* The controller polls Git every 3m by default. You can change this duration using the `timeout.reconciliation` and `timeout.reconciliation.jitter` setting in the `argocd-cm` ConfigMap. The value of the fields is a duration string e.g `60s`, `1m`, `1h` or `1d`.
+* The controller polls Git every 3m by default. You can change this duration using the `timeout.reconciliation` and `timeout.reconciliation.jitter` setting in the `argocd-cm` ConfigMap. The value of the fields is a [duration string](https://pkg.go.dev/time#ParseDuration) e.g `60s`, `1m` or `1h`.
 
 * If the controller is managing too many clusters and uses too much memory then you can shard clusters across multiple
 controller replicas. To enable sharding, increase the number of replicas in `argocd-application-controller` `StatefulSet`

--- a/docs/operator-manual/upgrading/2.0-2.1.md
+++ b/docs/operator-manual/upgrading/2.0-2.1.md
@@ -9,7 +9,7 @@ For example flag name `load_restrictor` is changed in Kustomize v4+. It is chang
 
 The`--app-resync` flag allows controlling how frequently Argo CD application controller checks resolve the target
 application revision of each application. In order to allow caching resolved revision per repository as opposed to per
-application, the `--app-resync` flag has been deprecated. Please use `timeout.reconciliation` setting in `argocd-cm` ConfigMap instead. The value of `timeout.reconciliation` is a duration string e.g `60s`, `1m`, `1h` or `1d`.
+application, the `--app-resync` flag has been deprecated. Please use `timeout.reconciliation` setting in `argocd-cm` ConfigMap instead. The value of `timeout.reconciliation` is a [duration string](https://pkg.go.dev/time#ParseDuration) e.g `60s`, `1m` or `1h`.
 See example in [argocd-cm.yaml](../argocd-cm.yaml).
 
 From here on you can follow the [regular upgrade process](./overview.md).


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

## Summary

The docs for the `timeout.reconciliation` had `1d` as an example, but this is not accepted by [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) which gives the error below and caused the default (`3m`) to be used:

```
❯ kubectl -n argocd logs argocd-application-controller-0 | head
time="2025-09-13T19:56:19Z" level=warning msg="Could not parse '7d' as a duration string from environment ARGOCD_RECONCILIATION_TIMEOUT"
```

The workaround was to use a value supported by [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration)  such as `24h`. Other users in https://github.com/argoproj/argo-cd/issues/11995 also reported the setting not taking effect when using a value of `1d`

## Checklist

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->

## Related issue

https://github.com/argoproj/argo-cd/issues/11995
