### PR TITLE
fix(repo-server): respect context cancellation in repository lock

### DIFF
--- a/reposerver/repository/lock.go
+++ b/reposerver/repository/lock.go
@@ -82,6 +82,12 @@ func (r *repositoryLock) Lock(ctx context.Context, path string, revision string,
 			state.cond.L.Unlock()
 			return closer, nil
 		}
+
+		if err := ctx.Err(); err != nil {
+			state.cond.L.Unlock()
+			return nil, err
+		}
+
 		state.cond.Wait()
 		if err := ctx.Err(); err != nil {
 			state.cond.L.Unlock()

--- a/reposerver/repository/lock.go
+++ b/reposerver/repository/lock.go
@@ -84,6 +84,12 @@ func (r *repositoryLock) Lock(ctx context.Context, path string, revision string,
 			state.cond.L.Unlock()
 			return closer, nil
 		}
+
+		if err := ctx.Err(); err != nil {
+			state.cond.L.Unlock()
+			return nil, err
+		}
+
 		state.cond.Wait()
 		if err := ctx.Err(); err != nil {
 			state.cond.L.Unlock()

--- a/reposerver/repository/lock.go
+++ b/reposerver/repository/lock.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"sync"
@@ -20,7 +21,7 @@ type repositoryLock struct {
 // Lock acquires lock unless lock is already acquired with the same commit and allowConcurrent is set to true
 // The init callback receives `clean` parameter which indicates if repo state must be cleaned after running non-concurrent operation.
 // The first init always runs with `clean` set to true because we cannot be sure about initial repo state.
-func (r *repositoryLock) Lock(path string, revision string, allowConcurrent bool, init func(clean bool) (io.Closer, error)) (io.Closer, error) {
+func (r *repositoryLock) Lock(ctx context.Context, path string, revision string, allowConcurrent bool, init func(clean bool) (io.Closer, error)) (io.Closer, error) {
 	r.lock.Lock()
 	state, ok := r.stateByKey[path]
 	if !ok {
@@ -50,6 +51,18 @@ func (r *repositoryLock) Lock(path string, revision string, allowConcurrent bool
 		return nil
 	})
 
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	stopf := context.AfterFunc(ctx, func() {
+		state.cond.L.Lock()
+		defer state.cond.L.Unlock()
+
+		state.cond.Broadcast()
+	})
+	defer stopf()
+
 	for {
 		state.cond.L.Lock()
 		if state.revision == "" {
@@ -72,6 +85,10 @@ func (r *repositoryLock) Lock(path string, revision string, allowConcurrent bool
 			return closer, nil
 		}
 		state.cond.Wait()
+		if err := ctx.Err(); err != nil {
+			state.cond.L.Unlock()
+			return nil, err
+		}
 		// wait when all in-flight processes of this revision complete and try again
 		state.cond.L.Unlock()
 	}

--- a/reposerver/repository/lock_test.go
+++ b/reposerver/repository/lock_test.go
@@ -1,12 +1,14 @@
 package repository
 
 import (
+	"context"
 	"errors"
 	"io"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	utilio "github.com/argoproj/argo-cd/v3/util/io"
 )
@@ -38,7 +40,7 @@ func TestLock_SameRevision(t *testing.T) {
 	initializedTimes := 0
 	init := numberOfInits(&initializedTimes)
 	closer1, done := lockQuickly(func() (io.Closer, error) {
-		return lock.Lock("myRepo", "1", true, init)
+		return lock.Lock(t.Context(), "myRepo", "1", true, init)
 	})
 
 	if !assert.True(t, done) {
@@ -46,7 +48,7 @@ func TestLock_SameRevision(t *testing.T) {
 	}
 
 	closer2, done := lockQuickly(func() (io.Closer, error) {
-		return lock.Lock("myRepo", "1", true, init)
+		return lock.Lock(t.Context(), "myRepo", "1", true, init)
 	})
 
 	if !assert.True(t, done) {
@@ -66,7 +68,7 @@ func TestLock_DifferentRevisions(t *testing.T) {
 	init := numberOfInits(&initializedTimes)
 
 	closer1, done := lockQuickly(func() (io.Closer, error) {
-		return lock.Lock("myRepo", "1", true, init)
+		return lock.Lock(t.Context(), "myRepo", "1", true, init)
 	})
 
 	if !assert.True(t, done) {
@@ -74,7 +76,7 @@ func TestLock_DifferentRevisions(t *testing.T) {
 	}
 
 	_, done = lockQuickly(func() (io.Closer, error) {
-		return lock.Lock("myRepo", "2", true, init)
+		return lock.Lock(t.Context(), "myRepo", "2", true, init)
 	})
 
 	if !assert.False(t, done) {
@@ -84,7 +86,7 @@ func TestLock_DifferentRevisions(t *testing.T) {
 	utilio.Close(closer1)
 
 	_, done = lockQuickly(func() (io.Closer, error) {
-		return lock.Lock("myRepo", "2", true, init)
+		return lock.Lock(t.Context(), "myRepo", "2", true, init)
 	})
 
 	if !assert.True(t, done) {
@@ -98,7 +100,7 @@ func TestLock_NoConcurrentWithSameRevision(t *testing.T) {
 	init := numberOfInits(&initializedTimes)
 
 	closer1, done := lockQuickly(func() (io.Closer, error) {
-		return lock.Lock("myRepo", "1", false, init)
+		return lock.Lock(t.Context(), "myRepo", "1", false, init)
 	})
 
 	if !assert.True(t, done) {
@@ -106,7 +108,7 @@ func TestLock_NoConcurrentWithSameRevision(t *testing.T) {
 	}
 
 	_, done = lockQuickly(func() (io.Closer, error) {
-		return lock.Lock("myRepo", "1", false, init)
+		return lock.Lock(t.Context(), "myRepo", "1", false, init)
 	})
 
 	if !assert.False(t, done) {
@@ -120,7 +122,7 @@ func TestLock_FailedInitialization(t *testing.T) {
 	lock := NewRepositoryLock()
 
 	closer1, done := lockQuickly(func() (io.Closer, error) {
-		return lock.Lock("myRepo", "1", true, func(_ bool) (io.Closer, error) {
+		return lock.Lock(t.Context(), "myRepo", "1", true, func(_ bool) (io.Closer, error) {
 			return utilio.NopCloser, errors.New("failed")
 		})
 	})
@@ -132,7 +134,7 @@ func TestLock_FailedInitialization(t *testing.T) {
 	assert.Nil(t, closer1)
 
 	closer2, done := lockQuickly(func() (io.Closer, error) {
-		return lock.Lock("myRepo", "1", true, func(_ bool) (io.Closer, error) {
+		return lock.Lock(t.Context(), "myRepo", "1", true, func(_ bool) (io.Closer, error) {
 			return utilio.NopCloser, nil
 		})
 	})
@@ -149,7 +151,7 @@ func TestLock_SameRevisionFirstNotConcurrent(t *testing.T) {
 	initializedTimes := 0
 	init := numberOfInits(&initializedTimes)
 	closer1, done := lockQuickly(func() (io.Closer, error) {
-		return lock.Lock("myRepo", "1", false, init)
+		return lock.Lock(t.Context(), "myRepo", "1", false, init)
 	})
 
 	if !assert.True(t, done) {
@@ -157,7 +159,7 @@ func TestLock_SameRevisionFirstNotConcurrent(t *testing.T) {
 	}
 
 	_, done = lockQuickly(func() (io.Closer, error) {
-		return lock.Lock("myRepo", "1", true, init)
+		return lock.Lock(t.Context(), "myRepo", "1", true, init)
 	})
 
 	if !assert.False(t, done) {
@@ -177,7 +179,7 @@ func TestLock_CleanForNonConcurrent(t *testing.T) {
 		return utilio.NopCloser, nil
 	}
 	closer, done := lockQuickly(func() (io.Closer, error) {
-		return lock.Lock("myRepo", "1", true, init)
+		return lock.Lock(t.Context(), "myRepo", "1", true, init)
 	})
 
 	assert.True(t, done)
@@ -186,10 +188,53 @@ func TestLock_CleanForNonConcurrent(t *testing.T) {
 	utilio.Close(closer)
 
 	closer, done = lockQuickly(func() (io.Closer, error) {
-		return lock.Lock("myRepo", "1", true, init)
+		return lock.Lock(t.Context(), "myRepo", "1", true, init)
 	})
 
 	assert.True(t, done)
 	assert.False(t, initClean)
 	utilio.Close(closer)
+}
+
+func TestLock_ContextCancelled(t *testing.T) {
+	lock := NewRepositoryLock()
+	init := numberOfInits(new(int))
+
+	closer, done := lockQuickly(func() (io.Closer, error) {
+		return lock.Lock(t.Context(), "myRepo", "1", true, init)
+	})
+	if !assert.True(t, done) {
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error)
+	go func() {
+		_, err := lock.Lock(ctx, "myRepo", "2", true, init)
+		errCh <- err
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(1 * time.Second):
+		t.Fatal("Lock did not return after context cancellation")
+	}
+
+	utilio.Close(closer)
+}
+
+func TestLock_ContextAlreadyCancelled(t *testing.T) {
+	lock := NewRepositoryLock()
+	init := numberOfInits(new(int))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := lock.Lock(ctx, "myRepo", "1", true, init)
+	require.ErrorIs(t, err, context.Canceled)
 }

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -252,7 +252,7 @@ func (s *Service) ListApps(ctx context.Context, q *apiclient.ListAppsRequest) (*
 	s.metricsServer.IncPendingRepoRequest(q.Repo.Repo)
 	defer s.metricsServer.DecPendingRepoRequest(q.Repo.Repo)
 
-	closer, err := s.repoLock.Lock(gitClient.Root(), commitSHA, true, func() (goio.Closer, error) {
+	closer, err := s.repoLock.Lock(ctx, gitClient.Root(), commitSHA, true, func() (goio.Closer, error) {
 		return s.checkoutRevision(gitClient, commitSHA, s.initConstants.SubmoduleEnabled, q.Repo.Depth)
 	})
 	if err != nil {
@@ -454,7 +454,7 @@ func (s *Service) runRepoOperation(
 			return &operationContext{chartPath, ""}, nil
 		})
 	}
-	closer, err := s.repoLock.Lock(gitClient.Root(), revision, settings.allowConcurrent, func() (goio.Closer, error) {
+	closer, err := s.repoLock.Lock(ctx, gitClient.Root(), revision, settings.allowConcurrent, func() (goio.Closer, error) {
 		return s.checkoutRevision(gitClient, revision, s.initConstants.SubmoduleEnabled, repo.Depth)
 	})
 	if err != nil {
@@ -839,7 +839,7 @@ func (s *Service) runManifestGenAsync(ctx context.Context, repoRoot, commitSHA, 
 							ch.errCh <- fmt.Errorf("cannot reference a different revision of the same repository (%s references %q which resolves to %q while the application references %q which resolves to %q)", refVar, refSourceMapping.TargetRevision, referencedCommitSHA, q.Revision, commitSHA)
 							return
 						}
-						closer, err := s.repoLock.Lock(gitClient.Root(), referencedCommitSHA, true, func() (goio.Closer, error) {
+						closer, err := s.repoLock.Lock(ctx, gitClient.Root(), referencedCommitSHA, true, func() (goio.Closer, error) {
 							return s.checkoutRevision(gitClient, referencedCommitSHA, s.initConstants.SubmoduleEnabled, q.Repo.Depth)
 						})
 						if err != nil {
@@ -2407,7 +2407,7 @@ func populatePluginAppDetails(ctx context.Context, res *apiclient.RepoAppDetails
 	return nil
 }
 
-func (s *Service) GetRevisionMetadata(_ context.Context, q *apiclient.RepoServerRevisionMetadataRequest) (*v1alpha1.RevisionMetadata, error) {
+func (s *Service) GetRevisionMetadata(ctx context.Context, q *apiclient.RepoServerRevisionMetadataRequest) (*v1alpha1.RevisionMetadata, error) {
 	if !git.IsCommitSHA(q.Revision) && !git.IsTruncatedCommitSHA(q.Revision) {
 		return nil, fmt.Errorf("revision %s must be resolved", q.Revision)
 	}
@@ -2442,7 +2442,7 @@ func (s *Service) GetRevisionMetadata(_ context.Context, q *apiclient.RepoServer
 	s.metricsServer.IncPendingRepoRequest(q.Repo.Repo)
 	defer s.metricsServer.DecPendingRepoRequest(q.Repo.Repo)
 
-	closer, err := s.repoLock.Lock(gitClient.Root(), q.Revision, true, func() (goio.Closer, error) {
+	closer, err := s.repoLock.Lock(ctx, gitClient.Root(), q.Revision, true, func() (goio.Closer, error) {
 		return s.checkoutRevision(gitClient, q.Revision, s.initConstants.SubmoduleEnabled, q.Repo.Depth)
 	})
 	if err != nil {
@@ -2866,7 +2866,7 @@ func (s *Service) ResolveRevision(ctx context.Context, q *apiclient.ResolveRevis
 	}, nil
 }
 
-func (s *Service) GetGitFiles(_ context.Context, request *apiclient.GitFilesRequest) (*apiclient.GitFilesResponse, error) {
+func (s *Service) GetGitFiles(ctx context.Context, request *apiclient.GitFilesRequest) (*apiclient.GitFilesResponse, error) {
 	repo := request.GetRepo()
 	revision := request.GetRevision()
 	gitPath := request.GetPath()
@@ -2901,7 +2901,7 @@ func (s *Service) GetGitFiles(_ context.Context, request *apiclient.GitFilesRequ
 	defer s.metricsServer.DecPendingRepoRequest(repo.Repo)
 
 	// cache miss, generate the results
-	closer, err := s.repoLock.Lock(gitClient.Root(), revision, true, func() (goio.Closer, error) {
+	closer, err := s.repoLock.Lock(ctx, gitClient.Root(), revision, true, func() (goio.Closer, error) {
 		return s.checkoutRevision(gitClient, revision, request.GetSubmoduleEnabled(), repo.Depth)
 	})
 	if err != nil {
@@ -2954,7 +2954,7 @@ func verifyCommitSignature(verifyCommit bool, gitClient git.Client, revision str
 	return nil
 }
 
-func (s *Service) GetGitDirectories(_ context.Context, request *apiclient.GitDirectoriesRequest) (*apiclient.GitDirectoriesResponse, error) {
+func (s *Service) GetGitDirectories(ctx context.Context, request *apiclient.GitDirectoriesRequest) (*apiclient.GitDirectoriesResponse, error) {
 	repo := request.GetRepo()
 	revision := request.GetRevision()
 	noRevisionCache := request.GetNoRevisionCache()
@@ -2983,7 +2983,7 @@ func (s *Service) GetGitDirectories(_ context.Context, request *apiclient.GitDir
 	defer s.metricsServer.DecPendingRepoRequest(repo.Repo)
 
 	// cache miss, generate the results
-	closer, err := s.repoLock.Lock(gitClient.Root(), revision, true, func() (goio.Closer, error) {
+	closer, err := s.repoLock.Lock(ctx, gitClient.Root(), revision, true, func() (goio.Closer, error) {
 		return s.checkoutRevision(gitClient, revision, request.GetSubmoduleEnabled(), repo.Depth)
 	})
 	if err != nil {
@@ -3032,7 +3032,7 @@ func (s *Service) GetGitDirectories(_ context.Context, request *apiclient.GitDir
 	}, nil
 }
 
-func (s *Service) gitSourceHasChanges(repo *v1alpha1.Repository, revision, syncedRevision string, refreshPaths []string, gitClientOpts git.ClientOpts) (string, string, bool, error) {
+func (s *Service) gitSourceHasChanges(ctx context.Context, repo *v1alpha1.Repository, revision, syncedRevision string, refreshPaths []string, gitClientOpts git.ClientOpts) (string, string, bool, error) {
 	if repo == nil {
 		return revision, syncedRevision, true, status.Error(codes.InvalidArgument, "must pass a valid repo")
 	}
@@ -3061,7 +3061,7 @@ func (s *Service) gitSourceHasChanges(repo *v1alpha1.Repository, revision, synce
 	s.metricsServer.IncPendingRepoRequest(repo.Repo)
 	defer s.metricsServer.DecPendingRepoRequest(repo.Repo)
 
-	closer, err := s.repoLock.Lock(gitClient.Root(), revision, true, func() (goio.Closer, error) {
+	closer, err := s.repoLock.Lock(ctx, gitClient.Root(), revision, true, func() (goio.Closer, error) {
 		return s.checkoutRevision(gitClient, revision, false, 0)
 	})
 	if err != nil {
@@ -3098,7 +3098,7 @@ func (s *Service) gitSourceHasChanges(repo *v1alpha1.Repository, revision, synce
 //
 // Example: cache contains manifest "x" under revision "a1a1a1". If the revision moves to "b2b2b2"
 // and no relevant files have changed, "x" will be stored again under the new revision key.
-func (s *Service) UpdateRevisionForPaths(_ context.Context, request *apiclient.UpdateRevisionForPathsRequest) (*apiclient.UpdateRevisionForPathsResponse, error) {
+func (s *Service) UpdateRevisionForPaths(ctx context.Context, request *apiclient.UpdateRevisionForPathsRequest) (*apiclient.UpdateRevisionForPathsResponse, error) {
 	logCtx := log.WithFields(log.Fields{"application": request.AppName, "appNamespace": request.Namespace})
 
 	// Store resolved revisions for cache update
@@ -3128,7 +3128,7 @@ func (s *Service) UpdateRevisionForPaths(_ context.Context, request *apiclient.U
 
 	if repo.Type == "git" {
 		if request.SyncedRevision != request.Revision {
-			resolvedRevision, syncedRevision, sourceHasChanges, err := s.gitSourceHasChanges(request.Repo, request.Revision, request.SyncedRevision, refreshPaths, gitClientOpts)
+			resolvedRevision, syncedRevision, sourceHasChanges, err := s.gitSourceHasChanges(ctx, request.Repo, request.Revision, request.SyncedRevision, refreshPaths, gitClientOpts)
 			if err != nil {
 				return nil, err
 			}
@@ -3183,7 +3183,7 @@ func (s *Service) UpdateRevisionForPaths(_ context.Context, request *apiclient.U
 		var err error
 
 		if sRefSource.TargetRevision != request.RefSources[refName].TargetRevision {
-			resolvedRevision, syncedRevision, sourceHasChanges, err = s.gitSourceHasChanges(&sRefSource.Repo, request.RefSources[refName].TargetRevision, sRefSource.TargetRevision, refreshPaths, gitClientOpts)
+			resolvedRevision, syncedRevision, sourceHasChanges, err = s.gitSourceHasChanges(ctx, &sRefSource.Repo, request.RefSources[refName].TargetRevision, sRefSource.TargetRevision, refreshPaths, gitClientOpts)
 			if err != nil {
 				return nil, err
 			}

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -260,7 +260,7 @@ func (s *Service) ListApps(ctx context.Context, q *apiclient.ListAppsRequest) (*
 	s.metricsServer.IncPendingRepoRequest(q.Repo.Repo)
 	defer s.metricsServer.DecPendingRepoRequest(q.Repo.Repo)
 
-	closer, err := s.repoLock.Lock(gitClient.Root(), commitSHA, true, func(clean bool) (goio.Closer, error) {
+	closer, err := s.repoLock.Lock(ctx, gitClient.Root(), commitSHA, true, func(clean bool) (goio.Closer, error) {
 		return s.checkoutRevision(gitClient, commitSHA, s.initConstants.SubmoduleEnabled, q.Repo.Depth, clean)
 	})
 	if err != nil {
@@ -466,7 +466,7 @@ func (s *Service) runRepoOperation(
 			return &operationContext{chartPath, "", nil}, nil
 		})
 	}
-	closer, err := s.repoLock.Lock(gitClient.Root(), revision, settings.allowConcurrent, func(clean bool) (goio.Closer, error) {
+	closer, err := s.repoLock.Lock(ctx, gitClient.Root(), revision, settings.allowConcurrent, func(clean bool) (goio.Closer, error) {
 		return s.checkoutRevision(gitClient, revision, s.initConstants.SubmoduleEnabled, repo.Depth, clean)
 	})
 	if err != nil {
@@ -886,7 +886,7 @@ func (s *Service) runManifestGenAsync(ctx context.Context, repoRoot, commitSHA, 
 							ch.errCh <- fmt.Errorf("cannot reference a different revision of the same repository (%s references %q which resolves to %q while the application references %q which resolves to %q)", refVar, refSourceMapping.TargetRevision, referencedCommitSHA, q.Revision, commitSHA)
 							return
 						}
-						closer, err := s.repoLock.Lock(gitClient.Root(), referencedCommitSHA, true, func(clean bool) (goio.Closer, error) {
+						closer, err := s.repoLock.Lock(ctx, gitClient.Root(), referencedCommitSHA, true, func(clean bool) (goio.Closer, error) {
 							return s.checkoutRevision(gitClient, referencedCommitSHA, s.initConstants.SubmoduleEnabled, q.Repo.Depth, clean)
 						})
 						if err != nil {
@@ -2394,7 +2394,7 @@ func (s *Service) GetAppDetails(ctx context.Context, q *apiclient.RepoServerAppD
 
 		switch appSourceType {
 		case v1alpha1.ApplicationSourceTypeHelm:
-			if err := s.populateHelmAppDetails(res, opContext.appPath, repoRoot, commitSHA, revision, q, s.gitRepoPaths); err != nil {
+			if err := s.populateHelmAppDetails(ctx, res, opContext.appPath, repoRoot, commitSHA, revision, q, s.gitRepoPaths); err != nil {
 				return err
 			}
 		case v1alpha1.ApplicationSourceTypeKustomize:
@@ -2433,7 +2433,7 @@ func (s *Service) createGetAppDetailsCacheHandler(res *apiclient.RepoAppDetailsR
 	}
 }
 
-func (s *Service) populateHelmAppDetails(res *apiclient.RepoAppDetailsResponse, appPath, repoRoot, commitSHA, revision string, q *apiclient.RepoServerAppDetailsQuery, gitRepoPaths utilio.TempPaths) error {
+func (s *Service) populateHelmAppDetails(ctx context.Context, res *apiclient.RepoAppDetailsResponse, appPath, repoRoot, commitSHA, revision string, q *apiclient.RepoServerAppDetailsQuery, gitRepoPaths utilio.TempPaths) error {
 	var selectedValueFiles []string
 	var availableValueFiles []string
 
@@ -2502,7 +2502,7 @@ func (s *Service) populateHelmAppDetails(res *apiclient.RepoAppDetailsResponse, 
 					key:       refName,
 				}
 			}
-			closer, err := s.repoLock.Lock(gitClient.Root(), refSHA, true, func(clean bool) (goio.Closer, error) {
+			closer, err := s.repoLock.Lock(ctx, gitClient.Root(), refSHA, true, func(clean bool) (goio.Closer, error) {
 				return s.checkoutRevision(gitClient, refSHA, s.initConstants.SubmoduleEnabled, refSource.Repo.Depth, clean)
 			})
 			if err != nil {
@@ -2653,7 +2653,7 @@ func populatePluginAppDetails(ctx context.Context, res *apiclient.RepoAppDetails
 	return nil
 }
 
-func (s *Service) GetRevisionMetadata(_ context.Context, q *apiclient.RepoServerRevisionMetadataRequest) (*v1alpha1.RevisionMetadata, error) {
+func (s *Service) GetRevisionMetadata(ctx context.Context, q *apiclient.RepoServerRevisionMetadataRequest) (*v1alpha1.RevisionMetadata, error) {
 	if !git.IsCommitSHA(q.Revision) && !git.IsTruncatedCommitSHA(q.Revision) {
 		return nil, fmt.Errorf("revision %s must be resolved", q.Revision)
 	}
@@ -2686,7 +2686,7 @@ func (s *Service) GetRevisionMetadata(_ context.Context, q *apiclient.RepoServer
 	s.metricsServer.IncPendingRepoRequest(q.Repo.Repo)
 	defer s.metricsServer.DecPendingRepoRequest(q.Repo.Repo)
 
-	closer, err := s.repoLock.Lock(gitClient.Root(), q.Revision, true, func(clean bool) (goio.Closer, error) {
+	closer, err := s.repoLock.Lock(ctx, gitClient.Root(), q.Revision, true, func(clean bool) (goio.Closer, error) {
 		return s.checkoutRevision(gitClient, q.Revision, s.initConstants.SubmoduleEnabled, q.Repo.Depth, clean)
 	})
 	if err != nil {
@@ -3113,7 +3113,7 @@ func (s *Service) ResolveRevision(ctx context.Context, q *apiclient.ResolveRevis
 	}, nil
 }
 
-func (s *Service) GetGitFiles(_ context.Context, request *apiclient.GitFilesRequest) (*apiclient.GitFilesResponse, error) {
+func (s *Service) GetGitFiles(ctx context.Context, request *apiclient.GitFilesRequest) (*apiclient.GitFilesResponse, error) {
 	repo := request.GetRepo()
 	revision := request.GetRevision()
 	gitPath := request.GetPath()
@@ -3144,7 +3144,7 @@ func (s *Service) GetGitFiles(_ context.Context, request *apiclient.GitFilesRequ
 	defer s.metricsServer.DecPendingRepoRequest(repo.Repo)
 
 	// cache miss, generate the results
-	closer, err := s.repoLock.Lock(gitClient.Root(), revision, true, func(clean bool) (goio.Closer, error) {
+	closer, err := s.repoLock.Lock(ctx, gitClient.Root(), revision, true, func(clean bool) (goio.Closer, error) {
 		return s.checkoutRevision(gitClient, revision, request.GetSubmoduleEnabled(), repo.Depth, clean)
 	})
 	if err != nil {
@@ -3191,7 +3191,7 @@ func (s *Service) GetGitFiles(_ context.Context, request *apiclient.GitFilesRequ
 	}, nil
 }
 
-func (s *Service) GetGitDirectories(_ context.Context, request *apiclient.GitDirectoriesRequest) (*apiclient.GitDirectoriesResponse, error) {
+func (s *Service) GetGitDirectories(ctx context.Context, request *apiclient.GitDirectoriesRequest) (*apiclient.GitDirectoriesResponse, error) {
 	repo := request.GetRepo()
 	revision := request.GetRevision()
 	noRevisionCache := request.GetNoRevisionCache()
@@ -3216,7 +3216,7 @@ func (s *Service) GetGitDirectories(_ context.Context, request *apiclient.GitDir
 	defer s.metricsServer.DecPendingRepoRequest(repo.Repo)
 
 	// cache miss, generate the results
-	closer, err := s.repoLock.Lock(gitClient.Root(), revision, true, func(clean bool) (goio.Closer, error) {
+	closer, err := s.repoLock.Lock(ctx, gitClient.Root(), revision, true, func(clean bool) (goio.Closer, error) {
 		return s.checkoutRevision(gitClient, revision, request.GetSubmoduleEnabled(), repo.Depth, clean)
 	})
 	if err != nil {
@@ -3279,7 +3279,7 @@ func (s *Service) GetGitDirectories(_ context.Context, request *apiclient.GitDir
 	}, nil
 }
 
-func (s *Service) gitSourceHasChanges(repo *v1alpha1.Repository, revision, syncedRevision string, refreshPaths []string, gitClientOpts git.ClientOpts) (string, string, bool, error) {
+func (s *Service) gitSourceHasChanges(ctx context.Context, repo *v1alpha1.Repository, revision, syncedRevision string, refreshPaths []string, gitClientOpts git.ClientOpts) (string, string, bool, error) {
 	if repo == nil {
 		return revision, syncedRevision, true, status.Error(codes.InvalidArgument, "must pass a valid repo")
 	}
@@ -3311,7 +3311,7 @@ func (s *Service) gitSourceHasChanges(repo *v1alpha1.Repository, revision, synce
 		s.metricsServer.IncPendingRepoRequest(repo.Repo)
 		defer s.metricsServer.DecPendingRepoRequest(repo.Repo)
 
-		closer, err := s.repoLock.Lock(gitClient.Root(), revision, true, func(clean bool) (goio.Closer, error) {
+		closer, err := s.repoLock.Lock(ctx, gitClient.Root(), revision, true, func(clean bool) (goio.Closer, error) {
 			return s.checkoutRevision(gitClient, revision, false, 0, clean)
 		})
 		if err != nil {
@@ -3362,7 +3362,7 @@ func (s *Service) gitSourceHasChanges(repo *v1alpha1.Repository, revision, synce
 //
 // Example: cache contains manifest "x" under revision "a1a1a1". If the revision moves to "b2b2b2"
 // and no relevant files have changed, "x" will be stored again under the new revision key.
-func (s *Service) UpdateRevisionForPaths(_ context.Context, request *apiclient.UpdateRevisionForPathsRequest) (*apiclient.UpdateRevisionForPathsResponse, error) {
+func (s *Service) UpdateRevisionForPaths(ctx context.Context, request *apiclient.UpdateRevisionForPathsRequest) (*apiclient.UpdateRevisionForPathsResponse, error) {
 	logCtx := log.WithFields(log.Fields{"application": request.AppName, "appNamespace": request.Namespace})
 
 	// Store resolved revisions for cache update
@@ -3393,7 +3393,7 @@ func (s *Service) UpdateRevisionForPaths(_ context.Context, request *apiclient.U
 
 	if repo.Type == "git" {
 		if request.SyncedRevision != request.Revision {
-			resolvedRevision, syncedRevision, sourceHasChanges, err := s.gitSourceHasChanges(request.Repo, request.Revision, request.SyncedRevision, refreshPaths, gitClientOpts)
+			resolvedRevision, syncedRevision, sourceHasChanges, err := s.gitSourceHasChanges(ctx, request.Repo, request.Revision, request.SyncedRevision, refreshPaths, gitClientOpts)
 			if err != nil {
 				return nil, err
 			}
@@ -3448,7 +3448,7 @@ func (s *Service) UpdateRevisionForPaths(_ context.Context, request *apiclient.U
 		var err error
 
 		if sRefSource.TargetRevision != request.RefSources[refName].TargetRevision {
-			resolvedRevision, syncedRevision, sourceHasChanges, err = s.gitSourceHasChanges(&sRefSource.Repo, request.RefSources[refName].TargetRevision, sRefSource.TargetRevision, refreshPaths, gitClientOpts)
+			resolvedRevision, syncedRevision, sourceHasChanges, err = s.gitSourceHasChanges(ctx, &sRefSource.Repo, request.RefSources[refName].TargetRevision, sRefSource.TargetRevision, refreshPaths, gitClientOpts)
 			if err != nil {
 				return nil, err
 			}

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -3394,7 +3394,7 @@ func Test_populateHelmAppDetails(t *testing.T) {
 	}
 	appPath, err := filepath.Abs("./testdata/values-files/")
 	require.NoError(t, err)
-	err = service.populateHelmAppDetails(&res, appPath, appPath, sha, "main", &q, emptyTempPaths)
+	err = service.populateHelmAppDetails(t.Context(), &res, appPath, appPath, sha, "main", &q, emptyTempPaths)
 	require.NoError(t, err)
 	assert.Len(t, res.Helm.Parameters, 3)
 	assert.Len(t, res.Helm.ValueFiles, 5)
@@ -3694,7 +3694,7 @@ func Test_populateHelmAppDetailsWithRef(t *testing.T) {
 			appPath, err = filepath.Abs(repoRoot)
 			require.NoError(t, err)
 			res = apiclient.RepoAppDetailsResponse{}
-			err = service.populateHelmAppDetails(&res, appPath, appPath, sha, "main", &query, service.gitRepoPaths)
+			err = service.populateHelmAppDetails(t.Context(), &res, appPath, appPath, sha, "main", &query, service.gitRepoPaths)
 			tc.testResults(t)
 		})
 	}
@@ -3707,7 +3707,7 @@ func Test_populateHelmAppDetails_values_symlinks(t *testing.T) {
 	t.Run("inbound", func(t *testing.T) {
 		res := apiclient.RepoAppDetailsResponse{}
 		q := apiclient.RepoServerAppDetailsQuery{Repo: &v1alpha1.Repository{}, Source: &v1alpha1.ApplicationSource{}}
-		err := service.populateHelmAppDetails(&res, "./testdata/in-bounds-values-file-link/", "./testdata/in-bounds-values-file-link/", "dummy_sha", "main", &q, emptyTempPaths)
+		err := service.populateHelmAppDetails(t.Context(), &res, "./testdata/in-bounds-values-file-link/", "./testdata/in-bounds-values-file-link/", "dummy_sha", "main", &q, emptyTempPaths)
 		require.NoError(t, err)
 		assert.NotEmpty(t, res.Helm.Values)
 		assert.NotEmpty(t, res.Helm.Parameters)
@@ -3716,7 +3716,7 @@ func Test_populateHelmAppDetails_values_symlinks(t *testing.T) {
 	t.Run("out of bounds", func(t *testing.T) {
 		res := apiclient.RepoAppDetailsResponse{}
 		q := apiclient.RepoServerAppDetailsQuery{Repo: &v1alpha1.Repository{}, Source: &v1alpha1.ApplicationSource{}}
-		err := service.populateHelmAppDetails(&res, "./testdata/out-of-bounds-values-file-link/", "./testdata/out-of-bounds-values-file-link/", sha, "main", &q, emptyTempPaths)
+		err := service.populateHelmAppDetails(t.Context(), &res, "./testdata/out-of-bounds-values-file-link/", "./testdata/out-of-bounds-values-file-link/", sha, "main", &q, emptyTempPaths)
 		require.NoError(t, err)
 		assert.Empty(t, res.Helm.Values)
 		assert.Empty(t, res.Helm.Parameters)


### PR DESCRIPTION
The repositoryLock.Lock() function blocks on sync.Cond.Wait() with no way to interrupt when the caller's context is cancelled. This causes:

- Requests stuck waiting for the lock even after client hangs up
- Wasted work when lock is eventually acquired for already-timed-out requests

This can be observed via argocd_repo_pending_request_total remaining elevated even after instances of the application-controller go away, since stuck goroutines don't exit until they acquire the lock.

Use context.AfterFunc to register a callback that broadcasts when context is cancelled, waking blocked goroutines so they can detect cancellation and return immediately.

Note: I'd appreciate if this could get cherry-picked into the 3.2 release branch, but not a requirement!

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).