### PR TITLE
chore(cli): plugins always have an argocd prefix

### DIFF
--- a/cmd/argocd/commands/plugin_test.go
+++ b/cmd/argocd/commands/plugin_test.go
@@ -320,25 +320,14 @@ func TestListAvailablePlugins(t *testing.T) {
 		expected    []string
 	}{
 		{
-			name:        "Standard argocd prefix finds plugins",
-			validPrefix: []string{"argocd"},
-			expected:    []string{"demo_plugin", "error", "foo", "status-code-plugin", "test-plugin", "version"},
-		},
-		{
-			name:        "Multiple prefixes",
-			validPrefix: []string{"argocd", "kubectl"},
-			expected:    []string{"demo_plugin", "error", "foo", "status-code-plugin", "test-plugin", "version"},
-		},
-		{
-			name:        "Non-existent prefix finds no plugins",
-			validPrefix: []string{"nonexistent"},
-			expected:    []string{},
+			name:     "Standard argocd prefix finds plugins",
+			expected: []string{"demo_plugin", "error", "foo", "status-code-plugin", "test-plugin", "version"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pluginHandler := NewDefaultPluginHandler(tt.validPrefix)
+			pluginHandler := NewDefaultPluginHandler()
 			plugins := pluginHandler.ListAvailablePlugins()
 
 			assert.Equal(t, tt.expected, plugins)
@@ -351,7 +340,7 @@ func TestListAvailablePluginsEmptyPath(t *testing.T) {
 	// Set empty PATH
 	t.Setenv("PATH", "")
 
-	pluginHandler := NewDefaultPluginHandler([]string{"argocd"})
+	pluginHandler := NewDefaultPluginHandler()
 	plugins := pluginHandler.ListAvailablePlugins()
 
 	assert.Empty(t, plugins, "Should return empty list when PATH is empty")
@@ -361,7 +350,7 @@ func TestListAvailablePluginsEmptyPath(t *testing.T) {
 func TestListAvailablePluginsNonExecutableFiles(t *testing.T) {
 	setupPluginPath(t)
 
-	pluginHandler := NewDefaultPluginHandler([]string{"argocd"})
+	pluginHandler := NewDefaultPluginHandler()
 	plugins := pluginHandler.ListAvailablePlugins()
 
 	// Should not include 'no-permission' since it's not executable
@@ -388,7 +377,7 @@ func TestListAvailablePluginsDeduplication(t *testing.T) {
 	testPath := dir1 + string(os.PathListSeparator) + dir2
 	t.Setenv("PATH", testPath)
 
-	pluginHandler := NewDefaultPluginHandler([]string{"argocd"})
+	pluginHandler := NewDefaultPluginHandler()
 	plugins := pluginHandler.ListAvailablePlugins()
 
 	assert.Equal(t, []string{"duplicate"}, plugins)

--- a/cmd/argocd/commands/plugin_test.go
+++ b/cmd/argocd/commands/plugin_test.go
@@ -28,7 +28,7 @@ func setupPluginPath(t *testing.T) {
 func TestNormalCommandWithPlugin(t *testing.T) {
 	setupPluginPath(t)
 
-	_ = NewDefaultPluginHandler([]string{"argocd"})
+	_ = NewDefaultPluginHandler()
 	args := []string{"argocd", "version", "--short", "--client"}
 	buf := new(bytes.Buffer)
 	cmd := NewVersionCmd(&argocdclient.ClientOptions{}, nil)
@@ -47,7 +47,7 @@ func TestNormalCommandWithPlugin(t *testing.T) {
 func TestPluginExecution(t *testing.T) {
 	setupPluginPath(t)
 
-	pluginHandler := NewDefaultPluginHandler([]string{"argocd"})
+	pluginHandler := NewDefaultPluginHandler()
 	cmd := NewCommand()
 	cmd.SilenceErrors = true
 	cmd.SilenceUsage = true
@@ -101,7 +101,7 @@ func TestPluginExecution(t *testing.T) {
 func TestNormalCommandError(t *testing.T) {
 	setupPluginPath(t)
 
-	pluginHandler := NewDefaultPluginHandler([]string{"argocd"})
+	pluginHandler := NewDefaultPluginHandler()
 	args := []string{"argocd", "version", "--non-existent-flag"}
 	cmd := NewVersionCmd(&argocdclient.ClientOptions{}, nil)
 	cmd.SetArgs(args[1:])
@@ -118,7 +118,7 @@ func TestNormalCommandError(t *testing.T) {
 // TestUnknownCommandNoPlugin tests the scenario when the command is neither a normal ArgoCD command
 // nor exists as a plugin
 func TestUnknownCommandNoPlugin(t *testing.T) {
-	pluginHandler := NewDefaultPluginHandler([]string{"argocd"})
+	pluginHandler := NewDefaultPluginHandler()
 	cmd := NewCommand()
 	cmd.SilenceErrors = true
 	cmd.SilenceUsage = true
@@ -137,7 +137,7 @@ func TestUnknownCommandNoPlugin(t *testing.T) {
 func TestPluginNoExecutePermission(t *testing.T) {
 	setupPluginPath(t)
 
-	pluginHandler := NewDefaultPluginHandler([]string{"argocd"})
+	pluginHandler := NewDefaultPluginHandler()
 	cmd := NewCommand()
 	cmd.SilenceErrors = true
 	cmd.SilenceUsage = true
@@ -156,7 +156,7 @@ func TestPluginNoExecutePermission(t *testing.T) {
 func TestPluginExecutionError(t *testing.T) {
 	setupPluginPath(t)
 
-	pluginHandler := NewDefaultPluginHandler([]string{"argocd"})
+	pluginHandler := NewDefaultPluginHandler()
 	cmd := NewCommand()
 	cmd.SilenceErrors = true
 	cmd.SilenceUsage = true
@@ -187,7 +187,7 @@ func TestPluginInRelativePathIgnored(t *testing.T) {
 
 	t.Setenv("PATH", os.Getenv("PATH")+string(os.PathListSeparator)+relativePath)
 
-	pluginHandler := NewDefaultPluginHandler([]string{"argocd"})
+	pluginHandler := NewDefaultPluginHandler()
 	cmd := NewCommand()
 	cmd.SilenceErrors = true
 	cmd.SilenceUsage = true
@@ -206,7 +206,7 @@ func TestPluginInRelativePathIgnored(t *testing.T) {
 func TestPluginFlagParsing(t *testing.T) {
 	setupPluginPath(t)
 
-	pluginHandler := NewDefaultPluginHandler([]string{"argocd"})
+	pluginHandler := NewDefaultPluginHandler()
 
 	tests := []struct {
 		name           string
@@ -255,7 +255,7 @@ func TestPluginFlagParsing(t *testing.T) {
 func TestPluginStatusCode(t *testing.T) {
 	setupPluginPath(t)
 
-	pluginHandler := NewDefaultPluginHandler([]string{"argocd"})
+	pluginHandler := NewDefaultPluginHandler()
 
 	tests := []struct {
 		name       string

--- a/cmd/argocd/commands/root.go
+++ b/cmd/argocd/commands/root.go
@@ -46,8 +46,7 @@ func NewCommand() *cobra.Command {
 		SilenceUsage:      true,
 		ValidArgsFunction: func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 			// Return available plugin commands for tab completion
-			pluginHandler := NewDefaultPluginHandler([]string{"argocd"})
-			plugins := pluginHandler.ListAvailablePlugins()
+			plugins := NewDefaultPluginHandler().ListAvailablePlugins()
 			return plugins, cobra.ShellCompDirectiveNoFileComp
 		},
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -83,12 +83,11 @@ func main() {
 	}
 
 	err := command.Execute()
-	// if the err is non-nil, try to look for various scenarios
+	// if an error is present, try to look for various scenarios
 	// such as if the error is from the execution of a normal argocd command,
 	// unknown command error or any other.
 	if err != nil {
-		pluginHandler := cli.NewDefaultPluginHandler([]string{"argocd"})
-		pluginErr := pluginHandler.HandleCommandExecutionError(err, isArgocdCLI, os.Args)
+		pluginErr := cli.NewDefaultPluginHandler().HandleCommandExecutionError(err, isArgocdCLI, os.Args)
 		if pluginErr != nil {
 			var exitErr *exec.ExitError
 			if errors.As(pluginErr, &exitErr) {


### PR DESCRIPTION
I don't think there's ever a scenario where we'd have plugins with prefixes other than `argocd-`. Reduce a bit of confusion working with the plugin handler by always using `argocd-` as a plugin prefix.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
