### PR TITLE
fix: don't show error about missing appset

### DIFF
--- a/ui/src/app/applications/components/application-status-panel/application-status-panel.tsx
+++ b/ui/src/app/applications/components/application-status-panel/application-status-panel.tsx
@@ -91,22 +91,15 @@ const ProgressiveSyncStatus = ({application}: {application: models.Application})
                 );
             }}
             load={async () => {
-                // Check if user has permission to read ApplicationSets
-                const canReadApplicationSets = await services.accounts.canI('applicationsets', 'get', application.spec.project + '/' + application.metadata.name);
-
                 // Find ApplicationSet by searching all namespaces dynamically
                 const appSetList = await services.applications.listApplicationSets();
                 const appSet = appSetList.items?.find(item => item.metadata.name === appSetRef.name);
 
-                if (!appSet) {
-                    throw new Error(`ApplicationSet ${appSetRef.name} not found in any namespace`);
-                }
-
-                return {canReadApplicationSets, appSet};
+                return {appSet};
             }}>
-            {({canReadApplicationSets, appSet}: {canReadApplicationSets: boolean; appSet: models.ApplicationSet}) => {
+            {({appSet}: {appSet: models.ApplicationSet}) => {
                 // Hide panel if: Progressive Sync disabled, no permission, or not RollingSync strategy
-                if (!appSet.status?.applicationStatus || appSet?.spec?.strategy?.type !== 'RollingSync' || !canReadApplicationSets) {
+                if (!appSet || !appSet.status?.applicationStatus || appSet?.spec?.strategy?.type !== 'RollingSync') {
                     return null;
                 }
 


### PR DESCRIPTION
ApplicationDetails page shows error message `ApplicationSet <appset name> not found in any namespace` if app is produced by an appset but user don't have access get applicationset.

The progressive sync panel should be just hidden if appset is not available.