### PR TITLE
fix: issue when cluster is moved to a different shard

### DIFF
--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -867,19 +867,16 @@ func (c *liveStateCache) handleModEvent(oldCluster *appv1.Cluster, newCluster *a
 				_ = cluster.EnsureSynced()
 			}()
 		}
-	} else {
-		// Cluster not in cache - check if we should add it, it may have just been moved to a new shard
-		if c.canHandleCluster(newCluster) {
-			log.Infof("Cluster %s reassigned to this shard, initializing cache", newCluster.Server)
-			if c.appInformer == nil {
-				log.Errorf("Cannot get a cluster appInformer. Cache for the recently moved cluster will not be started this time")
-				return
-			}
-			if c.isClusterHasApps(c.appInformer.GetStore().List(), newCluster) {
-				go func() {
-					_, _ = c.getSyncedCluster(newCluster)
-				}()
-			}
+	} else if c.canHandleCluster(newCluster) { // Cluster not in cache - check if we should add it, it may have just been moved to a new shard
+		log.Infof("Cluster %s reassigned to this shard, initializing cache", newCluster.Server)
+		if c.appInformer == nil {
+			log.Errorf("Cannot get a cluster appInformer. Cache for the recently moved cluster will not be started this time")
+			return
+		}
+		if c.isClusterHasApps(c.appInformer.GetStore().List(), newCluster) {
+			go func() {
+				_, _ = c.getSyncedCluster(newCluster)
+			}()
 		}
 	}
 }

--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -867,6 +867,20 @@ func (c *liveStateCache) handleModEvent(oldCluster *appv1.Cluster, newCluster *a
 				_ = cluster.EnsureSynced()
 			}()
 		}
+	} else {
+		// Cluster not in cache - check if we should add it, it may have just been moved to a new shard
+		if c.canHandleCluster(newCluster) {
+			log.Infof("Cluster %s reassigned to this shard, initializing cache", newCluster.Server)
+			if c.appInformer == nil {
+				log.Errorf("Cannot get a cluster appInformer. Cache for the recently moved cluster will not be started this time")
+				return
+			}
+			if c.isClusterHasApps(c.appInformer.GetStore().List(), newCluster) {
+				go func() {
+					_, _ = c.getSyncedCluster(newCluster)
+				}()
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes: http://github.com/argoproj/argo-cd/issues/19854

When using any sharding algorithm that moves shards with some frequency this issue becomes more apparent. 

Simple steps to reproduce:

**1.** When a cluster is moved for any reason (new cluster added, new app added, etc) you will see in the logs something like `Cluster https://XYZ.gr7.us-east-1.eks.amazonaws.com has changed shard from 4 to 6`
**2.1 handleModEvent() will be triggered on shard 4:**
It will go into `if !c.canHandleCluster(newCluster) {` and delete the cluster from the local cache: https://github.com/argoproj/argo-cd/blob/master/controller/cache/cache.go#L833
**2.2 handleModEvent() will be triggered on shard 6:**
As shard 6 hasn't had `newCluster.Server` in its cache before, ok is set to `false` and the entire logic of handleModEvent is skipped and the cluster is never added to this shard's cache.
```
	c.clusterSharding.Update(oldCluster, newCluster)
	c.lock.Lock()
	cluster, ok := c.clusters[newCluster.Server]
	c.lock.Unlock()
	if ok { // THIS IS COMPLETELY SKIPPED, THE FUNCTION DOES NOTHING 
```
This fix checks if the cluster is not in local cache, wether it should be added. The call to `getSyncedCluster` populates the local cache as it calls `getCluster` that sets the entry in the cache: https://github.com/argoproj/argo-cd/blob/master/controller/cache/cache.go#L479

I don't have the time to look into adding tests for a few days so if someone can guide me to the right place to add them it will save me a lot of time.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
