### PR TITLE
fix(ui): overlapping UI elements and add resource units to tooltips

### DIFF
--- a/ui/src/app/applications/components/application-pod-view/pod-tooltip.tsx
+++ b/ui/src/app/applications/components/application-pod-view/pod-tooltip.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import Moment from 'react-moment';
 import {Pod, ResourceName} from '../../../shared/models';
-import {isYoungerThanXMinutes} from '../utils';
-import {formatMetric} from './pod-view';
+import {isYoungerThanXMinutes, formatResourceInfo} from '../utils';
 
 export const PodTooltip = (props: {pod: Pod}) => {
     const pod = props.pod;
@@ -23,10 +22,20 @@ export const PodTooltip = (props: {pod: Pod}) => {
                 })
                 .map(i => {
                     const isPodRequests = i.name === ResourceName.ResourceCPU || i.name === ResourceName.ResourceMemory;
-                    const formattedValue = isPodRequests ? formatMetric(i.name as ResourceName, parseInt(i.value, 10)) : i.value;
+                    let formattedValue = i.value;
+                    let label = `${i.name}:`;
 
-                    //this is just to show cpu and mem info with "Requests" as prefix
-                    const label = i.name === ResourceName.ResourceCPU ? 'Requests CPU:' : i.name === ResourceName.ResourceMemory ? 'Requests MEM:' : `${i.name}:`;
+                    if (isPodRequests) {
+                        if (i.name === ResourceName.ResourceCPU) {
+                            const {displayValue} = formatResourceInfo('cpu', i.value);
+                            formattedValue = displayValue;
+                            label = 'Requests CPU:';
+                        } else if (i.name === ResourceName.ResourceMemory) {
+                            const {displayValue} = formatResourceInfo('memory', i.value);
+                            formattedValue = displayValue;
+                            label = 'Requests MEM:';
+                        }
+                    }
 
                     return (
                         <div className='row' key={i.name}>

--- a/ui/src/app/applications/components/application-resource-tree/application-resource-tree.scss
+++ b/ui/src/app/applications/components/application-resource-tree/application-resource-tree.scss
@@ -20,7 +20,7 @@
                     position: absolute;
                     color: #A3A3A3;
                     font-size: 10px;
-                    top: -10px;
+                    top: -9px;
                     transform: rotate(180deg);
                 }
             }

--- a/ui/src/app/applications/components/application-resource-tree/application-resource-tree.tsx
+++ b/ui/src/app/applications/components/application-resource-tree/application-resource-tree.tsx
@@ -548,11 +548,7 @@ function renderPodGroup(props: ApplicationResourceTreeProps, id: string, node: R
                                         // Use common formatting function for CPU and Memory
                                         if (i.name === 'cpu' || i.name === 'memory') {
                                             const {tooltipValue} = formatResourceInfo(i.name, `${i.value}`);
-                                            return (
-                                                <div key={i.name}>
-                                                    {tooltipValue}
-                                                </div>
-                                            );
+                                            return <div key={i.name}>{tooltipValue}</div>;
                                         } else {
                                             return (
                                                 <div key={i.name}>
@@ -854,23 +850,19 @@ function renderResourceNode(props: ApplicationResourceTreeProps, id: string, nod
                     <Tooltip
                         content={
                             <>
-                                    {(node.info || []).map(i => {
-                                        // Use common formatting function for CPU and Memory
-                                        if (i.name === 'cpu' || i.name === 'memory') {
-                                            const {tooltipValue} = formatResourceInfo(i.name, `${i.value}`);
-                                            return (
-                                                <div key={i.name}>
-                                                    {tooltipValue}
-                                                </div>
-                                            );
-                                        } else {
-                                            return (
-                                                <div key={i.name}>
-                                                    {i.name}: {i.value}
-                                                </div>
-                                            );
-                                        }
-                                    })}
+                                {(node.info || []).map(i => {
+                                    // Use common formatting function for CPU and Memory
+                                    if (i.name === 'cpu' || i.name === 'memory') {
+                                        const {tooltipValue} = formatResourceInfo(i.name, `${i.value}`);
+                                        return <div key={i.name}>{tooltipValue}</div>;
+                                    } else {
+                                        return (
+                                            <div key={i.name}>
+                                                {i.name}: {i.value}
+                                            </div>
+                                        );
+                                    }
+                                })}
                             </>
                         }
                         key={node.uid}>

--- a/ui/src/app/applications/components/application-resource-tree/application-resource-tree.tsx
+++ b/ui/src/app/applications/components/application-resource-tree/application-resource-tree.tsx
@@ -24,7 +24,8 @@ import {
     PodHealthIcon,
     getUsrMsgKeyToDisplay,
     getApplicationLinkURLFromNode,
-    getManagedByURLFromNode
+    getManagedByURLFromNode,
+    formatResourceInfo
 } from '../utils';
 import {NodeUpdateAnimation} from './node-update-animation';
 import {PodGroup} from '../application-pod-view/pod-view';
@@ -543,11 +544,23 @@ function renderPodGroup(props: ApplicationResourceTreeProps, id: string, node: R
                         <Tooltip
                             content={
                                 <>
-                                    {(node.info || []).map(i => (
-                                        <div key={i.name}>
-                                            {i.name}: {i.value}
-                                        </div>
-                                    ))}
+                                    {(node.info || []).map(i => {
+                                        // Use common formatting function for CPU and Memory
+                                        if (i.name === 'cpu' || i.name === 'memory') {
+                                            const {tooltipValue} = formatResourceInfo(i.name, `${i.value}`);
+                                            return (
+                                                <div key={i.name}>
+                                                    {tooltipValue}
+                                                </div>
+                                            );
+                                        } else {
+                                            return (
+                                                <div key={i.name}>
+                                                    {i.name}: {i.value}
+                                                </div>
+                                            );
+                                        }
+                                    })}
                                 </>
                             }
                             key={node.uid}>
@@ -675,9 +688,9 @@ function expandCollapse(node: ResourceTreeNode, props: ApplicationResourceTreePr
 
 function NodeInfoDetails({tag: tag, kind: kind}: {tag: models.InfoItem; kind: string}) {
     if (kind === 'Pod') {
-        const val = `${tag.name}`;
+        const val = tag.name;
         if (val === 'Status Reason') {
-            if (`${tag.value}` !== 'ImagePullBackOff')
+            if (String(tag.value) !== 'ImagePullBackOff')
                 return (
                     <span className='application-resource-tree__node-label' title={`Status: ${tag.value}`}>
                         {tag.value}
@@ -693,10 +706,10 @@ function NodeInfoDetails({tag: tag, kind: kind}: {tag: models.InfoItem; kind: st
                 );
             }
         } else if (val === 'Containers') {
-            const arr = `${tag.value}`.split('/');
+            const arr = String(tag.value).split('/');
             const title = `Number of containers in total: ${arr[1]} \nNumber of ready containers: ${arr[0]}`;
             return (
-                <span className='application-resource-tree__node-label' title={`${title}`}>
+                <span className='application-resource-tree__node-label' title={title}>
                     {tag.value}
                 </span>
             );
@@ -710,6 +723,14 @@ function NodeInfoDetails({tag: tag, kind: kind}: {tag: models.InfoItem; kind: st
             return (
                 <span className='application-resource-tree__node-label' title={`The revision in which pod present is: ${tag.value}`}>
                     {tag.value}
+                </span>
+            );
+        } else if (val === 'cpu' || val === 'memory') {
+            // Use common formatting function for CPU and Memory
+            const {displayValue, tooltipValue} = formatResourceInfo(val, String(tag.value));
+            return (
+                <span className='application-resource-tree__node-label' title={tooltipValue}>
+                    {displayValue}
                 </span>
             );
         } else {
@@ -829,15 +850,27 @@ function renderResourceNode(props: ApplicationResourceTreeProps, id: string, nod
                     .map((tag, i) => {
                         return <NodeInfoDetails tag={tag} kind={node.kind} key={i} />;
                     })}
-                {(node.info || []).length > 4 && (
+                {(node.info || []).length > 3 && (
                     <Tooltip
                         content={
                             <>
-                                {(node.info || []).map(i => (
-                                    <div key={i.name}>
-                                        {i.name}: {i.value}
-                                    </div>
-                                ))}
+                                    {(node.info || []).map(i => {
+                                        // Use common formatting function for CPU and Memory
+                                        if (i.name === 'cpu' || i.name === 'memory') {
+                                            const {tooltipValue} = formatResourceInfo(i.name, `${i.value}`);
+                                            return (
+                                                <div key={i.name}>
+                                                    {tooltipValue}
+                                                </div>
+                                            );
+                                        } else {
+                                            return (
+                                                <div key={i.name}>
+                                                    {i.name}: {i.value}
+                                                </div>
+                                            );
+                                        }
+                                    })}
                             </>
                         }
                         key={node.uid}>

--- a/ui/src/app/applications/components/application-resource-tree/application-resource-tree.tsx
+++ b/ui/src/app/applications/components/application-resource-tree/application-resource-tree.tsx
@@ -548,7 +548,11 @@ function renderPodGroup(props: ApplicationResourceTreeProps, id: string, node: R
                                         // Use common formatting function for CPU and Memory
                                         if (i.name === 'cpu' || i.name === 'memory') {
                                             const {tooltipValue} = formatResourceInfo(i.name, `${i.value}`);
-                                            return <div key={i.name}>{tooltipValue}</div>;
+                                            return (
+                                                <div key={i.name}>
+                                                    {tooltipValue}
+                                                </div>
+                                            );
                                         } else {
                                             return (
                                                 <div key={i.name}>
@@ -842,7 +846,7 @@ function renderResourceNode(props: ApplicationResourceTreeProps, id: string, nod
                 ) : null}
                 {(node.info || [])
                     .filter(tag => !tag.name.includes('Node') && tag.name !== 'managed-by-url')
-                    .slice(0, 4)
+                    .slice(0, 2)
                     .map((tag, i) => {
                         return <NodeInfoDetails tag={tag} kind={node.kind} key={i} />;
                     })}
@@ -850,19 +854,23 @@ function renderResourceNode(props: ApplicationResourceTreeProps, id: string, nod
                     <Tooltip
                         content={
                             <>
-                                {(node.info || []).map(i => {
-                                    // Use common formatting function for CPU and Memory
-                                    if (i.name === 'cpu' || i.name === 'memory') {
-                                        const {tooltipValue} = formatResourceInfo(i.name, `${i.value}`);
-                                        return <div key={i.name}>{tooltipValue}</div>;
-                                    } else {
-                                        return (
-                                            <div key={i.name}>
-                                                {i.name}: {i.value}
-                                            </div>
-                                        );
-                                    }
-                                })}
+                                    {(node.info || []).map(i => {
+                                        // Use common formatting function for CPU and Memory
+                                        if (i.name === 'cpu' || i.name === 'memory') {
+                                            const {tooltipValue} = formatResourceInfo(i.name, `${i.value}`);
+                                            return (
+                                                <div key={i.name}>
+                                                    {tooltipValue}
+                                                </div>
+                                            );
+                                        } else {
+                                            return (
+                                                <div key={i.name}>
+                                                    {i.name}: {i.value}
+                                                </div>
+                                            );
+                                        }
+                                    })}
                             </>
                         }
                         key={node.uid}>

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -1882,7 +1882,7 @@ export function formatMemoryTooltip(milliBytes: number): string {
 
 export function formatResourceInfo(name: string, value: string): {displayValue: string; tooltipValue: string} {
     const numValue = parseInt(value, 10);
-    
+
     if (name === 'cpu') {
         return {
             displayValue: formatCPUValue(numValue),
@@ -1894,7 +1894,7 @@ export function formatResourceInfo(name: string, value: string): {displayValue: 
             tooltipValue: formatMemoryTooltip(numValue)
         };
     }
-    
+
     return {
         displayValue: value,
         tooltipValue: `${name}: ${value}`

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -1882,26 +1882,7 @@ export function formatMemoryTooltip(milliBytes: number): string {
 
 export function formatResourceInfo(name: string, value: string): {displayValue: string; tooltipValue: string} {
     const numValue = parseInt(value, 10);
-
-    const formatCPUValue = (milliCpu: number): string => {
-        return milliCpu >= 1000 ? `${(milliCpu / 1000).toFixed(1)}` : `${milliCpu}m`;
-    };
-
-    const formatMemoryValue = (milliBytes: number): string => {
-        const mib = Math.round(milliBytes / (1024 * 1024 * 1000));
-        return `${mib}Mi`;
-    };
-
-    const formatCPUTooltip = (milliCpu: number): string => {
-        const displayValue = milliCpu >= 1000 ? `${(milliCpu / 1000).toFixed(1)} cores` : `${milliCpu}m`;
-        return `CPU Request: ${displayValue}`;
-    };
-
-    const formatMemoryTooltip = (milliBytes: number): string => {
-        const mib = Math.round(milliBytes / (1024 * 1024 * 1000));
-        return `Memory Request: ${mib}Mi`;
-    };
-
+    
     if (name === 'cpu') {
         return {
             displayValue: formatCPUValue(numValue),
@@ -1913,7 +1894,7 @@ export function formatResourceInfo(name: string, value: string): {displayValue: 
             tooltipValue: formatMemoryTooltip(numValue)
         };
     }
-
+    
     return {
         displayValue: value,
         tooltipValue: `${name}: ${value}`

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -1860,28 +1860,27 @@ export function getApplicationLinkURLFromNode(node: any, baseHref: string): {url
     return {url, isExternal};
 }
 
-// Common utility functions for formatting CPU and Memory values
-export function formatCPUValue(milliCpu: number): string {
-    return milliCpu >= 1000 ? `${(milliCpu / 1000).toFixed(1)}` : `${milliCpu}m`;
-}
-
-export function formatMemoryValue(milliBytes: number): string {
-    const mib = Math.round(milliBytes / (1024 * 1024 * 1000));
-    return `${mib}Mi`;
-}
-
-export function formatCPUTooltip(milliCpu: number): string {
-    const displayValue = milliCpu >= 1000 ? `${(milliCpu / 1000).toFixed(1)} cores` : `${milliCpu}m`;
-    return `CPU Request: ${displayValue}`;
-}
-
-export function formatMemoryTooltip(milliBytes: number): string {
-    const mib = Math.round(milliBytes / (1024 * 1024 * 1000));
-    return `Memory Request: ${mib}Mi`;
-}
-
 export function formatResourceInfo(name: string, value: string): {displayValue: string; tooltipValue: string} {
     const numValue = parseInt(value, 10);
+
+    const formatCPUValue = (milliCpu: number): string => {
+        return milliCpu >= 1000 ? `${(milliCpu / 1000).toFixed(1)}` : `${milliCpu}m`;
+    };
+
+    const formatMemoryValue = (milliBytes: number): string => {
+        const mib = Math.round(milliBytes / (1024 * 1024 * 1000));
+        return `${mib}Mi`;
+    };
+
+    const formatCPUTooltip = (milliCpu: number): string => {
+        const displayValue = milliCpu >= 1000 ? `${(milliCpu / 1000).toFixed(1)} cores` : `${milliCpu}m`;
+        return `CPU Request: ${displayValue}`;
+    };
+
+    const formatMemoryTooltip = (milliBytes: number): string => {
+        const mib = Math.round(milliBytes / (1024 * 1024 * 1000));
+        return `Memory Request: ${mib}Mi`;
+    };
 
     if (name === 'cpu') {
         return {

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -1883,6 +1883,25 @@ export function formatMemoryTooltip(milliBytes: number): string {
 export function formatResourceInfo(name: string, value: string): {displayValue: string; tooltipValue: string} {
     const numValue = parseInt(value, 10);
 
+    const formatCPUValue = (milliCpu: number): string => {
+        return milliCpu >= 1000 ? `${(milliCpu / 1000).toFixed(1)}` : `${milliCpu}m`;
+    };
+
+    const formatMemoryValue = (milliBytes: number): string => {
+        const mib = Math.round(milliBytes / (1024 * 1024 * 1000));
+        return `${mib}Mi`;
+    };
+
+    const formatCPUTooltip = (milliCpu: number): string => {
+        const displayValue = milliCpu >= 1000 ? `${(milliCpu / 1000).toFixed(1)} cores` : `${milliCpu}m`;
+        return `CPU Request: ${displayValue}`;
+    };
+
+    const formatMemoryTooltip = (milliBytes: number): string => {
+        const mib = Math.round(milliBytes / (1024 * 1024 * 1000));
+        return `Memory Request: ${mib}Mi`;
+    };
+
     if (name === 'cpu') {
         return {
             displayValue: formatCPUValue(numValue),

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -1859,3 +1859,44 @@ export function getApplicationLinkURLFromNode(node: any, baseHref: string): {url
     }
     return {url, isExternal};
 }
+
+// Common utility functions for formatting CPU and Memory values
+export function formatCPUValue(milliCpu: number): string {
+    return milliCpu >= 1000 ? `${(milliCpu / 1000).toFixed(1)}` : `${milliCpu}m`;
+}
+
+export function formatMemoryValue(milliBytes: number): string {
+    const mib = Math.round(milliBytes / (1024 * 1024 * 1000));
+    return `${mib}Mi`;
+}
+
+export function formatCPUTooltip(milliCpu: number): string {
+    const displayValue = milliCpu >= 1000 ? `${(milliCpu / 1000).toFixed(1)} cores` : `${milliCpu}m`;
+    return `CPU Request: ${displayValue}`;
+}
+
+export function formatMemoryTooltip(milliBytes: number): string {
+    const mib = Math.round(milliBytes / (1024 * 1024 * 1000));
+    return `Memory Request: ${mib}Mi`;
+}
+
+export function formatResourceInfo(name: string, value: string): {displayValue: string; tooltipValue: string} {
+    const numValue = parseInt(value, 10);
+    
+    if (name === 'cpu') {
+        return {
+            displayValue: formatCPUValue(numValue),
+            tooltipValue: formatCPUTooltip(numValue)
+        };
+    } else if (name === 'memory') {
+        return {
+            displayValue: formatMemoryValue(numValue),
+            tooltipValue: formatMemoryTooltip(numValue)
+        };
+    }
+    
+    return {
+        displayValue: value,
+        tooltipValue: `${name}: ${value}`
+    };
+}


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Related to #20637, #11513

After the above changes, I noticed that as `nodeInfo` increased, the `resource-tree view` UI started breaking.
It seems to have been caused by the combination of the two previous changes. I fixed the issue without altering the results of those already completed tasks. Therefore, I adjusted the number of resources displayed on each node in the `resource-tree view` to two, and improved the readability of the tooltip information.
I also noticed that the logic always showed a `more` button even when exactly four resources fit perfectly. I updated this so that only up to two resources are shown, and the `more` button appears when there are three or more resources.

The attached screenshots show the UI before and after the fix.
The issue only occurred in the `resource-tree view`. No changes were required for the `pod view`.
Additionally, to avoid duplicate code in `pod view` tooltips, I updated the resource unit display to reference a utility function I created.

Thanks!

### AS-IS
<img width="566" height="291" alt="before1" src="https://github.com/user-attachments/assets/30761207-cae0-429c-bfaf-2a3b651effe4" />

Even though I added the resource unit, the view was still rendered incorrectly.
<img width="649" height="307" alt="after1_still_overrapped" src="https://github.com/user-attachments/assets/a34d0c85-f2e1-4d13-b5f9-6b44acb75223" />

<img width="431" height="304" alt="before3" src="https://github.com/user-attachments/assets/1754e32c-4d99-47ba-b7e3-64cf82aba4e2" />


### TO-BE
<img width="756" height="386" alt="after1" src="https://github.com/user-attachments/assets/4bd01c9a-5987-4057-96a6-7830ba765574" />

<img width="576" height="452" alt="after2" src="https://github.com/user-attachments/assets/265c29e0-1226-4716-898d-4836939ba798" />



Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
