### PR TITLE
feat(controller): add incremental namespace sync feature

### DIFF
--- a/cmd/argocd-application-controller/commands/argocd_application_controller.go
+++ b/cmd/argocd-application-controller/commands/argocd_application_controller.go
@@ -91,6 +91,7 @@ func NewCommand() *cobra.Command {
 		persistResourceHealth            bool
 		shardingAlgorithm                string
 		enableDynamicClusterDistribution bool
+		enableIncrementalNamespaceSync   bool
 		serverSideDiff                   bool
 		ignoreNormalizerOpts             normalizers.IgnoreNormalizerOpts
 
@@ -216,6 +217,7 @@ func NewCommand() *cobra.Command {
 				&workqueueRateLimit,
 				serverSideDiff,
 				enableDynamicClusterDistribution,
+				enableIncrementalNamespaceSync,
 				ignoreNormalizerOpts,
 				enableK8sEvent,
 				hydratorEnabled,
@@ -299,6 +301,7 @@ func NewCommand() *cobra.Command {
 	command.Flags().DurationVar(&workqueueRateLimit.MaxDelay, "wq-maxdelay-ns", time.Duration(env.ParseInt64FromEnv("WORKQUEUE_MAX_DELAY_NS", time.Second.Nanoseconds(), 1*time.Millisecond.Nanoseconds(), (24*time.Hour).Nanoseconds())), "Set Workqueue Per Item Rate Limiter Max Delay duration in nanoseconds, default 1000000000 (1s)")
 	command.Flags().Float64Var(&workqueueRateLimit.BackoffFactor, "wq-backoff-factor", env.ParseFloat64FromEnv("WORKQUEUE_BACKOFF_FACTOR", 1.5, 0, math.MaxFloat64), "Set Workqueue Per Item Rate Limiter Backoff Factor, default is 1.5")
 	command.Flags().BoolVar(&enableDynamicClusterDistribution, "dynamic-cluster-distribution-enabled", env.ParseBoolFromEnv(common.EnvEnableDynamicClusterDistribution, false), "Enables dynamic cluster distribution.")
+	command.Flags().BoolVar(&enableIncrementalNamespaceSync, "incremental-namespace-sync-enabled", env.ParseBoolFromEnv(common.EnvEnableIncrementalNamespaceSync, false), "Enables incremental namespace sync in cluster cache for performance optimization. Default (\"false\")")
 	command.Flags().BoolVar(&serverSideDiff, "server-side-diff-enabled", env.ParseBoolFromEnv(common.EnvServerSideDiff, false), "Feature flag to enable ServerSide diff. Default (\"false\")")
 	command.Flags().DurationVar(&ignoreNormalizerOpts.JQExecutionTimeout, "ignore-normalizer-jq-execution-timeout-seconds", env.ParseDurationFromEnv("ARGOCD_IGNORE_NORMALIZER_JQ_TIMEOUT", 0*time.Second, 0, math.MaxInt64), "Set ignore normalizer JQ execution timeout")
 	// argocd k8s event logging flag

--- a/cmd/argocd-application-controller/commands/argocd_application_controller.go
+++ b/cmd/argocd-application-controller/commands/argocd_application_controller.go
@@ -89,6 +89,7 @@ func NewCommand() *cobra.Command {
 		persistResourceHealth            bool
 		shardingAlgorithm                string
 		enableDynamicClusterDistribution bool
+		enableIncrementalNamespaceSync   bool
 		serverSideDiff                   bool
 		ignoreNormalizerOpts             normalizers.IgnoreNormalizerOpts
 
@@ -214,6 +215,7 @@ func NewCommand() *cobra.Command {
 				&workqueueRateLimit,
 				serverSideDiff,
 				enableDynamicClusterDistribution,
+				enableIncrementalNamespaceSync,
 				ignoreNormalizerOpts,
 				enableK8sEvent,
 				hydratorEnabled,
@@ -297,6 +299,7 @@ func NewCommand() *cobra.Command {
 	command.Flags().DurationVar(&workqueueRateLimit.MaxDelay, "wq-maxdelay-ns", time.Duration(env.ParseInt64FromEnv("WORKQUEUE_MAX_DELAY_NS", time.Second.Nanoseconds(), 1*time.Millisecond.Nanoseconds(), (24*time.Hour).Nanoseconds())), "Set Workqueue Per Item Rate Limiter Max Delay duration in nanoseconds, default 1000000000 (1s)")
 	command.Flags().Float64Var(&workqueueRateLimit.BackoffFactor, "wq-backoff-factor", env.ParseFloat64FromEnv("WORKQUEUE_BACKOFF_FACTOR", 1.5, 0, math.MaxFloat64), "Set Workqueue Per Item Rate Limiter Backoff Factor, default is 1.5")
 	command.Flags().BoolVar(&enableDynamicClusterDistribution, "dynamic-cluster-distribution-enabled", env.ParseBoolFromEnv(common.EnvEnableDynamicClusterDistribution, false), "Enables dynamic cluster distribution.")
+	command.Flags().BoolVar(&enableIncrementalNamespaceSync, "incremental-namespace-sync-enabled", env.ParseBoolFromEnv(common.EnvEnableIncrementalNamespaceSync, false), "Enables incremental namespace sync in cluster cache for performance optimization. Default (\"false\")")
 	command.Flags().BoolVar(&serverSideDiff, "server-side-diff-enabled", env.ParseBoolFromEnv(common.EnvServerSideDiff, false), "Feature flag to enable ServerSide diff. Default (\"false\")")
 	command.Flags().DurationVar(&ignoreNormalizerOpts.JQExecutionTimeout, "ignore-normalizer-jq-execution-timeout-seconds", env.ParseDurationFromEnv("ARGOCD_IGNORE_NORMALIZER_JQ_TIMEOUT", 0*time.Second, 0, math.MaxInt64), "Set ignore normalizer JQ execution timeout")
 	// argocd k8s event logging flag

--- a/cmd/argocd/commands/admin/app.go
+++ b/cmd/argocd/commands/admin/app.go
@@ -478,5 +478,5 @@ func reconcileApplications(
 }
 
 func newLiveStateCache(argoDB db.ArgoDB, appInformer kubecache.SharedIndexInformer, settingsMgr *settings.SettingsManager, server *metrics.MetricsServer) cache.LiveStateCache {
-	return cache.NewLiveStateCache(argoDB, appInformer, settingsMgr, server, func(_ map[string]bool, _ corev1.ObjectReference) {}, &sharding.ClusterSharding{}, argo.NewResourceTracking())
+	return cache.NewLiveStateCache(argoDB, appInformer, settingsMgr, server, func(_ map[string]bool, _ corev1.ObjectReference) {}, &sharding.ClusterSharding{}, argo.NewResourceTracking(), false)
 }

--- a/common/common.go
+++ b/common/common.go
@@ -282,6 +282,8 @@ const (
 	EnvControllerShardingAlgorithm = "ARGOCD_CONTROLLER_SHARDING_ALGORITHM"
 	// EnvEnableDynamicClusterDistribution enables dynamic sharding (ALPHA)
 	EnvEnableDynamicClusterDistribution = "ARGOCD_ENABLE_DYNAMIC_CLUSTER_DISTRIBUTION"
+	// EnvEnableIncrementalNamespaceSync enables incremental namespace sync in cluster cache
+	EnvEnableIncrementalNamespaceSync = "ARGOCD_ENABLE_INCREMENTAL_NAMESPACE_SYNC"
 	// EnvEnableGRPCTimeHistogramEnv enables gRPC metrics collection
 	EnvEnableGRPCTimeHistogramEnv = "ARGOCD_ENABLE_GRPC_TIME_HISTOGRAM"
 	// EnvGithubAppCredsExpirationDuration controls the caching of Github app credentials. This value is in minutes (default: 60)

--- a/common/common.go
+++ b/common/common.go
@@ -296,6 +296,8 @@ const (
 	EnvControllerShardingAlgorithm = "ARGOCD_CONTROLLER_SHARDING_ALGORITHM"
 	// EnvEnableDynamicClusterDistribution enables dynamic sharding (ALPHA)
 	EnvEnableDynamicClusterDistribution = "ARGOCD_ENABLE_DYNAMIC_CLUSTER_DISTRIBUTION"
+	// EnvEnableIncrementalNamespaceSync enables incremental namespace sync in cluster cache
+	EnvEnableIncrementalNamespaceSync = "ARGOCD_ENABLE_INCREMENTAL_NAMESPACE_SYNC"
 	// EnvEnableGRPCTimeHistogramEnv enables gRPC metrics collection
 	EnvEnableGRPCTimeHistogramEnv = "ARGOCD_ENABLE_GRPC_TIME_HISTOGRAM"
 	// EnvGithubAppCredsExpirationDuration controls the caching of Github app credentials. This value is in minutes (default: 60)

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -144,7 +144,9 @@ type ApplicationController struct {
 
 	// dynamicClusterDistributionEnabled if disabled deploymentInformer is never initialized
 	dynamicClusterDistributionEnabled bool
-	deploymentInformer                informerv1.DeploymentInformer
+	// enableIncrementalNamespaceSync enables incremental namespace sync in cluster cache
+	enableIncrementalNamespaceSync bool
+	deploymentInformer             informerv1.DeploymentInformer
 
 	hydrator *hydrator.Hydrator
 }
@@ -178,6 +180,7 @@ func NewApplicationController(
 	rateLimiterConfig *ratelimiter.AppControllerRateLimiterConfig,
 	serverSideDiff bool,
 	dynamicClusterDistributionEnabled bool,
+	enableIncrementalNamespaceSync bool,
 	ignoreNormalizerOpts normalizers.IgnoreNormalizerOpts,
 	enableK8sEvent []string,
 	hydratorEnabled bool,
@@ -215,6 +218,7 @@ func NewApplicationController(
 		projByNameCache:                   sync.Map{},
 		applicationNamespaces:             applicationNamespaces,
 		dynamicClusterDistributionEnabled: dynamicClusterDistributionEnabled,
+		enableIncrementalNamespaceSync:    enableIncrementalNamespaceSync,
 		ignoreNormalizerOpts:              ignoreNormalizerOpts,
 		metricsClusterLabels:              metricsClusterLabels,
 	}
@@ -327,7 +331,7 @@ func NewApplicationController(
 			return nil, err
 		}
 	}
-	stateCache := statecache.NewLiveStateCache(db, appInformer, ctrl.settingsMgr, ctrl.metricsServer, ctrl.handleObjectUpdated, clusterSharding, argo.NewResourceTracking())
+	stateCache := statecache.NewLiveStateCache(db, appInformer, ctrl.settingsMgr, ctrl.metricsServer, ctrl.handleObjectUpdated, clusterSharding, argo.NewResourceTracking(), enableIncrementalNamespaceSync)
 	appStateManager := NewAppStateManager(db, applicationClientset, repoClientset, namespace, kubectl, ctrl.onKubectlRun, ctrl.settingsMgr, stateCache, ctrl.metricsServer, argoCache, ctrl.statusRefreshTimeout, argo.NewResourceTracking(), persistResourceHealth, repoErrorGracePeriod, serverSideDiff, ignoreNormalizerOpts)
 	ctrl.appInformer = appInformer
 	ctrl.appLister = appLister

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -144,9 +144,7 @@ type ApplicationController struct {
 
 	// dynamicClusterDistributionEnabled if disabled deploymentInformer is never initialized
 	dynamicClusterDistributionEnabled bool
-	// enableIncrementalNamespaceSync enables incremental namespace sync in cluster cache
-	enableIncrementalNamespaceSync bool
-	deploymentInformer             informerv1.DeploymentInformer
+	deploymentInformer                informerv1.DeploymentInformer
 
 	hydrator *hydrator.Hydrator
 }
@@ -218,7 +216,6 @@ func NewApplicationController(
 		projByNameCache:                   sync.Map{},
 		applicationNamespaces:             applicationNamespaces,
 		dynamicClusterDistributionEnabled: dynamicClusterDistributionEnabled,
-		enableIncrementalNamespaceSync:    enableIncrementalNamespaceSync,
 		ignoreNormalizerOpts:              ignoreNormalizerOpts,
 		metricsClusterLabels:              metricsClusterLabels,
 	}

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -142,7 +142,9 @@ type ApplicationController struct {
 
 	// dynamicClusterDistributionEnabled if disabled deploymentInformer is never initialized
 	dynamicClusterDistributionEnabled bool
-	deploymentInformer                informerv1.DeploymentInformer
+	// enableIncrementalNamespaceSync enables incremental namespace sync in cluster cache
+	enableIncrementalNamespaceSync bool
+	deploymentInformer             informerv1.DeploymentInformer
 
 	hydrator *hydrator.Hydrator
 }
@@ -176,6 +178,7 @@ func NewApplicationController(
 	rateLimiterConfig *ratelimiter.AppControllerRateLimiterConfig,
 	serverSideDiff bool,
 	dynamicClusterDistributionEnabled bool,
+	enableIncrementalNamespaceSync bool,
 	ignoreNormalizerOpts normalizers.IgnoreNormalizerOpts,
 	enableK8sEvent []string,
 	hydratorEnabled bool,
@@ -212,6 +215,7 @@ func NewApplicationController(
 		projByNameCache:                   sync.Map{},
 		applicationNamespaces:             applicationNamespaces,
 		dynamicClusterDistributionEnabled: dynamicClusterDistributionEnabled,
+		enableIncrementalNamespaceSync:    enableIncrementalNamespaceSync,
 		ignoreNormalizerOpts:              ignoreNormalizerOpts,
 		metricsClusterLabels:              metricsClusterLabels,
 	}
@@ -324,7 +328,7 @@ func NewApplicationController(
 			return nil, err
 		}
 	}
-	stateCache := statecache.NewLiveStateCache(db, appInformer, ctrl.settingsMgr, ctrl.metricsServer, ctrl.handleObjectUpdated, clusterSharding, argo.NewResourceTracking())
+	stateCache := statecache.NewLiveStateCache(db, appInformer, ctrl.settingsMgr, ctrl.metricsServer, ctrl.handleObjectUpdated, clusterSharding, argo.NewResourceTracking(), enableIncrementalNamespaceSync)
 	appStateManager := NewAppStateManager(db, applicationClientset, repoClientset, namespace, kubectl, ctrl.onKubectlRun, ctrl.settingsMgr, stateCache, ctrl.metricsServer, argoCache, ctrl.statusRefreshTimeout, argo.NewResourceTracking(), persistResourceHealth, repoErrorGracePeriod, serverSideDiff, ignoreNormalizerOpts)
 	ctrl.appInformer = appInformer
 	ctrl.appLister = appLister

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -142,9 +142,7 @@ type ApplicationController struct {
 
 	// dynamicClusterDistributionEnabled if disabled deploymentInformer is never initialized
 	dynamicClusterDistributionEnabled bool
-	// enableIncrementalNamespaceSync enables incremental namespace sync in cluster cache
-	enableIncrementalNamespaceSync bool
-	deploymentInformer             informerv1.DeploymentInformer
+	deploymentInformer                informerv1.DeploymentInformer
 
 	hydrator *hydrator.Hydrator
 }
@@ -215,7 +213,6 @@ func NewApplicationController(
 		projByNameCache:                   sync.Map{},
 		applicationNamespaces:             applicationNamespaces,
 		dynamicClusterDistributionEnabled: dynamicClusterDistributionEnabled,
-		enableIncrementalNamespaceSync:    enableIncrementalNamespaceSync,
 		ignoreNormalizerOpts:              ignoreNormalizerOpts,
 		metricsClusterLabels:              metricsClusterLabels,
 	}

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -204,6 +204,7 @@ func newFakeControllerWithResync(ctx context.Context, data *fakeData, appResyncP
 		nil,
 		false,
 		false,
+		false,
 		normalizers.IgnoreNormalizerOpts{},
 		testEnableEventList,
 		false,

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -205,6 +205,7 @@ func newFakeControllerWithResync(ctx context.Context, data *fakeData, appResyncP
 		nil,
 		false,
 		false,
+		false,
 		normalizers.IgnoreNormalizerOpts{},
 		testEnableEventList,
 		false,

--- a/docs/operator-manual/argocd-cmd-params-cm.yaml
+++ b/docs/operator-manual/argocd-cmd-params-cm.yaml
@@ -127,6 +127,12 @@ data:
   # _grpc_config.<hostname> are disabled to prevent excessive DNS queries that can cause timeouts in dual-stack environments.
   # See https://github.com/argoproj/argo-cd/issues/24991
   controller.grpc.enable.txt.service.config: "false"
+  # Enables incremental namespace sync in cluster cache for performance optimization. When enabled, only changed
+  # namespaces are synced instead of performing a full cluster cache rebuild. This significantly improves sync
+  # performance for clusters with many namespaces. (default "false")
+  #
+  # Feature state: Alpha (since v3.3.0)
+  controller.incremental.namespace.sync.enabled: "false"
 
   ## Server properties
   # Listen on given address for incoming connections (default "0.0.0.0")

--- a/docs/operator-manual/feature-maturity.md
+++ b/docs/operator-manual/feature-maturity.md
@@ -26,6 +26,7 @@ to indicate their stability and maturity. These are the statuses of non-stable f
 | [Cluster Sharding: consistent-hashing][9] | v2.12.0    | Alpha  |
 | [Service Account Impersonation][10]       | v2.13.0    | Alpha  |
 | [Source Hydrator][11]                     | v2.14.0    | Alpha  |
+| [Incremental Namespace Sync][12]          | v3.3.0     | Alpha  |
 
 ## Unstable Configurations
 
@@ -65,6 +66,8 @@ to indicate their stability and maturity. These are the statuses of non-stable f
 | [Proxy Extensions][3]                     | `ConfigMap/argocd-cm`                         | `extension.config`                                          | Alpha  |
 | [Dynamic Cluster Distribution][7]         | `Deployment/argocd-application-controller`    | `ARGOCD_ENABLE_DYNAMIC_CLUSTER_DISTRIBUTION`                | Alpha  |
 | [Dynamic Cluster Distribution][7]         | `Deployment/argocd-application-controller`    | `ARGOCD_CONTROLLER_HEARTBEAT_TIME`                          | Alpha  |
+| [Incremental Namespace Sync][12]          | `StatefulSet/argocd-application-controller`   | `ARGOCD_ENABLE_INCREMENTAL_NAMESPACE_SYNC`                  | Alpha  |
+| [Incremental Namespace Sync][12]          | `ConfigMap/argocd-cmd-params-cm`              | `controller.incremental.namespace.sync.enabled`             | Alpha  |
 | [Cluster Sharding: round-robin][6]        | `ConfigMap/argocd-cmd-params-cm`              | `controller.sharding.algorithm: round-robin`                | Alpha  |
 | [Cluster Sharding: round-robin][6]        | `StatefulSet/argocd-application-controller`   | `ARGOCD_CONTROLLER_SHARDING_ALGORITHM=round-robin`          | Alpha  |
 | [Cluster Sharding: consistent-hashing][9] | `ConfigMap/argocd-cmd-params-cm`              | `controller.sharding.algorithm: consistent-hashing`         | Alpha  |
@@ -81,3 +84,4 @@ to indicate their stability and maturity. These are the statuses of non-stable f
 [9]: ./high_availability.md#argocd-application-controller
 [10]: app-sync-using-impersonation.md
 [11]: ../user-guide/source-hydrator.md
+[12]: incremental-namespace-sync.md

--- a/docs/operator-manual/feature-maturity.md
+++ b/docs/operator-manual/feature-maturity.md
@@ -25,6 +25,7 @@ to indicate their stability and maturity. These are the statuses of non-stable f
 | [Cluster Sharding: consistent-hashing][9] | v2.12.0    | Alpha  |
 | [Service Account Impersonation][10]       | v2.13.0    | Alpha  |
 | [Source Hydrator][11]                     | v2.14.0    | Alpha  |
+| [Incremental Namespace Sync][12]          | v3.3.0     | Alpha  |
 
 ## Unstable Configurations
 
@@ -58,6 +59,8 @@ to indicate their stability and maturity. These are the statuses of non-stable f
 | [Proxy Extensions][3]                     | `ConfigMap/argocd-cm`                         | `extension.config`                                          | Beta   |
 | [Dynamic Cluster Distribution][7]         | `Deployment/argocd-application-controller`    | `ARGOCD_ENABLE_DYNAMIC_CLUSTER_DISTRIBUTION`                | Alpha  |
 | [Dynamic Cluster Distribution][7]         | `Deployment/argocd-application-controller`    | `ARGOCD_CONTROLLER_HEARTBEAT_TIME`                          | Alpha  |
+| [Incremental Namespace Sync][12]          | `StatefulSet/argocd-application-controller`   | `ARGOCD_ENABLE_INCREMENTAL_NAMESPACE_SYNC`                  | Alpha  |
+| [Incremental Namespace Sync][12]          | `ConfigMap/argocd-cmd-params-cm`              | `controller.incremental.namespace.sync.enabled`             | Alpha  |
 | [Cluster Sharding: round-robin][6]        | `ConfigMap/argocd-cmd-params-cm`              | `controller.sharding.algorithm: round-robin`                | Alpha  |
 | [Cluster Sharding: round-robin][6]        | `StatefulSet/argocd-application-controller`   | `ARGOCD_CONTROLLER_SHARDING_ALGORITHM=round-robin`          | Alpha  |
 | [Cluster Sharding: consistent-hashing][9] | `ConfigMap/argocd-cmd-params-cm`              | `controller.sharding.algorithm: consistent-hashing`         | Alpha  |
@@ -73,3 +76,4 @@ to indicate their stability and maturity. These are the statuses of non-stable f
 [9]: ./high_availability.md#argocd-application-controller
 [10]: app-sync-using-impersonation.md
 [11]: ../user-guide/source-hydrator.md
+[12]: incremental-namespace-sync.md

--- a/docs/operator-manual/incremental-namespace-sync.md
+++ b/docs/operator-manual/incremental-namespace-sync.md
@@ -1,0 +1,137 @@
+# Incremental Namespace Sync
+
+> [!WARNING]
+> **Alpha Feature (Since v3.3.0)**
+>
+> This is an experimental,
+> [alpha-quality](https://github.com/argoproj/argoproj/blob/main/community/feature-status.md#alpha)
+> feature. It may be removed in future releases or modified in
+> backwards-incompatible ways.
+
+*Current Status: [Alpha][1] (Since v3.3.0)*
+
+By default, when Argo CD detects namespace changes in a cluster configuration,
+it invalidates the entire cluster cache and performs a full resync of all
+namespaces. For clusters with many namespaces this can be slow and
+resource-intensive, as it requires listing all resources across all namespaces
+and re-establishing watches. During this time, cluster cache synchronization
+blocks all reconciliation operations, preventing applications from reconciling
+until the sync completes.
+
+Starting with v3.3.0, Argo CD supports incremental namespace synchronization.
+When namespaces are added or removed from the cluster configuration, only the
+affected namespaces are synchronized instead of triggering a full cluster cache
+rebuild.
+
+## Benefits
+
+- **Faster sync times**: Only sync the changed namespace instead of all namespaces
+- **Faster application reconciliation**: Cache sync blocks reconciliation, so faster sync means less downtime for application updates
+- **Reduced API calls**: Avoid listing resources in unchanged namespaces (10-50x reduction)
+- **Better scalability**: Enables managing clusters with many (100+) namespaces efficiently
+- **Reduced API server load**: Fewer LIST requests to the Kubernetes API server
+
+## Enabling Incremental Namespace Sync
+
+This feature is disabled by default while it is in alpha status. You can enable
+it using either a ConfigMap or environment variable.
+
+### Method 1: Via ConfigMap (Recommended)
+
+Update the `argocd-cmd-params-cm` ConfigMap:
+
+```bash
+kubectl patch configmap argocd-cmd-params-cm -n argocd --type merge \
+  -p '{"data":{"controller.incremental.namespace.sync.enabled":"true"}}'
+```
+
+Restart the controller:
+
+```bash
+kubectl rollout restart statefulset argocd-application-controller -n argocd
+```
+
+### Method 2: Via Environment Variable
+
+Edit the controller StatefulSet:
+
+```bash
+kubectl edit statefulset argocd-application-controller -n argocd
+```
+
+Add the environment variable:
+
+```yaml
+spec:
+  template:
+    spec:
+      containers:
+      - name: argocd-application-controller
+        env:
+        - name: ARGOCD_ENABLE_INCREMENTAL_NAMESPACE_SYNC
+          value: "true"
+```
+
+The controller pods will automatically restart to apply the change.
+
+### Method 3: Using kubectl set env
+
+Set the environment variable directly:
+
+```bash
+kubectl set env statefulset/argocd-application-controller \
+  ARGOCD_ENABLE_INCREMENTAL_NAMESPACE_SYNC=true -n argocd
+```
+
+This will trigger a rolling update of the controller pods.
+
+## How It Works
+
+When incremental namespace sync is enabled, the application controller uses a
+diff-based approach to detect namespace changes:
+
+1. **Compare namespace lists**: The controller compares the desired namespace set
+   (from cluster configuration) with the currently tracked namespace set (in cache)
+
+2. **Calculate additions and removals**:
+   - **Added namespaces**: Namespaces in the desired set but not in the current set
+   - **Removed namespaces**: Namespaces in the current set but not in the desired set
+
+3. **Apply incremental updates**:
+   - **For added namespaces**: Start watches and sync resources only in the new namespace
+   - **For removed namespaces**: Stop watches and remove cached resources only for that namespace
+   - **For unchanged namespaces**: No action taken - existing watches and cache remain
+
+This approach avoids the need to rebuild the entire cluster cache, which traditionally
+requires re-listing all resources across all namespaces.
+
+## When to Use This Feature
+
+Consider enabling this feature if:
+
+- ✅ You manage many namespaces per cluster
+- ✅ You frequently **add or remove namespaces** from cluster configurations
+- ✅ You experience **slow cluster sync times**
+- ✅ You see **API server rate limiting** or performance issues
+
+## Limitations and Considerations
+
+- **Alpha status**: The feature may change in future versions
+- **Namespace changes only**: Only optimizes namespace additions/removals, not other
+  cluster configuration changes (e.g., resource exclusions, API groups)
+- **Requires restart**: Enabling/disabling the feature requires controller restart
+- **Fallback behavior**: If incremental sync fails, the controller falls back to full
+    cluster cache invalidation to maintain consistency.
+
+## Monitoring
+
+You can monitor the feature's impact using:
+
+### Log-based Monitoring
+
+Parse controller logs to track namespace sync events:
+
+```bash
+kubectl logs -n argocd statefulset/argocd-application-controller | \
+  grep -E "syncing namespace|Namespace successfully synced|Failed to sync namespace"
+```

--- a/docs/operator-manual/server-commands/argocd-application-controller.md
+++ b/docs/operator-manual/server-commands/argocd-application-controller.md
@@ -37,6 +37,7 @@ argocd-application-controller [flags]
   -h, --help                                                      help for argocd-application-controller
       --hydrator-enabled                                          Feature flag to enable Hydrator. Default ("false")
       --ignore-normalizer-jq-execution-timeout-seconds duration   Set ignore normalizer JQ execution timeout
+      --incremental-namespace-sync-enabled                        Enables incremental namespace sync in cluster cache for performance optimization. Default ("false")
       --insecure-skip-tls-verify                                  If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string                                         Path to a kube config. Only required if out-of-cluster
       --kubectl-parallelism-limit int                             Number of allowed concurrent kubectl fork/execs. Any value less than 1 means no limit. (default 20)

--- a/gitops-engine/pkg/cache/cluster.go
+++ b/gitops-engine/pkg/cache/cluster.go
@@ -693,7 +693,16 @@ func (c *clusterCache) snapshotApisMeta() map[schema.GroupKind]*apiMeta {
 }
 
 // syncNamespaceResources lists and caches resources for the given namespace across all watched APIs
-func (c *clusterCache) syncNamespaceResources(namespace string, apisToSync map[schema.GroupKind]*apiMeta) error {
+func (c *clusterCache) syncNamespaceResources(namespace string, apisToSync map[schema.GroupKind]*apiMeta) (err error) {
+	c.log.Info("Start syncing namespace", "namespace", namespace)
+	defer func() {
+		if err != nil {
+			c.log.Error(err, "Failed to sync namespace", "namespace", namespace)
+		} else {
+			c.log.Info("Namespace successfully synced", "namespace", namespace)
+		}
+	}()
+
 	client, err := c.kubectl.NewDynamicClient(c.config)
 	if err != nil {
 		return fmt.Errorf("failed to create client: %w", err)

--- a/gitops-engine/pkg/cache/cluster.go
+++ b/gitops-engine/pkg/cache/cluster.go
@@ -758,7 +758,7 @@ func (c *clusterCache) loadNamespaceResources(ctx context.Context, client dynami
 		return listPager.EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
 			un, ok := obj.(*unstructured.Unstructured)
 			if !ok {
-				return fmt.Errorf("object %s/%s has an unexpected type", un.GroupVersionKind().String(), un.GetName())
+				return fmt.Errorf("object has unexpected type: %T", obj)
 			}
 			newRes := c.newResource(un)
 			c.lock.Lock()
@@ -922,7 +922,7 @@ func (c *clusterCache) loadInitialState(ctx context.Context, api kube.APIResourc
 	resourceVersion, err := c.listResources(ctx, resClient, func(listPager *pager.ListPager) error {
 		return listPager.EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
 			if un, ok := obj.(*unstructured.Unstructured); !ok {
-				return fmt.Errorf("object %s/%s has an unexpected type", un.GroupVersionKind().String(), un.GetName())
+				return fmt.Errorf("object has unexpected type: %T", obj)
 			} else {
 				items = append(items, c.newResource(un))
 			}
@@ -1236,7 +1236,7 @@ func (c *clusterCache) sync() error {
 			resourceVersion, err := c.listResources(ctx, resClient, func(listPager *pager.ListPager) error {
 				return listPager.EachListItem(context.Background(), metav1.ListOptions{}, func(obj runtime.Object) error {
 					if un, ok := obj.(*unstructured.Unstructured); !ok {
-						return fmt.Errorf("object %s/%s has an unexpected type", un.GroupVersionKind().String(), un.GetName())
+						return fmt.Errorf("object has unexpected type: %T", obj)
 					} else {
 						newRes := c.newResource(un)
 						lock.Lock()

--- a/gitops-engine/pkg/cache/cluster.go
+++ b/gitops-engine/pkg/cache/cluster.go
@@ -107,6 +107,11 @@ type apiMeta struct {
 	// watchCancel stops the watch of all resources for this API. This gets called when the cache is invalidated or when
 	// the watched API ceases to exist (e.g. a CRD gets deleted).
 	watchCancel context.CancelFunc
+	// watchCtx is the parent context for all watches of this API. Used to derive per-namespace contexts.
+	watchCtx context.Context
+	// namespaceCancels tracks per-namespace watch cancellation for incremental namespace operations.
+	// Only populated when using incremental namespace sync.
+	namespaceCancels map[string]context.CancelFunc
 }
 
 type eventMeta struct {
@@ -672,6 +677,15 @@ func (c *clusterCache) RemoveNamespace(namespace string) error {
 			delete(c.resources, key)
 		}
 	}
+
+	// Cancel watches for the removed namespace
+	for _, meta := range c.apisMeta {
+		if cancel, exists := meta.namespaceCancels[namespace]; exists {
+			cancel()
+			delete(meta.namespaceCancels, namespace)
+		}
+	}
+
 	c.lock.Unlock()
 
 	return nil
@@ -705,7 +719,6 @@ func (c *clusterCache) syncNamespaceResources(namespace string, apisToSync map[s
 		return err
 	}
 
-	ctx := context.Background()
 	for gk, meta := range apisToSync {
 		if !meta.namespaced {
 			continue
@@ -716,7 +729,11 @@ func (c *clusterCache) syncNamespaceResources(namespace string, apisToSync map[s
 			continue
 		}
 
-		if err := c.loadNamespaceResources(ctx, client, api, namespace); err != nil {
+		// Create per-namespace context derived from the API's parent context
+		nsCtx, nsCancel := context.WithCancel(meta.watchCtx)
+		meta.namespaceCancels[namespace] = nsCancel
+
+		if err := c.loadNamespaceResources(nsCtx, client, api, namespace); err != nil {
 			return fmt.Errorf("failed to load resources for %s in namespace %s: %w", gk.String(), namespace, err)
 		}
 	}
@@ -1211,7 +1228,12 @@ func (c *clusterCache) sync() error {
 
 		lock.Lock()
 		ctx, cancel := context.WithCancel(context.Background())
-		info := &apiMeta{namespaced: api.Meta.Namespaced, watchCancel: cancel}
+		info := &apiMeta{
+			namespaced:       api.Meta.Namespaced,
+			watchCancel:      cancel,
+			watchCtx:         ctx,
+			namespaceCancels: make(map[string]context.CancelFunc),
+		}
 		c.apisMeta[api.GroupKind] = info
 		c.namespacedResources[api.GroupKind] = api.Meta.Namespaced
 		lock.Unlock()

--- a/gitops-engine/pkg/cache/cluster.go
+++ b/gitops-engine/pkg/cache/cluster.go
@@ -723,6 +723,11 @@ func (c *clusterCache) syncNamespaceResources(namespace string, apisToSync map[s
 		return fmt.Errorf("failed to create client: %w", err)
 	}
 
+	clientset, err := kubernetes.NewForConfig(c.config)
+	if err != nil {
+		return fmt.Errorf("failed to create clientset: %w", err)
+	}
+
 	apiMap, err := c.buildAPIMap()
 	if err != nil {
 		return err
@@ -742,7 +747,7 @@ func (c *clusterCache) syncNamespaceResources(namespace string, apisToSync map[s
 		nsCtx, nsCancel := context.WithCancel(meta.watchCtx)
 		meta.namespaceCancels[namespace] = nsCancel
 
-		if err := c.loadNamespaceResources(nsCtx, client, api, namespace); err != nil {
+		if err := c.loadNamespaceResources(nsCtx, client, clientset, api, namespace); err != nil {
 			return fmt.Errorf("failed to load resources for %s in namespace %s: %w", gk.String(), namespace, err)
 		}
 	}
@@ -766,7 +771,7 @@ func (c *clusterCache) buildAPIMap() (map[schema.GroupKind]kube.APIResourceInfo,
 
 // loadNamespaceResources lists and caches all resources for a given API in a specific namespace,
 // and starts watching for changes
-func (c *clusterCache) loadNamespaceResources(ctx context.Context, client dynamic.Interface, api kube.APIResourceInfo, namespace string) error {
+func (c *clusterCache) loadNamespaceResources(ctx context.Context, client dynamic.Interface, clientset kubernetes.Interface, api kube.APIResourceInfo, namespace string) error {
 	resClient := client.Resource(api.GroupVersionResource).Namespace(namespace)
 
 	resourceVersion, err := c.listResources(ctx, resClient, func(listPager *pager.ListPager) error {
@@ -784,8 +789,9 @@ func (c *clusterCache) loadNamespaceResources(ctx context.Context, client dynami
 	})
 	if err != nil {
 		if c.isRestrictedResource(err) {
-			return nil
+			return c.handleRestrictedListError(ctx, clientset, api, namespace, err)
 		}
+
 		return err
 	}
 
@@ -1161,6 +1167,50 @@ func (c *clusterCache) checkPermission(ctx context.Context, reviewInterface auth
 	// checkPermission follows the same logic of determining namespace/cluster resource as the processApi function
 	// so if neither of the cases match it means the controller will not watch for it so it is safe to return true.
 	return true, nil
+}
+
+// checkPermissionForNamespace checks if the controller has permission to list a resource in a specific namespace
+func (c *clusterCache) checkPermissionForNamespace(ctx context.Context, reviewInterface authType1.SelfSubjectAccessReviewInterface, api kube.APIResourceInfo, namespace string) (bool, error) {
+	sar := &authorizationv1.SelfSubjectAccessReview{
+		Spec: authorizationv1.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: &authorizationv1.ResourceAttributes{
+				Namespace: namespace,
+				Verb:      "list",
+				Resource:  api.GroupVersionResource.Resource,
+			},
+		},
+	}
+
+	resp, err := reviewInterface.Create(ctx, sar, metav1.CreateOptions{})
+	if err != nil {
+		return false, fmt.Errorf("failed to create self subject access review: %w", err)
+	}
+
+	if resp != nil && resp.Status.Allowed {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// handleRestrictedListError manages forbidden/unauthorized list errors with optional self subject access review (SSAR) verification
+func (c *clusterCache) handleRestrictedListError(ctx context.Context, clientset kubernetes.Interface, api kube.APIResourceInfo, namespace string, listErr error) error {
+	if c.respectRBAC != RespectRbacStrict {
+		// RespectRbacNormal: silently skip forbidden resources
+		return nil
+	}
+
+	keep, permErr := c.checkPermissionForNamespace(ctx, clientset.AuthorizationV1().SelfSubjectAccessReviews(), api, namespace)
+	if permErr != nil {
+		return fmt.Errorf("failed to check permissions for %s in namespace %s: %w", api.GroupKind.String(), namespace, permErr)
+	}
+	if !keep {
+		// SSAR confirms no permission - silently skip this resource
+		return nil
+	}
+
+	// SSAR says we have permission, but list failed - propagate the original list error
+	return fmt.Errorf("list failed despite having permissions for %s in namespace %s: %w", api.GroupKind.String(), namespace, listErr)
 }
 
 // sync retrieves the current state of the cluster and stores relevant information in the clusterCache fields.

--- a/gitops-engine/pkg/cache/cluster.go
+++ b/gitops-engine/pkg/cache/cluster.go
@@ -708,7 +708,16 @@ func (c *clusterCache) snapshotApisMeta() map[schema.GroupKind]*apiMeta {
 }
 
 // syncNamespaceResources lists and caches resources for the given namespace across all watched APIs
-func (c *clusterCache) syncNamespaceResources(namespace string, apisToSync map[schema.GroupKind]*apiMeta) error {
+func (c *clusterCache) syncNamespaceResources(namespace string, apisToSync map[schema.GroupKind]*apiMeta) (err error) {
+	c.log.Info("Start syncing namespace", "namespace", namespace)
+	defer func() {
+		if err != nil {
+			c.log.Error(err, "Failed to sync namespace", "namespace", namespace)
+		} else {
+			c.log.Info("Namespace successfully synced", "namespace", namespace)
+		}
+	}()
+
 	client, err := c.kubectl.NewDynamicClient(c.config)
 	if err != nil {
 		return fmt.Errorf("failed to create client: %w", err)

--- a/gitops-engine/pkg/cache/cluster.go
+++ b/gitops-engine/pkg/cache/cluster.go
@@ -25,9 +25,9 @@
 package cache
 
 import (
-	"maps"
 	"context"
 	"fmt"
+	"maps"
 	"runtime/debug"
 	"strings"
 	"sync"
@@ -163,6 +163,8 @@ type ClusterCache interface {
 	Invalidate(opts ...UpdateSettingsFunc)
 	// AddNamespace incrementally syncs a new namespace to the cluster cache if incremental sync is enabled, otherwise falls back to full invalidation
 	AddNamespace(namespace string) error
+	// RemoveNamespace incrementally removes a namespace from the cluster cache if incremental sync is enabled, otherwise falls back to full invalidation
+	RemoveNamespace(namespace string) error
 	// FindResources returns resources that matches given list of predicates from specified namespace or everywhere if specified namespace is empty
 	FindResources(namespace string, predicates ...func(r *Resource) bool) map[kube.ResourceKey]*Resource
 	// IterateHierarchyV2 iterates resource tree starting from the specified top level resources and executes callback for each resource in the tree.
@@ -648,6 +650,41 @@ func (c *clusterCache) AddNamespace(namespace string) error {
 	c.lock.Unlock()
 
 	return c.syncNamespaceResources(namespace, apisToSync)
+}
+
+// RemoveNamespace incrementally removes a namespace from the cluster cache if incremental sync is enabled,
+// otherwise falls back to full cluster cache invalidation
+func (c *clusterCache) RemoveNamespace(namespace string) error {
+	if !c.incrementalNamespaceSync {
+		c.Invalidate(func(cache *clusterCache) {
+			cache.namespaces = removeNamespaceFromList(cache.namespaces, namespace)
+		})
+		return nil
+	}
+
+	// Feature enabled: incremental removal
+	c.lock.Lock()
+	c.namespaces = removeNamespaceFromList(c.namespaces, namespace)
+
+	// Remove all resources from the removed namespace
+	for key := range c.resources {
+		if key.Namespace == namespace {
+			delete(c.resources, key)
+		}
+	}
+	c.lock.Unlock()
+
+	return nil
+}
+
+func removeNamespaceFromList(namespaces []string, namespace string) []string {
+	result := make([]string, 0, len(namespaces)-1)
+	for _, ns := range namespaces {
+		if ns != namespace {
+			result = append(result, ns)
+		}
+	}
+	return result
 }
 
 func (c *clusterCache) snapshotApisMeta() map[schema.GroupKind]*apiMeta {

--- a/gitops-engine/pkg/cache/cluster.go
+++ b/gitops-engine/pkg/cache/cluster.go
@@ -645,16 +645,27 @@ func (c *clusterCache) AddNamespace(namespace string) error {
 		c.Invalidate(func(cache *clusterCache) {
 			cache.namespaces = append(cache.namespaces, namespace)
 		})
+
 		return nil
 	}
 
 	// Feature enabled: incremental sync
+	c.log.Info("Start syncing namespace", "namespace", namespace)
+
 	c.lock.Lock()
 	c.namespaces = append(c.namespaces, namespace)
 	apisToSync := c.snapshotApisMeta()
 	c.lock.Unlock()
 
-	return c.syncNamespaceResources(namespace, apisToSync)
+	err := c.syncNamespaceResources(namespace, apisToSync)
+	if err != nil {
+		c.log.Error(err, "Failed to sync namespace", "namespace", namespace)
+		return err
+	}
+
+	c.log.Info("Namespace successfully synced", "namespace", namespace)
+
+	return nil
 }
 
 // RemoveNamespace incrementally removes a namespace from the cluster cache if incremental sync is enabled,
@@ -708,16 +719,7 @@ func (c *clusterCache) snapshotApisMeta() map[schema.GroupKind]*apiMeta {
 }
 
 // syncNamespaceResources lists and caches resources for the given namespace across all watched APIs
-func (c *clusterCache) syncNamespaceResources(namespace string, apisToSync map[schema.GroupKind]*apiMeta) (err error) {
-	c.log.Info("Start syncing namespace", "namespace", namespace)
-	defer func() {
-		if err != nil {
-			c.log.Error(err, "Failed to sync namespace", "namespace", namespace)
-		} else {
-			c.log.Info("Namespace successfully synced", "namespace", namespace)
-		}
-	}()
-
+func (c *clusterCache) syncNamespaceResources(namespace string, apisToSync map[schema.GroupKind]*apiMeta) error {
 	client, err := c.kubectl.NewDynamicClient(c.config)
 	if err != nil {
 		return fmt.Errorf("failed to create client: %w", err)

--- a/gitops-engine/pkg/cache/cluster.go
+++ b/gitops-engine/pkg/cache/cluster.go
@@ -773,7 +773,7 @@ func (c *clusterCache) loadNamespaceResources(ctx context.Context, client dynami
 		return listPager.EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
 			un, ok := obj.(*unstructured.Unstructured)
 			if !ok {
-				return fmt.Errorf("object %s/%s has an unexpected type", un.GroupVersionKind().String(), un.GetName())
+				return fmt.Errorf("object has unexpected type: %T", obj)
 			}
 			newRes := c.newResource(un)
 			c.lock.Lock()
@@ -937,7 +937,7 @@ func (c *clusterCache) loadInitialState(ctx context.Context, api kube.APIResourc
 	resourceVersion, err := c.listResources(ctx, resClient, func(listPager *pager.ListPager) error {
 		return listPager.EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
 			if un, ok := obj.(*unstructured.Unstructured); !ok {
-				return fmt.Errorf("object %s/%s has an unexpected type", un.GroupVersionKind().String(), un.GetName())
+				return fmt.Errorf("object has unexpected type: %T", obj)
 			} else {
 				items = append(items, c.newResource(un))
 			}
@@ -1251,7 +1251,7 @@ func (c *clusterCache) sync() error {
 			resourceVersion, err := c.listResources(ctx, resClient, func(listPager *pager.ListPager) error {
 				return listPager.EachListItem(context.Background(), metav1.ListOptions{}, func(obj runtime.Object) error {
 					if un, ok := obj.(*unstructured.Unstructured); !ok {
-						return fmt.Errorf("object %s/%s has an unexpected type", un.GroupVersionKind().String(), un.GetName())
+						return fmt.Errorf("object has unexpected type: %T", obj)
 					} else {
 						newRes := c.newResource(un)
 						lock.Lock()

--- a/gitops-engine/pkg/cache/cluster.go
+++ b/gitops-engine/pkg/cache/cluster.go
@@ -25,6 +25,7 @@
 package cache
 
 import (
+	"maps"
 	"context"
 	"fmt"
 	"runtime/debug"
@@ -160,6 +161,8 @@ type ClusterCache interface {
 	GetGVKParser() *managedfields.GvkParser
 	// Invalidate cache and executes callback that optionally might update cache settings
 	Invalidate(opts ...UpdateSettingsFunc)
+	// AddNamespace incrementally syncs a new namespace to the cluster cache if incremental sync is enabled, otherwise falls back to full invalidation
+	AddNamespace(namespace string) error
 	// FindResources returns resources that matches given list of predicates from specified namespace or everywhere if specified namespace is empty
 	FindResources(namespace string, predicates ...func(r *Resource) bool) map[kube.ResourceKey]*Resource
 	// IterateHierarchyV2 iterates resource tree starting from the specified top level resources and executes callback for each resource in the tree.
@@ -268,6 +271,9 @@ type clusterCache struct {
 	namespaces       []string
 	clusterResources bool
 	settings         Settings
+
+	// incrementalNamespaceSync enables incremental namespace syncing instead of full cache invalidation
+	incrementalNamespaceSync bool
 
 	handlersLock                sync.Mutex
 	handlerKey                  uint64
@@ -623,6 +629,106 @@ func (c *clusterCache) Invalidate(opts ...UpdateSettingsFunc) {
 	c.apisMeta = nil
 	c.namespacedResources = nil
 	c.log.Info("Invalidated cluster")
+}
+
+// AddNamespace incrementally syncs a new namespace to the cluster cache if incremental sync is enabled,
+// otherwise falls back to full cluster cache invalidation
+func (c *clusterCache) AddNamespace(namespace string) error {
+	if !c.incrementalNamespaceSync {
+		c.Invalidate(func(cache *clusterCache) {
+			cache.namespaces = append(cache.namespaces, namespace)
+		})
+		return nil
+	}
+
+	// Feature enabled: incremental sync
+	c.lock.Lock()
+	c.namespaces = append(c.namespaces, namespace)
+	apisToSync := c.snapshotApisMeta()
+	c.lock.Unlock()
+
+	return c.syncNamespaceResources(namespace, apisToSync)
+}
+
+func (c *clusterCache) snapshotApisMeta() map[schema.GroupKind]*apiMeta {
+	snapshot := make(map[schema.GroupKind]*apiMeta)
+	maps.Copy(snapshot, c.apisMeta)
+	return snapshot
+}
+
+// syncNamespaceResources lists and caches resources for the given namespace across all watched APIs
+func (c *clusterCache) syncNamespaceResources(namespace string, apisToSync map[schema.GroupKind]*apiMeta) error {
+	client, err := c.kubectl.NewDynamicClient(c.config)
+	if err != nil {
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+
+	apiMap, err := c.buildAPIMap()
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	for gk, meta := range apisToSync {
+		if !meta.namespaced {
+			continue
+		}
+
+		api, exists := apiMap[gk]
+		if !exists {
+			continue
+		}
+
+		if err := c.loadNamespaceResources(ctx, client, api, namespace); err != nil {
+			return fmt.Errorf("failed to load resources for %s in namespace %s: %w", gk.String(), namespace, err)
+		}
+	}
+
+	return nil
+}
+
+// buildAPIMap creates a lookup map from GroupKind to APIResourceInfo
+func (c *clusterCache) buildAPIMap() (map[schema.GroupKind]kube.APIResourceInfo, error) {
+	apis, err := c.kubectl.GetAPIResources(c.config, true, c.settings.ResourcesFilter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get api resources: %w", err)
+	}
+
+	apiMap := make(map[schema.GroupKind]kube.APIResourceInfo)
+	for _, api := range apis {
+		apiMap[api.GroupKind] = api
+	}
+	return apiMap, nil
+}
+
+// loadNamespaceResources lists and caches all resources for a given API in a specific namespace,
+// and starts watching for changes
+func (c *clusterCache) loadNamespaceResources(ctx context.Context, client dynamic.Interface, api kube.APIResourceInfo, namespace string) error {
+	resClient := client.Resource(api.GroupVersionResource).Namespace(namespace)
+
+	resourceVersion, err := c.listResources(ctx, resClient, func(listPager *pager.ListPager) error {
+		return listPager.EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+			un, ok := obj.(*unstructured.Unstructured)
+			if !ok {
+				return fmt.Errorf("object %s/%s has an unexpected type", un.GroupVersionKind().String(), un.GetName())
+			}
+			newRes := c.newResource(un)
+			c.lock.Lock()
+			c.setNode(newRes)
+			c.lock.Unlock()
+			return nil
+		})
+	})
+	if err != nil {
+		if c.isRestrictedResource(err) {
+			return nil
+		}
+		return err
+	}
+
+	go c.watchEvents(ctx, api, resClient, namespace, resourceVersion)
+
+	return nil
 }
 
 // clusterCacheSync's lock should be held before calling this method

--- a/gitops-engine/pkg/cache/cluster_incremental_sync_test.go
+++ b/gitops-engine/pkg/cache/cluster_incremental_sync_test.go
@@ -1,0 +1,250 @@
+package cache
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	testcore "k8s.io/client-go/testing"
+
+	"github.com/argoproj/gitops-engine/pkg/utils/kube"
+	"github.com/argoproj/gitops-engine/pkg/utils/kube/kubetest"
+)
+
+func TestAddNamespace(t *testing.T) {
+	t.Run("feature disabled", func(t *testing.T) {
+		cache := NewClusterCache(
+			&rest.Config{},
+			SetKubectl(&kubetest.MockKubectlCmd{}),
+			SetNamespaces([]string{"existing-namespace"}),
+		)
+
+		// given: cache was previously synced
+		now := time.Now()
+		cache.syncStatus.lock.Lock()
+		cache.syncStatus.syncTime = &now
+		cache.syncStatus.lock.Unlock()
+
+		// when: adding a namespace with feature disabled
+		err := cache.AddNamespace("new-namespace")
+		assert.NoError(t, err)
+
+		// then: should invalidate the cache (observable via syncTime being cleared)
+		cache.syncStatus.lock.Lock()
+		actual := cache.syncStatus.syncTime
+		cache.syncStatus.lock.Unlock()
+		assert.Nil(t, actual, "given feature disabled, should invalidate cache when namespace added")
+
+		// then: should add namespace to the list
+		assert.Contains(t, cache.namespaces, "new-namespace", "given feature disabled, should add namespace to list")
+		assert.Contains(t, cache.namespaces, "existing-namespace", "given feature disabled, should preserve existing namespaces")
+	})
+
+	t.Run("feature enabled", func(t *testing.T) {
+		cache := NewClusterCache(
+			&rest.Config{},
+			SetKubectl(&kubetest.MockKubectlCmd{}),
+			SetNamespaces([]string{"existing-namespace"}),
+			WithIncrementalNamespaceSync(true),
+		)
+
+		// given: cache was previously synced
+		now := time.Now()
+		cache.syncStatus.lock.Lock()
+		cache.syncStatus.syncTime = &now
+		cache.syncStatus.lock.Unlock()
+
+		// when: adding a namespace with feature enabled
+		err := cache.AddNamespace("new-namespace")
+		assert.NoError(t, err)
+
+		// then: should NOT invalidate the cache (syncTime preserved)
+		cache.syncStatus.lock.Lock()
+		actual := cache.syncStatus.syncTime
+		cache.syncStatus.lock.Unlock()
+
+		assert.NotNil(t, actual, "given feature enabled, should preserve cache when namespace added")
+		assert.Equal(t, now.Unix(), actual.Unix(), "given feature enabled, should not change syncTime")
+
+		// then: should add namespace to the list
+		assert.Contains(t, cache.namespaces, "new-namespace", "given feature enabled, should add namespace to list")
+		assert.Contains(t, cache.namespaces, "existing-namespace", "given feature enabled, should preserve existing namespaces")
+	})
+
+	t.Run("feature enabled syncs resources in new namespace", func(t *testing.T) {
+		// given: a pod exists in the new namespace
+		pod := &corev1.Pod{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "new-namespace"},
+		}
+
+		_, mockKubectl := setupFakeCluster(pod)
+		cache := NewClusterCache(
+			&rest.Config{},
+			SetKubectl(mockKubectl),
+			SetNamespaces([]string{"existing-namespace"}),
+			WithIncrementalNamespaceSync(true),
+		)
+
+		// given: cache was previously synced (to populate apisMeta)
+		err := cache.EnsureSynced()
+		assert.NoError(t, err)
+
+		// Store the sync time to verify it's preserved
+		cache.syncStatus.lock.Lock()
+		syncTimeBefore := cache.syncStatus.syncTime
+		cache.syncStatus.lock.Unlock()
+
+		// when: adding a namespace with feature enabled
+		err = cache.AddNamespace("new-namespace")
+		assert.NoError(t, err)
+
+		// then: should preserve the sync time (not invalidate)
+		cache.syncStatus.lock.Lock()
+		syncTimeAfter := cache.syncStatus.syncTime
+		cache.syncStatus.lock.Unlock()
+		assert.Equal(t, syncTimeBefore, syncTimeAfter, "sync time should be preserved")
+
+		//then: should have the pod from new namespace in the cache
+		assertPodInCache(t, cache, "new-namespace", "test-pod", "pod from new namespace should be in cache")
+	})
+
+	t.Run("feature enabled watches new namespace for changes", func(t *testing.T) {
+		// given: initial pod in existing namespace
+		existingPod := &corev1.Pod{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+			ObjectMeta: metav1.ObjectMeta{Name: "existing-pod", Namespace: "existing-namespace"},
+		}
+
+		client, mockKubectl := setupFakeCluster(existingPod)
+		cache := NewClusterCache(
+			&rest.Config{},
+			SetKubectl(mockKubectl),
+			SetNamespaces([]string{"existing-namespace"}),
+			WithIncrementalNamespaceSync(true),
+		)
+
+		// given: cache was previously synced (starts watches for existing namespace)
+		err := cache.EnsureSynced()
+		assert.NoError(t, err)
+
+		// when: adding a new namespace
+		err = cache.AddNamespace("new-namespace")
+		assert.NoError(t, err)
+
+		// when: a new pod is created in the new namespace AFTER AddNamespace
+		newPod := &corev1.Pod{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+			ObjectMeta: metav1.ObjectMeta{Name: "new-pod", Namespace: "new-namespace", ResourceVersion: "124"},
+		}
+
+		podClient := client.Resource(schema.GroupVersionResource{
+			Group: "", Version: "v1", Resource: "pods",
+		}).Namespace("new-namespace")
+
+		_, err = podClient.Create(context.Background(), mustToUnstructured(newPod), metav1.CreateOptions{})
+		assert.NoError(t, err)
+
+		// then: the watch should pick up the new pod and add it to cache
+		time.Sleep(100 * time.Millisecond)
+
+		// then: the new pod should be in the cache (proves watches are active)
+		assertPodInCache(t, cache, "new-namespace", "new-pod", "pod created after AddNamespace should be in cache (proves watches are active)")
+	})
+
+	t.Run("feature enabled returns error for non-RBAC errors", func(t *testing.T) {
+		// given: a fake cluster that returns generic errors (not RBAC)
+		client := fake.NewSimpleDynamicClient(scheme.Scheme)
+
+		// given: setup reactor to return generic error for "error-namespace"
+		client.PrependReactor("list", "pods", func(action testcore.Action) (handled bool, ret runtime.Object, err error) {
+			listAction := action.(testcore.ListAction)
+			if listAction.GetNamespace() == "error-namespace" {
+				return true, nil, apierrors.NewInternalError(fmt.Errorf("internal server error"))
+			}
+			return false, nil, nil
+		})
+
+		apiResources := []kube.APIResourceInfo{{
+			GroupKind:            schema.GroupKind{Group: "", Kind: "Pod"},
+			GroupVersionResource: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+			Meta:                 metav1.APIResource{Namespaced: true},
+		}}
+
+		mockKubectl := &kubetest.MockKubectlCmd{
+			DynamicClient: client,
+			APIResources:  apiResources,
+			Version:       "v1.28.0",
+		}
+
+		cache := NewClusterCache(
+			&rest.Config{},
+			SetKubectl(mockKubectl),
+			SetNamespaces([]string{"existing-namespace"}),
+			WithIncrementalNamespaceSync(true),
+			SetRespectRBAC(RespectRbacNormal),
+		)
+
+		// given: cache was previously synced
+		err := cache.EnsureSynced()
+		assert.NoError(t, err)
+
+		// when: adding a namespace with non-RBAC errors
+		err = cache.AddNamespace("error-namespace")
+
+		// then: should return error (only RBAC errors should be ignored)
+		assert.Error(t, err, "AddNamespace should return error for non-RBAC errors")
+	})
+}
+
+func setupFakeCluster(objs ...runtime.Object) (*fake.FakeDynamicClient, *kubetest.MockKubectlCmd) {
+	client := fake.NewSimpleDynamicClient(scheme.Scheme, objs...)
+	reactor := client.ReactionChain[0]
+	client.PrependReactor("list", "*", func(action testcore.Action) (handled bool, ret runtime.Object, err error) {
+		handled, ret, err = reactor.React(action)
+		if err != nil || !handled {
+			return
+		}
+		ret.(metav1.ListInterface).SetResourceVersion("123")
+		return
+	})
+
+	apiResources := []kube.APIResourceInfo{{
+		GroupKind:            schema.GroupKind{Group: "", Kind: "Pod"},
+		GroupVersionResource: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+		Meta:                 metav1.APIResource{Namespaced: true},
+	}}
+
+	mockKubectl := &kubetest.MockKubectlCmd{
+		DynamicClient: client,
+		APIResources:  apiResources,
+		Version:       "v1.28.0",
+	}
+
+	return client, mockKubectl
+}
+
+func assertPodInCache(t *testing.T, cache *clusterCache, namespace, name, message string) {
+	t.Helper()
+	podKey := kube.NewResourceKey("", "Pod", namespace, name)
+	cache.lock.RLock()
+	cachedPod, exists := cache.resources[podKey]
+	cache.lock.RUnlock()
+
+	assert.True(t, exists, message)
+	assert.NotNil(t, cachedPod, "cached pod should not be nil")
+	if cachedPod != nil {
+		assert.Equal(t, name, cachedPod.Ref.Name)
+		assert.Equal(t, namespace, cachedPod.Ref.Namespace)
+	}
+}

--- a/gitops-engine/pkg/cache/cluster_incremental_sync_test.go
+++ b/gitops-engine/pkg/cache/cluster_incremental_sync_test.go
@@ -18,8 +18,8 @@ import (
 	"k8s.io/client-go/rest"
 	testcore "k8s.io/client-go/testing"
 
-	"github.com/argoproj/gitops-engine/pkg/utils/kube"
-	"github.com/argoproj/gitops-engine/pkg/utils/kube/kubetest"
+	"github.com/argoproj/argo-cd/gitops-engine/pkg/utils/kube"
+	"github.com/argoproj/argo-cd/gitops-engine/pkg/utils/kube/kubetest"
 )
 
 func TestAddNamespace(t *testing.T) {

--- a/gitops-engine/pkg/cache/cluster_test.go
+++ b/gitops-engine/pkg/cache/cluster_test.go
@@ -17,17 +17,19 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	testcore "k8s.io/client-go/testing"
@@ -212,7 +214,6 @@ func Benchmark_sync_CrossNamespace(b *testing.B) {
 
 	for _, tc := range testCases {
 		b.Run(tc.name, func(b *testing.B) {
-
 			resources := []runtime.Object{}
 
 			// Create cluster-scoped parents (ClusterRoles)
@@ -1438,7 +1439,6 @@ func testClusterChild() *rbacv1.ClusterRole {
 	}
 }
 
-
 func TestIterateHierarchyV2_ClusterScopedParent_FindsAllChildren(t *testing.T) {
 	// Test that cluster-scoped parents automatically find all their children (both cluster-scoped and namespaced)
 	// This is the core behavior of the new implementation - cross-namespace relationships are always tracked
@@ -1564,7 +1564,6 @@ func TestIterateHierarchyV2_MultiLevelClusterScoped_FindsNamespacedGrandchildren
 	}
 	assert.ElementsMatch(t, expected, keys)
 }
-
 func TestIterateHierarchyV2_ClusterScopedParentOnly_InferredUID(t *testing.T) {
 	// Test that passing only a cluster-scoped parent finds children even with inferred UIDs.
 	// This should never happen but we coded defensively for this case, and at worst it would link a child
@@ -2056,18 +2055,17 @@ func BenchmarkIterateHierarchyV2_ClusterParentTraversal(b *testing.B) {
 
 		// Secondary dimension: Within a namespace, % of resources that are cross-NS
 		// 5,000 total resources, 2% of namespaces (1/50) have cross-NS children
-		{"50NS_2pct_100perNS_10cross", 50, 100, 1, 10},  // 10% of namespace resources (10/100)
-		{"50NS_2pct_100perNS_25cross", 50, 100, 1, 25},  // 25% of namespace resources (25/100)
-		{"50NS_2pct_100perNS_50cross", 50, 100, 1, 50},  // 50% of namespace resources (50/100)
+		{"50NS_2pct_100perNS_10cross", 50, 100, 1, 10}, // 10% of namespace resources (10/100)
+		{"50NS_2pct_100perNS_25cross", 50, 100, 1, 25}, // 25% of namespace resources (25/100)
+		{"50NS_2pct_100perNS_50cross", 50, 100, 1, 50}, // 50% of namespace resources (50/100)
 
 		// Edge cases
-		{"100NS_1pct_100perNS_10cross", 100, 100, 1, 10},   // 1% of namespaces (1/100) - extreme clustering
-		{"50NS_100pct_100perNS_10cross", 50, 100, 50, 10},  // 100% of namespaces - worst case
+		{"100NS_1pct_100perNS_10cross", 100, 100, 1, 10},  // 1% of namespaces (1/100) - extreme clustering
+		{"50NS_100pct_100perNS_10cross", 50, 100, 50, 10}, // 100% of namespaces - worst case
 	}
 
 	for _, tc := range testCases {
 		b.Run(tc.name, func(b *testing.B) {
-
 			cluster := newCluster(b).WithAPIResources([]kube.APIResourceInfo{{
 				GroupKind:            schema.GroupKind{Group: "rbac.authorization.k8s.io", Kind: "ClusterRole"},
 				GroupVersionResource: schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"},
@@ -2080,7 +2078,7 @@ func BenchmarkIterateHierarchyV2_ClusterParentTraversal(b *testing.B) {
 
 			// CRITICAL: Initialize namespacedResources so setNode will populate orphanedChildren index
 			cluster.namespacedResources = map[schema.GroupKind]bool{
-				{Group: "", Kind: "Pod"}:                                   true,
+				{Group: "", Kind: "Pod"}:                                  true,
 				{Group: "rbac.authorization.k8s.io", Kind: "ClusterRole"}: false,
 			}
 
@@ -2238,7 +2236,6 @@ metadata:
 		})
 	}
 }
-
 func TestIterateHierarchyV2_NoDuplicatesInSameNamespace(t *testing.T) {
 	// Create a parent-child relationship in the same namespace
 	parent := &appsv1.Deployment{
@@ -2640,6 +2637,82 @@ func BenchmarkIncrementalIndexBuild(b *testing.B) {
 					cluster.addToParentUIDToChildren(child.parentUID, child.childKey)
 				}
 			}
+		})
+	}
+}
+
+func Test_checkPermissionForNamespace(t *testing.T) {
+	api := kube.APIResourceInfo{
+		GroupKind:            schema.GroupKind{Group: "", Kind: "Pod"},
+		GroupVersionResource: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+		Meta:                 metav1.APIResource{Namespaced: true},
+	}
+
+	tests := []struct {
+		name            string
+		ssarResponse    *authorizationv1.SelfSubjectAccessReview
+		ssarError       error
+		expectedAllowed bool
+		expectError     bool
+		errorContains   string
+	}{
+		{
+			name: "returns true when SSAR allows",
+			ssarResponse: &authorizationv1.SelfSubjectAccessReview{
+				Status: authorizationv1.SubjectAccessReviewStatus{
+					Allowed: true,
+				},
+			},
+			expectedAllowed: true,
+			expectError:     false,
+		},
+		{
+			name: "returns false when SSAR denies",
+			ssarResponse: &authorizationv1.SelfSubjectAccessReview{
+				Status: authorizationv1.SubjectAccessReviewStatus{
+					Allowed: false,
+				},
+			},
+			expectedAllowed: false,
+			expectError:     false,
+		},
+		{
+			name:            "returns error when SSAR API call fails",
+			ssarError:       fmt.Errorf("API server error"),
+			expectedAllowed: false,
+			expectError:     true,
+			errorContains:   "failed to create self subject access review",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Given: fake clientset with SSAR mock
+			fakeClient := k8sfake.NewSimpleClientset()
+			fakeClient.PrependReactor("create", "selfsubjectaccessreviews", func(action testcore.Action) (handled bool, ret runtime.Object, err error) {
+				if tt.ssarError != nil {
+					return true, nil, tt.ssarError
+				}
+				return true, tt.ssarResponse, nil
+			})
+
+			cache := &clusterCache{}
+
+			// When: checking permission for specific namespace
+			allowed, err := cache.checkPermissionForNamespace(
+				context.Background(),
+				fakeClient.AuthorizationV1().SelfSubjectAccessReviews(),
+				api,
+				"test-namespace",
+			)
+
+			// Then: verify results
+			if tt.expectError {
+				assert.ErrorContains(t, err, tt.errorContains)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expectedAllowed, allowed)
 		})
 	}
 }

--- a/gitops-engine/pkg/cache/mocks/ClusterCache.go
+++ b/gitops-engine/pkg/cache/mocks/ClusterCache.go
@@ -41,6 +41,57 @@ func (_m *ClusterCache) EXPECT() *ClusterCache_Expecter {
 	return &ClusterCache_Expecter{mock: &_m.Mock}
 }
 
+// AddNamespace provides a mock function for the type ClusterCache
+func (_mock *ClusterCache) AddNamespace(namespace string) error {
+	ret := _mock.Called(namespace)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddNamespace")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
+		r0 = returnFunc(namespace)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// ClusterCache_AddNamespace_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddNamespace'
+type ClusterCache_AddNamespace_Call struct {
+	*mock.Call
+}
+
+// AddNamespace is a helper method to define mock.On call
+//   - namespace string
+func (_e *ClusterCache_Expecter) AddNamespace(namespace interface{}) *ClusterCache_AddNamespace_Call {
+	return &ClusterCache_AddNamespace_Call{Call: _e.mock.On("AddNamespace", namespace)}
+}
+
+func (_c *ClusterCache_AddNamespace_Call) Run(run func(namespace string)) *ClusterCache_AddNamespace_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *ClusterCache_AddNamespace_Call) Return(err error) *ClusterCache_AddNamespace_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *ClusterCache_AddNamespace_Call) RunAndReturn(run func(namespace string) error) *ClusterCache_AddNamespace_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // EnsureSynced provides a mock function for the type ClusterCache
 func (_mock *ClusterCache) EnsureSynced() error {
 	ret := _mock.Called()
@@ -764,6 +815,57 @@ func (_c *ClusterCache_OnResourceUpdated_Call) Return(unsubscribe cache.Unsubscr
 }
 
 func (_c *ClusterCache_OnResourceUpdated_Call) RunAndReturn(run func(handler cache.OnResourceUpdatedHandler) cache.Unsubscribe) *ClusterCache_OnResourceUpdated_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// RemoveNamespace provides a mock function for the type ClusterCache
+func (_mock *ClusterCache) RemoveNamespace(namespace string) error {
+	ret := _mock.Called(namespace)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveNamespace")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
+		r0 = returnFunc(namespace)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// ClusterCache_RemoveNamespace_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemoveNamespace'
+type ClusterCache_RemoveNamespace_Call struct {
+	*mock.Call
+}
+
+// RemoveNamespace is a helper method to define mock.On call
+//   - namespace string
+func (_e *ClusterCache_Expecter) RemoveNamespace(namespace interface{}) *ClusterCache_RemoveNamespace_Call {
+	return &ClusterCache_RemoveNamespace_Call{Call: _e.mock.On("RemoveNamespace", namespace)}
+}
+
+func (_c *ClusterCache_RemoveNamespace_Call) Run(run func(namespace string)) *ClusterCache_RemoveNamespace_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *ClusterCache_RemoveNamespace_Call) Return(err error) *ClusterCache_RemoveNamespace_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *ClusterCache_RemoveNamespace_Call) RunAndReturn(run func(namespace string) error) *ClusterCache_RemoveNamespace_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/gitops-engine/pkg/cache/settings.go
+++ b/gitops-engine/pkg/cache/settings.go
@@ -73,6 +73,14 @@ func SetClusterResources(val bool) UpdateSettingsFunc {
 	}
 }
 
+// WithIncrementalNamespaceSync enables or disables incremental namespace syncing.
+// When enabled, adding a namespace syncs only that namespace instead of invalidating the entire cache.
+func WithIncrementalNamespaceSync(enabled bool) UpdateSettingsFunc {
+	return func(cache *clusterCache) {
+		cache.incrementalNamespaceSync = enabled
+	}
+}
+
 // SetConfig updates cluster rest config
 func SetConfig(config *rest.Config) UpdateSettingsFunc {
 	return func(cache *clusterCache) {

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,7 @@ github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFI
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/appscode/go v0.0.0-20191119085241-0887d8ec2ecc/go.mod h1:OawnOmAL4ZX3YaPdN+8HTNwBveT1jMsqP74moa9XUbE=
+
 github.com/argoproj/notifications-engine v0.5.1-0.20260119155007-a23b5827d630 h1:naE5KNRTOALjF5nVIGUHrHU5xjlB8QJJiCu+aISIlSs=
 github.com/argoproj/notifications-engine v0.5.1-0.20260119155007-a23b5827d630/go.mod h1:d1RazGXWvKRFv9//rg4MRRR7rbvbE7XLgTSMT5fITTE=
 github.com/argoproj/pkg v0.13.6 h1:36WPD9MNYECHcO1/R1pj6teYspiK7uMQLCgLGft2abM=

--- a/manifests/base/application-controller/argocd-application-controller-statefulset.yaml
+++ b/manifests/base/application-controller/argocd-application-controller-statefulset.yaml
@@ -298,6 +298,12 @@ spec:
               name: argocd-cmd-params-cm
               key: controller.diff.server.side
               optional: true
+        - name: ARGOCD_ENABLE_INCREMENTAL_NAMESPACE_SYNC
+          valueFrom:
+            configMapKeyRef:
+              name: argocd-cmd-params-cm
+              key: controller.incremental.namespace.sync.enabled
+              optional: true
         - name: ARGOCD_IGNORE_NORMALIZER_JQ_TIMEOUT
           valueFrom:
             configMapKeyRef:

--- a/manifests/core-install-with-hydrator.yaml
+++ b/manifests/core-install-with-hydrator.yaml
@@ -32334,6 +32334,12 @@ spec:
               key: controller.diff.server.side
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_ENABLE_INCREMENTAL_NAMESPACE_SYNC
+          valueFrom:
+            configMapKeyRef:
+              key: controller.incremental.namespace.sync.enabled
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_IGNORE_NORMALIZER_JQ_TIMEOUT
           valueFrom:
             configMapKeyRef:

--- a/manifests/core-install-with-hydrator.yaml
+++ b/manifests/core-install-with-hydrator.yaml
@@ -32358,6 +32358,12 @@ spec:
               key: controller.diff.server.side
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_ENABLE_INCREMENTAL_NAMESPACE_SYNC
+          valueFrom:
+            configMapKeyRef:
+              key: controller.incremental.namespace.sync.enabled
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_IGNORE_NORMALIZER_JQ_TIMEOUT
           valueFrom:
             configMapKeyRef:

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -32162,6 +32162,12 @@ spec:
               key: controller.diff.server.side
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_ENABLE_INCREMENTAL_NAMESPACE_SYNC
+          valueFrom:
+            configMapKeyRef:
+              key: controller.incremental.namespace.sync.enabled
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_IGNORE_NORMALIZER_JQ_TIMEOUT
           valueFrom:
             configMapKeyRef:

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -32186,6 +32186,12 @@ spec:
               key: controller.diff.server.side
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_ENABLE_INCREMENTAL_NAMESPACE_SYNC
+          valueFrom:
+            configMapKeyRef:
+              key: controller.incremental.namespace.sync.enabled
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_IGNORE_NORMALIZER_JQ_TIMEOUT
           valueFrom:
             configMapKeyRef:

--- a/manifests/ha/install-with-hydrator.yaml
+++ b/manifests/ha/install-with-hydrator.yaml
@@ -34427,6 +34427,12 @@ spec:
               key: controller.diff.server.side
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_ENABLE_INCREMENTAL_NAMESPACE_SYNC
+          valueFrom:
+            configMapKeyRef:
+              key: controller.incremental.namespace.sync.enabled
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_IGNORE_NORMALIZER_JQ_TIMEOUT
           valueFrom:
             configMapKeyRef:

--- a/manifests/ha/install-with-hydrator.yaml
+++ b/manifests/ha/install-with-hydrator.yaml
@@ -34530,6 +34530,12 @@ spec:
               key: controller.diff.server.side
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_ENABLE_INCREMENTAL_NAMESPACE_SYNC
+          valueFrom:
+            configMapKeyRef:
+              key: controller.incremental.namespace.sync.enabled
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_IGNORE_NORMALIZER_JQ_TIMEOUT
           valueFrom:
             configMapKeyRef:

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -34257,6 +34257,12 @@ spec:
               key: controller.diff.server.side
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_ENABLE_INCREMENTAL_NAMESPACE_SYNC
+          valueFrom:
+            configMapKeyRef:
+              key: controller.incremental.namespace.sync.enabled
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_IGNORE_NORMALIZER_JQ_TIMEOUT
           valueFrom:
             configMapKeyRef:

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -34360,6 +34360,12 @@ spec:
               key: controller.diff.server.side
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_ENABLE_INCREMENTAL_NAMESPACE_SYNC
+          valueFrom:
+            configMapKeyRef:
+              key: controller.incremental.namespace.sync.enabled
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_IGNORE_NORMALIZER_JQ_TIMEOUT
           valueFrom:
             configMapKeyRef:

--- a/manifests/ha/namespace-install-with-hydrator.yaml
+++ b/manifests/ha/namespace-install-with-hydrator.yaml
@@ -3674,6 +3674,12 @@ spec:
               key: controller.diff.server.side
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_ENABLE_INCREMENTAL_NAMESPACE_SYNC
+          valueFrom:
+            configMapKeyRef:
+              key: controller.incremental.namespace.sync.enabled
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_IGNORE_NORMALIZER_JQ_TIMEOUT
           valueFrom:
             configMapKeyRef:

--- a/manifests/ha/namespace-install-with-hydrator.yaml
+++ b/manifests/ha/namespace-install-with-hydrator.yaml
@@ -3753,6 +3753,12 @@ spec:
               key: controller.diff.server.side
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_ENABLE_INCREMENTAL_NAMESPACE_SYNC
+          valueFrom:
+            configMapKeyRef:
+              key: controller.incremental.namespace.sync.enabled
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_IGNORE_NORMALIZER_JQ_TIMEOUT
           valueFrom:
             configMapKeyRef:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -3504,6 +3504,12 @@ spec:
               key: controller.diff.server.side
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_ENABLE_INCREMENTAL_NAMESPACE_SYNC
+          valueFrom:
+            configMapKeyRef:
+              key: controller.incremental.namespace.sync.enabled
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_IGNORE_NORMALIZER_JQ_TIMEOUT
           valueFrom:
             configMapKeyRef:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -3583,6 +3583,12 @@ spec:
               key: controller.diff.server.side
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_ENABLE_INCREMENTAL_NAMESPACE_SYNC
+          valueFrom:
+            configMapKeyRef:
+              key: controller.incremental.namespace.sync.enabled
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_IGNORE_NORMALIZER_JQ_TIMEOUT
           valueFrom:
             configMapKeyRef:

--- a/manifests/install-with-hydrator.yaml
+++ b/manifests/install-with-hydrator.yaml
@@ -33455,6 +33455,12 @@ spec:
               key: controller.diff.server.side
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_ENABLE_INCREMENTAL_NAMESPACE_SYNC
+          valueFrom:
+            configMapKeyRef:
+              key: controller.incremental.namespace.sync.enabled
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_IGNORE_NORMALIZER_JQ_TIMEOUT
           valueFrom:
             configMapKeyRef:

--- a/manifests/install-with-hydrator.yaml
+++ b/manifests/install-with-hydrator.yaml
@@ -33498,6 +33498,12 @@ spec:
               key: controller.diff.server.side
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_ENABLE_INCREMENTAL_NAMESPACE_SYNC
+          valueFrom:
+            configMapKeyRef:
+              key: controller.incremental.namespace.sync.enabled
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_IGNORE_NORMALIZER_JQ_TIMEOUT
           valueFrom:
             configMapKeyRef:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -33283,6 +33283,12 @@ spec:
               key: controller.diff.server.side
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_ENABLE_INCREMENTAL_NAMESPACE_SYNC
+          valueFrom:
+            configMapKeyRef:
+              key: controller.incremental.namespace.sync.enabled
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_IGNORE_NORMALIZER_JQ_TIMEOUT
           valueFrom:
             configMapKeyRef:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -33326,6 +33326,12 @@ spec:
               key: controller.diff.server.side
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_ENABLE_INCREMENTAL_NAMESPACE_SYNC
+          valueFrom:
+            configMapKeyRef:
+              key: controller.incremental.namespace.sync.enabled
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_IGNORE_NORMALIZER_JQ_TIMEOUT
           valueFrom:
             configMapKeyRef:

--- a/manifests/namespace-install-with-hydrator.yaml
+++ b/manifests/namespace-install-with-hydrator.yaml
@@ -2702,6 +2702,12 @@ spec:
               key: controller.diff.server.side
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_ENABLE_INCREMENTAL_NAMESPACE_SYNC
+          valueFrom:
+            configMapKeyRef:
+              key: controller.incremental.namespace.sync.enabled
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_IGNORE_NORMALIZER_JQ_TIMEOUT
           valueFrom:
             configMapKeyRef:

--- a/manifests/namespace-install-with-hydrator.yaml
+++ b/manifests/namespace-install-with-hydrator.yaml
@@ -2721,6 +2721,12 @@ spec:
               key: controller.diff.server.side
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_ENABLE_INCREMENTAL_NAMESPACE_SYNC
+          valueFrom:
+            configMapKeyRef:
+              key: controller.incremental.namespace.sync.enabled
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_IGNORE_NORMALIZER_JQ_TIMEOUT
           valueFrom:
             configMapKeyRef:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -2530,6 +2530,12 @@ spec:
               key: controller.diff.server.side
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_ENABLE_INCREMENTAL_NAMESPACE_SYNC
+          valueFrom:
+            configMapKeyRef:
+              key: controller.incremental.namespace.sync.enabled
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_IGNORE_NORMALIZER_JQ_TIMEOUT
           valueFrom:
             configMapKeyRef:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -2549,6 +2549,12 @@ spec:
               key: controller.diff.server.side
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_ENABLE_INCREMENTAL_NAMESPACE_SYNC
+          valueFrom:
+            configMapKeyRef:
+              key: controller.incremental.namespace.sync.enabled
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_IGNORE_NORMALIZER_JQ_TIMEOUT
           valueFrom:
             configMapKeyRef:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ nav:
   - operator-manual/tls.md
   - operator-manual/cluster-management.md
   - operator-manual/cluster-bootstrapping.md
+  - operator-manual/incremental-namespace-sync.md
   - operator-manual/secret-management.md
   - operator-manual/disaster_recovery.md
   - operator-manual/reconcile.md

--- a/test/e2e/cluster_test.go
+++ b/test/e2e/cluster_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/argoproj/gitops-engine/pkg/health"
-	. "github.com/argoproj/gitops-engine/pkg/sync/common"
+	"github.com/argoproj/argo-cd/gitops-engine/pkg/health"
+	. "github.com/argoproj/argo-cd/gitops-engine/pkg/sync/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/test/e2e/cluster_test.go
+++ b/test/e2e/cluster_test.go
@@ -167,6 +167,26 @@ func TestClusterSet(t *testing.T) {
 		})
 }
 
+func TestClusterSet_WithIncrementalNamespaceSync(t *testing.T) {
+	fixture.EnsureCleanState(t)
+	defer fixture.RecordTestRun(t)
+	t.Setenv("ARGOCD_ENABLE_INCREMENTAL_NAMESPACE_SYNC", "true")
+	clusterFixture.
+		GivenWithSameState(t).
+		Project(fixture.ProjectName).
+		Name("in-cluster").
+		Namespaces([]string{"namespace-edit-1", "namespace-edit-2"}).
+		Server(KubernetesInternalAPIServerAddr).
+		When().
+		SetNamespaces().
+		GetByName("in-cluster").
+		Then().
+		AndCLIOutput(func(output string, _ error) {
+			assert.Contains(t, output, "namespace-edit-1")
+			assert.Contains(t, output, "namespace-edit-2")
+		})
+}
+
 func TestClusterGet(t *testing.T) {
 	fixture.SkipIfAlreadyRun(t)
 	fixture.EnsureCleanState(t)

--- a/test/e2e/cluster_test.go
+++ b/test/e2e/cluster_test.go
@@ -32,7 +32,7 @@ https://kubernetes.default.svc  in-cluster  %v  Successful           `, fixture.
 
 	// We need an application targeting the cluster, otherwise the test will
 	// fail if run isolated.
-	app.GivenWithSameState(ctx).
+	GivenWithSameState(ctx).
 		Path(guestbookPath).
 		When().
 		CreateApp()
@@ -172,20 +172,19 @@ func TestClusterSet(t *testing.T) {
 func TestClusterIncrementalAddNamespace(t *testing.T) {
 	// Given: cluster with 1 deployed app in 1 namespace and incremental
 	// namespace sync is enabled
-	fixture.EnsureCleanState(t)
-	t.Cleanup(func() { fixture.RecordTestRun(t) })
-	existingNs := fixture.DeploymentNamespace()
+	testCtx := fixture.EnsureCleanState(t)
+	existingNs := testCtx.DeploymentNamespace()
 	newNs := "new-ns"
 	t.Setenv("ARGOCD_ENABLE_INCREMENTAL_NAMESPACE_SYNC", "true")
 	clusterFixture.
-		GivenWithSameState(t).
+		GivenWithSameState(testCtx).
 		Project(fixture.ProjectName).
 		Name("in-cluster").
 		Namespaces([]string{existingNs}).
 		Server(KubernetesInternalAPIServerAddr).
 		When().
 		SetNamespaces()
-	GivenWithSameState(t).
+	GivenWithSameState(testCtx).
 		Name("app-1").
 		Path(guestbookPath).
 		When().
@@ -203,14 +202,14 @@ func TestClusterIncrementalAddNamespace(t *testing.T) {
 		errors.NewHandler(t).FailOnErr(fixture.Run("", "kubectl", "delete", "namespace", newNs, "--ignore-not-found=true"))
 	})
 	clusterFixture.
-		GivenWithSameState(t).
+		GivenWithSameState(testCtx).
 		Project(fixture.ProjectName).
 		Name("in-cluster").
 		Namespaces([]string{existingNs, newNs}).
 		Server(KubernetesInternalAPIServerAddr).
 		When().
 		SetNamespaces()
-	GivenWithSameState(t).
+	GivenWithSameState(testCtx).
 		Name("app-2").
 		Path(guestbookPath).
 		When().
@@ -218,14 +217,14 @@ func TestClusterIncrementalAddNamespace(t *testing.T) {
 		Sync()
 
 	// Then: both the new app and the existing app are healthy and synced
-	GivenWithSameState(t).
+	GivenWithSameState(testCtx).
 		Name("app-2").
 		When().
 		Then().
 		Expect(OperationPhaseIs(OperationSucceeded)).
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		Expect(HealthIs(health.HealthStatusHealthy))
-	GivenWithSameState(t).
+	GivenWithSameState(testCtx).
 		Name("app-1").
 		When().
 		Then().
@@ -236,9 +235,8 @@ func TestClusterIncrementalAddNamespace(t *testing.T) {
 func TestClusterIncrementalRemoveNamespace(t *testing.T) {
 	// Given: cluster with 2 namespaces, each with a deployed app and
 	// incremental namespace sync is enabled
-	fixture.EnsureCleanState(t)
-	t.Cleanup(func() { fixture.RecordTestRun(t) })
-	existingNs := fixture.DeploymentNamespace()
+	testCtx := fixture.EnsureCleanState(t)
+	existingNs := testCtx.DeploymentNamespace()
 	removableNs := "removable-ns"
 	t.Setenv("ARGOCD_ENABLE_INCREMENTAL_NAMESPACE_SYNC", "true")
 	errors.NewHandler(t).FailOnErr(fixture.Run("", "kubectl", "create", "namespace", removableNs))
@@ -246,14 +244,14 @@ func TestClusterIncrementalRemoveNamespace(t *testing.T) {
 		errors.NewHandler(t).FailOnErr(fixture.Run("", "kubectl", "delete", "namespace", removableNs, "--ignore-not-found=true"))
 	})
 	clusterFixture.
-		GivenWithSameState(t).
+		GivenWithSameState(testCtx).
 		Project(fixture.ProjectName).
 		Name("in-cluster").
 		Namespaces([]string{existingNs, removableNs}).
 		Server(KubernetesInternalAPIServerAddr).
 		When().
 		SetNamespaces()
-	GivenWithSameState(t).
+	GivenWithSameState(testCtx).
 		Name("app-1").
 		Path(guestbookPath).
 		When().
@@ -263,7 +261,7 @@ func TestClusterIncrementalRemoveNamespace(t *testing.T) {
 		Expect(OperationPhaseIs(OperationSucceeded)).
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		Expect(HealthIs(health.HealthStatusHealthy))
-	GivenWithSameState(t).
+	GivenWithSameState(testCtx).
 		Name("app-2").
 		Path(guestbookPath).
 		When().
@@ -276,7 +274,7 @@ func TestClusterIncrementalRemoveNamespace(t *testing.T) {
 
 	// When: One namespace is removed from the cluster configuration
 	clusterFixture.
-		GivenWithSameState(t).
+		GivenWithSameState(testCtx).
 		Project(fixture.ProjectName).
 		Name("in-cluster").
 		Namespaces([]string{existingNs}).
@@ -287,15 +285,16 @@ func TestClusterIncrementalRemoveNamespace(t *testing.T) {
 	// Then: the namespace is removed from config and the app in the
 	// remaining namespace is still healthy and synced
 	clusterFixture.
-		GivenWithSameState(t).
+		GivenWithSameState(testCtx).
+		Name("in-cluster").
 		When().
-		GetByName("in-cluster").
+		GetByName().
 		Then().
 		AndCLIOutput(func(output string, _ error) {
 			assert.Contains(t, output, existingNs)
 			assert.NotContains(t, output, removableNs)
 		})
-	GivenWithSameState(t).
+	GivenWithSameState(testCtx).
 		Name("app-1").
 		When().
 		Then().

--- a/test/e2e/fixture/cluster/context.go
+++ b/test/e2e/fixture/cluster/context.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v3/test/e2e/fixture"
 )
 
@@ -33,6 +34,10 @@ func GivenWithSameState(ctx fixture.TestContext) *Context {
 }
 
 func (c *Context) Name(name string) *Context {
+	if name == v1alpha1.KubernetesInClusterName {
+		c.SetNameRaw(name)
+		return c
+	}
 	c.SetName(name)
 	return c
 }

--- a/test/e2e/fixture/context.go
+++ b/test/e2e/fixture/context.go
@@ -73,7 +73,7 @@ func NewTestStateFromContext(ctx TestContext) *TestState {
 	}
 }
 
-// Name sets the DNS-friendly name for this context
+// SetName sets the DNS-friendly name for this context, appending the short ID suffix.
 func (s *TestState) SetName(name string) {
 	if name == "" {
 		s.name = ""
@@ -81,6 +81,12 @@ func (s *TestState) SetName(name string) {
 	}
 	suffix := "-" + s.shortId
 	s.name = DnsFriendly(strings.TrimSuffix(name, suffix), suffix)
+}
+
+// SetNameRaw sets the name without appending a suffix.
+// Use this for well-known names (e.g. "in-cluster") that must not be modified.
+func (s *TestState) SetNameRaw(name string) {
+	s.name = name
 }
 
 // GetName returns the DNS-friendly name for this context


### PR DESCRIPTION
## Incremental Namespace Sync - Alpha Feature

Closes #23806

This PR introduces **incremental namespace synchronization** for Argo CD clusters, optimizing cluster cache updates when namespaces are added or removed from cluster configurations. It is implemented behind a feature flag and stays fully-backwards compatible.

### Problem Statement

Currently, when Argo CD detects namespace changes in a cluster configuration, it invalidates the entire cluster cache and performs a full resync of all namespaces. For **namespace-mode** clusters with many namespaces (100+), this can be slow and resource-intensive:

- Requires listing all resources across all namespaces
- Re-establishes all watches (one per namespace per API)
- Blocks application reconciliation during the entire sync operation
- Generates significant API server load

I have added a [script](https://github.com/tricktron/argo-cd/blob/24562a21ac0bbf69b5d07c3f44c673d0b822e5d6/benchmark/README.md) to easily reproduce the problem and test this feature in a local Kind cluster.

### Solution

This PR implements incremental namespace sync using a diff-based approach:

1. **Namespace change detection** - Compare desired vs current namespace sets
2. **Targeted updates** - Only sync added/removed namespaces
3. **Cache preservation** - Keep existing namespace caches intact
4. **Graceful fallback** - Revert to full invalidation on errors

### Implementation Details

The main idea is that we Introduces a new namespace specific watch and cancel data structure where the namespace-specific contexts depend on the existing global API resource contexts so that the full cluster invalidation API context cancellation propagates to the namespace-specific contexts.

**Gitops-Engine Layer** (`gitops-engine/pkg/cache/cluster.go`):
- `AddNamespace(namespace string) error` - Incrementally adds namespace and syncs its resources
- `RemoveNamespace(namespace string) error` - Incrementally removes namespace and its resources
- `WithIncrementalNamespaceSync(enabled bool)` - Feature flag option
- Per-namespace watch contexts for selective cancellation

**Controller Layer** (`controller/cache/cache.go`):
- `handleNamespaceChanges()` - Detects namespace diffs and calls engine APIs
- Feature flag: `ARGOCD_ENABLE_INCREMENTAL_NAMESPACE_SYNC` (opt-in)
- CLI flag: `--incremental-namespace-sync-enabled`
- Automatic fallback to full invalidation on errors

### Testing

**Unit tests** (`gitops-engine/pkg/cache/cluster_incremental_sync_test.go`):
- ✅ AddNamespace with feature enabled/disabled
- ✅ RemoveNamespace with feature enabled/disabled
- ✅ Resource syncing and watch management
- ✅ Error handling and fallback behavior
- ✅ Race condition detection

**Integration tests** (`controller/cache/cache_test.go`):
- ✅ Namespace additions with incremental sync
- ✅ Namespace removals with incremental sync
- ✅ Simultaneous add/remove operations
- ✅ Error handling with fallback
- ✅ Backward compatibility (feature disabled)

**E2E tests** (`test/e2e/cluster_test.go`):
- ✅ `TestClusterIncrementalAddNamespace` - Multi-app cluster with namespace addition
- ✅ `TestClusterIncrementalRemoveNamespace` - Multi-app cluster with namespace removal

### Documentation

- ✅ Operator manual: `docs/operator-manual/incremental-namespace-sync.md`

Checklist:

* [] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
