### PR TITLE
feat: Add application filter for operation status to UI

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -208,6 +208,7 @@ Currently, the following organizations are **officially** using Argo CD:
 1. [Kurly](https://www.kurly.com/)
 1. [Kvist](https://kvistsolutions.com)
 1. [Kyriba](https://www.kyriba.com/)
+1. [Lattice](https://lattice.com)
 1. [LeFigaro](https://www.lefigaro.fr/)
 1. [Lely](https://www.lely.com/)
 1. [LexisNexis](https://www.lexisnexis.com/)

--- a/ui/src/app/applications/components/applications-list/applications-filter.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-filter.tsx
@@ -293,46 +293,40 @@ function getOperationOptions(apps: FilteredApp[]) {
 
     const counts = getCounts(apps, 'operation', app => getOperationStateTitle(app), operationStateTitles) as Map<OperationStateTitle, number>;
 
-    const options: Array<{label: OperationStateTitle; icon: React.ReactNode; count: number}> = [
+    /**
+     * Combine syncing, terminated (terminating), and deleting counts into a single count for syncing status.
+     * Deleting and Terminating are considered syncing statuses. Terminating operations will always end in a
+     * failed or error state.
+     */
+    const combinedSyncingCount = counts.get(OperationStateTitles.Syncing) + counts.get(OperationStateTitles.Terminated) + counts.get(OperationStateTitles.Deleting);
+
+    return [
         {
             label: OperationStateTitles.Syncing,
             icon: <i className='fa fa-circle-notch' style={{color: COLORS.operation.running}} />,
-            count: counts.get('Syncing')
+            count: combinedSyncingCount
         },
         {
-            label: OperationStateTitles['Sync OK'],
+            label: OperationStateTitles.SyncOK,
             icon: <i className='fa fa-check-circle' style={{color: COLORS.operation.success}} />,
-            count: counts.get('Sync OK')
+            count: counts.get(OperationStateTitles.SyncOK)
         },
         {
-            label: OperationStateTitles.Deleting,
-            icon: <i className='fa fa-trash' style={{color: COLORS.operation.terminating}} />,
-            count: counts.get('Deleting')
-        },
-        {
-            label: OperationStateTitles['Sync error'],
+            label: OperationStateTitles.SyncError,
             icon: <i className='fa fa-exclamation-circle' style={{color: COLORS.operation.error}} />,
-            count: counts.get('Sync error')
+            count: counts.get(OperationStateTitles.SyncError)
         },
         {
-            label: OperationStateTitles['Sync failed'],
+            label: OperationStateTitles.SyncFailed,
             icon: <i className='fa fa-times-circle' style={{color: COLORS.operation.failed}} />,
-            count: counts.get('Sync failed')
-        },
-        {
-            label: OperationStateTitles.Terminated,
-            icon: <i className='fa fa-circle-stop' style={{color: COLORS.operation.terminating}} />,
-            count: counts.get('Terminated')
+            count: counts.get(OperationStateTitles.SyncFailed)
         },
         {
             label: OperationStateTitles.Unknown,
             icon: <i className='fa fa-question-circle' style={{color: COLORS.health.unknown}} />,
-            count: counts.get('Unknown')
+            count: counts.get(OperationStateTitles.Unknown)
         }
     ];
-
-    // Only show phases that have at least one app
-    return options.filter(option => option.count > 0);
 }
 
 const OperationFilter = (props: AppFilterProps) => (

--- a/ui/src/app/applications/components/applications-list/applications-list.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-list.tsx
@@ -122,6 +122,12 @@ const ViewPref = ({children}: {children: (pref: AppsListPreferences & {page: num
                                 .split(',')
                                 .filter(item => !!item);
                         }
+                        if (params.get('operation') != null) {
+                            viewPref.operationFilter = params
+                                .get('operation')
+                                .split(',')
+                                .filter(item => !!item);
+                        }
                         if (params.get('health') != null) {
                             viewPref.healthFilter = params
                                 .get('health')
@@ -423,7 +429,8 @@ export const ApplicationsList = (props: RouteComponentProps<any> & {objectListKi
                 health: newPref.healthFilter.join(','),
                 namespace: newPref.namespacesFilter.join(','),
                 cluster: newPref.clustersFilter.join(','),
-                labels: newPref.labelsFilter.map(encodeURIComponent).join(',')
+                labels: newPref.labelsFilter.map(encodeURIComponent).join(','),
+                operation: newPref.operationFilter.join(',')
             },
             {replace: true}
         );

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -1212,7 +1212,7 @@ export function getOperationType(application: appModels.Application) {
     return 'Unknown';
 }
 
-const getOperationStateTitle = (app: appModels.Application) => {
+export const getOperationStateTitle = (app: appModels.Application): appModels.OperationStateTitle => {
     const appOperationState = getAppOperationState(app);
     const operationType = getOperationType(app);
     switch (operationType) {

--- a/ui/src/app/shared/models.ts
+++ b/ui/src/app/shared/models.ts
@@ -90,6 +90,18 @@ export interface OperationState {
     finishedAt: models.Time;
 }
 
+export type OperationStateTitle = 'Deleting' | 'Syncing' | 'Sync error' | 'Sync failed' | 'Sync OK' | 'Terminated' | 'Unknown';
+
+export const OperationStateTitles = {
+    'Deleting': 'Deleting' as OperationStateTitle,
+    'Syncing': 'Syncing' as OperationStateTitle,
+    'Sync error': 'Sync error' as OperationStateTitle,
+    'Sync failed': 'Sync failed' as OperationStateTitle,
+    'Sync OK': 'Sync OK' as OperationStateTitle,
+    'Terminated': 'Terminated' as OperationStateTitle,
+    'Unknown': 'Unknown' as OperationStateTitle
+};
+
 export type HookType = 'PreSync' | 'Sync' | 'PostSync' | 'SyncFail' | 'Skip';
 
 export interface RevisionMetadata {

--- a/ui/src/app/shared/models.ts
+++ b/ui/src/app/shared/models.ts
@@ -93,14 +93,14 @@ export interface OperationState {
 export type OperationStateTitle = 'Deleting' | 'Syncing' | 'Sync error' | 'Sync failed' | 'Sync OK' | 'Terminated' | 'Unknown';
 
 export const OperationStateTitles = {
-    'Deleting': 'Deleting' as OperationStateTitle,
-    'Syncing': 'Syncing' as OperationStateTitle,
-    'Sync error': 'Sync error' as OperationStateTitle,
-    'Sync failed': 'Sync failed' as OperationStateTitle,
-    'Sync OK': 'Sync OK' as OperationStateTitle,
-    'Terminated': 'Terminated' as OperationStateTitle,
-    'Unknown': 'Unknown' as OperationStateTitle
-};
+    Deleting: 'Deleting',
+    Syncing: 'Syncing',
+    SyncError: 'Sync error',
+    SyncFailed: 'Sync failed',
+    SyncOK: 'Sync OK',
+    Terminated: 'Terminated',
+    Unknown: 'Unknown'
+} satisfies Record<string, OperationStateTitle>;
 
 export type HookType = 'PreSync' | 'Sync' | 'PostSync' | 'SyncFail' | 'Skip';
 

--- a/ui/src/app/shared/services/view-preferences-service.ts
+++ b/ui/src/app/shared/services/view-preferences-service.ts
@@ -85,15 +85,21 @@ export class AbstractAppsListPreferences {
 
 export class AppsListPreferences extends AbstractAppsListPreferences {
     public static countEnabledFilters(pref: AppsListPreferences) {
-        return [pref.clustersFilter, pref.healthFilter, pref.labelsFilter, pref.namespacesFilter, pref.projectsFilter, pref.reposFilter, pref.syncFilter].reduce(
-            (count, filter) => {
-                if (filter && filter.length > 0) {
-                    return count + 1;
-                }
-                return count;
-            },
-            0
-        );
+        return [
+            pref.clustersFilter,
+            pref.healthFilter,
+            pref.labelsFilter,
+            pref.namespacesFilter,
+            pref.projectsFilter,
+            pref.reposFilter,
+            pref.syncFilter,
+            pref.operationFilter
+        ].reduce((count, filter) => {
+            if (filter && filter.length > 0) {
+                return count + 1;
+            }
+            return count;
+        }, 0);
     }
 
     public static clearFilters(pref: AppsListPreferences) {
@@ -105,6 +111,7 @@ export class AppsListPreferences extends AbstractAppsListPreferences {
         pref.reposFilter = [];
         pref.syncFilter = [];
         pref.autoSyncFilter = [];
+        pref.operationFilter = [];
     }
 
     public projectsFilter: string[];
@@ -113,6 +120,7 @@ export class AppsListPreferences extends AbstractAppsListPreferences {
     public autoSyncFilter: string[];
     public namespacesFilter: string[];
     public clustersFilter: string[];
+    public operationFilter: string[];
 }
 
 export class AppSetsListPreferences extends AbstractAppsListPreferences {
@@ -179,6 +187,7 @@ const DEFAULT_PREFERENCES: ViewPreferences = {
         syncFilter: new Array<string>(),
         autoSyncFilter: new Array<string>(),
         healthFilter: new Array<string>(),
+        operationFilter: new Array<string>(),
         hideFilters: false,
         showFavorites: false,
         favoritesAppList: new Array<string>(),


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

## Closes: #25637

<img width="444" height="440" alt="image" src="https://github.com/user-attachments/assets/13155e88-4ab6-4385-a268-c3283274221d" />

> Screenshot where we return all options in `getOperationOptions`. 

This introduces a new Application filter for `OPERATION STATUS` following the design of those for `SYNC STATUS` and `HEALTH STATUS`. 

This will be massively useful for us to see which applications at a bird's eye view are Out of Sync and not actively Syncing (influencing decisions to enable self-heal, mess with ignoreDifferences, etc!). 

Without this, there is a gap for applications that might be stuck syncing or failed syncing, but not necessarily "Degraded" or otherwise distinguishable. 

I opted to place this below SYNC STATUS and HEALTH STATUS in the list (and above labels) to not completely restructure the familiarity with the application filters defined today.

~I also implemented a `.filter()` for the possible operationstate phases that don't have any applications, since there are 8 possible values in that type, and many like "Pending", "Waiting", etc. might not be relevant to all users.~

> _EDIT: Since we are now combining the `Deleting`, `Running`, and `Terminating` phases under the single "Syncing" operation state count, there's no need for the `.filter()` on 0 counts since the total amount of phases are small enough to not clutter the UI._ 
>
> _See:_
> - https://github.com/argoproj/argo-cd/pull/25636#discussion_r2616613144

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
