### PR TITLE
docs: fix exponential backoff timeout parameter documentation (#21021)

### DIFF
--- a/docs/operator-manual/argocd-cmd-params-cm.yaml
+++ b/docs/operator-manual/argocd-cmd-params-cm.yaml
@@ -60,8 +60,10 @@ data:
   controller.log.level: "info"
   # Prometheus metrics cache expiration (disabled  by default. e.g. 24h0m0s)
   controller.metrics.cache.expiration: "24h0m0s"
+  # Specifies timeout between application self heal attempts
+  controller.self.heal.timeout.seconds: "0"
   # Specifies exponential backoff timeout parameters between application self heal attempts
-  controller.self.heal.timeout.seconds: "2"
+  controller.self.heal.backoff.timeout.seconds: "2"
   controller.self.heal.backoff.factor: "3"
   controller.self.heal.backoff.cap.seconds: "300"
   # Specifies a sync timeout for applications. "0" means no timeout (default "0")


### PR DESCRIPTION
## Description

Fixes incorrect documentation in `docs/operator-manual/argocd-cmd-params-cm.yaml` 
regarding exponential backoff timeout parameters for application self-healing.

The documentation incorrectly categorized `controller.self.heal.timeout.seconds` 
as an exponential backoff parameter, when it is actually a simple timeout value. 
According to the source code in `cmd/argocd-application-controller/commands/`, 
`controller.self.heal.backoff.timeout.seconds` is the correct parameter for the 
initial exponential backoff timeout.

## Changes Made

- Separated comments to clearly distinguish between regular self-heal timeout and 
  exponential backoff parameters
- Added missing `controller.self.heal.backoff.timeout.seconds` configuration 
  (initial timeout for exponential backoff)
- Corrected default value of `controller.self.heal.timeout.seconds` from `"2"` to `"0"` 
  (this is not an exponential backoff parameter)
- Properly grouped and documented the three exponential backoff parameters:
  - `controller.self.heal.backoff.timeout.seconds` (initial timeout duration)
  - `controller.self.heal.backoff.factor` (exponential multiplier)
  - `controller.self.heal.backoff.cap.seconds` (maximum backoff cap)

## Related Issue

Closes #21021

## Checklist

- [x] This is a documentation fix
- [x] The title conforms to the PR title guidelines
- [x] I have included "Closes #21021" in the description
- [x] Documentation has been updated as required
- [x] No code changes needed (documentation only)