### PR TITLE
docs: Correct CMP find command docs

### DIFF
--- a/docs/operator-manual/config-management-plugins.md
+++ b/docs/operator-manual/config-management-plugins.md
@@ -65,7 +65,7 @@ spec:
     find:
       # This does the same thing as fileName, but it supports double-star (nested directory) glob patterns.
       glob: "**/Chart.yaml"
-      # The find command runs in the repository's root directory. To match, it must exit with status code 0 _and_ 
+      # The find command runs in the Application source directory. To match, it must exit with status code 0 _and_ 
       # produce non-empty output to standard out.
       command: [sh, -c, find . -name env.yaml]
   # The parameters config describes what parameters the UI should display for an Application. It is up to the user to


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Fixes [ISSUE #24836]
Edits the documentation to state that the find command runs from the Application source instead of the repository root. 

Code ref: [plugin.go source](https://github.com/argoproj/argo-cd/blob/ef5b77811d7cb1d07a0305bc0b39caed179553fd/cmpserver/plugin/plugin.go#L365C1-L366C1)

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
