### PR TITLE
docs: high availability notes for CMP 

### DIFF
--- a/docs/operator-manual/config-management-plugins.md
+++ b/docs/operator-manual/config-management-plugins.md
@@ -318,7 +318,7 @@ If you don't need to set any environment variables, you can set an empty plugin 
 > [!IMPORTANT]
 > If your CMP command runs too long, the command will be killed, and the UI will show an error. The CMP server
 > respects the timeouts set by the `server.repo.server.timeout.seconds` and `controller.repo.server.timeout.seconds` 
-> items in `argocd-cm`. Increase their values from the default of 60s.
+> items in `argocd-cmd-params-cm`. Increase their values from the default of 60s.
 >
 > Each CMP command will also independently timeout on the `ARGOCD_EXEC_TIMEOUT` set for the CMP sidecar. The default
 > is 90s. So if you increase the repo server timeout greater than 90s, be sure to set `ARGOCD_EXEC_TIMEOUT` on the

--- a/docs/operator-manual/high_availability.md
+++ b/docs/operator-manual/high_availability.md
@@ -36,7 +36,7 @@ and might fail. To avoid failed syncs use the `ARGOCD_GIT_ATTEMPTS_COUNT` enviro
 * `argocd-repo-server` will issue a `SIGTERM` signal to a command that has elapsed the `ARGOCD_EXEC_TIMEOUT`. In most cases, well-behaved commands will exit immediately when receiving the signal. However, if this does not happen, `argocd-repo-server` will wait an additional timeout of `ARGOCD_EXEC_FATAL_TIMEOUT` and then forcefully exit the command with a `SIGKILL` to prevent stalling. Note that a failure to exit with `SIGTERM` is usually a bug in either the offending command or in the way `argocd-repo-server` calls it and should be reported to the issue tracker for further investigation.
 
 * When using the `discovery` option in Config Management Plugins (CMP), `argocd-repo-server` copies the repository (or only the files specified via the `argocd.argoproj.io/manifest-generate-paths` annotation) into a separate directory for each plugin.
-This can place a heavy load on disk resources, especially if the repository contains large files. To mitigate this, consider disabling `discovery` or using [Plugin tar stream exclusions](./config-management-plugins.md#plugin-tar-stream-exclusions).
+This can place a heavy load on disk resources for a **argocd-repo-server**, especially if the repository contains large files. To mitigate this, consider disabling `discovery` or using [Plugin tar stream exclusions](./config-management-plugins.md#plugin-tar-stream-exclusions).
 
 **metrics:**
 

--- a/docs/operator-manual/high_availability.md
+++ b/docs/operator-manual/high_availability.md
@@ -35,6 +35,9 @@ and might fail. To avoid failed syncs use the `ARGOCD_GIT_ATTEMPTS_COUNT` enviro
 
 * `argocd-repo-server` will issue a `SIGTERM` signal to a command that has elapsed the `ARGOCD_EXEC_TIMEOUT`. In most cases, well-behaved commands will exit immediately when receiving the signal. However, if this does not happen, `argocd-repo-server` will wait an additional timeout of `ARGOCD_EXEC_FATAL_TIMEOUT` and then forcefully exit the command with a `SIGKILL` to prevent stalling. Note that a failure to exit with `SIGTERM` is usually a bug in either the offending command or in the way `argocd-repo-server` calls it and should be reported to the issue tracker for further investigation.
 
+* When using the `discovery` option in Config Management Plugins (CMP), `argocd-repo-server` copies the repository (or only the files specified via the `argocd.argoproj.io/manifest-generate-paths` annotation) into a separate directory for each plugin.
+This can place a heavy load on disk resources, especially if the repository contains large files. To mitigate this, consider disabling `discovery` or using [Plugin tar stream exclusions](./config-management-plugins.md#plugin-tar-stream-exclusions).
+
 **metrics:**
 
 * `argocd_git_request_total` - Number of git requests. This metric provides two tags:


### PR DESCRIPTION
Changed made:

- fixed name of CM in CMP docs for using `server.repo.server.timeout.seconds`
- added a note to the docs to explain the issue and suggest ways to reduce the impact

Let me know if anything should be adjusted.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
