### PR TITLE
fix: update cmp plugin find command to search in repository root

### DIFF
--- a/cmpserver/plugin/plugin.go
+++ b/cmpserver/plugin/plugin.go
@@ -362,7 +362,7 @@ func (s *Service) matchRepository(ctx context.Context, workdir string, envEntrie
 	if len(config.Spec.Discover.Find.Command.Command) > 0 {
 		log.Debugf("Going to try runCommand.")
 		env := append(os.Environ(), environ(envEntries)...)
-		find, err := runCommand(ctx, config.Spec.Discover.Find.Command, appPath, env)
+		find, err := runCommand(ctx, config.Spec.Discover.Find.Command, workdir, env)
 		if err != nil {
 			return false, true, fmt.Errorf("error running find command: %w", err)
 		}


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Fixes [ISSUE #24836]
Changes `config.Spec.Discover.Find.Command` to run from the repository root
<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
