### PR TITLE
fix(server): Fix different js content per architecture

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1410,6 +1410,10 @@ func newRedirectServer(port int, rootPath string) *http.Server {
 
 // registerDownloadHandlers registers HTTP handlers to support downloads directly from the API server
 // (e.g. argocd CLI)
+//
+// Deprecated: We have removed the primary consumer of this API from the UI to resolve asset hash diff per architecture.
+// We should remove this in the next major ArgoCD release (4.0).
+// For details, see https://github.com/argoproj/argo-cd/issues/11262.
 func registerDownloadHandlers(mux *http.ServeMux, base string) {
 	linuxPath, err := exec.LookPath("argocd")
 	if err != nil {

--- a/ui/src/app/help/components/help.tsx
+++ b/ui/src/app/help/components/help.tsx
@@ -37,8 +37,11 @@ export const Help = () => {
                                     <div className='columns large-4 small-6'>
                                         <div className='help-box'>
                                             <p>Want to download the CLI tool?</p>
-                                            <a href={`download/argocd-linux-${process.env.HOST_ARCH}`} className='user-info-panel-buttons argo-button argo-button--base'>
-                                                <i className='fab fa-linux' /> Linux ({process.env.HOST_ARCH})
+                                            <a
+                                                href='https://github.com/argoproj/argo-cd/releases'
+                                                target='_blank'
+                                                className='user-info-panel-buttons argo-button argo-button--base'>
+                                                Releases
                                             </a>
                                             &nbsp;
                                             {Object.keys(binaryUrls || {}).map(binaryName => {


### PR DESCRIPTION
## Summary

closes #11262

JavaScript contained different contents per built architecture, leading to servers deployed in different architectures serving different contents.
This leads to issues like #11262 which prevents rendering of the whole UI if ArgoCD is deployed in HA mode.

I picked this comment's approach to just embed release URL page of ArgoCD repo, since this seems to be the simplest and the most robust approach.
https://github.com/argoproj/argo-cd/issues/11262#issuecomment-1730231300

~~I also removed `/download/` path from the server, which is *technically* a breaking change.~~
~~But if the only (official) usage of this path is from this part of the UI, I think it's pretty much safe to delete this path to cleanup the code altogether.~~
~~There's not much reason to allow users to download the pod's binary directly - they can download it from the releases page, and if there is an absoute need to do so they can enter the pod to debug the issue anyway.~~
EDIT: Since this is technically a breaking change, removing this path is at least deferred to the next major release.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
    * probably no
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
