### PR TITLE
chore: allow docs approvers to merge for docs/operator-manual

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,4 +16,5 @@
 # CLI
 /cmd/argocd/** @argoproj/argocd-approvers @argoproj/argocd-approvers-cli
 /cmd/main.go @argoproj/argocd-approvers @argoproj/argocd-approvers-cli
-/docs/operator-manual/ @argoproj/argocd-approvers @argoproj/argocd-approvers-cli
+# Also include @argoproj/argocd-approvers-docs to avoid requiring CLI approvers for docs-only PRs.
+/docs/operator-manual/ @argoproj/argocd-approvers @argoproj/argocd-approvers-docs @argoproj/argocd-approvers-cli


### PR DESCRIPTION
Docs approver role should be enough to merge any docs-only PR. Conversation about the problem: https://cloud-native.slack.com/archives/C020XM04CUW/p1759346087734039
