### PR TITLE
fix: reposerver should return syncRevision if no changes detected (#17280)

### DIFF
--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -3089,12 +3089,15 @@ func (s *Service) UpdateRevisionForPaths(_ context.Context, request *apiclient.U
 			// Only warn with the error, no need to block anything if there is a caching error.
 			logCtx.Warnf("error updating cached revision for repo %s with revision %s: %v", repo.Repo, revision, err)
 			return &apiclient.UpdateRevisionForPathsResponse{
-				Revision: revision,
+				Revision: syncedRevision,
 			}, nil
 		}
 
+		// Return the synced revision when no changes are detected in the manifest-generate-paths.
+		// This ensures that sync history only records revisions with actual relevant changes,
+		// avoiding clutter from commits in unrelated paths.
 		return &apiclient.UpdateRevisionForPathsResponse{
-			Revision: revision,
+			Revision: syncedRevision,
 		}, nil
 	}
 

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -4030,7 +4030,7 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 				KubeVersion:       "v1.16.0",
 			},
 		}, want: &apiclient.UpdateRevisionForPathsResponse{
-			Revision: "632039659e542ed7de0c170a4fcc1c571b288fc0",
+			Revision: "1e67a504d03def3a6a1125d934cb511680f72555",
 		}, wantErr: assert.NoError, cacheHit: &cacheHit{
 			previousRevision: "1e67a504d03def3a6a1125d934cb511680f72555",
 			revision:         "632039659e542ed7de0c170a4fcc1c571b288fc0",
@@ -4073,7 +4073,7 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 				HasMultipleSources: true,
 			},
 		}, want: &apiclient.UpdateRevisionForPathsResponse{
-			Revision: "632039659e542ed7de0c170a4fcc1c571b288fc0",
+			Revision: "1e67a504d03def3a6a1125d934cb511680f72555",
 		}, wantErr: assert.NoError, cacheHit: &cacheHit{
 			previousRevision: "1e67a504d03def3a6a1125d934cb511680f72555",
 			revision:         "632039659e542ed7de0c170a4fcc1c571b288fc0",


### PR DESCRIPTION
When using the `argocd.argoproj.io/manifest-generate-paths` the user
explicitly requests argocd NOT to sync if files irrelevant to the
application change.
The repo server logic did properly report no changes when this
annotation is set, but it incorrectly reported the latest commit hash
known to the repo server. This commit hash then pollutes the sync
history of an application, because no actual sync of resources is
happening and the history will show commits unrelated to the service.

This change fixes this behaviour, and returns the provided syncRevision
back to the caller if no new changes were detected since the
syncRevision.

Fixes #17280

Signed-off-by: Zoltán Reegn <zoltan.reegn@gmail.com>

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

- [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
- [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
- [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
- [ ] Does this PR require documentation updates?
- [ ] I've updated documentation as required by this PR.
- [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
- [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
- [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
- [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
- [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
- [ ] Optional. My organization is added to USERS.md.
- [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
