### PR TITLE
fix(cmp): fix plugins not having access to argocd cli for git ASKPASS

### DIFF
--- a/manifests/base/repo-server/argocd-repo-server-deployment.yaml
+++ b/manifests/base/repo-server/argocd-repo-server-deployment.yaml
@@ -301,13 +301,13 @@ spec:
         - mountPath: /home/argocd/cmp-server/plugins
           name: plugins
       initContainers:
-      - command:
-        - /bin/cp
-        - -n
-        - /usr/local/bin/argocd
-        - /var/run/argocd/argocd
+      - args:
+          - /bin/cp -n /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln -s /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+        command:
+          - sh
+          - '-c'
         image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd
+        name: copyutil
         securityContext:
           runAsNonRoot: true
           readOnlyRootFilesystem: true
@@ -320,25 +320,6 @@ spec:
         volumeMounts:
         - mountPath: /var/run/argocd
           name: var-files
-      - command:
-          - /bin/ln
-          - -s
-          - /var/run/argocd/argocd
-          - /var/run/argocd/argocd-cmp-server
-        image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd-cmp-server
-        securityContext:
-          runAsNonRoot: true
-          readOnlyRootFilesystem: true
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-              - ALL
-          seccompProfile:
-            type: RuntimeDefault
-        volumeMounts:
-          - mountPath: /var/run/argocd
-            name: var-files
       volumes:
         - name: ssh-known-hosts
           configMap:

--- a/manifests/base/repo-server/argocd-repo-server-deployment.yaml
+++ b/manifests/base/repo-server/argocd-repo-server-deployment.yaml
@@ -305,9 +305,9 @@ spec:
         - /bin/cp
         - -n
         - /usr/local/bin/argocd
-        - /var/run/argocd/argocd-cmp-server
+        - /var/run/argocd/argocd
         image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd-cmp-server
+        name: copyutil-argocd
         securityContext:
           runAsNonRoot: true
           readOnlyRootFilesystem: true
@@ -321,12 +321,12 @@ spec:
         - mountPath: /var/run/argocd
           name: var-files
       - command:
-          - /bin/cp
-          - -n
-          - /usr/local/bin/argocd
+          - /bin/ln
+          - -s
           - /var/run/argocd/argocd
+          - /var/run/argocd/argocd-cmp-server
         image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd
+        name: copyutil-argocd-cmp-server
         securityContext:
           runAsNonRoot: true
           readOnlyRootFilesystem: true

--- a/manifests/base/repo-server/argocd-repo-server-deployment.yaml
+++ b/manifests/base/repo-server/argocd-repo-server-deployment.yaml
@@ -307,7 +307,7 @@ spec:
         - /usr/local/bin/argocd
         - /var/run/argocd/argocd-cmp-server
         image: quay.io/argoproj/argocd:latest
-        name: copyutil
+        name: copyutil-argocd-cmp-server
         securityContext:
           runAsNonRoot: true
           readOnlyRootFilesystem: true
@@ -320,6 +320,25 @@ spec:
         volumeMounts:
         - mountPath: /var/run/argocd
           name: var-files
+      - command:
+          - /bin/cp
+          - -n
+          - /usr/local/bin/argocd
+          - /var/run/argocd/argocd
+        image: quay.io/argoproj/argocd:latest
+        name: copyutil-argocd
+        securityContext:
+          runAsNonRoot: true
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+          - mountPath: /var/run/argocd
+            name: var-files
       volumes:
         - name: ssh-known-hosts
           configMap:

--- a/manifests/core-install-with-hydrator.yaml
+++ b/manifests/core-install-with-hydrator.yaml
@@ -25430,32 +25430,14 @@ spec:
         - mountPath: /home/argocd/cmp-server/plugins
           name: plugins
       initContainers:
-      - command:
-        - /bin/cp
-        - -n
-        - /usr/local/bin/argocd
-        - /var/run/argocd/argocd
+      - args:
+        - /bin/cp -n /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln -s /var/run/argocd/argocd
+          /var/run/argocd/argocd-cmp-server
+        command:
+        - sh
+        - -c
         image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
-        volumeMounts:
-        - mountPath: /var/run/argocd
-          name: var-files
-      - command:
-        - /bin/ln
-        - -s
-        - /var/run/argocd/argocd
-        - /var/run/argocd/argocd-cmp-server
-        image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd-cmp-server
+        name: copyutil
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/core-install-with-hydrator.yaml
+++ b/manifests/core-install-with-hydrator.yaml
@@ -25436,7 +25436,26 @@ spec:
         - /usr/local/bin/argocd
         - /var/run/argocd/argocd-cmp-server
         image: quay.io/argoproj/argocd:latest
-        name: copyutil
+        name: copyutil-argocd-cmp-server
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /var/run/argocd
+          name: var-files
+      - command:
+        - /bin/cp
+        - -n
+        - /usr/local/bin/argocd
+        - /var/run/argocd/argocd
+        image: quay.io/argoproj/argocd:latest
+        name: copyutil-argocd
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/core-install-with-hydrator.yaml
+++ b/manifests/core-install-with-hydrator.yaml
@@ -25434,9 +25434,9 @@ spec:
         - /bin/cp
         - -n
         - /usr/local/bin/argocd
-        - /var/run/argocd/argocd-cmp-server
+        - /var/run/argocd/argocd
         image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd-cmp-server
+        name: copyutil-argocd
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -25450,12 +25450,12 @@ spec:
         - mountPath: /var/run/argocd
           name: var-files
       - command:
-        - /bin/cp
-        - -n
-        - /usr/local/bin/argocd
+        - /bin/ln
+        - -s
         - /var/run/argocd/argocd
+        - /var/run/argocd/argocd-cmp-server
         image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd
+        name: copyutil-argocd-cmp-server
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -25264,32 +25264,14 @@ spec:
         - mountPath: /home/argocd/cmp-server/plugins
           name: plugins
       initContainers:
-      - command:
-        - /bin/cp
-        - -n
-        - /usr/local/bin/argocd
-        - /var/run/argocd/argocd
+      - args:
+        - /bin/cp -n /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln -s /var/run/argocd/argocd
+          /var/run/argocd/argocd-cmp-server
+        command:
+        - sh
+        - -c
         image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
-        volumeMounts:
-        - mountPath: /var/run/argocd
-          name: var-files
-      - command:
-        - /bin/ln
-        - -s
-        - /var/run/argocd/argocd
-        - /var/run/argocd/argocd-cmp-server
-        image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd-cmp-server
+        name: copyutil
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -25270,7 +25270,26 @@ spec:
         - /usr/local/bin/argocd
         - /var/run/argocd/argocd-cmp-server
         image: quay.io/argoproj/argocd:latest
-        name: copyutil
+        name: copyutil-argocd-cmp-server
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /var/run/argocd
+          name: var-files
+      - command:
+        - /bin/cp
+        - -n
+        - /usr/local/bin/argocd
+        - /var/run/argocd/argocd
+        image: quay.io/argoproj/argocd:latest
+        name: copyutil-argocd
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -25268,9 +25268,9 @@ spec:
         - /bin/cp
         - -n
         - /usr/local/bin/argocd
-        - /var/run/argocd/argocd-cmp-server
+        - /var/run/argocd/argocd
         image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd-cmp-server
+        name: copyutil-argocd
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -25284,12 +25284,12 @@ spec:
         - mountPath: /var/run/argocd
           name: var-files
       - command:
-        - /bin/cp
-        - -n
-        - /usr/local/bin/argocd
+        - /bin/ln
+        - -s
         - /var/run/argocd/argocd
+        - /var/run/argocd/argocd-cmp-server
         image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd
+        name: copyutil-argocd-cmp-server
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/ha/install-with-hydrator.yaml
+++ b/manifests/ha/install-with-hydrator.yaml
@@ -27071,7 +27071,26 @@ spec:
         - /usr/local/bin/argocd
         - /var/run/argocd/argocd-cmp-server
         image: quay.io/argoproj/argocd:latest
-        name: copyutil
+        name: copyutil-argocd-cmp-server
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /var/run/argocd
+          name: var-files
+      - command:
+        - /bin/cp
+        - -n
+        - /usr/local/bin/argocd
+        - /var/run/argocd/argocd
+        image: quay.io/argoproj/argocd:latest
+        name: copyutil-argocd
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/ha/install-with-hydrator.yaml
+++ b/manifests/ha/install-with-hydrator.yaml
@@ -27065,32 +27065,14 @@ spec:
         - mountPath: /home/argocd/cmp-server/plugins
           name: plugins
       initContainers:
-      - command:
-        - /bin/cp
-        - -n
-        - /usr/local/bin/argocd
-        - /var/run/argocd/argocd
+      - args:
+        - /bin/cp -n /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln -s /var/run/argocd/argocd
+          /var/run/argocd/argocd-cmp-server
+        command:
+        - sh
+        - -c
         image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
-        volumeMounts:
-        - mountPath: /var/run/argocd
-          name: var-files
-      - command:
-        - /bin/ln
-        - -s
-        - /var/run/argocd/argocd
-        - /var/run/argocd/argocd-cmp-server
-        image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd-cmp-server
+        name: copyutil
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/ha/install-with-hydrator.yaml
+++ b/manifests/ha/install-with-hydrator.yaml
@@ -27069,9 +27069,9 @@ spec:
         - /bin/cp
         - -n
         - /usr/local/bin/argocd
-        - /var/run/argocd/argocd-cmp-server
+        - /var/run/argocd/argocd
         image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd-cmp-server
+        name: copyutil-argocd
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -27085,12 +27085,12 @@ spec:
         - mountPath: /var/run/argocd
           name: var-files
       - command:
-        - /bin/cp
-        - -n
-        - /usr/local/bin/argocd
+        - /bin/ln
+        - -s
         - /var/run/argocd/argocd
+        - /var/run/argocd/argocd-cmp-server
         image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd
+        name: copyutil-argocd-cmp-server
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -26907,7 +26907,26 @@ spec:
         - /usr/local/bin/argocd
         - /var/run/argocd/argocd-cmp-server
         image: quay.io/argoproj/argocd:latest
-        name: copyutil
+        name: copyutil-argocd-cmp-server
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /var/run/argocd
+          name: var-files
+      - command:
+        - /bin/cp
+        - -n
+        - /usr/local/bin/argocd
+        - /var/run/argocd/argocd
+        image: quay.io/argoproj/argocd:latest
+        name: copyutil-argocd
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -26905,9 +26905,9 @@ spec:
         - /bin/cp
         - -n
         - /usr/local/bin/argocd
-        - /var/run/argocd/argocd-cmp-server
+        - /var/run/argocd/argocd
         image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd-cmp-server
+        name: copyutil-argocd
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -26921,12 +26921,12 @@ spec:
         - mountPath: /var/run/argocd
           name: var-files
       - command:
-        - /bin/cp
-        - -n
-        - /usr/local/bin/argocd
+        - /bin/ln
+        - -s
         - /var/run/argocd/argocd
+        - /var/run/argocd/argocd-cmp-server
         image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd
+        name: copyutil-argocd-cmp-server
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -26901,32 +26901,14 @@ spec:
         - mountPath: /home/argocd/cmp-server/plugins
           name: plugins
       initContainers:
-      - command:
-        - /bin/cp
-        - -n
-        - /usr/local/bin/argocd
-        - /var/run/argocd/argocd
+      - args:
+        - /bin/cp -n /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln -s /var/run/argocd/argocd
+          /var/run/argocd/argocd-cmp-server
+        command:
+        - sh
+        - -c
         image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
-        volumeMounts:
-        - mountPath: /var/run/argocd
-          name: var-files
-      - command:
-        - /bin/ln
-        - -s
-        - /var/run/argocd/argocd
-        - /var/run/argocd/argocd-cmp-server
-        image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd-cmp-server
+        name: copyutil
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/ha/namespace-install-with-hydrator.yaml
+++ b/manifests/ha/namespace-install-with-hydrator.yaml
@@ -2756,9 +2756,9 @@ spec:
         - /bin/cp
         - -n
         - /usr/local/bin/argocd
-        - /var/run/argocd/argocd-cmp-server
+        - /var/run/argocd/argocd
         image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd-cmp-server
+        name: copyutil-argocd
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -2772,12 +2772,12 @@ spec:
         - mountPath: /var/run/argocd
           name: var-files
       - command:
-        - /bin/cp
-        - -n
-        - /usr/local/bin/argocd
+        - /bin/ln
+        - -s
         - /var/run/argocd/argocd
+        - /var/run/argocd/argocd-cmp-server
         image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd
+        name: copyutil-argocd-cmp-server
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/ha/namespace-install-with-hydrator.yaml
+++ b/manifests/ha/namespace-install-with-hydrator.yaml
@@ -2752,32 +2752,14 @@ spec:
         - mountPath: /home/argocd/cmp-server/plugins
           name: plugins
       initContainers:
-      - command:
-        - /bin/cp
-        - -n
-        - /usr/local/bin/argocd
-        - /var/run/argocd/argocd
+      - args:
+        - /bin/cp -n /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln -s /var/run/argocd/argocd
+          /var/run/argocd/argocd-cmp-server
+        command:
+        - sh
+        - -c
         image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
-        volumeMounts:
-        - mountPath: /var/run/argocd
-          name: var-files
-      - command:
-        - /bin/ln
-        - -s
-        - /var/run/argocd/argocd
-        - /var/run/argocd/argocd-cmp-server
-        image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd-cmp-server
+        name: copyutil
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/ha/namespace-install-with-hydrator.yaml
+++ b/manifests/ha/namespace-install-with-hydrator.yaml
@@ -2758,7 +2758,26 @@ spec:
         - /usr/local/bin/argocd
         - /var/run/argocd/argocd-cmp-server
         image: quay.io/argoproj/argocd:latest
-        name: copyutil
+        name: copyutil-argocd-cmp-server
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /var/run/argocd
+          name: var-files
+      - command:
+        - /bin/cp
+        - -n
+        - /usr/local/bin/argocd
+        - /var/run/argocd/argocd
+        image: quay.io/argoproj/argocd:latest
+        name: copyutil-argocd
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -2594,7 +2594,26 @@ spec:
         - /usr/local/bin/argocd
         - /var/run/argocd/argocd-cmp-server
         image: quay.io/argoproj/argocd:latest
-        name: copyutil
+        name: copyutil-argocd-cmp-server
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /var/run/argocd
+          name: var-files
+      - command:
+        - /bin/cp
+        - -n
+        - /usr/local/bin/argocd
+        - /var/run/argocd/argocd
+        image: quay.io/argoproj/argocd:latest
+        name: copyutil-argocd
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -2592,9 +2592,9 @@ spec:
         - /bin/cp
         - -n
         - /usr/local/bin/argocd
-        - /var/run/argocd/argocd-cmp-server
+        - /var/run/argocd/argocd
         image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd-cmp-server
+        name: copyutil-argocd
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -2608,12 +2608,12 @@ spec:
         - mountPath: /var/run/argocd
           name: var-files
       - command:
-        - /bin/cp
-        - -n
-        - /usr/local/bin/argocd
+        - /bin/ln
+        - -s
         - /var/run/argocd/argocd
+        - /var/run/argocd/argocd-cmp-server
         image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd
+        name: copyutil-argocd-cmp-server
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -2588,32 +2588,14 @@ spec:
         - mountPath: /home/argocd/cmp-server/plugins
           name: plugins
       initContainers:
-      - command:
-        - /bin/cp
-        - -n
-        - /usr/local/bin/argocd
-        - /var/run/argocd/argocd
+      - args:
+        - /bin/cp -n /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln -s /var/run/argocd/argocd
+          /var/run/argocd/argocd-cmp-server
+        command:
+        - sh
+        - -c
         image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
-        volumeMounts:
-        - mountPath: /var/run/argocd
-          name: var-files
-      - command:
-        - /bin/ln
-        - -s
-        - /var/run/argocd/argocd
-        - /var/run/argocd/argocd-cmp-server
-        image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd-cmp-server
+        name: copyutil
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/install-with-hydrator.yaml
+++ b/manifests/install-with-hydrator.yaml
@@ -26101,7 +26101,26 @@ spec:
         - /usr/local/bin/argocd
         - /var/run/argocd/argocd-cmp-server
         image: quay.io/argoproj/argocd:latest
-        name: copyutil
+        name: copyutil-argocd-cmp-server
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /var/run/argocd
+          name: var-files
+      - command:
+        - /bin/cp
+        - -n
+        - /usr/local/bin/argocd
+        - /var/run/argocd/argocd
+        image: quay.io/argoproj/argocd:latest
+        name: copyutil-argocd
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/install-with-hydrator.yaml
+++ b/manifests/install-with-hydrator.yaml
@@ -26099,9 +26099,9 @@ spec:
         - /bin/cp
         - -n
         - /usr/local/bin/argocd
-        - /var/run/argocd/argocd-cmp-server
+        - /var/run/argocd/argocd
         image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd-cmp-server
+        name: copyutil-argocd
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -26115,12 +26115,12 @@ spec:
         - mountPath: /var/run/argocd
           name: var-files
       - command:
-        - /bin/cp
-        - -n
-        - /usr/local/bin/argocd
+        - /bin/ln
+        - -s
         - /var/run/argocd/argocd
+        - /var/run/argocd/argocd-cmp-server
         image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd
+        name: copyutil-argocd-cmp-server
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/install-with-hydrator.yaml
+++ b/manifests/install-with-hydrator.yaml
@@ -26095,32 +26095,14 @@ spec:
         - mountPath: /home/argocd/cmp-server/plugins
           name: plugins
       initContainers:
-      - command:
-        - /bin/cp
-        - -n
-        - /usr/local/bin/argocd
-        - /var/run/argocd/argocd
+      - args:
+        - /bin/cp -n /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln -s /var/run/argocd/argocd
+          /var/run/argocd/argocd-cmp-server
+        command:
+        - sh
+        - -c
         image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
-        volumeMounts:
-        - mountPath: /var/run/argocd
-          name: var-files
-      - command:
-        - /bin/ln
-        - -s
-        - /var/run/argocd/argocd
-        - /var/run/argocd/argocd-cmp-server
-        image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd-cmp-server
+        name: copyutil
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -25929,32 +25929,14 @@ spec:
         - mountPath: /home/argocd/cmp-server/plugins
           name: plugins
       initContainers:
-      - command:
-        - /bin/cp
-        - -n
-        - /usr/local/bin/argocd
-        - /var/run/argocd/argocd
+      - args:
+        - /bin/cp -n /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln -s /var/run/argocd/argocd
+          /var/run/argocd/argocd-cmp-server
+        command:
+        - sh
+        - -c
         image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
-        volumeMounts:
-        - mountPath: /var/run/argocd
-          name: var-files
-      - command:
-        - /bin/ln
-        - -s
-        - /var/run/argocd/argocd
-        - /var/run/argocd/argocd-cmp-server
-        image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd-cmp-server
+        name: copyutil
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -25935,7 +25935,26 @@ spec:
         - /usr/local/bin/argocd
         - /var/run/argocd/argocd-cmp-server
         image: quay.io/argoproj/argocd:latest
-        name: copyutil
+        name: copyutil-argocd-cmp-server
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /var/run/argocd
+          name: var-files
+      - command:
+        - /bin/cp
+        - -n
+        - /usr/local/bin/argocd
+        - /var/run/argocd/argocd
+        image: quay.io/argoproj/argocd:latest
+        name: copyutil-argocd
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -25933,9 +25933,9 @@ spec:
         - /bin/cp
         - -n
         - /usr/local/bin/argocd
-        - /var/run/argocd/argocd-cmp-server
+        - /var/run/argocd/argocd
         image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd-cmp-server
+        name: copyutil-argocd
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -25949,12 +25949,12 @@ spec:
         - mountPath: /var/run/argocd
           name: var-files
       - command:
-        - /bin/cp
-        - -n
-        - /usr/local/bin/argocd
+        - /bin/ln
+        - -s
         - /var/run/argocd/argocd
+        - /var/run/argocd/argocd-cmp-server
         image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd
+        name: copyutil-argocd-cmp-server
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/namespace-install-with-hydrator.yaml
+++ b/manifests/namespace-install-with-hydrator.yaml
@@ -1782,32 +1782,14 @@ spec:
         - mountPath: /home/argocd/cmp-server/plugins
           name: plugins
       initContainers:
-      - command:
-        - /bin/cp
-        - -n
-        - /usr/local/bin/argocd
-        - /var/run/argocd/argocd
+      - args:
+        - /bin/cp -n /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln -s /var/run/argocd/argocd
+          /var/run/argocd/argocd-cmp-server
+        command:
+        - sh
+        - -c
         image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
-        volumeMounts:
-        - mountPath: /var/run/argocd
-          name: var-files
-      - command:
-        - /bin/ln
-        - -s
-        - /var/run/argocd/argocd
-        - /var/run/argocd/argocd-cmp-server
-        image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd-cmp-server
+        name: copyutil
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/namespace-install-with-hydrator.yaml
+++ b/manifests/namespace-install-with-hydrator.yaml
@@ -1788,7 +1788,26 @@ spec:
         - /usr/local/bin/argocd
         - /var/run/argocd/argocd-cmp-server
         image: quay.io/argoproj/argocd:latest
-        name: copyutil
+        name: copyutil-argocd-cmp-server
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /var/run/argocd
+          name: var-files
+      - command:
+        - /bin/cp
+        - -n
+        - /usr/local/bin/argocd
+        - /var/run/argocd/argocd
+        image: quay.io/argoproj/argocd:latest
+        name: copyutil-argocd
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/namespace-install-with-hydrator.yaml
+++ b/manifests/namespace-install-with-hydrator.yaml
@@ -1786,9 +1786,9 @@ spec:
         - /bin/cp
         - -n
         - /usr/local/bin/argocd
-        - /var/run/argocd/argocd-cmp-server
+        - /var/run/argocd/argocd
         image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd-cmp-server
+        name: copyutil-argocd
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -1802,12 +1802,12 @@ spec:
         - mountPath: /var/run/argocd
           name: var-files
       - command:
-        - /bin/cp
-        - -n
-        - /usr/local/bin/argocd
+        - /bin/ln
+        - -s
         - /var/run/argocd/argocd
+        - /var/run/argocd/argocd-cmp-server
         image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd
+        name: copyutil-argocd-cmp-server
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -1620,9 +1620,9 @@ spec:
         - /bin/cp
         - -n
         - /usr/local/bin/argocd
-        - /var/run/argocd/argocd-cmp-server
+        - /var/run/argocd/argocd
         image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd-cmp-server
+        name: copyutil-argocd
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -1636,12 +1636,12 @@ spec:
         - mountPath: /var/run/argocd
           name: var-files
       - command:
-        - /bin/cp
-        - -n
-        - /usr/local/bin/argocd
+        - /bin/ln
+        - -s
         - /var/run/argocd/argocd
+        - /var/run/argocd/argocd-cmp-server
         image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd
+        name: copyutil-argocd-cmp-server
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -1616,32 +1616,14 @@ spec:
         - mountPath: /home/argocd/cmp-server/plugins
           name: plugins
       initContainers:
-      - command:
-        - /bin/cp
-        - -n
-        - /usr/local/bin/argocd
-        - /var/run/argocd/argocd
+      - args:
+        - /bin/cp -n /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln -s /var/run/argocd/argocd
+          /var/run/argocd/argocd-cmp-server
+        command:
+        - sh
+        - -c
         image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
-        volumeMounts:
-        - mountPath: /var/run/argocd
-          name: var-files
-      - command:
-        - /bin/ln
-        - -s
-        - /var/run/argocd/argocd
-        - /var/run/argocd/argocd-cmp-server
-        image: quay.io/argoproj/argocd:latest
-        name: copyutil-argocd-cmp-server
+        name: copyutil
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -1622,7 +1622,26 @@ spec:
         - /usr/local/bin/argocd
         - /var/run/argocd/argocd-cmp-server
         image: quay.io/argoproj/argocd:latest
-        name: copyutil
+        name: copyutil-argocd-cmp-server
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /var/run/argocd
+          name: var-files
+      - command:
+        - /bin/cp
+        - -n
+        - /usr/local/bin/argocd
+        - /var/run/argocd/argocd
+        image: quay.io/argoproj/argocd:latest
+        name: copyutil-argocd
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
This is important for plugins with `provideGitCreds: true`. https://argo-cd.readthedocs.io/en/stable/operator-manual/config-management-plugins/#provide-git-credentials