### PR TITLE
feat(Jitter): Add Configurable Jitter for Webhook-Triggered application Refreshes

### DIFF
--- a/cmd/argocd-server/commands/argocd_server.go
+++ b/cmd/argocd-server/commands/argocd_server.go
@@ -89,6 +89,7 @@ func NewCommand() *cobra.Command {
 		enableProxyExtension     bool
 		webhookParallelism       int
 		globCacheSize            int
+		webhookRefreshWorkers    int
 		hydratorEnabled          bool
 		syncWithReplaceAllowed   bool
 
@@ -248,6 +249,7 @@ func NewCommand() *cobra.Command {
 				ApplicationNamespaces:   applicationNamespaces,
 				EnableProxyExtension:    enableProxyExtension,
 				WebhookParallelism:      webhookParallelism,
+				WebhookRefreshWorkers:   webhookRefreshWorkers,
 				EnableK8sEvent:          enableK8sEvent,
 				HydratorEnabled:         hydratorEnabled,
 				SyncWithReplaceAllowed:  syncWithReplaceAllowed,
@@ -330,6 +332,7 @@ func NewCommand() *cobra.Command {
 	command.Flags().BoolVar(&enableProxyExtension, "enable-proxy-extension", env.ParseBoolFromEnv("ARGOCD_SERVER_ENABLE_PROXY_EXTENSION", false), "Enable Proxy Extension feature")
 	command.Flags().IntVar(&webhookParallelism, "webhook-parallelism-limit", env.ParseNumFromEnv("ARGOCD_SERVER_WEBHOOK_PARALLELISM_LIMIT", 50, 1, 1000), "Number of webhook requests processed concurrently")
 	command.Flags().IntVar(&globCacheSize, "glob-cache-size", env.ParseNumFromEnv("ARGOCD_SERVER_GLOB_CACHE_SIZE", utilglob.DefaultGlobCacheSize, 1, math.MaxInt32), "Maximum number of compiled glob patterns to cache for RBAC evaluation")
+	command.Flags().IntVar(&webhookRefreshWorkers, "webhook-refresh-workers", env.ParseNumFromEnv("ARGOCD_SERVER_WEBHOOK_REFRESH_WORKERS", 20, 1, 1000), "Number of webhook refresh requests processed concurrently")
 	command.Flags().StringSliceVar(&enableK8sEvent, "enable-k8s-event", env.StringsFromEnv("ARGOCD_ENABLE_K8S_EVENT", argo.DefaultEnableEventList(), ","), "Enable ArgoCD to use k8s event. For disabling all events, set the value as `none`. (e.g --enable-k8s-event=none), For enabling specific events, set the value as `event reason`. (e.g --enable-k8s-event=StatusRefreshed,ResourceCreated)")
 	command.Flags().BoolVar(&hydratorEnabled, "hydrator-enabled", env.ParseBoolFromEnv("ARGOCD_HYDRATOR_ENABLED", false), "Feature flag to enable Hydrator. Default (\"false\")")
 	command.Flags().BoolVar(&syncWithReplaceAllowed, "sync-with-replace-allowed", env.ParseBoolFromEnv("ARGOCD_SYNC_WITH_REPLACE_ALLOWED", true), "Whether to allow users to select replace for syncs from UI/CLI")

--- a/docs/operator-manual/argocd-cm.yaml
+++ b/docs/operator-manual/argocd-cm.yaml
@@ -347,6 +347,13 @@ data:
   # be between 3 and 4 minutes. Disabled when the value is 0, defaults to 1 minute.
   timeout.reconciliation.jitter: 60s
 
+  # webhook.jitter is the maximum jitter duration that can be added to the webhook-triggered application refresh.
+  # When multiple webhook events are received simultaneously (e.g., after a bulk merge), this jitter helps spread out the
+  # refresh load over time to prevent spikes in the repo-server component. The jitter is a random delay between 0 and the
+  # configured duration that is applied before refreshing each application. For example, if set to 60s, each webhook-triggered
+  # refresh will wait between 0 and 60 seconds before processing. Disabled when the value is 0 (default).
+  webhook.jitter: 0s
+
   # cluster.inClusterEnabled indicates whether to allow in-cluster server address. This is enabled by default.
   cluster.inClusterEnabled: "true"
 

--- a/docs/operator-manual/argocd-cm.yaml
+++ b/docs/operator-manual/argocd-cm.yaml
@@ -347,12 +347,12 @@ data:
   # be between 3 and 4 minutes. Disabled when the value is 0, defaults to 1 minute.
   timeout.reconciliation.jitter: 60s
 
-  # webhook.jitter is the maximum jitter duration that can be added to the webhook-triggered application refresh.
+  # webhook.reconciliation.jitter is the maximum jitter duration that can be added to the webhook-triggered application refresh.
   # When multiple webhook events are received simultaneously (e.g., after a bulk merge), this jitter helps spread out the
   # refresh load over time to prevent spikes in the repo-server component. The jitter is a random delay between 0 and the
   # configured duration that is applied before refreshing each application. For example, if set to 60s, each webhook-triggered
   # refresh will wait between 0 and 60 seconds before processing. Disabled when the value is 0 (default).
-  webhook.jitter: 0s
+  webhook.reconciliation.jitter: 0s
 
   # cluster.inClusterEnabled indicates whether to allow in-cluster server address. This is enabled by default.
   cluster.inClusterEnabled: "true"

--- a/docs/operator-manual/argocd-cm.yaml
+++ b/docs/operator-manual/argocd-cm.yaml
@@ -354,6 +354,13 @@ data:
   # refresh will wait between 0 and 60 seconds before processing. Disabled when the value is 0 (default).
   webhook.reconciliation.jitter: 0s
 
+  # webhook.reconciliation.jitter.threshold is the minimum number of applications that must be affected by a webhook event
+  # before jitter is applied. This prevents adding unnecessary delays for webhook events that affect only a few applications.
+  # For example, if set to 10, jitter will only be applied when more than 10 applications are affected by a single webhook
+  # event. When the number of affected applications is at or below this threshold, refreshes happen immediately without jitter.
+  # This works together with webhook.reconciliation.jitter. Default is 10.
+  webhook.reconciliation.jitter.threshold: "10"
+
   # cluster.inClusterEnabled indicates whether to allow in-cluster server address. This is enabled by default.
   cluster.inClusterEnabled: "true"
 

--- a/docs/operator-manual/argocd-cm.yaml
+++ b/docs/operator-manual/argocd-cm.yaml
@@ -347,19 +347,19 @@ data:
   # be between 3 and 4 minutes. Disabled when the value is 0, defaults to 1 minute.
   timeout.reconciliation.jitter: 60s
 
-  # webhook.reconciliation.jitter is the maximum jitter duration that can be added to the webhook-triggered application refresh.
+  # webhook.refresh.jitter is the maximum jitter duration that can be added to the webhook-triggered application refresh.
   # When multiple webhook events are received simultaneously (e.g., after a bulk merge), this jitter helps spread out the
   # refresh load over time to prevent spikes in the repo-server component. The jitter is a random delay between 0 and the
   # configured duration that is applied before refreshing each application. For example, if set to 60s, each webhook-triggered
   # refresh will wait between 0 and 60 seconds before processing. Disabled when the value is 0 (default).
-  webhook.reconciliation.jitter: 0s
+  webhook.refresh.jitter: 0s
 
-  # webhook.reconciliation.jitter.threshold is the minimum number of applications that must be affected by a webhook event
+  # webhook.refresh.jitter.threshold is the minimum number of applications that must be affected by a webhook event
   # before jitter is applied. This prevents adding unnecessary delays for webhook events that affect only a few applications.
   # For example, if set to 10, jitter will only be applied when more than 10 applications are affected by a single webhook
   # event. When the number of affected applications is at or below this threshold, refreshes happen immediately without jitter.
-  # This works together with webhook.reconciliation.jitter. Default is 10.
-  webhook.reconciliation.jitter.threshold: "10"
+  # This works together with webhook.refresh.jitter. Default is 10.
+  webhook.refresh.jitter.threshold: "10"
 
   # cluster.inClusterEnabled indicates whether to allow in-cluster server address. This is enabled by default.
   cluster.inClusterEnabled: "true"

--- a/docs/operator-manual/argocd-cmd-params-cm.yaml
+++ b/docs/operator-manual/argocd-cmd-params-cm.yaml
@@ -152,6 +152,10 @@ data:
   server.webhook.parallelism.limit: "50"
   # Maximum number of compiled glob patterns to cache for RBAC evaluation (default 10000)
   server.glob.cache.size: "10000"
+  # Number of concurrent workers processing webhook-triggered app refresh requests (default 20).
+  # Increase this value when webhook events affect large numbers of applications to reduce refresh latency.
+  # Works together with webhook.refresh.jitter / webhook.refresh.jitter.threshold in argocd-cm.
+  server.webhook.refresh.workers: "20"
   # Whether to allow sync with replace checked to go through. Resource-level annotation to replace override this setting, i.e. it's only enforced on the API server level.
   server.sync.replace.allowed: "true"
 

--- a/docs/operator-manual/high_availability.md
+++ b/docs/operator-manual/high_availability.md
@@ -510,6 +510,32 @@ To configure the jitter you can set the following environment variables:
 
 * `ARGOCD_RECONCILIATION_JITTER` - The jitter to apply to the sync timeout. Disabled when value is 0. Defaults to 60.
 
+### Webhook Reconciliation Jitter
+
+When a webhook event arrives (e.g. after a bulk merge to a monorepo), Argo CD may simultaneously enqueue refreshes for
+a large number of applications, causing a spike in load on the repo-server. To spread these refreshes out over time you
+can configure a random jitter that is applied before each webhook-triggered refresh is processed.
+
+The following `argocd-cm` ConfigMap keys control this behaviour:
+
+* `webhook.reconciliation.jitter` – The maximum duration of the random delay added before each webhook-triggered
+  application refresh. For example, if set to `60s`, each refresh will wait between 0 and 60 seconds before being
+  processed. Disabled when the value is `0` (default).
+* `webhook.reconciliation.jitter.threshold` – The minimum number of applications that must be affected by a single
+  webhook event before jitter is applied. This prevents unnecessary delays for small events. For example, if set to
+  `10` (the default), jitter is only applied when more than 10 applications are affected.
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+data:
+  # Apply up to 60s of jitter when more than 10 applications are affected
+  webhook.reconciliation.jitter: "60s"
+  webhook.reconciliation.jitter.threshold: "10"
+```
+
 ## Rate Limiting Application Reconciliations
 
 To prevent high controller resource usage or sync loops caused either due to misbehaving apps or other environment

--- a/docs/operator-manual/high_availability.md
+++ b/docs/operator-manual/high_availability.md
@@ -536,6 +536,19 @@ data:
   webhook.refresh.jitter.threshold: "10"
 ```
 
+You can also tune the number of concurrent workers that process the refresh queue using the
+`server.webhook.refresh.workers` key in `argocd-cmd-params-cm` (default: `20`). Under high webhook load it may be
+beneficial to raise this value alongside the jitter settings to drain the queue faster once the jitter delay expires.
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cmd-params-cm
+data:
+  server.webhook.refresh.workers: "40"
+```
+
 ## Rate Limiting Application Reconciliations
 
 To prevent high controller resource usage or sync loops caused either due to misbehaving apps or other environment

--- a/docs/operator-manual/high_availability.md
+++ b/docs/operator-manual/high_availability.md
@@ -518,10 +518,10 @@ can configure a random jitter that is applied before each webhook-triggered refr
 
 The following `argocd-cm` ConfigMap keys control this behaviour:
 
-* `webhook.reconciliation.jitter` – The maximum duration of the random delay added before each webhook-triggered
+* `webhook.refresh.jitter` – The maximum duration of the random delay added before each webhook-triggered
   application refresh. For example, if set to `60s`, each refresh will wait between 0 and 60 seconds before being
   processed. Disabled when the value is `0` (default).
-* `webhook.reconciliation.jitter.threshold` – The minimum number of applications that must be affected by a single
+* `webhook.refresh.jitter.threshold` – The minimum number of applications that must be affected by a single
   webhook event before jitter is applied. This prevents unnecessary delays for small events. For example, if set to
   `10` (the default), jitter is only applied when more than 10 applications are affected.
 
@@ -532,8 +532,8 @@ metadata:
   name: argocd-cm
 data:
   # Apply up to 60s of jitter when more than 10 applications are affected
-  webhook.reconciliation.jitter: "60s"
-  webhook.reconciliation.jitter.threshold: "10"
+  webhook.refresh.jitter: "60s"
+  webhook.refresh.jitter.threshold: "10"
 ```
 
 ## Rate Limiting Application Reconciliations

--- a/docs/operator-manual/server-commands/argocd-server.md
+++ b/docs/operator-manual/server-commands/argocd-server.md
@@ -116,6 +116,7 @@ argocd-server [flags]
       --user string                                     The name of the kubeconfig user to use
       --username string                                 Username for basic authentication to the API server
       --webhook-parallelism-limit int                   Number of webhook requests processed concurrently (default 50)
+      --webhook-refresh-workers int                     Number of webhook refresh requests processed concurrently (default 20)
       --x-frame-options value                           Set X-Frame-Options header in HTTP responses to value. To disable, set to "". (default "sameorigin")
 ```
 

--- a/manifests/base/server/argocd-server-deployment.yaml
+++ b/manifests/base/server/argocd-server-deployment.yaml
@@ -321,6 +321,11 @@ spec:
                 configMapKeyRef:
                   name: argocd-cmd-params-cm
                   key: server.glob.cache.size
+            - name: ARGOCD_SERVER_WEBHOOK_REFRESH_WORKERS
+              valueFrom:
+                configMapKeyRef:
+                  name: argocd-cmd-params-cm
+                  key: server.webhook.refresh.workers
                   optional: true
             - name: ARGOCD_APPLICATIONSET_CONTROLLER_ENABLE_NEW_GIT_FILE_GLOBBING
               valueFrom:

--- a/manifests/ha/install-with-hydrator.yaml
+++ b/manifests/ha/install-with-hydrator.yaml
@@ -34207,6 +34207,7 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: server.glob.cache.size
+              name: argocd-cmd-params-cm
         - name: ARGOCD_SERVER_WEBHOOK_REFRESH_WORKERS
           valueFrom:
             configMapKeyRef:

--- a/manifests/ha/install-with-hydrator.yaml
+++ b/manifests/ha/install-with-hydrator.yaml
@@ -34207,6 +34207,10 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: server.glob.cache.size
+        - name: ARGOCD_SERVER_WEBHOOK_REFRESH_WORKERS
+          valueFrom:
+            configMapKeyRef:
+              key: server.webhook.refresh.workers
               name: argocd-cmd-params-cm
               optional: true
         - name: ARGOCD_APPLICATIONSET_CONTROLLER_ENABLE_NEW_GIT_FILE_GLOBBING

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -34037,6 +34037,10 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: server.glob.cache.size
+        - name: ARGOCD_SERVER_WEBHOOK_REFRESH_WORKERS
+          valueFrom:
+            configMapKeyRef:
+              key: server.webhook.refresh.workers
               name: argocd-cmd-params-cm
               optional: true
         - name: ARGOCD_APPLICATIONSET_CONTROLLER_ENABLE_NEW_GIT_FILE_GLOBBING

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -34037,6 +34037,7 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: server.glob.cache.size
+              name: argocd-cmd-params-cm
         - name: ARGOCD_SERVER_WEBHOOK_REFRESH_WORKERS
           valueFrom:
             configMapKeyRef:

--- a/manifests/ha/namespace-install-with-hydrator.yaml
+++ b/manifests/ha/namespace-install-with-hydrator.yaml
@@ -3309,6 +3309,7 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: server.glob.cache.size
+              name: argocd-cmd-params-cm
         - name: ARGOCD_SERVER_WEBHOOK_REFRESH_WORKERS
           valueFrom:
             configMapKeyRef:

--- a/manifests/ha/namespace-install-with-hydrator.yaml
+++ b/manifests/ha/namespace-install-with-hydrator.yaml
@@ -3309,6 +3309,10 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: server.glob.cache.size
+        - name: ARGOCD_SERVER_WEBHOOK_REFRESH_WORKERS
+          valueFrom:
+            configMapKeyRef:
+              key: server.webhook.refresh.workers
               name: argocd-cmd-params-cm
               optional: true
         - name: ARGOCD_APPLICATIONSET_CONTROLLER_ENABLE_NEW_GIT_FILE_GLOBBING

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -3139,6 +3139,10 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: server.glob.cache.size
+        - name: ARGOCD_SERVER_WEBHOOK_REFRESH_WORKERS
+          valueFrom:
+            configMapKeyRef:
+              key: server.webhook.refresh.workers
               name: argocd-cmd-params-cm
               optional: true
         - name: ARGOCD_APPLICATIONSET_CONTROLLER_ENABLE_NEW_GIT_FILE_GLOBBING

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -3139,6 +3139,7 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: server.glob.cache.size
+              name: argocd-cmd-params-cm
         - name: ARGOCD_SERVER_WEBHOOK_REFRESH_WORKERS
           valueFrom:
             configMapKeyRef:

--- a/manifests/install-with-hydrator.yaml
+++ b/manifests/install-with-hydrator.yaml
@@ -33175,6 +33175,7 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: server.glob.cache.size
+              name: argocd-cmd-params-cm
         - name: ARGOCD_SERVER_WEBHOOK_REFRESH_WORKERS
           valueFrom:
             configMapKeyRef:

--- a/manifests/install-with-hydrator.yaml
+++ b/manifests/install-with-hydrator.yaml
@@ -33175,6 +33175,10 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: server.glob.cache.size
+        - name: ARGOCD_SERVER_WEBHOOK_REFRESH_WORKERS
+          valueFrom:
+            configMapKeyRef:
+              key: server.webhook.refresh.workers
               name: argocd-cmd-params-cm
               optional: true
         - name: ARGOCD_APPLICATIONSET_CONTROLLER_ENABLE_NEW_GIT_FILE_GLOBBING

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -33003,6 +33003,7 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: server.glob.cache.size
+              name: argocd-cmd-params-cm
         - name: ARGOCD_SERVER_WEBHOOK_REFRESH_WORKERS
           valueFrom:
             configMapKeyRef:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -33003,6 +33003,10 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: server.glob.cache.size
+        - name: ARGOCD_SERVER_WEBHOOK_REFRESH_WORKERS
+          valueFrom:
+            configMapKeyRef:
+              key: server.webhook.refresh.workers
               name: argocd-cmd-params-cm
               optional: true
         - name: ARGOCD_APPLICATIONSET_CONTROLLER_ENABLE_NEW_GIT_FILE_GLOBBING

--- a/manifests/namespace-install-with-hydrator.yaml
+++ b/manifests/namespace-install-with-hydrator.yaml
@@ -2277,6 +2277,7 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: server.glob.cache.size
+              name: argocd-cmd-params-cm
         - name: ARGOCD_SERVER_WEBHOOK_REFRESH_WORKERS
           valueFrom:
             configMapKeyRef:

--- a/manifests/namespace-install-with-hydrator.yaml
+++ b/manifests/namespace-install-with-hydrator.yaml
@@ -2277,6 +2277,10 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: server.glob.cache.size
+        - name: ARGOCD_SERVER_WEBHOOK_REFRESH_WORKERS
+          valueFrom:
+            configMapKeyRef:
+              key: server.webhook.refresh.workers
               name: argocd-cmd-params-cm
               optional: true
         - name: ARGOCD_APPLICATIONSET_CONTROLLER_ENABLE_NEW_GIT_FILE_GLOBBING

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -2105,6 +2105,10 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: server.glob.cache.size
+        - name: ARGOCD_SERVER_WEBHOOK_REFRESH_WORKERS
+          valueFrom:
+            configMapKeyRef:
+              key: server.webhook.refresh.workers
               name: argocd-cmd-params-cm
               optional: true
         - name: ARGOCD_APPLICATIONSET_CONTROLLER_ENABLE_NEW_GIT_FILE_GLOBBING

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -2105,6 +2105,7 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: server.glob.cache.size
+              name: argocd-cmd-params-cm
         - name: ARGOCD_SERVER_WEBHOOK_REFRESH_WORKERS
           valueFrom:
             configMapKeyRef:

--- a/server/server.go
+++ b/server/server.go
@@ -249,6 +249,7 @@ type ArgoCDServerOpts struct {
 	ApplicationNamespaces   []string
 	EnableProxyExtension    bool
 	WebhookParallelism      int
+	WebhookRefreshWorkers   int
 	EnableK8sEvent          []string
 	HydratorEnabled         bool
 	SyncWithReplaceAllowed  bool
@@ -1255,7 +1256,7 @@ func (server *ArgoCDServer) newHTTPServer(ctx context.Context, port int, grpcWeb
 
 	// Webhook handler for git events (Note: cache timeouts are hardcoded because API server does not write to cache and not really using them)
 	argoDB := db.NewDB(server.Namespace, server.settingsMgr, server.KubeClientset)
-	acdWebhookHandler := webhook.NewHandler(server.Namespace, server.ApplicationNamespaces, server.WebhookParallelism, server.AppClientset, server.appLister, server.settings, server.settingsMgr, server.RepoServerCache, server.Cache, argoDB, server.settingsMgr.GetMaxWebhookPayloadSize())
+	acdWebhookHandler := webhook.NewHandler(server.Namespace, server.ApplicationNamespaces, server.WebhookParallelism, server.WebhookRefreshWorkers, server.AppClientset, server.appLister, server.settings, server.settingsMgr, server.RepoServerCache, server.Cache, argoDB, server.settingsMgr.GetMaxWebhookPayloadSize(), server.settingsMgr.GetWebhookRefreshJitter())
 
 	mux.HandleFunc("/api/webhook", acdWebhookHandler.Handler)
 

--- a/server/server.go
+++ b/server/server.go
@@ -1256,7 +1256,7 @@ func (server *ArgoCDServer) newHTTPServer(ctx context.Context, port int, grpcWeb
 
 	// Webhook handler for git events (Note: cache timeouts are hardcoded because API server does not write to cache and not really using them)
 	argoDB := db.NewDB(server.Namespace, server.settingsMgr, server.KubeClientset)
-	acdWebhookHandler := webhook.NewHandler(server.Namespace, server.ApplicationNamespaces, server.WebhookParallelism, server.WebhookRefreshWorkers, server.AppClientset, server.appLister, server.settings, server.settingsMgr, server.RepoServerCache, server.Cache, argoDB, server.settingsMgr.GetMaxWebhookPayloadSize(), server.settingsMgr.GetWebhookRefreshJitter())
+	acdWebhookHandler := webhook.NewHandler(server.Namespace, server.ApplicationNamespaces, server.WebhookParallelism, server.WebhookRefreshWorkers, server.AppClientset, server.appLister, server.settings, server.settingsMgr, server.RepoServerCache, server.Cache, argoDB, server.settingsMgr.GetMaxWebhookPayloadSize(), server.settingsMgr.GetWebhookRefreshJitter(), server.settingsMgr.GetWebhookRefreshJitterThreshold())
 
 	mux.HandleFunc("/api/webhook", acdWebhookHandler.Handler)
 

--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -462,6 +462,8 @@ const (
 	settingsWebhookMaxPayloadSizeMB = "webhook.maxPayloadSizeMB"
 	// settingsWebhookRefreshJitter is the key for the maximum jitter duration for webhook-triggered refreshes
 	settingsWebhookRefreshJitter = "webhook.reconciliation.jitter"
+	// settingsWebhookRefreshJitterThreshold is the key for the minimum number of apps to trigger jitter
+	settingsWebhookRefreshJitterThreshold = "webhook.reconciliation.jitter.threshold"
 	// settingsApplicationInstanceLabelKey is the key to configure injected app instance label key
 	settingsApplicationInstanceLabelKey = "application.instanceLabelKey"
 	// settingsResourceTrackingMethodKey is the key to configure tracking method for application resources
@@ -2584,6 +2586,7 @@ func (mgr *SettingsManager) GetMaxWebhookPayloadSize() int64 {
 func (mgr *SettingsManager) GetWebhookRefreshJitter() time.Duration {
 	argoCDCM, err := mgr.getConfigMap()
 	if err != nil {
+		log.Warnf("Failed to get config map for webhook refresh jitter: %v", err)
 		return 0
 	}
 
@@ -2598,6 +2601,31 @@ func (mgr *SettingsManager) GetWebhookRefreshJitter() time.Duration {
 	}
 
 	return *jitter
+}
+
+func (mgr *SettingsManager) GetWebhookRefreshJitterThreshold() int {
+	argoCDCM, err := mgr.getConfigMap()
+	if err != nil {
+		log.Warnf("Failed to get config map for webhook refresh jitter threshold: %v", err)
+		return 10
+	}
+
+	if argoCDCM.Data[settingsWebhookRefreshJitterThreshold] == "" {
+		return 10
+	}
+
+	threshold, err := strconv.Atoi(argoCDCM.Data[settingsWebhookRefreshJitterThreshold])
+	if err != nil {
+		log.Warnf("Failed to parse '%s' key: %v", settingsWebhookRefreshJitterThreshold, err)
+		return 10
+	}
+
+	if threshold < 0 {
+		log.Warnf("Invalid '%s' value %d, must be >= 0, using default 10", settingsWebhookRefreshJitterThreshold, threshold)
+		return 10
+	}
+
+	return threshold
 }
 
 // IsImpersonationEnabled returns true if application sync with impersonation feature is enabled in argocd-cm configmap

--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -569,6 +569,9 @@ const (
 	// default max webhook payload size is 50MB
 	defaultMaxWebhookPayloadSize = int64(50) * 1024 * 1024
 
+	// default webhook refresh jitter threshold
+	defaultWebhookRefreshJitterThreshold = 10
+
 	// application sync with impersonation feature is disabled by default.
 	defaultImpersonationEnabledFlag = false
 
@@ -2607,22 +2610,22 @@ func (mgr *SettingsManager) GetWebhookRefreshJitterThreshold() int {
 	argoCDCM, err := mgr.getConfigMap()
 	if err != nil {
 		log.Warnf("Failed to get config map for webhook refresh jitter threshold: %v", err)
-		return 10
+		return defaultWebhookRefreshJitterThreshold
 	}
 
 	if argoCDCM.Data[settingsWebhookRefreshJitterThreshold] == "" {
-		return 10
+		return defaultWebhookRefreshJitterThreshold
 	}
 
 	threshold, err := strconv.Atoi(argoCDCM.Data[settingsWebhookRefreshJitterThreshold])
 	if err != nil {
 		log.Warnf("Failed to parse '%s' key: %v", settingsWebhookRefreshJitterThreshold, err)
-		return 10
+		return defaultWebhookRefreshJitterThreshold
 	}
 
 	if threshold < 0 {
-		log.Warnf("Invalid '%s' value %d, must be >= 0, using default 10", settingsWebhookRefreshJitterThreshold, threshold)
-		return 10
+		log.Warnf("Invalid '%s' value %d, must be >= 0, using default %d", settingsWebhookRefreshJitterThreshold, threshold, defaultWebhookRefreshJitterThreshold)
+		return defaultWebhookRefreshJitterThreshold
 	}
 
 	return threshold

--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -460,6 +460,8 @@ const (
 	settingsWebhookAzureDevOpsPasswordKey = "webhook.azuredevops.password"
 	// settingsWebhookMaxPayloadSize is the key for the maximum payload size for webhooks in MB
 	settingsWebhookMaxPayloadSizeMB = "webhook.maxPayloadSizeMB"
+	// settingsWebhookRefreshJitter is the key for the maximum jitter duration for webhook-triggered refreshes
+	settingsWebhookRefreshJitter = "webhook.jitter"
 	// settingsApplicationInstanceLabelKey is the key to configure injected app instance label key
 	settingsApplicationInstanceLabelKey = "application.instanceLabelKey"
 	// settingsResourceTrackingMethodKey is the key to configure tracking method for application resources
@@ -2577,6 +2579,25 @@ func (mgr *SettingsManager) GetMaxWebhookPayloadSize() int64 {
 	}
 
 	return maxPayloadSizeMB * 1024 * 1024
+}
+
+func (mgr *SettingsManager) GetWebhookRefreshJitter() time.Duration {
+	argoCDCM, err := mgr.getConfigMap()
+	if err != nil {
+		return 0
+	}
+
+	if argoCDCM.Data[settingsWebhookRefreshJitter] == "" {
+		return 0
+	}
+
+	jitter, err := timeutil.ParseDuration(argoCDCM.Data[settingsWebhookRefreshJitter])
+	if err != nil {
+		log.Warnf("Failed to parse '%s' key: %v", settingsWebhookRefreshJitter, err)
+		return 0
+	}
+
+	return *jitter
 }
 
 // IsImpersonationEnabled returns true if application sync with impersonation feature is enabled in argocd-cm configmap

--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -461,9 +461,9 @@ const (
 	// settingsWebhookMaxPayloadSize is the key for the maximum payload size for webhooks in MB
 	settingsWebhookMaxPayloadSizeMB = "webhook.maxPayloadSizeMB"
 	// settingsWebhookRefreshJitter is the key for the maximum jitter duration for webhook-triggered refreshes
-	settingsWebhookRefreshJitter = "webhook.reconciliation.jitter"
+	settingsWebhookRefreshJitter = "webhook.refresh.jitter"
 	// settingsWebhookRefreshJitterThreshold is the key for the minimum number of apps to trigger jitter
-	settingsWebhookRefreshJitterThreshold = "webhook.reconciliation.jitter.threshold"
+	settingsWebhookRefreshJitterThreshold = "webhook.refresh.jitter.threshold"
 	// settingsApplicationInstanceLabelKey is the key to configure injected app instance label key
 	settingsApplicationInstanceLabelKey = "application.instanceLabelKey"
 	// settingsResourceTrackingMethodKey is the key to configure tracking method for application resources

--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -461,7 +461,7 @@ const (
 	// settingsWebhookMaxPayloadSize is the key for the maximum payload size for webhooks in MB
 	settingsWebhookMaxPayloadSizeMB = "webhook.maxPayloadSizeMB"
 	// settingsWebhookRefreshJitter is the key for the maximum jitter duration for webhook-triggered refreshes
-	settingsWebhookRefreshJitter = "webhook.jitter"
+	settingsWebhookRefreshJitter = "webhook.reconciliation.jitter"
 	// settingsApplicationInstanceLabelKey is the key to configure injected app instance label key
 	settingsApplicationInstanceLabelKey = "application.instanceLabelKey"
 	// settingsResourceTrackingMethodKey is the key to configure tracking method for application resources

--- a/util/settings/settings_test.go
+++ b/util/settings/settings_test.go
@@ -2789,7 +2789,6 @@ func TestEscapeDollarSignsInMap(t *testing.T) {
 		assert.Equal(t, original, input["bindPW"])
 	})
 }
-
 func TestSettingsManager_GetWebhookRefreshJitter(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/util/settings/settings_test.go
+++ b/util/settings/settings_test.go
@@ -2789,6 +2789,7 @@ func TestEscapeDollarSignsInMap(t *testing.T) {
 		assert.Equal(t, original, input["bindPW"])
 	})
 }
+
 func TestSettingsManager_GetWebhookRefreshJitter(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/util/settings/settings_test.go
+++ b/util/settings/settings_test.go
@@ -2827,7 +2827,7 @@ func TestSettingsManager_GetWebhookRefreshJitter(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			configMap := map[string]string{}
 			if !tt.notConfigured {
-				configMap["webhook.reconciliation.jitter"] = tt.input
+				configMap["webhook.refresh.jitter"] = tt.input
 			}
 			_, settingsManager := fixtures(t.Context(), configMap)
 			jitter := settingsManager.GetWebhookRefreshJitter()

--- a/util/settings/settings_test.go
+++ b/util/settings/settings_test.go
@@ -2789,3 +2789,49 @@ func TestEscapeDollarSignsInMap(t *testing.T) {
 		assert.Equal(t, original, input["bindPW"])
 	})
 }
+
+func TestSettingsManager_GetWebhookRefreshJitter(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		notConfigured bool
+		output        time.Duration
+	}{
+		{
+			name:   "Valid jitter value",
+			input:  "60s",
+			output: 60 * time.Second,
+		},
+		{
+			name:          "Not configured",
+			notConfigured: true,
+			output:        0,
+		},
+		{
+			name:   "Empty input",
+			input:  "",
+			output: 0,
+		},
+		{
+			name:   "Invalid format",
+			input:  "invalid",
+			output: 0,
+		},
+		{
+			name:   "Invalid format with only number",
+			input:  "60",
+			output: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configMap := map[string]string{}
+			if !tt.notConfigured {
+				configMap["webhook.reconciliation.jitter"] = tt.input
+			}
+			_, settingsManager := fixtures(t.Context(), configMap)
+			jitter := settingsManager.GetWebhookRefreshJitter()
+			assert.Equal(t, tt.output, jitter)
+		})
+	}
+}

--- a/util/webhook/registry_test.go
+++ b/util/webhook/registry_test.go
@@ -75,8 +75,7 @@ func TestRegistryPackageEvent(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	h.Handler(w, req)
-	close(h.queue)
-	h.Wait()
+	h.Shutdown()
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assertLogContains(t, hook, "Received registry webhook event")

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -88,20 +88,20 @@ type appRefreshRequest struct {
 }
 
 type ArgoCDWebhookHandler struct {
-	sync.WaitGroup         // for testing
-	repoCache              *cache.Cache
-	serverCache            *servercache.Cache
-	db                     db.ArgoDB
-	ns                     string
-	appNs                  []string
-	appClientset           appclientset.Interface
-	appsLister             alpha1.ApplicationLister
-	parsers                []Extractor
-	settings               *settings.ArgoCDSettings
-	settingsSrc            settingsSource
-	queue                  chan any
-	refreshQueue           workqueue.TypedDelayingInterface[any]
-	maxWebhookPayloadSizeB int64
+	sync.WaitGroup                // for testing
+	repoCache                     *cache.Cache
+	serverCache                   *servercache.Cache
+	db                            db.ArgoDB
+	ns                            string
+	appNs                         []string
+	appClientset                  appclientset.Interface
+	appsLister                    alpha1.ApplicationLister
+	parsers                       []Extractor
+	settings                      *settings.ArgoCDSettings
+	settingsSrc                   settingsSource
+	queue                         chan any
+	refreshQueue                  workqueue.TypedDelayingInterface[*appRefreshRequest]
+	maxWebhookPayloadSizeB        int64
 	webhookRefreshJitter          time.Duration
 	webhookRefreshJitterThreshold int
 }
@@ -169,7 +169,7 @@ func NewHandler(namespace string, applicationNamespaces []string, webhookParalle
 		settings:                      set,
 		db:                            argoDB,
 		queue:                         make(chan any, payloadQueueSize),
-		refreshQueue:                  workqueue.NewTypedDelayingQueue[any](),
+		refreshQueue:                  workqueue.NewTypedDelayingQueue[*appRefreshRequest](),
 		maxWebhookPayloadSizeB:        maxWebhookPayloadSizeB,
 		appsLister:                    appsLister,
 		webhookRefreshJitter:          webhookRefreshJitter,
@@ -202,25 +202,19 @@ func (a *ArgoCDWebhookHandler) startRefreshWorkers(count int) {
 	for range count {
 		a.Go(func() {
 			for {
-				item, shutdown := a.refreshQueue.Get()
+				req, shutdown := a.refreshQueue.Get()
 				if shutdown {
 					return
 				}
-				guard.RecoverAndLog(func() { a.processAppRefresh(item) }, log.WithField("component", "api-server-webhook-refresh"), panicMsgServer)
-				a.refreshQueue.Done(item)
+				guard.RecoverAndLog(func() { a.processAppRefresh(req) }, log.WithField("component", "api-server-webhook-refresh"), panicMsgServer)
+				a.refreshQueue.Done(req)
 			}
 		})
 	}
 }
 
 // processAppRefresh processes a single app refresh request
-func (a *ArgoCDWebhookHandler) processAppRefresh(item any) {
-	req, ok := item.(*appRefreshRequest)
-	if !ok {
-		log.Warnf("Invalid refresh request type: %T", item)
-		return
-	}
-
+func (a *ArgoCDWebhookHandler) processAppRefresh(req *appRefreshRequest) {
 	namespacedAppInterface := a.appClientset.ArgoprojV1alpha1().Applications(req.appNamespace)
 	_, err := argo.RefreshApp(namespacedAppInterface, req.appName, v1alpha1.RefreshTypeNormal, req.hydrateType)
 	if err != nil {

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -472,6 +472,9 @@ func (a *ArgoCDWebhookHandler) HandleEvent(payload any) {
 		}
 	}
 
+	// Track app count for conditional jitter
+	appCount := 0
+
 	for _, webURL := range webURLs {
 		repoRegexp, err := GetWebURLRegex(webURL)
 		if err != nil {
@@ -489,6 +492,7 @@ func (a *ArgoCDWebhookHandler) HandleEvent(payload any) {
 			}
 		}
 
+		appCount := 0
 		// iterate over apps and check if any files specified in their sources have changed
 		for _, app := range filteredApps {
 			// get all sources, including sync source and dry source if source hydrator is configured
@@ -517,12 +521,14 @@ func (a *ArgoCDWebhookHandler) HandleEvent(payload any) {
 						if hydrateType != nil {
 							log.Infof("webhook trigger refresh app to hydrate '%s'", app.Name)
 						}
+						appCount++
 						req := &appRefreshRequest{
 							appName:      app.Name,
 							appNamespace: app.Namespace,
 							hydrateType:  hydrateType,
 						}
-						if a.webhookRefreshJitter != 0 {
+						// Apply jitter only if more than 10 apps are affected
+						if appCount > 10 && a.webhookRefreshJitter != 0 {
 							jitter := time.Duration(float64(a.webhookRefreshJitter) * rand.Float64())
 							a.refreshQueue.AddAfter(req, jitter)
 						} else {

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -199,10 +199,8 @@ func (a *ArgoCDWebhookHandler) startWorkerPool(webhookParallelism int) {
 
 // startRefreshWorkers starts worker goroutines to process app refresh requests from the refresh queue
 func (a *ArgoCDWebhookHandler) startRefreshWorkers(count int) {
-	for i := 0; i < count; i++ {
-		a.Add(1)
-		go func() {
-			defer a.Done()
+	for range count {
+		a.Go(func() {
 			for {
 				item, shutdown := a.refreshQueue.Get()
 				if shutdown {
@@ -211,7 +209,7 @@ func (a *ArgoCDWebhookHandler) startRefreshWorkers(count int) {
 				guard.RecoverAndLog(func() { a.processAppRefresh(item) }, log.WithField("component", "api-server-webhook-refresh"), panicMsgServer)
 				a.refreshQueue.Done(item)
 			}
-		}()
+		})
 	}
 }
 

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -102,13 +102,11 @@ type ArgoCDWebhookHandler struct {
 	queue                  chan any
 	refreshQueue           workqueue.TypedDelayingInterface[any]
 	maxWebhookPayloadSizeB int64
-	webhookRefreshJitter   time.Duration
+	webhookRefreshJitter          time.Duration
+	webhookRefreshJitterThreshold int
 }
 
-func NewHandler(namespace string, applicationNamespaces []string, webhookParallelism int, webhookRefreshWorkers int, appClientset appclientset.Interface, appsLister alpha1.ApplicationLister,
-	set *settings.ArgoCDSettings, settingsSrc settingsSource, repoCache *cache.Cache,
-	serverCache *servercache.Cache, argoDB db.ArgoDB, maxWebhookPayloadSizeB int64, webhookRefreshJitter time.Duration,
-) *ArgoCDWebhookHandler {
+func NewHandler(namespace string, applicationNamespaces []string, webhookParallelism int, webhookRefreshWorkers int, appClientset appclientset.Interface, appsLister alpha1.ApplicationLister, set *settings.ArgoCDSettings, settingsSrc settingsSource, repoCache *cache.Cache, serverCache *servercache.Cache, argoDB db.ArgoDB, maxWebhookPayloadSizeB int64, webhookRefreshJitter time.Duration, webhookRefreshJitterThreshold int) *ArgoCDWebhookHandler {
 	githubWebhook, err := github.New(github.Options.Secret(set.GetWebhookGitHubSecret()))
 	if err != nil {
 		log.Warnf("Unable to init the GitHub webhook")
@@ -157,23 +155,25 @@ func NewHandler(namespace string, applicationNamespaces []string, webhookParalle
 	}
 	parsers = append(parsers, newGHCRParser(set.GetWebhookGitHubSecret()))
 
-	log.Infof("webhookRefreshJitter=%v", webhookRefreshJitter)
+	log.Debugf("webhookRefreshJitter=%v", webhookRefreshJitter)
+	log.Debugf("webhookRefreshJitterThreshold=%d", webhookRefreshJitterThreshold)
 
 	acdWebhook := ArgoCDWebhookHandler{
-		ns:                     namespace,
-		appNs:                  applicationNamespaces,
-		appClientset:           appClientset,
-		parsers:                parsers,
-		settingsSrc:            settingsSrc,
-		repoCache:              repoCache,
-		serverCache:            serverCache,
-		settings:               set,
-		db:                     argoDB,
-		queue:                  make(chan any, payloadQueueSize),
-		refreshQueue:           workqueue.NewTypedDelayingQueue[any](),
-		maxWebhookPayloadSizeB: maxWebhookPayloadSizeB,
-		appsLister:             appsLister,
-		webhookRefreshJitter:   webhookRefreshJitter,
+		ns:                            namespace,
+		appNs:                         applicationNamespaces,
+		appClientset:                  appClientset,
+		parsers:                       parsers,
+		settingsSrc:                   settingsSrc,
+		repoCache:                     repoCache,
+		serverCache:                   serverCache,
+		settings:                      set,
+		db:                            argoDB,
+		queue:                         make(chan any, payloadQueueSize),
+		refreshQueue:                  workqueue.NewTypedDelayingQueue[any](),
+		maxWebhookPayloadSizeB:        maxWebhookPayloadSizeB,
+		appsLister:                    appsLister,
+		webhookRefreshJitter:          webhookRefreshJitter,
+		webhookRefreshJitterThreshold: webhookRefreshJitterThreshold,
 	}
 
 	acdWebhook.startWorkerPool(webhookParallelism)
@@ -472,9 +472,6 @@ func (a *ArgoCDWebhookHandler) HandleEvent(payload any) {
 		}
 	}
 
-	// Track app count for conditional jitter
-	appCount := 0
-
 	for _, webURL := range webURLs {
 		repoRegexp, err := GetWebURLRegex(webURL)
 		if err != nil {
@@ -527,8 +524,8 @@ func (a *ArgoCDWebhookHandler) HandleEvent(payload any) {
 							appNamespace: app.Namespace,
 							hydrateType:  hydrateType,
 						}
-						// Apply jitter only if more than 10 apps are affected
-						if appCount > 10 && a.webhookRefreshJitter != 0 {
+						// Apply jitter only if more than threshold apps are affected
+						if appCount > a.webhookRefreshJitterThreshold && a.webhookRefreshJitter != 0 {
 							jitter := time.Duration(float64(a.webhookRefreshJitter) * rand.Float64())
 							a.refreshQueue.AddAfter(req, jitter)
 						} else {
@@ -860,18 +857,6 @@ func (a *ArgoCDWebhookHandler) processWebhook(r *http.Request) (any, bool, error
 // Shutdown gracefully shuts down the webhook handler by closing queues and waiting for workers
 func (a *ArgoCDWebhookHandler) Shutdown() {
 	close(a.queue)
-	// Wait for refresh queue to drain and finish processing all items
-	for a.refreshQueue.Len() > 0 || !a.refreshQueue.ShuttingDown() {
-		time.Sleep(10 * time.Millisecond)
-		// If queue is empty and not processing, we can break
-		if a.refreshQueue.Len() == 0 {
-			// Give a small grace period for items being processed
-			time.Sleep(50 * time.Millisecond)
-			if a.refreshQueue.Len() == 0 {
-				break
-			}
-		}
-	}
-	a.refreshQueue.ShutDown()
+	a.refreshQueue.ShutDownWithDrain()
 	a.Wait()
 }

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"os"
@@ -16,6 +17,7 @@ import (
 
 	bb "github.com/ktrysmt/go-bitbucket"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/util/workqueue"
 
 	alpha1 "github.com/argoproj/argo-cd/v3/pkg/client/listers/application/v1alpha1"
 
@@ -78,6 +80,13 @@ var (
 
 var _ settingsSource = &settings.SettingsManager{}
 
+// appRefreshRequest represents a request to refresh an application with optional jitter
+type appRefreshRequest struct {
+	appName      string
+	appNamespace string
+	hydrateType  *v1alpha1.HydrateType
+}
+
 type ArgoCDWebhookHandler struct {
 	sync.WaitGroup         // for testing
 	repoCache              *cache.Cache
@@ -91,12 +100,14 @@ type ArgoCDWebhookHandler struct {
 	settings               *settings.ArgoCDSettings
 	settingsSrc            settingsSource
 	queue                  chan any
+	refreshQueue           workqueue.TypedDelayingInterface[any]
 	maxWebhookPayloadSizeB int64
+	webhookRefreshJitter   time.Duration
 }
 
-func NewHandler(namespace string, applicationNamespaces []string, webhookParallelism int, appClientset appclientset.Interface, appsLister alpha1.ApplicationLister,
+func NewHandler(namespace string, applicationNamespaces []string, webhookParallelism int, webhookRefreshWorkers int, appClientset appclientset.Interface, appsLister alpha1.ApplicationLister,
 	set *settings.ArgoCDSettings, settingsSrc settingsSource, repoCache *cache.Cache,
-	serverCache *servercache.Cache, argoDB db.ArgoDB, maxWebhookPayloadSizeB int64,
+	serverCache *servercache.Cache, argoDB db.ArgoDB, maxWebhookPayloadSizeB int64, webhookRefreshJitter time.Duration,
 ) *ArgoCDWebhookHandler {
 	githubWebhook, err := github.New(github.Options.Secret(set.GetWebhookGitHubSecret()))
 	if err != nil {
@@ -146,6 +157,8 @@ func NewHandler(namespace string, applicationNamespaces []string, webhookParalle
 	}
 	parsers = append(parsers, newGHCRParser(set.GetWebhookGitHubSecret()))
 
+	log.Infof("webhookRefreshJitter=%v", webhookRefreshJitter)
+
 	acdWebhook := ArgoCDWebhookHandler{
 		ns:                     namespace,
 		appNs:                  applicationNamespaces,
@@ -157,11 +170,14 @@ func NewHandler(namespace string, applicationNamespaces []string, webhookParalle
 		settings:               set,
 		db:                     argoDB,
 		queue:                  make(chan any, payloadQueueSize),
+		refreshQueue:           workqueue.NewTypedDelayingQueue[any](),
 		maxWebhookPayloadSizeB: maxWebhookPayloadSizeB,
 		appsLister:             appsLister,
+		webhookRefreshJitter:   webhookRefreshJitter,
 	}
 
 	acdWebhook.startWorkerPool(webhookParallelism)
+	acdWebhook.startRefreshWorkers(webhookRefreshWorkers)
 
 	return &acdWebhook
 }
@@ -178,6 +194,50 @@ func (a *ArgoCDWebhookHandler) startWorkerPool(webhookParallelism int) {
 				guard.RecoverAndLog(func() { a.HandleEvent(payload) }, compLog, panicMsgServer)
 			}
 		})
+	}
+}
+
+// startRefreshWorkers starts worker goroutines to process app refresh requests from the refresh queue
+func (a *ArgoCDWebhookHandler) startRefreshWorkers(count int) {
+	for i := 0; i < count; i++ {
+		a.Add(1)
+		go func() {
+			defer a.Done()
+			for {
+				item, shutdown := a.refreshQueue.Get()
+				if shutdown {
+					return
+				}
+				guard.RecoverAndLog(func() { a.processAppRefresh(item) }, log.WithField("component", "api-server-webhook-refresh"), panicMsgServer)
+				a.refreshQueue.Done(item)
+			}
+		}()
+	}
+}
+
+// processAppRefresh processes a single app refresh request
+func (a *ArgoCDWebhookHandler) processAppRefresh(item any) {
+	req, ok := item.(*appRefreshRequest)
+	if !ok {
+		log.Warnf("Invalid refresh request type: %T", item)
+		return
+	}
+
+	namespacedAppInterface := a.appClientset.ArgoprojV1alpha1().Applications(req.appNamespace)
+	_, err := argo.RefreshApp(namespacedAppInterface, req.appName, v1alpha1.RefreshTypeNormal, req.hydrateType)
+	if err != nil {
+		if req.hydrateType != nil {
+			log.Warnf("Failed to hydrate app '%s' for controller reprocessing: %v", req.appName, err)
+		} else {
+			log.Warnf("Failed to refresh app '%s' for controller reprocessing: %v", req.appName, err)
+		}
+		return
+	}
+
+	if req.hydrateType != nil {
+		log.Infof("Requested app '%s' hydration", req.appName)
+	} else {
+		log.Infof("Requested app '%s' refresh", req.appName)
 	}
 }
 
@@ -457,9 +517,16 @@ func (a *ArgoCDWebhookHandler) HandleEvent(payload any) {
 						if hydrateType != nil {
 							log.Infof("webhook trigger refresh app to hydrate '%s'", app.Name)
 						}
-						namespacedAppInterface := a.appClientset.ArgoprojV1alpha1().Applications(app.Namespace)
-						if _, err := argo.RefreshApp(namespacedAppInterface, app.Name, v1alpha1.RefreshTypeNormal, hydrateType); err != nil {
-							log.Errorf("Failed to refresh app '%s': %v", app.Name, err)
+						req := &appRefreshRequest{
+							appName:      app.Name,
+							appNamespace: app.Namespace,
+							hydrateType:  hydrateType,
+						}
+						if a.webhookRefreshJitter != 0 {
+							jitter := time.Duration(float64(a.webhookRefreshJitter) * rand.Float64())
+							a.refreshQueue.AddAfter(req, jitter)
+						} else {
+							a.refreshQueue.Add(req)
 						}
 						break // we don't need to check other sources
 					} else if change.shaBefore != "" && change.shaAfter != "" && !cacheWarmDisabled {
@@ -782,4 +849,23 @@ func (a *ArgoCDWebhookHandler) processWebhook(r *http.Request) (any, bool, error
 	}
 	log.Debug("Ignoring unknown webhook event")
 	return nil, false, nil
+}
+
+// Shutdown gracefully shuts down the webhook handler by closing queues and waiting for workers
+func (a *ArgoCDWebhookHandler) Shutdown() {
+	close(a.queue)
+	// Wait for refresh queue to drain and finish processing all items
+	for a.refreshQueue.Len() > 0 || !a.refreshQueue.ShuttingDown() {
+		time.Sleep(10 * time.Millisecond)
+		// If queue is empty and not processing, we can break
+		if a.refreshQueue.Len() == 0 {
+			// Give a small grace period for items being processed
+			time.Sleep(50 * time.Millisecond)
+			if a.refreshQueue.Len() == 0 {
+				break
+			}
+		}
+	}
+	a.refreshQueue.ShutDown()
+	a.Wait()
 }

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -161,12 +161,12 @@ func newMockHandler(reactor *reactorDef, applicationNamespaces []string, maxPayl
 		appClientset.AddReactor(reactor.verb, reactor.resource, reactor.reaction)
 	}
 	cacheClient := cacheutil.NewCache(cacheutil.NewInMemoryCache(1 * time.Hour))
-	return NewHandler("argocd", applicationNamespaces, 10, appClientset, &fakeAppsLister{clientset: appClientset}, argoSettings, &fakeSettingsSrc{}, cache.NewCache(
+	return NewHandler("argocd", applicationNamespaces, 10, 10, appClientset, &fakeAppsLister{clientset: appClientset}, argoSettings, &fakeSettingsSrc{}, cache.NewCache(
 		cacheClient,
 		1*time.Minute,
 		1*time.Minute,
 		10*time.Second,
-	), servercache.NewCache(appstate.NewCache(cacheClient, time.Minute), time.Minute, time.Minute), argoDB, maxPayloadSize)
+	), servercache.NewCache(appstate.NewCache(cacheClient, time.Minute), time.Minute, time.Minute), argoDB, maxPayloadSize, 0)
 }
 
 func TestGitHubCommitEvent(t *testing.T) {
@@ -179,8 +179,7 @@ func TestGitHubCommitEvent(t *testing.T) {
 	req.Body = io.NopCloser(bytes.NewReader(eventJSON))
 	w := httptest.NewRecorder()
 	h.Handler(w, req)
-	close(h.queue)
-	h.Wait()
+	h.Shutdown()
 	assert.Equal(t, http.StatusOK, w.Code)
 	expectedLogResult := "Received push event repo: https://github.com/jessesuen/test-repo, revision: master, touchedHead: true"
 	assertLogContains(t, hook, expectedLogResult)
@@ -197,11 +196,69 @@ func TestAzureDevOpsCommitEvent(t *testing.T) {
 	req.Body = io.NopCloser(bytes.NewReader(eventJSON))
 	w := httptest.NewRecorder()
 	h.Handler(w, req)
-	close(h.queue)
-	h.Wait()
+	h.Shutdown()
 	assert.Equal(t, http.StatusOK, w.Code)
 	expectedLogResult := "Received push event repo: https://dev.azure.com/alexander0053/alex-test/_git/alex-test, revision: master, touchedHead: true"
 	assertLogContains(t, hook, expectedLogResult)
+	hook.Reset()
+}
+
+// TestGitHubCommitEvent_MultiSource_Refresh makes sure that a webhook will refresh a multi-source app when at least
+// one source matches.
+func TestGitHubCommitEvent_MultiSource_Refresh(t *testing.T) {
+	hook := test.NewGlobal()
+	var patched bool
+	reaction := func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+		patchAction := action.(kubetesting.PatchAction)
+		assert.Equal(t, "app-to-refresh", patchAction.GetName())
+		patched = true
+		return true, nil, nil
+	}
+	h := NewMockHandler(&reactorDef{"patch", "applications", reaction}, []string{}, &v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "app-to-refresh",
+			Namespace: "argocd",
+		},
+		Spec: v1alpha1.ApplicationSpec{
+			Sources: v1alpha1.ApplicationSources{
+				{
+					RepoURL: "https://github.com/some/unrelated-repo",
+					Path:    ".",
+				},
+				{
+					RepoURL: "https://github.com/jessesuen/test-repo",
+					Path:    ".",
+				},
+			},
+		},
+	}, &v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "app-to-ignore",
+		},
+		Spec: v1alpha1.ApplicationSpec{
+			Sources: v1alpha1.ApplicationSources{
+				{
+					RepoURL: "https://github.com/some/unrelated-repo",
+					Path:    ".",
+				},
+			},
+		},
+	},
+	)
+	req := httptest.NewRequest(http.MethodPost, "/api/webhook", http.NoBody)
+	req.Header.Set("X-GitHub-Event", "push")
+	eventJSON, err := os.ReadFile("testdata/github-commit-event.json")
+	require.NoError(t, err)
+	req.Body = io.NopCloser(bytes.NewReader(eventJSON))
+	w := httptest.NewRecorder()
+	h.Handler(w, req)
+	h.Shutdown()
+	assert.Equal(t, http.StatusOK, w.Code)
+	expectedLogResult := "Requested app 'app-to-refresh' refresh"
+	assert.Equal(t, expectedLogResult, hook.LastEntry().Message)
+	assert.True(t, patched)
+	hook.Reset()
+}
 	hook.Reset()
 }
 
@@ -279,8 +336,7 @@ func TestGitHubCommitEvent_AppsInOtherNamespaces(t *testing.T) {
 	req.Body = io.NopCloser(bytes.NewReader(eventJSON))
 	w := httptest.NewRecorder()
 	h.Handler(w, req)
-	close(h.queue)
-	h.Wait()
+	h.Shutdown()
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	logMessages := make([]string, 0, len(hook.Entries))
@@ -303,6 +359,71 @@ func TestGitHubCommitEvent_AppsInOtherNamespaces(t *testing.T) {
 	hook.Reset()
 }
 
+// TestGitHubCommitEvent_Hydrate makes sure that a webhook will hydrate an app when dry source changed.
+func TestGitHubCommitEvent_Hydrate(t *testing.T) {
+	hook := test.NewGlobal()
+	var patched bool
+	reaction := func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+		patchAction := action.(kubetesting.PatchAction)
+		assert.Equal(t, "app-to-hydrate", patchAction.GetName())
+		patched = true
+		return true, nil, nil
+	}
+	h := NewMockHandler(&reactorDef{"patch", "applications", reaction}, []string{}, &v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "app-to-hydrate",
+			Namespace: "argocd",
+		},
+		Spec: v1alpha1.ApplicationSpec{
+			SourceHydrator: &v1alpha1.SourceHydrator{
+				DrySource: v1alpha1.DrySource{
+					RepoURL:        "https://github.com/jessesuen/test-repo",
+					TargetRevision: "HEAD",
+					Path:           ".",
+				},
+				SyncSource: v1alpha1.SyncSource{
+					TargetBranch: "environments/dev",
+					Path:         ".",
+				},
+				HydrateTo: nil,
+			},
+		},
+	}, &v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "app-to-ignore",
+		},
+		Spec: v1alpha1.ApplicationSpec{
+			Sources: v1alpha1.ApplicationSources{
+				{
+					RepoURL: "https://github.com/some/unrelated-repo",
+					Path:    ".",
+				},
+			},
+		},
+	},
+	)
+	req := httptest.NewRequest(http.MethodPost, "/api/webhook", http.NoBody)
+	req.Header.Set("X-GitHub-Event", "push")
+	eventJSON, err := os.ReadFile("testdata/github-commit-event.json")
+	require.NoError(t, err)
+	req.Body = io.NopCloser(bytes.NewReader(eventJSON))
+	w := httptest.NewRecorder()
+	h.Handler(w, req)
+	h.Shutdown()
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.True(t, patched)
+
+	logMessages := make([]string, 0, len(hook.Entries))
+	for _, entry := range hook.Entries {
+		logMessages = append(logMessages, entry.Message)
+	}
+
+	assert.Contains(t, logMessages, "webhook trigger refresh app to hydrate 'app-to-hydrate'")
+	assert.NotContains(t, logMessages, "webhook trigger refresh app to hydrate 'app-to-ignore'")
+
+	hook.Reset()
+}
+
 func TestGitHubTagEvent(t *testing.T) {
 	hook := test.NewGlobal()
 	h := NewMockHandler(nil, []string{})
@@ -313,8 +434,7 @@ func TestGitHubTagEvent(t *testing.T) {
 	req.Body = io.NopCloser(bytes.NewReader(eventJSON))
 	w := httptest.NewRecorder()
 	h.Handler(w, req)
-	close(h.queue)
-	h.Wait()
+	h.Shutdown()
 	assert.Equal(t, http.StatusOK, w.Code)
 	expectedLogResult := "Received push event repo: https://github.com/jessesuen/test-repo, revision: v1.0, touchedHead: false"
 	assertLogContains(t, hook, expectedLogResult)
@@ -331,8 +451,7 @@ func TestGitHubPingEvent(t *testing.T) {
 	req.Body = io.NopCloser(bytes.NewReader(eventJSON))
 	w := httptest.NewRecorder()
 	h.Handler(w, req)
-	close(h.queue)
-	h.Wait()
+	h.Shutdown()
 	assert.Equal(t, http.StatusOK, w.Code)
 	expectedLogResult := "Ignoring webhook event"
 	assertLogContains(t, hook, expectedLogResult)
@@ -349,8 +468,7 @@ func TestBitbucketServerRepositoryReferenceChangedEvent(t *testing.T) {
 	req.Body = io.NopCloser(bytes.NewReader(eventJSON))
 	w := httptest.NewRecorder()
 	h.Handler(w, req)
-	close(h.queue)
-	h.Wait()
+	h.Shutdown()
 	assert.Equal(t, http.StatusOK, w.Code)
 	expectedLogResultSSH := "Received push event repo: ssh://git@bitbucketserver:7999/myproject/test-repo.git, revision: master, touchedHead: true"
 	assertLogContains(t, hook, expectedLogResultSSH)
@@ -367,8 +485,7 @@ func TestBitbucketServerRepositoryDiagnosticPingEvent(t *testing.T) {
 	req.Header.Set("X-Event-Key", "diagnostics:ping")
 	w := httptest.NewRecorder()
 	h.Handler(w, req)
-	close(h.queue)
-	h.Wait()
+	h.Shutdown()
 	assert.Equal(t, http.StatusOK, w.Code)
 	expectedLogResult := "Ignoring webhook event"
 	assertLogContains(t, hook, expectedLogResult)
@@ -385,8 +502,7 @@ func TestGogsPushEvent(t *testing.T) {
 	req.Body = io.NopCloser(bytes.NewReader(eventJSON))
 	w := httptest.NewRecorder()
 	h.Handler(w, req)
-	close(h.queue)
-	h.Wait()
+	h.Shutdown()
 	assert.Equal(t, http.StatusOK, w.Code)
 	expectedLogResult := "Received push event repo: http://gogs-server/john/repo-test, revision: master, touchedHead: true"
 	assertLogContains(t, hook, expectedLogResult)
@@ -403,8 +519,7 @@ func TestGitLabPushEvent(t *testing.T) {
 	req.Body = io.NopCloser(bytes.NewReader(eventJSON))
 	w := httptest.NewRecorder()
 	h.Handler(w, req)
-	close(h.queue)
-	h.Wait()
+	h.Shutdown()
 	assert.Equal(t, http.StatusOK, w.Code)
 	expectedLogResult := "Received push event repo: https://gitlab.com/group/name, revision: master, touchedHead: true"
 	assertLogContains(t, hook, expectedLogResult)
@@ -421,8 +536,7 @@ func TestGitLabSystemEvent(t *testing.T) {
 	req.Body = io.NopCloser(bytes.NewReader(eventJSON))
 	w := httptest.NewRecorder()
 	h.Handler(w, req)
-	close(h.queue)
-	h.Wait()
+	h.Shutdown()
 	assert.Equal(t, http.StatusOK, w.Code)
 	expectedLogResult := "Received push event repo: https://gitlab.com/group/name, revision: master, touchedHead: true"
 	assertLogContains(t, hook, expectedLogResult)
@@ -436,8 +550,7 @@ func TestInvalidMethod(t *testing.T) {
 	req.Header.Set("X-GitHub-Event", "push")
 	w := httptest.NewRecorder()
 	h.Handler(w, req)
-	close(h.queue)
-	h.Wait()
+	h.Shutdown()
 	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
 	assertLogContains(t, hook, "Webhook processing failed: invalid HTTP Method")
 	assert.Equal(t, "Webhook processing failed\n", w.Body.String())
@@ -451,8 +564,7 @@ func TestInvalidEvent(t *testing.T) {
 	req.Header.Set("X-GitHub-Event", "push")
 	w := httptest.NewRecorder()
 	h.Handler(w, req)
-	close(h.queue)
-	h.Wait()
+	h.Shutdown()
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assertLogContainsSubstr(t, hook, "Webhook processing failed: payload too large or corrupted (limit 50 MB)")
 	assert.Equal(t, "Webhook processing failed: payload must be valid JSON under 50 MB\n", w.Body.String())
@@ -466,8 +578,7 @@ func TestUnknownEvent(t *testing.T) {
 	req.Header.Set("X-Unknown-Event", "push")
 	w := httptest.NewRecorder()
 	h.Handler(w, req)
-	close(h.queue)
-	h.Wait()
+	h.Shutdown()
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Equal(t, "Unknown webhook event\n", w.Body.String())
 	hook.Reset()
@@ -768,8 +879,7 @@ func TestGitHubCommitEventMaxPayloadSize(t *testing.T) {
 	req.Body = io.NopCloser(bytes.NewReader(eventJSON))
 	w := httptest.NewRecorder()
 	h.Handler(w, req)
-	close(h.queue)
-	h.Wait()
+	h.Shutdown()
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assertLogContainsSubstr(t, hook, "Webhook processing failed: payload too large or corrupted (limit 0 MB)")
 	hook.Reset()

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -1873,5 +1873,4 @@ func TestProcessAppRefresh(t *testing.T) {
 
 		assert.Contains(t, hook.LastEntry().Message, "Requested app 'test-app' hydration")
 	})
-
 }

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -166,7 +166,7 @@ func newMockHandler(reactor *reactorDef, applicationNamespaces []string, maxPayl
 		1*time.Minute,
 		1*time.Minute,
 		10*time.Second,
-	), servercache.NewCache(appstate.NewCache(cacheClient, time.Minute), time.Minute, time.Minute), argoDB, maxPayloadSize, 0)
+	), servercache.NewCache(appstate.NewCache(cacheClient, time.Minute), time.Minute, time.Minute), argoDB, maxPayloadSize, 0, 10)
 }
 
 func TestGitHubCommitEvent(t *testing.T) {
@@ -252,6 +252,7 @@ func TestGitHubCommitEvent_MultiSource_Refresh(t *testing.T) {
 	req.Body = io.NopCloser(bytes.NewReader(eventJSON))
 	w := httptest.NewRecorder()
 	h.Handler(w, req)
+	time.Sleep(50 * time.Millisecond) // Give workers time to process the queued items
 	h.Shutdown()
 	assert.Equal(t, http.StatusOK, w.Code)
 	expectedLogResult := "Requested app 'app-to-refresh' refresh"
@@ -336,6 +337,7 @@ func TestGitHubCommitEvent_AppsInOtherNamespaces(t *testing.T) {
 	req.Body = io.NopCloser(bytes.NewReader(eventJSON))
 	w := httptest.NewRecorder()
 	h.Handler(w, req)
+	time.Sleep(50 * time.Millisecond) // Give workers time to process the queued items
 	h.Shutdown()
 	assert.Equal(t, http.StatusOK, w.Code)
 
@@ -409,6 +411,7 @@ func TestGitHubCommitEvent_Hydrate(t *testing.T) {
 	req.Body = io.NopCloser(bytes.NewReader(eventJSON))
 	w := httptest.NewRecorder()
 	h.Handler(w, req)
+	time.Sleep(50 * time.Millisecond) // Give workers time to process the queued items
 	h.Shutdown()
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.True(t, patched)
@@ -1866,6 +1869,7 @@ func TestWebhookRefreshWithJitter(t *testing.T) {
 			&mocks.ArgoDB{},
 			int64(50)*1024*1024,
 			2*time.Second,
+			10,
 		)
 
 		req := &appRefreshRequest{

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -1874,14 +1874,4 @@ func TestProcessAppRefresh(t *testing.T) {
 		assert.Contains(t, hook.LastEntry().Message, "Requested app 'test-app' hydration")
 	})
 
-	t.Run("logs warning for invalid request type", func(t *testing.T) {
-		hook := test.NewGlobal()
-		defer hook.Reset()
-
-		h := NewMockHandler(nil, []string{}, &app)
-		h.processAppRefresh("invalid-type")
-		h.Shutdown()
-
-		assert.Contains(t, hook.LastEntry().Message, "Invalid refresh request type")
-	})
 }

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -203,66 +203,6 @@ func TestAzureDevOpsCommitEvent(t *testing.T) {
 	hook.Reset()
 }
 
-// TestGitHubCommitEvent_MultiSource_Refresh makes sure that a webhook will refresh a multi-source app when at least
-// one source matches.
-func TestGitHubCommitEvent_MultiSource_Refresh(t *testing.T) {
-	hook := test.NewGlobal()
-	var patched bool
-	reaction := func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
-		patchAction := action.(kubetesting.PatchAction)
-		assert.Equal(t, "app-to-refresh", patchAction.GetName())
-		patched = true
-		return true, nil, nil
-	}
-	h := NewMockHandler(&reactorDef{"patch", "applications", reaction}, []string{}, &v1alpha1.Application{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "app-to-refresh",
-			Namespace: "argocd",
-		},
-		Spec: v1alpha1.ApplicationSpec{
-			Sources: v1alpha1.ApplicationSources{
-				{
-					RepoURL: "https://github.com/some/unrelated-repo",
-					Path:    ".",
-				},
-				{
-					RepoURL: "https://github.com/jessesuen/test-repo",
-					Path:    ".",
-				},
-			},
-		},
-	}, &v1alpha1.Application{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "app-to-ignore",
-		},
-		Spec: v1alpha1.ApplicationSpec{
-			Sources: v1alpha1.ApplicationSources{
-				{
-					RepoURL: "https://github.com/some/unrelated-repo",
-					Path:    ".",
-				},
-			},
-		},
-	},
-	)
-	req := httptest.NewRequest(http.MethodPost, "/api/webhook", http.NoBody)
-	req.Header.Set("X-GitHub-Event", "push")
-	eventJSON, err := os.ReadFile("testdata/github-commit-event.json")
-	require.NoError(t, err)
-	req.Body = io.NopCloser(bytes.NewReader(eventJSON))
-	w := httptest.NewRecorder()
-	h.Handler(w, req)
-	time.Sleep(50 * time.Millisecond) // Give workers time to process the queued items
-	h.Shutdown()
-	assert.Equal(t, http.StatusOK, w.Code)
-	expectedLogResult := "Requested app 'app-to-refresh' refresh"
-	assert.Equal(t, expectedLogResult, hook.LastEntry().Message)
-	assert.True(t, patched)
-	hook.Reset()
-}
-	hook.Reset()
-}
-
 // TestGitHubCommitEvent_AppsInOtherNamespaces makes sure that webhooks properly find apps in the configured set of
 // allowed namespaces when Apps are allowed in any namespace
 func TestGitHubCommitEvent_AppsInOtherNamespaces(t *testing.T) {
@@ -357,72 +297,6 @@ func TestGitHubCommitEvent_AppsInOtherNamespaces(t *testing.T) {
 	assert.Contains(t, patchedApps, types.NamespacedName{Name: "app-to-refresh-in-globbed-namespace", Namespace: "app-team-two"})
 	assert.NotContains(t, patchedApps, types.NamespacedName{Name: "app-to-ignore", Namespace: "kube-system"})
 	assert.Len(t, patchedApps, 3)
-
-	hook.Reset()
-}
-
-// TestGitHubCommitEvent_Hydrate makes sure that a webhook will hydrate an app when dry source changed.
-func TestGitHubCommitEvent_Hydrate(t *testing.T) {
-	hook := test.NewGlobal()
-	var patched bool
-	reaction := func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
-		patchAction := action.(kubetesting.PatchAction)
-		assert.Equal(t, "app-to-hydrate", patchAction.GetName())
-		patched = true
-		return true, nil, nil
-	}
-	h := NewMockHandler(&reactorDef{"patch", "applications", reaction}, []string{}, &v1alpha1.Application{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "app-to-hydrate",
-			Namespace: "argocd",
-		},
-		Spec: v1alpha1.ApplicationSpec{
-			SourceHydrator: &v1alpha1.SourceHydrator{
-				DrySource: v1alpha1.DrySource{
-					RepoURL:        "https://github.com/jessesuen/test-repo",
-					TargetRevision: "HEAD",
-					Path:           ".",
-				},
-				SyncSource: v1alpha1.SyncSource{
-					TargetBranch: "environments/dev",
-					Path:         ".",
-				},
-				HydrateTo: nil,
-			},
-		},
-	}, &v1alpha1.Application{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "app-to-ignore",
-		},
-		Spec: v1alpha1.ApplicationSpec{
-			Sources: v1alpha1.ApplicationSources{
-				{
-					RepoURL: "https://github.com/some/unrelated-repo",
-					Path:    ".",
-				},
-			},
-		},
-	},
-	)
-	req := httptest.NewRequest(http.MethodPost, "/api/webhook", http.NoBody)
-	req.Header.Set("X-GitHub-Event", "push")
-	eventJSON, err := os.ReadFile("testdata/github-commit-event.json")
-	require.NoError(t, err)
-	req.Body = io.NopCloser(bytes.NewReader(eventJSON))
-	w := httptest.NewRecorder()
-	h.Handler(w, req)
-	time.Sleep(50 * time.Millisecond) // Give workers time to process the queued items
-	h.Shutdown()
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.True(t, patched)
-
-	logMessages := make([]string, 0, len(hook.Entries))
-	for _, entry := range hook.Entries {
-		logMessages = append(logMessages, entry.Message)
-	}
-
-	assert.Contains(t, logMessages, "webhook trigger refresh app to hydrate 'app-to-hydrate'")
-	assert.NotContains(t, logMessages, "webhook trigger refresh app to hydrate 'app-to-ignore'")
 
 	hook.Reset()
 }
@@ -1273,6 +1147,7 @@ func TestHandleEvent(t *testing.T) {
 				"argocd",
 				[]string{},
 				10,
+				1,
 				appClientset,
 				&fakeAppsLister{clientset: appClientset},
 				&settings.ArgoCDSettings{},
@@ -1281,6 +1156,8 @@ func TestHandleEvent(t *testing.T) {
 				serverCache,
 				mockDB,
 				int64(50)*1024*1024,
+				0,
+				10,
 			)
 
 			// Create payload with the changed file
@@ -1291,8 +1168,13 @@ func TestHandleEvent(t *testing.T) {
 
 			w := httptest.NewRecorder()
 			h.Handler(w, req)
-			close(h.queue)
-			h.Wait()
+
+			// Wait briefly for refresh processing
+			time.Sleep(50 * time.Millisecond)
+
+			// Shutdown properly
+			h.Shutdown()
+
 			assert.Equal(t, http.StatusOK, w.Code)
 
 			// Verify refresh behavior
@@ -1838,6 +1720,8 @@ func setupTestCache(t *testing.T, repoCache *cache.Cache, appName string, source
 		AppName:     appName,
 	}, dummyManifests)
 	require.NoError(t, err)
+}
+
 func TestWebhookRefreshWithJitter(t *testing.T) {
 	app := v1alpha1.Application{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1852,8 +1736,23 @@ func TestWebhookRefreshWithJitter(t *testing.T) {
 		},
 	}
 
-	t.Run("items are delayed when jitter is configured", func(t *testing.T) {
+	t.Run("items are processed after jitter delay", func(t *testing.T) {
+		var patched bool
+		reaction := func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+			if action.GetVerb() == "patch" {
+				patched = true
+			}
+			return true, nil, nil
+		}
+
 		appClientset := appclientset.NewSimpleClientset(&app)
+		defaultReactor := appClientset.ReactionChain[0]
+		appClientset.ReactionChain = nil
+		appClientset.AddReactor("list", "*", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+			return defaultReactor.React(action)
+		})
+		appClientset.AddReactor("patch", "applications", reaction)
+
 		cacheClient := cacheutil.NewCache(cacheutil.NewInMemoryCache(1 * time.Hour))
 		h := NewHandler(
 			"argocd",
@@ -1879,13 +1778,51 @@ func TestWebhookRefreshWithJitter(t *testing.T) {
 		}
 
 		startTime := time.Now()
-		h.refreshQueue.AddAfter(req, 1*time.Second)
+		h.refreshQueue.AddAfter(req, 500*time.Millisecond)
 
-		time.Sleep(1200 * time.Millisecond)
+		// Wait for processing
+		time.Sleep(800 * time.Millisecond)
 		h.Shutdown()
 
 		elapsed := time.Since(startTime)
-		assert.GreaterOrEqual(t, elapsed.Milliseconds(), int64(1000))
+		// Verify delay was applied
+		assert.GreaterOrEqual(t, elapsed.Milliseconds(), int64(500))
+		// Verify app was actually patched (refresh processed)
+		assert.True(t, patched, "app should be patched after jitter delay")
+	})
+
+	t.Run("no jitter applied when threshold not exceeded", func(_ *testing.T) {
+		appClientset := appclientset.NewSimpleClientset(&app)
+		cacheClient := cacheutil.NewCache(cacheutil.NewInMemoryCache(1 * time.Hour))
+		h := NewHandler(
+			"argocd",
+			[]string{},
+			10,
+			5,
+			appClientset,
+			&fakeAppsLister{clientset: appClientset},
+			&settings.ArgoCDSettings{},
+			&fakeSettingsSrc{},
+			cache.NewCache(cacheClient, 1*time.Minute, 1*time.Minute, 10*time.Second),
+			servercache.NewCache(appstate.NewCache(cacheClient, time.Minute), time.Minute, time.Minute),
+			&mocks.ArgoDB{},
+			int64(50)*1024*1024,
+			2*time.Second,
+			100, // High threshold - won't be exceeded
+		)
+
+		req := &appRefreshRequest{
+			appName:      "test-app",
+			appNamespace: "argocd",
+			hydrate:      false,
+		}
+
+		// Add without explicit delay
+		h.refreshQueue.Add(req)
+
+		// Should process quickly without jitter
+		time.Sleep(100 * time.Millisecond)
+		h.Shutdown()
 	})
 }
 
@@ -1918,6 +1855,23 @@ func TestProcessAppRefresh(t *testing.T) {
 		h.Shutdown()
 
 		assert.Contains(t, hook.LastEntry().Message, "Requested app 'test-app' refresh")
+	})
+
+	t.Run("processes valid hydrate request", func(t *testing.T) {
+		hook := test.NewGlobal()
+		defer hook.Reset()
+
+		h := NewMockHandler(nil, []string{}, &app)
+		req := &appRefreshRequest{
+			appName:      "test-app",
+			appNamespace: "argocd",
+			hydrate:      true,
+		}
+
+		h.processAppRefresh(req)
+		h.Shutdown()
+
+		assert.Contains(t, hook.LastEntry().Message, "Requested app 'test-app' hydration")
 	})
 
 	t.Run("logs warning for invalid request type", func(t *testing.T) {

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -1835,4 +1835,95 @@ func setupTestCache(t *testing.T, repoCache *cache.Cache, appName string, source
 		AppName:     appName,
 	}, dummyManifests)
 	require.NoError(t, err)
+func TestWebhookRefreshWithJitter(t *testing.T) {
+	app := v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-app",
+			Namespace: "argocd",
+		},
+		Spec: v1alpha1.ApplicationSpec{
+			Source: &v1alpha1.ApplicationSource{
+				RepoURL:        "https://github.com/test/repo",
+				TargetRevision: "main",
+			},
+		},
+	}
+
+	t.Run("items are delayed when jitter is configured", func(t *testing.T) {
+		appClientset := appclientset.NewSimpleClientset(&app)
+		cacheClient := cacheutil.NewCache(cacheutil.NewInMemoryCache(1 * time.Hour))
+		h := NewHandler(
+			"argocd",
+			[]string{},
+			10,
+			5,
+			appClientset,
+			&fakeAppsLister{clientset: appClientset},
+			&settings.ArgoCDSettings{},
+			&fakeSettingsSrc{},
+			cache.NewCache(cacheClient, 1*time.Minute, 1*time.Minute, 10*time.Second),
+			servercache.NewCache(appstate.NewCache(cacheClient, time.Minute), time.Minute, time.Minute),
+			&mocks.ArgoDB{},
+			int64(50)*1024*1024,
+			2*time.Second,
+		)
+
+		req := &appRefreshRequest{
+			appName:      "test-app",
+			appNamespace: "argocd",
+			hydrate:      false,
+		}
+
+		startTime := time.Now()
+		h.refreshQueue.AddAfter(req, 1*time.Second)
+
+		time.Sleep(1200 * time.Millisecond)
+		h.Shutdown()
+
+		elapsed := time.Since(startTime)
+		assert.GreaterOrEqual(t, elapsed.Milliseconds(), int64(1000))
+	})
+}
+
+func TestProcessAppRefresh(t *testing.T) {
+	app := v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-app",
+			Namespace: "argocd",
+		},
+		Spec: v1alpha1.ApplicationSpec{
+			Source: &v1alpha1.ApplicationSource{
+				RepoURL:        "https://github.com/test/repo",
+				TargetRevision: "main",
+			},
+		},
+	}
+
+	t.Run("processes valid refresh request", func(t *testing.T) {
+		hook := test.NewGlobal()
+		defer hook.Reset()
+
+		h := NewMockHandler(nil, []string{}, &app)
+		req := &appRefreshRequest{
+			appName:      "test-app",
+			appNamespace: "argocd",
+			hydrate:      false,
+		}
+
+		h.processAppRefresh(req)
+		h.Shutdown()
+
+		assert.Contains(t, hook.LastEntry().Message, "Requested app 'test-app' refresh")
+	})
+
+	t.Run("logs warning for invalid request type", func(t *testing.T) {
+		hook := test.NewGlobal()
+		defer hook.Reset()
+
+		h := NewMockHandler(nil, []string{}, &app)
+		h.processAppRefresh("invalid-type")
+		h.Shutdown()
+
+		assert.Contains(t, hook.LastEntry().Message, "Invalid refresh request type")
+	})
 }

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -1774,7 +1774,7 @@ func TestWebhookRefreshWithJitter(t *testing.T) {
 		req := &appRefreshRequest{
 			appName:      "test-app",
 			appNamespace: "argocd",
-			hydrate:      false,
+			hydrateType:  nil,
 		}
 
 		startTime := time.Now()
@@ -1814,7 +1814,7 @@ func TestWebhookRefreshWithJitter(t *testing.T) {
 		req := &appRefreshRequest{
 			appName:      "test-app",
 			appNamespace: "argocd",
-			hydrate:      false,
+			hydrateType:  nil,
 		}
 
 		// Add without explicit delay
@@ -1848,7 +1848,7 @@ func TestProcessAppRefresh(t *testing.T) {
 		req := &appRefreshRequest{
 			appName:      "test-app",
 			appNamespace: "argocd",
-			hydrate:      false,
+			hydrateType:  nil,
 		}
 
 		h.processAppRefresh(req)
@@ -1861,11 +1861,12 @@ func TestProcessAppRefresh(t *testing.T) {
 		hook := test.NewGlobal()
 		defer hook.Reset()
 
+		hydrateType := v1alpha1.HydrateTypeNormal
 		h := NewMockHandler(nil, []string{}, &app)
 		req := &appRefreshRequest{
 			appName:      "test-app",
 			appNamespace: "argocd",
-			hydrate:      true,
+			hydrateType:  &hydrateType,
 		}
 
 		h.processAppRefresh(req)


### PR DESCRIPTION
closes:  #25462

This PR introduces webhook jitter to Argo CD, preventing thundering-herd effects when a single commit triggers reconciliation for a large number of Applications. Instead of enqueueing all affected Applications at the same instant, jitter spreads webhook-triggered refresh events across a configurable time window.

## Why This Is Needed
Without jitter, a webhook that affects hundreds or thousands of Applications leads to:
- simultaneous enqueue of all apps leads to burst of api calls to repo-server and cache stampede (repo-server cache bypass)
- high kube-apiserver load
- controller CPU saturation over a long plateau
- potential control-plane instability

In large installations this creates major load spikes.


### Changes
1. Webhook Refresh Queue with Jitter
Introduced a dedicated refreshQueue so, Webhook processing is now decoupled from immediate Application refresh.
Each affected Application is enqueued with a random delay (0 → configured jitter) to avoid thundering-herd spikes.

2.  Jitter can be configured through a webhook.jitter field in the argocd-cm

#### Observed Results:
- ls-remote calls reduced by ~50% (all apps where configured to a single repo)
- Load becomes smoother and less bursty
- CPU peak remains the same (expected) but time spent at peak is significantly shorter
- Repo-server avoids concurrency stampede and maintains healthy response latency

<img width="1093" height="684" alt="image" src="https://github.com/user-attachments/assets/b750837b-1d97-4e87-8670-c3b339108b13" />
<img width="1093" height="417" alt="image" src="https://github.com/user-attachments/assets/a8be2e54-237f-47df-b15b-9737527f24c7" />
Left is with jitter and right one is without jitter

### Edit

Added "webhook.reconciliation.jitter.threshold", which will enable user to configure the threshold app count . so, if total no. of app affected by webhook commit is less than defined threshold then Jitter won't be applied.



Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* -[x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* -[x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* -[x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* -[x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* -[x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* -[x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* -[x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* -[x] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

