### PR TITLE
feat: Inject string module in LUA VM by default

### DIFF
--- a/util/lua/lua.go
+++ b/util/lua/lua.go
@@ -85,6 +85,7 @@ func (vm VM) runLuaWithResourceActionParameters(obj *unstructured.Unstructured, 
 		{lua.LoadLibName, lua.OpenPackage},
 		{lua.BaseLibName, lua.OpenBase},
 		{lua.TabLibName, lua.OpenTable},
+		{lua.StringLibName, lua.OpenString},
 		// load our 'safe' version of the OS library
 		{lua.OsLibName, OpenSafeOs},
 	} {

--- a/util/lua/lua_test.go
+++ b/util/lua/lua_test.go
@@ -890,10 +890,10 @@ metadata:
 	const script = `
 hs = {}
 str = "Using lua standard library"
-if string.find(str, "standard") then
-  hs.message = "Standard lib was used"
+if math.random(10) > 5 then
+  hs.message = "Random number generated"
 else
-  hs.message = "Standard lib was not used"
+  hs.message = "Random number generated"
 end
 hs.status = "Healthy"
 return hs`
@@ -945,7 +945,7 @@ return hs`
 		require.NoError(t, err)
 		expectedStatus := &health.HealthStatus{
 			Status:  health.HealthStatusHealthy,
-			Message: "Standard lib was used",
+			Message: "Random number generated",
 		}
 		assert.Equal(t, expectedStatus, status)
 	})
@@ -956,7 +956,7 @@ return hs`
 		status, err := overrides.GetResourceHealth(testObj)
 		var target *lua.ApiError
 		require.ErrorAs(t, err, &target)
-		expectedErr := "<string>:4: attempt to index a non-table object(nil) with key 'find'"
+		expectedErr := "<string>:4: attempt to index a non-table object(nil) with key 'random'"
 		require.EqualError(t, err, expectedErr)
 		assert.Nil(t, status)
 	})


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->
Greetings!

It's not possible today to set `UseOpenLibs` for actions which severely limit their usefulness (matching a string, concat, regex, etc...). I think having the `string` module available would be an improvement for everyone writing custom actions without any obvious downsides I can see?

As a follow-up, an enhancement on adding the `useOpenLibs` flag to actions could be created, do you think it would be worth it?

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
