### PR TITLE
fix: fix cherry-pick bot again because I broke sign off

### DIFF
--- a/.github/workflows/cherry-pick-single.yml
+++ b/.github/workflows/cherry-pick-single.yml
@@ -92,13 +92,16 @@ jobs:
         run: |
           # Create cherry-pick PR
           TITLE="${PR_TITLE} (cherry-pick #${{ inputs.pr_number }} for ${{ inputs.version_number }})"
-          BODY="Cherry-picked ${PR_TITLE} (#${{ inputs.pr_number }})"
+          BODY=$(cat <<EOF
+          Cherry-picked ${PR_TITLE} (#${{ inputs.pr_number }})
+
+          ${{ steps.cherry-pick.outputs.signoff }}
+          EOF
+          )
 
           gh pr create \
             --title "$TITLE" \
-            --body "$BODY"
-
-          ${{ steps.cherry-pick.outputs.signoff }}" \
+            --body "$BODY" \
             --base "${{ steps.cherry-pick.outputs.target_branch }}" \
             --head "${{ steps.cherry-pick.outputs.branch_name }}"
 


### PR DESCRIPTION
Fixes the bug I introduced as discussed here: https://github.com/argoproj/argo-cd/pull/25017#discussion_r2452096445

Tested by running it as a shell script locally