### PR TITLE
fix: config loader accepts multiple parameters with the same key

### DIFF
--- a/util/config/env.go
+++ b/util/config/env.go
@@ -11,7 +11,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var flags map[string]string
+var flags map[string][]string
 
 func init() {
 	err := LoadFlags()
@@ -21,11 +21,26 @@ func init() {
 }
 
 func LoadFlags() error {
-	flags = make(map[string]string)
+	flags = make(map[string][]string)
 
 	opts, err := shellquote.Split(os.Getenv("ARGOCD_OPTS"))
 	if err != nil {
 		return err
+	}
+
+	setKey := func(key string) {
+		// pkg shellquota doesn't recognize `=` so that the opts in format `foo=bar` could not work.
+		// issue ref: https://github.com/argoproj/argo-cd/issues/6822
+		if strings.Contains(key, "=") {
+			kv := strings.SplitN(key, "=", 2)
+			actualKey, actualValue := kv[0], kv[1]
+			flags[actualKey] = append(flags[actualKey], actualValue)
+		} else {
+			if _, ok := flags[key]; !ok {
+				// empty slice means bool flag.
+				flags[key] = []string{}
+			}
+		}
 	}
 
 	var key string
@@ -33,47 +48,50 @@ func LoadFlags() error {
 		switch {
 		case strings.HasPrefix(opt, "--"):
 			if key != "" {
-				flags[key] = "true"
+				setKey(key)
 			}
 			key = strings.TrimPrefix(opt, "--")
 		case key != "":
-			flags[key] = opt
+			flags[key] = append(flags[key], opt)
 			key = ""
 		default:
 			return errors.New("ARGOCD_OPTS invalid at '" + opt + "'")
 		}
 	}
 	if key != "" {
-		flags[key] = "true"
-	}
-	// pkg shellquota doesn't recognize `=` so that the opts in format `foo=bar` could not work.
-	// issue ref: https://github.com/argoproj/argo-cd/issues/6822
-	for k, v := range flags {
-		if strings.Contains(k, "=") && v == "true" {
-			kv := strings.SplitN(k, "=", 2)
-			actualKey, actualValue := kv[0], kv[1]
-			if _, ok := flags[actualKey]; !ok {
-				flags[actualKey] = actualValue
-			}
-		}
+		setKey(key)
 	}
 	return nil
 }
 
-func GetFlag(key, fallback string) string {
+func getFlag(key string) (string, bool) {
 	val, ok := flags[key]
-	if ok {
-		return val
+	if !ok {
+		return "", false
 	}
-	return fallback
+	if len(val) == 0 {
+		// return "true" string for bool flag.
+		return "true", true
+	}
+	// last flag wins for backward compatibility.
+	return val[len(val)-1], true
+}
+
+func GetFlag(key, fallback string) string {
+	val, ok := getFlag(key)
+	if !ok {
+		return fallback
+	}
+	return val
 }
 
 func GetBoolFlag(key string) bool {
-	return GetFlag(key, "false") == "true"
+	_, ok := flags[key]
+	return ok
 }
 
 func GetIntFlag(key string, fallback int) int {
-	val, ok := flags[key]
+	val, ok := getFlag(key)
 	if !ok {
 		return fallback
 	}
@@ -91,14 +109,15 @@ func GetStringSliceFlag(key string, fallback []string) []string {
 		return fallback
 	}
 
-	if val == "" {
-		return []string{}
+	s := []string{}
+	for _, v := range val {
+		// use csv reader to parse quoted string with comma
+		csvReader := csv.NewReader(strings.NewReader(v))
+		v, err := csvReader.Read()
+		if err != nil {
+			log.Fatal(err)
+		}
+		s = append(s, v...)
 	}
-	stringReader := strings.NewReader(val)
-	csvReader := csv.NewReader(stringReader)
-	v, err := csvReader.Read()
-	if err != nil {
-		log.Fatal(err)
-	}
-	return v
+	return s
 }

--- a/util/config/env_test.go
+++ b/util/config/env_test.go
@@ -113,6 +113,24 @@ func TestStringSliceFlagAtEnd(t *testing.T) {
 	assert.Equal(t, "Strict-Transport-Security: max-age=31536000", strings[0])
 }
 
+func TestStringSliceMultiple(t *testing.T) {
+	loadOpts(t, "--header 'Content-Type: application/json; charset=utf-8' --header 'Strict-Transport-Security: max-age=31536000'")
+	strings := GetStringSliceFlag("header", []string{})
+
+	assert.Len(t, strings, 2)
+	assert.Equal(t, "Content-Type: application/json; charset=utf-8", strings[0])
+	assert.Equal(t, "Strict-Transport-Security: max-age=31536000", strings[1])
+}
+
+func TestStringSliceMultipleWithEqualSign(t *testing.T) {
+	loadOpts(t, "--header='Content-Type: application/json; charset=utf-8' --header='Strict-Transport-Security: max-age=31536000'")
+	strings := GetStringSliceFlag("header", []string{})
+
+	assert.Len(t, strings, 2)
+	assert.Equal(t, "Content-Type: application/json; charset=utf-8", strings[0])
+	assert.Equal(t, "Strict-Transport-Security: max-age=31536000", strings[1])
+}
+
 func TestFlagAtStart(t *testing.T) {
 	loadOpts(t, "--foo bar")
 
@@ -147,4 +165,10 @@ func TestFlagWithEqualSign(t *testing.T) {
 	loadOpts(t, "--foo=bar")
 
 	assert.Equal(t, "bar", GetFlag("foo", ""))
+}
+
+func TestFlagMultiple(t *testing.T) {
+	loadOpts(t, "--foo bar --foo baz")
+
+	assert.Equal(t, "baz", GetFlag("foo", "qux"))
 }

--- a/util/config/env_test.go
+++ b/util/config/env_test.go
@@ -172,3 +172,73 @@ func TestFlagMultiple(t *testing.T) {
 
 	assert.Equal(t, "baz", GetFlag("foo", "qux"))
 }
+
+func TestProcessFlagKey(t *testing.T) {
+	tests := []struct {
+		name          string
+		initialFlags  map[string][]string
+		key           string
+		expectedFlags map[string][]string
+	}{
+		{
+			name:         "boolean flag",
+			initialFlags: map[string][]string{},
+			key:          "foo",
+			expectedFlags: map[string][]string{
+				"foo": {},
+			},
+		},
+		{
+			name: "boolean flag with existing key",
+			initialFlags: map[string][]string{
+				"foo": {},
+			},
+			key: "foo",
+			expectedFlags: map[string][]string{
+				"foo": {},
+			},
+		},
+		{
+			name:         "key with equal sign",
+			initialFlags: map[string][]string{},
+			key:          "foo=bar",
+			expectedFlags: map[string][]string{
+				"foo": {"bar"},
+			},
+		},
+		{
+			name:         "key with equal sign and empty value",
+			initialFlags: map[string][]string{},
+			key:          "foo=",
+			expectedFlags: map[string][]string{
+				"foo": {""},
+			},
+		},
+		{
+			name:         "key with multiple equal signs",
+			initialFlags: map[string][]string{},
+			key:          "foo=bar=baz",
+			expectedFlags: map[string][]string{
+				"foo": {"bar=baz"},
+			},
+		},
+		{
+			name: "key with equal sign appends to existing key",
+			initialFlags: map[string][]string{
+				"foo": {"bar"},
+			},
+			key: "foo=baz",
+			expectedFlags: map[string][]string{
+				"foo": {"bar", "baz"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flags := tt.initialFlags
+			processFlagKey(flags, tt.key)
+			assert.Equal(t, tt.expectedFlags, flags)
+		})
+	}
+}


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

This PR resolves https://github.com/argoproj/argo-cd/issues/24065.

This PR fixes an issue where the `ARGOCD_OPTS` environment variable config loader could not accept multiple parameters with the same key.
Setting ARGOCD_OPTS would be identically to setting the CLI options.

I modified the internal flags storage from `map[string]string` to `map[string][]string` to support multiple values per key. 
`GetStringSliceFlag` properly handle multiple flag occurrences, while `GetFlag`, `GetIntFlag` keeps returning the last specified value.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
