### PR TITLE
chore(ci): update github runners to oci gh arc runners (3.2) (#24632)

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -407,7 +407,7 @@ jobs:
   test-e2e:
     name: Run end-to-end tests
     if: ${{ needs.changes.outputs.backend == 'true' }}
-    runs-on: ubuntu-latest-16-cores
+    runs-on: oracle-vm-16cpu-64gb-x86-64
     strategy:
       fail-fast: false
       matrix:
@@ -426,7 +426,7 @@ jobs:
       - build-go
       - changes
     env:
-      GOPATH: /home/runner/go
+      GOPATH: /home/ubuntu/go
       ARGOCD_FAKE_IN_CLUSTER: 'true'
       ARGOCD_SSH_DATA_PATH: '/tmp/argo-e2e/app/config/ssh'
       ARGOCD_TLS_DATA_PATH: '/tmp/argo-e2e/app/config/tls'
@@ -462,9 +462,9 @@ jobs:
           set -x
           curl -sfL https://get.k3s.io | sh -
           sudo chmod -R a+rw /etc/rancher/k3s
-          sudo mkdir -p $HOME/.kube && sudo chown -R runner $HOME/.kube
+          sudo mkdir -p $HOME/.kube && sudo chown -R ubuntu $HOME/.kube
           sudo k3s kubectl config view --raw > $HOME/.kube/config
-          sudo chown runner $HOME/.kube/config
+          sudo chown ubuntu $HOME/.kube/config
           sudo chmod go-r $HOME/.kube/config
           kubectl version
       - name: Restore go build cache
@@ -474,7 +474,7 @@ jobs:
           key: ${{ runner.os }}-go-build-v1-${{ github.run_id }}
       - name: Add ~/go/bin to PATH
         run: |
-          echo "/home/runner/go/bin" >> $GITHUB_PATH
+          echo "/home/ubuntu/go/bin" >> $GITHUB_PATH
       - name: Add /usr/local/bin to PATH
         run: |
           echo "/usr/local/bin" >> $GITHUB_PATH
@@ -500,7 +500,7 @@ jobs:
       - name: Create target directory for binaries in the build-process
         run: |
           mkdir -p dist
-          chown runner dist
+          chown ubuntu dist
       - name: Run E2E server and wait for it being available
         timeout-minutes: 30
         run: |


### PR DESCRIPTION
Using a runner that won't cost CNCF money.