### PR TITLE
chore: add unit tests for printKeyTable (header, rows, uppercase subtype) (#24274)

### DIFF
--- a/cmd/argocd/commands/gpg_test.go
+++ b/cmd/argocd/commands/gpg_test.go
@@ -1,0 +1,104 @@
+package commands
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	appsv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+)
+
+// splitColumns splits a line produced by tabwriter using runs of 2 or more spaces
+// as delimiters to obtain logical columns regardless of alignment padding.
+func splitColumns(line string) []string {
+	re := regexp.MustCompile(`\s{2,}`)
+	return re.Split(strings.TrimSpace(line), -1)
+}
+
+func Test_printKeyTable_Empty(t *testing.T) {
+	out, err := captureOutput(func() error {
+		printKeyTable([]appsv1.GnuPGPublicKey{})
+		return nil
+	})
+	require.NoError(t, err)
+
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	require.Len(t, lines, 1)
+
+	headerCols := splitColumns(lines[0])
+	assert.Equal(t, []string{"KEYID", "TYPE", "IDENTITY"}, headerCols)
+}
+
+func Test_printKeyTable_Single(t *testing.T) {
+	keys := []appsv1.GnuPGPublicKey{
+		{
+			KeyID:   "ABCDEF1234567890",
+			SubType: "rsa4096",
+			Owner:   "Alice <alice@example.com>",
+		},
+	}
+
+	out, err := captureOutput(func() error {
+		printKeyTable(keys)
+		return nil
+	})
+	require.NoError(t, err)
+
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	require.Len(t, lines, 2)
+
+	// Header
+	assert.Equal(t, []string{"KEYID", "TYPE", "IDENTITY"}, splitColumns(lines[0]))
+
+	// Row
+	row := splitColumns(lines[1])
+	require.Len(t, row, 3)
+	assert.Equal(t, "ABCDEF1234567890", row[0])
+	assert.Equal(t, "RSA4096", row[1]) // subtype upper-cased
+	assert.Equal(t, "Alice <alice@example.com>", row[2])
+}
+
+func Test_printKeyTable_Multiple(t *testing.T) {
+	keys := []appsv1.GnuPGPublicKey{
+		{
+			KeyID:   "ABCD",
+			SubType: "ed25519",
+			Owner:   "User One <one@example.com>",
+		},
+		{
+			KeyID:   "0123456789ABCDEF",
+			SubType: "rsa2048",
+			Owner:   "Second User <second@example.com>",
+		},
+	}
+
+	out, err := captureOutput(func() error {
+		printKeyTable(keys)
+		return nil
+	})
+	require.NoError(t, err)
+
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	require.Len(t, lines, 3)
+
+	// Header
+	assert.Equal(t, []string{"KEYID", "TYPE", "IDENTITY"}, splitColumns(lines[0]))
+
+	// First row
+	row1 := splitColumns(lines[1])
+	require.Len(t, row1, 3)
+	assert.Equal(t, "ABCD", row1[0])
+	assert.Equal(t, "ED25519", row1[1])
+	assert.Equal(t, "User One <one@example.com>", row1[2])
+
+	// Second row
+	row2 := splitColumns(lines[2])
+	require.Len(t, row2, 3)
+	assert.Equal(t, "0123456789ABCDEF", row2[0])
+	assert.Equal(t, "RSA2048", row2[1])
+	assert.Equal(t, "Second User <second@example.com>", row2[2])
+}
+

--- a/cmd/argocd/commands/gpg_test.go
+++ b/cmd/argocd/commands/gpg_test.go
@@ -101,4 +101,3 @@ func Test_printKeyTable_Multiple(t *testing.T) {
 	assert.Equal(t, "RSA2048", row2[1])
 	assert.Equal(t, "Second User <second@example.com>", row2[2])
 }
-


### PR DESCRIPTION
### Summary
Add unit tests to verify the tabular output of printKeyTable in `cmd/argocd/commands/gpg_test.go`.

### Changes
- Verify header presence: `KEYID`, `TYPE`, `IDENTITY`.
- Verify row formatting for empty, single-key, and multiple-key inputs.
- Verify upper-casing of key subtype (e.g., rsa4096 -> RSA4096).
- Capture stdout using the existing captureOutput pattern and parse columns robustly by splitting on 2+ spaces (independent of tabwriter alignment).

### Tests
go test ./cmd/argocd/commands -run Test_printKeyTable -v passes locally.

### Closes #24274

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
