### PR TITLE
fix(health): incorrect reason in PullRequest script

### DIFF
--- a/resource_customizations/promoter.argoproj.io/PullRequest/health.lua
+++ b/resource_customizations/promoter.argoproj.io/PullRequest/health.lua
@@ -26,7 +26,7 @@ if obj.status.conditions then
                 hs.message = "Waiting for pull request spec update to be observed"
                 return hs
             end
-            if condition.status == "False" and (condition.reason == "ReconcileError" or condition.reason == "Failed") then
+            if condition.status == "False" then
                 hs.status = "Degraded"
                 hs.message = "Pull request reconciliation failed: " .. (condition.message or "Unknown error")
                 return hs

--- a/resource_customizations/promoter.argoproj.io/PullRequest/health_test.yaml
+++ b/resource_customizations/promoter.argoproj.io/PullRequest/health_test.yaml
@@ -14,7 +14,7 @@ tests:
 - healthStatus:
     status: Degraded
     message: "Pull request reconciliation failed: Something went wrong"
-  inputPath: testdata/reconcile-error.yaml
+  inputPath: testdata/reconciliation-error.yaml
 - healthStatus:
     status: Progressing
     message: Pull request is not ready yet

--- a/resource_customizations/promoter.argoproj.io/PullRequest/testdata/reconciliation-error.yaml
+++ b/resource_customizations/promoter.argoproj.io/PullRequest/testdata/reconciliation-error.yaml
@@ -7,7 +7,7 @@ status:
   conditions:
     - type: Ready
       status: "False"
-      reason: ReconcileError
+      reason: ReconciliationError
       message: Something went wrong
       observedGeneration: 2
 


### PR DESCRIPTION
The reason should have been `ReconciliationError` instead of `ReconcilieError`, but actually if Ready is False, we should just always consider it Degraded.