### PR TITLE
feat(appset): use clone instead of replace on sprig templates to reduce function copies

### DIFF
--- a/applicationset/generators/generator_spec_processor_test.go
+++ b/applicationset/generators/generator_spec_processor_test.go
@@ -551,7 +551,7 @@ func TestInterpolateGeneratorError(t *testing.T) {
 			},
 			useGoTemplate:     true,
 			goTemplateOptions: []string{},
-		}, want: argov1alpha1.ApplicationSetGenerator{}, expectedErrStr: "failed to replace parameters in generator: failed to execute go template {{ index .rmap (default .override .test) }}: template: :1:3: executing \"\" at <index .rmap (default .override .test)>: error calling index: index of untyped nil"},
+		}, want: argov1alpha1.ApplicationSetGenerator{}, expectedErrStr: "failed to replace parameters in generator: failed to execute go template {{ index .rmap (default .override .test) }}: template: base:1:3: executing \"base\" at <index .rmap (default .override .test)>: error calling index: index of untyped nil"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/applicationset/utils/utils.go
+++ b/applicationset/utils/utils.go
@@ -30,6 +30,10 @@ import (
 
 var sprigFuncMap = sprig.GenericFuncMap() // a singleton for better performance
 
+// baseTemplate is a pre-initialized template with all sprig functions loaded.
+// Cloning this is much faster than calling Funcs() on a new template each time.
+var baseTemplate *template.Template
+
 func init() {
 	// Avoid allowing the user to learn things about the environment.
 	delete(sprigFuncMap, "env")
@@ -40,6 +44,10 @@ func init() {
 	sprigFuncMap["toYaml"] = toYAML
 	sprigFuncMap["fromYaml"] = fromYAML
 	sprigFuncMap["fromYamlArray"] = fromYAMLArray
+
+	// Initialize the base template with sprig functions once at startup.
+	// This must be done after modifying sprigFuncMap above.
+	baseTemplate = template.New("base").Funcs(sprigFuncMap)
 }
 
 type Renderer interface {
@@ -309,16 +317,21 @@ var isTemplatedRegex = regexp.MustCompile(".*{{.*}}.*")
 // remaining in the substituted template.
 func (r *Render) Replace(tmpl string, replaceMap map[string]any, useGoTemplate bool, goTemplateOptions []string) (string, error) {
 	if useGoTemplate {
-		template, err := template.New("").Funcs(sprigFuncMap).Parse(tmpl)
+		// Clone the base template which has sprig funcs pre-loaded
+		cloned, err := baseTemplate.Clone()
+		if err != nil {
+			return "", fmt.Errorf("failed to clone base template: %w", err)
+		}
+		for _, option := range goTemplateOptions {
+			cloned = cloned.Option(option)
+		}
+		parsed, err := cloned.Parse(tmpl)
 		if err != nil {
 			return "", fmt.Errorf("failed to parse template %s: %w", tmpl, err)
 		}
-		for _, option := range goTemplateOptions {
-			template = template.Option(option)
-		}
 
 		var replacedTmplBuffer bytes.Buffer
-		if err = template.Execute(&replacedTmplBuffer, replaceMap); err != nil {
+		if err = parsed.Execute(&replacedTmplBuffer, replaceMap); err != nil {
 			return "", fmt.Errorf("failed to execute go template %s: %w", tmpl, err)
 		}
 

--- a/applicationset/utils/utils_test.go
+++ b/applicationset/utils/utils_test.go
@@ -514,7 +514,7 @@ func TestRenderTemplateParamsGoTemplate(t *testing.T) {
 			params: map[string]any{
 				"data": `a data string`,
 			},
-			errorMessage: `failed to parse template {{functiondoesnotexist}}: template: :1: function "functiondoesnotexist" not defined`,
+			errorMessage: `failed to parse template {{functiondoesnotexist}}: template: base:1: function "functiondoesnotexist" not defined`,
 		},
 		{
 			name:        "Test template error",
@@ -523,7 +523,7 @@ func TestRenderTemplateParamsGoTemplate(t *testing.T) {
 			params: map[string]any{
 				"data": `a data string`,
 			},
-			errorMessage: `failed to execute go template {{.data.test}}: template: :1:7: executing "" at <.data.test>: can't evaluate field test in type interface {}`,
+			errorMessage: `failed to execute go template {{.data.test}}: template: base:1:7: executing "base" at <.data.test>: can't evaluate field test in type interface {}`,
 		},
 		{
 			name:        "lookup missing value with missingkey=default",
@@ -543,7 +543,7 @@ func TestRenderTemplateParamsGoTemplate(t *testing.T) {
 				"unused": "this is not used",
 			},
 			templateOptions: []string{"missingkey=error"},
-			errorMessage:    `failed to execute go template --> {{.doesnotexist}} <--: template: :1:6: executing "" at <.doesnotexist>: map has no entry for key "doesnotexist"`,
+			errorMessage:    `failed to execute go template --> {{.doesnotexist}} <--: template: base:1:6: executing "base" at <.doesnotexist>: map has no entry for key "doesnotexist"`,
 		},
 		{
 			name:        "toYaml",
@@ -563,7 +563,7 @@ func TestRenderTemplateParamsGoTemplate(t *testing.T) {
 			name:         "toYaml Error",
 			fieldVal:     `{{ toYaml . | indent 2 }}`,
 			expectedVal:  "  foo:\n    bar:\n      bool: true\n      number: 2\n      str: Hello world",
-			errorMessage: "failed to execute go template {{ toYaml . | indent 2 }}: template: :1:3: executing \"\" at <toYaml .>: error calling toYaml: error marshaling into JSON: json: unsupported type: func(*string)",
+			errorMessage: "failed to execute go template {{ toYaml . | indent 2 }}: template: base:1:3: executing \"base\" at <toYaml .>: error calling toYaml: error marshaling into JSON: json: unsupported type: func(*string)",
 			params: map[string]any{
 				"foo": func(_ *string) {
 				},
@@ -581,7 +581,7 @@ func TestRenderTemplateParamsGoTemplate(t *testing.T) {
 			name:         "fromYaml error",
 			fieldVal:     `{{ get (fromYaml .value) "hello" }}`,
 			expectedVal:  "world",
-			errorMessage: "failed to execute go template {{ get (fromYaml .value) \"hello\" }}: template: :1:8: executing \"\" at <fromYaml .value>: error calling fromYaml: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type map[string]interface {}",
+			errorMessage: "failed to execute go template {{ get (fromYaml .value) \"hello\" }}: template: base:1:8: executing \"base\" at <fromYaml .value>: error calling fromYaml: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type map[string]interface {}",
 			params: map[string]any{
 				"value": "non\n compliant\n yaml",
 			},
@@ -598,7 +598,7 @@ func TestRenderTemplateParamsGoTemplate(t *testing.T) {
 			name:         "fromYamlArray error",
 			fieldVal:     `{{ fromYamlArray .value | last }}`,
 			expectedVal:  "bonjour tout le monde",
-			errorMessage: "failed to execute go template {{ fromYamlArray .value | last }}: template: :1:3: executing \"\" at <fromYamlArray .value>: error calling fromYamlArray: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type []interface {}",
+			errorMessage: "failed to execute go template {{ fromYamlArray .value | last }}: template: base:1:3: executing \"base\" at <fromYamlArray .value>: error calling fromYamlArray: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type []interface {}",
 			params: map[string]any{
 				"value": "non\n compliant\n yaml",
 			},


### PR DESCRIPTION
I was pprofing the applicationset controller and noticed a lot of time spent in template funcs. We can clone the template instead of creating a copy. Addressing `ListClusters` in #25577.

| **Metric**                              | **Time**   | **% of Total** |
|-----------------------------------------|------------|-----------------|
| Total samples                           | 447.17s    | 100%           |
| text/template.(*Template).Funcs         | 21.04s     | 4.71%          |
| text/template.addValueFuncs             | 12.31s     | 2.75%          |
| Render.Replace                          | 24.93s     | 5.58%          |
| Render.deeplyReplace                    | 25.71s     | 5.75%          |
| ListClusters                            | 90.46s     | 20.23%         |

When using go templating, every call was doing `template.New("").Funcs(sprigFuncMap)` which copies the entire function map. `Clone()` shares the function map reference rather than copying. From the [docs](https://pkg.go.dev/text/template#Template.Clone), _Clone can be used to prepare common templates and use them with variant definitions for other templates by adding the variants after the clone is made._

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
