### PR TITLE
fix: cross-namespace resource traversal (#24379)

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -611,6 +611,9 @@ func (ctrl *ApplicationController) getResourceTree(destCluster *appv1.Cluster, a
 			managedResourcesKeys = append(managedResourcesKeys, kube.GetResourceKey(live))
 		}
 	}
+	// Always scan the destination namespace for orphaned resources (children of cluster-scoped
+	// resources that weren't in the initial keys). This handles operators like Crossplane that
+	// create resources in their namespace from cluster-scoped parents.
 	err = ctrl.stateCache.IterateHierarchyV2(destCluster, managedResourcesKeys, func(child appv1.ResourceNode, _ string) bool {
 		permitted, _ := proj.IsResourcePermitted(schema.GroupKind{Group: child.Group, Kind: child.Kind}, child.Namespace, destCluster, func(project string) ([]*appv1.Cluster, error) {
 			clusters, err := ctrl.db.GetProjectClusters(context.TODO(), project)
@@ -624,7 +627,7 @@ func (ctrl *ApplicationController) getResourceTree(destCluster *appv1.Cluster, a
 		}
 		nodes = append(nodes, child)
 		return true
-	})
+	}, a.Spec.Destination.Namespace)
 	if err != nil {
 		return nil, fmt.Errorf("failed to iterate resource hierarchy v2: %w", err)
 	}
@@ -636,6 +639,7 @@ func (ctrl *ApplicationController) getResourceTree(destCluster *appv1.Cluster, a
 			orphanedNodesKeys = append(orphanedNodesKeys, k)
 		}
 	}
+	// Process orphaned resources (always scans the destination namespace for orphaned resources)
 	err = ctrl.stateCache.IterateHierarchyV2(destCluster, orphanedNodesKeys, func(child appv1.ResourceNode, appName string) bool {
 		belongToAnotherApp := false
 		if appName != "" {
@@ -658,7 +662,7 @@ func (ctrl *ApplicationController) getResourceTree(destCluster *appv1.Cluster, a
 		}
 		orphanedNodes = append(orphanedNodes, child)
 		return true
-	})
+	}, a.Spec.Destination.Namespace)
 	if err != nil {
 		return nil, err
 	}

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -224,7 +224,7 @@ func newFakeControllerWithResync(data *fakeData, appResyncPeriod time.Duration, 
 	mockStateCache.On("GetNamespaceTopLevelResources", mock.Anything, mock.Anything).Return(response, nil)
 	mockStateCache.On("IterateResources", mock.Anything, mock.Anything).Return(nil)
 	mockStateCache.On("GetClusterCache", mock.Anything).Return(&clusterCacheMock, nil)
-	mockStateCache.On("IterateHierarchyV2", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+	mockStateCache.On("IterateHierarchyV2", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 		keys := args[1].([]kube.ResourceKey)
 		action := args[2].(func(child v1alpha1.ResourceNode, appName string) bool)
 		for _, key := range keys {

--- a/controller/cache/mocks/LiveStateCache.go
+++ b/controller/cache/mocks/LiveStateCache.go
@@ -472,16 +472,16 @@ func (_c *LiveStateCache_IsNamespaced_Call) RunAndReturn(run func(server *v1alph
 }
 
 // IterateHierarchyV2 provides a mock function for the type LiveStateCache
-func (_mock *LiveStateCache) IterateHierarchyV2(server *v1alpha1.Cluster, keys []kube.ResourceKey, action func(child v1alpha1.ResourceNode, appName string) bool) error {
-	ret := _mock.Called(server, keys, action)
+func (_mock *LiveStateCache) IterateHierarchyV2(server *v1alpha1.Cluster, keys []kube.ResourceKey, action func(child v1alpha1.ResourceNode, appName string) bool, orphanedResourceNamespace string) error {
+	ret := _mock.Called(server, keys, action, orphanedResourceNamespace)
 
 	if len(ret) == 0 {
 		panic("no return value specified for IterateHierarchyV2")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(*v1alpha1.Cluster, []kube.ResourceKey, func(child v1alpha1.ResourceNode, appName string) bool) error); ok {
-		r0 = returnFunc(server, keys, action)
+	if returnFunc, ok := ret.Get(0).(func(*v1alpha1.Cluster, []kube.ResourceKey, func(child v1alpha1.ResourceNode, appName string) bool, string) error); ok {
+		r0 = returnFunc(server, keys, action, orphanedResourceNamespace)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -497,11 +497,12 @@ type LiveStateCache_IterateHierarchyV2_Call struct {
 //   - server *v1alpha1.Cluster
 //   - keys []kube.ResourceKey
 //   - action func(child v1alpha1.ResourceNode, appName string) bool
-func (_e *LiveStateCache_Expecter) IterateHierarchyV2(server interface{}, keys interface{}, action interface{}) *LiveStateCache_IterateHierarchyV2_Call {
-	return &LiveStateCache_IterateHierarchyV2_Call{Call: _e.mock.On("IterateHierarchyV2", server, keys, action)}
+//   - orphanedResourceNamespace string
+func (_e *LiveStateCache_Expecter) IterateHierarchyV2(server interface{}, keys interface{}, action interface{}, orphanedResourceNamespace interface{}) *LiveStateCache_IterateHierarchyV2_Call {
+	return &LiveStateCache_IterateHierarchyV2_Call{Call: _e.mock.On("IterateHierarchyV2", server, keys, action, orphanedResourceNamespace)}
 }
 
-func (_c *LiveStateCache_IterateHierarchyV2_Call) Run(run func(server *v1alpha1.Cluster, keys []kube.ResourceKey, action func(child v1alpha1.ResourceNode, appName string) bool)) *LiveStateCache_IterateHierarchyV2_Call {
+func (_c *LiveStateCache_IterateHierarchyV2_Call) Run(run func(server *v1alpha1.Cluster, keys []kube.ResourceKey, action func(child v1alpha1.ResourceNode, appName string) bool, orphanedResourceNamespace string)) *LiveStateCache_IterateHierarchyV2_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 *v1alpha1.Cluster
 		if args[0] != nil {
@@ -515,10 +516,15 @@ func (_c *LiveStateCache_IterateHierarchyV2_Call) Run(run func(server *v1alpha1.
 		if args[2] != nil {
 			arg2 = args[2].(func(child v1alpha1.ResourceNode, appName string) bool)
 		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -529,7 +535,7 @@ func (_c *LiveStateCache_IterateHierarchyV2_Call) Return(err error) *LiveStateCa
 	return _c
 }
 
-func (_c *LiveStateCache_IterateHierarchyV2_Call) RunAndReturn(run func(server *v1alpha1.Cluster, keys []kube.ResourceKey, action func(child v1alpha1.ResourceNode, appName string) bool) error) *LiveStateCache_IterateHierarchyV2_Call {
+func (_c *LiveStateCache_IterateHierarchyV2_Call) RunAndReturn(run func(server *v1alpha1.Cluster, keys []kube.ResourceKey, action func(child v1alpha1.ResourceNode, appName string) bool, orphanedResourceNamespace string) error) *LiveStateCache_IterateHierarchyV2_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/gitops-engine/pkg/cache/cluster.go
+++ b/gitops-engine/pkg/cache/cluster.go
@@ -1130,7 +1130,7 @@ func (c *clusterCache) IterateHierarchyV2(keys []kube.ResourceKey, action func(r
 	// First process the namespaces we have explicit keys for
 	for namespace, namespaceKeys := range keysPerNamespace {
 		nsNodes := c.nsIndex[namespace]
-		
+
 		// Only use cross-namespace graph for namespaced resources that might have cluster parents
 		var graph map[kube.ResourceKey]map[types.UID]*Resource
 		if namespace != "" && len(clusterNodesByUID) > 0 {
@@ -1283,20 +1283,22 @@ func buildGraph(nsNodes map[kube.ResourceKey]*Resource) map[kube.ResourceKey]map
 			uidNodes, ok := nodesByUID[ownerRef.UID]
 			if ok {
 				for _, uidNode := range uidNodes {
+					// Cache ResourceKey() to avoid repeated expensive calls
+					uidNodeKey := uidNode.ResourceKey()
 					// Update the graph for this owner to include the child.
-					if _, ok := graph[uidNode.ResourceKey()]; !ok {
-						graph[uidNode.ResourceKey()] = make(map[types.UID]*Resource)
+					if _, ok := graph[uidNodeKey]; !ok {
+						graph[uidNodeKey] = make(map[types.UID]*Resource)
 					}
-					r, ok := graph[uidNode.ResourceKey()][childNode.Ref.UID]
+					r, ok := graph[uidNodeKey][childNode.Ref.UID]
 					if !ok {
-						graph[uidNode.ResourceKey()][childNode.Ref.UID] = childNode
+						graph[uidNodeKey][childNode.Ref.UID] = childNode
 					} else if r != nil {
 						// The object might have multiple children with the same UID (e.g. replicaset from apps and extensions group).
 						// It is ok to pick any object, but we need to make sure we pick the same child after every refresh.
 						key1 := r.ResourceKey()
 						key2 := childNode.ResourceKey()
 						if strings.Compare(key1.String(), key2.String()) > 0 {
-							graph[uidNode.ResourceKey()][childNode.Ref.UID] = childNode
+							graph[uidNodeKey][childNode.Ref.UID] = childNode
 						}
 					}
 				}
@@ -1339,17 +1341,19 @@ func buildGraphWithCrossNamespace(nsNodes map[kube.ResourceKey]*Resource, cluste
 			}
 			if ok {
 				for _, uidNode := range uidNodes {
-					if _, ok := graph[uidNode.ResourceKey()]; !ok {
-						graph[uidNode.ResourceKey()] = make(map[types.UID]*Resource)
+					// Cache ResourceKey() to avoid repeated expensive calls
+					uidNodeKey := uidNode.ResourceKey()
+					if _, ok := graph[uidNodeKey]; !ok {
+						graph[uidNodeKey] = make(map[types.UID]*Resource)
 					}
-					r, ok := graph[uidNode.ResourceKey()][childNode.Ref.UID]
+					r, ok := graph[uidNodeKey][childNode.Ref.UID]
 					if !ok {
-						graph[uidNode.ResourceKey()][childNode.Ref.UID] = childNode
+						graph[uidNodeKey][childNode.Ref.UID] = childNode
 					} else if r != nil {
 						key1 := r.ResourceKey()
 						key2 := childNode.ResourceKey()
 						if strings.Compare(key1.String(), key2.String()) > 0 {
-							graph[uidNode.ResourceKey()][childNode.Ref.UID] = childNode
+							graph[uidNodeKey][childNode.Ref.UID] = childNode
 						}
 					}
 				}

--- a/gitops-engine/pkg/cache/cluster.go
+++ b/gitops-engine/pkg/cache/cluster.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"context"
 	"fmt"
+	"os"
 	"runtime/debug"
 	"strings"
 	"sync"
@@ -59,6 +60,15 @@ const (
 	defaultEventProcessingInterval = 100 * time.Millisecond
 )
 
+// Environment variables
+const (
+	// EnvDisableClusterScopedParentRefs disables cluster-scoped parent owner reference resolution
+	// when set to any non-empty value. This provides an emergency fallback to disable the
+	// cluster-scoped to namespaced hierarchy traversal feature if performance issues are encountered.
+	// Default behavior (empty/unset) enables cluster-scoped parent owner reference resolution.
+	EnvDisableClusterScopedParentRefs = "GITOPS_ENGINE_DISABLE_CLUSTER_SCOPED_PARENT_REFS"
+)
+
 const (
 	// RespectRbacDisabled default value for respectRbac
 	RespectRbacDisabled = iota
@@ -78,6 +88,13 @@ type apiMeta struct {
 type eventMeta struct {
 	event watch.EventType
 	un    *unstructured.Unstructured
+}
+
+// missingOwnerRef tracks owner references that need cluster-scoped parent resolution
+type missingOwnerRef struct {
+	childResource *Resource
+	ownerRefIndex int
+	parentKey     kube.ResourceKey // cluster-scoped parent key (Namespace: "")
 }
 
 // ClusterInfo holds cluster cache stats
@@ -187,6 +204,8 @@ func NewClusterCache(config *rest.Config, opts ...UpdateSettingsFunc) *clusterCa
 		listRetryLimit:          1,
 		listRetryUseBackoff:     false,
 		listRetryFunc:           ListRetryFuncNever,
+		// Check environment variable once at startup for performance
+		disableClusterScopedParentRefs: os.Getenv("GITOPS_ENGINE_DISABLE_CLUSTER_SCOPED_PARENT_REFS") != "",
 	}
 	for i := range opts {
 		opts[i](cache)
@@ -245,6 +264,10 @@ type clusterCache struct {
 	gvkParser                   *managedfields.GvkParser
 
 	respectRBAC int
+
+	// disableClusterScopedParentRefs is set at initialization to cache the environment variable check
+	// When true, cluster-scoped parent owner reference resolution is disabled for emergency fallback
+	disableClusterScopedParentRefs bool
 }
 
 type clusterCacheSync struct {
@@ -1055,43 +1078,87 @@ func (c *clusterCache) FindResources(namespace string, predicates ...func(r *Res
 func (c *clusterCache) IterateHierarchyV2(keys []kube.ResourceKey, action func(resource *Resource, namespaceResources map[kube.ResourceKey]*Resource) bool) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
+
+	// Build namespace map with resource validation
 	keysPerNamespace := make(map[string][]kube.ResourceKey)
+	hasClusterNamespace := false
 	for _, key := range keys {
-		_, ok := c.resources[key]
-		if !ok {
-			continue
+		// PERFORMANCE HOTSPOT: This resource lookup is the most expensive operation in the function
+		// (~50% of CPU time). The map access triggers hash computation for ResourceKey.
+		if _, ok := c.resources[key]; ok {
+			keysPerNamespace[key.Namespace] = append(keysPerNamespace[key.Namespace], key)
+			if key.Namespace == "" {
+				hasClusterNamespace = true
+			}
 		}
-		keysPerNamespace[key.Namespace] = append(keysPerNamespace[key.Namespace], key)
 	}
+
+	// Fast path: feature disabled, no keys involve cluster namespace, or no cluster resources
+	// PERFORMANCE NOTE: Condition order matters! Check cheaper boolean conditions before map lookups.
+	// The len(c.nsIndex[""]) check involves a map access and should be evaluated last.
+	if c.disableClusterScopedParentRefs || !hasClusterNamespace || len(c.nsIndex[""]) == 0 {
+		// Process all namespaces with simple graph building (no cross-namespace overhead)
+		for namespace, namespaceKeys := range keysPerNamespace {
+			nsNodes := c.nsIndex[namespace]
+			graph := buildGraph(nsNodes)
+			// Use per-namespace visited map for better cache locality
+			visited := make(map[kube.ResourceKey]int, len(namespaceKeys))
+			c.processNamespaceHierarchy(namespaceKeys, nsNodes, graph, visited, action)
+		}
+		return
+	}
+
+	// Slow path: cross-namespace refs enabled, cluster resources exist, and we're processing cluster keys
+	clusterNodes := c.nsIndex[""]
+	clusterNodesByUID := make(map[types.UID][]*Resource, len(clusterNodes))
+	for _, node := range clusterNodes {
+		clusterNodesByUID[node.Ref.UID] = append(clusterNodesByUID[node.Ref.UID], node)
+	}
+
+	// Slow path: cross-namespace refs enabled and detected
+	// clusterNodesByUID already built above for detection
+
+	// Process namespaces that might have cross-namespace references
+	// Use a shared visited map to prevent duplicate visits across namespaces
+	visited := make(map[kube.ResourceKey]int, len(keys))
 	for namespace, namespaceKeys := range keysPerNamespace {
 		nsNodes := c.nsIndex[namespace]
-		graph := buildGraph(nsNodes)
-		visited := make(map[kube.ResourceKey]int)
-		for _, key := range namespaceKeys {
-			visited[key] = 0
+		graph := buildGraphWithCrossNamespace(nsNodes, clusterNodesByUID)
+		c.processNamespaceHierarchy(namespaceKeys, nsNodes, graph, visited, action)
+	}
+}
+
+// processNamespaceHierarchy processes hierarchy for keys within a single namespace
+func (c *clusterCache) processNamespaceHierarchy(
+	namespaceKeys []kube.ResourceKey,
+	nsNodes map[kube.ResourceKey]*Resource,
+	graph map[kube.ResourceKey]map[types.UID]*Resource,
+	visited map[kube.ResourceKey]int,
+	action func(resource *Resource, namespaceResources map[kube.ResourceKey]*Resource) bool,
+) {
+	for _, key := range namespaceKeys {
+		visited[key] = 0
+	}
+	for _, key := range namespaceKeys {
+		res := c.resources[key]
+		if visited[key] == 2 || !action(res, nsNodes) {
+			continue
 		}
-		for _, key := range namespaceKeys {
-			// The check for existence of key is done above.
-			res := c.resources[key]
-			if visited[key] == 2 || !action(res, nsNodes) {
-				continue
-			}
-			visited[key] = 1
-			if _, ok := graph[key]; ok {
-				for _, child := range graph[key] {
-					if visited[child.ResourceKey()] == 0 && action(child, nsNodes) {
-						child.iterateChildrenV2(graph, nsNodes, visited, func(err error, child *Resource, namespaceResources map[kube.ResourceKey]*Resource) bool {
-							if err != nil {
-								c.log.V(2).Info(err.Error())
-								return false
-							}
-							return action(child, namespaceResources)
-						})
-					}
+		visited[key] = 1
+		if _, ok := graph[key]; ok {
+			for _, child := range graph[key] {
+				if visited[child.ResourceKey()] == 0 && action(child, nsNodes) {
+					child.iterateChildrenV2(graph, nsNodes, visited, func(err error, child *Resource, namespaceResources map[kube.ResourceKey]*Resource) bool {
+						if err != nil {
+							c.log.V(2).Info(err.Error())
+							return false
+						}
+						return action(child, namespaceResources)
+					})
 				}
 			}
-			visited[key] = 2
 		}
+		visited[key] = 2
 	}
 }
 
@@ -1102,7 +1169,7 @@ func buildGraph(nsNodes map[kube.ResourceKey]*Resource) map[kube.ResourceKey]map
 		nodesByUID[node.Ref.UID] = append(nodesByUID[node.Ref.UID], node)
 	}
 
-	// In graph, they key is the parent and the value is a list of children.
+	// In graph, the key is the parent and the value is a list of children.
 	graph := make(map[kube.ResourceKey]map[types.UID]*Resource)
 
 	// Loop through all nodes, calling each one "childNode," because we're only bothering with it if it has a parent.
@@ -1138,6 +1205,59 @@ func buildGraph(nsNodes map[kube.ResourceKey]*Resource) map[kube.ResourceKey]map
 					} else if r != nil {
 						// The object might have multiple children with the same UID (e.g. replicaset from apps and extensions group).
 						// It is ok to pick any object, but we need to make sure we pick the same child after every refresh.
+						key1 := r.ResourceKey()
+						key2 := childNode.ResourceKey()
+						if strings.Compare(key1.String(), key2.String()) > 0 {
+							graph[uidNode.ResourceKey()][childNode.Ref.UID] = childNode
+						}
+					}
+				}
+			}
+		}
+	}
+	return graph
+}
+
+// buildGraphWithCrossNamespace builds graph with cross-namespace support
+func buildGraphWithCrossNamespace(nsNodes map[kube.ResourceKey]*Resource, clusterNodesByUID map[types.UID][]*Resource) map[kube.ResourceKey]map[types.UID]*Resource {
+	nodesByUID := make(map[types.UID][]*Resource, len(nsNodes))
+	for _, node := range nsNodes {
+		nodesByUID[node.Ref.UID] = append(nodesByUID[node.Ref.UID], node)
+	}
+
+	graph := make(map[kube.ResourceKey]map[types.UID]*Resource)
+
+	for _, childNode := range nsNodes {
+		for i, ownerRef := range childNode.OwnerRefs {
+			if ownerRef.UID == "" {
+				group, err := schema.ParseGroupVersion(ownerRef.APIVersion)
+				if err != nil {
+					continue
+				}
+				// Try same-namespace lookup first (most common case)
+				graphKeyNode, ok := nsNodes[kube.ResourceKey{Group: group.Group, Kind: ownerRef.Kind, Namespace: childNode.Ref.Namespace, Name: ownerRef.Name}]
+				if ok {
+					ownerRef.UID = graphKeyNode.Ref.UID
+					childNode.OwnerRefs[i] = ownerRef
+				}
+				// If not found in same namespace, UID remains empty and we'll check cluster-scoped below
+			}
+
+			// Check namespace-local parents first (most common case)
+			uidNodes, ok := nodesByUID[ownerRef.UID]
+			if !ok && ownerRef.UID != "" {
+				// Check cluster-scoped parents only if we have a UID
+				uidNodes, ok = clusterNodesByUID[ownerRef.UID]
+			}
+			if ok {
+				for _, uidNode := range uidNodes {
+					if _, ok := graph[uidNode.ResourceKey()]; !ok {
+						graph[uidNode.ResourceKey()] = make(map[types.UID]*Resource)
+					}
+					r, ok := graph[uidNode.ResourceKey()][childNode.Ref.UID]
+					if !ok {
+						graph[uidNode.ResourceKey()][childNode.Ref.UID] = childNode
+					} else if r != nil {
 						key1 := r.ResourceKey()
 						key2 := childNode.ResourceKey()
 						if strings.Compare(key1.String(), key2.String()) > 0 {

--- a/gitops-engine/pkg/cache/cluster.go
+++ b/gitops-engine/pkg/cache/cluster.go
@@ -1145,71 +1145,82 @@ func (c *clusterCache) IterateHierarchyV2(keys []kube.ResourceKey, action func(r
 	// Check for orphaned resources in the specified namespace (if any)
 	// These are children of cluster-scoped resources that weren't in the initial keys
 	if orphanedResourceNamespace != "" /* hasClusterNamespace is always true here */ {
-		// Skip if we already processed this namespace
-		if _, processed := keysPerNamespace[orphanedResourceNamespace]; processed {
-			return
+		c.processOrphanedResources(orphanedResourceNamespace, keysPerNamespace, clusterNodesByUID, visited, action)
+	}
+}
+
+// processOrphanedResources processes orphaned resources in a specified namespace that are children of cluster-scoped resources
+func (c *clusterCache) processOrphanedResources(
+	orphanedResourceNamespace string,
+	keysPerNamespace map[string][]kube.ResourceKey,
+	clusterNodesByUID map[types.UID][]*Resource,
+	visited map[kube.ResourceKey]int,
+	action func(resource *Resource, namespaceResources map[kube.ResourceKey]*Resource) bool,
+) {
+	// Skip if we already processed this namespace
+	if _, processed := keysPerNamespace[orphanedResourceNamespace]; processed {
+		return
+	}
+
+	nsNodes, ok := c.nsIndex[orphanedResourceNamespace]
+	if !ok {
+		return // Namespace doesn't exist or has no resources
+	}
+
+	// Get UIDs and build a map of cluster-scoped keys for lookups
+	clusterKeyUIDs := make(map[types.UID]bool)
+	clusterKeysByNameAndKind := make(map[string]kube.ResourceKey)
+	for _, clusterKey := range keysPerNamespace[""] {
+		if res, ok := c.resources[clusterKey]; ok {
+			clusterKeyUIDs[res.Ref.UID] = true
+			// Also index by APIVersion/Kind/Name for inferred owner refs
+			key := fmt.Sprintf("%s/%s/%s", res.Ref.APIVersion, res.Ref.Kind, res.Ref.Name)
+			clusterKeysByNameAndKind[key] = clusterKey
 		}
+	}
 
-		nsNodes, ok := c.nsIndex[orphanedResourceNamespace]
-		if !ok {
-			return // Namespace doesn't exist or has no resources
-		}
+	// First, check if this namespace has any potential children of our cluster-scoped keys
+	// This avoids building the expensive graph for namespaces that don't have relevant resources
+	var namespaceCandidates []*Resource
+	for _, resource := range nsNodes {
+		for _, ownerRef := range resource.OwnerRefs {
+			isChildOfOurKeys := false
 
-		// Get UIDs and build a map of cluster-scoped keys for lookups
-		clusterKeyUIDs := make(map[types.UID]bool)
-		clusterKeysByNameAndKind := make(map[string]kube.ResourceKey)
-		for _, clusterKey := range keysPerNamespace[""] {
-			if res, ok := c.resources[clusterKey]; ok {
-				clusterKeyUIDs[res.Ref.UID] = true
-				// Also index by APIVersion/Kind/Name for inferred owner refs
-				key := fmt.Sprintf("%s/%s/%s", res.Ref.APIVersion, res.Ref.Kind, res.Ref.Name)
-				clusterKeysByNameAndKind[key] = clusterKey
-			}
-		}
-
-		// First, check if this namespace has any potential children of our cluster-scoped keys
-		// This avoids building the expensive graph for namespaces that don't have relevant resources
-		var namespaceCandidates []*Resource
-		for _, resource := range nsNodes {
-			for _, ownerRef := range resource.OwnerRefs {
-				isChildOfOurKeys := false
-
-				// Check by UID if available
-				if ownerRef.UID != "" && clusterKeyUIDs[ownerRef.UID] {
+			// Check by UID if available
+			if ownerRef.UID != "" && clusterKeyUIDs[ownerRef.UID] {
+				isChildOfOurKeys = true
+			} else if ownerRef.UID == "" {
+				// Check by APIVersion/Kind/Name for inferred owner refs
+				key := fmt.Sprintf("%s/%s/%s", ownerRef.APIVersion, ownerRef.Kind, ownerRef.Name)
+				if _, ok := clusterKeysByNameAndKind[key]; ok {
 					isChildOfOurKeys = true
-				} else if ownerRef.UID == "" {
-					// Check by APIVersion/Kind/Name for inferred owner refs
-					key := fmt.Sprintf("%s/%s/%s", ownerRef.APIVersion, ownerRef.Kind, ownerRef.Name)
-					if _, ok := clusterKeysByNameAndKind[key]; ok {
-						isChildOfOurKeys = true
-					}
-				}
-
-				if isChildOfOurKeys {
-					namespaceCandidates = append(namespaceCandidates, resource)
-					break // No need to check other owner refs for this resource
 				}
 			}
+
+			if isChildOfOurKeys {
+				namespaceCandidates = append(namespaceCandidates, resource)
+				break // No need to check other owner refs for this resource
+			}
 		}
+	}
 
-		// Only build the graph if we found potential children
-		if len(namespaceCandidates) > 0 {
-			graph := buildGraphWithCrossNamespace(nsNodes, clusterNodesByUID)
+	// Only build the graph if we found potential children
+	if len(namespaceCandidates) > 0 {
+		graph := buildGraphWithCrossNamespace(nsNodes, clusterNodesByUID)
 
-			// Process the candidate resources
-			for _, resource := range namespaceCandidates {
-				childKey := resource.ResourceKey()
-				if visited[childKey] == 0 && action(resource, nsNodes) {
-					visited[childKey] = 1
-					resource.iterateChildrenV2(graph, nsNodes, visited, func(err error, child *Resource, namespaceResources map[kube.ResourceKey]*Resource) bool {
-						if err != nil {
-							c.log.V(2).Info(err.Error())
-							return false
-						}
-						return action(child, namespaceResources)
-					})
-					visited[childKey] = 2
-				}
+		// Process the candidate resources
+		for _, resource := range namespaceCandidates {
+			childKey := resource.ResourceKey()
+			if visited[childKey] == 0 && action(resource, nsNodes) {
+				visited[childKey] = 1
+				resource.iterateChildrenV2(graph, nsNodes, visited, func(err error, child *Resource, namespaceResources map[kube.ResourceKey]*Resource) bool {
+					if err != nil {
+						c.log.V(2).Info(err.Error())
+						return false
+					}
+					return action(child, namespaceResources)
+				})
+				visited[childKey] = 2
 			}
 		}
 	}

--- a/gitops-engine/pkg/cache/cluster.go
+++ b/gitops-engine/pkg/cache/cluster.go
@@ -148,7 +148,8 @@ type ClusterCache interface {
 	FindResources(namespace string, predicates ...func(r *Resource) bool) map[kube.ResourceKey]*Resource
 	// IterateHierarchyV2 iterates resource tree starting from the specified top level resources and executes callback for each resource in the tree.
 	// The action callback returns true if iteration should continue and false otherwise.
-	IterateHierarchyV2(keys []kube.ResourceKey, action func(resource *Resource, namespaceResources map[kube.ResourceKey]*Resource) bool)
+	// If orphanedResourceNamespace is provided (non-empty), it will scan that namespace for orphaned resources
+	IterateHierarchyV2(keys []kube.ResourceKey, action func(resource *Resource, namespaceResources map[kube.ResourceKey]*Resource) bool, orphanedResourceNamespace string)
 	// IsNamespaced answers if specified group/kind is a namespaced resource API or not
 	IsNamespaced(gk schema.GroupKind) (bool, error)
 	// GetManagedLiveObjs helps finding matching live K8S resources for a given resources list.
@@ -1075,7 +1076,13 @@ func (c *clusterCache) FindResources(namespace string, predicates ...func(r *Res
 }
 
 // IterateHierarchy iterates resource tree starting from the specified top level resources and executes callback for each resource in the tree
-func (c *clusterCache) IterateHierarchyV2(keys []kube.ResourceKey, action func(resource *Resource, namespaceResources map[kube.ResourceKey]*Resource) bool) {
+
+// IterateHierarchyV2 iterates through the hierarchy of resources starting from the given keys.
+// It iterates through all resources that have parent-child relationships either through
+// ownership references or namespace-based hierarchy.
+// If orphanedResourceNamespace is provided (non-empty), it will scan that namespace for orphaned resources
+// (resources with cluster-scoped parents that weren't in the initial keys).
+func (c *clusterCache) IterateHierarchyV2(keys []kube.ResourceKey, action func(resource *Resource, namespaceResources map[kube.ResourceKey]*Resource) bool, orphanedResourceNamespace string) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 
@@ -1109,22 +1116,103 @@ func (c *clusterCache) IterateHierarchyV2(keys []kube.ResourceKey, action func(r
 	}
 
 	// Slow path: cross-namespace refs enabled, cluster resources exist, and we're processing cluster keys
+
+	// Use a shared visited map to prevent duplicate visits across namespaces
+	visited := make(map[kube.ResourceKey]int, len(keys))
+
+	// Build cluster nodes map for cross-namespace lookups
 	clusterNodes := c.nsIndex[""]
 	clusterNodesByUID := make(map[types.UID][]*Resource, len(clusterNodes))
 	for _, node := range clusterNodes {
 		clusterNodesByUID[node.Ref.UID] = append(clusterNodesByUID[node.Ref.UID], node)
 	}
 
-	// Slow path: cross-namespace refs enabled and detected
-	// clusterNodesByUID already built above for detection
-
-	// Process namespaces that might have cross-namespace references
-	// Use a shared visited map to prevent duplicate visits across namespaces
-	visited := make(map[kube.ResourceKey]int, len(keys))
+	// First process the namespaces we have explicit keys for
 	for namespace, namespaceKeys := range keysPerNamespace {
 		nsNodes := c.nsIndex[namespace]
-		graph := buildGraphWithCrossNamespace(nsNodes, clusterNodesByUID)
+		
+		// Only use cross-namespace graph for namespaced resources that might have cluster parents
+		var graph map[kube.ResourceKey]map[types.UID]*Resource
+		if namespace != "" && len(clusterNodesByUID) > 0 {
+			// This is a namespace that might have cluster-scoped parents
+			graph = buildGraphWithCrossNamespace(nsNodes, clusterNodesByUID)
+		} else {
+			// Cluster namespace or no cluster resources - use simple graph
+			graph = buildGraph(nsNodes)
+		}
 		c.processNamespaceHierarchy(namespaceKeys, nsNodes, graph, visited, action)
+	}
+
+	// Check for orphaned resources in the specified namespace (if any)
+	// These are children of cluster-scoped resources that weren't in the initial keys
+	if hasClusterNamespace && orphanedResourceNamespace != "" {
+		// Skip if we already processed this namespace
+		if _, processed := keysPerNamespace[orphanedResourceNamespace]; processed {
+			return
+		}
+
+		nsNodes, ok := c.nsIndex[orphanedResourceNamespace]
+		if !ok {
+			return // Namespace doesn't exist or has no resources
+		}
+
+		// Get UIDs and build a map of cluster-scoped keys for lookups
+		clusterKeyUIDs := make(map[types.UID]bool)
+		clusterKeysByNameAndKind := make(map[string]kube.ResourceKey)
+		for _, clusterKey := range keysPerNamespace[""] {
+			if res, ok := c.resources[clusterKey]; ok {
+				clusterKeyUIDs[res.Ref.UID] = true
+				// Also index by APIVersion/Kind/Name for inferred owner refs
+				key := fmt.Sprintf("%s/%s/%s", res.Ref.APIVersion, res.Ref.Kind, res.Ref.Name)
+				clusterKeysByNameAndKind[key] = clusterKey
+			}
+		}
+
+		// First, check if this namespace has any potential children of our cluster-scoped keys
+		// This avoids building the expensive graph for namespaces that don't have relevant resources
+		var namespaceCandidates []*Resource
+		for _, resource := range nsNodes {
+			for _, ownerRef := range resource.OwnerRefs {
+				isChildOfOurKeys := false
+
+				// Check by UID if available
+				if ownerRef.UID != "" && clusterKeyUIDs[ownerRef.UID] {
+					isChildOfOurKeys = true
+				} else if ownerRef.UID == "" {
+					// Check by APIVersion/Kind/Name for inferred owner refs
+					key := fmt.Sprintf("%s/%s/%s", ownerRef.APIVersion, ownerRef.Kind, ownerRef.Name)
+					if _, ok := clusterKeysByNameAndKind[key]; ok {
+						isChildOfOurKeys = true
+					}
+				}
+
+				if isChildOfOurKeys {
+					namespaceCandidates = append(namespaceCandidates, resource)
+					break // No need to check other owner refs for this resource
+				}
+			}
+		}
+
+		// Only build the graph if we found potential children
+		if len(namespaceCandidates) > 0 {
+			graph := buildGraphWithCrossNamespace(nsNodes, clusterNodesByUID)
+
+			// Process the candidate resources
+			for _, resource := range namespaceCandidates {
+				childKey := resource.ResourceKey()
+				if visited[childKey] == 0 && action(resource, nsNodes) {
+					visited[childKey] = 1
+					resource.iterateChildrenV2(graph, nsNodes, visited, func(err error, child *Resource, namespaceResources map[kube.ResourceKey]*Resource) bool {
+						if err != nil {
+							c.log.V(2).Info(err.Error())
+							return false
+						}
+						return action(child, namespaceResources)
+					})
+					visited[childKey] = 2
+				}
+			}
+		}
 	}
 }
 

--- a/gitops-engine/pkg/cache/cluster.go
+++ b/gitops-engine/pkg/cache/cluster.go
@@ -1075,13 +1075,12 @@ func (c *clusterCache) FindResources(namespace string, predicates ...func(r *Res
 	return result
 }
 
-// IterateHierarchy iterates resource tree starting from the specified top level resources and executes callback for each resource in the tree
-
 // IterateHierarchyV2 iterates through the hierarchy of resources starting from the given keys.
 // It iterates through all resources that have parent-child relationships either through
 // ownership references or namespace-based hierarchy.
 // If orphanedResourceNamespace is provided (non-empty), it will scan that namespace for orphaned resources
 // (resources with cluster-scoped parents that weren't in the initial keys).
+// It executes the callback on each resource in the tree.
 func (c *clusterCache) IterateHierarchyV2(keys []kube.ResourceKey, action func(resource *Resource, namespaceResources map[kube.ResourceKey]*Resource) bool, orphanedResourceNamespace string) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
@@ -1145,7 +1144,7 @@ func (c *clusterCache) IterateHierarchyV2(keys []kube.ResourceKey, action func(r
 
 	// Check for orphaned resources in the specified namespace (if any)
 	// These are children of cluster-scoped resources that weren't in the initial keys
-	if hasClusterNamespace && orphanedResourceNamespace != "" {
+	if orphanedResourceNamespace != "" /* hasClusterNamespace is always true here */ {
 		// Skip if we already processed this namespace
 		if _, processed := keysPerNamespace[orphanedResourceNamespace]; processed {
 			return

--- a/gitops-engine/pkg/cache/cluster.go
+++ b/gitops-engine/pkg/cache/cluster.go
@@ -1087,22 +1087,17 @@ func (c *clusterCache) IterateHierarchyV2(keys []kube.ResourceKey, action func(r
 
 	// Build namespace map with resource validation
 	keysPerNamespace := make(map[string][]kube.ResourceKey)
-	hasClusterNamespace := false
 	for _, key := range keys {
 		// PERFORMANCE HOTSPOT: This resource lookup is the most expensive operation in the function
 		// (~50% of CPU time). The map access triggers hash computation for ResourceKey.
 		if _, ok := c.resources[key]; ok {
 			keysPerNamespace[key.Namespace] = append(keysPerNamespace[key.Namespace], key)
-			if key.Namespace == "" {
-				hasClusterNamespace = true
-			}
 		}
 	}
 
-	// Fast path: feature disabled, no keys involve cluster namespace, or no cluster resources
-	// PERFORMANCE NOTE: Condition order matters! Check cheaper boolean conditions before map lookups.
-	// The len(c.nsIndex[""]) check involves a map access and should be evaluated last.
-	if c.disableClusterScopedParentRefs || !hasClusterNamespace || len(c.nsIndex[""]) == 0 {
+	// Fast path: feature disabled or no orphaned namespace scanning
+	// All cross-namespace complexity is deferred to orphaned resource processing
+	if c.disableClusterScopedParentRefs || orphanedResourceNamespace == "" {
 		// Process all namespaces with simple graph building (no cross-namespace overhead)
 		for namespace, namespaceKeys := range keysPerNamespace {
 			nsNodes := c.nsIndex[namespace]
@@ -1114,39 +1109,29 @@ func (c *clusterCache) IterateHierarchyV2(keys []kube.ResourceKey, action func(r
 		return
 	}
 
-	// Slow path: cross-namespace refs enabled, cluster resources exist, and we're processing cluster keys
+	// Slow path: cross-namespace refs enabled and orphaned namespace scanning requested
+	// Process explicit keys with simple graphs, then do comprehensive orphaned scanning
 
 	// Use a shared visited map to prevent duplicate visits across namespaces
 	visited := make(map[kube.ResourceKey]int, len(keys))
 
-	// Build cluster nodes map for cross-namespace lookups
+	// Process explicit keys with simple per-namespace graphs
+	for namespace, namespaceKeys := range keysPerNamespace {
+		nsNodes := c.nsIndex[namespace]
+		graph := buildGraph(nsNodes) // Always simple graph for explicit keys
+		c.processNamespaceHierarchy(namespaceKeys, nsNodes, graph, visited, action)
+	}
+
+	// Build cluster nodes map for cross-namespace lookups in orphaned processing
 	clusterNodes := c.nsIndex[""]
 	clusterNodesByUID := make(map[types.UID][]*Resource, len(clusterNodes))
 	for _, node := range clusterNodes {
 		clusterNodesByUID[node.Ref.UID] = append(clusterNodesByUID[node.Ref.UID], node)
 	}
 
-	// First process the namespaces we have explicit keys for
-	for namespace, namespaceKeys := range keysPerNamespace {
-		nsNodes := c.nsIndex[namespace]
-
-		// Only use cross-namespace graph for namespaced resources that might have cluster parents
-		var graph map[kube.ResourceKey]map[types.UID]*Resource
-		if namespace != "" && len(clusterNodesByUID) > 0 {
-			// This is a namespace that might have cluster-scoped parents
-			graph = buildGraphWithCrossNamespace(nsNodes, clusterNodesByUID)
-		} else {
-			// Cluster namespace or no cluster resources - use simple graph
-			graph = buildGraph(nsNodes)
-		}
-		c.processNamespaceHierarchy(namespaceKeys, nsNodes, graph, visited, action)
-	}
-
-	// Check for orphaned resources in the specified namespace (if any)
-	// These are children of cluster-scoped resources that weren't in the initial keys
-	if orphanedResourceNamespace != "" /* hasClusterNamespace is always true here */ {
-		c.processOrphanedResources(orphanedResourceNamespace, keysPerNamespace, clusterNodesByUID, visited, action)
-	}
+	// Check for orphaned resources in the specified namespace
+	// All cross-namespace relationships discovered here
+	c.processOrphanedResources(orphanedResourceNamespace, keysPerNamespace, clusterNodesByUID, visited, action)
 }
 
 // processOrphanedResources processes orphaned resources in a specified namespace that are children of cluster-scoped resources

--- a/gitops-engine/pkg/cache/cluster_test.go
+++ b/gitops-engine/pkg/cache/cluster_test.go
@@ -1231,8 +1231,8 @@ func TestIterateHierarchyV2_ClusterScopedParents(t *testing.T) {
 	require.NoError(t, err)
 
 	keys := []kube.ResourceKey{}
-	// In production, if you want to iterate a cluster-scoped resource and its namespaced children,
-	// you would include both in the keys (e.g., as part of managed resources)
+	// Edge case:  cluster-scoped resource and its namespaced children, both referred to in the manifest.  They should
+	// link up in the graph.
 	cluster.IterateHierarchyV2(
 		[]kube.ResourceKey{
 			kube.GetResourceKey(mustToUnstructured(testClusterParent())),
@@ -1334,9 +1334,10 @@ func TestIterateHierarchyV2_ClusterScopedParentOnly_WithNamespaceScanning(t *tes
 	}, keys)
 }
 
-
 func TestIterateHierarchyV2_ClusterScopedParentOnly_InferredUID(t *testing.T) {
-	// Test that passing only a cluster-scoped parent finds children even with inferred UIDs
+	// Test that passing only a cluster-scoped parent finds children even with inferred UIDs.
+	// This should never happen but we coded defensively for this case, and at worst it would link a child
+	// to the wrong parent if there were multiple parents with the same name (i.e. deleted and recreated).
 	namespacedChildNoUID := &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",

--- a/gitops-engine/pkg/cache/mocks/ClusterCache.go
+++ b/gitops-engine/pkg/cache/mocks/ClusterCache.go
@@ -232,9 +232,9 @@ func (_m *ClusterCache) IsNamespaced(gk schema.GroupKind) (bool, error) {
 	return r0, r1
 }
 
-// IterateHierarchyV2 provides a mock function with given fields: keys, action
-func (_m *ClusterCache) IterateHierarchyV2(keys []kube.ResourceKey, action func(*cache.Resource, map[kube.ResourceKey]*cache.Resource) bool) {
-	_m.Called(keys, action)
+// IterateHierarchyV2 provides a mock function with given fields: keys, action, orphanedResourceNamespace
+func (_m *ClusterCache) IterateHierarchyV2(keys []kube.ResourceKey, action func(*cache.Resource, map[kube.ResourceKey]*cache.Resource) bool, orphanedResourceNamespace string) {
+	_m.Called(keys, action, orphanedResourceNamespace)
 }
 
 // OnEvent provides a mock function with given fields: handler

--- a/gitops-engine/pkg/cache/predicates_test.go
+++ b/gitops-engine/pkg/cache/predicates_test.go
@@ -118,6 +118,6 @@ func ExampleNewClusterCache_inspectNamespaceResources() {
 		clusterCache.IterateHierarchyV2([]kube.ResourceKey{root.ResourceKey()}, func(resource *Resource, _ map[kube.ResourceKey]*Resource) bool {
 			fmt.Printf("resource: %s, info: %v\n", resource.Ref.String(), resource.Info)
 			return true
-		})
+		}, "")
 	}
 }

--- a/gitops-engine/pkg/cache/resource.go
+++ b/gitops-engine/pkg/cache/resource.go
@@ -91,9 +91,9 @@ func (r *Resource) iterateChildrenV2(graph map[kube.ResourceKey]map[types.UID]*R
 	if !ok || children == nil {
 		return
 	}
-	for _, c := range children {
-		childKey := c.ResourceKey()
-		child := ns[childKey]
+	for _, child := range children {
+		childKey := child.ResourceKey()
+		// For cross-namespace relationships, child might not be in ns, so use it directly from graph
 		switch visited[childKey] {
 		case 1:
 			// Since we encountered a node that we're currently processing, we know we have a circular dependency.


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Fixes #24379.

This PR adds resource-tree (including UI) support for cluster-scoped parents owning namespaced children.  This is a valid kube owner relationship which is sometimes manifested in projects like Crossplane, but in the current version we don't actually capture the children in the resource tree.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
