### PR TITLE
fix: Revert test tools image redis to non-alpine based image (#25381)

### DIFF
--- a/test/container/Dockerfile
+++ b/test/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/redis:8.2.3-alpine@sha256:28c9c4d7596949a24b183eaaab6455f8e5d55ecbf72d02ff5e2c17fe72671d31 AS redis
+FROM docker.io/library/redis:8.2.3@sha256:66e31e0cae26a8d291c9a4991eec0a12af4ec2185d01fdaabbed027472f1f42b AS redis
 
 # There are libraries we will want to copy from here in the final stage of the
 # build, but the COPY directive does not have a way to determine system


### PR DESCRIPTION
A prior PR #25272 changed the redis image used in `test-tools-image` to one based on alpine. This broke `make test-tools-image` due to libraries missing under `/usr/lib/$(uname -m)-linux-gnu/`. This PR changes the alpine image back to a debian-based one.

Fixes #25381


<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
    * Bugfix, and likely doesn't need to be in the release notes
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
    * Not applicable, no CLI / UI change
* [ ] Does this PR require documentation updates?
    * No
* [ ] I've updated documentation as required by this PR.
    * No documentation needed
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
    * Not applicable (although maybe upstream should implement a CI check to make sure this image builds properly for any changes that touch it)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
    * Bugfix
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).


<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
