### PR TITLE
fix: regression on creationTimestamp with server-side diff

### DIFF
--- a/gitops-engine/pkg/diff/diff.go
+++ b/gitops-engine/pkg/diff/diff.go
@@ -175,6 +175,8 @@ func serverSideDiff(config, live *unstructured.Unstructured, opts ...Option) (*D
 	if err != nil {
 		return nil, fmt.Errorf("error converting json string to unstructured for resource %s/%s: %w", config.GetKind(), config.GetName(), err)
 	}
+	// Remarshal predictedLive to ensure it receives the same normalization as live.
+	predictedLive = remarshal(predictedLive, o)
 
 	if o.ignoreMutationWebhook {
 		predictedLive, err = removeWebhookMutation(predictedLive, live, o.gvkParser, o.manager)

--- a/gitops-engine/pkg/diff/diff.go
+++ b/gitops-engine/pkg/diff/diff.go
@@ -175,8 +175,6 @@ func serverSideDiff(config, live *unstructured.Unstructured, opts ...Option) (*D
 	if err != nil {
 		return nil, fmt.Errorf("error converting json string to unstructured for resource %s/%s: %w", config.GetKind(), config.GetName(), err)
 	}
-	// Remarshal predictedLive to ensure it receives the same normalization as live.
-	predictedLive = remarshal(predictedLive, o)
 
 	if o.ignoreMutationWebhook {
 		predictedLive, err = removeWebhookMutation(predictedLive, live, o.gvkParser, o.manager)
@@ -184,6 +182,9 @@ func serverSideDiff(config, live *unstructured.Unstructured, opts ...Option) (*D
 			return nil, fmt.Errorf("error removing non config mutations for resource %s/%s: %w", config.GetKind(), config.GetName(), err)
 		}
 	}
+
+	// Remarshal predictedLive to ensure it receives the same normalization as live.
+	predictedLive = remarshal(predictedLive, o)
 
 	Normalize(predictedLive, opts...)
 	unstructured.RemoveNestedField(predictedLive.Object, "metadata", "managedFields")

--- a/gitops-engine/pkg/diff/diff_test.go
+++ b/gitops-engine/pkg/diff/diff_test.go
@@ -1607,6 +1607,68 @@ metadata:
 	assert.False(t, ok)
 }
 
+func TestRemarshalStatefulSetCreationTimestamp(t *testing.T) {
+	manifest := []byte(`
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-sts
+  creationTimestamp: "2025-11-06T19:35:31Z"
+spec:
+  serviceName: test
+  selector:
+    matchLabels:
+      app: test
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: test
+    spec:
+      containers:
+      - name: test
+        image: nginx
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+      creationTimestamp: null
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi
+`)
+	var un unstructured.Unstructured
+	require.NoError(t, yaml.Unmarshal(manifest, &un))
+
+	// Verify creationTimestamp exists in nested metadata before remarshal
+	spec := un.Object["spec"].(map[string]any)
+	templateMetadata := spec["template"].(map[string]any)["metadata"].(map[string]any)
+	_, ok := templateMetadata["creationTimestamp"]
+	assert.True(t, ok, "creationTimestamp should exist in template.metadata before remarshal")
+
+	volumeClaimTemplates := spec["volumeClaimTemplates"].([]any)
+	vctMetadata := volumeClaimTemplates[0].(map[string]any)["metadata"].(map[string]any)
+	_, ok = vctMetadata["creationTimestamp"]
+	assert.True(t, ok, "creationTimestamp should exist in volumeClaimTemplates[0].metadata before remarshal")
+
+	// Remarshal
+	newUn := remarshal(&un, applyOptions(diffOptionsForTest()))
+
+	// Verify creationTimestamp is removed from nested metadata after remarshal
+	// (top-level metadata.creationTimestamp is preserved as it's part of the resource identity)
+	spec = newUn.Object["spec"].(map[string]any)
+	templateMetadata = spec["template"].(map[string]any)["metadata"].(map[string]any)
+	_, ok = templateMetadata["creationTimestamp"]
+	assert.False(t, ok, "creationTimestamp should be removed from template.metadata after remarshal")
+
+	volumeClaimTemplates = spec["volumeClaimTemplates"].([]any)
+	vctMetadata = volumeClaimTemplates[0].(map[string]any)["metadata"].(map[string]any)
+	_, ok = vctMetadata["creationTimestamp"]
+	assert.False(t, ok, "creationTimestamp should be removed from volumeClaimTemplates[0].metadata after remarshal")
+}
+
 func TestRemarshalResources(t *testing.T) {
 	getRequests := func(un *unstructured.Unstructured) map[string]any {
 		return un.Object["spec"].(map[string]any)["containers"].([]any)[0].(map[string]any)["resources"].(map[string]any)["requests"].(map[string]any)


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

fixes https://github.com/argoproj/argo-cd/issues/25184

remarshal now behaves differently on statefulSets with PVCs.
It used to keep `creationTimestamp: null `but now it deletes it from the manifest. Maybe something changed with the Go struct for Stateful Sets in k8 1.34.

The straightforward fix is to use remarshal on predictedLive so it will also delete that field and keep it the same as live. I don't think there is any reason not to add it.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
