### PR TITLE
fix: allow for backwards compatibility of durations defined in days

### DIFF
--- a/util/env/env.go
+++ b/util/env/env.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	timeutil "github.com/argoproj/pkg/time"
+
 	log "github.com/sirupsen/logrus"
 )
 
@@ -125,8 +127,13 @@ func ParseDurationFromEnv(env string, defaultValue, minimum, maximum time.Durati
 	}
 	dur, err := time.ParseDuration(str)
 	if err != nil {
-		log.Warnf("Could not parse '%s' as a duration string from environment %s", str, env)
-		return defaultValue
+		// provides backwards compatibility for durations defined in days, see: https://github.com/argoproj/argo-cd/issues/24740
+		durPtr, err2 := timeutil.ParseDuration(str)
+		if err2 != nil {
+			log.Warnf("Could not parse '%s' as a duration from environment %s", str, env)
+			return defaultValue
+		}
+		dur = *durPtr
 	}
 
 	if dur < minimum {


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Fixes: https://github.com/argoproj/argo-cd/issues/24740
This bug was introduced in v2.14.0 and has been in every v2.14 and v3 release ever since.

**To note**
All the test cases pass with the pre-v2.14 version with one notable exception: https://github.com/argoproj/argo-cd/pull/24769/files#diff-f4cf5d4ad87bc07ff0573f18f4b68af0adf34871c09b32eae1554b3334e5a93cR183

time.ParseDuration allows for decimal durations (1.5h, 5.5m, etc), while the old function didn't. 

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
