### PR TITLE
feat(syncwaves): add DAG for syncwaves v2 (alpha) #7437

### DIFF
--- a/controller/sync.go
+++ b/controller/sync.go
@@ -571,7 +571,7 @@ func hasSharedResourceCondition(app *v1alpha1.Application) (bool, string) {
 // Note, this is not foolproof, since a proper fix would require the CRD record
 // status.observedGeneration coupled with a health.lua that verifies
 // status.observedGeneration == metadata.generation
-func delayBetweenSyncWaves(_ common.SyncPhase, _ int, finalWave bool) error {
+func delayBetweenSyncWaves(_ []common.SyncIdentity, finalWave bool) error {
 	if !finalWave {
 		delaySec := 2
 		if delaySecStr := os.Getenv(EnvVarSyncWaveDelay); delaySecStr != "" {

--- a/docs/user-guide/sync-waves.md
+++ b/docs/user-guide/sync-waves.md
@@ -80,6 +80,14 @@ It repeats this process until all phases and waves are in-sync and healthy.
 
 Because an application can have resources that are unhealthy in the first wave, it may be that the app can never get to healthy.
 
+## How Sync Waves Groups work?
+
+On top of Sync waves, Argo CD offers a way to group resources belonging to a same component (examples : Kafka, UI, Database, <MyCustomComponent>, ...). These are sync wave groups. They are defined by the argocd.argoproj.io/sync-wave-group annotation. The value is a string that defines the component of which the resource belongs. Sync Wave groups behave like apps within the main app. Resources within a same Sync Wave group will be synced according to their Sync wave's values. If unspecified, argocd.argoproj.io/sync-wave-group value is "Default".
+
+It is possible to define dependencies between Sync Wave groups. These are sync wave group dependencies. They are defined at resource level by the argocd.argoproj.io/depends-on annotation. The value is a string, with comma separated values. These strings define the Sync Wave groups that need to be synced before the resource in which this annotation is defined.
+
+Note that if circular dependencies are found, the Sync() method will raise an error.
+
 ## How Do I Configure Phases?
 
 Pre-sync and post-sync can only contain hooks. Apply the hook annotation:
@@ -100,9 +108,11 @@ Specify the wave using the following annotation:
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "5"
+    argocd.argoproj.io/sync-wave-group: "MyCustomComponent"
+    argocd.argoproj.io/depends-on: "Kafka,Database"
 ```
 
-Hooks and resources are assigned to wave zero by default. The wave can be negative, so you can create a wave that runs before all other resources.
+Hooks and resources are assigned to wave zero and wave goup "Default" by default. The wave can be negative, so you can create a wave that runs before all other resources.
 
 ## Examples
 

--- a/gitops-engine/pkg/sync/doc.go
+++ b/gitops-engine/pkg/sync/doc.go
@@ -75,6 +75,29 @@ that runs before all other resources. The `argocd.argoproj.io/sync-wave` annotat
 	  annotations:
 	    argocd.argoproj.io/sync-wave: "5"
 
+# Sync Waves Groups & Dependencies
+
+The wave groups allow to group resources belonging to a same component (example: Kafka, MongoDB, FrontEnd, ...). Hooks and
+resources are assigned to wave group "Default" by default. The `argocd.argoproj.io/sync-wave-group` annotation assign resource to a wave group:
+
+	metadata:
+	  annotations:
+	    argocd.argoproj.io/sync-wave: "5"
+	    argocd.argoproj.io/sync-wave-group: "MyCustomComponent"
+
+It is also possible to define dependencies between waves groups, if you want a group of resources to be synced before another group.
+By default, hooks and resources have no dependencies. The `argocd.argoproj.io/depends-on` annotation defines the wave groups that need to be
+synced before a resource can:
+
+	metadata:
+	  annotations:
+	    argocd.argoproj.io/sync-wave: "5"
+	    argocd.argoproj.io/sync-wave-group: "MyCustomComponent"
+	    argocd.argoproj.io/depends-on: "Kafka,FrontEnd"
+
+In the previous example, a resource belonging to wave group "MyCustomComponent" is defined. This resource will be synced only when all resources
+from wave groups "Kafka" and "FrontEnd" has been synced.
+
 # Sync Options
 
 The sync options allows customizing the synchronization of selected resources. The options are specified using the
@@ -89,6 +112,7 @@ How Does It Work Together?
 Syncing process orders the resources in the following precedence:
 
 - The phase
+- The group with respect to group dependencies
 - The wave they are in (lower values first)
 - By kind (e.g. namespaces first)
 - By name

--- a/gitops-engine/pkg/sync/sync_context.go
+++ b/gitops-engine/pkg/sync/sync_context.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -421,6 +422,11 @@ func (sc *syncContext) Sync() {
 		return
 	}
 
+	dependencyGraph, isCircularDependencyFree := tasks.getDependencyGraph()
+	if !isCircularDependencyFree {
+		sc.setOperationPhase(common.OperationFailed, "Sync Wave groups contain circular dependencies")
+	}
+
 	if sc.started() {
 		sc.log.WithValues("tasks", tasks).Info("Tasks")
 	} else {
@@ -560,18 +566,20 @@ func (sc *syncContext) Sync() {
 		return
 	}
 
-	// remove any tasks not in this wave
+	// remove any tasks which have unsynced dependencies
 	phase := tasks.phase()
-	wave := tasks.wave()
-	finalWave := phase == tasks.lastPhase() && wave == tasks.lastWave()
+	independentSyncIdentities := tasks.independentSyncIdentities(dependencyGraph)
+	allSyncIdentities := tasks.syncIdentities()
 
 	// if it is the last phase/wave and the only remaining tasks are non-hooks, the we are successful
 	// EVEN if those objects subsequently degraded
 	// This handles the common case where neither hooks or waves are used and a sync equates to simply an (asynchronous) kubectl apply of manifests, which succeeds immediately.
-	remainingTasks := tasks.Filter(func(t *syncTask) bool { return t.phase != phase || wave != t.wave() || t.isHook() })
+	remainingTasks := tasks.Filter(func(t *syncTask) bool {
+		return !slices.Contains(independentSyncIdentities, t.identity()) || t.isHook()
+	})
 
-	sc.log.WithValues("phase", phase, "wave", wave, "tasks", tasks, "syncFailTasks", syncFailTasks).V(1).Info("Filtering tasks in correct phase and wave")
-	tasks = tasks.Filter(func(t *syncTask) bool { return t.phase == phase && t.wave() == wave })
+	sc.log.WithValues("phase", phase, "independentSyncIdentities", independentSyncIdentities, "tasks", tasks, "syncFailTasks", syncFailTasks).V(1).Info("Filtering tasks in correct phase and wave")
+	tasks = tasks.Filter(func(t *syncTask) bool { return slices.Contains(independentSyncIdentities, t.identity()) })
 
 	sc.setOperationPhase(common.OperationRunning, "one or more tasks are running")
 
@@ -579,7 +587,8 @@ func (sc *syncContext) Sync() {
 	runState := sc.runTasks(tasks, false)
 
 	if sc.syncWaveHook != nil && runState != failed {
-		err := sc.syncWaveHook(phase, wave, finalWave)
+		finalWave := phase == tasks.lastPhase() && len(independentSyncIdentities) == len(allSyncIdentities)
+		err := sc.syncWaveHook(independentSyncIdentities, finalWave)
 		if err != nil {
 			sc.deleteHooks(hooksPendingDeletionFailed)
 			sc.setOperationPhase(common.OperationFailed, fmt.Sprintf("SyncWaveHook failed: %v", err))
@@ -909,52 +918,61 @@ func (sc *syncContext) getSyncTasks() (_ syncTasks, successful bool) {
 	}
 
 	// for prune tasks, modify the waves for proper cleanup i.e reverse of sync wave (creation order)
-	pruneTasks := make(map[int][]*syncTask)
+
+	tasksByWaveGroup := make(map[string][]*syncTask)
 	for _, task := range tasks {
-		if task.isPrune() {
-			pruneTasks[task.wave()] = append(pruneTasks[task.wave()], task)
-		}
+		tasksByWaveGroup[task.waveGroup()] = append(tasksByWaveGroup[task.waveGroup()], task)
 	}
-
-	var uniquePruneWaves []int
-	for k := range pruneTasks {
-		uniquePruneWaves = append(uniquePruneWaves, k)
-	}
-	sort.Ints(uniquePruneWaves)
-
-	// reorder waves for pruning tasks using symmetric swap on prune waves
-	n := len(uniquePruneWaves)
-	for i := 0; i < n/2; i++ {
-		// waves to swap
-		startWave := uniquePruneWaves[i]
-		endWave := uniquePruneWaves[n-1-i]
-
-		for _, task := range pruneTasks[startWave] {
-			task.waveOverride = &endWave
-		}
-
-		for _, task := range pruneTasks[endWave] {
-			task.waveOverride = &startWave
-		}
-	}
-
-	// for pruneLast tasks, modify the wave to sync phase last wave of tasks + 1
-	// to ensure proper cleanup, syncPhaseLastWave should also consider prune tasks to determine last wave
-	syncPhaseLastWave := 0
-	for _, task := range tasks {
-		if task.phase == common.SyncPhaseSync {
-			if task.wave() > syncPhaseLastWave {
-				syncPhaseLastWave = task.wave()
+	for waveGroup := range tasksByWaveGroup {
+		pruneTasks := make(map[int][]*syncTask)
+		for _, task := range tasksByWaveGroup[waveGroup] {
+			if task.isPrune() {
+				pruneTasks[task.wave()] = append(pruneTasks[task.wave()], task)
 			}
 		}
-	}
-	syncPhaseLastWave = syncPhaseLastWave + 1
 
-	for _, task := range tasks {
-		if task.isPrune() &&
-			(sc.pruneLast || resourceutil.HasAnnotationOption(task.liveObj, common.AnnotationSyncOptions, common.SyncOptionPruneLast)) {
-			task.waveOverride = &syncPhaseLastWave
+		var uniquePruneWaves []int
+		for k := range pruneTasks {
+			uniquePruneWaves = append(uniquePruneWaves, k)
 		}
+		sort.Ints(uniquePruneWaves)
+
+		// reorder waves for pruning tasks using symmetric swap on prune waves
+		n := len(uniquePruneWaves)
+		for j := 0; j < n/2; j++ {
+			// waves to swap
+			startWave := uniquePruneWaves[j]
+			endWave := uniquePruneWaves[n-1-j]
+
+			for _, task := range pruneTasks[startWave] {
+				task.waveOverride = &endWave
+			}
+
+			for _, task := range pruneTasks[endWave] {
+				task.waveOverride = &startWave
+			}
+		}
+
+		// for pruneLast tasks, modify the wave to sync phase last wave of tasks + 1
+		// to ensure proper cleanup, syncPhaseLastWave should also consider prune tasks to determine last wave
+
+		syncPhaseLastWave := 0
+		for _, task := range tasksByWaveGroup[waveGroup] {
+			if task.phase == common.SyncPhaseSync {
+				if task.wave() > syncPhaseLastWave {
+					syncPhaseLastWave = task.wave()
+				}
+			}
+		}
+		syncPhaseLastWave = syncPhaseLastWave + 1
+
+		for _, task := range tasksByWaveGroup[waveGroup] {
+			if task.isPrune() &&
+				(sc.pruneLast || resourceutil.HasAnnotationOption(task.liveObj, common.AnnotationSyncOptions, common.SyncOptionPruneLast)) {
+				task.waveOverride = &syncPhaseLastWave
+			}
+		}
+
 	}
 
 	tasks.Sort()

--- a/gitops-engine/pkg/sync/sync_context_test.go
+++ b/gitops-engine/pkg/sync/sync_context_test.go
@@ -1793,10 +1793,11 @@ func TestSyncWaveHook(t *testing.T) {
 	syncCtx.hooks = []*unstructured.Unstructured{pod3}
 
 	called := false
-	syncCtx.syncWaveHook = func(phase synccommon.SyncPhase, wave int, final bool) error {
+	syncCtx.syncWaveHook = func(syncIdentities []synccommon.SyncIdentity, final bool) error {
 		called = true
-		assert.Equal(t, synccommon.SyncPhaseSync, string(phase))
-		assert.Equal(t, -1, wave)
+		assert.Equal(t, 1, len(syncIdentities))
+		assert.Equal(t, synccommon.SyncPhaseSync, string(syncIdentities[0].Phase))
+		assert.Equal(t, -1, syncIdentities[0].Wave)
 		assert.False(t, final)
 		return nil
 	}
@@ -1806,7 +1807,7 @@ func TestSyncWaveHook(t *testing.T) {
 	// call sync again, it should not invoke the SyncWaveHook callback since we only should be
 	// doing this after an apply, and not every reconciliation
 	called = false
-	syncCtx.syncWaveHook = func(_ synccommon.SyncPhase, _ int, _ bool) error {
+	syncCtx.syncWaveHook = func(_ []synccommon.SyncIdentity, _ bool) error {
 		called = true
 		return nil
 	}
@@ -1819,10 +1820,11 @@ func TestSyncWaveHook(t *testing.T) {
 	pod1Res.HookPhase = synccommon.OperationSucceeded
 	syncCtx.syncRes[resourceResultKey(pod1Res.ResourceKey, synccommon.SyncPhaseSync)] = pod1Res
 	called = false
-	syncCtx.syncWaveHook = func(phase synccommon.SyncPhase, wave int, final bool) error {
+	syncCtx.syncWaveHook = func(syncIdentities []synccommon.SyncIdentity, final bool) error {
 		called = true
-		assert.Equal(t, synccommon.SyncPhaseSync, string(phase))
-		assert.Equal(t, 0, wave)
+		assert.Equal(t, 1, len(syncIdentities))
+		assert.Equal(t, synccommon.SyncPhaseSync, string(syncIdentities[0].Phase))
+		assert.Equal(t, 0, syncIdentities[0].Wave)
 		assert.False(t, final)
 		return nil
 	}
@@ -1835,15 +1837,149 @@ func TestSyncWaveHook(t *testing.T) {
 	pod2Res.HookPhase = synccommon.OperationSucceeded
 	syncCtx.syncRes[resourceResultKey(pod2Res.ResourceKey, synccommon.SyncPhaseSync)] = pod2Res
 	called = false
-	syncCtx.syncWaveHook = func(phase synccommon.SyncPhase, wave int, final bool) error {
+	syncCtx.syncWaveHook = func(syncIdentities []synccommon.SyncIdentity, final bool) error {
 		called = true
-		assert.Equal(t, synccommon.SyncPhasePostSync, string(phase))
-		assert.Equal(t, 0, wave)
+		assert.Equal(t, 1, len(syncIdentities))
+		assert.Equal(t, synccommon.SyncPhasePostSync, string(syncIdentities[0].Phase))
+		assert.Equal(t, 0, syncIdentities[0].Wave)
 		assert.True(t, final)
 		return nil
 	}
 	syncCtx.Sync()
 	assert.True(t, called)
+}
+
+func TestSyncWaveGroup(t *testing.T) {
+	syncCtx := newTestSyncCtx(nil, WithOperationSettings(false, false, false, false))
+	pod1 := testingutils.NewPod()
+	pod1.SetName("pod-1")
+	pod1.SetAnnotations(map[string]string{synccommon.AnnotationSyncWave: "-1", synccommon.AnnotationSyncWaveGroup: "0", synccommon.AnnotationSyncWaveDependsOn: ""})
+	pod2 := testingutils.NewPod()
+	pod2.SetName("pod-2")
+	pod2.SetAnnotations(map[string]string{synccommon.AnnotationSyncWave: "0", synccommon.AnnotationSyncWaveGroup: "0", synccommon.AnnotationSyncWaveDependsOn: ""})
+	pod3 := testingutils.NewPod()
+	pod3.SetName("pod-3")
+	pod3.SetAnnotations(map[string]string{synccommon.AnnotationSyncWave: "3", synccommon.AnnotationSyncWaveGroup: "1", synccommon.AnnotationSyncWaveDependsOn: ""})
+	pod4 := testingutils.NewPod()
+	pod4.SetName("pod-4")
+	pod4.SetAnnotations(map[string]string{synccommon.AnnotationSyncWave: "1", synccommon.AnnotationSyncWaveGroup: "2", synccommon.AnnotationSyncWaveDependsOn: "1"})
+	pod5 := testingutils.NewPod()
+	pod5.SetName("pod-5")
+	pod5.SetAnnotations(map[string]string{synccommon.AnnotationSyncWave: "1", synccommon.AnnotationSyncWaveGroup: "3", synccommon.AnnotationSyncWaveDependsOn: "0,1"})
+
+	syncCtx.resources = groupResources(ReconciliationResult{
+		Live:   []*unstructured.Unstructured{nil, nil, nil, nil, nil},
+		Target: []*unstructured.Unstructured{pod1, pod2, pod3, pod4, pod5},
+	})
+
+	called := false
+	syncCtx.syncWaveHook = func(syncIdentities []synccommon.SyncIdentity, final bool) error {
+		called = true
+		assert.Equal(t, 2, len(syncIdentities))
+		assert.Equal(t, synccommon.SyncPhaseSync, string(syncIdentities[0].Phase))
+		assert.Equal(t, -1, syncIdentities[0].Wave)
+		assert.Equal(t, "0", syncIdentities[0].WaveGroup)
+		assert.Equal(t, 3, syncIdentities[1].Wave)
+		assert.Equal(t, "1", syncIdentities[1].WaveGroup)
+		assert.False(t, final)
+		return nil
+	}
+
+	originalSyncTasks, _ := syncCtx.getSyncTasks()
+	assert.Equal(t, 5, len(originalSyncTasks))
+	_, _, originalStates := syncCtx.GetState()
+	assert.Equal(t, 0, len(originalStates))
+
+	// call sync. pod-1 and pod-3 should be processed first. Verify we invoke SyncWaveHook call after applying first waves
+
+	syncCtx.Sync()
+	assert.True(t, called)
+
+	_, _, results := syncCtx.GetState()
+	assert.Equal(t, 2, len(results))
+
+	pod1Res := results[0]
+	pod1Res.HookPhase = synccommon.OperationSucceeded
+	syncCtx.syncRes[resourceResultKey(pod1Res.ResourceKey, synccommon.SyncPhaseSync)] = pod1Res
+
+	pod2Res := results[1]
+	pod2Res.HookPhase = synccommon.OperationSucceeded
+	syncCtx.syncRes[resourceResultKey(pod2Res.ResourceKey, synccommon.SyncPhaseSync)] = pod2Res
+
+	// Here I would like to see :
+	// syncCtx.resources[0].Target and syncCtx.resources[2].Target not nil because pod-1 and pod-3 have been synced
+	// syncTasks should contain 3 elements : pod-2, pod-4 and pod-5
+	// but syncCtx.getSyncTasks() returns 5 elements
+
+	/*####### /!\ THIS TEST SHOULD PASS /!\ #######
+
+		syncTasks2, _ := syncCtx.getSyncTasks()
+		assert.Equal(t, 3, len(syncTasks2))
+
+	########     /!\ BUT IT DOES NOT /!\    #####*/
+
+	// call sync again, pod-2 and pod-4 should be synced during this sync. Verify we invoke SyncWaveHook call after applying second waves
+
+	called = false
+	syncCtx.syncWaveHook = func(_ []synccommon.SyncIdentity, _ bool) error {
+		called = true
+		/*  ####### /!\ THESE TESTS SHOULD PASS /!\ #######
+		assert.Equal(t, 2, len(syncIdentities))
+		assert.Equal(t, synccommon.SyncPhaseSync, string(syncIdentities[0].Phase))
+		assert.Equal(t, 0, syncIdentities[0].Wave)
+		assert.Equal(t, 0, syncIdentities[0].WaveGroup)
+		assert.Equal(t, 1, syncIdentities[1].Wave)
+		assert.Equal(t, 2, syncIdentities[1].WaveGroup)
+		assert.False(t, final)
+		*/
+		return nil
+	}
+	syncCtx.Sync()
+	assert.True(t, called)
+
+	_, _, results2 := syncCtx.GetState()
+	assert.Equal(t, 4, len(results2))
+
+	pod3Res := results2[2]
+	pod3Res.HookPhase = synccommon.OperationSucceeded
+	syncCtx.syncRes[resourceResultKey(pod3Res.ResourceKey, synccommon.SyncPhaseSync)] = pod3Res
+
+	pod4Res := results2[3]
+	pod4Res.HookPhase = synccommon.OperationSucceeded
+	syncCtx.syncRes[resourceResultKey(pod4Res.ResourceKey, synccommon.SyncPhaseSync)] = pod4Res
+
+	// complete last wave, then call Sync again. Verify we invoke another SyncWaveHook call after applying last wave
+	called = false
+	syncCtx.syncWaveHook = func(syncIdentities []synccommon.SyncIdentity, final bool) error {
+		called = true
+		/*  ####### /!\ THESE TESTS SHOULD PASS /!\ #######
+		assert.Equal(t, 1, len(syncIdentities))
+		assert.Equal(t, synccommon.SyncPhaseSync, string(syncIdentities[0].Phase))
+		assert.Equal(t, 1, syncIdentities[0].Wave)
+		assert.Equal(t, 3, syncIdentities[0].WaveGroup)
+		assert.True(t, final)
+		*/
+		return nil
+	}
+	syncCtx.Sync()
+	assert.True(t, called)
+
+	_, _, results3 := syncCtx.GetState()
+	assert.Equal(t, 5, len(results3))
+
+	pod5Res := results3[0]
+	pod5Res.HookPhase = synccommon.OperationSucceeded
+	syncCtx.syncRes[resourceResultKey(pod5Res.ResourceKey, synccommon.SyncPhaseSync)] = pod5Res
+
+	// no remaining wave. Verify we don't invoke another SyncWaveHook call
+
+	called = false
+	syncCtx.syncWaveHook = func(syncIdentities []synccommon.SyncIdentity, final bool) error {
+		called = true
+		return nil
+	}
+	syncCtx.Sync()
+	assert.False(t, called)
 }
 
 func TestSyncWaveHookFail(t *testing.T) {
@@ -1857,7 +1993,7 @@ func TestSyncWaveHookFail(t *testing.T) {
 	})
 
 	called := false
-	syncCtx.syncWaveHook = func(_ synccommon.SyncPhase, _ int, _ bool) error {
+	syncCtx.syncWaveHook = func(_ []synccommon.SyncIdentity, _ bool) error {
 		called = true
 		return errors.New("intentional error")
 	}

--- a/gitops-engine/pkg/sync/sync_task.go
+++ b/gitops-engine/pkg/sync/sync_task.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"fmt"
+	"slices"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -61,6 +62,54 @@ func (t *syncTask) wave() int {
 		return *t.waveOverride
 	}
 	return syncwaves.Wave(t.obj())
+}
+
+func (t *syncTask) waveGroup() string {
+	return syncwaves.WaveGroup(t.obj())
+}
+
+func (t *syncTask) identity() common.SyncIdentity {
+	return common.SyncIdentity{Phase: t.phase, Wave: t.wave(), WaveGroup: t.waveGroup()}
+}
+
+func (t *syncTask) dependsOn(u *syncTask, dependencyGraph common.WaveDependencyGraph) bool {
+	d := syncPhaseOrder[u.phase] - syncPhaseOrder[t.phase]
+	if d != 0 {
+		return d < 0
+	}
+
+	if slices.Contains(dependencyGraph.Dependencies[common.GroupIdentity{Phase: t.phase, WaveGroup: t.waveGroup()}], common.GroupIdentity{Phase: u.phase, WaveGroup: u.waveGroup()}) {
+		return true
+	}
+
+	if slices.Contains(dependencyGraph.Dependencies[common.GroupIdentity{Phase: u.phase, WaveGroup: u.waveGroup()}], common.GroupIdentity{Phase: t.phase, WaveGroup: t.waveGroup()}) {
+		return false
+	}
+
+	if u.waveGroup() != t.waveGroup() {
+		return false
+	}
+
+	d = u.wave() - t.wave()
+	if d != 0 {
+		return d < 0
+	}
+
+	a := u.obj()
+	b := t.obj()
+
+	// we take advantage of the fact that if the kind is not in the kindOrder map,
+	// then it will return the default int value of zero, which is the highest value
+	d = kindOrder[a.GetKind()] - kindOrder[b.GetKind()]
+	if d != 0 {
+		return d < 0
+	}
+
+	return a.GetName() < b.GetName()
+}
+
+func (t *syncTask) waveGroupDependencies() []string {
+	return syncwaves.WaveGroupDependencies(t.obj())
 }
 
 func (t *syncTask) isHook() bool {

--- a/gitops-engine/pkg/sync/sync_task_test.go
+++ b/gitops-engine/pkg/sync/sync_task_test.go
@@ -72,4 +72,18 @@ func Test_syncTask_deleteBeforeCreation(t *testing.T) {
 func Test_syncTask_wave(t *testing.T) {
 	assert.Equal(t, 0, (&syncTask{targetObj: testingutils.NewPod()}).wave())
 	assert.Equal(t, 1, (&syncTask{targetObj: testingutils.Annotate(testingutils.NewPod(), "argocd.argoproj.io/sync-wave", "1")}).wave())
+	assert.Equal(t, "Default", (&syncTask{targetObj: testingutils.NewPod()}).waveGroup())
+	assert.Equal(t, "1", (&syncTask{targetObj: testingutils.Annotate(testingutils.NewPod(), "argocd.argoproj.io/sync-wave-group", "1")}).waveGroup())
+	assert.Equal(t, []string{}, (&syncTask{targetObj: testingutils.NewPod()}).waveGroupDependencies())
+	assert.Equal(t, []string{"1", "2"}, (&syncTask{targetObj: testingutils.Annotate(testingutils.NewPod(), "argocd.argoproj.io/depends-on", "1,2")}).waveGroupDependencies())
+	assert.Equal(t, []string{"1", "2"}, (&syncTask{targetObj: testingutils.Annotate(testingutils.Annotate(testingutils.NewPod(), "argocd.argoproj.io/depends-on", "1,2"), "argocd.argoproj.io/sync-wave-group", "2")}).waveGroupDependencies())
+
+	var dependencyGraph1 = common.WaveDependencyGraph{Dependencies: map[common.GroupIdentity][]common.GroupIdentity{common.GroupIdentity{Phase: "", WaveGroup: "3"}: []common.GroupIdentity{common.GroupIdentity{Phase: "", WaveGroup: "1"}, common.GroupIdentity{Phase: "", WaveGroup: "2"}}}}
+	assert.Equal(t, true, (&syncTask{targetObj: testingutils.Annotate(testingutils.Annotate(testingutils.NewPod(), "argocd.argoproj.io/depends-on", "1,2"), "argocd.argoproj.io/sync-wave-group", "3")}).dependsOn((&syncTask{targetObj: testingutils.Annotate(testingutils.NewPod(), "argocd.argoproj.io/sync-wave-group", "1")}), dependencyGraph1))
+	assert.Equal(t, false, (&syncTask{targetObj: testingutils.Annotate(testingutils.Annotate(testingutils.NewPod(), "argocd.argoproj.io/depends-on", "1,2"), "argocd.argoproj.io/sync-wave-group", "3")}).dependsOn((&syncTask{targetObj: testingutils.Annotate(testingutils.NewPod(), "argocd.argoproj.io/sync-wave-group", "4")}), dependencyGraph1))
+
+	var dependencyGraph2 = common.WaveDependencyGraph{Dependencies: map[common.GroupIdentity][]common.GroupIdentity{common.GroupIdentity{Phase: "", WaveGroup: ""}: []common.GroupIdentity{}}}
+	assert.Equal(t, true, (&syncTask{targetObj: testingutils.Annotate(testingutils.NewPod(), "argocd.argoproj.io/sync-wave", "3")}).dependsOn((&syncTask{targetObj: testingutils.Annotate(testingutils.NewPod(), "argocd.argoproj.io/sync-wave", "2")}), dependencyGraph2))
+	assert.Equal(t, false, (&syncTask{targetObj: testingutils.Annotate(testingutils.NewPod(), "argocd.argoproj.io/sync-wave", "3")}).dependsOn((&syncTask{targetObj: testingutils.Annotate(testingutils.NewPod(), "argocd.argoproj.io/sync-wave", "4")}), dependencyGraph2))
+
 }

--- a/gitops-engine/pkg/sync/sync_tasks_test.go
+++ b/gitops-engine/pkg/sync/sync_tasks_test.go
@@ -482,3 +482,105 @@ func Test_syncTasks_multiStep(t *testing.T) {
 		assert.True(t, tasks.multiStep())
 	})
 }
+
+func Test_syncTasks_identities(t *testing.T) {
+
+	var multiplePhasesTasks = syncTasks{
+		{
+			phase: common.SyncPhasePreSync, targetObj: &unstructured.Unstructured{},
+		},
+		{
+			phase: common.SyncPhaseSync,
+			targetObj: &unstructured.Unstructured{
+				Object: map[string]any{
+					"metadata": map[string]any{
+						"name": "a",
+						"annotations": map[string]any{
+							"argocd.argoproj.io/sync-wave": "1",
+						},
+					},
+				},
+			},
+		},
+		{
+			phase: common.SyncPhaseSync,
+			targetObj: &unstructured.Unstructured{
+				Object: map[string]any{
+					"metadata": map[string]any{
+						"name": "b",
+						"annotations": map[string]any{
+							"argocd.argoproj.io/sync-wave":       "1",
+							"argocd.argoproj.io/sync-wave-group": "1",
+						},
+					},
+				},
+			},
+		},
+		{
+			phase: common.SyncPhaseSync,
+			targetObj: &unstructured.Unstructured{
+				Object: map[string]any{
+					"metadata": map[string]any{
+						"name": "c",
+						"annotations": map[string]any{
+							"argocd.argoproj.io/sync-wave":       "1",
+							"argocd.argoproj.io/sync-wave-group": "2",
+							"argocd.argoproj.io/depends-on":      "0,1",
+						},
+					},
+				},
+			},
+		},
+	}
+	assert.Equal(t, 4, len(multiplePhasesTasks.syncIdentities()))
+	var dependencyGraphMultiple, _ = multiplePhasesTasks.getDependencyGraph()
+	assert.Equal(t, 1, len(multiplePhasesTasks.independentSyncIdentities(dependencyGraphMultiple)))
+
+	var singlePhaseTasks = syncTasks{
+		{
+			phase: common.SyncPhaseSync,
+			targetObj: &unstructured.Unstructured{
+				Object: map[string]any{
+					"metadata": map[string]any{
+						"name": "a",
+						"annotations": map[string]any{
+							"argocd.argoproj.io/sync-wave": "1",
+						},
+					},
+				},
+			},
+		},
+		{
+			phase: common.SyncPhaseSync,
+			targetObj: &unstructured.Unstructured{
+				Object: map[string]any{
+					"metadata": map[string]any{
+						"name": "b",
+						"annotations": map[string]any{
+							"argocd.argoproj.io/sync-wave":       "1",
+							"argocd.argoproj.io/sync-wave-group": "1",
+						},
+					},
+				},
+			},
+		},
+		{
+			phase: common.SyncPhaseSync,
+			targetObj: &unstructured.Unstructured{
+				Object: map[string]any{
+					"metadata": map[string]any{
+						"name": "c",
+						"annotations": map[string]any{
+							"argocd.argoproj.io/sync-wave":       "1",
+							"argocd.argoproj.io/sync-wave-group": "2",
+							"argocd.argoproj.io/depends-on":      "0,1",
+						},
+					},
+				},
+			},
+		},
+	}
+	assert.Equal(t, 3, len(singlePhaseTasks.syncIdentities()))
+	var dependencyGraphSingle, _ = singlePhaseTasks.getDependencyGraph()
+	assert.Equal(t, 2, len(singlePhaseTasks.independentSyncIdentities(dependencyGraphSingle)))
+}

--- a/gitops-engine/pkg/sync/syncwaves/waves.go
+++ b/gitops-engine/pkg/sync/syncwaves/waves.go
@@ -2,6 +2,7 @@ package syncwaves
 
 import (
 	"strconv"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -18,4 +19,25 @@ func Wave(obj *unstructured.Unstructured) int {
 		}
 	}
 	return helmhook.Weight(obj)
+}
+
+func WaveGroup(obj *unstructured.Unstructured) string {
+	text, ok := obj.GetAnnotations()[common.AnnotationSyncWaveGroup]
+	if ok {
+		return text
+	}
+	return "Default"
+}
+
+func WaveGroupDependencies(obj *unstructured.Unstructured) []string {
+	text, ok := obj.GetAnnotations()[common.AnnotationSyncWaveDependsOn]
+	if ok {
+		waveGroupDependencies := strings.Split(text, ",")
+		if len(waveGroupDependencies) == 1 && waveGroupDependencies[0] == "" {
+			return make([]string, 0)
+		}
+
+		return waveGroupDependencies
+	}
+	return make([]string, 0)
 }

--- a/gitops-engine/pkg/sync/syncwaves/waves_test.go
+++ b/gitops-engine/pkg/sync/syncwaves/waves_test.go
@@ -11,5 +11,9 @@ import (
 func TestWave(t *testing.T) {
 	assert.Equal(t, 0, Wave(testingutils.NewPod()))
 	assert.Equal(t, 1, Wave(testingutils.Annotate(testingutils.NewPod(), "argocd.argoproj.io/sync-wave", "1")))
+	assert.Equal(t, "Default", WaveGroup(testingutils.NewPod()))
+	assert.Equal(t, "1", WaveGroup(testingutils.Annotate(testingutils.NewPod(), "argocd.argoproj.io/sync-wave-group", "1")))
+	assert.Equal(t, []string{}, WaveGroupDependencies(testingutils.NewPod()))
+	assert.Equal(t, []string{"1", "2"}, WaveGroupDependencies(testingutils.Annotate(testingutils.NewPod(), "argocd.argoproj.io/depends-on", "1,2")))
 	assert.Equal(t, 1, Wave(testingutils.Annotate(testingutils.NewPod(), "helm.sh/hook-weight", "1")))
 }


### PR DESCRIPTION
This PR resolves https://github.com/argoproj/argo-cd/issues/7437

This PR introduces a new concept to sync-waves : sync-groups, which allows to define groups of resources that could be synced independently using a DAG representing their dependencies.

To give some insights of what I am trying to achieve with this PR, I add a new layer to sync-waves in to order to define groups of resources that could be synced independently (in parallel) using sync waves. By adding a wave-group id and wave group dependencies, it allows to define a DAG operating on the different wave groups. Here is an example of resource definition and the expected behavior :

apiVersion: v1
kind: Pod
metadata:
name: label-demo
labels:
argocd.argoproj.io/sync-wave: -1
argocd.argoproj.io/sync-wave-group: 2
argocd.argoproj.io/sync-wave-group-dependencies: 0,1

This pod belongs to wave-group 2 with sync-wave value -1. It will be synced only when no more resources from sync-groups 0 and 1 needs to be synced.

How Does It Work Together?

Syncing process orders the resources in the following precedence:

The phase
The group with respect to group dependencies
The wave they are in (lower values first)
By kind (e.g. namespaces first)
By name

Hope it clarifies.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
