### PR TITLE
fix(metrics): more consistent oci metrics

### DIFF
--- a/util/oci/client.go
+++ b/util/oci/client.go
@@ -224,26 +224,24 @@ type nativeOCIClient struct {
 // TestRepo verifies that the remote OCI repo can be connected to.
 func (c *nativeOCIClient) TestRepo(ctx context.Context) (bool, error) {
 	inc := c.OnTestRepo(c.repoURL)
+	defer inc()
 	// Currently doesn't do anything in regard to measuring spans, but keep it consistent with OnTestRepo()
 	fail := c.OnTestRepoFail(c.repoURL)
 	err := c.pingFunc(ctx)
 	if err != nil {
 		fail()
-	} else {
-		inc()
 	}
 	return err == nil, err
 }
 
 func (c *nativeOCIClient) Extract(ctx context.Context, digest string) (string, utilio.Closer, error) {
 	inc := c.OnExtract(c.repoURL)
+	defer inc()
 	// Currently doesn't do anything in regard to measuring spans, but keep it consistent with OnExtract()
 	fail := c.OnExtractFail(c.repoURL)
 	extract, closer, err := c.extract(ctx, digest)
 	if err != nil {
 		fail(digest)
-	} else {
-		inc()
 	}
 	return extract, closer, err
 }
@@ -332,13 +330,12 @@ func (c *nativeOCIClient) CleanCache(revision string) error {
 // DigestMetadata extracts the OCI manifest for a given revision and returns it to the caller.
 func (c *nativeOCIClient) DigestMetadata(ctx context.Context, digest string) (*imagev1.Manifest, error) {
 	inc := c.OnDigestMetadata(c.repoURL)
+	defer inc()
 	// Currently doesn't do anything in regard to measuring spans, but keep it consistent with OnDigestMetadata()
 	fail := c.OnDigestMetadataFail(c.repoURL)
 	metadata, err := c.digestMetadata(ctx, digest)
 	if err != nil {
 		fail(digest)
-	} else {
-		inc()
 	}
 	return metadata, err
 }
@@ -359,13 +356,12 @@ func (c *nativeOCIClient) digestMetadata(ctx context.Context, digest string) (*i
 
 func (c *nativeOCIClient) ResolveRevision(ctx context.Context, revision string, noCache bool) (string, error) {
 	inc := c.OnResolveRevision(c.repoURL)
+	defer inc()
 	// Currently doesn't do anything in regard to measuring spans, but keep it consistent with OnResolveRevision()
 	fail := c.OnResolveRevisionFail(c.repoURL)
 	resolveRevision, err := c.resolveRevision(ctx, revision, noCache)
 	if err != nil {
 		fail(revision)
-	} else {
-		inc()
 	}
 	return resolveRevision, err
 }
@@ -397,13 +393,12 @@ func (c *nativeOCIClient) resolveRevision(ctx context.Context, revision string, 
 
 func (c *nativeOCIClient) GetTags(ctx context.Context, noCache bool) ([]string, error) {
 	inc := c.OnGetTags(c.repoURL)
+	defer inc()
 	// Currently doesn't do anything in regard to measuring spans, but keep it consistent with OnGetTags()
 	fail := c.OnGetTagsFail(c.repoURL)
 	tags, err := c.getTags(ctx, noCache)
 	if err != nil {
 		fail()
-	} else {
-		inc()
 	}
 	return tags, err
 }

--- a/util/oci/client.go
+++ b/util/oci/client.go
@@ -223,18 +223,32 @@ type nativeOCIClient struct {
 
 // TestRepo verifies that the remote OCI repo can be connected to.
 func (c *nativeOCIClient) TestRepo(ctx context.Context) (bool, error) {
-	defer c.OnTestRepo(c.repoURL)()
-
+	inc := c.OnTestRepo(c.repoURL)
+	// Currently doesn't do anything in regard to measuring spans, but keep it consistent with OnTestRepo()
+	fail := c.OnTestRepoFail(c.repoURL)
 	err := c.pingFunc(ctx)
 	if err != nil {
-		defer c.OnTestRepoFail(c.repoURL)()
+		fail()
+	} else {
+		inc()
 	}
 	return err == nil, err
 }
 
 func (c *nativeOCIClient) Extract(ctx context.Context, digest string) (string, utilio.Closer, error) {
-	defer c.OnExtract(c.repoURL)()
+	inc := c.OnExtract(c.repoURL)
+	// Currently doesn't do anything in regard to measuring spans, but keep it consistent with OnExtract()
+	fail := c.OnExtractFail(c.repoURL)
+	extract, closer, err := c.extract(ctx, digest)
+	if err != nil {
+		fail(digest)
+	} else {
+		inc()
+	}
+	return extract, closer, err
+}
 
+func (c *nativeOCIClient) extract(ctx context.Context, digest string) (string, utilio.Closer, error) {
 	cachedPath, err := c.getCachedPath(digest)
 	if err != nil {
 		return "", nil, fmt.Errorf("error getting oci path for digest %s: %w", digest, err)
@@ -251,7 +265,6 @@ func (c *nativeOCIClient) Extract(ctx context.Context, digest string) (string, u
 	if !exists {
 		ociManifest, err := getOCIManifest(ctx, digest, c.repo)
 		if err != nil {
-			defer c.OnExtractFail(c.repoURL)(digest)
 			return "", nil, err
 		}
 
@@ -318,8 +331,19 @@ func (c *nativeOCIClient) CleanCache(revision string) error {
 
 // DigestMetadata extracts the OCI manifest for a given revision and returns it to the caller.
 func (c *nativeOCIClient) DigestMetadata(ctx context.Context, digest string) (*imagev1.Manifest, error) {
-	defer c.OnDigestMetadata(c.repoURL)()
+	inc := c.OnDigestMetadata(c.repoURL)
+	// Currently doesn't do anything in regard to measuring spans, but keep it consistent with OnDigestMetadata()
+	fail := c.OnDigestMetadataFail(c.repoURL)
+	metadata, err := c.digestMetadata(ctx, digest)
+	if err != nil {
+		fail(digest)
+	} else {
+		inc()
+	}
+	return metadata, err
+}
 
+func (c *nativeOCIClient) digestMetadata(ctx context.Context, digest string) (*imagev1.Manifest, error) {
 	path, err := c.getCachedPath(digest)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching oci metadata path for digest %s: %w", digest, err)
@@ -334,8 +358,19 @@ func (c *nativeOCIClient) DigestMetadata(ctx context.Context, digest string) (*i
 }
 
 func (c *nativeOCIClient) ResolveRevision(ctx context.Context, revision string, noCache bool) (string, error) {
-	defer c.OnResolveRevision(c.repoURL)()
+	inc := c.OnResolveRevision(c.repoURL)
+	// Currently doesn't do anything in regard to measuring spans, but keep it consistent with OnResolveRevision()
+	fail := c.OnResolveRevisionFail(c.repoURL)
+	resolveRevision, err := c.resolveRevision(ctx, revision, noCache)
+	if err != nil {
+		fail(revision)
+	} else {
+		inc()
+	}
+	return resolveRevision, err
+}
 
+func (c *nativeOCIClient) resolveRevision(ctx context.Context, revision string, noCache bool) (string, error) {
 	digest, err := c.resolveDigest(ctx, revision) // Lookup explicit revision
 	if err != nil {
 		// If the revision is not a semver constraint, just return the error
@@ -361,7 +396,19 @@ func (c *nativeOCIClient) ResolveRevision(ctx context.Context, revision string, 
 }
 
 func (c *nativeOCIClient) GetTags(ctx context.Context, noCache bool) ([]string, error) {
-	defer c.OnGetTags(c.repoURL)()
+	inc := c.OnGetTags(c.repoURL)
+	// Currently doesn't do anything in regard to measuring spans, but keep it consistent with OnGetTags()
+	fail := c.OnGetTagsFail(c.repoURL)
+	tags, err := c.getTags(ctx, noCache)
+	if err != nil {
+		fail()
+	} else {
+		inc()
+	}
+	return tags, err
+}
+
+func (c *nativeOCIClient) getTags(ctx context.Context, noCache bool) ([]string, error) {
 	indexLock.Lock(c.repoURL)
 	defer indexLock.Unlock(c.repoURL)
 
@@ -377,7 +424,6 @@ func (c *nativeOCIClient) GetTags(ctx context.Context, noCache bool) ([]string, 
 		start := time.Now()
 		result, err := c.tagsFunc(ctx, "")
 		if err != nil {
-			defer c.OnDigestMetadataFail(c.repoURL)
 			return nil, fmt.Errorf("failed to get tags: %w", err)
 		}
 
@@ -407,7 +453,6 @@ func (c *nativeOCIClient) GetTags(ctx context.Context, noCache bool) ([]string, 
 func (c *nativeOCIClient) resolveDigest(ctx context.Context, revision string) (string, error) {
 	descriptor, err := c.repo.Resolve(ctx, revision)
 	if err != nil {
-		defer c.OnResolveRevisionFail(c.repoURL)(revision)
 		return "", fmt.Errorf("cannot get digest for revision %s: %w", revision, err)
 	}
 

--- a/util/oci/client_test.go
+++ b/util/oci/client_test.go
@@ -467,6 +467,9 @@ func fakeEventHandlers(t *testing.T, repoURL string) EventHandlers {
 		OnDigestMetadata:  func(repo string) func() { return func() { require.Equal(t, repoURL, repo) } },
 		OnTestRepo:        func(repo string) func() { return func() { require.Equal(t, repoURL, repo) } },
 		OnGetTags:         func(repo string) func() { return func() { require.Equal(t, repoURL, repo) } },
+		OnGetTagsFail: func(repo string) func() {
+			return func() { require.Equal(t, repoURL, repo) }
+		},
 		OnExtractFail: func(repo string) func(revision string) {
 			return func(_ string) { require.Equal(t, repoURL, repo) }
 		},


### PR DESCRIPTION
A follow-up to #25493. IMO it's easier to reason what is going on if we extract the bulk of the oci logic to separate private methods. I also found some missing metric invocations while doing this.

We also need to ensure that the spans in the happy path case gets measured properly. We first get the function (where the timer initially gets set), and then invoke the closure if we get a nil error.

We do the same in the error case as well, although there are currently no timers measuring how long a failing request takes.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
