### PR TITLE
fix: make webhook payload handlers recover from panics (cherry-pick #24862 for 2.14)

### DIFF
--- a/applicationset/webhook/webhook.go
+++ b/applicationset/webhook/webhook.go
@@ -117,7 +117,7 @@ func (h *WebhookHandler) startWorkerPool(webhookParallelism int) {
 				if !ok {
 					return
 				}
-				guard.Run(func() { h.HandleEvent(payload) }, compLog, panicMsgAppSet)
+				guard.RecoverAndLog(func() { h.HandleEvent(payload) }, compLog, panicMsgAppSet)
 			}
 		}()
 	}

--- a/applicationset/webhook/webhook.go
+++ b/applicationset/webhook/webhook.go
@@ -25,9 +25,13 @@ import (
 	"github.com/go-playground/webhooks/v6/github"
 	"github.com/go-playground/webhooks/v6/gitlab"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/argoproj/argo-cd/v2/util/guard"
 )
 
 const payloadQueueSize = 50000
+
+const panicMsgAppSet = "panic while processing applicationset-controller webhook event"
 
 type WebhookHandler struct {
 	sync.WaitGroup // for testing
@@ -103,6 +107,7 @@ func NewWebhookHandler(namespace string, webhookParallelism int, argocdSettingsM
 }
 
 func (h *WebhookHandler) startWorkerPool(webhookParallelism int) {
+	compLog := log.WithField("component", "applicationset-webhook")
 	for i := 0; i < webhookParallelism; i++ {
 		h.Add(1)
 		go func() {
@@ -112,7 +117,7 @@ func (h *WebhookHandler) startWorkerPool(webhookParallelism int) {
 				if !ok {
 					return
 				}
-				h.HandleEvent(payload)
+				guard.Run(func() { h.HandleEvent(payload) }, compLog, panicMsgAppSet)
 			}
 		}()
 	}

--- a/util/guard/guard.go
+++ b/util/guard/guard.go
@@ -8,7 +8,7 @@ import (
 type Logger interface{ Errorf(string, ...any) }
 
 // Run executes fn and recovers a panic, logging a component-specific message.
-func Run(fn func(), log Logger, msg string) {
+func RecoverAndLog(fn func(), log Logger, msg string) {
 	defer func() {
 		if r := recover(); r != nil {
 			if log != nil {

--- a/util/guard/guard.go
+++ b/util/guard/guard.go
@@ -1,0 +1,20 @@
+package guard
+
+import (
+	"runtime/debug"
+)
+
+// Minimal logger contract; avoids depending on any specific logging package.
+type Logger interface{ Errorf(string, ...any) }
+
+// Run executes fn and recovers a panic, logging a component-specific message.
+func Run(fn func(), log Logger, msg string) {
+	defer func() {
+		if r := recover(); r != nil {
+			if log != nil {
+				log.Errorf("%s: %v %s", msg, r, debug.Stack())
+			}
+		}
+	}()
+	fn()
+}

--- a/util/guard/guard_test.go
+++ b/util/guard/guard_test.go
@@ -1,0 +1,92 @@
+package guard
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type nop struct{}
+
+func (nop) Errorf(string, ...any) {}
+
+// recorder is a thread-safe logger that captures formatted messages.
+type recorder struct {
+	mu    sync.Mutex
+	calls int
+	msgs  []string
+}
+
+func (r *recorder) Errorf(format string, args ...any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls++
+	r.msgs = append(r.msgs, fmt.Sprintf(format, args...))
+}
+
+func TestRun_Recovers(_ *testing.T) {
+	Run(func() { panic("boom") }, nop{}, "msg") // fails if panic escapes
+}
+
+func TestRun_AllowsNextCall(t *testing.T) {
+	ran := false
+	Run(func() { panic("boom") }, nop{}, "msg")
+	Run(func() { ran = true }, nop{}, "msg")
+	if !ran {
+		t.Fatal("expected second callback to run")
+	}
+}
+
+func TestRun_LogsMessageAndStack(t *testing.T) {
+	r := &recorder{}
+	Run(func() { panic("boom") }, r, "msg")
+	if r.calls != 1 {
+		t.Fatalf("expected 1 log call, got %d", r.calls)
+	}
+	got := strings.Join(r.msgs, "\n")
+	if !strings.Contains(got, "msg") {
+		t.Errorf("expected log to contain message %q; got %q", "msg", got)
+	}
+	if !strings.Contains(got, "boom") {
+		t.Errorf("expected log to contain panic value %q; got %q", "boom", got)
+	}
+	// Heuristic check that a stack trace was included.
+	if !strings.Contains(got, "guard.go") && !strings.Contains(got, "runtime/panic.go") && !strings.Contains(got, "goroutine") {
+		t.Errorf("expected log to contain a stack trace; got %q", got)
+	}
+}
+
+func TestRun_NilLoggerDoesNotPanic(_ *testing.T) {
+	var l Logger // nil
+	Run(func() { panic("boom") }, l, "ignored")
+}
+
+func TestRun_NoPanicDoesNotLog(t *testing.T) {
+	r := &recorder{}
+	ran := false
+	Run(func() { ran = true }, r, "msg")
+	if !ran {
+		t.Fatal("expected fn to run")
+	}
+	if r.calls != 0 {
+		t.Fatalf("expected 0 log calls, got %d", r.calls)
+	}
+}
+
+func TestRun_ConcurrentPanicsLogged(t *testing.T) {
+	r := &recorder{}
+	const n = 10
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			Run(func() { panic(fmt.Sprintf("boom-%d", i)) }, r, "msg")
+		}(i)
+	}
+	wg.Wait()
+	if r.calls != n {
+		t.Fatalf("expected %d log calls, got %d", n, r.calls)
+	}
+}

--- a/util/guard/guard_test.go
+++ b/util/guard/guard_test.go
@@ -26,13 +26,13 @@ func (r *recorder) Errorf(format string, args ...any) {
 }
 
 func TestRun_Recovers(_ *testing.T) {
-	Run(func() { panic("boom") }, nop{}, "msg") // fails if panic escapes
+	RecoverAndLog(func() { panic("boom") }, nop{}, "msg") // fails if panic escapes
 }
 
 func TestRun_AllowsNextCall(t *testing.T) {
 	ran := false
-	Run(func() { panic("boom") }, nop{}, "msg")
-	Run(func() { ran = true }, nop{}, "msg")
+	RecoverAndLog(func() { panic("boom") }, nop{}, "msg")
+	RecoverAndLog(func() { ran = true }, nop{}, "msg")
 	if !ran {
 		t.Fatal("expected second callback to run")
 	}
@@ -40,7 +40,7 @@ func TestRun_AllowsNextCall(t *testing.T) {
 
 func TestRun_LogsMessageAndStack(t *testing.T) {
 	r := &recorder{}
-	Run(func() { panic("boom") }, r, "msg")
+	RecoverAndLog(func() { panic("boom") }, r, "msg")
 	if r.calls != 1 {
 		t.Fatalf("expected 1 log call, got %d", r.calls)
 	}
@@ -59,13 +59,13 @@ func TestRun_LogsMessageAndStack(t *testing.T) {
 
 func TestRun_NilLoggerDoesNotPanic(_ *testing.T) {
 	var l Logger // nil
-	Run(func() { panic("boom") }, l, "ignored")
+	RecoverAndLog(func() { panic("boom") }, l, "ignored")
 }
 
 func TestRun_NoPanicDoesNotLog(t *testing.T) {
 	r := &recorder{}
 	ran := false
-	Run(func() { ran = true }, r, "msg")
+	RecoverAndLog(func() { ran = true }, r, "msg")
 	if !ran {
 		t.Fatal("expected fn to run")
 	}
@@ -82,7 +82,7 @@ func TestRun_ConcurrentPanicsLogged(t *testing.T) {
 	for i := 0; i < n; i++ {
 		go func(i int) {
 			defer wg.Done()
-			Run(func() { panic(fmt.Sprintf("boom-%d", i)) }, r, "msg")
+			RecoverAndLog(func() { panic(fmt.Sprintf("boom-%d", i)) }, r, "msg")
 		}(i)
 	}
 	wg.Wait()

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -134,7 +134,7 @@ func (a *ArgoCDWebhookHandler) startWorkerPool(webhookParallelism int) {
 				if !ok {
 					return
 				}
-				guard.Run(func() { a.HandleEvent(payload) }, compLog, panicMsgServer)
+				guard.RecoverAndLog(func() { a.HandleEvent(payload) }, compLog, panicMsgServer)
 			}
 		}()
 	}

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -33,6 +33,7 @@ import (
 	"github.com/argoproj/argo-cd/v2/util/argo"
 	"github.com/argoproj/argo-cd/v2/util/db"
 	"github.com/argoproj/argo-cd/v2/util/glob"
+	"github.com/argoproj/argo-cd/v2/util/guard"
 	"github.com/argoproj/argo-cd/v2/util/settings"
 )
 
@@ -47,6 +48,8 @@ type settingsSource interface {
 const usernameRegex = `[a-zA-Z0-9_\.][a-zA-Z0-9_\.-]{0,30}[a-zA-Z0-9_\.\$-]?`
 
 const payloadQueueSize = 50000
+
+const panicMsgServer = "panic while processing api-server webhook event"
 
 var _ settingsSource = &settings.SettingsManager{}
 
@@ -121,6 +124,7 @@ func NewHandler(namespace string, applicationNamespaces []string, webhookParalle
 }
 
 func (a *ArgoCDWebhookHandler) startWorkerPool(webhookParallelism int) {
+	compLog := log.WithField("component", "api-server-webhook")
 	for i := 0; i < webhookParallelism; i++ {
 		a.Add(1)
 		go func() {
@@ -130,7 +134,7 @@ func (a *ArgoCDWebhookHandler) startWorkerPool(webhookParallelism int) {
 				if !ok {
 					return
 				}
-				a.HandleEvent(payload)
+				guard.Run(func() { a.HandleEvent(payload) }, compLog, panicMsgServer)
 			}
 		}()
 	}


### PR DESCRIPTION
Cherry-picked fix: make webhook payload handlers recover from panics (https://github.com/argoproj/argo-cd/pull/24862)