### PR TITLE
docs: Document usage of ?. in notifications triggers and fix examples (#25352)

### DIFF
--- a/docs/operator-manual/notifications/triggers.md
+++ b/docs/operator-manual/notifications/triggers.md
@@ -47,8 +47,8 @@ data:
 ## Accessing Optional Manifest Sections and Fields
 
 Note that in the trigger example above, the `?.` (optional chaining) operator is used to access the Application's
-`status.operationState` section. This section is optional; it's empty when an operation has been initiated but has not yet started
-by the Application Controller.
+`status.operationState` section. This section is optional; it is not present when an operation has been initiated but has not yet
+started by the Application Controller.
 
 If the `?.` operator were not used, `status.operationState` would resolve to `nil` and the evaluation of the
 `app.status.operationState.phase` expression would fail.  The `app.status?.operationState.phase` expression is equivalent to

--- a/docs/operator-manual/notifications/triggers.md
+++ b/docs/operator-manual/notifications/triggers.md
@@ -35,13 +35,25 @@ metadata:
   name: argocd-notifications-cm
 data:
   trigger.sync-operation-change: |
-    - when: app.status.operationState.phase in ['Succeeded']
+    - when: app.status?.operationState.phase in ['Succeeded']
       send: [github-commit-status]
-    - when: app.status.operationState.phase in ['Running']
+    - when: app.status?.operationState.phase in ['Running']
       send: [github-commit-status]
-    - when: app.status.operationState.phase in ['Error', 'Failed']
+    - when: app.status?.operationState.phase in ['Error', 'Failed']
       send: [app-sync-failed, github-commit-status]
 ```
+
+
+## Accessing Optional Manifest Sections and Fields
+
+Note that in the trigger example above, the `?.` (optional chaining) operator is used to access the Application's
+`status.operationState` section. This section is optional; it's empty when an operation has been initiated but has not yet started
+by the Application Controller.
+
+If the `?.` operator were not used, `status.operationState` would resolve to `nil` and the evaluation of the
+`app.status.operationState.phase` expression would fail.  The `app.status?.operationState.phase` expression is equivalent to
+`app.status.operationState != nil ?  app.status.operationState.phase : nil`.
+
 
 ## Avoid Sending Same Notification Too Often
 
@@ -60,14 +72,14 @@ data:
   # Optional 'oncePer' property ensure that notification is sent only once per specified field value
   # E.g. following is triggered once per sync revision
   trigger.on-deployed: |
-    when: app.status.operationState.phase in ['Succeeded'] and app.status.health.status == 'Healthy'
+    when: app.status?.operationState.phase in ['Succeeded'] and app.status.health.status == 'Healthy'
     oncePer: app.status.sync.revision
     send: [app-sync-succeeded]
 ```
 
 **Mono Repo Usage**
 
-When one repo is used to sync multiple applications, the `oncePer: app.status.sync.revision` field will trigger a notification for each commit. For mono repos, the better approach will be using `oncePer: app.status.operationState.syncResult.revision` statement. This way a notification will be sent only for a particular Application's revision.
+When one repo is used to sync multiple applications, the `oncePer: app.status.sync.revision` field will trigger a notification for each commit. For mono repos, the better approach will be using `oncePer: app.status?.operationState.syncResult.revision` statement. This way a notification will be sent only for a particular Application's revision.
 
 ### oncePer
 
@@ -122,7 +134,7 @@ Triggers have access to the set of built-in functions.
 Example:
 
 ```yaml
-when: time.Now().Sub(time.Parse(app.status.operationState.startedAt)).Minutes() >= 5
+when: time.Now().Sub(time.Parse(app.status?.operationState.startedAt)).Minutes() >= 5
 ```
 
 {!docs/operator-manual/notifications/functions.md!}


### PR DESCRIPTION
This PR explains how to access optional manifest fields
and sections in notification triggers using the `?.` operator.

It fixes as well the examples in the documentation to use this operator to access fields under `app.status.operationState`, which may not exist when when an operation has been initiated but has not yet started by the Application Controller.

The triggers in `notifications_catalog/` are already using the
`?.` operator and do not need to be fixed.


Closes #25352

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [X] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
