### PR TITLE
fix:(ui) don't render ApplicationSelector unless the panel is showing

### DIFF
--- a/ui/src/app/applications/components/applications-refresh-panel/applications-refresh-panel.tsx
+++ b/ui/src/app/applications/components/applications-refresh-panel/applications-refresh-panel.tsx
@@ -94,7 +94,7 @@ export const ApplicationsRefreshPanel = ({show, apps, hide}: {show: boolean; app
                                         ))}
                                     </div>
                                 </div>
-                                <ApplicationSelector apps={apps} formApi={formApi} />
+                                {show && <ApplicationSelector apps={apps} formApi={formApi} />}
                             </div>
                         )}
                     </Form>

--- a/ui/src/app/applications/components/applications-sync-panel/applications-sync-panel.tsx
+++ b/ui/src/app/applications/components/applications-sync-panel/applications-sync-panel.tsx
@@ -146,7 +146,7 @@ export const ApplicationsSyncPanel = ({show, apps, hide}: {show: boolean; apps: 
 
                                 <ApplicationRetryOptions id='applications-sync-panel' formApi={formApi} />
 
-                                <ApplicationSelector apps={apps} formApi={formApi} />
+                                {show && <ApplicationSelector apps={apps} formApi={formApi} />}
                             </div>
                         )}
                     </Form>


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->
Partially addresses #14947

In Profiling our UI code I noticed that the `ApplicationSelector` component, which lives in several drawers on the applications list page. seems to be rendering regardless of the state of the drawer, which is causing significant slowdown as this selector renders the entire list of applications. This is a quick fix to not render this list while the drawer is not showing.

**More Details:**
Below are several screenshots of profiling sessions Ive done on initial page loads for `/applications`. I used the [React Developer tools](https://react.dev/learn/react-developer-tools)'s profiler for these tests, profiled the initial page load, and filtered out any commits/renders that took less than 15ms (16ms is often cited as the "ideal" maximum render time for an application)
<img width="1401" height="771" alt="image" src="https://github.com/user-attachments/assets/5c3c551a-6178-450f-8df7-ff994cfa9b0f" />
This first shows our app with the call to `/api/applications` overridden to return a lot (>2000) applications. I selected the most significant commit with a render duration of `173ms`, and you can see that the two `ApplicationSelector` components account for the majority of the render time (each taking ~75-80ms to render). You can see at the top right there are 3 other commits that also took a while to render, they also seem to be impacted heavily by the `ApplicationSelector` components, but not as heavily as this initial commit.
<img width="1711" height="1228" alt="image" src="https://github.com/user-attachments/assets/0d3718e9-7d36-4826-990d-fa9dfcf7c4e7" />
This next Screengrab is after these changes are applied. Now there is only 1 render >15ms. This is a quick fix that should dramatically improve the initial load time for the applications list.

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [X] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [X] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
