### PR TITLE
fix: makefile mkdocs directive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,8 @@ endif
 
 ARGOCD_PROCFILE?=Procfile
 
-# pointing to python 3.7 to match https://github.com/argoproj/argo-cd/blob/master/.readthedocs.yml
-MKDOCS_DOCKER_IMAGE?=python:3.7-alpine
+# pointing to python 3.12 to match https://github.com/argoproj/argo-cd/blob/master/.readthedocs.yaml
+MKDOCS_DOCKER_IMAGE?=python:3.12-alpine
 MKDOCS_RUN_ARGS?=
 
 # Configuration for building argocd-test-tools image
@@ -580,7 +580,7 @@ build-docs-local:
 
 .PHONY: build-docs
 build-docs:
-	$(DOCKER) run ${MKDOCS_RUN_ARGS} --rm -it -v ${CURRENT_DIR}:/docs -w /docs --entrypoint "" ${MKDOCS_DOCKER_IMAGE} sh -c 'pip install mkdocs; pip install $$(mkdocs get-deps); mkdocs build'
+	$(DOCKER) run ${MKDOCS_RUN_ARGS} --rm -it -v ${CURRENT_DIR}:/docs -w /docs --entrypoint "" ${MKDOCS_DOCKER_IMAGE} sh -c 'pip install -r docs/requirements.txt; mkdocs build'
 
 .PHONY: serve-docs-local
 serve-docs-local:
@@ -588,7 +588,7 @@ serve-docs-local:
 
 .PHONY: serve-docs
 serve-docs:
-	$(DOCKER) run ${MKDOCS_RUN_ARGS} --rm -it -p 8000:8000 -v ${CURRENT_DIR}:/docs -w /docs --entrypoint "" ${MKDOCS_DOCKER_IMAGE} sh -c 'pip install mkdocs; pip install $$(mkdocs get-deps); mkdocs serve -a $$(ip route get 1 | awk '\''{print $$7}'\''):8000'
+	$(DOCKER) run ${MKDOCS_RUN_ARGS} --rm -it -p 8000:8000 -v ${CURRENT_DIR}:/docs -w /docs --entrypoint "" ${MKDOCS_DOCKER_IMAGE} sh -c 'pip install -r docs/requirements.txt; mkdocs serve -a $$(ip route get 1 | awk '\''{print $$7}'\''):8000'
 
 # Verify that kubectl can connect to your K8s cluster from Docker
 .PHONY: verify-kube-connect

--- a/docs/user-guide/source-hydrator.md
+++ b/docs/user-guide/source-hydrator.md
@@ -106,9 +106,7 @@ spec:
 ```
 
 In this example, the hydrated manifests will be pushed to the `environments/dev` branch of the `argocd-example-apps`
-repository. The `drySource` field tells Argo CD where your original, unrendered configuration lives.
-This can be a Helm chart, a Kustomize directory, or plain manifests. Argo CD reads this source, renders the final Kubernetes
-manifests from it, and then writes those hydrated manifests into the location specified by `syncSource.path`.
+repository.
 
 When using source hydration, the `syncSource.path` field is required and must always point to a non-root
 directory in the repository. Setting the path to the repository root (for eg. `"."` or `""`) is not

--- a/docs/user-guide/source-hydrator.md
+++ b/docs/user-guide/source-hydrator.md
@@ -106,7 +106,9 @@ spec:
 ```
 
 In this example, the hydrated manifests will be pushed to the `environments/dev` branch of the `argocd-example-apps`
-repository.
+repository. The `drySource` field tells Argo CD where your original, unrendered configuration lives.
+This can be a Helm chart, a Kustomize directory, or plain manifests. Argo CD reads this source, renders the final Kubernetes
+manifests from it, and then writes those hydrated manifests into the location specified by `syncSource.path`.
 
 When using source hydration, the `syncSource.path` field is required and must always point to a non-root
 directory in the repository. Setting the path to the repository root (for eg. `"."` or `""`) is not


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->
## What

Fixes https://github.com/argoproj/argo-cd/issues/25479

## Before

```
make serve-docs
...
ERROR   -  Config value 'plugins': The "gh-admonitions" plugin is not installed

Aborted with 1 configuration errors!
```

## After

```
make serve-docs
...
INFO    -  Doc file 'proposals/parameterized-config-management-plugins.md' contains a link '#upgrade--downgrade-strategy', but there is no such anchor on this page.
INFO    -  Doc file 'proposals/proxy-extensions.md' contains a link '#upgrade--downgrade', but there is no such anchor on this page.
INFO    -  Doc file 'proposals/server-side-apply.md' contains a link '#non-functional-requirements', but there is no such anchor on this page.
INFO    -  Doc file 'proposals/server-side-apply.md' contains a link '#upgrade--downgrade', but there is no such anchor on this page.
INFO    -  Doc file 'user-guide/annotations-and-labels.md' contains a link 'resource_hooks.md#hook-deletion-policies', but the doc 'user-guide/resource_hooks.md' does not contain an anchor
           '#hook-deletion-policies'.
INFO    -  Doc file 'user-guide/annotations-and-labels.md' contains a link '../operator-manual/high_availability.md#webhook-and-manifest-paths-annotation', but the doc 'operator-manual/high_availability.md'
           does not contain an anchor '#webhook-and-manifest-paths-annotation'.
INFO    -  Documentation built in 2.34 seconds
INFO    -  [00:15:16] Serving on http://172.17.0.2:8000/

```

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
