### PR TITLE
fix(controller): apply HideSecretData to server-side diff results for Secrets (#25260)

### DIFF
--- a/controller/sync.go
+++ b/controller/sync.go
@@ -102,14 +102,24 @@ func (s *secretNormalizingApplier) ApplyResource(ctx context.Context, obj *unstr
 		return result, err
 	}
 
+	isCoreSecret := obj.GetKind() == kube.SecretKind && (obj.GroupVersionKind().Group == "" || obj.GroupVersionKind().Group == "core")
+	if dryRunStrategy != cmdutil.DryRunServer || !isCoreSecret {
+		return result, nil
+	}
+
+	trimmedResult := strings.TrimSpace(result)
+	if !strings.HasPrefix(trimmedResult, "{") {
+		return result, nil
+	}
+
 	resultObj := &unstructured.Unstructured{}
 	if err := json.Unmarshal([]byte(result), resultObj); err != nil {
-		return result, err
+		return result, nil
 	}
 
 	// Apply hideSecretData
-	if resultObj.GetKind() == kube.SecretKind && resultObj.GroupVersionKind().Group == "" {
-		_, normalized, err := gitopsDiff.HideSecretData(nil, resultObj, s.settingsMgr.GetSensitiveAnnotations())
+	if resultObj.GetKind() == kube.SecretKind && (resultObj.GroupVersionKind().Group == "" || resultObj.GroupVersionKind().Group == "core") {
+		_, normalized, err := gitopsDiff.HideSecretData(obj, resultObj, s.settingsMgr.GetSensitiveAnnotations())
 		if err != nil {
 			return result, fmt.Errorf("error normalizing secret data: %w", err)
 		}

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -84,8 +84,8 @@ func (m *appStateManager) getServerSideDiffDryRunApplier(cluster *v1alpha1.Clust
 	}
 
 	wrappedOps := &secretNormalizingApplier{
-		inner:       ops,
-		settingsMgr: m.settingsMgr,
+		inner:                ops,
+		sensitiveAnnotations: m.settingsMgr.GetSensitiveAnnotations(),
 	}
 
 	return wrappedOps, cleanup, nil
@@ -93,8 +93,8 @@ func (m *appStateManager) getServerSideDiffDryRunApplier(cluster *v1alpha1.Clust
 
 // secretNormalizingApplier wraps a KubeApplier to normalize Secret data
 type secretNormalizingApplier struct {
-	inner       gitopsDiff.KubeApplier
-	settingsMgr *settings.SettingsManager
+	inner                gitopsDiff.KubeApplier
+	sensitiveAnnotations map[string]bool
 }
 
 func (s *secretNormalizingApplier) ApplyResource(ctx context.Context, obj *unstructured.Unstructured, dryRunStrategy cmdutil.DryRunStrategy, force, validate, serverSideApply bool, manager string) (string, error) {
@@ -103,7 +103,7 @@ func (s *secretNormalizingApplier) ApplyResource(ctx context.Context, obj *unstr
 		return result, err
 	}
 
-	isCoreSecret := obj.GetKind() == kube.SecretKind && (obj.GroupVersionKind().Group == "" || obj.GroupVersionKind().Group == "core")
+	isCoreSecret := obj.GetKind() == kube.SecretKind && obj.GroupVersionKind().Group == ""
 	if dryRunStrategy != cmdutil.DryRunServer || !isCoreSecret {
 		return result, nil
 	}
@@ -119,8 +119,8 @@ func (s *secretNormalizingApplier) ApplyResource(ctx context.Context, obj *unstr
 	}
 
 	// Apply hideSecretData
-	if resultObj.GetKind() == kube.SecretKind && (resultObj.GroupVersionKind().Group == "" || resultObj.GroupVersionKind().Group == "core") {
-		_, normalized, err := gitopsDiff.HideSecretData(obj, resultObj, s.settingsMgr.GetSensitiveAnnotations())
+	if resultObj.GetKind() == kube.SecretKind && resultObj.GroupVersionKind().Group == "" {
+		_, normalized, err := gitopsDiff.HideSecretData(obj, resultObj, s.sensitiveAnnotations)
 		if err != nil {
 			return result, fmt.Errorf("error normalizing secret data: %w", err)
 		}

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	stderrors "errors"
 	"fmt"
 	"os"
@@ -13,6 +14,8 @@ import (
 	cdcommon "github.com/argoproj/argo-cd/v3/common"
 
 	gitopsDiff "github.com/argoproj/argo-cd/gitops-engine/pkg/diff"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+
 	"github.com/argoproj/argo-cd/gitops-engine/pkg/sync"
 	"github.com/argoproj/argo-cd/gitops-engine/pkg/sync/common"
 	"github.com/argoproj/argo-cd/gitops-engine/pkg/utils/kube"
@@ -78,7 +81,47 @@ func (m *appStateManager) getServerSideDiffDryRunApplier(cluster *v1alpha1.Clust
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating kubectl ResourceOperations: %w", err)
 	}
-	return ops, cleanup, nil
+
+	wrappedOps := &secretNormalizingApplier{
+		inner:       ops,
+		settingsMgr: m.settingsMgr,
+	}
+
+	return wrappedOps, cleanup, nil
+}
+
+// secretNormalizingApplier wraps a KubeApplier to normalize Secret data
+type secretNormalizingApplier struct {
+	inner       gitopsDiff.KubeApplier
+	settingsMgr *settings.SettingsManager
+}
+
+func (s *secretNormalizingApplier) ApplyResource(ctx context.Context, obj *unstructured.Unstructured, dryRunStrategy cmdutil.DryRunStrategy, force, validate, serverSideApply bool, manager string) (string, error) {
+	result, err := s.inner.ApplyResource(ctx, obj, dryRunStrategy, force, validate, serverSideApply, manager)
+	if err != nil {
+		return result, err
+	}
+
+	resultObj := &unstructured.Unstructured{}
+	if err := json.Unmarshal([]byte(result), resultObj); err != nil {
+		return result, err
+	}
+
+	// Apply hideSecretData
+	if resultObj.GetKind() == kube.SecretKind && resultObj.GroupVersionKind().Group == "" {
+		_, normalized, err := gitopsDiff.HideSecretData(nil, resultObj, s.settingsMgr.GetSensitiveAnnotations())
+		if err != nil {
+			return result, fmt.Errorf("error normalizing secret data: %w", err)
+		}
+
+		normalizedBytes, err := json.Marshal(normalized)
+		if err != nil {
+			return result, fmt.Errorf("error marshaling normalized secret: %w", err)
+		}
+		return string(normalizedBytes), nil
+	}
+
+	return result, nil
 }
 
 func NewOperationState(operation v1alpha1.Operation) *v1alpha1.OperationState {

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/strategicpatch"

--- a/controller/sync_test.go
+++ b/controller/sync_test.go
@@ -27,8 +27,6 @@ import (
 	"github.com/argoproj/argo-cd/v3/util/argo/normalizers"
 	"github.com/argoproj/argo-cd/v3/util/settings"
 
-	gitopsDiff "github.com/argoproj/argo-cd/gitops-engine/pkg/diff"
-	kubefake "k8s.io/client-go/kubernetes/fake"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
@@ -1777,23 +1775,11 @@ func TestValidateSyncPermissions(t *testing.T) {
 }
 
 func TestSecretNormalizingApplier(t *testing.T) {
-	kubeclientset := kubefake.NewSimpleClientset(&corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "argocd",
-			Name:      "argocd-cm",
-			Labels: map[string]string{
-				"app.kubernetes.io/part-of": "argocd",
-			},
-		},
-	}, &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "argocd-secret",
-			Namespace: "argocd",
-		},
-	})
-
 	ctx := t.Context()
-	settingsMgr := settings.NewSettingsManager(ctx, kubeclientset, "argocd")
+
+	sensitiveAnnots := map[string]bool{
+		"my-custom-sensitive-field": true,
+	}
 
 	desired := &unstructured.Unstructured{
 		Object: map[string]any{
@@ -1802,44 +1788,27 @@ func TestSecretNormalizingApplier(t *testing.T) {
 			"metadata": map[string]any{
 				"name":      "test-secret",
 				"namespace": "default",
+				"annotations": map[string]any{
+					"my-custom-sensitive-field": "very-secret-value",
+				},
 			},
 			"type": "Opaque",
 			"data": map[string]any{
-				"password": base64.StdEncoding.EncodeToString([]byte("vault:test/data/test#TEST")),
-			},
-		},
-	}
-
-	live := &unstructured.Unstructured{
-		Object: map[string]any{
-			"apiVersion": "v1",
-			"kind":       "Secret",
-			"metadata": map[string]any{
-				"name":      "test-secret",
-				"namespace": "default",
-			},
-			"type": "Opaque",
-			"data": map[string]any{
-				"password": base64.StdEncoding.EncodeToString([]byte("actual-password-from-vault")),
+				"password": base64.StdEncoding.EncodeToString([]byte("actual-password")),
 			},
 		},
 	}
 
 	mockApplier := &simpleKubeApplier{
 		applyResult: func(obj *unstructured.Unstructured) string {
-			if obj.GetKind() == "Secret" {
-				result := live.DeepCopy()
-				bytes, _ := json.Marshal(result)
-				return string(bytes)
-			}
 			bytes, _ := json.Marshal(obj)
 			return string(bytes)
 		},
 	}
 
 	normalizer := &secretNormalizingApplier{
-		inner:       mockApplier,
-		settingsMgr: settingsMgr,
+		inner:                mockApplier,
+		sensitiveAnnotations: sensitiveAnnots,
 	}
 
 	t.Run("core v1 secret is normalized during dry run", func(t *testing.T) {
@@ -1850,52 +1819,16 @@ func TestSecretNormalizingApplier(t *testing.T) {
 			false, false, true, "argocd",
 		)
 		require.NoError(t, err)
-		assert.Contains(t, result, "Secret")
 
-		// verify that the result is normalized
 		resultObj := &unstructured.Unstructured{}
 		err = json.Unmarshal([]byte(result), resultObj)
 		require.NoError(t, err)
 
-		assert.Equal(t, "Secret", resultObj.GetKind())
-		assert.Equal(t, "test-secret", resultObj.GetName())
+		data, _, _ := unstructured.NestedMap(resultObj.Object, "data")
+		assert.Equal(t, "++++++++", data["password"], "Secret data should be masked with asterisks")
 
-		// verify that HideSecretData was applied
-		data, found, err := unstructured.NestedMap(resultObj.Object, "data")
-		require.NoError(t, err)
-		assert.True(t, found, "data field should exist")
-
-		// password should exist, but may be normalized
-		_, passwordExists := data["password"]
-		assert.True(t, passwordExists, "password should exist after normalization")
-		assert.NotEqual(t, live.Object["data"], data, "secret data should be normalized/masked")
-
-		// normalize both using HideSecretData
-		_, normalizedGit, err := gitopsDiff.HideSecretData(nil, desired, settingsMgr.GetSensitiveAnnotations())
-		require.NoError(t, err)
-
-		_, normalizedResult, err := gitopsDiff.HideSecretData(nil, resultObj, settingsMgr.GetSensitiveAnnotations())
-		require.NoError(t, err)
-
-		// diff between normalized secrets
-		diffResult, _ := gitopsDiff.Diff(normalizedGit, normalizedResult)
-
-		// verify that there is NO diff after normalization (mutation webhook changes don't cause OutOfSync)
-		assert.False(t, diffResult.Modified, "normalized secrets should not show as modified")
-		if diffResult.Modified {
-			t.Logf("NormalizedLive: %s", string(diffResult.NormalizedLive))
-			t.Logf("PredictedLive: %s", string(diffResult.PredictedLive))
-		}
-
-		// both have the same structure
-		gitData, _, _ := unstructured.NestedMap(normalizedGit.Object, "data")
-		resultData, _, _ := unstructured.NestedMap(normalizedResult.Object, "data")
-
-		// should have password after normalization
-		_, gitHasPassword := gitData["password"]
-		_, resultHasPassword := resultData["password"]
-		assert.True(t, gitHasPassword, "git secret should have password field after normalization")
-		assert.True(t, resultHasPassword, "result secret should have password field after normalization")
+		annotations := resultObj.GetAnnotations()
+		assert.Equal(t, "++++++++", annotations["my-custom-sensitive-field"], "Sensitive annotations should be masked")
 	})
 
 	t.Run("non-json result is returned unchanged", func(t *testing.T) {
@@ -1906,12 +1839,12 @@ func TestSecretNormalizingApplier(t *testing.T) {
 
 		result, err := normalizer.ApplyResource(ctx, desired, cmdutil.DryRunServer, false, false, true, "argocd")
 		require.NoError(t, err)
-		assert.Equal(t, nonJSON, result, "wrapper should return non-json result without error") //nolint:testifylint
+		assert.Equal(t, nonJSON, result)
 	})
 
 	t.Run("non-core group secret is not normalized", func(t *testing.T) {
 		customSecret := desired.DeepCopy()
-		customSecret.SetAPIVersion("custom.io/v1")
+		customSecret.SetAPIVersion("custom.io/v1") // Group이 ""이 아님
 
 		mockApplier.applyResult = func(obj *unstructured.Unstructured) string {
 			bytes, _ := json.Marshal(obj)
@@ -1925,15 +1858,12 @@ func TestSecretNormalizingApplier(t *testing.T) {
 		err = json.Unmarshal([]byte(result), resultObj)
 		require.NoError(t, err)
 
-		assert.Equal(t, customSecret.Object["data"], resultObj.Object["data"], "non-core secret should not be modified")
+		// 데이터가 변하지 않았음을 확인
+		assert.Equal(t, customSecret.Object["data"], resultObj.Object["data"])
+		assert.Equal(t, "very-secret-value", resultObj.GetAnnotations()["my-custom-sensitive-field"])
 	})
 
 	t.Run("normalization is skipped for non-dry run server", func(t *testing.T) {
-		mockApplier.applyResult = func(_ *unstructured.Unstructured) string {
-			bytes, _ := json.Marshal(live)
-			return string(bytes)
-		}
-
 		result, err := normalizer.ApplyResource(ctx, desired, cmdutil.DryRunNone, false, false, true, "argocd")
 		require.NoError(t, err)
 
@@ -1941,7 +1871,8 @@ func TestSecretNormalizingApplier(t *testing.T) {
 		err = json.Unmarshal([]byte(result), resultObj)
 		require.NoError(t, err)
 
-		assert.Equal(t, live.Object["data"], resultObj.Object["data"])
+		// DryRun이 아니면 마스킹 되지 않아야 함
+		assert.Equal(t, desired.Object["data"], resultObj.Object["data"])
 	})
 }
 

--- a/controller/sync_test.go
+++ b/controller/sync_test.go
@@ -1839,12 +1839,12 @@ func TestSecretNormalizingApplier(t *testing.T) {
 
 		result, err := normalizer.ApplyResource(ctx, desired, cmdutil.DryRunServer, false, false, true, "argocd")
 		require.NoError(t, err)
-		assert.Equal(t, nonJSON, result)
+		assert.Equal(t, nonJSON, result) //nolint:testifylint
 	})
 
 	t.Run("non-core group secret is not normalized", func(t *testing.T) {
 		customSecret := desired.DeepCopy()
-		customSecret.SetAPIVersion("custom.io/v1") // Group이 ""이 아님
+		customSecret.SetAPIVersion("custom.io/v1")
 
 		mockApplier.applyResult = func(obj *unstructured.Unstructured) string {
 			bytes, _ := json.Marshal(obj)
@@ -1858,7 +1858,6 @@ func TestSecretNormalizingApplier(t *testing.T) {
 		err = json.Unmarshal([]byte(result), resultObj)
 		require.NoError(t, err)
 
-		// 데이터가 변하지 않았음을 확인
 		assert.Equal(t, customSecret.Object["data"], resultObj.Object["data"])
 		assert.Equal(t, "very-secret-value", resultObj.GetAnnotations()["my-custom-sensitive-field"])
 	})
@@ -1871,7 +1870,6 @@ func TestSecretNormalizingApplier(t *testing.T) {
 		err = json.Unmarshal([]byte(result), resultObj)
 		require.NoError(t, err)
 
-		// DryRun이 아니면 마스킹 되지 않아야 함
 		assert.Equal(t, desired.Object["data"], resultObj.Object["data"])
 	})
 }

--- a/controller/sync_test.go
+++ b/controller/sync_test.go
@@ -1822,30 +1822,30 @@ func TestSecretNormalizingApplier(t *testing.T) {
 	settingsMgr := settings.NewSettingsManager(ctx, kubeclientset, "argocd")
 
 	desired := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "v1",
 			"kind":       "Secret",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "test-secret",
 				"namespace": "default",
 			},
 			"type": "Opaque",
-			"data": map[string]interface{}{
+			"data": map[string]any{
 				"password": base64.StdEncoding.EncodeToString([]byte("vault:test/data/test#TEST")),
 			},
 		},
 	}
 
 	live := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "v1",
 			"kind":       "Secret",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "test-secret",
 				"namespace": "default",
 			},
 			"type": "Opaque",
-			"data": map[string]interface{}{
+			"data": map[string]any{
 				"password": base64.StdEncoding.EncodeToString([]byte("actual-password-from-vault")),
 			},
 		},
@@ -1927,10 +1927,10 @@ type simpleKubeApplier struct {
 	applyResult func(*unstructured.Unstructured) string
 }
 
-func (s *simpleKubeApplier) ApplyResource(_ context.Context, obj *unstructured.Unstructured, dryRunStrategy cmdutil.DryRunStrategy, force, validate, serverSideApply bool, manager string) (string, error) {
+func (s *simpleKubeApplier) ApplyResource(_ context.Context, obj *unstructured.Unstructured, _ cmdutil.DryRunStrategy, force, validate, serverSideApply bool, manager string) (string, error) {
 	return s.applyResult(obj), nil
 }
 
-func (s *simpleKubeApplier) ConvertToVersion(obj *unstructured.Unstructured, _, version string) (*unstructured.Unstructured, error) {
+func (s *simpleKubeApplier) ConvertToVersion(obj *unstructured.Unstructured, _, _ string) (*unstructured.Unstructured, error) {
 	return obj, nil
 }

--- a/controller/sync_test.go
+++ b/controller/sync_test.go
@@ -1818,7 +1818,7 @@ func TestSecretNormalizingApplier(t *testing.T) {
 		},
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	settingsMgr := settings.NewSettingsManager(ctx, kubeclientset, "argocd")
 
 	desired := &unstructured.Unstructured{
@@ -1869,7 +1869,7 @@ func TestSecretNormalizingApplier(t *testing.T) {
 	}
 
 	result, err := normalizer.ApplyResource(
-		context.Background(),
+		t.Context(),
 		desired,
 		cmdutil.DryRunServer,
 		false, false, true, "argocd",
@@ -1927,10 +1927,10 @@ type simpleKubeApplier struct {
 	applyResult func(*unstructured.Unstructured) string
 }
 
-func (s *simpleKubeApplier) ApplyResource(ctx context.Context, obj *unstructured.Unstructured, dryRunStrategy cmdutil.DryRunStrategy, force, validate, serverSideApply bool, manager string) (string, error) {
+func (s *simpleKubeApplier) ApplyResource(_ context.Context, obj *unstructured.Unstructured, dryRunStrategy cmdutil.DryRunStrategy, force, validate, serverSideApply bool, manager string) (string, error) {
 	return s.applyResult(obj), nil
 }
 
-func (s *simpleKubeApplier) ConvertToVersion(obj *unstructured.Unstructured, group, version string) (*unstructured.Unstructured, error) {
+func (s *simpleKubeApplier) ConvertToVersion(obj *unstructured.Unstructured, _, version string) (*unstructured.Unstructured, error) {
 	return obj, nil
 }

--- a/controller/sync_test.go
+++ b/controller/sync_test.go
@@ -1927,7 +1927,7 @@ type simpleKubeApplier struct {
 	applyResult func(*unstructured.Unstructured) string
 }
 
-func (s *simpleKubeApplier) ApplyResource(_ context.Context, obj *unstructured.Unstructured, _ cmdutil.DryRunStrategy, force, validate, serverSideApply bool, manager string) (string, error) {
+func (s *simpleKubeApplier) ApplyResource(_ context.Context, obj *unstructured.Unstructured, _ cmdutil.DryRunStrategy, _, _, _ bool, _ string) (string, error) {
 	return s.applyResult(obj), nil
 }
 

--- a/controller/sync_test.go
+++ b/controller/sync_test.go
@@ -1925,14 +1925,14 @@ func TestSecretNormalizingApplier(t *testing.T) {
 	})
 
 	t.Run("non-json result is returned unchanged", func(t *testing.T) {
-		nonJSON := "kubectl applied (dry-run)"
-		mockApplier.applyResult = func(obj *unstructured.Unstructured) string {
+		nonJSON := "kubectl applied dry-run"
+		mockApplier.applyResult = func(_ *unstructured.Unstructured) string {
 			return nonJSON
 		}
 
 		result, err := normalizer.ApplyResource(ctx, desired, cmdutil.DryRunServer, false, false, true, "argocd")
-		assert.NoError(t, err)
-		assert.Equal(t, nonJSON, result, "wrapper should return non-json result without error")
+		require.NoError(t, err)
+		assert.Equal(t, nonJSON, result, "wrapper should return non-json result without error") //nolint:testifylint
 	})
 
 	t.Run("non-core group secret is not normalized", func(t *testing.T) {
@@ -1945,24 +1945,28 @@ func TestSecretNormalizingApplier(t *testing.T) {
 		}
 
 		result, err := normalizer.ApplyResource(ctx, customSecret, cmdutil.DryRunServer, false, false, true, "argocd")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		resultObj := &unstructured.Unstructured{}
-		json.Unmarshal([]byte(result), resultObj)
+		err = json.Unmarshal([]byte(result), resultObj)
+		require.NoError(t, err)
+
 		assert.Equal(t, customSecret.Object["data"], resultObj.Object["data"], "non-core secret should not be modified")
 	})
 
 	t.Run("normalization is skipped for non-dry run server", func(t *testing.T) {
-		mockApplier.applyResult = func(obj *unstructured.Unstructured) string {
+		mockApplier.applyResult = func(_ *unstructured.Unstructured) string {
 			bytes, _ := json.Marshal(live)
 			return string(bytes)
 		}
 
 		result, err := normalizer.ApplyResource(ctx, desired, cmdutil.DryRunNone, false, false, true, "argocd")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		resultObj := &unstructured.Unstructured{}
-		json.Unmarshal([]byte(result), resultObj)
+		err = json.Unmarshal([]byte(result), resultObj)
+		require.NoError(t, err)
+
 		assert.Equal(t, live.Object["data"], resultObj.Object["data"])
 	})
 }

--- a/controller/sync_test.go
+++ b/controller/sync_test.go
@@ -32,7 +32,6 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
-
 func TestPersistRevisionHistory(t *testing.T) {
 	app := newFakeApp()
 	app.Status.OperationState = nil

--- a/controller/sync_test.go
+++ b/controller/sync_test.go
@@ -1868,59 +1868,103 @@ func TestSecretNormalizingApplier(t *testing.T) {
 		settingsMgr: settingsMgr,
 	}
 
-	result, err := normalizer.ApplyResource(
-		t.Context(),
-		desired,
-		cmdutil.DryRunServer,
-		false, false, true, "argocd",
-	)
+	t.Run("core v1 secret is normalized during dry run", func(t *testing.T) {
+		result, err := normalizer.ApplyResource(
+			ctx,
+			desired,
+			cmdutil.DryRunServer,
+			false, false, true, "argocd",
+		)
+		require.NoError(t, err)
+		assert.Contains(t, result, "Secret")
 
-	require.NoError(t, err)
-	assert.Contains(t, result, "Secret")
+		// verify that the result is normalized
+		resultObj := &unstructured.Unstructured{}
+		err = json.Unmarshal([]byte(result), resultObj)
+		require.NoError(t, err)
 
-	// verify that the result is normalized
-	resultObj := &unstructured.Unstructured{}
-	err = json.Unmarshal([]byte(result), resultObj)
-	require.NoError(t, err)
+		assert.Equal(t, "Secret", resultObj.GetKind())
+		assert.Equal(t, "test-secret", resultObj.GetName())
 
-	assert.Equal(t, "Secret", resultObj.GetKind())
-	assert.Equal(t, "test-secret", resultObj.GetName())
+		// verify that HideSecretData was applied
+		data, found, err := unstructured.NestedMap(resultObj.Object, "data")
+		require.NoError(t, err)
+		assert.True(t, found, "data field should exist")
 
-	// verify that HideSecretData was applied
-	data, found, err := unstructured.NestedMap(resultObj.Object, "data")
-	require.NoError(t, err)
-	assert.True(t, found, "data field should exist")
+		// password should exist, but may be normalized
+		_, passwordExists := data["password"]
+		assert.True(t, passwordExists, "password should exist after normalization")
+		assert.NotEqual(t, live.Object["data"], data, "secret data should be normalized/masked")
 
-	// password should exist, but may be normalized
-	_, passwordExists := data["password"]
-	assert.True(t, passwordExists, "password should exist after normalization")
+		// normalize both using HideSecretData
+		_, normalizedGit, err := gitopsDiff.HideSecretData(nil, desired, settingsMgr.GetSensitiveAnnotations())
+		require.NoError(t, err)
 
-	// normalize both using HideSecretData
-	_, normalizedGit, err := gitopsDiff.HideSecretData(nil, desired, settingsMgr.GetSensitiveAnnotations())
-	require.NoError(t, err)
+		_, normalizedResult, err := gitopsDiff.HideSecretData(nil, resultObj, settingsMgr.GetSensitiveAnnotations())
+		require.NoError(t, err)
 
-	_, normalizedResult, err := gitopsDiff.HideSecretData(nil, resultObj, settingsMgr.GetSensitiveAnnotations())
-	require.NoError(t, err)
+		// diff between normalized secrets
+		diffResult, _ := gitopsDiff.Diff(normalizedGit, normalizedResult)
 
-	// diff between normalized secrets
-	diffResult, _ := gitopsDiff.Diff(normalizedGit, normalizedResult)
+		// verify that there is NO diff after normalization (mutation webhook changes don't cause OutOfSync)
+		assert.False(t, diffResult.Modified, "normalized secrets should not show as modified")
+		if diffResult.Modified {
+			t.Logf("NormalizedLive: %s", string(diffResult.NormalizedLive))
+			t.Logf("PredictedLive: %s", string(diffResult.PredictedLive))
+		}
 
-	// verify that there is NO diff after normalization (mutation webhook changes don't cause OutOfSync)
-	assert.False(t, diffResult.Modified, "normalized secrets should not show as modified")
-	if diffResult.Modified {
-		t.Logf("NormalizedLive: %s", string(diffResult.NormalizedLive))
-		t.Logf("PredictedLive: %s", string(diffResult.PredictedLive))
-	}
+		// both have the same structure
+		gitData, _, _ := unstructured.NestedMap(normalizedGit.Object, "data")
+		resultData, _, _ := unstructured.NestedMap(normalizedResult.Object, "data")
 
-	// both have the same structure
-	gitData, _, _ := unstructured.NestedMap(normalizedGit.Object, "data")
-	resultData, _, _ := unstructured.NestedMap(normalizedResult.Object, "data")
+		// should have password after normalization
+		_, gitHasPassword := gitData["password"]
+		_, resultHasPassword := resultData["password"]
+		assert.True(t, gitHasPassword, "git secret should have password field after normalization")
+		assert.True(t, resultHasPassword, "result secret should have password field after normalization")
+	})
 
-	// should have password  after normalization
-	_, gitHasPassword := gitData["password"]
-	_, resultHasPassword := resultData["password"]
-	assert.True(t, gitHasPassword, "Git secret should have password field after normalization")
-	assert.True(t, resultHasPassword, "Result secret should have password field after normalization")
+	t.Run("non-json result is returned unchanged", func(t *testing.T) {
+		nonJSON := "kubectl applied (dry-run)"
+		mockApplier.applyResult = func(obj *unstructured.Unstructured) string {
+			return nonJSON
+		}
+
+		result, err := normalizer.ApplyResource(ctx, desired, cmdutil.DryRunServer, false, false, true, "argocd")
+		assert.NoError(t, err)
+		assert.Equal(t, nonJSON, result, "wrapper should return non-json result without error")
+	})
+
+	t.Run("non-core group secret is not normalized", func(t *testing.T) {
+		customSecret := desired.DeepCopy()
+		customSecret.SetAPIVersion("custom.io/v1")
+
+		mockApplier.applyResult = func(obj *unstructured.Unstructured) string {
+			bytes, _ := json.Marshal(obj)
+			return string(bytes)
+		}
+
+		result, err := normalizer.ApplyResource(ctx, customSecret, cmdutil.DryRunServer, false, false, true, "argocd")
+		assert.NoError(t, err)
+
+		resultObj := &unstructured.Unstructured{}
+		json.Unmarshal([]byte(result), resultObj)
+		assert.Equal(t, customSecret.Object["data"], resultObj.Object["data"], "non-core secret should not be modified")
+	})
+
+	t.Run("normalization is skipped for non-dry run server", func(t *testing.T) {
+		mockApplier.applyResult = func(obj *unstructured.Unstructured) string {
+			bytes, _ := json.Marshal(live)
+			return string(bytes)
+		}
+
+		result, err := normalizer.ApplyResource(ctx, desired, cmdutil.DryRunNone, false, false, true, "argocd")
+		assert.NoError(t, err)
+
+		resultObj := &unstructured.Unstructured{}
+		json.Unmarshal([]byte(result), resultObj)
+		assert.Equal(t, live.Object["data"], resultObj.Object["data"])
+	})
 }
 
 type simpleKubeApplier struct {
@@ -1929,8 +1973,4 @@ type simpleKubeApplier struct {
 
 func (s *simpleKubeApplier) ApplyResource(_ context.Context, obj *unstructured.Unstructured, _ cmdutil.DryRunStrategy, _, _, _ bool, _ string) (string, error) {
 	return s.applyResult(obj), nil
-}
-
-func (s *simpleKubeApplier) ConvertToVersion(obj *unstructured.Unstructured, _, _ string) (*unstructured.Unstructured, error) {
-	return obj, nil
 }

--- a/controller/sync_test.go
+++ b/controller/sync_test.go
@@ -1,12 +1,18 @@
 package controller
 
 import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"os"
 	"strconv"
 	"testing"
 
 	"github.com/argoproj/argo-cd/gitops-engine/pkg/sync"
 	synccommon "github.com/argoproj/argo-cd/gitops-engine/pkg/sync/common"
 	"github.com/argoproj/argo-cd/gitops-engine/pkg/utils/kube"
+	"github.com/ghodss/yaml"
+	openapi_v2 "github.com/google/gnostic-models/openapiv2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -23,7 +29,34 @@ import (
 	"github.com/argoproj/argo-cd/v3/util/argo/diff"
 	"github.com/argoproj/argo-cd/v3/util/argo/normalizers"
 	"github.com/argoproj/argo-cd/v3/util/settings"
+
+	gitopsDiff "github.com/argoproj/argo-cd/gitops-engine/pkg/diff"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
+
+type fakeDiscovery struct {
+	schema *openapi_v2.Document
+}
+
+func (f *fakeDiscovery) OpenAPISchema() (*openapi_v2.Document, error) {
+	return f.schema, nil
+}
+
+func loadCRDSchema(t *testing.T, path string) *openapi_v2.Document {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	jsonData, err := yaml.YAMLToJSON(data)
+	require.NoError(t, err)
+
+	doc, err := openapi_v2.ParseDocument(jsonData)
+	require.NoError(t, err)
+
+	return doc
+}
 
 func TestPersistRevisionHistory(t *testing.T) {
 	app := newFakeApp()
@@ -1767,4 +1800,137 @@ func TestValidateSyncPermissions(t *testing.T) {
 
 		assert.NoError(t, err)
 	})
+}
+
+func TestSecretNormalizingApplier(t *testing.T) {
+	kubeclientset := kubefake.NewSimpleClientset(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "argocd",
+			Name:      "argocd-cm",
+			Labels: map[string]string{
+				"app.kubernetes.io/part-of": "argocd",
+			},
+		},
+	}, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "argocd-secret",
+			Namespace: "argocd",
+		},
+	})
+
+	ctx := context.Background()
+	settingsMgr := settings.NewSettingsManager(ctx, kubeclientset, "argocd")
+
+	desired := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]interface{}{
+				"name":      "test-secret",
+				"namespace": "default",
+			},
+			"type": "Opaque",
+			"data": map[string]interface{}{
+				"password": base64.StdEncoding.EncodeToString([]byte("vault:test/data/test#TEST")),
+			},
+		},
+	}
+
+	live := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]interface{}{
+				"name":      "test-secret",
+				"namespace": "default",
+			},
+			"type": "Opaque",
+			"data": map[string]interface{}{
+				"password": base64.StdEncoding.EncodeToString([]byte("actual-password-from-vault")),
+			},
+		},
+	}
+
+	mockApplier := &simpleKubeApplier{
+		applyResult: func(obj *unstructured.Unstructured) string {
+			if obj.GetKind() == "Secret" {
+				result := live.DeepCopy()
+				bytes, _ := json.Marshal(result)
+				return string(bytes)
+			}
+			bytes, _ := json.Marshal(obj)
+			return string(bytes)
+		},
+	}
+
+	normalizer := &secretNormalizingApplier{
+		inner:       mockApplier,
+		settingsMgr: settingsMgr,
+	}
+
+	result, err := normalizer.ApplyResource(
+		context.Background(),
+		desired,
+		cmdutil.DryRunServer,
+		false, false, true, "argocd",
+	)
+
+	require.NoError(t, err)
+	assert.Contains(t, result, "Secret")
+
+	// verify that the result is normalized
+	resultObj := &unstructured.Unstructured{}
+	err = json.Unmarshal([]byte(result), resultObj)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Secret", resultObj.GetKind())
+	assert.Equal(t, "test-secret", resultObj.GetName())
+
+	// verify that HideSecretData was applied
+	data, found, err := unstructured.NestedMap(resultObj.Object, "data")
+	require.NoError(t, err)
+	assert.True(t, found, "data field should exist")
+
+	// password should exist, but may be normalized
+	_, passwordExists := data["password"]
+	assert.True(t, passwordExists, "password should exist after normalization")
+
+	// normalize both using HideSecretData
+	_, normalizedGit, err := gitopsDiff.HideSecretData(nil, desired, settingsMgr.GetSensitiveAnnotations())
+	require.NoError(t, err)
+
+	_, normalizedResult, err := gitopsDiff.HideSecretData(nil, resultObj, settingsMgr.GetSensitiveAnnotations())
+	require.NoError(t, err)
+
+	// diff between normalized secrets
+	diffResult, _ := gitopsDiff.Diff(normalizedGit, normalizedResult)
+
+	// verify that there is NO diff after normalization (mutation webhook changes don't cause OutOfSync)
+	assert.False(t, diffResult.Modified, "normalized secrets should not show as modified")
+	if diffResult.Modified {
+		t.Logf("NormalizedLive: %s", string(diffResult.NormalizedLive))
+		t.Logf("PredictedLive: %s", string(diffResult.PredictedLive))
+	}
+
+	// both have the same structure
+	gitData, _, _ := unstructured.NestedMap(normalizedGit.Object, "data")
+	resultData, _, _ := unstructured.NestedMap(normalizedResult.Object, "data")
+
+	// should have password  after normalization
+	_, gitHasPassword := gitData["password"]
+	_, resultHasPassword := resultData["password"]
+	assert.True(t, gitHasPassword, "Git secret should have password field after normalization")
+	assert.True(t, resultHasPassword, "Result secret should have password field after normalization")
+}
+
+type simpleKubeApplier struct {
+	applyResult func(*unstructured.Unstructured) string
+}
+
+func (s *simpleKubeApplier) ApplyResource(ctx context.Context, obj *unstructured.Unstructured, dryRunStrategy cmdutil.DryRunStrategy, force, validate, serverSideApply bool, manager string) (string, error) {
+	return s.applyResult(obj), nil
+}
+
+func (s *simpleKubeApplier) ConvertToVersion(obj *unstructured.Unstructured, group, version string) (*unstructured.Unstructured, error) {
+	return obj, nil
 }

--- a/controller/sync_test.go
+++ b/controller/sync_test.go
@@ -4,15 +4,12 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"os"
 	"strconv"
 	"testing"
 
 	"github.com/argoproj/argo-cd/gitops-engine/pkg/sync"
 	synccommon "github.com/argoproj/argo-cd/gitops-engine/pkg/sync/common"
 	"github.com/argoproj/argo-cd/gitops-engine/pkg/utils/kube"
-	"github.com/ghodss/yaml"
-	openapi_v2 "github.com/google/gnostic-models/openapiv2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -35,28 +32,6 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
-type fakeDiscovery struct {
-	schema *openapi_v2.Document
-}
-
-func (f *fakeDiscovery) OpenAPISchema() (*openapi_v2.Document, error) {
-	return f.schema, nil
-}
-
-func loadCRDSchema(t *testing.T, path string) *openapi_v2.Document {
-	t.Helper()
-
-	data, err := os.ReadFile(path)
-	require.NoError(t, err)
-
-	jsonData, err := yaml.YAMLToJSON(data)
-	require.NoError(t, err)
-
-	doc, err := openapi_v2.ParseDocument(jsonData)
-	require.NoError(t, err)
-
-	return doc
-}
 
 func TestPersistRevisionHistory(t *testing.T) {
 	app := newFakeApp()

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8
 	github.com/golang/protobuf v1.5.4
 	github.com/google/btree v1.1.3
-	github.com/google/gnostic-models v0.7.0 // indirect
+	github.com/google/gnostic-models v0.7.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-github/v69 v69.2.0
 	github.com/google/go-jsonnet v0.22.0
@@ -182,7 +182,7 @@ require (
 	github.com/fatih/camelcase v1.0.0 // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
-	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/ghodss/yaml v1.0.0
 	github.com/go-errors/errors v1.5.1 // indirect
 	github.com/go-fed/httpsig v1.1.0 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8
 	github.com/golang/protobuf v1.5.4
 	github.com/google/btree v1.1.3
-	github.com/google/gnostic-models v0.7.0
+	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-github/v69 v69.2.0
 	github.com/google/go-jsonnet v0.22.0
@@ -182,7 +182,7 @@ require (
 	github.com/fatih/camelcase v1.0.0 // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
-	github.com/ghodss/yaml v1.0.0
+	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-errors/errors v1.5.1 // indirect
 	github.com/go-fed/httpsig v1.1.0 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Fixes #25260

## Summary  
  
Fixes Secret resources showing persistent OutOfSync status when using `IncludeMutationWebhook=true` with mutation webhooks.  
  
## Problem  
  
Applies `hideSecretData` normalization to desired state(Git) but not to server-side diff dry-run results, causing false OutOfSync status for Secrets modified by mutation webhooks.  

## Solution  
  
Wraps the KubeApplier returned by `getServerSideDiffDryRunApplier` to apply consistent `HideSecretData` normalization to both desired and live states.  
  
<br>

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
