### PR TITLE
fix: only queue ApplicationSets matching cluster secret

### DIFF
--- a/applicationset/controllers/clustereventhandler.go
+++ b/applicationset/controllers/clustereventhandler.go
@@ -122,7 +122,6 @@ func (h *clusterSecretEventHandler) queueRelatedAppGenerators(ctx context.Contex
 
 // clusterSelectorMatches returns true if the cluster secret labels match the generator's selector (or selector is empty).
 func (h *clusterSecretEventHandler) clusterSelectorMatches(selector metav1.LabelSelector, secretLabels map[string]string) bool {
-
 	if len(selector.MatchLabels) == 0 && len(selector.MatchExpressions) == 0 {
 		return true
 	}

--- a/applicationset/controllers/clustereventhandler.go
+++ b/applicationset/controllers/clustereventhandler.go
@@ -17,7 +17,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	"github.com/argoproj/argo-cd/v3/common"
-	"github.com/argoproj/argo-cd/v3/applicationset/utils"
 	argoprojiov1alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 )
 

--- a/applicationset/controllers/clustereventhandler.go
+++ b/applicationset/controllers/clustereventhandler.go
@@ -121,8 +121,7 @@ func (h *clusterSecretEventHandler) queueRelatedAppGenerators(ctx context.Contex
 	}
 }
 
-// clusterSelectorMatches checks if the provided cluster secret labels match the cluster generator's selector.
-// If the selector is empty, it returns true (matches all clusters).
+// clusterSelectorMatches returns true if the cluster secret labels match the generator's selector (or selector is empty).
 func (h *clusterSecretEventHandler) clusterSelectorMatches(selector metav1.LabelSelector, secretLabels map[string]string) bool {
 
 	if len(selector.MatchLabels) == 0 && len(selector.MatchExpressions) == 0 {
@@ -140,8 +139,7 @@ func (h *clusterSecretEventHandler) clusterSelectorMatches(selector metav1.Label
 	return kubeSelector.Matches(secretLabelSet)
 }
 
-// nestedGeneratorsHaveMatchingClusterGenerator checks if any of the nested generators have a cluster generator
-// whose selector matches the provided secret labels.
+// nestedGeneratorsHaveMatchingClusterGenerator returns true if any nested generator's selector matches the secret labels.
 func (h *clusterSecretEventHandler) nestedGeneratorsHaveMatchingClusterGenerator(generators []argoprojiov1alpha1.ApplicationSetNestedGenerator, secretLabels map[string]string) (bool, error) {
 	for _, generator := range generators {
 		if ok, err := h.nestedGeneratorHasMatchingClusterGenerator(generator, secretLabels); ok || err != nil {
@@ -151,8 +149,7 @@ func (h *clusterSecretEventHandler) nestedGeneratorsHaveMatchingClusterGenerator
 	return false, nil
 }
 
-// nestedGeneratorHasMatchingClusterGenerator checks if the provided nested generator has a cluster generator
-// whose selector matches the provided secret labels.
+// nestedGeneratorHasMatchingClusterGenerator returns true if the nested generator's selector matches the secret labels.
 func (h *clusterSecretEventHandler) nestedGeneratorHasMatchingClusterGenerator(nested argoprojiov1alpha1.ApplicationSetNestedGenerator, secretLabels map[string]string) (bool, error) {
 	if nested.Clusters != nil {
 		return h.clusterSelectorMatches(nested.Clusters.Selector, secretLabels), nil

--- a/applicationset/controllers/clustereventhandler_test.go
+++ b/applicationset/controllers/clustereventhandler_test.go
@@ -33,7 +33,7 @@ func TestClusterEventHandler(t *testing.T) {
 	scheme := runtime.NewScheme()
 	err := argov1alpha1.AddToScheme(scheme)
 	require.NoError(t, err)
-	
+
 	tests := []struct {
 		name             string
 		items            []argov1alpha1.ApplicationSet
@@ -563,7 +563,7 @@ func TestClusterEventHandler(t *testing.T) {
 					Name:      "prod-cluster-secret",
 					Namespace: "argocd",
 					Labels: map[string]string{
-						"environment": "prod",
+						"environment":                 "prod",
 						argocommon.LabelKeySecretType: argocommon.LabelValueSecretTypeCluster,
 					},
 				},
@@ -595,8 +595,8 @@ func TestClusterEventHandler(t *testing.T) {
 					Name:      "prod-secret",
 					Namespace: "argocd",
 					Labels: map[string]string{
-						"environment":                  "prod",
-						argocommon.LabelKeySecretType:  argocommon.LabelValueSecretTypeCluster,
+						"environment":                 "prod",
+						argocommon.LabelKeySecretType: argocommon.LabelValueSecretTypeCluster,
 					},
 				},
 			},
@@ -609,7 +609,7 @@ func TestClusterEventHandler(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Name: "app-empty-selector", Namespace: "argocd"},
 					Spec: argov1alpha1.ApplicationSetSpec{
 						Generators: []argov1alpha1.ApplicationSetGenerator{
-							{ Clusters: &argov1alpha1.ClusterGenerator{} }, // empty selector
+							{Clusters: &argov1alpha1.ClusterGenerator{}}, // empty selector
 						},
 					},
 				},
@@ -619,8 +619,8 @@ func TestClusterEventHandler(t *testing.T) {
 					Name:      "any-secret",
 					Namespace: "argocd",
 					Labels: map[string]string{
-						"any-label":                    "value",
-						argocommon.LabelKeySecretType:  argocommon.LabelValueSecretTypeCluster,
+						"any-label":                   "value",
+						argocommon.LabelKeySecretType: argocommon.LabelValueSecretTypeCluster,
 					},
 				},
 			},
@@ -635,7 +635,7 @@ func TestClusterEventHandler(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Name: "app1", Namespace: "argocd"},
 					Spec: argov1alpha1.ApplicationSetSpec{
 						Generators: []argov1alpha1.ApplicationSetGenerator{
-							{ Clusters: &argov1alpha1.ClusterGenerator{} },
+							{Clusters: &argov1alpha1.ClusterGenerator{}},
 						},
 					},
 				},
@@ -644,12 +644,11 @@ func TestClusterEventHandler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "non-cluster-secret",
 					Namespace: "argocd",
-					Labels: map[string]string{"foo": "bar"}, // missing cluster type label
+					Labels:    map[string]string{"foo": "bar"}, // missing cluster type label
 				},
 			},
 			expectedRequests: []reconcile.Request{}, // should be ignored
 		},
-
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->

## Description

Currently, the `clusterSecretEventHandler` queues all `ApplicationSets` with a cluster generator  
regardless of whether the secret corresponds to the target cluster.

This change ensures that only `ApplicationSets` targeting the cluster from the secret  
are queued for reconciliation, reducing unnecessary workloads.