### PR TITLE
feat(ui): add annotation filtering support to applications list

### DIFF
--- a/ui/src/app/applications/components/applications-list/applications-filter.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-filter.tsx
@@ -173,7 +173,15 @@ const LabelsFilter = (props: AppFilterProps) => {
         return {label: s};
     });
 
-    return <Filter label='LABELS' selected={props.pref.labelsFilter} setSelected={s => props.onChange({...props.pref, labelsFilter: s})} field={true} options={labelOptions} />;
+    return (
+        <Filter
+            label='LABELS'
+            selected={props.pref.labelsFilter}
+            setSelected={s => props.onChange({...props.pref, labelsFilter: s})}
+            field={true}
+            options={labelOptions}
+        />
+    );
 };
 
 const AnnotationsFilter = (props: AppFilterProps) => {
@@ -199,7 +207,15 @@ const AnnotationsFilter = (props: AppFilterProps) => {
         return {label: s};
     });
 
-    return <Filter label='ANNOTATIONS' selected={props.pref.annotationsFilter} setSelected={s => props.onChange({...props.pref, annotationsFilter: s})} field={true} options={annotationOptions} />;
+    return (
+        <Filter
+            label='ANNOTATIONS'
+            selected={props.pref.annotationsFilter}
+            setSelected={s => props.onChange({...props.pref, annotationsFilter: s})}
+            field={true}
+            options={annotationOptions}
+        />
+    );
 };
 
 const ProjectFilter = (props: AppFilterProps) => {

--- a/ui/src/app/applications/components/applications-list/applications-filter.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-filter.tsx
@@ -46,8 +46,8 @@ export function getAutoSyncStatus(syncPolicy?: SyncPolicy) {
 }
 
 export function getFilterResults(applications: Application[], pref: AppsListPreferences): FilteredApp[] {
-    const labelSelector = createMetadataSelector(pref.labelsFilter || [], 'label');
-    const annotationSelector = createMetadataSelector(pref.annotationsFilter || [], 'annotation');
+    const labelSelector = createMetadataSelector(pref.labelsFilter || []);
+    const annotationSelector = createMetadataSelector(pref.annotationsFilter || []);
 
     return applications.map(app => ({
         ...app,
@@ -173,15 +173,7 @@ const LabelsFilter = (props: AppFilterProps) => {
         return {label: s};
     });
 
-    return (
-        <Filter
-            label='LABELS'
-            selected={props.pref.labelsFilter}
-            setSelected={s => props.onChange({...props.pref, labelsFilter: s})}
-            field={true}
-            options={labelOptions}
-        />
-    );
+    return <Filter label='LABELS' selected={props.pref.labelsFilter} setSelected={s => props.onChange({...props.pref, labelsFilter: s})} field={true} options={labelOptions} />;
 };
 
 const AnnotationsFilter = (props: AppFilterProps) => {

--- a/ui/src/app/applications/components/applications-list/applications-filter.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-filter.tsx
@@ -177,27 +177,30 @@ const LabelsFilter = (props: AppFilterProps) => {
 };
 
 const AnnotationsFilter = (props: AppFilterProps) => {
-    const annotations = new Map<string, Set<string>>();
-    props.apps
-        .filter(app => app.metadata && app.metadata.annotations)
-        .forEach(app =>
-            Object.keys(app.metadata.annotations).forEach(annotation => {
-                let values = annotations.get(annotation);
-                if (!values) {
-                    values = new Set<string>();
-                    annotations.set(annotation, values);
-                }
-                values.add(app.metadata.annotations[annotation]);
-            })
-        );
-    const suggestions = new Array<string>();
-    Array.from(annotations.entries()).forEach(([annotation, values]) => {
-        suggestions.push(annotation);
-        values.forEach(val => suggestions.push(`${annotation}=${val}`));
-    });
-    const annotationOptions = suggestions.map(s => {
-        return {label: s};
-    });
+    const annotationOptions = React.useMemo(() => {
+        const annotations = new Map<string, Set<string>>();
+
+        props.apps
+            .filter(app => app.metadata && app.metadata.annotations)
+            .forEach(app =>
+                Object.keys(app.metadata.annotations).forEach(annotation => {
+                    let values = annotations.get(annotation);
+                    if (!values) {
+                        values = new Set<string>();
+                        annotations.set(annotation, values);
+                    }
+                    values.add(app.metadata.annotations[annotation]);
+                })
+            );
+
+        const suggestions = new Array<string>();
+        Array.from(annotations.entries()).forEach(([annotation, values]) => {
+            suggestions.push(annotation);
+            values.forEach(val => suggestions.push(`${annotation}=${val}`));
+        });
+
+        return suggestions.map(s => ({label: s}));
+    }, [props.apps]);
 
     return (
         <Filter

--- a/ui/src/app/applications/components/applications-list/applications-list.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-list.tsx
@@ -159,6 +159,13 @@ const ViewPref = ({children}: {children: (pref: AppsListPreferences & {page: num
                                 .map(decodeURIComponent)
                                 .filter(item => !!item);
                         }
+                        if (params.get('annotations') != null) {
+                            viewPref.annotationsFilter = params
+                                .get('annotations')
+                                .split(',')
+                                .map(decodeURIComponent)
+                                .filter(item => !!item);
+                        }
                         return {...viewPref, page: parseInt(params.get('page') || '0', 10), search: params.get('search') || ''};
                     })
                 )
@@ -430,6 +437,7 @@ export const ApplicationsList = (props: RouteComponentProps<any> & {objectListKi
                 namespace: newPref.namespacesFilter.join(','),
                 cluster: newPref.clustersFilter.join(','),
                 labels: newPref.labelsFilter.map(encodeURIComponent).join(','),
+                annotations: newPref.annotationsFilter.map(encodeURIComponent).join(','),
                 operation: newPref.operationFilter.join(',')
             },
             {replace: true}

--- a/ui/src/app/applications/components/applications-list/applications-tiles.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-tiles.tsx
@@ -208,6 +208,32 @@ export const ApplicationTiles = ({applications, syncApplication, refreshApplicat
                                                         </div>
                                                     </div>
                                                     <div className='row'>
+                                                        <div className='columns small-3' title='Annotations:'>
+                                                            Annotations:
+                                                        </div>
+                                                        <div className='columns small-9'>
+                                                            <Tooltip
+                                                                zIndex={4}
+                                                                content={
+                                                                    <div>
+                                                                        {Object.keys(app.metadata.annotations || {})
+                                                                            .map(annotation => ({label: annotation, value: app.metadata.annotations[annotation]}))
+                                                                            .map(item => (
+                                                                                <div key={item.label}>
+                                                                                    {item.label}={item.value}
+                                                                                </div>
+                                                                            ))}
+                                                                    </div>
+                                                                }>
+                                                                <span>
+                                                                    {Object.keys(app.metadata.annotations || {})
+                                                                        .map(annotation => `${annotation}=${app.metadata.annotations[annotation]}`)
+                                                                        .join(', ')}
+                                                                </span>
+                                                            </Tooltip>
+                                                        </div>
+                                                    </div>
+                                                    <div className='row'>
                                                         <div className='columns small-3' title='Status:'>
                                                             Status:
                                                         </div>

--- a/ui/src/app/applications/components/selectors.test.ts
+++ b/ui/src/app/applications/components/selectors.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Test cases for annotation and label selectors
+ */
+import {createMetadataSelector} from './selectors';
+
+describe('Selectors', () => {
+    describe('createMetadataSelector', () => {
+        it('should match annotations with key=value format', () => {
+            const annotations = {team: 'core'};
+            const selector = createMetadataSelector(['team=core'], 'annotation');
+            expect(selector(annotations)).toBe(true);
+        });
+
+        it('should match annotations with key only format', () => {
+            const annotations = {team: 'core'};
+            const selector = createMetadataSelector(['team'], 'annotation');
+            expect(selector(annotations)).toBe(true);
+        });
+
+        it('should not match annotations with wrong value', () => {
+            const annotations = {team: 'core'};
+            const selector = createMetadataSelector(['team=ops'], 'annotation');
+            expect(selector(annotations)).toBe(false);
+        });
+
+        it('should not match when annotation key does not exist', () => {
+            const annotations = {};
+            const selector = createMetadataSelector(['team'], 'annotation');
+            expect(selector(annotations)).toBe(false);
+        });
+
+        it('should match version annotation correctly', () => {
+            const annotations = {version: 'v2'};
+            const selector = createMetadataSelector(['version=v2'], 'annotation');
+            expect(selector(annotations)).toBe(true);
+        });
+
+        it('should support multiple selectors with AND logic', () => {
+            const annotations = {team: 'core', version: 'v2'};
+            const selector = createMetadataSelector(['team=core', 'version=v2'], 'annotation');
+            expect(selector(annotations)).toBe(true);
+        });
+
+        it('should fail when one of multiple selectors does not match', () => {
+            const annotations = {team: 'core', version: 'v1'};
+            const selector = createMetadataSelector(['team=core', 'version=v2'], 'annotation');
+            expect(selector(annotations)).toBe(false);
+        });
+
+        it('should work with labels as well', () => {
+            const labels = {env: 'production', tier: 'frontend'};
+            const selector = createMetadataSelector(['env=production', 'tier'], 'label');
+            expect(selector(labels)).toBe(true);
+        });
+    });
+});

--- a/ui/src/app/applications/components/selectors.ts
+++ b/ui/src/app/applications/components/selectors.ts
@@ -9,7 +9,7 @@ export interface Selector {
  * Create a metadata selector that can be used for both labels and annotations
  * Reuses existing LabelSelector functionality including all operators (==, !=, in, notin, gt, lt)
  */
-export const createMetadataSelector = (selectors: string[], type: 'label' | 'annotation') => {
+export const createMetadataSelector = (selectors: string[]) => {
     return (metadata: Record<string, string> | undefined): boolean => {
         return selectors.every(selector => LabelSelector.match(selector, metadata || {}));
     };
@@ -20,12 +20,11 @@ export const createMetadataSelector = (selectors: string[], type: 'label' | 'ann
  * using the powerful LabelSelector functionality for both
  */
 export const createAppFilter = (pref: any) => {
-    const labelSelector = createMetadataSelector(pref.labelsFilter || [], 'label');
-    const annotationSelector = createMetadataSelector(pref.annotationsFilter || [], 'annotation');
+    const labelSelector = createMetadataSelector(pref.labelsFilter || []);
+    const annotationSelector = createMetadataSelector(pref.annotationsFilter || []);
 
     return (app: Application): boolean => {
-        return labelSelector(app.metadata.labels) &&
-               annotationSelector(app.metadata.annotations);
+        return labelSelector(app.metadata.labels) && annotationSelector(app.metadata.annotations);
     };
 };
 

--- a/ui/src/app/applications/components/selectors.ts
+++ b/ui/src/app/applications/components/selectors.ts
@@ -1,5 +1,5 @@
 import * as LabelSelector from './label-selector';
-import { Application } from '../../shared/models';
+import {Application} from '../../shared/models';
 
 export interface Selector {
     match(resource: Record<string, string> | undefined): boolean;
@@ -32,7 +32,7 @@ export const createAppFilter = (pref: any) => {
 /**
  * Backward compatibility: maintain existing LabelSelector functionality
  */
-export { LabelSelector };
+export {LabelSelector};
 
 /**
  * Test cases for annotation filtering

--- a/ui/src/app/applications/components/selectors.ts
+++ b/ui/src/app/applications/components/selectors.ts
@@ -1,5 +1,4 @@
 import * as LabelSelector from './label-selector';
-import {Application} from '../../shared/models';
 
 export interface Selector {
     match(resource: Record<string, string> | undefined): boolean;
@@ -16,31 +15,6 @@ export const createMetadataSelector = (selectors: string[]) => {
 };
 
 /**
- * Create a universal application filter that handles both labels and annotations
- * using the powerful LabelSelector functionality for both
- */
-export const createAppFilter = (pref: any) => {
-    const labelSelector = createMetadataSelector(pref.labelsFilter || []);
-    const annotationSelector = createMetadataSelector(pref.annotationsFilter || []);
-
-    return (app: Application): boolean => {
-        return labelSelector(app.metadata.labels) && annotationSelector(app.metadata.annotations);
-    };
-};
-
-/**
  * Backward compatibility: maintain existing LabelSelector functionality
  */
 export {LabelSelector};
-
-/**
- * Test cases for annotation filtering
- * These cases should all pass:
- *
- * annotations    filter    expected
- * {team: core}    ["team=core"]    PASS
- * {team: core}    ["team"]    PASS
- * {team: core}    ["team=ops"]    FAIL
- * {}    ["team"]    FAIL
- * {version: "v2"}    ["version=v2"]    PASS
- */

--- a/ui/src/app/applications/components/selectors.ts
+++ b/ui/src/app/applications/components/selectors.ts
@@ -1,0 +1,47 @@
+import * as LabelSelector from './label-selector';
+import { Application } from '../../shared/models';
+
+export interface Selector {
+    match(resource: Record<string, string> | undefined): boolean;
+}
+
+/**
+ * Create a metadata selector that can be used for both labels and annotations
+ * Reuses existing LabelSelector functionality including all operators (==, !=, in, notin, gt, lt)
+ */
+export const createMetadataSelector = (selectors: string[], type: 'label' | 'annotation') => {
+    return (metadata: Record<string, string> | undefined): boolean => {
+        return selectors.every(selector => LabelSelector.match(selector, metadata || {}));
+    };
+};
+
+/**
+ * Create a universal application filter that handles both labels and annotations
+ * using the powerful LabelSelector functionality for both
+ */
+export const createAppFilter = (pref: any) => {
+    const labelSelector = createMetadataSelector(pref.labelsFilter || [], 'label');
+    const annotationSelector = createMetadataSelector(pref.annotationsFilter || [], 'annotation');
+
+    return (app: Application): boolean => {
+        return labelSelector(app.metadata.labels) &&
+               annotationSelector(app.metadata.annotations);
+    };
+};
+
+/**
+ * Backward compatibility: maintain existing LabelSelector functionality
+ */
+export { LabelSelector };
+
+/**
+ * Test cases for annotation filtering
+ * These cases should all pass:
+ *
+ * annotations    filter    expected
+ * {team: core}    ["team=core"]    PASS
+ * {team: core}    ["team"]    PASS
+ * {team: core}    ["team=ops"]    FAIL
+ * {}    ["team"]    FAIL
+ * {version: "v2"}    ["version=v2"]    PASS
+ */

--- a/ui/src/app/shared/services/view-preferences-service.ts
+++ b/ui/src/app/shared/services/view-preferences-service.ts
@@ -71,10 +71,12 @@ export class AbstractAppsListPreferences {
     public static clearFilters(pref: AbstractAppsListPreferences) {
         pref.healthFilter = [];
         pref.labelsFilter = [];
+        pref.annotationsFilter = [];
         pref.showFavorites = false;
     }
 
     public labelsFilter: string[];
+    public annotationsFilter: string[];
     public healthFilter: string[];
     public view: AppsListViewType;
     public hideFilters: boolean;
@@ -89,6 +91,7 @@ export class AppsListPreferences extends AbstractAppsListPreferences {
             pref.clustersFilter,
             pref.healthFilter,
             pref.labelsFilter,
+            pref.annotationsFilter,
             pref.namespacesFilter,
             pref.projectsFilter,
             pref.reposFilter,
@@ -180,6 +183,7 @@ const DEFAULT_PREFERENCES: ViewPreferences = {
     appList: {
         view: 'tiles' as AppsListViewType,
         labelsFilter: new Array<string>(),
+        annotationsFilter: new Array<string>(),
         projectsFilter: new Array<string>(),
         namespacesFilter: new Array<string>(),
         clustersFilter: new Array<string>(),


### PR DESCRIPTION

Closes #25087

> **Note:**
> This PR replaces my previous PR (#25527), which became conflicted during rebase.
> I have recreated the branch cleanly and fully incorporated all reviewer feedback, including adopting a unified metadata selector consistent with `LabelSelector`.

## Summary
This PR adds client-side filtering support for `metadata.annotations` in the Argo CD Applications List UI.

Argo CD already provides label-based filtering, but many production environments rely heavily on annotations for operational metadata, automation behaviors, and tooling integrations. This enhancement brings annotations to first-class filtering support alongside labels.

## Motivation
Annotations are widely used for:
- Automated image updates (e.g., Argo CD Image Updater)
- Environment or deployment classification
- Operational metadata and synchronization behaviors
- Custom automation workflows

However, the current UI does not allow filtering applications by annotations, making it difficult for users to locate workloads tied to operational metadata.

This PR improves usability by introducing dedicated annotation filtering capable of matching both:
- `key`
- `key=value`

## Implementation Details

### ✔ Unified Metadata Selector
Reviewer feedback suggested aligning annotation filtering with internal label filtering behavior.

This PR introduces:
- `createMetadataSelector()` → wraps existing `LabelSelector.match`
- Enables all label-selector operators (`=`, `!=`, `in`, `notin`, `gt`, `lt`, …)
- Applies the same parser for both labels and annotations

### ✔ UI Enhancements
- Adds a new **ANNOTATIONS** filter group next to **LABELS**
- Automatically gathers `key` / `key=value` suggestions from loaded applications
- Updates:
  - `FilterResult`
  - `AppsListPreferences`
  - URL query param sync (`?annotations=team%3Dcore,version%3Dv2`)
  - Clear filters behavior
  - Filter counting logic

### ✔ No backend changes
All functionality runs fully client-side and does not modify server APIs.

## Related Issue
Closes #25087

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
