### PR TITLE
feat(cli): Updated CLI to show  Plugins during tab completion

### DIFF
--- a/cmd/argocd/commands/plugin.go
+++ b/cmd/argocd/commands/plugin.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/argoproj/argo-cd/v3/util/cli"
@@ -145,11 +146,10 @@ func (h *DefaultPluginHandler) command(name string, arg ...string) *exec.Cmd {
 // ListAvailablePlugins returns a list of plugin names that are available in the user's PATH
 // for tab completion. It searches for executables matching the ValidPrefixes pattern.
 func (h *DefaultPluginHandler) ListAvailablePlugins() []string {
-
 	// Get PATH environment variable
 	pathEnv := os.Getenv("PATH")
 	if pathEnv == "" {
-		return plugins
+		return []string{}
 	}
 
 	// Split PATH into individual directories
@@ -204,5 +204,11 @@ func (h *DefaultPluginHandler) ListAvailablePlugins() []string {
 		}
 	}
 
-	return sort.Strings(maps.Keys(seenPlugins))
+	// Convert map keys to sorted slice
+	plugins := make([]string, 0, len(seenPlugins))
+	for plugin := range seenPlugins {
+		plugins = append(plugins, plugin)
+	}
+	slices.Sort(plugins)
+	return plugins
 }

--- a/cmd/argocd/commands/plugin.go
+++ b/cmd/argocd/commands/plugin.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
     "maps"
+    "maps"
 	"slices"
 	"strings"
 

--- a/cmd/argocd/commands/plugin.go
+++ b/cmd/argocd/commands/plugin.go
@@ -141,3 +141,72 @@ func (h *DefaultPluginHandler) command(name string, arg ...string) *exec.Cmd {
 	}
 	return cmd
 }
+
+// ListAvailablePlugins returns a list of plugin names that are available in the user's PATH
+// for tab completion. It searches for executables matching the ValidPrefixes pattern.
+func (h *DefaultPluginHandler) ListAvailablePlugins() []string {
+	var plugins []string
+
+	// Get PATH environment variable
+	pathEnv := os.Getenv("PATH")
+	if pathEnv == "" {
+		return plugins
+	}
+
+	// Split PATH into individual directories
+	pathDirs := filepath.SplitList(pathEnv)
+
+	// Track seen plugin names to avoid duplicates
+	seenPlugins := make(map[string]bool)
+
+	// Search through each directory in PATH
+	for _, dir := range pathDirs {
+		// Skip empty directories
+		if dir == "" {
+			continue
+		}
+
+		// Read directory contents
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+
+		// Check each file in the directory
+		for _, entry := range entries {
+			// Skip directories and non-executable files
+			if entry.IsDir() {
+				continue
+			}
+
+			name := entry.Name()
+
+			// Check if the file matches any of our valid prefixes
+			for _, prefix := range h.ValidPrefixes {
+				pluginPrefix := prefix + "-"
+				if strings.HasPrefix(name, pluginPrefix) {
+					// Extract the plugin command name (everything after the prefix)
+					pluginName := strings.TrimPrefix(name, pluginPrefix)
+
+					// Skip empty plugin names or names with path separators
+					if pluginName == "" || strings.Contains(pluginName, "/") || strings.Contains(pluginName, "\\") {
+						continue
+					}
+
+					// Check if the file is executable
+					if info, err := entry.Info(); err == nil {
+						// On Unix-like systems, check executable bit
+						if info.Mode()&0111 != 0 {
+							if !seenPlugins[pluginName] {
+								plugins = append(plugins, pluginName)
+								seenPlugins[pluginName] = true
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return plugins
+}

--- a/cmd/argocd/commands/plugin.go
+++ b/cmd/argocd/commands/plugin.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+    "maps"
 	"slices"
 	"strings"
 

--- a/cmd/argocd/commands/plugin.go
+++ b/cmd/argocd/commands/plugin.go
@@ -147,14 +147,8 @@ func (h *DefaultPluginHandler) command(name string, arg ...string) *exec.Cmd {
 // ListAvailablePlugins returns a list of plugin names that are available in the user's PATH
 // for tab completion. It searches for executables matching the ValidPrefixes pattern.
 func (h *DefaultPluginHandler) ListAvailablePlugins() []string {
-	// Get PATH environment variable
-	pathEnv := os.Getenv("PATH")
-	if pathEnv == "" {
-		return []string{}
-	}
-
 	// Split PATH into individual directories
-	pathDirs := filepath.SplitList(pathEnv)
+	pathDirs := filepath.SplitList(os.Getenv("PATH"))
 	if len(pathDirs) == 0 {
 		return []string{}
 	}

--- a/cmd/argocd/commands/plugin.go
+++ b/cmd/argocd/commands/plugin.go
@@ -196,7 +196,7 @@ func (h *DefaultPluginHandler) ListAvailablePlugins() []string {
 					// Check if the file is executable
 					if info, err := entry.Info(); err == nil {
 						// On Unix-like systems, check executable bit
-						if info.Mode()&0111 != 0 {
+						if info.Mode()&0o111 != 0 {
 							if !seenPlugins[pluginName] {
 								plugins = append(plugins, pluginName)
 								seenPlugins[pluginName] = true

--- a/cmd/argocd/commands/plugin.go
+++ b/cmd/argocd/commands/plugin.go
@@ -205,5 +205,5 @@ func (h *DefaultPluginHandler) ListAvailablePlugins() []string {
 		}
 	}
 
-	return plugins
+	return sort.Strings(maps.Keys(seenPlugins))
 }

--- a/cmd/argocd/commands/plugin.go
+++ b/cmd/argocd/commands/plugin.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -154,6 +155,9 @@ func (h *DefaultPluginHandler) ListAvailablePlugins() []string {
 
 	// Split PATH into individual directories
 	pathDirs := filepath.SplitList(pathEnv)
+	if len(pathDirs) == 0 {
+		return []string{}
+	}
 
 	// Track seen plugin names to avoid duplicates
 	seenPlugins := make(map[string]bool)
@@ -204,11 +208,11 @@ func (h *DefaultPluginHandler) ListAvailablePlugins() []string {
 		}
 	}
 
-	// Convert map keys to sorted slice
-	plugins := make([]string, 0, len(seenPlugins))
-	for plugin := range seenPlugins {
-		plugins = append(plugins, plugin)
+	// Convert map keys to sorted slice and return
+	if len(seenPlugins) == 0 {
+		return []string{}
 	}
+	plugins := slices.Collect(maps.Keys(seenPlugins))
 	slices.Sort(plugins)
 	return plugins
 }

--- a/cmd/argocd/commands/plugin.go
+++ b/cmd/argocd/commands/plugin.go
@@ -197,10 +197,7 @@ func (h *DefaultPluginHandler) ListAvailablePlugins() []string {
 					if info, err := entry.Info(); err == nil {
 						// On Unix-like systems, check executable bit
 						if info.Mode()&0o111 != 0 {
-							if !seenPlugins[pluginName] {
-								plugins = append(plugins, pluginName)
-								seenPlugins[pluginName] = true
-							}
+							seenPlugins[pluginName] = true
 						}
 					}
 				}

--- a/cmd/argocd/commands/plugin.go
+++ b/cmd/argocd/commands/plugin.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-    "maps"
-    "maps"
 	"slices"
 	"strings"
 

--- a/cmd/argocd/commands/plugin.go
+++ b/cmd/argocd/commands/plugin.go
@@ -145,7 +145,6 @@ func (h *DefaultPluginHandler) command(name string, arg ...string) *exec.Cmd {
 // ListAvailablePlugins returns a list of plugin names that are available in the user's PATH
 // for tab completion. It searches for executables matching the ValidPrefixes pattern.
 func (h *DefaultPluginHandler) ListAvailablePlugins() []string {
-	var plugins []string
 
 	// Get PATH environment variable
 	pathEnv := os.Getenv("PATH")

--- a/cmd/argocd/commands/plugin_test.go
+++ b/cmd/argocd/commands/plugin_test.go
@@ -322,12 +322,12 @@ func TestListAvailablePlugins(t *testing.T) {
 		{
 			name:        "Standard argocd prefix finds plugins",
 			validPrefix: []string{"argocd"},
-			expected:    []string{"foo", "demo_plugin", "error", "test-plugin", "status-code-plugin", "version"},
+			expected:    []string{"demo_plugin", "error", "foo", "status-code-plugin", "test-plugin", "version"},
 		},
 		{
 			name:        "Multiple prefixes",
 			validPrefix: []string{"argocd", "kubectl"},
-			expected:    []string{"foo", "demo_plugin", "error", "test-plugin", "status-code-plugin", "version"},
+			expected:    []string{"demo_plugin", "error", "foo", "status-code-plugin", "test-plugin", "version"},
 		},
 		{
 			name:        "Non-existent prefix finds no plugins",
@@ -340,11 +340,6 @@ func TestListAvailablePlugins(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			pluginHandler := NewDefaultPluginHandler(tt.validPrefix)
 			plugins := pluginHandler.ListAvailablePlugins()
-
-			if len(tt.expected) == 0 {
-				assert.Empty(t, plugins)
-				return
-			}
 
 			assert.Equal(t, tt.expected, plugins)
 		})

--- a/cmd/argocd/commands/plugin_test.go
+++ b/cmd/argocd/commands/plugin_test.go
@@ -346,8 +346,7 @@ func TestListAvailablePlugins(t *testing.T) {
 				return
 			}
 
-			// Sort both slices for comparison since order is not guaranteed
-			assert.ElementsMatch(t, tt.expected, plugins)
+			assert.Equal(t, tt.expected, plugins)
 		})
 	}
 }

--- a/cmd/argocd/commands/plugin_test.go
+++ b/cmd/argocd/commands/plugin_test.go
@@ -398,14 +398,5 @@ func TestListAvailablePluginsDeduplication(t *testing.T) {
 	pluginHandler := NewDefaultPluginHandler([]string{"argocd"})
 	plugins := pluginHandler.ListAvailablePlugins()
 
-	// Should only find "duplicate" once, not twice
-	duplicateCount := 0
-	for _, plugin := range plugins {
-		if plugin == "duplicate" {
-			duplicateCount++
-		}
-	}
-
-	assert.Equal(t, 1, duplicateCount, "Duplicate plugin should only appear once")
-	assert.Contains(t, plugins, "duplicate")
+	assert.Equal(t, []string{"duplicate"}, plugins)
 }

--- a/cmd/argocd/commands/plugin_test.go
+++ b/cmd/argocd/commands/plugin_test.go
@@ -354,11 +354,6 @@ func TestListAvailablePlugins(t *testing.T) {
 
 // TestListAvailablePluginsEmptyPath tests plugin discovery when PATH is empty
 func TestListAvailablePluginsEmptyPath(t *testing.T) {
-	// Save original PATH
-	originalPath := os.Getenv("PATH")
-	defer func() {
-		t.Setenv("PATH", originalPath)
-	}()
 
 	// Set empty PATH
 	t.Setenv("PATH", "")

--- a/cmd/argocd/commands/plugin_test.go
+++ b/cmd/argocd/commands/plugin_test.go
@@ -348,7 +348,6 @@ func TestListAvailablePlugins(t *testing.T) {
 
 // TestListAvailablePluginsEmptyPath tests plugin discovery when PATH is empty
 func TestListAvailablePluginsEmptyPath(t *testing.T) {
-
 	// Set empty PATH
 	t.Setenv("PATH", "")
 

--- a/cmd/argocd/commands/root.go
+++ b/cmd/argocd/commands/root.go
@@ -44,7 +44,7 @@ func NewCommand() *cobra.Command {
 		},
 		DisableAutoGenTag: true,
 		SilenceUsage:      true,
-		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		ValidArgsFunction: func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 			// Return available plugin commands for tab completion
 			pluginHandler := NewDefaultPluginHandler([]string{"argocd"})
 			plugins := pluginHandler.ListAvailablePlugins()

--- a/cmd/argocd/commands/root.go
+++ b/cmd/argocd/commands/root.go
@@ -44,6 +44,12 @@ func NewCommand() *cobra.Command {
 		},
 		DisableAutoGenTag: true,
 		SilenceUsage:      true,
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			// Return available plugin commands for tab completion
+			pluginHandler := NewDefaultPluginHandler([]string{"argocd"})
+			plugins := pluginHandler.ListAvailablePlugins()
+			return plugins, cobra.ShellCompDirectiveNoFileComp
+		},
 	}
 
 	command.AddCommand(NewCompletionCommand())


### PR DESCRIPTION
Fixes #24742 

This update shows plugins (if any) when you run `argocd <TAB>`. This puts it in parity with how the `kubectl` command behaves.