### PR TITLE
fix: Allow parent applications to delete child applications

### DIFF
--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -3082,3 +3082,92 @@ func TestSelfHealBackoffCooldownElapsed(t *testing.T) {
 		assert.False(t, elapsed)
 	})
 }
+
+func TestIsSelfReferencedApp(t *testing.T) {
+	tests := []struct {
+		name     string
+		app      *v1alpha1.Application
+		ref      corev1.ObjectReference
+		expected bool
+	}{
+		{
+			name: "same application instance - should prevent deletion",
+			app: &v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "parent-app",
+					Namespace: "argocd",
+					UID:       "parent-uid-123",
+				},
+			},
+			ref: corev1.ObjectReference{
+				Name:       "parent-app",
+				Namespace:  "argocd",
+				UID:        "parent-uid-123",
+				APIVersion: "argoproj.io/v1alpha1",
+				Kind:       "Application",
+			},
+			expected: true,
+		},
+		{
+			name: "different application instance - should allow deletion (App of Apps pattern)",
+			app: &v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "parent-app",
+					Namespace: "argocd",
+					UID:       "parent-uid-123",
+				},
+			},
+			ref: corev1.ObjectReference{
+				Name:       "child-app",
+				Namespace:  "argocd",
+				UID:        "child-uid-456",
+				APIVersion: "argoproj.io/v1alpha1",
+				Kind:       "Application",
+			},
+			expected: false,
+		},
+		{
+			name: "different application instance with same name - should allow deletion",
+			app: &v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "parent-app",
+					Namespace: "argocd",
+					UID:       "parent-uid-123",
+				},
+			},
+			ref: corev1.ObjectReference{
+				Name:       "parent-app",
+				Namespace:  "argocd",
+				UID:        "different-uid-789",
+				APIVersion: "argoproj.io/v1alpha1",
+				Kind:       "Application",
+			},
+			expected: false,
+		},
+		{
+			name: "non-application resource - should allow deletion",
+			app: &v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "parent-app",
+					Namespace: "argocd",
+					UID:       "parent-uid-123",
+				},
+			},
+			ref: corev1.ObjectReference{
+				Name:       "deployment",
+				Namespace:  "default",
+				UID:        "deployment-uid-123",
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isSelfReferencedApp(tt.app, tt.ref)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
… Apps pattern

Fixes #24972

The issue was in the isSelfReferencedApp function which was preventing parent applications from deleting child applications when the child application manifest was removed from the Git repository.

The original implementation checked if the resource had the same name, namespace, and UID as the parent application. However, this was too restrictive for the App of Apps pattern where a parent application manages child Application resources.

The fix changes the logic to only prevent deletion/health-check when the resource is literally the same application instance (same non-empty UID). This allows parent applications to properly delete child applications while still preventing an application from deleting or affecting its own health status.

Changes:
- Updated isSelfReferencedApp to use UID-based comparison with non-empty check
- Added comprehensive test coverage for the updated function
- All existing tests pass including TestChildAppHealth

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
