### PR TITLE
docs(webhook): document Azure DevOps username/password

### DIFF
--- a/docs/operator-manual/argocd-secret.yaml
+++ b/docs/operator-manual/argocd-secret.yaml
@@ -34,6 +34,10 @@ data:
   webhook.bitbucketserver.secret: shhhh! it's a bitbucket server secret
   # gogs server webhook secret
   webhook.gogs.secret: shhhh! it's a gogs server secret
+  # azure devops webhook username
+  webhook.azuredevops.username: shhhh! it's an azure devops secret
+  # azure devops webhook password
+  webhook.azuredevops.password: shhhh! it's an azure devops secret
 
   # an additional user password and its last modified time (see user definition in argocd-cm.yaml)
   accounts.alice.password:


### PR DESCRIPTION
Just noticed these are missing from the file