### PR TITLE
fix: wrap returned errors with context (#10592)

### DIFF
--- a/controller/sync.go
+++ b/controller/sync.go
@@ -317,7 +317,7 @@ func (m *appStateManager) SyncAppState(app *v1alpha1.Application, project *v1alp
 					return m.db.GetProjectClusters(context.TODO(), project)
 				})
 				if err != nil {
-					return err
+					return fmt.Errorf("failed to check if destination cluster %s and namespace %s are permitted in project %s: %w", destCluster, un.GetNamespace(), project.Name, err)
 				}
 
 				if !permitted {


### PR DESCRIPTION
### Summary

This PR wraps returned errors with context in several helper functions, improving error messages for debugging.

### Motivation

Addresses issue #10592 — plain `return err` statements make it harder to understand what failed.

### Checklist

* [x] This is a bug fix
* [x] The title of the PR states what changed and the related issue number (#10592)
* [x] Signed off all commits as required by DCO
* [x] Unit tests pass (no tests broken)
* [x] Build is green
* [ ] Documentation updates not required
