### PR TITLE
fix: correct memory value formatting in pod display

### DIFF
--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -1927,7 +1927,7 @@ export function formatResourceInfo(name: string, value: string): {displayValue: 
     };
 
     const formatMemoryValue = (milliBytes: number): string => {
-        const mib = Math.round(milliBytes / (1024 * 1024 * 1000));
+        const mib = Math.round(milliBytes / (1024 * 1024));
         return `${mib}Mi`;
     };
 
@@ -1937,7 +1937,7 @@ export function formatResourceInfo(name: string, value: string): {displayValue: 
     };
 
     const formatMemoryTooltip = (milliBytes: number): string => {
-        const mib = Math.round(milliBytes / (1024 * 1024 * 1000));
+        const mib = Math.round(milliBytes / (1024 * 1024));
         return `Memory Request: ${mib}Mi`;
     };
 


### PR DESCRIPTION

Fixes #25363

The `formatMemoryValue` and `formatMemoryTooltip` functions in the UI were using an incorrect divisor of `(1024 * 1024 * 1000)` instead of `(1024 * 1024)` when converting bytes to MiB.

This bug caused memory values to be displayed 1000x larger than actual (e.g., 1.1 TiB instead of 154Mi).

The fix removes the erroneous `* 1000` factor to correctly display memory values.

## What changed
- `ui/src/app/applications/components/utils.tsx`: Fixed `formatMemoryValue` and `formatMemoryTooltip` functions (lines 1927-1942)

## Impact
- Corrects memory display values throughout the Argo CD UI in pod resource views and tooltips
- Non-breaking change - only affects visual display
- No backend or data storage logic affected

## Testing
- Mathematical verification: 154Mi = 161,480,704 bytes / (1024 * 1024) = 154 MiB ✓
- Manual testing recommended in a real Argo CD environment to verify UI displays correct values matching `kubectl top pod` and `kubectl describe pod` output
