### PR TITLE
fix: optimize cli server-side diff with parallel dynamic batching

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -1279,7 +1279,7 @@ type objKeyLiveTarget struct {
 
 // addServerSideDiffPerfFlags adds server-side diff performance tuning flags to a command
 func addServerSideDiffPerfFlags(command *cobra.Command, serverSideDiffConcurrency *int, serverSideDiffMaxBatchKB *int) {
-	command.Flags().IntVar(serverSideDiffConcurrency, "server-side-diff-concurrency", -1, "Max concurrent batches for server-side diff. -1 = unlimited, 0+ = limit concurrent requests")
+	command.Flags().IntVar(serverSideDiffConcurrency, "server-side-diff-concurrency", -1, "Max concurrent batches for server-side diff. -1 = unlimited, 1 = sequential, 2+ = concurrent (0 = invalid, CLI will hang)")
 	command.Flags().IntVar(serverSideDiffMaxBatchKB, "server-side-diff-max-batch-kb", 250, "Max batch size in KB for server-side diff. Smaller values are safer for proxies")
 }
 

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -1279,7 +1279,7 @@ type objKeyLiveTarget struct {
 
 // addServerSideDiffPerfFlags adds server-side diff performance tuning flags to a command
 func addServerSideDiffPerfFlags(command *cobra.Command, serverSideDiffConcurrency *int, serverSideDiffMaxBatchKB *int) {
-	command.Flags().IntVar(serverSideDiffConcurrency, "server-side-diff-concurrency", -1, "Max concurrent batches for server-side diff. -1 = unlimited, 1 = sequential, 2+ = concurrent (0 = invalid, CLI will hang)")
+	command.Flags().IntVar(serverSideDiffConcurrency, "server-side-diff-concurrency", -1, "Max concurrent batches for server-side diff. -1 = unlimited, 1 = sequential, 2+ = concurrent (0 = invalid)")
 	command.Flags().IntVar(serverSideDiffMaxBatchKB, "server-side-diff-max-batch-kb", 250, "Max batch size in KB for server-side diff. Smaller values are safer for proxies")
 }
 
@@ -1466,6 +1466,10 @@ func printResourceDiff(group, kind, namespace, name string, live, target *unstru
 
 // findAndPrintServerSideDiff performs a server-side diff by making requests to the api server and prints the response
 func findAndPrintServerSideDiff(ctx context.Context, app *argoappv1.Application, items []objKeyLiveTarget, resources *application.ManagedResourcesResponse, appIf application.ApplicationServiceClient, appName, appNs string, maxConcurrency int, maxBatchSizeKB int) bool {
+	if maxConcurrency == 0 {
+		errors.CheckError(fmt.Errorf("invalid value for --server-side-diff-concurrency: 0 is not allowed (use -1 for unlimited, or a positive number to limit concurrency)"))
+	}
+
 	liveResources := make([]*argoappv1.ResourceDiff, 0, len(items))
 	targetManifests := make([]string, 0, len(items))
 

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -1467,7 +1467,7 @@ func printResourceDiff(group, kind, namespace, name string, live, target *unstru
 // findAndPrintServerSideDiff performs a server-side diff by making requests to the api server and prints the response
 func findAndPrintServerSideDiff(ctx context.Context, app *argoappv1.Application, items []objKeyLiveTarget, resources *application.ManagedResourcesResponse, appIf application.ApplicationServiceClient, appName, appNs string, maxConcurrency int, maxBatchSizeKB int) bool {
 	if maxConcurrency == 0 {
-		errors.CheckError(fmt.Errorf("invalid value for --server-side-diff-concurrency: 0 is not allowed (use -1 for unlimited, or a positive number to limit concurrency)"))
+		errors.CheckError(stderrors.New("invalid value for --server-side-diff-concurrency: 0 is not allowed (use -1 for unlimited, or a positive number to limit concurrency)"))
 	}
 
 	liveResources := make([]*argoappv1.ResourceDiff, 0, len(items))

--- a/docs/user-guide/commands/argocd_app_diff.md
+++ b/docs/user-guide/commands/argocd_app_diff.md
@@ -31,7 +31,7 @@ argocd app diff APPNAME [flags]
       --revision string                                   Compare live app to a particular revision
       --revisions stringArray                             Show manifests at specific revisions for source position in source-positions
       --server-side-diff                                  Use server-side diff to calculate the diff. This will default to true if the ServerSideDiff annotation is set on the application.
-      --server-side-diff-concurrency int                  Max concurrent batches for server-side diff. 0 = unlimited, >0 = limit concurrent requests
+      --server-side-diff-concurrency int                  Max concurrent batches for server-side diff. -1 = unlimited, 0+ = limit concurrent requests (default -1)
       --server-side-diff-max-batch-kb int                 Max batch size in KB for server-side diff. Smaller values are safer for proxies (default 250)
       --server-side-generate                              Used with --local, this will send your manifests to the server for diffing
       --source-names stringArray                          List of source names. Default is an empty array.

--- a/docs/user-guide/commands/argocd_app_diff.md
+++ b/docs/user-guide/commands/argocd_app_diff.md
@@ -31,7 +31,7 @@ argocd app diff APPNAME [flags]
       --revision string                                   Compare live app to a particular revision
       --revisions stringArray                             Show manifests at specific revisions for source position in source-positions
       --server-side-diff                                  Use server-side diff to calculate the diff. This will default to true if the ServerSideDiff annotation is set on the application.
-      --server-side-diff-concurrency int                  Max concurrent batches for server-side diff. -1 = unlimited, 0+ = limit concurrent requests (default -1)
+      --server-side-diff-concurrency int                  Max concurrent batches for server-side diff. -1 = unlimited, 1 = sequential, 2+ = concurrent (0 = invalid, CLI will hang) (default -1)
       --server-side-diff-max-batch-kb int                 Max batch size in KB for server-side diff. Smaller values are safer for proxies (default 250)
       --server-side-generate                              Used with --local, this will send your manifests to the server for diffing
       --source-names stringArray                          List of source names. Default is an empty array.

--- a/docs/user-guide/commands/argocd_app_diff.md
+++ b/docs/user-guide/commands/argocd_app_diff.md
@@ -31,7 +31,7 @@ argocd app diff APPNAME [flags]
       --revision string                                   Compare live app to a particular revision
       --revisions stringArray                             Show manifests at specific revisions for source position in source-positions
       --server-side-diff                                  Use server-side diff to calculate the diff. This will default to true if the ServerSideDiff annotation is set on the application.
-      --server-side-diff-concurrency int                  Max concurrent batches for server-side diff. -1 = unlimited, 1 = sequential, 2+ = concurrent (0 = invalid, CLI will hang) (default -1)
+      --server-side-diff-concurrency int                  Max concurrent batches for server-side diff. -1 = unlimited, 1 = sequential, 2+ = concurrent (0 = invalid) (default -1)
       --server-side-diff-max-batch-kb int                 Max batch size in KB for server-side diff. Smaller values are safer for proxies (default 250)
       --server-side-generate                              Used with --local, this will send your manifests to the server for diffing
       --source-names stringArray                          List of source names. Default is an empty array.

--- a/docs/user-guide/commands/argocd_app_diff.md
+++ b/docs/user-guide/commands/argocd_app_diff.md
@@ -31,6 +31,8 @@ argocd app diff APPNAME [flags]
       --revision string                                   Compare live app to a particular revision
       --revisions stringArray                             Show manifests at specific revisions for source position in source-positions
       --server-side-diff                                  Use server-side diff to calculate the diff. This will default to true if the ServerSideDiff annotation is set on the application.
+      --server-side-diff-concurrency int                  Max concurrent batches for server-side diff. 0 = unlimited, >0 = limit concurrent requests
+      --server-side-diff-max-batch-kb int                 Max batch size in KB for server-side diff. Smaller values are safer for proxies (default 250)
       --server-side-generate                              Used with --local, this will send your manifests to the server for diffing
       --source-names stringArray                          List of source names. Default is an empty array.
       --source-positions int64Slice                       List of source positions. Default is empty array. Counting start at 1. (default [])

--- a/docs/user-guide/commands/argocd_app_sync.md
+++ b/docs/user-guide/commands/argocd_app_sync.md
@@ -69,7 +69,7 @@ argocd app sync [APPNAME... | -l selector | --project project-name] [flags]
       --revisions stringArray                             Show manifests at specific revisions for source position in source-positions
   -l, --selector string                                   Sync apps that match this label. Supports '=', '==', '!=', in, notin, exists & not exists. Matching apps must satisfy all of the specified label constraints.
       --server-side                                       Use server-side apply while syncing the application
-      --server-side-diff-concurrency int                  Max concurrent batches for server-side diff. -1 = unlimited, 0+ = limit concurrent requests (default -1)
+      --server-side-diff-concurrency int                  Max concurrent batches for server-side diff. -1 = unlimited, 1 = sequential, 2+ = concurrent (0 = invalid, CLI will hang) (default -1)
       --server-side-diff-max-batch-kb int                 Max batch size in KB for server-side diff. Smaller values are safer for proxies (default 250)
       --source-names stringArray                          List of source names. Default is an empty array.
       --source-positions int64Slice                       List of source positions. Default is empty array. Counting start at 1. (default [])

--- a/docs/user-guide/commands/argocd_app_sync.md
+++ b/docs/user-guide/commands/argocd_app_sync.md
@@ -69,7 +69,7 @@ argocd app sync [APPNAME... | -l selector | --project project-name] [flags]
       --revisions stringArray                             Show manifests at specific revisions for source position in source-positions
   -l, --selector string                                   Sync apps that match this label. Supports '=', '==', '!=', in, notin, exists & not exists. Matching apps must satisfy all of the specified label constraints.
       --server-side                                       Use server-side apply while syncing the application
-      --server-side-diff-concurrency int                  Max concurrent batches for server-side diff. -1 = unlimited, 1 = sequential, 2+ = concurrent (0 = invalid, CLI will hang) (default -1)
+      --server-side-diff-concurrency int                  Max concurrent batches for server-side diff. -1 = unlimited, 1 = sequential, 2+ = concurrent (0 = invalid) (default -1)
       --server-side-diff-max-batch-kb int                 Max batch size in KB for server-side diff. Smaller values are safer for proxies (default 250)
       --source-names stringArray                          List of source names. Default is an empty array.
       --source-positions int64Slice                       List of source positions. Default is empty array. Counting start at 1. (default [])

--- a/docs/user-guide/commands/argocd_app_sync.md
+++ b/docs/user-guide/commands/argocd_app_sync.md
@@ -69,6 +69,8 @@ argocd app sync [APPNAME... | -l selector | --project project-name] [flags]
       --revisions stringArray                             Show manifests at specific revisions for source position in source-positions
   -l, --selector string                                   Sync apps that match this label. Supports '=', '==', '!=', in, notin, exists & not exists. Matching apps must satisfy all of the specified label constraints.
       --server-side                                       Use server-side apply while syncing the application
+      --server-side-diff-concurrency int                  Max concurrent batches for server-side diff. -1 = unlimited, 0+ = limit concurrent requests (default -1)
+      --server-side-diff-max-batch-kb int                 Max batch size in KB for server-side diff. Smaller values are safer for proxies (default 250)
       --source-names stringArray                          List of source names. Default is an empty array.
       --source-positions int64Slice                       List of source positions. Default is empty array. Counting start at 1. (default [])
       --strategy string                                   Sync strategy (one of: apply|hook)


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

# Problem

The current server-side diff implementation introduced by https://github.com/argoproj/argo-cd/pull/23978 makes **one API call per resource**, causing severe performance degradation for applications with many resources. For example, an application with 50 resources can take minutes to diff, making the feature impractical.

Fixes https://github.com/argoproj/argo-cd/issues/25573

# Proposed solution

This PR refactors the CLI to leverage the server's existing batch processing capability:
1. **It collects all resources upfront** and groups them into size-based batches (250KB each) to stay within HTTP proxy limits avoiding 413 status code (Content Too Large).
2. **processes batches in parallel** using goroutines to minimize total time, and **writes results directly to a pre-allocated slice**
 
The implementation is **configurable via two new flags**:

- `--server-side-diff-max-batch-kb` (default 250) to tune batch size for different proxy limits
- `--server-side-diff-concurrency` (default 0=unlimited) to control parallel request limits.

# Visual Representation of the change 

**Before (N API calls):**
```
Resource 1 ──► API Call ──► Process ──► Print
Resource 2 ──► API Call ──► Process ──► Print
Resource 3 ──► API Call ──► Process ──► Print
   ...
Resource N ──► API Call ──► Process ──► Print
```

**After (Batched + Parallel):**
```
Resources 1-10  ─┐
Resources 11-20 ─┼──► API Calls (parallel) ──► Process ──► Print (ordered)
Resources 21-30 ─┘
```

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
