### PR TITLE
docs: Application source is not an array

### DIFF
--- a/docs/operator-manual/applicationset.yaml
+++ b/docs/operator-manual/applicationset.yaml
@@ -258,21 +258,21 @@ spec:
         - CreateNamespace=true  
       # defines from which Git repository to extract the desired Application manifests
       source:
-        - chart: '{{.chart}}'
+        chart: '{{.chart}}'
         # developers may customize app details using JSON files from above repo URL
-          repoURL: https://github.com/argoproj/argo-cd.git
-          targetRevision: HEAD
-          # Path within the repository where Kubernetes manifests are located
-          path: applicationset/examples/list-generator/guestbook/{{cluster}}
-          helm:
-            useCredentials: "{{.useCredentials}}"  # This field may NOT be templated, because it is a boolean field
-          parameters:
-          - name: "image.tag"
-            value: "pull-{{head_sha}}"
-          - name: "{{.name}}"
-            value: "{{.value}}"
-          - name: throw-away
-            value: "{{end}}"
+        repoURL: https://github.com/argoproj/argo-cd.git
+        targetRevision: HEAD
+        # Path within the repository where Kubernetes manifests are located
+        path: applicationset/examples/list-generator/guestbook/{{cluster}}
+        helm:
+          useCredentials: "{{.useCredentials}}"  # This field may NOT be templated, because it is a boolean field
+        parameters:
+        - name: "image.tag"
+          value: "pull-{{head_sha}}"
+        - name: "{{.name}}"
+          value: "{{.value}}"
+        - name: throw-away
+          value: "{{end}}"
       destination:
         # Only one of name or server may be specified: if both are specified, an error is returned.
         #  Name of the cluster (within Argo CD) to deploy to


### PR DESCRIPTION
The documentation includes an example on all available fields for an ApplicationSet. However, sources are shown as an array which does not work with the stable version.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).
