### PR TITLE
fix(health): use promotion resource Ready condition regardless of reason

### DIFF
--- a/resource_customizations/promoter.argoproj.io/ArgoCDCommitStatus/health.lua
+++ b/resource_customizations/promoter.argoproj.io/ArgoCDCommitStatus/health.lua
@@ -25,9 +25,17 @@ if obj.status.conditions then
                 hs.message = "Waiting for Argo CD commit status spec update to be observed"
                 return hs
             end
-            if condition.status == "False" and condition.reason == "ReconciliationError" then
+            -- Check for any False condition status
+            if condition.status == "False" then
                 hs.status = "Degraded"
-                hs.message = "Argo CD commit status reconciliation failed: " .. (condition.message or "Unknown error")
+                local msg = condition.message or "Unknown error"
+                local reason = condition.reason or "Unknown"
+                -- Don't include ReconciliationError in the message since it's redundant
+                if reason == "ReconciliationError" then
+                    hs.message = "Argo CD commit status reconciliation failed: " .. msg
+                else
+                    hs.message = "Argo CD commit status reconciliation failed (" .. reason .. "): " .. msg
+                end
                 return hs
             end
         end

--- a/resource_customizations/promoter.argoproj.io/ArgoCDCommitStatus/health_test.yaml
+++ b/resource_customizations/promoter.argoproj.io/ArgoCDCommitStatus/health_test.yaml
@@ -16,6 +16,10 @@ tests:
     message: "Argo CD commit status reconciliation failed: Something went wrong"
   inputPath: testdata/reconcile-error.yaml
 - healthStatus:
+    status: Degraded
+    message: "Argo CD commit status reconciliation failed: Failed to query Argo CD applications: connection timeout"
+  inputPath: testdata/non-reconciliation-error.yaml
+- healthStatus:
     status: Progressing
     message: Argo CD commit status is not ready yet
   inputPath: testdata/no-ready-condition.yaml

--- a/resource_customizations/promoter.argoproj.io/ArgoCDCommitStatus/testdata/non-reconciliation-error.yaml
+++ b/resource_customizations/promoter.argoproj.io/ArgoCDCommitStatus/testdata/non-reconciliation-error.yaml
@@ -1,0 +1,21 @@
+apiVersion: promoter.argoproj.io/v1alpha1
+kind: ArgoCDCommitStatus
+metadata:
+  name: test-commit-status
+  namespace: test
+  generation: 1
+spec:
+  applicationSelector:
+    matchLabels:
+      environment: production
+  promotionStrategyRef:
+    name: test
+status:
+  conditions:
+    - lastTransitionTime: '2025-10-15T16:00:00Z'
+      message: 'Failed to query Argo CD applications: connection timeout'
+      observedGeneration: 1
+      reason: ReconciliationError
+      status: 'False'
+      type: Ready
+

--- a/resource_customizations/promoter.argoproj.io/ChangeTransferPolicy/health.lua
+++ b/resource_customizations/promoter.argoproj.io/ChangeTransferPolicy/health.lua
@@ -26,9 +26,17 @@ if obj.status.conditions then
                 hs.message = "Waiting for change transfer policy spec update to be observed"
                 return hs
             end
-            if condition.status == "False" and condition.reason == "ReconciliationError" then
+            -- Check for any False condition status
+            if condition.status == "False" then
                 hs.status = "Degraded"
-                hs.message = "Change transfer policy reconciliation failed: " .. (condition.message or "Unknown error")
+                local msg = condition.message or "Unknown error"
+                local reason = condition.reason or "Unknown"
+                -- Don't include ReconciliationError in the message since it's redundant
+                if reason == "ReconciliationError" then
+                    hs.message = "Change transfer policy reconciliation failed: " .. msg
+                else
+                    hs.message = "Change transfer policy reconciliation failed (" .. reason .. "): " .. msg
+                end
                 return hs
             end
         end

--- a/resource_customizations/promoter.argoproj.io/ChangeTransferPolicy/health_test.yaml
+++ b/resource_customizations/promoter.argoproj.io/ChangeTransferPolicy/health_test.yaml
@@ -39,3 +39,7 @@ tests:
     status: Healthy
     message: "Environment is up-to-date, but there are non-successful active commit statuses: 1 pending, 0 successful, 0 failed. Pending commit statuses: argocd-health. "
   inputPath: testdata/non-successful-environments.yaml
+- healthStatus:
+    status: Degraded
+    message: "Change transfer policy reconciliation failed (PullRequestNotReady): PullRequest \"deployment-environments-qal-usw2-next-environments-qal-usw2-7a8e7b70\" is not Ready because \"ReconciliationError\": Reconciliation failed: failed to merge pull request: failed to merge pull request: failed to merge pull request: PUT https://github.example.com/api/v3/repos/org/deployment/pulls/3/merge: 405 At least 2 approving reviews are required by reviewers with write access. Required status check \"continuous-integration/jenkins/pr-head\" is expected. You're not authorized to push to this branch."
+  inputPath: testdata/missing-sha-and-not-ready.yaml

--- a/resource_customizations/promoter.argoproj.io/ChangeTransferPolicy/testdata/missing-sha-and-not-ready.yaml
+++ b/resource_customizations/promoter.argoproj.io/ChangeTransferPolicy/testdata/missing-sha-and-not-ready.yaml
@@ -1,0 +1,87 @@
+apiVersion: promoter.argoproj.io/v1alpha1
+kind: ChangeTransferPolicy
+metadata:
+  annotations:
+    promoter.argoproj.io/reconcile-at: '2025-10-15T17:11:51.672763364Z'
+  creationTimestamp: '2025-10-15T16:26:17Z'
+  generation: 1
+  labels:
+    promoter.argoproj.io/environment: environments-qal-usw2
+    promoter.argoproj.io/promotion-strategy: strategy
+  name: strategy-environments-qal-usw2-27894e05
+  namespace: test
+  ownerReferences:
+    - apiVersion: promoter.argoproj.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PromotionStrategy
+      name: strategy
+      uid: 146aaaba-72d5-4155-bf5b-b5fd03b8a6d0
+  resourceVersion: '116412858'
+  uid: 62e1ed12-d808-4c78-9217-f80822f930ae
+spec:
+  activeBranch: environments/qal-usw2
+  activeCommitStatuses:
+    - key: argocd-health
+  autoMerge: true
+  gitRepositoryRef:
+    name: repo
+  proposedBranch: environments/qal-usw2-next
+status:
+  active:
+    commitStatuses:
+      - key: argocd-health
+        phase: pending
+    dry: {}
+    hydrated:
+      author: ServiceAccount
+      commitTime: '2025-10-15T15:38:20Z'
+      sha: b060fc7f5079a5aa7364a3844cfe26ee3084e282
+      subject: '[Changed] - infrastructure deployment'
+  conditions:
+    - lastTransitionTime: '2025-10-15T17:34:14Z'
+      message: 'PullRequest "deployment-environments-qal-usw2-next-environments-qal-usw2-7a8e7b70" is not Ready because "ReconciliationError": Reconciliation failed: failed to merge pull request: failed to merge pull request: failed to merge pull request: PUT https://github.example.com/api/v3/repos/org/deployment/pulls/3/merge: 405 At least 2 approving reviews are required by reviewers with write access. Required status check "continuous-integration/jenkins/pr-head" is expected. You''re not authorized to push to this branch.'
+      observedGeneration: 1
+      reason: PullRequestNotReady
+      status: 'False'
+      type: Ready
+  history:
+    - active:
+        dry: {}
+        hydrated:
+          author: ServiceAccount
+          commitTime: '2025-10-15T15:38:20Z'
+          sha: b060fc7f5079a5aa7364a3844cfe26ee3084e282
+          subject: '[Changed] - infrastructure deployment'
+      proposed:
+        hydrated: {}
+      pullRequest: {}
+    - active:
+        dry: {}
+        hydrated:
+          author: ServiceAccount
+          commitTime: '2025-10-15T15:15:27Z'
+          sha: bb607f8854d83de1724bcc5515f685adf9d8a704
+          subject: Initial commit
+      proposed:
+        hydrated: {}
+      pullRequest: {}
+  proposed:
+    dry:
+      author: user <user@example.com>
+      commitTime: '2025-10-15T16:24:35Z'
+      repoURL: https://github.example.com/org/deployment.git
+      sha: ac7866685e376f32aaf09dced3cf2d39dc1ba50e
+      subject: Create promotion-strategy.yaml
+    hydrated:
+      author: Argo CD
+      body: 'Co-authored-by: user <user@example.com>'
+      commitTime: '2025-10-15T16:26:18Z'
+      sha: 2e8097c049a97c05e6f787f46aabfe3cc2a8af21
+      subject: 'ac78666: Create promotion-strategy.yaml'
+  pullRequest:
+    id: '3'
+    prCreationTime: '2025-10-15T17:11:53Z'
+    state: open
+    url: https://github.example.com/org/deployment/pull/3
+

--- a/resource_customizations/promoter.argoproj.io/CommitStatus/health.lua
+++ b/resource_customizations/promoter.argoproj.io/CommitStatus/health.lua
@@ -25,9 +25,17 @@ if obj.status.conditions then
                 hs.message = "Waiting for commit status spec update to be observed"
                 return hs
             end
-            if condition.status == "False" and condition.reason == "ReconciliationError" then
+            -- Check for any False condition status
+            if condition.status == "False" then
                 hs.status = "Degraded"
-                hs.message = "Commit status reconciliation failed: " .. (condition.message or "Unknown error")
+                local msg = condition.message or "Unknown error"
+                local reason = condition.reason or "Unknown"
+                -- Don't include ReconciliationError in the message since it's redundant
+                if reason == "ReconciliationError" then
+                    hs.message = "Commit status reconciliation failed: " .. msg
+                else
+                    hs.message = "Commit status reconciliation failed (" .. reason .. "): " .. msg
+                end
                 return hs
             end
         end

--- a/resource_customizations/promoter.argoproj.io/CommitStatus/health_test.yaml
+++ b/resource_customizations/promoter.argoproj.io/CommitStatus/health_test.yaml
@@ -16,6 +16,10 @@ tests:
     message: "Commit status reconciliation failed: Something went wrong"
   inputPath: testdata/reconcile-error.yaml
 - healthStatus:
+    status: Degraded
+    message: "Commit status reconciliation failed: Failed to update commit status: API request failed"
+  inputPath: testdata/non-reconciliation-error.yaml
+- healthStatus:
     status: Progressing
     message: Commit status is not ready yet
   inputPath: testdata/no-ready-condition.yaml

--- a/resource_customizations/promoter.argoproj.io/CommitStatus/testdata/non-reconciliation-error.yaml
+++ b/resource_customizations/promoter.argoproj.io/CommitStatus/testdata/non-reconciliation-error.yaml
@@ -1,0 +1,25 @@
+apiVersion: promoter.argoproj.io/v1alpha1
+kind: CommitStatus
+metadata:
+  name: test-commit-status
+  namespace: test
+  generation: 1
+spec:
+  sha: abc1234567890
+  url: https://example.com/ci/test
+  gitRepositoryRef:
+    name: repo
+  description: example
+  name: example
+  phase: success
+status:
+  conditions:
+    - lastTransitionTime: '2025-10-15T16:00:00Z'
+      message: 'Failed to update commit status: API request failed'
+      observedGeneration: 1
+      reason: ReconciliationError
+      status: 'False'
+      type: Ready
+  id: "1"
+  sha: abc1234567890
+

--- a/resource_customizations/promoter.argoproj.io/PromotionStrategy/health.lua
+++ b/resource_customizations/promoter.argoproj.io/PromotionStrategy/health.lua
@@ -26,9 +26,17 @@ if obj.status.conditions then
                 hs.message = "Waiting for promotion strategy spec update to be observed"
                 return hs
             end
-            if condition.status == "False" and condition.reason == "ReconciliationError" then
+            -- Check for any False condition status
+            if condition.status == "False" then
                 hs.status = "Degraded"
-                hs.message = "Promotion strategy reconciliation failed: " .. (condition.message or "Unknown error")
+                local msg = condition.message or "Unknown error"
+                local reason = condition.reason or "Unknown"
+                -- Don't include ReconciliationError in the message since it's redundant
+                if reason == "ReconciliationError" then
+                    hs.message = "Promotion strategy reconciliation failed: " .. msg
+                else
+                    hs.message = "Promotion strategy reconciliation failed (" .. reason .. "): " .. msg
+                end
                 return hs
             end
         end

--- a/resource_customizations/promoter.argoproj.io/PromotionStrategy/health_test.yaml
+++ b/resource_customizations/promoter.argoproj.io/PromotionStrategy/health_test.yaml
@@ -43,3 +43,7 @@ tests:
     status: Progressing
     message: Not all environments have the same proposed commit SHA. This likely means the hydrator has not run for all environments yet.
   inputPath: testdata/different-proposed-commits.yaml
+- healthStatus:
+    status: Degraded
+    message: "Promotion strategy reconciliation failed (ChangeTransferPolicyNotReady): ChangeTransferPolicy \"strategy-environments-qal-usw2-27894e05\" is not Ready because \"ReconciliationError\": Reconciliation failed: failed to calculate ChangeTransferPolicy status: failed to get SHAs for proposed branch \"environments/qal-usw2-next\": exit status 128: fatal: 'origin/environments/qal-usw2-next' is not a commit and a branch 'environments/qal-usw2-next' cannot be created from it"
+  inputPath: testdata/missing-sha-and-not-ready.yaml

--- a/resource_customizations/promoter.argoproj.io/PromotionStrategy/testdata/missing-sha-and-not-ready.yaml
+++ b/resource_customizations/promoter.argoproj.io/PromotionStrategy/testdata/missing-sha-and-not-ready.yaml
@@ -1,0 +1,38 @@
+apiVersion: promoter.argoproj.io/v1alpha1
+kind: PromotionStrategy
+metadata:
+  name: strategy
+  namespace: test
+spec:
+  activeCommitStatuses:
+    - key: argocd-health
+  environments:
+    - autoMerge: true
+      branch: environments/qal-usw2
+    - autoMerge: true
+      branch: environments/e2e-usw2
+  gitRepositoryRef:
+    name: repo
+status:
+  conditions:
+    - lastTransitionTime: '2025-10-15T16:31:47Z'
+      message: 'ChangeTransferPolicy "strategy-environments-qal-usw2-27894e05" is not Ready because "ReconciliationError": Reconciliation failed: failed to calculate ChangeTransferPolicy status: failed to get SHAs for proposed branch "environments/qal-usw2-next": exit status 128: fatal: ''origin/environments/qal-usw2-next'' is not a commit and a branch ''environments/qal-usw2-next'' cannot be created from it'
+      observedGeneration: 1
+      reason: ChangeTransferPolicyNotReady
+      status: 'False'
+      type: Ready
+  environments:
+    - active:
+        dry: {}
+        hydrated: {}
+      branch: environments/qal-usw2
+      proposed:
+        dry: {}
+        hydrated: {}
+    - active:
+        dry: {}
+        hydrated: {}
+      branch: environments/e2e-usw2
+      proposed:
+        dry: {}
+        hydrated: {}

--- a/resource_customizations/promoter.argoproj.io/PullRequest/health.lua
+++ b/resource_customizations/promoter.argoproj.io/PullRequest/health.lua
@@ -28,7 +28,14 @@ if obj.status.conditions then
             end
             if condition.status == "False" then
                 hs.status = "Degraded"
-                hs.message = "Pull request reconciliation failed: " .. (condition.message or "Unknown error")
+                local msg = condition.message or "Unknown error"
+                local reason = condition.reason or "Unknown"
+                -- Don't include ReconciliationError in the message since it's redundant
+                if reason == "ReconciliationError" then
+                    hs.message = "Pull request reconciliation failed: " .. msg
+                else
+                    hs.message = "Pull request reconciliation failed (" .. reason .. "): " .. msg
+                end
                 return hs
             end
         end

--- a/resource_customizations/promoter.argoproj.io/PullRequest/health_test.yaml
+++ b/resource_customizations/promoter.argoproj.io/PullRequest/health_test.yaml
@@ -16,6 +16,10 @@ tests:
     message: "Pull request reconciliation failed: Something went wrong"
   inputPath: testdata/reconciliation-error.yaml
 - healthStatus:
+    status: Degraded
+    message: "Pull request reconciliation failed: Failed to create pull request: authentication failed"
+  inputPath: testdata/non-reconciliation-error.yaml
+- healthStatus:
     status: Progressing
     message: Pull request is not ready yet
   inputPath: testdata/no-ready-condition.yaml

--- a/resource_customizations/promoter.argoproj.io/PullRequest/testdata/non-reconciliation-error.yaml
+++ b/resource_customizations/promoter.argoproj.io/PullRequest/testdata/non-reconciliation-error.yaml
@@ -1,0 +1,22 @@
+apiVersion: promoter.argoproj.io/v1alpha1
+kind: PullRequest
+metadata:
+  name: test-pr
+  namespace: test
+  generation: 1
+spec:
+  sourceBranch: app-next
+  targetBranch: app
+  gitRepositoryRef:
+    name: repo
+  title: Test Pull Request
+  state: open
+status:
+  conditions:
+    - lastTransitionTime: '2025-10-15T16:00:00Z'
+      message: 'Failed to create pull request: authentication failed'
+      observedGeneration: 1
+      reason: ReconciliationError
+      status: 'False'
+      type: Ready
+


### PR DESCRIPTION
Right now we only catch Ready=False if the reason is ReconciliationError. But GitOps Promoter now produces other reasons. So right now we miss the failure condition and instead fall into logic about missing data in the `status.environments` block.

The change handles Ready=False regardless of reason. It injects the reason name in the message if it's not just ReconciliationError.

