### PR TITLE
feat(cli): Add additional examples to `proj list` command

### DIFF
--- a/cmd/argocd/commands/project.go
+++ b/cmd/argocd/commands/project.go
@@ -827,14 +827,8 @@ func NewProjectListCommand(clientOpts *argocdclient.ClientOptions) *cobra.Comman
 			# List all available projects
 			argocd proj list
 
-			# List all available projects in yaml format
+			# List all available projects in yaml format (other options are "json" and "name")
 			argocd proj list -o yaml
-
-			# List all available projects in json format
-			argocd proj list -o json
-
-			# List names of all available projects
-			argocd proj list -o name
 		`),
 		Run: func(c *cobra.Command, _ []string) {
 			ctx := c.Context()

--- a/cmd/argocd/commands/project.go
+++ b/cmd/argocd/commands/project.go
@@ -41,8 +41,9 @@ type policyOpts struct {
 // NewProjectCommand returns a new instance of an `argocd proj` command
 func NewProjectCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 	command := &cobra.Command{
-		Use:   "proj",
-		Short: "Manage projects",
+		Use:     "proj",
+		Short:   "Manage projects",
+		Aliases: []string{"project"},
 		Example: templates.Examples(`
 			# List all available projects
 			argocd proj list
@@ -828,6 +829,12 @@ func NewProjectListCommand(clientOpts *argocdclient.ClientOptions) *cobra.Comman
 
 			# List all available projects in yaml format
 			argocd proj list -o yaml
+
+			# List all available projects in json format
+			argocd proj list -o json
+
+			# List names of all available projects
+			argocd proj list -o name
 		`),
 		Run: func(c *cobra.Command, _ []string) {
 			ctx := c.Context()

--- a/docs/user-guide/commands/argocd_proj_list.md
+++ b/docs/user-guide/commands/argocd_proj_list.md
@@ -14,14 +14,8 @@ argocd proj list [flags]
   # List all available projects
   argocd proj list
   
-  # List all available projects in yaml format
+  # List all available projects in yaml format (other options are "json" and "name")
   argocd proj list -o yaml
-  
-  # List all available projects in json format
-  argocd proj list -o json
-  
-  # List names of all available projects
-  argocd proj list -o name
 ```
 
 ### Options

--- a/docs/user-guide/commands/argocd_proj_list.md
+++ b/docs/user-guide/commands/argocd_proj_list.md
@@ -16,6 +16,12 @@ argocd proj list [flags]
   
   # List all available projects in yaml format
   argocd proj list -o yaml
+  
+  # List all available projects in json format
+  argocd proj list -o json
+  
+  # List names of all available projects
+  argocd proj list -o name
 ```
 
 ### Options


### PR DESCRIPTION
`argocd proj list` command can display output in different formats, only one format was supported / displayed in the [argocd command reference documentation. ](https://argo-cd.readthedocs.io/en/stable/user-guide/commands/argocd_proj_list/#examples)
This PR:
- Updates Examples section of `argocd proj list` command to be reflected on its documentation
- Adds `project` as an alias for `proj` so users can use both of them instead of getting error if user typed `proj`, I believe that `project` is somehow expected to be used more.