### PR TITLE
fix(cli): handle multiple paths in KUBECONFIG for core mode (#19381)

### DIFF
--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -3627,7 +3627,6 @@ func (c *Cluster) RawRestConfig() (*rest.Config, error) {
 	switch {
 	case c.Server == KubernetesInternalAPIServerAddr && env.ParseBoolFromEnv(EnvVarFakeInClusterConfig, false):
 		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-		loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
 		config, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 			loadingRules,
 			&clientcmd.ConfigOverrides{},

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -3626,17 +3626,12 @@ func (c *Cluster) RawRestConfig() (*rest.Config, error) {
 
 	switch {
 	case c.Server == KubernetesInternalAPIServerAddr && env.ParseBoolFromEnv(EnvVarFakeInClusterConfig, false):
-		conf, exists := os.LookupEnv("KUBECONFIG")
-		if exists {
-			config, err = clientcmd.BuildConfigFromFlags("", conf)
-		} else {
-			var homeDir string
-			homeDir, err = os.UserHomeDir()
-			if err != nil {
-				homeDir = ""
-			}
-			config, err = clientcmd.BuildConfigFromFlags("", filepath.Join(homeDir, ".kube", "config"))
-		}
+		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+		loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
+		config, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+			loadingRules,
+			&clientcmd.ConfigOverrides{},
+		).ClientConfig()
 	case c.Server == KubernetesInternalAPIServerAddr && c.Config.Username == "" && c.Config.Password == "" && c.Config.BearerToken == "":
 		config, err = rest.InClusterConfig()
 	case c.Server == KubernetesInternalAPIServerAddr:

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -4807,6 +4807,7 @@ func TestCluster_RawRestConfig_KUBECONFIG(t *testing.T) {
 		{
 			name: "SingleKubeconfigPath",
 			setupFunc: func(t *testing.T) string {
+				t.Helper()
 				tmpDir := t.TempDir()
 				kubeconfigPath := path.Join(tmpDir, "config")
 				kubeconfigContent := `apiVersion: v1
@@ -4820,7 +4821,7 @@ contexts:
     cluster: test-cluster
   name: test-context
 current-context: test-context`
-				err := os.WriteFile(kubeconfigPath, []byte(kubeconfigContent), 0644)
+				err := os.WriteFile(kubeconfigPath, []byte(kubeconfigContent), 0o644)
 				require.NoError(t, err)
 				return kubeconfigPath
 			},
@@ -4830,6 +4831,7 @@ current-context: test-context`
 		{
 			name: "MultipleKubeconfigPaths",
 			setupFunc: func(t *testing.T) string {
+				t.Helper()
 				tmpDir := t.TempDir()
 				kubeconfig1 := path.Join(tmpDir, "config1")
 				kubeconfig2 := path.Join(tmpDir, "config2")
@@ -4858,9 +4860,9 @@ contexts:
   name: second-context
 current-context: second-context`
 
-				err := os.WriteFile(kubeconfig1, []byte(kubeconfig1Content), 0644)
+				err := os.WriteFile(kubeconfig1, []byte(kubeconfig1Content), 0o644)
 				require.NoError(t, err)
-				err = os.WriteFile(kubeconfig2, []byte(kubeconfig2Content), 0644)
+				err = os.WriteFile(kubeconfig2, []byte(kubeconfig2Content), 0o644)
 				require.NoError(t, err)
 
 				return kubeconfig1 + ":" + kubeconfig2
@@ -4871,6 +4873,7 @@ current-context: second-context`
 		{
 			name: "EmptyKubeconfigEnv",
 			setupFunc: func(t *testing.T) string {
+				t.Helper()
 				return ""
 			},
 			expectedHost:  "",
@@ -4879,6 +4882,7 @@ current-context: second-context`
 		{
 			name: "NonExistentPath",
 			setupFunc: func(t *testing.T) string {
+				t.Helper()
 				return "/non/existent/path"
 			},
 			expectedHost:  "",


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

Closes #19381 

The PR fixes the ArgoCD CLI to properly handle multiple colon-separated paths in the KUBECONFIG environment variable when using `--core` mode.

  Previously, the CLI would fail with "no such file or directory" error when KUBECONFIG contained multiple paths (e.g., `KUBECONFIG=/path1:/path2`), making it incompatible with standard Kubernetes tooling practices. The fix
  replaces `clientcmd.BuildConfigFromFlags` with `clientcmd.NewDefaultClientConfigLoadingRules` to follow Kubernetes client-go standards for kubeconfig path resolution.