### PR TITLE
docs: sync-waves guide: Use markdown formatting

### DIFF
--- a/docs/user-guide/sync-waves.md
+++ b/docs/user-guide/sync-waves.md
@@ -17,11 +17,12 @@ Adding the argocd.argoproj.io/hook annotation to a resource will assign it to a 
 
 ## How phases work?
 
-Argo CD will respect resources assigned to different phases, during a sync operation Argo CD will do the following.
+Argo CD will respect resources assigned to different phases, during a sync operation Argo CD will do the following:
 
-Apply all the resources marked as PreSync hooks. If any of them fails the whole sync process will stop and will be marked as failed
-Apply all the resources marked as Sync hooks. If any of them fails the whole sync process will be marked as failed. Hooks marked with SyncFail will also run
-Apply all the resources marked as PostSync hooks. If any of them fails the whole sync process will be marked as failed.
+1. Apply all the resources marked as PreSync hooks. If any of them fails the whole sync process will stop and will be marked as failed
+2. Apply all the resources marked as Sync hooks. If any of them fails the whole sync process will be marked as failed. Hooks marked with SyncFail will also run
+3. Apply all the resources marked as PostSync hooks. If any of them fails the whole sync process will be marked as failed.
+
 Hooks marked with Skip will not be applied.
 
 Here is a graphical overview of the sync process:
@@ -55,8 +56,9 @@ Argo CD also offers an alternative method of changing the sync order of resource
 Hooks and resources are assigned to wave 0 by default. The wave can be negative, so you can create a wave that runs before all other resources.
 
 When a sync operation takes place, Argo CD will:
-Order all resources according to their wave (lowest to highest)
-Apply the resources according to the resulting sequence
+
+1. Order all resources according to their wave (lowest to highest)
+2. Apply the resources according to the resulting sequence
 
 There is currently a delay between each sync wave in order to give other controllers a chance to react to the spec change that was just applied. This also prevents Argo CD from assessing resource health too quickly (against the stale object), causing hooks to fire prematurely. The current delay between each sync wave is 2 seconds and can be configured via the environment variable ARGOCD_SYNC_WAVE_DELAY.
 
@@ -68,16 +70,16 @@ While you can use sync waves on their own, for maximum flexibility you can combi
 
 When Argo CD starts a sync, it orders the resources in the following precedence:
 
-The phase
-The wave they are in (lower values first)
-By kind (e.g. namespaces first and then other Kubernetes resources, followed by custom resources)
-By name
+1. The phase
+2. The wave they are in (lower values first)
+3. By kind (e.g. namespaces first and then other Kubernetes resources, followed by custom resources)
+4. By name
 
 Once the order is defined:
 
-First Argo CD determines the number of the first wave to apply. This is the first number where any resource is out-of-sync or unhealthy.
-It applies resources in that wave.
-It repeats this process until all phases and waves are in-sync and healthy.
+1. First Argo CD determines the number of the first wave to apply. This is the first number where any resource is out-of-sync or unhealthy.
+2. It applies resources in that wave.
+3. It repeats this process until all phases and waves are in-sync and healthy.
 
 Because an application can have resources that are unhealthy in the first wave, it may be that the app can never get to healthy.
 


### PR DESCRIPTION
Use Markdown lists for properly formatting the sync-waves guide. For example:

<img width="985" height="215" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/c815a03f-7877-4ad7-81b7-419ce91eccd3" />


<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
