### PR TITLE
fix: add X-Frame-Options and CSP headers to Swagger UI

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1241,7 +1241,7 @@ func (server *ArgoCDServer) newHTTPServer(ctx context.Context, port int, grpcWeb
 	mustRegisterGWHandler(ctx, gpgkeypkg.RegisterGPGKeyServiceHandler, gwmux, conn)
 
 	// Swagger UI
-	swagger.ServeSwaggerUI(mux, assets.SwaggerJSON, "/swagger-ui", server.RootPath)
+	swagger.ServeSwaggerUI(mux, assets.SwaggerJSON, "/swagger-ui", server.RootPath, server.XFrameOptions, server.ContentSecurityPolicy)
 	healthz.ServeHealthCheck(mux, server.healthCheck)
 
 	// Dex reverse proxy and OAuth2 login/callback

--- a/util/swagger/swagger.go
+++ b/util/swagger/swagger.go
@@ -12,19 +12,39 @@ import (
 const redocScriptName = "redoc.standalone.js"
 
 // ServeSwaggerUI serves the Swagger UI and JSON spec.
-func ServeSwaggerUI(mux *http.ServeMux, swaggerJSON string, uiPath string, rootPath string) {
+func ServeSwaggerUI(mux *http.ServeMux, swaggerJSON string, uiPath string, rootPath string, xFrameOptions string, contentSecurityPolicy string) {
 	prefix := path.Dir(uiPath)
 	swaggerPath := path.Join(prefix, "swagger.json")
 	mux.HandleFunc(swaggerPath, func(w http.ResponseWriter, _ *http.Request) {
+		// Set security headers
+		if xFrameOptions != "" {
+			w.Header().Set("X-Frame-Options", xFrameOptions)
+		}
+		if contentSecurityPolicy != "" {
+			w.Header().Set("Content-Security-Policy", contentSecurityPolicy)
+		}
 		_, _ = fmt.Fprint(w, swaggerJSON)
 	})
 
 	specURL := path.Join(prefix, rootPath, "swagger.json")
 	scriptURL := path.Join(prefix, rootPath, "assets", "scripts", redocScriptName)
-	mux.Handle(uiPath, middleware.Redoc(middleware.RedocOpts{
+
+	// Wrap the Redoc handler to add security headers
+	redocHandler := middleware.Redoc(middleware.RedocOpts{
 		BasePath: prefix,
 		SpecURL:  specURL,
 		Path:     path.Base(uiPath),
 		RedocURL: scriptURL,
-	}, http.NotFoundHandler()))
+	}, http.NotFoundHandler())
+
+	mux.HandleFunc(uiPath, func(w http.ResponseWriter, r *http.Request) {
+		// Set security headers
+		if xFrameOptions != "" {
+			w.Header().Set("X-Frame-Options", xFrameOptions)
+		}
+		if contentSecurityPolicy != "" {
+			w.Header().Set("Content-Security-Policy", contentSecurityPolicy)
+		}
+		redocHandler.ServeHTTP(w, r)
+	})
 }


### PR DESCRIPTION
## Description
Fixes #22877

Added X-Frame-Options and Content-Security-Policy headers to Swagger UI endpoints to prevent clickjacking attacks.

## Motivation
During security review, it was discovered that ArgoCD's Swagger UI does not include the X-Frame-Options HTTP header. This could allow the Swagger interface to be embedded in external iframes, exposing it to clickjacking attacks.

ArgoCD already has these security headers configured for the main UI, but they were not applied to Swagger UI endpoints which are served separately.

## Changes
- Modified `ServeSwaggerUI()` to accept `xFrameOptions` and `contentSecurityPolicy` parameters
- Set security headers on both swagger.json and swagger-ui endpoints
- Updated `server.go` to pass configured security header values
- Added `TestSwaggerUISecurityHeaders` to verify headers are set correctly
- Updated existing test to pass new parameters

## Implementation Details
The implementation uses the same security header configuration as the rest of the ArgoCD application (configurable via `--x-frame-options` and `--content-security-policy` flags), ensuring consistent security posture across all endpoints.

Default values:
- X-Frame-Options: `sameorigin`
- Content-Security-Policy: `frame-ancestors 'self';`

## Type of Change
- [x] Security enhancement
- [x] Bug fix

## Checklist
- [x] Either (a) I've created an enhancement proposal and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [x] I've included "Fixes #22877" in the description to automatically close the associated issue.
- [x] I have signed off all my commits as required by DCO
- [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
- [x] My build is green (troubleshooting builds).
- [x] I have added a brief description of why this PR is necessary and/or what this PR solves.Fixes #22877

Added X-Frame-Options and Content-Security-Policy headers to Swagger UI endpoints to prevent clickjacking attacks.

Changes:
- Modified ServeSwaggerUI() to accept xFrameOptions and contentSecurityPolicy parameters
- Set security headers on both swagger.json and swagger-ui endpoints
- Updated server.go to pass configured security header values
- Added TestSwaggerUISecurityHeaders to verify headers are set correctly
- Updated existing test to pass new parameters

The implementation uses the same security header configuration as the rest of the ArgoCD application (configurable via --x-frame-options and --content-security-policy flags), ensuring consistent security posture across all endpoints.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
