### PR TITLE
fix: respect IgnoreAggregatedRoles from compare options

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -1574,11 +1574,10 @@ func findAndPrintDiff(ctx context.Context, app *argoappv1.Application, proj *arg
 			overrides[k] = *val
 		}
 
-		// TODO remove hardcoded IgnoreAggregatedRoles and retrieve the
-		// compareOptions in the protobuf
-		ignoreAggregatedRoles := false
+		compareOptions, err := argoSettings.GetResourceCompareOptions()
+		errors.CheckError(err)
 		diffConfig, err := argodiff.NewDiffConfigBuilder().
-			WithDiffSettings(app.Spec.IgnoreDifferences, overrides, ignoreAggregatedRoles, ignoreNormalizerOpts).
+			WithDiffSettings(app.Spec.IgnoreDifferences, overrides, compareOptions.IgnoreAggregatedRoles, ignoreNormalizerOpts).
 			WithTracking(argoSettings.AppLabelKey, argoSettings.TrackingMethod).
 			WithNoCache().
 			WithLogger(logutils.NewLogrusLogger(logutils.NewWithCurrentConfig())).


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

---

### Summary

This PR resolves a TODO in `findAndPrintDiff` by removing the hardcoded 
`ignoreAggregatedRoles` value and retrieving the value from 
`argoSettings.GetResourceCompareOptions()`.

The change ensures that the diff behavior respects user-configured 
CompareOptions from the ArgoCD ConfigMap, instead of always using `false`. 
No protobuf changes are required since `GetResourceCompareOptions()` 
already abstracts configuration and gRPC API mapping.

### Changes

- Removed `ignoreAggregatedRoles := false`
- Added `compareOptions, err := argoSettings.GetResourceCompareOptions()`
- Passed `compareOptions.IgnoreAggregatedRoles` into `WithDiffSettings()`

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
