### PR TITLE
chore: add `triage/pending` label to new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: 'bug'
+labels: ['bug', 'triage/pending']
 assignees: ''
 ---
 
@@ -10,9 +10,9 @@ assignees: ''
 
 Checklist:
 
-* [ ] I've searched in the docs and FAQ for my answer: https://bit.ly/argocd-faq.
-* [ ] I've included steps to reproduce the bug.
-* [ ] I've pasted the output of `argocd version`.
+- [ ] I've searched in the docs and FAQ for my answer: https://bit.ly/argocd-faq.
+- [ ] I've included steps to reproduce the bug.
+- [ ] I've pasted the output of `argocd version`.
 
 **Describe the bug**
 

--- a/.github/ISSUE_TEMPLATE/enhancement_proposal.md
+++ b/.github/ISSUE_TEMPLATE/enhancement_proposal.md
@@ -2,9 +2,10 @@
 name: Enhancement proposal
 about: Propose an enhancement for this project
 title: ''
-labels: 'enhancement'
+labels: ['enhancement', 'triage/pending']
 assignees: ''
 ---
+
 # Summary
 
 What change you think needs making.

--- a/.github/ISSUE_TEMPLATE/new_dev_tool.md
+++ b/.github/ISSUE_TEMPLATE/new_dev_tool.md
@@ -2,17 +2,17 @@
 name: New Dev Tool Request
 about: This is a request for adding a new tool for setting up a dev environment.
 title: ''
-labels: ''
+labels: ['component:dev-env', 'triage/pending']
 assignees: ''
 ---
 
 Checklist:
 
-* [ ] I am willing to maintain this tool, or have another Argo CD maintainer who is. 
-* [ ] I have another Argo CD maintainer who is willing to help maintain this tool (there needs to be at least two maintainers willing to maintain this tool)
-* [ ] I have a lead sponsor who is a core Argo CD maintainer
-* [ ] There is a PR which adds said tool - this is so that the maintainers can assess the impact of having this in the tree
-* [ ] I have given a motivation why this should be added
+- [ ] I am willing to maintain this tool, or have another Argo CD maintainer who is.
+- [ ] I have another Argo CD maintainer who is willing to help maintain this tool (there needs to be at least two maintainers willing to maintain this tool)
+- [ ] I have a lead sponsor who is a core Argo CD maintainer
+- [ ] There is a PR which adds said tool - this is so that the maintainers can assess the impact of having this in the tree
+- [ ] I have given a motivation why this should be added
 
 ### The proposer
 
@@ -24,7 +24,7 @@ Checklist:
 
 ### Motivation
 
-<!-- Why this tool would be useful to have in the tree. --> 
+<!-- Why this tool would be useful to have in the tree. -->
 
 ### Link to PR (Optional)
 

--- a/.github/ISSUE_TEMPLATE/security_logs.md
+++ b/.github/ISSUE_TEMPLATE/security_logs.md
@@ -1,10 +1,11 @@
 ---
 name: Security log
 about: Propose adding security-related logs or tagging existing logs with security fields
-title: "seclog: [Event Description]"
-labels: security-log
-assignees: notfromstatefarm
+title: 'seclog: [Event Description]'
+labels: ['security', 'triage/pending']
+assignees: ''
 ---
+
 # Event to be logged
 
 Specify the event that needs to be logged or existing logs that need to be tagged.
@@ -16,4 +17,3 @@ What security level should these events be logged under? Refer to https://argo-c
 # Common Weakness Enumeration
 
 Is there an associated [CWE](https://cwe.mitre.org/) that could be tagged as well?
-

--- a/docs/bug_triage.md
+++ b/docs/bug_triage.md
@@ -62,7 +62,7 @@ applied to all new issues in our tracker.
 
 If it is not yet possible to classify the bug, i.e. because more information is
 required to correctly classify the bug, you should always set the label
-`bug/in-triage` to make it clear that triage process has started but could not
+`triage/pending` to make it clear that triage process has started but could not
 yet be completed.
 
 ### Issue type


### PR DESCRIPTION
Add a label by default so contributors doing the triage can remove the label when the issue is triaged. Due to the volume of issues, adding the label when the issue requires more triage is not effective. We should always consider new issues as not yet triaged.