### PR TITLE
chore(log): change high frequency logs to DEBUG level

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -1696,7 +1696,7 @@ func (ctrl *ApplicationController) processAppRefreshQueueItem() (processNext boo
 			"time_ms":  reconcileDuration.Milliseconds(),
 			"patch_ms": patchDuration.Milliseconds(),
 			"setop_ms": setOpDuration.Milliseconds(),
-		}).Info("Reconciliation completed")
+		}).Debug("Reconciliation completed")
 	}()
 
 	if comparisonLevel == ComparisonWithNothing {

--- a/controller/state.go
+++ b/controller/state.go
@@ -344,7 +344,7 @@ func (m *appStateManager) GetRepoObjs(ctx context.Context, app *v1alpha1.Applica
 		logCtx = logCtx.WithField(k, v.Milliseconds())
 	}
 	logCtx = logCtx.WithField("time_ms", time.Since(ts.StartTime).Milliseconds())
-	logCtx.Info("GetRepoObjs stats")
+	logCtx.Debug("GetRepoObjs stats")
 
 	return targetObjs, manifestInfos, revisionsMayHaveChanges, nil
 }

--- a/docs/operator-manual/upgrading/3.1-3.2.md
+++ b/docs/operator-manual/upgrading/3.1-3.2.md
@@ -94,3 +94,9 @@ credentials of project-scoped repositories and clusters.
 The `resources` field of the `status` resource of an ApplicationSet is now limited to 5000 elements by default. This is
 to prevent status bloat and exceeding etcd limits. The limit can be configured by setting the `applicationsetcontroller.status.max.resources.count`
 field in the `argocd-cmd-params-cm` ConfigMap.
+
+## High frequency reconciliation logs moved to DEBUG level
+
+To reduce log volume and align with Kubernetes controller best practices, routine reconciliation completion logs have been moved from INFO to DEBUG level. This includes:
+- "Reconciliation completed" logs in the application controller
+- "GetRepoObjs stats" logs during manifest generation


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->
fixes https://github.com/argoproj/argo-cd/issues/25093

We noticed 2x increase in log volume likely due to this change: https://github.com/argoproj/argo-cd/pull/21442/files#diff-9312ec23ecb354e9d5c3c7434a6b0d37f6c5d780153e7f1f28221af48ddde453

I think `logCtx.Info("Reconciliation completed")` should be DEBUG level because
1. we can use `argocd_app_reconcile` metrics to track this stat already
2. Can still see other state change logging like refreshing, syncing, status updates
3. Still have an option to show it with DEBUG logs.

Same with `logCtx.Info("GetRepoObjs stats")` - i don't see too much value in having this as log level INFO as well. This is also contributing to high volume as it appears on every reconcile.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
