### PR TITLE
chore(ci): enable Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+}


### PR DESCRIPTION
At one point I thought this file had to be deleted to ensure we used self-hosted Renovate. But I now think it's required either way.