### PR TITLE
fix: prevent automatic refreshes from informer resync and status updates

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -1019,11 +1019,6 @@ func (ctrl *ApplicationController) processAppOperationQueueItem() (processNext b
 	var logCtx *log.Entry
 
 	if !exists {
-		// App not in informer - this can happen if:
-		// 1. App was just created and informer hasn't synced yet
-		// 2. App is in a namespace not watched by informer (external namespace)
-		// 3. App was deleted
-		// Try to get it directly from API server to check for operations
 		parts := strings.Split(appKey, "/")
 		if len(parts) != 2 {
 			log.WithField("appkey", appKey).Warn("Unexpected appKey format, expected namespace/name")
@@ -1033,19 +1028,14 @@ func (ctrl *ApplicationController) processAppOperationQueueItem() (processNext b
 		freshApp, apiErr := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(appNamespace).Get(context.Background(), appName, metav1.GetOptions{})
 		if apiErr != nil {
 			if apierrors.IsNotFound(apiErr) {
-				// App was deleted, skip processing
 				return processNext
 			}
 			log.WithField("appkey", appKey).WithError(apiErr).Error("Failed to retrieve application from API server")
 			return processNext
 		}
-		// Only process if there's an operation - operations are the reason items are queued
-		// If there's no operation, it was likely queued before the app was created or the operation was cleared
 		if freshApp.Operation == nil {
-			// No operation, skip processing
 			return processNext
 		}
-		// We already have fresh data from API server, use it directly
 		app = freshApp
 		logCtx = log.WithFields(applog.GetAppLogFields(app))
 	} else {
@@ -1057,9 +1047,6 @@ func (ctrl *ApplicationController) processAppOperationQueueItem() (processNext b
 		app = origApp.DeepCopy()
 		logCtx = log.WithFields(applog.GetAppLogFields(app))
 
-		// Always retrieve fresh data from API server when processing operations
-		// The informer might have stale data, and operations are time-sensitive
-		// We cannot rely on informer since applications might be updated by both application controller and api server
 		if app.Operation != nil {
 			freshApp, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(app.ObjectMeta.Namespace).Get(context.Background(), app.Name, metav1.GetOptions{})
 			if err != nil {
@@ -1068,9 +1055,7 @@ func (ctrl *ApplicationController) processAppOperationQueueItem() (processNext b
 				}
 				return processNext
 			}
-			// Check if operation was cleared (e.g., already processed by another worker)
 			if freshApp.Operation == nil {
-				// Operation was cleared, skip processing
 				return processNext
 			}
 			app = freshApp
@@ -2477,19 +2462,16 @@ func (ctrl *ApplicationController) canProcessApp(obj any) bool {
 	return ctrl.clusterSharding.IsManagedCluster(destCluster)
 }
 
-// Checks if the operation was added or changed between old and new app
 func operationChanged(oldApp, newApp *appv1.Application) bool {
 	return (oldApp.Operation == nil && newApp.Operation != nil) ||
 		(oldApp.Operation != nil && newApp.Operation != nil && !equality.Semantic.DeepEqual(oldApp.Operation, newApp.Operation))
 }
 
-// Checks if the deletion timestamp changed between old and new app
 func deletionTimestampChanged(oldApp, newApp *appv1.Application) bool {
 	return (oldApp.DeletionTimestamp == nil && newApp.DeletionTimestamp != nil) ||
 		(oldApp.DeletionTimestamp != nil && newApp.DeletionTimestamp != nil && !oldApp.DeletionTimestamp.Equal(newApp.DeletionTimestamp))
 }
 
-// Checks if the update only changed status/metadata without changing spec, operations, or deletion timestamp
 func isStatusOnlyUpdate(oldApp, newApp *appv1.Application) bool {
 	if !equality.Semantic.DeepEqual(oldApp.Spec, newApp.Spec) {
 		return false
@@ -2615,7 +2597,6 @@ func (ctrl *ApplicationController) newApplicationInformerAndLister() (cache.Shar
 				var delay *time.Duration
 
 				if oldOK && newOK {
-					// Skip refresh requests for informer resync events (same ResourceVersion)
 					if oldApp.ResourceVersion == newApp.ResourceVersion {
 						if ctrl.hydrator != nil {
 							ctrl.appHydrateQueue.AddRateLimited(newApp.QualifiedName())
@@ -2624,8 +2605,6 @@ func (ctrl *ApplicationController) newApplicationInformerAndLister() (cache.Shar
 						return
 					}
 
-					// Skip refresh requests for status-only updates (spec unchanged)
-					// This prevents feedback loop: status update → UpdateFunc → requestAppRefresh → refresh → status update
 					if isStatusOnlyUpdate(oldApp, newApp) {
 						oldAnnotations := oldApp.GetAnnotations()
 						newAnnotations := newApp.GetAnnotations()
@@ -2663,7 +2642,7 @@ func (ctrl *ApplicationController) newApplicationInformerAndLister() (cache.Shar
 					return
 				}
 				// IndexerInformer uses a delta queue, therefore for deletes we have to use this
-				// key function.
+				// Key function.
 				key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 				if err == nil {
 					// for deletes, we immediately add to the refresh queue

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"maps"
 	"math"
-	"math/rand"
 	"net/http"
 	"reflect"
 	"runtime/debug"
@@ -27,6 +26,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/semaphore"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -125,7 +125,6 @@ type ApplicationController struct {
 	stateCache                    statecache.LiveStateCache
 	statusRefreshTimeout          time.Duration
 	statusHardRefreshTimeout      time.Duration
-	statusRefreshJitter           time.Duration
 	selfHealTimeout               time.Duration
 	selfHealBackoff               *wait.Backoff
 	syncTimeout                   time.Duration
@@ -202,7 +201,6 @@ func NewApplicationController(
 		db:                                db,
 		statusRefreshTimeout:              appResyncPeriod,
 		statusHardRefreshTimeout:          appHardResyncPeriod,
-		statusRefreshJitter:               appResyncJitter,
 		refreshRequestedApps:              make(map[string]CompareWith),
 		refreshRequestedAppsMutex:         &sync.Mutex{},
 		auditLogger:                       argo.NewAuditLogger(kubeClientset, namespace, common.CommandApplicationController, enableK8sEvent),
@@ -1016,17 +1014,71 @@ func (ctrl *ApplicationController) processAppOperationQueueItem() (processNext b
 		log.WithField("appkey", appKey).WithError(err).Error("Failed to get application from informer index")
 		return processNext
 	}
+
+	var app *appv1.Application
+	var logCtx *log.Entry
+
 	if !exists {
-		// This happens after app was deleted, but the work queue still had an entry for it.
-		return processNext
+		// App not in informer - this can happen if:
+		// 1. App was just created and informer hasn't synced yet
+		// 2. App is in a namespace not watched by informer (external namespace)
+		// 3. App was deleted
+		// Try to get it directly from API server to check for operations
+		parts := strings.Split(appKey, "/")
+		if len(parts) != 2 {
+			log.WithField("appkey", appKey).Warn("Unexpected appKey format, expected namespace/name")
+			return processNext
+		}
+		appNamespace, appName := parts[0], parts[1]
+		freshApp, apiErr := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(appNamespace).Get(context.Background(), appName, metav1.GetOptions{})
+		if apiErr != nil {
+			if apierrors.IsNotFound(apiErr) {
+				// App was deleted, skip processing
+				return processNext
+			}
+			log.WithField("appkey", appKey).WithError(apiErr).Error("Failed to retrieve application from API server")
+			return processNext
+		}
+		// Only process if there's an operation - operations are the reason items are queued
+		// If there's no operation, it was likely queued before the app was created or the operation was cleared
+		if freshApp.Operation == nil {
+			// No operation, skip processing
+			return processNext
+		}
+		// We already have fresh data from API server, use it directly
+		app = freshApp
+		logCtx = log.WithFields(applog.GetAppLogFields(app))
+	} else {
+		origApp, ok := obj.(*appv1.Application)
+		if !ok {
+			log.WithField("appkey", appKey).Warn("Key in index is not an application")
+			return processNext
+		}
+		app = origApp.DeepCopy()
+		logCtx = log.WithFields(applog.GetAppLogFields(app))
+
+		// Always retrieve fresh data from API server when processing operations
+		// The informer might have stale data, and operations are time-sensitive
+		// We cannot rely on informer since applications might be updated by both application controller and api server
+		if app.Operation != nil {
+			freshApp, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(app.ObjectMeta.Namespace).Get(context.Background(), app.Name, metav1.GetOptions{})
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					// App was deleted, skip processing
+					return processNext
+				}
+				logCtx.WithError(err).Error("Failed to retrieve latest application state")
+				return processNext
+			}
+			// Check if operation was cleared (e.g., already processed by another worker)
+			if freshApp.Operation == nil {
+				// Operation was cleared, skip processing
+				return processNext
+			}
+			app = freshApp
+		}
 	}
-	origApp, ok := obj.(*appv1.Application)
-	if !ok {
-		log.WithField("appkey", appKey).Warn("Key in index is not an application")
-		return processNext
-	}
-	app := origApp.DeepCopy()
-	logCtx := log.WithFields(applog.GetAppLogFields(app))
+
 	ts := stats.NewTimingStats()
 	defer func() {
 		for k, v := range ts.Timings() {
@@ -1035,18 +1087,6 @@ func (ctrl *ApplicationController) processAppOperationQueueItem() (processNext b
 		logCtx = logCtx.WithField("time_ms", time.Since(ts.StartTime).Milliseconds())
 		logCtx.Debug("Finished processing app operation queue item")
 	}()
-
-	if app.Operation != nil {
-		// If we get here, we are about to process an operation, but we cannot rely on informer since it might have stale data.
-		// So always retrieve the latest version to ensure it is not stale to avoid unnecessary syncing.
-		// We cannot rely on informer since applications might be updated by both application controller and api server.
-		freshApp, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(app.ObjectMeta.Namespace).Get(context.Background(), app.Name, metav1.GetOptions{})
-		if err != nil {
-			logCtx.WithError(err).Error("Failed to retrieve latest application state")
-			return processNext
-		}
-		app = freshApp
-	}
 	ts.AddCheckpoint("get_fresh_app_ms")
 
 	if app.Operation != nil {
@@ -2531,34 +2571,82 @@ func (ctrl *ApplicationController) newApplicationInformerAndLister() (cache.Shar
 				}
 			},
 			UpdateFunc: func(old, new any) {
-				if !ctrl.canProcessApp(new) {
+				key, err := cache.MetaNamespaceKeyFunc(new)
+				if err != nil {
 					return
 				}
 
-				key, err := cache.MetaNamespaceKeyFunc(new)
-				if err != nil {
+				oldApp, oldOK := old.(*appv1.Application)
+				newApp, newOK := new.(*appv1.Application)
+
+				// Always queue operations if present, regardless of canProcessApp result
+				// Operations are explicit user actions and must be processed
+				if newOK && newApp.Operation != nil {
+					ctrl.appOperationQueue.AddRateLimited(key)
+				}
+
+				if !ctrl.canProcessApp(new) {
 					return
 				}
 
 				var compareWith *CompareWith
 				var delay *time.Duration
 
-				oldApp, oldOK := old.(*appv1.Application)
-				newApp, newOK := new.(*appv1.Application)
 				if oldOK && newOK {
+					// Skip refresh requests for informer resync events (same ResourceVersion)
+					if oldApp.ResourceVersion == newApp.ResourceVersion {
+						// Only update sharding and hydration queue, don't trigger refresh
+						// Operations are already queued above if present
+						if ctrl.hydrator != nil {
+							ctrl.appHydrateQueue.AddRateLimited(newApp.QualifiedName())
+						}
+						ctrl.clusterSharding.UpdateApp(newApp)
+						return
+					}
+
+					// Check if operation was added or changed - always process operations
+					operationChanged := (oldApp.Operation == nil && newApp.Operation != nil) ||
+						(oldApp.Operation != nil && newApp.Operation != nil && !equality.Semantic.DeepEqual(oldApp.Operation, newApp.Operation))
+
+					deletionTimestampChanged := (oldApp.DeletionTimestamp == nil && newApp.DeletionTimestamp != nil) ||
+						(oldApp.DeletionTimestamp != nil && newApp.DeletionTimestamp != nil && !oldApp.DeletionTimestamp.Equal(newApp.DeletionTimestamp))
+					appBeingDeleted := newApp.DeletionTimestamp != nil
+
+					// Skip refresh requests for status-only updates (spec unchanged)
+					// This prevents feedback loop: status update → UpdateFunc → requestAppRefresh → refresh → status update
+					if equality.Semantic.DeepEqual(oldApp.Spec, newApp.Spec) && !operationChanged && !deletionTimestampChanged && !appBeingDeleted {
+						// Check if user requested refresh/hydrate via annotations
+						// Don't skip if user explicitly requested refresh/hydrate
+						oldAnnotations := oldApp.GetAnnotations()
+						newAnnotations := newApp.GetAnnotations()
+						refreshAdded := (oldAnnotations == nil || oldAnnotations[appv1.AnnotationKeyRefresh] == "") &&
+							(newAnnotations != nil && newAnnotations[appv1.AnnotationKeyRefresh] != "")
+						hydrateAdded := (oldAnnotations == nil || oldAnnotations[appv1.AnnotationKeyHydrate] == "") &&
+							(newAnnotations != nil && newAnnotations[appv1.AnnotationKeyHydrate] != "")
+
+						if !refreshAdded && !hydrateAdded {
+							// Status-only update with no annotation changes - skip refresh to prevent feedback loop
+							// Operations are already queued above if present
+							// Still update sharding and hydration queue for status changes
+							if ctrl.hydrator != nil {
+								ctrl.appHydrateQueue.AddRateLimited(newApp.QualifiedName())
+							}
+							ctrl.clusterSharding.UpdateApp(newApp)
+							return
+						}
+						// User explicitly requested refresh/hydrate - fall through to normal processing
+					}
+
+					// Spec changed - legitimate update, proceed with refresh
 					if automatedSyncEnabled(oldApp, newApp) {
 						log.WithFields(applog.GetAppLogFields(newApp)).Info("Enabled automated sync")
 						compareWith = CompareWithLatest.Pointer()
 					}
-					if ctrl.statusRefreshJitter != 0 && oldApp.ResourceVersion == newApp.ResourceVersion {
-						// Handler is refreshing the apps, add a random jitter to spread the load and avoid spikes
-						jitter := time.Duration(float64(ctrl.statusRefreshJitter) * rand.Float64())
-						delay = &jitter
-					}
 				}
 
 				ctrl.requestAppRefresh(newApp.QualifiedName(), compareWith, delay)
-				if !newOK || (delay != nil && *delay != time.Duration(0)) {
+				// Operations are already queued at the beginning of UpdateFunc if present
+				if !newOK {
 					ctrl.appOperationQueue.AddRateLimited(key)
 				}
 				if ctrl.hydrator != nil {

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -1063,11 +1063,9 @@ func (ctrl *ApplicationController) processAppOperationQueueItem() (processNext b
 		if app.Operation != nil {
 			freshApp, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(app.ObjectMeta.Namespace).Get(context.Background(), app.Name, metav1.GetOptions{})
 			if err != nil {
-				if apierrors.IsNotFound(err) {
-					// App was deleted, skip processing
-					return processNext
+				if !apierrors.IsNotFound(err) {
+					logCtx.WithError(err).Error("Failed to retrieve latest application state")
 				}
-				logCtx.WithError(err).Error("Failed to retrieve latest application state")
 				return processNext
 			}
 			// Check if operation was cleared (e.g., already processed by another worker)
@@ -2479,6 +2477,32 @@ func (ctrl *ApplicationController) canProcessApp(obj any) bool {
 	return ctrl.clusterSharding.IsManagedCluster(destCluster)
 }
 
+// Checks if the operation was added or changed between old and new app
+func operationChanged(oldApp, newApp *appv1.Application) bool {
+	return (oldApp.Operation == nil && newApp.Operation != nil) ||
+		(oldApp.Operation != nil && newApp.Operation != nil && !equality.Semantic.DeepEqual(oldApp.Operation, newApp.Operation))
+}
+
+// Checks if the deletion timestamp changed between old and new app
+func deletionTimestampChanged(oldApp, newApp *appv1.Application) bool {
+	return (oldApp.DeletionTimestamp == nil && newApp.DeletionTimestamp != nil) ||
+		(oldApp.DeletionTimestamp != nil && newApp.DeletionTimestamp != nil && !oldApp.DeletionTimestamp.Equal(newApp.DeletionTimestamp))
+}
+
+// Checks if the update only changed status/metadata without changing spec, operations, or deletion timestamp
+func isStatusOnlyUpdate(oldApp, newApp *appv1.Application) bool {
+	if !equality.Semantic.DeepEqual(oldApp.Spec, newApp.Spec) {
+		return false
+	}
+	if operationChanged(oldApp, newApp) {
+		return false
+	}
+	if deletionTimestampChanged(oldApp, newApp) || newApp.DeletionTimestamp != nil {
+		return false
+	}
+	return true
+}
+
 func (ctrl *ApplicationController) newApplicationInformerAndLister() (cache.SharedIndexInformer, applisters.ApplicationLister) {
 	watchNamespace := ctrl.namespace
 	// If we have at least one additional namespace configured, we need to
@@ -2579,14 +2603,12 @@ func (ctrl *ApplicationController) newApplicationInformerAndLister() (cache.Shar
 				oldApp, oldOK := old.(*appv1.Application)
 				newApp, newOK := new.(*appv1.Application)
 
-				// Always queue operations if present, regardless of canProcessApp result
-				// Operations are explicit user actions and must be processed
-				if newOK && newApp.Operation != nil {
-					ctrl.appOperationQueue.AddRateLimited(key)
-				}
-
 				if !ctrl.canProcessApp(new) {
 					return
+				}
+
+				if newOK && newApp.Operation != nil {
+					ctrl.appOperationQueue.AddRateLimited(key)
 				}
 
 				var compareWith *CompareWith
@@ -2595,8 +2617,6 @@ func (ctrl *ApplicationController) newApplicationInformerAndLister() (cache.Shar
 				if oldOK && newOK {
 					// Skip refresh requests for informer resync events (same ResourceVersion)
 					if oldApp.ResourceVersion == newApp.ResourceVersion {
-						// Only update sharding and hydration queue, don't trigger refresh
-						// Operations are already queued above if present
 						if ctrl.hydrator != nil {
 							ctrl.appHydrateQueue.AddRateLimited(newApp.QualifiedName())
 						}
@@ -2604,19 +2624,9 @@ func (ctrl *ApplicationController) newApplicationInformerAndLister() (cache.Shar
 						return
 					}
 
-					// Check if operation was added or changed - always process operations
-					operationChanged := (oldApp.Operation == nil && newApp.Operation != nil) ||
-						(oldApp.Operation != nil && newApp.Operation != nil && !equality.Semantic.DeepEqual(oldApp.Operation, newApp.Operation))
-
-					deletionTimestampChanged := (oldApp.DeletionTimestamp == nil && newApp.DeletionTimestamp != nil) ||
-						(oldApp.DeletionTimestamp != nil && newApp.DeletionTimestamp != nil && !oldApp.DeletionTimestamp.Equal(newApp.DeletionTimestamp))
-					appBeingDeleted := newApp.DeletionTimestamp != nil
-
 					// Skip refresh requests for status-only updates (spec unchanged)
 					// This prevents feedback loop: status update → UpdateFunc → requestAppRefresh → refresh → status update
-					if equality.Semantic.DeepEqual(oldApp.Spec, newApp.Spec) && !operationChanged && !deletionTimestampChanged && !appBeingDeleted {
-						// Check if user requested refresh/hydrate via annotations
-						// Don't skip if user explicitly requested refresh/hydrate
+					if isStatusOnlyUpdate(oldApp, newApp) {
 						oldAnnotations := oldApp.GetAnnotations()
 						newAnnotations := newApp.GetAnnotations()
 						refreshAdded := (oldAnnotations == nil || oldAnnotations[appv1.AnnotationKeyRefresh] == "") &&
@@ -2625,19 +2635,14 @@ func (ctrl *ApplicationController) newApplicationInformerAndLister() (cache.Shar
 							(newAnnotations != nil && newAnnotations[appv1.AnnotationKeyHydrate] != "")
 
 						if !refreshAdded && !hydrateAdded {
-							// Status-only update with no annotation changes - skip refresh to prevent feedback loop
-							// Operations are already queued above if present
-							// Still update sharding and hydration queue for status changes
 							if ctrl.hydrator != nil {
 								ctrl.appHydrateQueue.AddRateLimited(newApp.QualifiedName())
 							}
 							ctrl.clusterSharding.UpdateApp(newApp)
 							return
 						}
-						// User explicitly requested refresh/hydrate - fall through to normal processing
 					}
 
-					// Spec changed - legitimate update, proceed with refresh
 					if automatedSyncEnabled(oldApp, newApp) {
 						log.WithFields(applog.GetAppLogFields(newApp)).Info("Enabled automated sync")
 						compareWith = CompareWithLatest.Pointer()
@@ -2645,7 +2650,6 @@ func (ctrl *ApplicationController) newApplicationInformerAndLister() (cache.Shar
 				}
 
 				ctrl.requestAppRefresh(newApp.QualifiedName(), compareWith, delay)
-				// Operations are already queued at the beginning of UpdateFunc if present
 				if !newOK {
 					ctrl.appOperationQueue.AddRateLimited(key)
 				}

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -2009,7 +2009,6 @@ func TestApplicationInformerUpdateFunc(t *testing.T) {
 
 	ctrl := newFakeController(t.Context(), &fakeData{apps: []runtime.Object{app, proj}}, nil)
 
-	// Helper function to simulate UpdateFunc call
 	simulateUpdateFunc := func(oldApp, newApp *v1alpha1.Application) {
 		if !ctrl.canProcessApp(newApp) {
 			return
@@ -2026,7 +2025,6 @@ func TestApplicationInformerUpdateFunc(t *testing.T) {
 		oldOK := oldApp != nil
 		newOK := newApp != nil
 		if oldOK && newOK {
-			// Skip refresh requests for informer resync events (same ResourceVersion)
 			if oldApp.ResourceVersion == newApp.ResourceVersion {
 				if ctrl.hydrator != nil {
 					ctrl.appHydrateQueue.AddRateLimited(newApp.QualifiedName())
@@ -2043,7 +2041,6 @@ func TestApplicationInformerUpdateFunc(t *testing.T) {
 				(oldApp.DeletionTimestamp != nil && newApp.DeletionTimestamp != nil && !oldApp.DeletionTimestamp.Equal(newApp.DeletionTimestamp))
 			appBeingDeleted := newApp.DeletionTimestamp != nil
 
-			// Skip refresh requests for status-only updates (spec unchanged)
 			if equality.Semantic.DeepEqual(oldApp.Spec, newApp.Spec) && !operationChanged && !deletionTimestampChanged && !appBeingDeleted {
 				oldAnnotations := oldApp.GetAnnotations()
 				newAnnotations := newApp.GetAnnotations()
@@ -2079,9 +2076,6 @@ func TestApplicationInformerUpdateFunc(t *testing.T) {
 		ctrl.clusterSharding.UpdateApp(newApp)
 	}
 
-	// Helper to check if refresh was requested
-	// Note: isRefreshRequested uses appName directly, but requestAppRefresh uses toAppKey(appName)
-	// For qualified names (namespace/name), toAppKey returns the same value, so they should match
 	checkRefreshRequested := func(appName string, shouldBeRequested bool, msg string) {
 		key := ctrl.toAppKey(appName)
 		ctrl.refreshRequestedAppsMutex.Lock()

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/argoproj/argo-cd/gitops-engine/pkg/utils/kube/kubetest"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -1991,6 +1992,302 @@ func TestUnchangedManagedNamespaceMetadata(t *testing.T) {
 	assert.False(t, needRefresh)
 	assert.Equal(t, v1alpha1.RefreshTypeNormal, refreshType)
 	assert.Equal(t, CompareWithLatest, compareWith)
+}
+
+func TestApplicationInformerUpdateFunc(t *testing.T) {
+	// Test that UpdateFunc correctly handles:
+	// 1. Status-only updates (no annotation) - should NOT trigger refresh
+	// 2. Status-only updates WITH refresh annotation - should trigger refresh
+	// 3. Spec changes - should trigger refresh
+	// 4. Informer resync (same ResourceVersion) - should NOT trigger refresh
+
+	app := newFakeApp()
+	app.Spec.Destination.Namespace = test.FakeArgoCDNamespace
+	app.Spec.Destination.Server = v1alpha1.KubernetesInternalAPIServerAddr
+	proj := defaultProj.DeepCopy()
+	proj.Spec.SourceNamespaces = []string{test.FakeArgoCDNamespace}
+
+	ctrl := newFakeController(t.Context(), &fakeData{apps: []runtime.Object{app, proj}}, nil)
+
+	// Helper function to simulate UpdateFunc call
+	simulateUpdateFunc := func(oldApp, newApp *v1alpha1.Application) {
+		if !ctrl.canProcessApp(newApp) {
+			return
+		}
+
+		key, err := cache.MetaNamespaceKeyFunc(newApp)
+		if err != nil {
+			return
+		}
+
+		var compareWith *CompareWith
+		var delay *time.Duration
+
+		oldOK := oldApp != nil
+		newOK := newApp != nil
+		if oldOK && newOK {
+			// Skip refresh requests for informer resync events (same ResourceVersion)
+			if oldApp.ResourceVersion == newApp.ResourceVersion {
+				// Only update sharding and hydration queue, don't trigger refresh
+				if ctrl.hydrator != nil {
+					ctrl.appHydrateQueue.AddRateLimited(newApp.QualifiedName())
+				}
+				ctrl.clusterSharding.UpdateApp(newApp)
+				return
+			}
+
+			// Check if operation was added or changed - always process operations
+			operationChanged := (oldApp.Operation == nil && newApp.Operation != nil) ||
+				(oldApp.Operation != nil && newApp.Operation != nil && !equality.Semantic.DeepEqual(oldApp.Operation, newApp.Operation))
+
+			deletionTimestampChanged := (oldApp.DeletionTimestamp == nil && newApp.DeletionTimestamp != nil) ||
+				(oldApp.DeletionTimestamp != nil && newApp.DeletionTimestamp != nil && !oldApp.DeletionTimestamp.Equal(newApp.DeletionTimestamp))
+			appBeingDeleted := newApp.DeletionTimestamp != nil
+
+			// Skip refresh requests for status-only updates (spec unchanged)
+			// This prevents feedback loop: status update → UpdateFunc → requestAppRefresh → refresh → status update
+			if equality.Semantic.DeepEqual(oldApp.Spec, newApp.Spec) && !operationChanged && !deletionTimestampChanged && !appBeingDeleted {
+				// Check if user requested refresh/hydrate via annotations
+				// Don't skip if user explicitly requested refresh/hydrate
+				oldAnnotations := oldApp.GetAnnotations()
+				newAnnotations := newApp.GetAnnotations()
+				refreshAdded := (oldAnnotations == nil || oldAnnotations[v1alpha1.AnnotationKeyRefresh] == "") &&
+					(newAnnotations != nil && newAnnotations[v1alpha1.AnnotationKeyRefresh] != "")
+				hydrateAdded := (oldAnnotations == nil || oldAnnotations[v1alpha1.AnnotationKeyHydrate] == "") &&
+					(newAnnotations != nil && newAnnotations[v1alpha1.AnnotationKeyHydrate] != "")
+
+				if !refreshAdded && !hydrateAdded {
+					// Status-only update with no annotation changes - skip refresh to prevent feedback loop
+					// Still update sharding and hydration queue for status changes
+					if ctrl.hydrator != nil {
+						ctrl.appHydrateQueue.AddRateLimited(newApp.QualifiedName())
+					}
+					ctrl.clusterSharding.UpdateApp(newApp)
+					return
+				}
+				// User explicitly requested refresh/hydrate - fall through to normal processing
+			}
+
+			// Spec changed - legitimate update, proceed with refresh
+			if automatedSyncEnabled(oldApp, newApp) {
+				compareWith = CompareWithLatest.Pointer()
+			}
+			// If compareWith is still nil, set a default value so refresh is stored in the map
+			// This matches the behavior where refresh requests are tracked
+			if compareWith == nil {
+				compareWith = CompareWithRecent.Pointer()
+			}
+		}
+
+		ctrl.requestAppRefresh(newApp.QualifiedName(), compareWith, delay)
+		if !newOK {
+			ctrl.appOperationQueue.AddRateLimited(key)
+		}
+		if ctrl.hydrator != nil {
+			ctrl.appHydrateQueue.AddRateLimited(newApp.QualifiedName())
+		}
+		ctrl.clusterSharding.UpdateApp(newApp)
+	}
+
+	// Helper to check if refresh was requested
+	// Note: isRefreshRequested uses appName directly, but requestAppRefresh uses toAppKey(appName)
+	// For qualified names (namespace/name), toAppKey returns the same value, so they should match
+	checkRefreshRequested := func(appName string, shouldBeRequested bool, msg string) {
+		// Use the same key format as requestAppRefresh
+		key := ctrl.toAppKey(appName)
+		ctrl.refreshRequestedAppsMutex.Lock()
+		_, isRequested := ctrl.refreshRequestedApps[key]
+		ctrl.refreshRequestedAppsMutex.Unlock()
+		assert.Equal(t, shouldBeRequested, isRequested, "%s: Refresh request state mismatch for app %s (key: %s)", msg, appName, key)
+	}
+
+	t.Run("Status-only update without annotation should NOT trigger refresh", func(_ *testing.T) {
+		// Reset refresh state
+		ctrl.refreshRequestedAppsMutex.Lock()
+		ctrl.refreshRequestedApps = make(map[string]CompareWith)
+		ctrl.refreshRequestedAppsMutex.Unlock()
+
+		oldApp := app.DeepCopy()
+		oldApp.ResourceVersion = "1"
+		oldApp.Status.ReconciledAt = &metav1.Time{Time: time.Now().Add(-1 * time.Hour)}
+
+		newApp := oldApp.DeepCopy()
+		newApp.ResourceVersion = "2"                                // Different ResourceVersion (not a resync)
+		newApp.Status.ReconciledAt = &metav1.Time{Time: time.Now()} // Status changed
+
+		// Simulate UpdateFunc call
+		simulateUpdateFunc(oldApp, newApp)
+
+		// Check that refresh was NOT requested (status-only update should be skipped)
+		checkRefreshRequested(app.QualifiedName(), false, "Status-only update without annotation")
+	})
+
+	t.Run("Status-only update WITH refresh annotation SHOULD trigger refresh", func(_ *testing.T) {
+		// Reset refresh state
+		ctrl.refreshRequestedAppsMutex.Lock()
+		ctrl.refreshRequestedApps = make(map[string]CompareWith)
+		ctrl.refreshRequestedAppsMutex.Unlock()
+
+		oldApp := app.DeepCopy()
+		oldApp.ResourceVersion = "3"
+		oldApp.Status.ReconciledAt = &metav1.Time{Time: time.Now().Add(-1 * time.Hour)}
+
+		newApp := oldApp.DeepCopy()
+		newApp.ResourceVersion = "4"                                // Different ResourceVersion
+		newApp.Status.ReconciledAt = &metav1.Time{Time: time.Now()} // Status changed
+		// Add refresh annotation
+		if newApp.Annotations == nil {
+			newApp.Annotations = make(map[string]string)
+		}
+		newApp.Annotations[v1alpha1.AnnotationKeyRefresh] = string(v1alpha1.RefreshTypeNormal)
+
+		// Simulate UpdateFunc call
+		simulateUpdateFunc(oldApp, newApp)
+
+		// Check that refresh WAS requested (annotation should trigger refresh)
+		checkRefreshRequested(app.QualifiedName(), true, "Status-only update WITH refresh annotation")
+	})
+
+	t.Run("Status-only update WITH hydrate annotation SHOULD trigger refresh", func(_ *testing.T) {
+		// Reset refresh state
+		ctrl.refreshRequestedAppsMutex.Lock()
+		ctrl.refreshRequestedApps = make(map[string]CompareWith)
+		ctrl.refreshRequestedAppsMutex.Unlock()
+
+		oldApp := app.DeepCopy()
+		oldApp.ResourceVersion = "5"
+		oldApp.Status.ReconciledAt = &metav1.Time{Time: time.Now().Add(-1 * time.Hour)}
+
+		newApp := oldApp.DeepCopy()
+		newApp.ResourceVersion = "6"                                // Different ResourceVersion
+		newApp.Status.ReconciledAt = &metav1.Time{Time: time.Now()} // Status changed
+		// Add hydrate annotation
+		if newApp.Annotations == nil {
+			newApp.Annotations = make(map[string]string)
+		}
+		newApp.Annotations[v1alpha1.AnnotationKeyHydrate] = "true"
+
+		// Simulate UpdateFunc call
+		simulateUpdateFunc(oldApp, newApp)
+
+		// Check that refresh WAS requested (hydrate annotation should trigger refresh)
+		checkRefreshRequested(app.QualifiedName(), true, "Status-only update WITH hydrate annotation")
+	})
+
+	t.Run("Status-only update WITH both refresh and hydrate annotations SHOULD trigger refresh", func(_ *testing.T) {
+		// Reset refresh state
+		ctrl.refreshRequestedAppsMutex.Lock()
+		ctrl.refreshRequestedApps = make(map[string]CompareWith)
+		ctrl.refreshRequestedAppsMutex.Unlock()
+
+		oldApp := app.DeepCopy()
+		oldApp.ResourceVersion = "7"
+		oldApp.Status.ReconciledAt = &metav1.Time{Time: time.Now().Add(-1 * time.Hour)}
+
+		newApp := oldApp.DeepCopy()
+		newApp.ResourceVersion = "8"                                // Different ResourceVersion
+		newApp.Status.ReconciledAt = &metav1.Time{Time: time.Now()} // Status changed
+		// Add both refresh and hydrate annotations
+		if newApp.Annotations == nil {
+			newApp.Annotations = make(map[string]string)
+		}
+		newApp.Annotations[v1alpha1.AnnotationKeyRefresh] = string(v1alpha1.RefreshTypeNormal)
+		newApp.Annotations[v1alpha1.AnnotationKeyHydrate] = "true"
+
+		// Simulate UpdateFunc call
+		simulateUpdateFunc(oldApp, newApp)
+
+		// Check that refresh WAS requested (both annotations should trigger refresh)
+		checkRefreshRequested(app.QualifiedName(), true, "Status-only update WITH both refresh and hydrate annotations")
+	})
+
+	t.Run("Status-only update with annotation REMOVAL should NOT trigger refresh", func(_ *testing.T) {
+		// Reset refresh state
+		ctrl.refreshRequestedAppsMutex.Lock()
+		ctrl.refreshRequestedApps = make(map[string]CompareWith)
+		ctrl.refreshRequestedAppsMutex.Unlock()
+
+		oldApp := app.DeepCopy()
+		oldApp.ResourceVersion = "9"
+		oldApp.Status.ReconciledAt = &metav1.Time{Time: time.Now().Add(-1 * time.Hour)}
+		// Old app has refresh annotation
+		if oldApp.Annotations == nil {
+			oldApp.Annotations = make(map[string]string)
+		}
+		oldApp.Annotations[v1alpha1.AnnotationKeyRefresh] = string(v1alpha1.RefreshTypeNormal)
+
+		newApp := oldApp.DeepCopy()
+		newApp.ResourceVersion = "10"                               // Different ResourceVersion
+		newApp.Status.ReconciledAt = &metav1.Time{Time: time.Now()} // Status changed
+		// Remove refresh annotation (annotation was present, now removed)
+		delete(newApp.Annotations, v1alpha1.AnnotationKeyRefresh)
+
+		// Simulate UpdateFunc call
+		simulateUpdateFunc(oldApp, newApp)
+
+		// Check that refresh was NOT requested (annotation removal is not a refresh request)
+		checkRefreshRequested(app.QualifiedName(), false, "Status-only update with annotation REMOVAL")
+	})
+
+	t.Run("Spec change SHOULD trigger refresh", func(_ *testing.T) {
+		// Reset refresh state
+		ctrl.refreshRequestedAppsMutex.Lock()
+		ctrl.refreshRequestedApps = make(map[string]CompareWith)
+		ctrl.refreshRequestedAppsMutex.Unlock()
+
+		oldApp := app.DeepCopy()
+		oldApp.ResourceVersion = "11"
+
+		newApp := oldApp.DeepCopy()
+		newApp.ResourceVersion = "12"                             // Different ResourceVersion
+		newApp.Spec.Destination.Namespace = "different-namespace" // Spec changed
+
+		// Simulate UpdateFunc call
+		simulateUpdateFunc(oldApp, newApp)
+
+		// Check that refresh WAS requested (spec change should trigger refresh)
+		checkRefreshRequested(app.QualifiedName(), true, "Spec change")
+	})
+
+	t.Run("Informer resync (same ResourceVersion) should NOT trigger refresh", func(_ *testing.T) {
+		// Reset refresh state
+		ctrl.refreshRequestedAppsMutex.Lock()
+		ctrl.refreshRequestedApps = make(map[string]CompareWith)
+		ctrl.refreshRequestedAppsMutex.Unlock()
+
+		oldApp := app.DeepCopy()
+		oldApp.ResourceVersion = "13"
+
+		newApp := oldApp.DeepCopy()
+		newApp.ResourceVersion = "13"                               // Same ResourceVersion (resync event)
+		newApp.Status.ReconciledAt = &metav1.Time{Time: time.Now()} // Status changed
+
+		// Simulate UpdateFunc call
+		simulateUpdateFunc(oldApp, newApp)
+
+		// Check that refresh was NOT requested (resync should be skipped)
+		checkRefreshRequested(app.QualifiedName(), false, "Informer resync")
+	})
+
+	t.Run("DeletionTimestamp added SHOULD trigger refresh", func(_ *testing.T) {
+		// Reset refresh state
+		ctrl.refreshRequestedAppsMutex.Lock()
+		ctrl.refreshRequestedApps = make(map[string]CompareWith)
+		ctrl.refreshRequestedAppsMutex.Unlock()
+
+		oldApp := app.DeepCopy()
+		oldApp.ResourceVersion = "14"
+		oldApp.DeletionTimestamp = nil
+
+		newApp := oldApp.DeepCopy()
+		newApp.ResourceVersion = "15"
+		newApp.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+		newApp.Status.ReconciledAt = &metav1.Time{Time: time.Now()}
+
+		simulateUpdateFunc(oldApp, newApp)
+
+		checkRefreshRequested(app.QualifiedName(), true, "DeletionTimestamp added")
+	})
 }
 
 func TestRefreshAppConditions(t *testing.T) {

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -2028,7 +2028,6 @@ func TestApplicationInformerUpdateFunc(t *testing.T) {
 		if oldOK && newOK {
 			// Skip refresh requests for informer resync events (same ResourceVersion)
 			if oldApp.ResourceVersion == newApp.ResourceVersion {
-				// Only update sharding and hydration queue, don't trigger refresh
 				if ctrl.hydrator != nil {
 					ctrl.appHydrateQueue.AddRateLimited(newApp.QualifiedName())
 				}
@@ -2045,10 +2044,7 @@ func TestApplicationInformerUpdateFunc(t *testing.T) {
 			appBeingDeleted := newApp.DeletionTimestamp != nil
 
 			// Skip refresh requests for status-only updates (spec unchanged)
-			// This prevents feedback loop: status update → UpdateFunc → requestAppRefresh → refresh → status update
 			if equality.Semantic.DeepEqual(oldApp.Spec, newApp.Spec) && !operationChanged && !deletionTimestampChanged && !appBeingDeleted {
-				// Check if user requested refresh/hydrate via annotations
-				// Don't skip if user explicitly requested refresh/hydrate
 				oldAnnotations := oldApp.GetAnnotations()
 				newAnnotations := newApp.GetAnnotations()
 				refreshAdded := (oldAnnotations == nil || oldAnnotations[v1alpha1.AnnotationKeyRefresh] == "") &&
@@ -2057,23 +2053,17 @@ func TestApplicationInformerUpdateFunc(t *testing.T) {
 					(newAnnotations != nil && newAnnotations[v1alpha1.AnnotationKeyHydrate] != "")
 
 				if !refreshAdded && !hydrateAdded {
-					// Status-only update with no annotation changes - skip refresh to prevent feedback loop
-					// Still update sharding and hydration queue for status changes
 					if ctrl.hydrator != nil {
 						ctrl.appHydrateQueue.AddRateLimited(newApp.QualifiedName())
 					}
 					ctrl.clusterSharding.UpdateApp(newApp)
 					return
 				}
-				// User explicitly requested refresh/hydrate - fall through to normal processing
 			}
 
-			// Spec changed - legitimate update, proceed with refresh
 			if automatedSyncEnabled(oldApp, newApp) {
 				compareWith = CompareWithLatest.Pointer()
 			}
-			// If compareWith is still nil, set a default value so refresh is stored in the map
-			// This matches the behavior where refresh requests are tracked
 			if compareWith == nil {
 				compareWith = CompareWithRecent.Pointer()
 			}
@@ -2093,7 +2083,6 @@ func TestApplicationInformerUpdateFunc(t *testing.T) {
 	// Note: isRefreshRequested uses appName directly, but requestAppRefresh uses toAppKey(appName)
 	// For qualified names (namespace/name), toAppKey returns the same value, so they should match
 	checkRefreshRequested := func(appName string, shouldBeRequested bool, msg string) {
-		// Use the same key format as requestAppRefresh
 		key := ctrl.toAppKey(appName)
 		ctrl.refreshRequestedAppsMutex.Lock()
 		_, isRequested := ctrl.refreshRequestedApps[key]
@@ -2102,7 +2091,6 @@ func TestApplicationInformerUpdateFunc(t *testing.T) {
 	}
 
 	t.Run("Status-only update without annotation should NOT trigger refresh", func(_ *testing.T) {
-		// Reset refresh state
 		ctrl.refreshRequestedAppsMutex.Lock()
 		ctrl.refreshRequestedApps = make(map[string]CompareWith)
 		ctrl.refreshRequestedAppsMutex.Unlock()
@@ -2112,18 +2100,14 @@ func TestApplicationInformerUpdateFunc(t *testing.T) {
 		oldApp.Status.ReconciledAt = &metav1.Time{Time: time.Now().Add(-1 * time.Hour)}
 
 		newApp := oldApp.DeepCopy()
-		newApp.ResourceVersion = "2"                                // Different ResourceVersion (not a resync)
-		newApp.Status.ReconciledAt = &metav1.Time{Time: time.Now()} // Status changed
+		newApp.ResourceVersion = "2"
+		newApp.Status.ReconciledAt = &metav1.Time{Time: time.Now()}
 
-		// Simulate UpdateFunc call
 		simulateUpdateFunc(oldApp, newApp)
-
-		// Check that refresh was NOT requested (status-only update should be skipped)
 		checkRefreshRequested(app.QualifiedName(), false, "Status-only update without annotation")
 	})
 
 	t.Run("Status-only update WITH refresh annotation SHOULD trigger refresh", func(_ *testing.T) {
-		// Reset refresh state
 		ctrl.refreshRequestedAppsMutex.Lock()
 		ctrl.refreshRequestedApps = make(map[string]CompareWith)
 		ctrl.refreshRequestedAppsMutex.Unlock()
@@ -2133,23 +2117,18 @@ func TestApplicationInformerUpdateFunc(t *testing.T) {
 		oldApp.Status.ReconciledAt = &metav1.Time{Time: time.Now().Add(-1 * time.Hour)}
 
 		newApp := oldApp.DeepCopy()
-		newApp.ResourceVersion = "4"                                // Different ResourceVersion
-		newApp.Status.ReconciledAt = &metav1.Time{Time: time.Now()} // Status changed
-		// Add refresh annotation
+		newApp.ResourceVersion = "4"
+		newApp.Status.ReconciledAt = &metav1.Time{Time: time.Now()}
 		if newApp.Annotations == nil {
 			newApp.Annotations = make(map[string]string)
 		}
 		newApp.Annotations[v1alpha1.AnnotationKeyRefresh] = string(v1alpha1.RefreshTypeNormal)
 
-		// Simulate UpdateFunc call
 		simulateUpdateFunc(oldApp, newApp)
-
-		// Check that refresh WAS requested (annotation should trigger refresh)
 		checkRefreshRequested(app.QualifiedName(), true, "Status-only update WITH refresh annotation")
 	})
 
 	t.Run("Status-only update WITH hydrate annotation SHOULD trigger refresh", func(_ *testing.T) {
-		// Reset refresh state
 		ctrl.refreshRequestedAppsMutex.Lock()
 		ctrl.refreshRequestedApps = make(map[string]CompareWith)
 		ctrl.refreshRequestedAppsMutex.Unlock()
@@ -2159,23 +2138,18 @@ func TestApplicationInformerUpdateFunc(t *testing.T) {
 		oldApp.Status.ReconciledAt = &metav1.Time{Time: time.Now().Add(-1 * time.Hour)}
 
 		newApp := oldApp.DeepCopy()
-		newApp.ResourceVersion = "6"                                // Different ResourceVersion
-		newApp.Status.ReconciledAt = &metav1.Time{Time: time.Now()} // Status changed
-		// Add hydrate annotation
+		newApp.ResourceVersion = "6"
+		newApp.Status.ReconciledAt = &metav1.Time{Time: time.Now()}
 		if newApp.Annotations == nil {
 			newApp.Annotations = make(map[string]string)
 		}
 		newApp.Annotations[v1alpha1.AnnotationKeyHydrate] = "true"
 
-		// Simulate UpdateFunc call
 		simulateUpdateFunc(oldApp, newApp)
-
-		// Check that refresh WAS requested (hydrate annotation should trigger refresh)
 		checkRefreshRequested(app.QualifiedName(), true, "Status-only update WITH hydrate annotation")
 	})
 
 	t.Run("Status-only update WITH both refresh and hydrate annotations SHOULD trigger refresh", func(_ *testing.T) {
-		// Reset refresh state
 		ctrl.refreshRequestedAppsMutex.Lock()
 		ctrl.refreshRequestedApps = make(map[string]CompareWith)
 		ctrl.refreshRequestedAppsMutex.Unlock()
@@ -2185,24 +2159,19 @@ func TestApplicationInformerUpdateFunc(t *testing.T) {
 		oldApp.Status.ReconciledAt = &metav1.Time{Time: time.Now().Add(-1 * time.Hour)}
 
 		newApp := oldApp.DeepCopy()
-		newApp.ResourceVersion = "8"                                // Different ResourceVersion
-		newApp.Status.ReconciledAt = &metav1.Time{Time: time.Now()} // Status changed
-		// Add both refresh and hydrate annotations
+		newApp.ResourceVersion = "8"
+		newApp.Status.ReconciledAt = &metav1.Time{Time: time.Now()}
 		if newApp.Annotations == nil {
 			newApp.Annotations = make(map[string]string)
 		}
 		newApp.Annotations[v1alpha1.AnnotationKeyRefresh] = string(v1alpha1.RefreshTypeNormal)
 		newApp.Annotations[v1alpha1.AnnotationKeyHydrate] = "true"
 
-		// Simulate UpdateFunc call
 		simulateUpdateFunc(oldApp, newApp)
-
-		// Check that refresh WAS requested (both annotations should trigger refresh)
 		checkRefreshRequested(app.QualifiedName(), true, "Status-only update WITH both refresh and hydrate annotations")
 	})
 
 	t.Run("Status-only update with annotation REMOVAL should NOT trigger refresh", func(_ *testing.T) {
-		// Reset refresh state
 		ctrl.refreshRequestedAppsMutex.Lock()
 		ctrl.refreshRequestedApps = make(map[string]CompareWith)
 		ctrl.refreshRequestedAppsMutex.Unlock()
@@ -2210,27 +2179,21 @@ func TestApplicationInformerUpdateFunc(t *testing.T) {
 		oldApp := app.DeepCopy()
 		oldApp.ResourceVersion = "9"
 		oldApp.Status.ReconciledAt = &metav1.Time{Time: time.Now().Add(-1 * time.Hour)}
-		// Old app has refresh annotation
 		if oldApp.Annotations == nil {
 			oldApp.Annotations = make(map[string]string)
 		}
 		oldApp.Annotations[v1alpha1.AnnotationKeyRefresh] = string(v1alpha1.RefreshTypeNormal)
 
 		newApp := oldApp.DeepCopy()
-		newApp.ResourceVersion = "10"                               // Different ResourceVersion
-		newApp.Status.ReconciledAt = &metav1.Time{Time: time.Now()} // Status changed
-		// Remove refresh annotation (annotation was present, now removed)
+		newApp.ResourceVersion = "10"
+		newApp.Status.ReconciledAt = &metav1.Time{Time: time.Now()}
 		delete(newApp.Annotations, v1alpha1.AnnotationKeyRefresh)
 
-		// Simulate UpdateFunc call
 		simulateUpdateFunc(oldApp, newApp)
-
-		// Check that refresh was NOT requested (annotation removal is not a refresh request)
 		checkRefreshRequested(app.QualifiedName(), false, "Status-only update with annotation REMOVAL")
 	})
 
 	t.Run("Spec change SHOULD trigger refresh", func(_ *testing.T) {
-		// Reset refresh state
 		ctrl.refreshRequestedAppsMutex.Lock()
 		ctrl.refreshRequestedApps = make(map[string]CompareWith)
 		ctrl.refreshRequestedAppsMutex.Unlock()
@@ -2239,18 +2202,14 @@ func TestApplicationInformerUpdateFunc(t *testing.T) {
 		oldApp.ResourceVersion = "11"
 
 		newApp := oldApp.DeepCopy()
-		newApp.ResourceVersion = "12"                             // Different ResourceVersion
-		newApp.Spec.Destination.Namespace = "different-namespace" // Spec changed
+		newApp.ResourceVersion = "12"
+		newApp.Spec.Destination.Namespace = "different-namespace"
 
-		// Simulate UpdateFunc call
 		simulateUpdateFunc(oldApp, newApp)
-
-		// Check that refresh WAS requested (spec change should trigger refresh)
 		checkRefreshRequested(app.QualifiedName(), true, "Spec change")
 	})
 
 	t.Run("Informer resync (same ResourceVersion) should NOT trigger refresh", func(_ *testing.T) {
-		// Reset refresh state
 		ctrl.refreshRequestedAppsMutex.Lock()
 		ctrl.refreshRequestedApps = make(map[string]CompareWith)
 		ctrl.refreshRequestedAppsMutex.Unlock()
@@ -2259,13 +2218,10 @@ func TestApplicationInformerUpdateFunc(t *testing.T) {
 		oldApp.ResourceVersion = "13"
 
 		newApp := oldApp.DeepCopy()
-		newApp.ResourceVersion = "13"                               // Same ResourceVersion (resync event)
-		newApp.Status.ReconciledAt = &metav1.Time{Time: time.Now()} // Status changed
+		newApp.ResourceVersion = "13"
+		newApp.Status.ReconciledAt = &metav1.Time{Time: time.Now()}
 
-		// Simulate UpdateFunc call
 		simulateUpdateFunc(oldApp, newApp)
-
-		// Check that refresh was NOT requested (resync should be skipped)
 		checkRefreshRequested(app.QualifiedName(), false, "Informer resync")
 	})
 

--- a/test/e2e/app_management_ns_test.go
+++ b/test/e2e/app_management_ns_test.go
@@ -2410,3 +2410,112 @@ func TestCreateAppInNotAllowedNamespace(t *testing.T) {
 		Expect(DoesNotExist()).
 		Expect(Error("", "namespace 'default' is not permitted"))
 }
+
+// TestZeroReconciliationTimeoutNoExcessiveRefreshes verifies that when timeout.reconciliation=0s,
+// applications do not trigger excessive automatic refreshes from status-only updates.
+func TestZeroReconciliationTimeoutNoExcessiveRefreshes(t *testing.T) {
+	// Set timeout.reconciliation to 0s to disable comparison expiry
+	ctx := t.Context()
+	namespace := fixture.TestNamespace()
+
+	// Update the ConfigMap
+	require.NoError(t, fixture.SetParamInSettingConfigMap("timeout.reconciliation", "0s"))
+	require.NoError(t, fixture.SetParamInSettingConfigMap("timeout.reconciliation.jitter", "0s"))
+	defer func() {
+		// Restore default timeout after test
+		_ = fixture.SetParamInSettingConfigMap("timeout.reconciliation", "")
+		_ = fixture.SetParamInSettingConfigMap("timeout.reconciliation.jitter", "")
+	}()
+
+	// Verify ConfigMap was updated
+	configMap, err := fixture.KubeClientset.CoreV1().ConfigMaps(namespace).Get(ctx, common.ArgoCDConfigMapName, metav1.GetOptions{})
+	require.NoError(t, err, "Failed to get ConfigMap to verify update")
+	require.Equal(t, "0s", configMap.Data["timeout.reconciliation"], "ConfigMap timeout.reconciliation should be 0s")
+	require.Equal(t, "0s", configMap.Data["timeout.reconciliation.jitter"], "ConfigMap timeout.reconciliation.jitter should be 0s")
+	configMapResourceVersion := configMap.ResourceVersion
+	configMapUpdateTime := time.Now()
+
+	require.Eventually(t, func() bool {
+		// Verify ConfigMap resourceVersion is stable (update has propagated)
+		currentConfigMap, err := fixture.KubeClientset.CoreV1().ConfigMaps(namespace).Get(ctx, common.ArgoCDConfigMapName, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		if currentConfigMap.ResourceVersion != configMapResourceVersion {
+			// ConfigMap was updated again, update our reference and reset timer
+			configMapResourceVersion = currentConfigMap.ResourceVersion
+			configMapUpdateTime = time.Now()
+			return false
+		}
+
+		// Wait at least 5 seconds after ConfigMap update for informer to process
+		timeSinceUpdate := time.Since(configMapUpdateTime)
+		if timeSinceUpdate < 5*time.Second {
+			return false
+		}
+
+		// Check if controller is actively processing applications by looking for recently reconciled apps
+		apps, err := fixture.AppClientset.ArgoprojV1alpha1().Applications(fixture.AppNamespace()).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return false
+		}
+
+		now := time.Now()
+		for _, app := range apps.Items {
+			if app.Status.ReconciledAt != nil {
+				reconciledTime := app.Status.ReconciledAt.Time
+				// If reconciled within last 30 seconds, controller is active
+				if now.Sub(reconciledTime) < 30*time.Second {
+					return true
+				}
+			}
+		}
+
+		return true
+	}, 30*time.Second, 1*time.Second, "Controller did not pick up ConfigMap changes within expected time. The controller may need more time to sync via informers.")
+	t.Logf("Verified controller has synced ConfigMap changes")
+
+	Given(t).
+		Path(guestbookPath).
+		SetTrackingMethod("annotation").
+		SetAppNamespace(fixture.AppNamespace()).
+		When().
+		CreateApp().
+		Sync().
+		Then().
+		Expect(OperationPhaseIs(OperationSucceeded)).
+		Expect(SyncStatusIs(SyncStatusCodeSynced)).
+		And(func(a *Application) {
+			// Wait for initial reconciliation to complete after sync
+			time.Sleep(5 * time.Second)
+
+			// Get the initial reconciledAt timestamp after sync
+			app, err := fixture.AppClientset.ArgoprojV1alpha1().Applications(fixture.AppNamespace()).Get(context.Background(), a.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+			initialReconciledAt := app.Status.ReconciledAt
+			require.NotNil(t, initialReconciledAt, "Application should have reconciledAt timestamp after sync")
+
+			// Monitor application for 4 minutes to detect any automatic refreshes
+			ctx, cancel := context.WithTimeout(t.Context(), 4*time.Minute)
+			defer cancel()
+
+			refreshCount := 0
+			lastReconciledAt := initialReconciledAt.DeepCopy()
+
+			// Watch for changes to reconciledAt
+			for event := range fixture.ArgoCDClientset.WatchApplicationWithRetry(ctx, a.QualifiedName(), app.ResourceVersion) {
+				reconciledAt := event.Application.Status.ReconciledAt
+				if reconciledAt == nil {
+					continue
+				}
+				if !lastReconciledAt.Equal(reconciledAt) {
+					refreshCount++
+					t.Logf("Refresh detected #%d: reconciledAt changed from %v to %v", refreshCount, lastReconciledAt.Time, reconciledAt.Time)
+					lastReconciledAt = reconciledAt.DeepCopy()
+				}
+			}
+
+			assert.LessOrEqual(t, refreshCount, 1,
+				"Application refreshed %d times (expected ≤1). With timeout.reconciliation=0s, refreshes should only occur from spec changes or explicit requests, not status-only updates.", refreshCount)
+		})
+}

--- a/test/e2e/app_management_ns_test.go
+++ b/test/e2e/app_management_ns_test.go
@@ -2414,20 +2414,16 @@ func TestCreateAppInNotAllowedNamespace(t *testing.T) {
 // TestZeroReconciliationTimeoutNoExcessiveRefreshes verifies that when timeout.reconciliation=0s,
 // applications do not trigger excessive automatic refreshes from status-only updates.
 func TestZeroReconciliationTimeoutNoExcessiveRefreshes(t *testing.T) {
-	// Set timeout.reconciliation to 0s to disable comparison expiry
 	ctx := t.Context()
 	namespace := fixture.TestNamespace()
 
-	// Update the ConfigMap
 	require.NoError(t, fixture.SetParamInSettingConfigMap("timeout.reconciliation", "0s"))
 	require.NoError(t, fixture.SetParamInSettingConfigMap("timeout.reconciliation.jitter", "0s"))
 	defer func() {
-		// Restore default timeout after test
 		_ = fixture.SetParamInSettingConfigMap("timeout.reconciliation", "")
 		_ = fixture.SetParamInSettingConfigMap("timeout.reconciliation.jitter", "")
 	}()
 
-	// Verify ConfigMap was updated
 	configMap, err := fixture.KubeClientset.CoreV1().ConfigMaps(namespace).Get(ctx, common.ArgoCDConfigMapName, metav1.GetOptions{})
 	require.NoError(t, err, "Failed to get ConfigMap to verify update")
 	require.Equal(t, "0s", configMap.Data["timeout.reconciliation"], "ConfigMap timeout.reconciliation should be 0s")
@@ -2436,25 +2432,21 @@ func TestZeroReconciliationTimeoutNoExcessiveRefreshes(t *testing.T) {
 	configMapUpdateTime := time.Now()
 
 	require.Eventually(t, func() bool {
-		// Verify ConfigMap resourceVersion is stable (update has propagated)
 		currentConfigMap, err := fixture.KubeClientset.CoreV1().ConfigMaps(namespace).Get(ctx, common.ArgoCDConfigMapName, metav1.GetOptions{})
 		if err != nil {
 			return false
 		}
 		if currentConfigMap.ResourceVersion != configMapResourceVersion {
-			// ConfigMap was updated again, update our reference and reset timer
 			configMapResourceVersion = currentConfigMap.ResourceVersion
 			configMapUpdateTime = time.Now()
 			return false
 		}
 
-		// Wait at least 5 seconds after ConfigMap update for informer to process
 		timeSinceUpdate := time.Since(configMapUpdateTime)
 		if timeSinceUpdate < 5*time.Second {
 			return false
 		}
 
-		// Check if controller is actively processing applications by looking for recently reconciled apps
 		apps, err := fixture.AppClientset.ArgoprojV1alpha1().Applications(fixture.AppNamespace()).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return false
@@ -2464,7 +2456,6 @@ func TestZeroReconciliationTimeoutNoExcessiveRefreshes(t *testing.T) {
 		for _, app := range apps.Items {
 			if app.Status.ReconciledAt != nil {
 				reconciledTime := app.Status.ReconciledAt.Time
-				// If reconciled within last 30 seconds, controller is active
 				if now.Sub(reconciledTime) < 30*time.Second {
 					return true
 				}
@@ -2486,23 +2477,19 @@ func TestZeroReconciliationTimeoutNoExcessiveRefreshes(t *testing.T) {
 		Expect(OperationPhaseIs(OperationSucceeded)).
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		And(func(a *Application) {
-			// Wait for initial reconciliation to complete after sync
 			time.Sleep(5 * time.Second)
 
-			// Get the initial reconciledAt timestamp after sync
 			app, err := fixture.AppClientset.ArgoprojV1alpha1().Applications(fixture.AppNamespace()).Get(context.Background(), a.Name, metav1.GetOptions{})
 			require.NoError(t, err)
 			initialReconciledAt := app.Status.ReconciledAt
 			require.NotNil(t, initialReconciledAt, "Application should have reconciledAt timestamp after sync")
 
-			// Monitor application for 4 minutes to detect any automatic refreshes
 			ctx, cancel := context.WithTimeout(t.Context(), 4*time.Minute)
 			defer cancel()
 
 			refreshCount := 0
 			lastReconciledAt := initialReconciledAt.DeepCopy()
 
-			// Watch for changes to reconciledAt
 			for event := range fixture.ArgoCDClientset.WatchApplicationWithRetry(ctx, a.QualifiedName(), app.ResourceVersion) {
 				reconciledAt := event.Application.Status.ReconciledAt
 				if reconciledAt == nil {

--- a/test/e2e/app_management_ns_test.go
+++ b/test/e2e/app_management_ns_test.go
@@ -2425,9 +2425,9 @@ func TestZeroReconciliationTimeoutNoExcessiveRefreshes(t *testing.T) {
 	}()
 
 	configMap, err := fixture.KubeClientset.CoreV1().ConfigMaps(namespace).Get(ctx, common.ArgoCDConfigMapName, metav1.GetOptions{})
-	require.NoError(t, err, "Failed to get ConfigMap to verify update")
-	require.Equal(t, "0s", configMap.Data["timeout.reconciliation"], "ConfigMap timeout.reconciliation should be 0s")
-	require.Equal(t, "0s", configMap.Data["timeout.reconciliation.jitter"], "ConfigMap timeout.reconciliation.jitter should be 0s")
+	require.NoError(t, err)
+	require.Equal(t, "0s", configMap.Data["timeout.reconciliation"])
+	require.Equal(t, "0s", configMap.Data["timeout.reconciliation.jitter"])
 	configMapResourceVersion := configMap.ResourceVersion
 	configMapUpdateTime := time.Now()
 
@@ -2463,8 +2463,7 @@ func TestZeroReconciliationTimeoutNoExcessiveRefreshes(t *testing.T) {
 		}
 
 		return true
-	}, 30*time.Second, 1*time.Second, "Controller did not pick up ConfigMap changes within expected time. The controller may need more time to sync via informers.")
-	t.Logf("Verified controller has synced ConfigMap changes")
+	}, 30*time.Second, 1*time.Second, "controller did not sync ConfigMap in time")
 
 	Given(t).
 		Path(guestbookPath).
@@ -2482,7 +2481,7 @@ func TestZeroReconciliationTimeoutNoExcessiveRefreshes(t *testing.T) {
 			app, err := fixture.AppClientset.ArgoprojV1alpha1().Applications(fixture.AppNamespace()).Get(context.Background(), a.Name, metav1.GetOptions{})
 			require.NoError(t, err)
 			initialReconciledAt := app.Status.ReconciledAt
-			require.NotNil(t, initialReconciledAt, "Application should have reconciledAt timestamp after sync")
+			require.NotNil(t, initialReconciledAt)
 
 			ctx, cancel := context.WithTimeout(t.Context(), 4*time.Minute)
 			defer cancel()
@@ -2497,12 +2496,10 @@ func TestZeroReconciliationTimeoutNoExcessiveRefreshes(t *testing.T) {
 				}
 				if !lastReconciledAt.Equal(reconciledAt) {
 					refreshCount++
-					t.Logf("Refresh detected #%d: reconciledAt changed from %v to %v", refreshCount, lastReconciledAt.Time, reconciledAt.Time)
 					lastReconciledAt = reconciledAt.DeepCopy()
 				}
 			}
 
-			assert.LessOrEqual(t, refreshCount, 1,
-				"Application refreshed %d times (expected ≤1). With timeout.reconciliation=0s, refreshes should only occur from spec changes or explicit requests, not status-only updates.", refreshCount)
+			assert.LessOrEqual(t, refreshCount, 1, "application refreshed %d times (expected ≤1) with timeout.reconciliation=0s", refreshCount)
 		})
 }


### PR DESCRIPTION
Fixes: #25291 

When timeout.reconciliation is set to 0s, Argo CD should disable automatic
refreshes. However, the informer's UpdateFunc handler was calling
requestAppRefresh() unconditionally on every update event, including:

1. Informer resync events (periodic re-list operations with same ResourceVersion)
2. Status-only updates (controller's own status patches)

This created a feedback loop where status updates triggered refresh requests,
which caused refreshes to occur every ~2-4 minutes even when
timeout.reconciliation=0s.

The fix:
- Skip refresh requests for informer resync events (ResourceVersion == ResourceVersion)
- Skip refresh requests for status-only updates (spec unchanged)
- Still process legitimate spec changes and automated sync enablement

This ensures that when timeout.reconciliation=0s, no automatic refreshes occur
from resync events or status update feedback loops, while still allowing manual
refreshes and legitimate spec changes to trigger refreshes as expected.


See logs 

```
Monitoring for up to 10 minutes to detect refresh pattern...

Check 1 (2025-11-14T14:52:12Z): Still 2025-11-14T14:51:11Z (no change)
Check 2 (2025-11-14T14:52:27Z): Still 2025-11-14T14:51:11Z (no change)
Check 3 (2025-11-14T14:52:42Z): Still 2025-11-14T14:51:11Z (no change)
Check 4 (2025-11-14T14:52:58Z): Still 2025-11-14T14:51:11Z (no change)
Check 5 (2025-11-14T14:53:13Z): Still 2025-11-14T14:51:11Z (no change)
Check 6 (2025-11-14T14:53:28Z): Still 2025-11-14T14:51:11Z (no change)
Check 7 (2025-11-14T14:53:43Z): Still 2025-11-14T14:51:11Z (no change)
Check 8 (2025-11-14T14:53:58Z): Still 2025-11-14T14:51:11Z (no change)
Check 9 (2025-11-14T14:54:13Z): Still 2025-11-14T14:51:11Z (no change)
Check 10 (2025-11-14T14:54:28Z): Still 2025-11-14T14:51:11Z (no change)
Check 11 (2025-11-14T14:54:43Z): Still 2025-11-14T14:51:11Z (no change)
Check 12 (2025-11-14T14:54:58Z): Still 2025-11-14T14:51:11Z (no change)
Check 13 (2025-11-14T14:55:13Z): Still 2025-11-14T14:51:11Z (no change)
Check 14 (2025-11-14T14:55:28Z): Still 2025-11-14T14:51:11Z (no change)
Check 15 (2025-11-14T14:55:43Z): Still 2025-11-14T14:51:11Z (no change)
Check 16 (2025-11-14T14:55:58Z): Still 2025-11-14T14:51:11Z (no change)
Check 17 (2025-11-14T14:56:14Z): Still 2025-11-14T14:51:11Z (no change)
Check 18 (2025-11-14T14:56:29Z): Still 2025-11-14T14:51:11Z (no change)
Check 19 (2025-11-14T14:56:44Z): Still 2025-11-14T14:51:11Z (no change)
Check 20 (2025-11-14T14:56:59Z): Still 2025-11-14T14:51:11Z (no change)
Check 21 (2025-11-14T14:57:14Z): Still 2025-11-14T14:51:11Z (no change)
Check 22 (2025-11-14T14:57:29Z): Still 2025-11-14T14:51:11Z (no change)
Check 23 (2025-11-14T14:57:44Z): Still 2025-11-14T14:51:11Z (no change)
Check 24 (2025-11-14T14:57:59Z): Still 2025-11-14T14:51:11Z (no change)
Check 25 (2025-11-14T14:58:14Z): Still 2025-11-14T14:51:11Z (no change)
Check 26 (2025-11-14T14:58:29Z): Still 2025-11-14T14:51:11Z (no change)
Check 27 (2025-11-14T14:58:44Z): Still 2025-11-14T14:51:11Z (no change)
Check 28 (2025-11-14T14:58:59Z): Still 2025-11-14T14:51:11Z (no change)
Check 29 (2025-11-14T14:59:15Z): Still 2025-11-14T14:51:11Z (no change)
Check 30 (2025-11-14T14:59:30Z): Still 2025-11-14T14:51:11Z (no change)
Check 31 (2025-11-14T14:59:45Z): Still 2025-11-14T14:51:11Z (no change)
Check 32 (2025-11-14T15:00:00Z): Still 2025-11-14T14:51:11Z (no change)
Check 33 (2025-11-14T15:00:15Z): Still 2025-11-14T14:51:11Z (no change)
Check 34 (2025-11-14T15:00:30Z): Still 2025-11-14T14:51:11Z (no change)
Check 35 (2025-11-14T15:00:45Z): Still 2025-11-14T14:51:11Z (no change)
Check 36 (2025-11-14T15:01:00Z): Still 2025-11-14T14:51:11Z (no change)
Check 37 (2025-11-14T15:01:15Z): Still 2025-11-14T14:51:11Z (no change)
Check 38 (2025-11-14T15:01:30Z): Still 2025-11-14T14:51:11Z (no change)
Check 39 (2025-11-14T15:01:46Z): Still 2025-11-14T14:51:11Z (no change)
Check 40 (2025-11-14T15:02:01Z): Still 2025-11-14T14:51:11Z (no change)

=== Summary ===
✅ No automatic refreshes detected during monitoring period
```
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
