### PR TITLE
chore: respect KUBECONFIG env var when running `make start`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ HOST_OS:=$(shell go env GOOS)
 HOST_ARCH:=$(shell go env GOARCH)
 
 TARGET_ARCH?=linux/amd64
-KUBECONFIG?=${HOME}/.kube
+KUBECONFIG?=${HOME}/.kube/config
 
 VERSION=$(shell cat ${CURRENT_DIR}/VERSION)
 BUILD_DATE:=$(if $(BUILD_DATE),$(BUILD_DATE),$(shell date -u +'%Y-%m-%dT%H:%M:%SZ'))

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ HOST_OS:=$(shell go env GOOS)
 HOST_ARCH:=$(shell go env GOARCH)
 
 TARGET_ARCH?=linux/amd64
+KUBECONFIG?=${HOME}/.kube
 
 VERSION=$(shell cat ${CURRENT_DIR}/VERSION)
 BUILD_DATE:=$(if $(BUILD_DATE),$(BUILD_DATE),$(shell date -u +'%Y-%m-%dT%H:%M:%SZ'))
@@ -123,7 +124,7 @@ define run-in-test-server
 		-v ${DOCKER_SRC_MOUNT} \
 		-v ${GOPATH}/pkg/mod:/go/pkg/mod${VOLUME_MOUNT} \
 		-v ${GOCACHE}:/tmp/go-build-cache${VOLUME_MOUNT} \
-		-v ${HOME}/.kube:/home/user/.kube${VOLUME_MOUNT} \
+		--mount type=bind,source=$(KUBECONFIG),target=/home/user/.kube/config \
 		-w ${DOCKER_WORKDIR} \
 		-p ${ARGOCD_E2E_APISERVER_PORT}:8080 \
 		-p 4000:4000 \
@@ -148,7 +149,7 @@ define run-in-test-client
 		-v ${DOCKER_SRC_MOUNT} \
 		-v ${GOPATH}/pkg/mod:/go/pkg/mod${VOLUME_MOUNT} \
 		-v ${GOCACHE}:/tmp/go-build-cache${VOLUME_MOUNT} \
-		-v ${HOME}/.kube:/home/user/.kube${VOLUME_MOUNT} \
+		--mount type=bind,source=$(KUBECONFIG),target=/home/user/.kube/config \
 		-w ${DOCKER_WORKDIR} \
 		$(DOCKER_NETWORK_ARG)\
 		$(PODMAN_ARGS) \


### PR DESCRIPTION
This makes it easier to run the dev environment on a Mac with KinD.