### PR TITLE
fix(ui): reconnect SSE when tab becomes visible (#25328)

### DIFF
--- a/ui/src/app/shared/services/requests.test.ts
+++ b/ui/src/app/shared/services/requests.test.ts
@@ -1,0 +1,107 @@
+import { initVisibilityRecovery } from './requests';
+
+describe('initVisibilityRecovery', () => {
+    let mockGetEventSource: jest.Mock;
+    let mockGetLastMessage: jest.Mock;
+    let mockTriggerReconnect: jest.Mock;
+    let mockEventSource: any;
+    let addEventListenerSpy: jest.SpyInstance;
+    let removeEventListenerSpy: jest.SpyInstance;
+    let eventListener: EventListener;
+
+    beforeEach(() => {
+        mockEventSource = {
+            readyState: 1, // OPEN
+            close: jest.fn()
+        };
+        mockGetEventSource = jest.fn().mockReturnValue(mockEventSource);
+        mockGetLastMessage = jest.fn().mockReturnValue(Date.now());
+        mockTriggerReconnect = jest.fn();
+
+        // Mock addEventListener using spyOn
+        addEventListenerSpy = jest.spyOn(document, 'addEventListener').mockImplementation((event, handler) => {
+            if (event === 'visibilitychange') {
+                eventListener = handler as EventListener;
+            }
+        });
+        removeEventListenerSpy = jest.spyOn(document, 'removeEventListener').mockImplementation();
+
+        // Define visibilityState property to be mutable
+        Object.defineProperty(document, 'visibilityState', {
+            value: 'visible',
+            writable: true,
+            configurable: true
+        });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('should register visibilitychange listener', () => {
+        initVisibilityRecovery(mockGetEventSource, mockGetLastMessage, mockTriggerReconnect);
+        expect(document.addEventListener).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
+    });
+
+    it('should return a cleanup function that removes the listener', () => {
+        const cleanup = initVisibilityRecovery(mockGetEventSource, mockGetLastMessage, mockTriggerReconnect);
+        cleanup();
+        expect(document.removeEventListener).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
+    });
+
+    it('should do nothing if visibilityState is hidden', () => {
+        initVisibilityRecovery(mockGetEventSource, mockGetLastMessage, mockTriggerReconnect);
+        
+        // Change visibility to hidden
+        Object.defineProperty(document, 'visibilityState', { value: 'hidden', writable: true });
+        
+        eventListener({} as Event);
+        
+        expect(mockTriggerReconnect).not.toHaveBeenCalled();
+    });
+
+    it('should trigger reconnect if readyState is not OPEN', () => {
+        mockEventSource.readyState = 2; // CLOSED
+        initVisibilityRecovery(mockGetEventSource, mockGetLastMessage, mockTriggerReconnect);
+        
+        Object.defineProperty(document, 'visibilityState', { value: 'visible', writable: true });
+        eventListener({} as Event);
+        
+        expect(mockTriggerReconnect).toHaveBeenCalled();
+    });
+
+    it('should trigger reconnect if connection is stale (zombie connection)', () => {
+        const ZOMBIE_THRESHOLD = 2 * 60 * 1000;
+        const staleTime = Date.now() - ZOMBIE_THRESHOLD - 1000; // 2분 1초 전
+        mockGetLastMessage.mockReturnValue(staleTime);
+        
+        initVisibilityRecovery(mockGetEventSource, mockGetLastMessage, mockTriggerReconnect);
+        
+        Object.defineProperty(document, 'visibilityState', { value: 'visible', writable: true });
+        eventListener({} as Event);
+        
+        expect(mockTriggerReconnect).toHaveBeenCalled();
+    });
+
+    it('should NOT trigger reconnect if connection is healthy', () => {
+        mockEventSource.readyState = 1; // OPEN
+        mockGetLastMessage.mockReturnValue(Date.now()); // Fresh
+        
+        initVisibilityRecovery(mockGetEventSource, mockGetLastMessage, mockTriggerReconnect);
+        
+        Object.defineProperty(document, 'visibilityState', { value: 'visible', writable: true });
+        eventListener({} as Event);
+        
+        expect(mockTriggerReconnect).not.toHaveBeenCalled();
+    });
+
+    it('should handle null event source gracefully', () => {
+        mockGetEventSource.mockReturnValue(null);
+        initVisibilityRecovery(mockGetEventSource, mockGetLastMessage, mockTriggerReconnect);
+        
+        Object.defineProperty(document, 'visibilityState', { value: 'visible', writable: true });
+        eventListener({} as Event);
+        
+        expect(mockTriggerReconnect).not.toHaveBeenCalled();
+    });
+});

--- a/ui/src/app/shared/services/requests.ts
+++ b/ui/src/app/shared/services/requests.ts
@@ -41,7 +41,7 @@ function initHandlers(req: agent.Request) {
     return req;
 }
 
-function initVisibilityRecovery(getEventSource: () => EventSource | null, getLastMessage: () => number, triggerReconnect: () => void) {
+export function initVisibilityRecovery(getEventSource: () => EventSource | null, getLastMessage: () => number, triggerReconnect: () => void) {
     if (typeof document === 'undefined' || typeof document.addEventListener !== 'function') {
         return null;
     }


### PR DESCRIPTION
<!--

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

-->

## Summary

Fixes #25328

This PR fixes an issue where the Argo CD UI would hang on loading when users switch back to a tab that has been in the background for a long time. The problem occurs because the browser may silently close the Server-Sent Events (SSE) connection while the tab is inactive, but the UI continues to wait for responses on the stale connection until it times out.

## Changes

- Added `visibilitychange` event listener to detect when the browser tab becomes visible again
- When the tab becomes visible, check if the EventSource connection is still in `OPEN` state or if the last received message is stale (older than 2 minutes)
- If the connection is not open or stale, immediately close the connection and trigger reconnection through the existing retry mechanism

## Why is this PR necessary?

When users leave the Argo CD UI tab in the background for an extended period (e.g., during a long break), browsers may close idle SSE connections to save resources. When users return to the tab, the UI still thinks the connection is active and waits for responses, causing a long loading delay. This fix detects when the tab becomes visible again and immediately checks the connection health, allowing for faster recovery.

## Testing

Manual testing:
1. Open Argo CD UI and navigate to the applications list
2. Switch to another tab or minimize the browser for several minutes
3. Switch back to the Argo CD tab
4. The applications list should reconnect quickly instead of hanging

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.

* [x] The title of the PR states what changed and the related issues number (used for the release note).

* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)

* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.

* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
  - UI only change, no CLI changes needed

* [ ] Does this PR require documentation updates?
  - No documentation updates needed

* [ ] I've updated documentation as required by this PR.

* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)

* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.

* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).

* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
  - This is a bug fix, not a new feature

* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.

* [ ] Optional. My organization is added to USERS.md.

* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).
  - This fix should be considered for backport to recent stable releases as it improves user experience

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->

