### PR TITLE
feat: add prerelease suffix filtering for wildcard version constraints

### DIFF
--- a/util/versions/tags_test.go
+++ b/util/versions/tags_test.go
@@ -60,6 +60,28 @@ func TestTags_MaxVersion(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "0.7.2", version)
 	})
+	t.Run("Constraint wildcard suffix", func(t *testing.T) {
+		qaTags := []string{
+			"1.1.0-qa",
+			"1.1.1-qa",
+			"1.1.2",
+		}
+		version, err := MaxVersion("*.*.*-qa", qaTags)
+		require.NoError(t, err)
+		assert.Equal(t, "1.1.1-qa", version)
+	})
+	t.Run("Constraint wildcard stable only", func(t *testing.T) {
+		mixedTags := []string{
+			"1.1.0-qa",
+			"1.1.1-qa",
+			"1.1.2",
+			"1.2.0-qa.1",
+			"1.2.0",
+		}
+		version, err := MaxVersion("*.*.*", mixedTags)
+		require.NoError(t, err)
+		assert.Equal(t, "1.2.0", version)
+	})
 	t.Run("Constraint missing", func(t *testing.T) {
 		_, err := MaxVersion("0.7.*", []string{})
 		require.Error(t, err)


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->
This PR adds support for filtering prerelease versions when using wildcard constraints in TargetRevision.

**Problem**
Currently, when TargetRevision is set to a wildcard pattern like \*.\*.\*-qa, ArgoCD ignores the suffix and selects the highest version available, regardless of whether it has the -qa prerelease tag or not.
Example of current behavior:

Available tags: 1.1.0-qa, 1.1.1-qa, 1.1.2
TargetRevision: \*.\*.\*-qa
Result: Deploys 1.1.2 (incorrect) ❌

Expected behavior:

Available tags: 1.1.0-qa, 1.1.1-qa, 1.1.2
TargetRevision: \*.\*.\*-qa
Result: Deploys 1.1.1-qa (correct) ✅

This makes it impossible to reliably track prerelease versions (qa, staging, rc, etc.) using wildcard constraints.

**Solution**
This PR introduces prerelease suffix filtering for wildcard constraints:

Explicit suffix matching: When a wildcard constraint includes a prerelease suffix (e.g., \*.\*.\*-qa), only versions with that exact suffix are considered
Stable version preference: When using wildcards without a suffix (e.g., \*.\*.\*), only stable versions (without prerelease tags) are considered
Standard constraints unchanged: Non-wildcard constraints (e.g., >= 1.0.0) continue to work as before, matching all versions including prereleases

Changes

Added constraintFilters() function to extract and validate prerelease suffixes from wildcard patterns
Added matchesPrereleaseSuffix() helper to match prerelease tags against the extracted suffix
Modified MaxVersion() to filter versions based on the extracted suffix requirements
Added test cases for wildcard suffix matching and stable-only filtering

**Examples**
| TargetRevision | Available Tags | Selected Version | Reason |
|----------------|----------------|------------------|--------|
| `*.*.*-qa` | `1.0.0-qa`, `1.1.0-qa`, `1.1.0` | `1.1.0-qa` | Matches only `-qa` suffix |
| `*.*.*-qa` | `1.0.0-qa.1`, `1.0.0-qa.2` | `1.0.0-qa.2` | Matches `-qa` prefix with dot separator |
| `*.*.*` | `1.0.0-qa`, `1.1.0`, `1.2.0` | `1.2.0` | Prefers stable versions when no suffix specified |
| `>= 1.0.0` | `1.0.0-qa`, `1.1.0` | `1.1.0` | Non-wildcard constraints work as before |
| `0.5.3` | (any) | `0.5.3` | Exact versions unchanged |


Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
