### PR TITLE
fix(ui): crash when deleting ReplicaSet from grouped resources panel

### DIFF
--- a/ui/src/app/applications/components/application-details/application-resource-list.test.tsx
+++ b/ui/src/app/applications/components/application-details/application-resource-list.test.tsx
@@ -1,0 +1,183 @@
+import {nodeKey} from '../utils';
+import * as models from '../../../shared/models';
+
+/**
+ * Tests for the filtering logic in ApplicationResourceList component.
+ * 
+ * The component filters resources based on whether they exist in the tree,
+ * preventing crashes when resources are deleted but still referenced in state.
+ */
+
+const createMockResource = (name: string, kind: string = 'ReplicaSet', namespace: string = 'default'): models.ResourceStatus => ({
+    name,
+    kind,
+    namespace,
+    group: 'apps',
+    version: 'v1',
+    status: 'Synced' as models.SyncStatusCode,
+    health: {status: 'Healthy'} as models.HealthStatus
+});
+
+const createMockNode = (name: string, kind: string = 'ReplicaSet', namespace: string = 'default'): models.ResourceNode => ({
+    name,
+    kind,
+    namespace,
+    group: 'apps',
+    version: 'v1',
+    uid: `uid-${name}`,
+    resourceVersion: '1',
+    parentRefs: [],
+    info: [{name: 'Revision', value: 'Rev:1'}]
+});
+
+describe('ApplicationResourceList filtering logic', () => {
+    describe('filterDeletedResources', () => {
+        // This simulates the filtering logic used in the component:
+        // const resourcesToSort = props.resources.filter(res => nodeByKey.has(nodeKey(res)));
+        
+        const filterResources = (resources: models.ResourceStatus[], nodes: models.ResourceNode[]): models.ResourceStatus[] => {
+            const nodeByKey = new Map<string, models.ResourceNode>();
+            nodes.forEach(node => nodeByKey.set(nodeKey(node), node));
+            return resources.filter(res => nodeByKey.has(nodeKey(res)));
+        };
+
+        it('should filter out resources that do not exist in the tree', () => {
+            const resources = [
+                createMockResource('rs-1'),
+                createMockResource('rs-2'),
+                createMockResource('rs-3')
+            ];
+
+            // Tree only contains rs-1 and rs-3, rs-2 has been deleted
+            const nodes = [
+                createMockNode('rs-1'),
+                createMockNode('rs-3')
+            ];
+
+            const filtered = filterResources(resources, nodes);
+
+            expect(filtered).toHaveLength(2);
+            expect(filtered.map(r => r.name)).toEqual(['rs-1', 'rs-3']);
+            expect(filtered.find(r => r.name === 'rs-2')).toBeUndefined();
+        });
+
+        it('should return empty array when all resources are deleted from tree', () => {
+            const resources = [
+                createMockResource('rs-1'),
+                createMockResource('rs-2')
+            ];
+
+            // Tree is empty - all resources deleted
+            const nodes: models.ResourceNode[] = [];
+
+            const filtered = filterResources(resources, nodes);
+
+            expect(filtered).toHaveLength(0);
+        });
+
+        it('should return all resources when all exist in tree', () => {
+            const resources = [
+                createMockResource('rs-1'),
+                createMockResource('rs-2'),
+                createMockResource('rs-3')
+            ];
+
+            const nodes = [
+                createMockNode('rs-1'),
+                createMockNode('rs-2'),
+                createMockNode('rs-3')
+            ];
+
+            const filtered = filterResources(resources, nodes);
+
+            expect(filtered).toHaveLength(3);
+            expect(filtered.map(r => r.name)).toEqual(['rs-1', 'rs-2', 'rs-3']);
+        });
+
+        it('should handle resources with different namespaces correctly', () => {
+            const resources = [
+                createMockResource('rs-1', 'ReplicaSet', 'namespace-a'),
+                createMockResource('rs-1', 'ReplicaSet', 'namespace-b')
+            ];
+
+            // Only the one in namespace-a exists
+            const nodes = [
+                createMockNode('rs-1', 'ReplicaSet', 'namespace-a')
+            ];
+
+            const filtered = filterResources(resources, nodes);
+
+            expect(filtered).toHaveLength(1);
+            expect(filtered[0].namespace).toBe('namespace-a');
+        });
+
+        it('should handle resources with different kinds correctly', () => {
+            const resources = [
+                createMockResource('my-resource', 'ReplicaSet'),
+                createMockResource('my-resource', 'Deployment')
+            ];
+
+            // Only the ReplicaSet exists
+            const nodes = [
+                createMockNode('my-resource', 'ReplicaSet')
+            ];
+
+            const filtered = filterResources(resources, nodes);
+
+            expect(filtered).toHaveLength(1);
+            expect(filtered[0].kind).toBe('ReplicaSet');
+        });
+    });
+
+    describe('safe info access', () => {
+        it('should handle node without info property', () => {
+            const nodeWithoutInfo: models.ResourceNode = {
+                name: 'rs-1',
+                kind: 'ReplicaSet',
+                namespace: 'default',
+                group: 'apps',
+                version: 'v1',
+                uid: 'uid-rs-1',
+                resourceVersion: '1',
+                parentRefs: []
+                // info is intentionally omitted
+            };
+
+            // Simulates the optional chaining: (node?.info || [])
+            const info = nodeWithoutInfo.info || [];
+            
+            expect(info).toEqual([]);
+            expect(() => info.filter(tag => !tag.name.includes('Node'))).not.toThrow();
+        });
+
+        it('should handle node with undefined info', () => {
+            const nodeWithUndefinedInfo = {
+                name: 'rs-1',
+                kind: 'ReplicaSet',
+                namespace: 'default',
+                group: 'apps',
+                version: 'v1',
+                uid: 'uid-rs-1',
+                resourceVersion: '1',
+                parentRefs: [],
+                info: undefined
+            } as models.ResourceNode;
+
+            // Simulates: ((nodeByKey.get(nodeKey(res)) as ResourceNode)?.info || [])
+            const info = nodeWithUndefinedInfo?.info || [];
+            
+            expect(info).toEqual([]);
+        });
+
+        it('should safely access info when node is undefined', () => {
+            const nodeByKey = new Map<string, models.ResourceNode>();
+            const missingNode = nodeByKey.get('non-existent-key');
+
+            // Simulates: ((nodeByKey.get(nodeKey(res)) as ResourceNode)?.info || [])
+            const info = (missingNode as models.ResourceNode)?.info || [];
+            
+            expect(info).toEqual([]);
+            expect(() => info.filter(tag => !tag.name.includes('Node'))).not.toThrow();
+        });
+    });
+});

--- a/ui/src/app/applications/components/application-details/application-resource-list.tsx
+++ b/ui/src/app/applications/components/application-details/application-resource-list.tsx
@@ -62,7 +62,8 @@ export const ApplicationResourceList = (props: ApplicationResourceListProps) => 
     };
 
     const sortedResources = React.useMemo(() => {
-        const resourcesToSort = [...props.resources];
+        // Filter out resources that no longer exist in the tree (e.g., deleted resources)
+        const resourcesToSort = props.resources.filter(res => nodeByKey.has(nodeKey(res)));
         resourcesToSort.sort((a, b) => {
             let compare = 0;
             switch (sortConfig.key) {
@@ -114,7 +115,7 @@ export const ApplicationResourceList = (props: ApplicationResourceListProps) => 
             return sortConfig.direction === 'asc' ? compare : -compare;
         });
         return resourcesToSort;
-    }, [props.resources, sortConfig]);
+    }, [props.resources, sortConfig, props.tree]);
 
     const firstParentNode = props.resources.length > 0 && (nodeByKey.get(nodeKey(props.resources[0])) as ResourceNode)?.parentRefs?.[0];
     const isSameParent = firstParentNode && props.resources?.every(x => (nodeByKey.get(nodeKey(x)) as ResourceNode)?.parentRefs?.every(p => isSameNode(p, firstParentNode)));
@@ -189,7 +190,7 @@ export const ApplicationResourceList = (props: ApplicationResourceListProps) => 
                                             <div>{ResourceLabel({kind: res.kind})}</div>
                                         </div>
                                     </div>
-                                    <Tooltip content={res.name} enabled={!!res.name}>
+                                    <Tooltip content={res.name ?? ''} enabled={!!res.name}>
                                         <div className='columns small-2 xxxlarge-2 application-details__item'>
                                             <span className='application-details__item_text'>{res.name}</span>
                                             {res.kind === 'Application' && (
@@ -218,18 +219,18 @@ export const ApplicationResourceList = (props: ApplicationResourceListProps) => 
                                             )}
                                         </div>
                                     </Tooltip>
-                                    <Tooltip content={groupkindjoin}>
-                                        <div className='columns small-1 xxxlarge-1'>{groupkindjoin}</div>
+                                    <Tooltip content={groupkindjoin} enabled={!!groupkindjoin}>
+                                        <div className='columns small-1 xxxlarge-1'>{groupkindjoin || '-'}</div>
                                     </Tooltip>
-                                    <Tooltip content={res.syncWave} enabled={!!res.syncWave}>
+                                    <Tooltip content={res.syncWave ?? ''} enabled={!!res.syncWave}>
                                         <div className='columns small-1 xxxlarge-1'>{res.syncWave || '-'}</div>
                                     </Tooltip>
-                                    <Tooltip content={res.namespace} enabled={!!res.namespace}>
+                                    <Tooltip content={res.namespace ?? ''} enabled={!!res.namespace}>
                                         <div className='columns small-2 xxxlarge-1'>{res.namespace}</div>
                                     </Tooltip>
                                     {isSameKind &&
                                         res.kind === 'ReplicaSet' &&
-                                        ((nodeByKey.get(nodeKey(res)) as ResourceNode).info || [])
+                                        ((nodeByKey.get(nodeKey(res)) as ResourceNode)?.info || [])
                                             .filter(tag => !tag.name.includes('Node'))
                                             .slice(0, 4)
                                             .map((tag, i) => {
@@ -239,7 +240,7 @@ export const ApplicationResourceList = (props: ApplicationResourceListProps) => 
                                                     </div>
                                                 );
                                             })}
-                                    <Tooltip content={res.createdAt} enabled={!!res.createdAt}>
+                                    <Tooltip content={res.createdAt ?? ''} enabled={!!res.createdAt}>
                                         <div className='columns small-2 xxxlarge-2'>
                                             {res.createdAt && (
                                                 <span>


### PR DESCRIPTION
## Summary
Fixes UI crash when deleting a resource (e.g., ReplicaSet) from the grouped resources sliding panel.

## Root Cause
When a resource is deleted:
1. The backend updates `tree.nodes` (resource removed)
2. `groupedResources` state still contains the deleted resource
3. Code tries to access `.info` on a node that no longer exists → crash

## Changes
- Filter `sortedResources` to only include resources that exist in `props.tree`
- Add optional chaining (`?.`) when accessing node properties
- Add fallback values for Tooltip `content` prop to prevent warnings

## How to Reproduce
1. Create an app with multiple ReplicaSets (5+) so they get grouped
2. Enable "Group Nodes" view
3. Click on the grouped ReplicaSets to open the sliding panel
4. Delete one of the ReplicaSets
5. **Before fix:** UI crashes with `TypeError: Cannot read properties of undefined (reading 'info')`
6. **After fix:** Row is removed cleanly from the list

## Testing
- Manually tested deletion of grouped ReplicaSets
- Verified rows update correctly after deletion
- No new warnings or errors in console

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->


Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
