### PR TITLE
fix(gitops-engine): set default verbosity as 0 when dry run strategy is none

### DIFF
--- a/gitops-engine/pkg/utils/kube/resource_ops.go
+++ b/gitops-engine/pkg/utils/kube/resource_ops.go
@@ -334,7 +334,7 @@ func (k *kubectlResourceOperations) ApplyResource(ctx context.Context, obj *unst
 	span.SetBaggageItem("kind", obj.GetKind())
 	span.SetBaggageItem("name", obj.GetName())
 	defer span.Finish()
-	logWithLevel := k.log
+	logWithLevel := k.log.V(0)
 	if dryRunStrategy != cmdutil.DryRunNone {
 		logWithLevel = logWithLevel.V(1)
 	}


### PR DESCRIPTION
Info level logs should not be displayed when argocd running with `logLevel=error`
``` 
{"dry-run":"none","level":"info","manager":"argocd-controller","msg":"Applying resource Deployment/guestbook-ui in cluster: [https://172.30.0.1:443](https://172.30.0.1/), namespace: openshift-gitops","serverSideApply":false,"serverSideDiff":true,"time":"2025-09-23T22:37:51Z"}
```
Logs like above from gitops-engine https://github.com/argoproj/argo-cd/blob/master/gitops-engine/pkg/utils/kube/resource_ops.go#L341 show up in application controller.
This change sets the verbosity level to 0 when dry run strategy is none.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
