### PR TITLE
feat: add health checks for Apigee Hybrid CRDs

### DIFF
--- a/resource_customizations/apigee.cloud.google.com/ApigeeDatastore/health.lua
+++ b/resource_customizations/apigee.cloud.google.com/ApigeeDatastore/health.lua
@@ -1,0 +1,13 @@
+health_status = {}
+if obj.status ~= nil then
+  if obj.status.state ~= nil then
+    if obj.status.state == "running" then
+      health_status.status = "Healthy"
+      health_status.message = "Install of Apigee Datastore is done"
+      return health_status
+    end
+  end
+end
+health_status.status = "Progressing"
+health_status.message = "An install plan for an Apigee Datastore is pending installation"
+return health_status

--- a/resource_customizations/apigee.cloud.google.com/ApigeeDeployment/health.lua
+++ b/resource_customizations/apigee.cloud.google.com/ApigeeDeployment/health.lua
@@ -1,0 +1,13 @@
+health_status = {}
+if obj.status ~= nil then
+  if obj.status.state ~= nil then
+    if obj.status.state == "running" then
+      health_status.status = "Healthy"
+      health_status.message = "Install of Apigee Deployment is done"
+      return health_status
+    end
+  end
+end
+health_status.status = "Progressing"
+health_status.message = "An install plan for an Apigee Deployment is pending installation"
+return health_status

--- a/resource_customizations/apigee.cloud.google.com/ApigeeEnvironment/health.lua
+++ b/resource_customizations/apigee.cloud.google.com/ApigeeEnvironment/health.lua
@@ -1,0 +1,13 @@
+health_status = {}
+if obj.status ~= nil then
+  if obj.status.state ~= nil then
+    if obj.status.state == "running" then
+      health_status.status = "Healthy"
+      health_status.message = "Install of Apigee Environment is done"
+      return health_status
+    end
+  end
+end
+health_status.status = "Progressing"
+health_status.message = "An install plan for an Apigee Environment is pending installation"
+return health_status

--- a/resource_customizations/apigee.cloud.google.com/ApigeeOrganization/health.lua
+++ b/resource_customizations/apigee.cloud.google.com/ApigeeOrganization/health.lua
@@ -1,0 +1,13 @@
+health_status = {}
+if obj.status ~= nil then
+  if obj.status.state ~= nil then
+    if obj.status.state == "running" then
+      health_status.status = "Healthy"
+      health_status.message = "Install of Apigee Organization is done"
+      return health_status
+    end
+  end
+end
+health_status.status = "Progressing"
+health_status.message = "An install plan for an Apigee Organization is pending installation"
+return health_status

--- a/resource_customizations/apigee.cloud.google.com/ApigeeRedis/health.lua
+++ b/resource_customizations/apigee.cloud.google.com/ApigeeRedis/health.lua
@@ -1,0 +1,13 @@
+health_status = {}
+if obj.status ~= nil then
+  if obj.status.state ~= nil then
+    if obj.status.state == "running" then
+      health_status.status = "Healthy"
+      health_status.message = "Install of Apigee Redis is done"
+      return health_status
+    end
+  end
+end
+health_status.status = "Progressing"
+health_status.message = "An install plan for an Apigee Redis is pending installation"
+return health_status

--- a/resource_customizations/apigee.cloud.google.com/ApigeeTelemetry/health.lua
+++ b/resource_customizations/apigee.cloud.google.com/ApigeeTelemetry/health.lua
@@ -1,0 +1,13 @@
+health_status = {}
+if obj.status ~= nil then
+  if obj.status.state ~= nil then
+    if obj.status.state == "running" then
+      health_status.status = "Healthy"
+      health_status.message = "Install of Apigee Telemetry is done"
+      return health_status
+    end
+  end
+end
+health_status.status = "Progressing"
+health_status.message = "An install plan for an Apigee Telemetry is pending installation"
+return health_status


### PR DESCRIPTION
Apigee is "Google Cloud’s native API management tool to build, manage, and secure APIs—for any use case, environment, or scale."

This pull request introduces custom health checks for the following Apigee Hybrid CRDs:
* ApigeeDatastore
* ApigeeDeployment
* ApigeeEnvironment
* ApigeeOrganization
* ApigeeRedis
* ApigeeTelemetry

These health checks enable ArgoCD to accurately assess the health status of these specific resources within the apigee.cloud.google.com group, enhancing deployment reliability and monitoring capabilities in ArgoCD.

Ref documentation from editor:
* [Kubernetes and custom resources used by Apigee](https://docs.cloud.google.com/apigee/docs/hybrid/kubernetes-resources)
