### PR TITLE
fix: revert "chore(docs): update all installs to use --server-side"

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -66,14 +66,14 @@ release:
 
     ```shell
     kubectl create namespace argocd
-    kubectl apply -n argocd --server-side -f https://raw.githubusercontent.com/argoproj/argo-cd/{{.Tag}}/manifests/install.yaml
+    kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/{{.Tag}}/manifests/install.yaml
     ```
 
     ### HA:
 
     ```shell
     kubectl create namespace argocd
-    kubectl apply -n argocd --server-side -f https://raw.githubusercontent.com/argoproj/argo-cd/{{.Tag}}/manifests/ha/install.yaml
+    kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/{{.Tag}}/manifests/ha/install.yaml
     ```
 
     ## Release Signatures and Provenance

--- a/docs/developer-guide/development-environment.md
+++ b/docs/developer-guide/development-environment.md
@@ -109,7 +109,7 @@ make install-codegen-tools-local
 
 ```shell
 kubectl create namespace argocd &&
-kubectl apply -n argocd --server-side -f https://raw.githubusercontent.com/argoproj/argo-cd/master/manifests/install.yaml
+kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/master/manifests/install.yaml
 ```
 
 Set kubectl config to avoid specifying the namespace in every kubectl command.  

--- a/docs/developer-guide/running-locally.md
+++ b/docs/developer-guide/running-locally.md
@@ -21,7 +21,7 @@ First push the installation manifest into argocd namespace:
 
 ```shell
 kubectl create namespace argocd
-kubectl apply -n argocd --server-side -f manifests/install.yaml
+kubectl apply -n argocd --force -f manifests/install.yaml
 ```
 
 The services you will start later assume you are running in the namespace where Argo CD is installed. You can set the current context default namespace as follows:
@@ -245,5 +245,5 @@ make manifests-local
 The final step is to push the manifests to your cluster, so it will pull and run your image:
 
 ```bash
-kubectl apply -n argocd --server-side -f manifests/install.yaml
+kubectl apply -n argocd --force -f manifests/install.yaml
 ```

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -13,7 +13,7 @@
 
 ```bash
 kubectl create namespace argocd
-kubectl apply -n argocd --server-side -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
 ```
 
 This will create a new `argocd` namespace where all Argo CD services and application resources will reside. It will also install Argo CD by applying the official manifests from the stable branch. Using a pinned version (like `v3.2.0`) is recommended for production.

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ Application deployment and lifecycle management should be automated, auditable, 
 
 ```bash
 kubectl create namespace argocd
-kubectl apply -n argocd --server-side -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
 ```
 
 Follow our [getting started guide](getting_started.md). Further user oriented [documentation](user-guide/)

--- a/docs/operator-manual/applicationset/Controlling-Resource-Modification.md
+++ b/docs/operator-manual/applicationset/Controlling-Resource-Modification.md
@@ -283,7 +283,7 @@ cd applicationset/manifests
 # as described in the previous section.
 
 # Apply the change to the cluster
-kubectl apply -n argocd --server-side -f install.yaml
+kubectl apply -n argocd -f install.yaml
 ```
 
 ## Preserving changes made to an Applications annotations and labels

--- a/docs/operator-manual/applicationset/Getting-Started.md
+++ b/docs/operator-manual/applicationset/Getting-Started.md
@@ -29,7 +29,7 @@ The ApplicationSet controller *must* be installed into the same namespace as the
 Presuming that Argo CD is installed into the `argocd` namespace, run the following command:
 
 ```bash
-kubectl apply -n argocd --server-side -f https://raw.githubusercontent.com/argoproj/applicationset/v0.4.0/manifests/install.yaml
+kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/applicationset/v0.4.0/manifests/install.yaml
 ```
 
 Once installed, the ApplicationSet controller requires no additional setup.
@@ -47,7 +47,7 @@ The `manifests/install.yaml` file contains the Kubernetes manifests required to 
 
 Development builds of the ApplicationSet controller can be installed by running the following command:
 ```bash
-kubectl apply -n argocd --server-side -f https://raw.githubusercontent.com/argoproj/applicationset/master/manifests/install.yaml
+kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/applicationset/master/manifests/install.yaml
 ```
 
 With this option you will need to ensure that Argo CD is already installed into the `argocd` namespace.

--- a/docs/operator-manual/core.md
+++ b/docs/operator-manual/core.md
@@ -58,7 +58,7 @@ Example:
 ```
 export ARGOCD_VERSION=<desired argo cd release version (e.g. v2.7.0)>
 kubectl create namespace argocd
-kubectl apply -n argocd --server-side -f https://raw.githubusercontent.com/argoproj/argo-cd/$ARGOCD_VERSION/manifests/core-install.yaml
+kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/$ARGOCD_VERSION/manifests/core-install.yaml
 ```
 
 ## Using

--- a/docs/operator-manual/managed-by-url.md
+++ b/docs/operator-manual/managed-by-url.md
@@ -121,11 +121,11 @@ To test the annotation with two local Argo CD instances:
 ```bash
 # Install primary instance
 kubectl create namespace argocd
-kubectl apply -n argocd --server-side -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
 
 # Install secondary instance
 kubectl create namespace namespace-b
-kubectl apply -n namespace-b --server-side -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+kubectl apply -n namespace-b -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
 
 # Port forward both instances
 kubectl port-forward -n argocd svc/argocd-server 8080:443 &

--- a/docs/operator-manual/notifications/index.md
+++ b/docs/operator-manual/notifications/index.md
@@ -11,7 +11,7 @@ So you can just use them instead of reinventing new ones.
 * Install Triggers and Templates from the catalog
 
     ```bash
-    kubectl apply -n argocd --server-side -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/notifications_catalog/install.yaml
+    kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/notifications_catalog/install.yaml
     ```
 
 * Add email username and password token to the `argocd-notifications-secret` secret

--- a/docs/operator-manual/upgrading/overview.md
+++ b/docs/operator-manual/upgrading/overview.md
@@ -20,13 +20,13 @@ command to upgrade Argo CD. Make sure to replace `<version>` with the required v
 **Non-HA**:
 
 ```bash
-kubectl apply -n argocd --server-side -f https://raw.githubusercontent.com/argoproj/argo-cd/<version>/manifests/install.yaml
+kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/<version>/manifests/install.yaml
 ```
 
 **HA**:
 
 ```bash
-kubectl apply -n argocd --server-side -f https://raw.githubusercontent.com/argoproj/argo-cd/<version>/manifests/ha/install.yaml
+kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/<version>/manifests/ha/install.yaml
 ```
 
 > [!WARNING]

--- a/docs/proposals/decouple-application-sync-user-using-impersonation.md
+++ b/docs/proposals/decouple-application-sync-user-using-impersonation.md
@@ -194,7 +194,7 @@ In this specific scenario, service account name `generic-deployer` will get used
 
 - Install ArgoCD in the `argocd` namespace.
 ```shell
-kubectl apply --server-side -f https://raw.githubusercontent.com/argoproj/argo-cd/master/manifests/install.yaml -n argocd
+kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-cd/master/manifests/install.yaml -n argocd
 ```
 
 - Enable the impersonation feature in ArgoCD.
@@ -258,7 +258,7 @@ In this specific scenario, service account name `guestbook-deployer` will get us
 
 - Install ArgoCD in the `argocd` namespace.
 ```shell
-kubectl apply --server-side -f https://raw.githubusercontent.com/argoproj/argo-cd/master/manifests/install.yaml -n argocd
+kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-cd/master/manifests/install.yaml -n argocd
 ```
 
 - Enable the impersonation feature in ArgoCD.
@@ -326,7 +326,7 @@ spec:
 
 - Install ArgoCD in the `argocd` namespace.
 ```shell
-kubectl apply --server-side -f https://raw.githubusercontent.com/argoproj/argo-cd/master/manifests/install.yaml -n argocd
+kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-cd/master/manifests/install.yaml -n argocd
 ```
 
 - Enable the impersonation feature in ArgoCD.
@@ -399,7 +399,7 @@ spec:
 
 - Install ArgoCD in the `argocd` namespace.
 ```shell
-kubectl apply --server-side -f https://raw.githubusercontent.com/argoproj/argo-cd/master/manifests/install.yaml -n argocd
+kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-cd/master/manifests/install.yaml -n argocd
 ```
 
 - Enable the impersonation feature in ArgoCD.

--- a/docs/try_argo_cd_locally.md
+++ b/docs/try_argo_cd_locally.md
@@ -30,7 +30,7 @@ This command verifies that `kubectl` is pointed to the right cluster.
 You can now install Argo CD on your `kind` cluster. First, apply the Argo CD manifest to create the necessary resources:
 ```bash
 kubectl create namespace argocd
-kubectl apply -n argocd --server-side -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
 ```
 
 ## Expose ArgoCD API Server


### PR DESCRIPTION
Reverts argoproj/argo-cd#25538

On a local install, I got:

Apply failed with 1 conflict: conflict with "kubectl-client-side-apply" using apps/v1: .spec.template.spec.containers[name="argocd-applicationset-controller"].env[name="NAMESPACE"].valueFrom.fieldRef
Please review the fields above--they currently have other managers. Here
are the ways you can resolve this warning:
* If you intend to manage all of these fields, please re-run the apply
  command with the `--force-conflicts` flag.
* If you do not intend to manage all of the fields, please edit your
  manifest to remove references to the fields that should keep their
  current managers.
* You may co-own fields by updating your manifest to match the existing
  value; in this case, you'll become the manager if the other manager(s)
  stop managing the field (remove it from their configuration).
See https://kubernetes.io/docs/reference/using-api/server-side-apply/#conflicts
Apply failed with 1 conflict: conflict with "kubectl-client-side-apply" using networking.k8s.io/v1: .spec.ingress
Please review the fields above--they currently have other managers. Here
are the ways you can resolve this warning:
* If you intend to manage all of these fields, please re-run the apply
  command with the `--force-conflicts` flag.
* If you do not intend to manage all of the fields, please edit your
  manifest to remove references to the fields that should keep their
  current managers.
* You may co-own fields by updating your manifest to match the existing
  value; in this case, you'll become the manager if the other manager(s)
  stop managing the field (remove it from their configuration).
See https://kubernetes.io/docs/reference/using-api/server-side-apply/#conflicts
Apply failed with 1 conflict: conflict with "kubectl-client-side-apply" using networking.k8s.io/v1: .spec.ingress
Please review the fields above--they currently have other managers. Here
are the ways you can resolve this warning:
* If you intend to manage all of these fields, please re-run the apply
  command with the `--force-conflicts` flag.
* If you do not intend to manage all of the fields, please edit your
  manifest to remove references to the fields that should keep their
  current managers.
* You may co-own fields by updating your manifest to match the existing
  value; in this case, you'll become the manager if the other manager(s)
  stop managing the field (remove it from their configuration).
See https://kubernetes.io/docs/reference/using-api/server-side-apply/#conflicts

Not sure whether we just need to document better or do something else.