### PR TITLE
chore: add cel validations for v1alpha.application crd

### DIFF
--- a/assets/swagger.json
+++ b/assets/swagger.json
@@ -7772,7 +7772,7 @@
     },
     "v1alpha1ApplicationSpec": {
       "type": "object",
-      "title": "ApplicationSpec represents desired application state. Contains link to repository with application definition and additional parameters link definition revision.\n+kubebuilder:validation:XValidation:rule=\"!((has(self.source) && self.source != null) && (has(self.sources) && size(self.sources) > 0))\",message=\"source and sources are mutually exclusive\"\n+kubebuilder:validation:XValidation:rule=\"!((has(self.destination.server) && self.destination.server.size() > 0) && (has(self.destination.name) && self.destination.name.size() > 0))\",message=\"destination server and name are mutually exclusive\"",
+      "title": "ApplicationSpec represents desired application state. Contains link to repository with application definition and additional parameters link definition revision.\n+kubebuilder:validation:XValidation:rule=\"!((has(self.source) && self.source != null) && (has(self.sources) && size(self.sources) > 0))\",message=\"application spec can't have both source and sources defined\"\n+kubebuilder:validation:XValidation:rule=\"!((has(self.destination.server) && self.destination.server.size() > 0) && (has(self.destination.name) && self.destination.name.size() > 0))\",message=\"application destination can't have both name and server defined\",messageExpression=\"'application destination can\\\\'t have both name and server defined: ' + self.destination.name + ' ' + self.destination.server\"",
       "properties": {
         "destination": {
           "$ref": "#/definitions/v1alpha1ApplicationDestination"

--- a/assets/swagger.json
+++ b/assets/swagger.json
@@ -7771,8 +7771,8 @@
       }
     },
     "v1alpha1ApplicationSpec": {
-      "description": "ApplicationSpec represents desired application state. Contains link to repository with application definition and additional parameters link definition revision.",
       "type": "object",
+      "title": "ApplicationSpec represents desired application state. Contains link to repository with application definition and additional parameters link definition revision.\n+kubebuilder:validation:XValidation:rule=\"(has(self.source) && self.source != null) != (has(self.sources) && size(self.sources) > 0)\",message=\"source and sources are mutually exclusive, exactly one must be set\"\n+kubebuilder:validation:XValidation:rule=\"(has(self.destination.server) && self.destination.server.size() > 0) != (has(self.destination.name) && self.destination.name.size() > 0)\",message=\"destination server and name are mutually exclusive, exactly one must be set\"",
       "properties": {
         "destination": {
           "$ref": "#/definitions/v1alpha1ApplicationDestination"

--- a/assets/swagger.json
+++ b/assets/swagger.json
@@ -7772,7 +7772,7 @@
     },
     "v1alpha1ApplicationSpec": {
       "type": "object",
-      "title": "ApplicationSpec represents desired application state. Contains link to repository with application definition and additional parameters link definition revision.\n+kubebuilder:validation:XValidation:rule=\"(has(self.source) && self.source != null) != (has(self.sources) && size(self.sources) > 0)\",message=\"source and sources are mutually exclusive, exactly one must be set\"\n+kubebuilder:validation:XValidation:rule=\"(has(self.destination.server) && self.destination.server.size() > 0) != (has(self.destination.name) && self.destination.name.size() > 0)\",message=\"destination server and name are mutually exclusive, exactly one must be set\"",
+      "title": "ApplicationSpec represents desired application state. Contains link to repository with application definition and additional parameters link definition revision.\n+kubebuilder:validation:XValidation:rule=\"!((has(self.source) && self.source != null) && (has(self.sources) && size(self.sources) > 0))\",message=\"source and sources are mutually exclusive\"\n+kubebuilder:validation:XValidation:rule=\"!((has(self.destination.server) && self.destination.server.size() > 0) && (has(self.destination.name) && self.destination.name.size() > 0))\",message=\"destination server and name are mutually exclusive\"",
       "properties": {
         "destination": {
           "$ref": "#/definitions/v1alpha1ApplicationDestination"

--- a/manifests/core-install-with-hydrator.yaml
+++ b/manifests/core-install-with-hydrator.yaml
@@ -2308,6 +2308,16 @@ spec:
             - destination
             - project
             type: object
+            x-kubernetes-validations:
+            - message: source and sources are mutually exclusive, exactly one must
+                be set
+              rule: (has(self.source) && self.source != null) != (has(self.sources)
+                && size(self.sources) > 0)
+            - message: destination server and name are mutually exclusive, exactly
+                one must be set
+              rule: (has(self.destination.server) && self.destination.server.size()
+                > 0) != (has(self.destination.name) && self.destination.name.size()
+                > 0)
           status:
             description: ApplicationStatus contains status information for the application
             properties:
@@ -7940,6 +7950,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -8848,6 +8868,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -9757,6 +9787,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -10644,6 +10684,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -11556,6 +11606,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -12464,6 +12526,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -13373,6 +13447,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -14260,6 +14346,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -15155,6 +15253,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -16277,6 +16387,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -17390,6 +17512,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -18294,6 +18428,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -19208,6 +19352,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -20116,6 +20272,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -21025,6 +21193,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -21912,6 +22092,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -22807,6 +22999,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -23929,6 +24133,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -25042,6 +25258,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -25950,6 +26178,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -26844,6 +27082,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -27966,6 +28214,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -29079,6 +29337,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -30060,6 +30328,16 @@ spec:
                     - destination
                     - project
                     type: object
+                    x-kubernetes-validations:
+                    - message: source and sources are mutually exclusive, exactly
+                        one must be set
+                      rule: (has(self.source) && self.source != null) != (has(self.sources)
+                        && size(self.sources) > 0)
+                    - message: destination server and name are mutually exclusive,
+                        exactly one must be set
+                      rule: (has(self.destination.server) && self.destination.server.size()
+                        > 0) != (has(self.destination.name) && self.destination.name.size()
+                        > 0)
                 required:
                 - metadata
                 - spec

--- a/manifests/core-install-with-hydrator.yaml
+++ b/manifests/core-install-with-hydrator.yaml
@@ -2309,15 +2309,13 @@ spec:
             - project
             type: object
             x-kubernetes-validations:
-            - message: source and sources are mutually exclusive, exactly one must
-                be set
-              rule: (has(self.source) && self.source != null) != (has(self.sources)
-                && size(self.sources) > 0)
-            - message: destination server and name are mutually exclusive, exactly
-                one must be set
-              rule: (has(self.destination.server) && self.destination.server.size()
-                > 0) != (has(self.destination.name) && self.destination.name.size()
-                > 0)
+            - message: source and sources are mutually exclusive
+              rule: '!((has(self.source) && self.source != null) && (has(self.sources)
+                && size(self.sources) > 0))'
+            - message: destination server and name are mutually exclusive
+              rule: '!((has(self.destination.server) && self.destination.server.size()
+                > 0) && (has(self.destination.name) && self.destination.name.size()
+                > 0))'
           status:
             description: ApplicationStatus contains status information for the application
             properties:
@@ -7951,15 +7949,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -8869,15 +8866,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -9788,15 +9784,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -10685,15 +10680,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -11608,16 +11602,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -12528,16 +12522,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -13449,16 +13443,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -14348,16 +14342,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -15255,16 +15249,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -16389,16 +16383,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -17514,16 +17508,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -18429,15 +18423,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -19354,16 +19347,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -20274,16 +20267,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -21195,16 +21188,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -22094,16 +22087,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -23001,16 +22994,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -24135,16 +24128,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -25260,16 +25253,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -26179,15 +26172,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -27083,15 +27075,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -28215,15 +28206,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -29338,15 +29328,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -30329,15 +30318,13 @@ spec:
                     - project
                     type: object
                     x-kubernetes-validations:
-                    - message: source and sources are mutually exclusive, exactly
-                        one must be set
-                      rule: (has(self.source) && self.source != null) != (has(self.sources)
-                        && size(self.sources) > 0)
-                    - message: destination server and name are mutually exclusive,
-                        exactly one must be set
-                      rule: (has(self.destination.server) && self.destination.server.size()
-                        > 0) != (has(self.destination.name) && self.destination.name.size()
-                        > 0)
+                    - message: source and sources are mutually exclusive
+                      rule: '!((has(self.source) && self.source != null) && (has(self.sources)
+                        && size(self.sources) > 0))'
+                    - message: destination server and name are mutually exclusive
+                      rule: '!((has(self.destination.server) && self.destination.server.size()
+                        > 0) && (has(self.destination.name) && self.destination.name.size()
+                        > 0))'
                 required:
                 - metadata
                 - spec

--- a/manifests/core-install-with-hydrator.yaml
+++ b/manifests/core-install-with-hydrator.yaml
@@ -2309,10 +2309,12 @@ spec:
             - project
             type: object
             x-kubernetes-validations:
-            - message: source and sources are mutually exclusive
+            - message: application spec can't have both source and sources defined
               rule: '!((has(self.source) && self.source != null) && (has(self.sources)
                 && size(self.sources) > 0))'
-            - message: destination server and name are mutually exclusive
+            - message: application destination can't have both name and server defined
+              messageExpression: '''application destination can\''t have both name
+                and server defined: '' + self.destination.name + '' '' + self.destination.server'
               rule: '!((has(self.destination.server) && self.destination.server.size()
                 > 0) && (has(self.destination.name) && self.destination.name.size()
                 > 0))'
@@ -7949,11 +7951,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -8866,11 +8872,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -9784,11 +9794,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -10680,11 +10694,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -11601,13 +11619,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -12521,13 +12542,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -13442,13 +13466,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -14341,13 +14368,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -15248,13 +15278,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -16382,13 +16415,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -17507,13 +17543,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -18423,11 +18462,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -19346,13 +19389,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -20266,13 +20312,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -21187,13 +21236,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -22086,13 +22138,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -22993,13 +23048,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -24127,13 +24185,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -25252,13 +25313,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -26172,11 +26236,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -27075,11 +27143,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -28206,11 +28278,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -29328,11 +29404,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -30318,10 +30398,15 @@ spec:
                     - project
                     type: object
                     x-kubernetes-validations:
-                    - message: source and sources are mutually exclusive
+                    - message: application spec can't have both source and sources
+                        defined
                       rule: '!((has(self.source) && self.source != null) && (has(self.sources)
                         && size(self.sources) > 0))'
-                    - message: destination server and name are mutually exclusive
+                    - message: application destination can't have both name and server
+                        defined
+                      messageExpression: '''application destination can\''t have both
+                        name and server defined: '' + self.destination.name + '' ''
+                        + self.destination.server'
                       rule: '!((has(self.destination.server) && self.destination.server.size()
                         > 0) && (has(self.destination.name) && self.destination.name.size()
                         > 0))'

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -2308,6 +2308,16 @@ spec:
             - destination
             - project
             type: object
+            x-kubernetes-validations:
+            - message: source and sources are mutually exclusive, exactly one must
+                be set
+              rule: (has(self.source) && self.source != null) != (has(self.sources)
+                && size(self.sources) > 0)
+            - message: destination server and name are mutually exclusive, exactly
+                one must be set
+              rule: (has(self.destination.server) && self.destination.server.size()
+                > 0) != (has(self.destination.name) && self.destination.name.size()
+                > 0)
           status:
             description: ApplicationStatus contains status information for the application
             properties:
@@ -7940,6 +7950,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -8848,6 +8868,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -9757,6 +9787,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -10644,6 +10684,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -11556,6 +11606,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -12464,6 +12526,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -13373,6 +13447,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -14260,6 +14346,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -15155,6 +15253,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -16277,6 +16387,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -17390,6 +17512,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -18294,6 +18428,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -19208,6 +19352,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -20116,6 +20272,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -21025,6 +21193,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -21912,6 +22092,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -22807,6 +22999,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -23929,6 +24133,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -25042,6 +25258,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -25950,6 +26178,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -26844,6 +27082,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -27966,6 +28214,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -29079,6 +29337,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -30060,6 +30328,16 @@ spec:
                     - destination
                     - project
                     type: object
+                    x-kubernetes-validations:
+                    - message: source and sources are mutually exclusive, exactly
+                        one must be set
+                      rule: (has(self.source) && self.source != null) != (has(self.sources)
+                        && size(self.sources) > 0)
+                    - message: destination server and name are mutually exclusive,
+                        exactly one must be set
+                      rule: (has(self.destination.server) && self.destination.server.size()
+                        > 0) != (has(self.destination.name) && self.destination.name.size()
+                        > 0)
                 required:
                 - metadata
                 - spec

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -2309,15 +2309,13 @@ spec:
             - project
             type: object
             x-kubernetes-validations:
-            - message: source and sources are mutually exclusive, exactly one must
-                be set
-              rule: (has(self.source) && self.source != null) != (has(self.sources)
-                && size(self.sources) > 0)
-            - message: destination server and name are mutually exclusive, exactly
-                one must be set
-              rule: (has(self.destination.server) && self.destination.server.size()
-                > 0) != (has(self.destination.name) && self.destination.name.size()
-                > 0)
+            - message: source and sources are mutually exclusive
+              rule: '!((has(self.source) && self.source != null) && (has(self.sources)
+                && size(self.sources) > 0))'
+            - message: destination server and name are mutually exclusive
+              rule: '!((has(self.destination.server) && self.destination.server.size()
+                > 0) && (has(self.destination.name) && self.destination.name.size()
+                > 0))'
           status:
             description: ApplicationStatus contains status information for the application
             properties:
@@ -7951,15 +7949,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -8869,15 +8866,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -9788,15 +9784,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -10685,15 +10680,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -11608,16 +11602,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -12528,16 +12522,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -13449,16 +13443,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -14348,16 +14342,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -15255,16 +15249,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -16389,16 +16383,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -17514,16 +17508,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -18429,15 +18423,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -19354,16 +19347,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -20274,16 +20267,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -21195,16 +21188,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -22094,16 +22087,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -23001,16 +22994,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -24135,16 +24128,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -25260,16 +25253,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -26179,15 +26172,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -27083,15 +27075,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -28215,15 +28206,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -29338,15 +29328,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -30329,15 +30318,13 @@ spec:
                     - project
                     type: object
                     x-kubernetes-validations:
-                    - message: source and sources are mutually exclusive, exactly
-                        one must be set
-                      rule: (has(self.source) && self.source != null) != (has(self.sources)
-                        && size(self.sources) > 0)
-                    - message: destination server and name are mutually exclusive,
-                        exactly one must be set
-                      rule: (has(self.destination.server) && self.destination.server.size()
-                        > 0) != (has(self.destination.name) && self.destination.name.size()
-                        > 0)
+                    - message: source and sources are mutually exclusive
+                      rule: '!((has(self.source) && self.source != null) && (has(self.sources)
+                        && size(self.sources) > 0))'
+                    - message: destination server and name are mutually exclusive
+                      rule: '!((has(self.destination.server) && self.destination.server.size()
+                        > 0) && (has(self.destination.name) && self.destination.name.size()
+                        > 0))'
                 required:
                 - metadata
                 - spec

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -2309,10 +2309,12 @@ spec:
             - project
             type: object
             x-kubernetes-validations:
-            - message: source and sources are mutually exclusive
+            - message: application spec can't have both source and sources defined
               rule: '!((has(self.source) && self.source != null) && (has(self.sources)
                 && size(self.sources) > 0))'
-            - message: destination server and name are mutually exclusive
+            - message: application destination can't have both name and server defined
+              messageExpression: '''application destination can\''t have both name
+                and server defined: '' + self.destination.name + '' '' + self.destination.server'
               rule: '!((has(self.destination.server) && self.destination.server.size()
                 > 0) && (has(self.destination.name) && self.destination.name.size()
                 > 0))'
@@ -7949,11 +7951,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -8866,11 +8872,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -9784,11 +9794,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -10680,11 +10694,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -11601,13 +11619,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -12521,13 +12542,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -13442,13 +13466,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -14341,13 +14368,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -15248,13 +15278,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -16382,13 +16415,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -17507,13 +17543,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -18423,11 +18462,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -19346,13 +19389,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -20266,13 +20312,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -21187,13 +21236,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -22086,13 +22138,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -22993,13 +23048,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -24127,13 +24185,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -25252,13 +25313,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -26172,11 +26236,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -27075,11 +27143,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -28206,11 +28278,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -29328,11 +29404,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -30318,10 +30398,15 @@ spec:
                     - project
                     type: object
                     x-kubernetes-validations:
-                    - message: source and sources are mutually exclusive
+                    - message: application spec can't have both source and sources
+                        defined
                       rule: '!((has(self.source) && self.source != null) && (has(self.sources)
                         && size(self.sources) > 0))'
-                    - message: destination server and name are mutually exclusive
+                    - message: application destination can't have both name and server
+                        defined
+                      messageExpression: '''application destination can\''t have both
+                        name and server defined: '' + self.destination.name + '' ''
+                        + self.destination.server'
                       rule: '!((has(self.destination.server) && self.destination.server.size()
                         > 0) && (has(self.destination.name) && self.destination.name.size()
                         > 0))'

--- a/manifests/crds/application-crd.yaml
+++ b/manifests/crds/application-crd.yaml
@@ -2308,15 +2308,13 @@ spec:
             - project
             type: object
             x-kubernetes-validations:
-            - message: source and sources are mutually exclusive, exactly one must
-                be set
-              rule: (has(self.source) && self.source != null) != (has(self.sources)
-                && size(self.sources) > 0)
-            - message: destination server and name are mutually exclusive, exactly
-                one must be set
-              rule: (has(self.destination.server) && self.destination.server.size()
-                > 0) != (has(self.destination.name) && self.destination.name.size()
-                > 0)
+            - message: source and sources are mutually exclusive
+              rule: '!((has(self.source) && self.source != null) && (has(self.sources)
+                && size(self.sources) > 0))'
+            - message: destination server and name are mutually exclusive
+              rule: '!((has(self.destination.server) && self.destination.server.size()
+                > 0) && (has(self.destination.name) && self.destination.name.size()
+                > 0))'
           status:
             description: ApplicationStatus contains status information for the application
             properties:

--- a/manifests/crds/application-crd.yaml
+++ b/manifests/crds/application-crd.yaml
@@ -2307,6 +2307,16 @@ spec:
             - destination
             - project
             type: object
+            x-kubernetes-validations:
+            - message: source and sources are mutually exclusive, exactly one must
+                be set
+              rule: (has(self.source) && self.source != null) != (has(self.sources)
+                && size(self.sources) > 0)
+            - message: destination server and name are mutually exclusive, exactly
+                one must be set
+              rule: (has(self.destination.server) && self.destination.server.size()
+                > 0) != (has(self.destination.name) && self.destination.name.size()
+                > 0)
           status:
             description: ApplicationStatus contains status information for the application
             properties:

--- a/manifests/crds/application-crd.yaml
+++ b/manifests/crds/application-crd.yaml
@@ -2308,10 +2308,12 @@ spec:
             - project
             type: object
             x-kubernetes-validations:
-            - message: source and sources are mutually exclusive
+            - message: application spec can't have both source and sources defined
               rule: '!((has(self.source) && self.source != null) && (has(self.sources)
                 && size(self.sources) > 0))'
-            - message: destination server and name are mutually exclusive
+            - message: application destination can't have both name and server defined
+              messageExpression: '''application destination can\''t have both name
+                and server defined: '' + self.destination.name + '' '' + self.destination.server'
               rule: '!((has(self.destination.server) && self.destination.server.size()
                 > 0) && (has(self.destination.name) && self.destination.name.size()
                 > 0))'

--- a/manifests/crds/applicationset-crd.yaml
+++ b/manifests/crds/applicationset-crd.yaml
@@ -937,15 +937,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -1855,15 +1854,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -2774,15 +2772,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -3671,15 +3668,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -4594,16 +4590,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -5514,16 +5510,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -6435,16 +6431,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -7334,16 +7330,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -8241,16 +8237,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -9375,16 +9371,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -10500,16 +10496,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -11415,15 +11411,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -12340,16 +12335,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -13260,16 +13255,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -14181,16 +14176,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -15080,16 +15075,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -15987,16 +15982,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -17121,16 +17116,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -18246,16 +18241,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -19165,15 +19160,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -20069,15 +20063,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -21201,15 +21194,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -22324,15 +22316,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -23315,15 +23306,13 @@ spec:
                     - project
                     type: object
                     x-kubernetes-validations:
-                    - message: source and sources are mutually exclusive, exactly
-                        one must be set
-                      rule: (has(self.source) && self.source != null) != (has(self.sources)
-                        && size(self.sources) > 0)
-                    - message: destination server and name are mutually exclusive,
-                        exactly one must be set
-                      rule: (has(self.destination.server) && self.destination.server.size()
-                        > 0) != (has(self.destination.name) && self.destination.name.size()
-                        > 0)
+                    - message: source and sources are mutually exclusive
+                      rule: '!((has(self.source) && self.source != null) && (has(self.sources)
+                        && size(self.sources) > 0))'
+                    - message: destination server and name are mutually exclusive
+                      rule: '!((has(self.destination.server) && self.destination.server.size()
+                        > 0) && (has(self.destination.name) && self.destination.name.size()
+                        > 0))'
                 required:
                 - metadata
                 - spec

--- a/manifests/crds/applicationset-crd.yaml
+++ b/manifests/crds/applicationset-crd.yaml
@@ -937,11 +937,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -1854,11 +1858,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -2772,11 +2780,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -3668,11 +3680,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -4589,13 +4605,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -5509,13 +5528,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -6430,13 +6452,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -7329,13 +7354,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -8236,13 +8264,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -9370,13 +9401,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -10495,13 +10529,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -11411,11 +11448,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -12334,13 +12375,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -13254,13 +13298,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -14175,13 +14222,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -15074,13 +15124,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -15981,13 +16034,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -17115,13 +17171,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -18240,13 +18299,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -19160,11 +19222,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -20063,11 +20129,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -21194,11 +21264,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -22316,11 +22390,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -23306,10 +23384,15 @@ spec:
                     - project
                     type: object
                     x-kubernetes-validations:
-                    - message: source and sources are mutually exclusive
+                    - message: application spec can't have both source and sources
+                        defined
                       rule: '!((has(self.source) && self.source != null) && (has(self.sources)
                         && size(self.sources) > 0))'
-                    - message: destination server and name are mutually exclusive
+                    - message: application destination can't have both name and server
+                        defined
+                      messageExpression: '''application destination can\''t have both
+                        name and server defined: '' + self.destination.name + '' ''
+                        + self.destination.server'
                       rule: '!((has(self.destination.server) && self.destination.server.size()
                         > 0) && (has(self.destination.name) && self.destination.name.size()
                         > 0))'

--- a/manifests/crds/applicationset-crd.yaml
+++ b/manifests/crds/applicationset-crd.yaml
@@ -936,6 +936,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -1844,6 +1854,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -2753,6 +2773,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -3640,6 +3670,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -4552,6 +4592,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -5460,6 +5512,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -6369,6 +6433,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -7256,6 +7332,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -8151,6 +8239,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -9273,6 +9373,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -10386,6 +10498,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -11290,6 +11414,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -12204,6 +12338,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -13112,6 +13258,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -14021,6 +14179,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -14908,6 +15078,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -15803,6 +15985,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -16925,6 +17119,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -18038,6 +18244,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -18946,6 +19164,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -19840,6 +20068,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -20962,6 +21200,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -22075,6 +22323,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -23056,6 +23314,16 @@ spec:
                     - destination
                     - project
                     type: object
+                    x-kubernetes-validations:
+                    - message: source and sources are mutually exclusive, exactly
+                        one must be set
+                      rule: (has(self.source) && self.source != null) != (has(self.sources)
+                        && size(self.sources) > 0)
+                    - message: destination server and name are mutually exclusive,
+                        exactly one must be set
+                      rule: (has(self.destination.server) && self.destination.server.size()
+                        > 0) != (has(self.destination.name) && self.destination.name.size()
+                        > 0)
                 required:
                 - metadata
                 - spec

--- a/manifests/ha/install-with-hydrator.yaml
+++ b/manifests/ha/install-with-hydrator.yaml
@@ -2308,6 +2308,16 @@ spec:
             - destination
             - project
             type: object
+            x-kubernetes-validations:
+            - message: source and sources are mutually exclusive, exactly one must
+                be set
+              rule: (has(self.source) && self.source != null) != (has(self.sources)
+                && size(self.sources) > 0)
+            - message: destination server and name are mutually exclusive, exactly
+                one must be set
+              rule: (has(self.destination.server) && self.destination.server.size()
+                > 0) != (has(self.destination.name) && self.destination.name.size()
+                > 0)
           status:
             description: ApplicationStatus contains status information for the application
             properties:
@@ -7940,6 +7950,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -8848,6 +8868,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -9757,6 +9787,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -10644,6 +10684,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -11556,6 +11606,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -12464,6 +12526,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -13373,6 +13447,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -14260,6 +14346,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -15155,6 +15253,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -16277,6 +16387,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -17390,6 +17512,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -18294,6 +18428,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -19208,6 +19352,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -20116,6 +20272,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -21025,6 +21193,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -21912,6 +22092,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -22807,6 +22999,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -23929,6 +24133,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -25042,6 +25258,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -25950,6 +26178,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -26844,6 +27082,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -27966,6 +28214,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -29079,6 +29337,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -30060,6 +30328,16 @@ spec:
                     - destination
                     - project
                     type: object
+                    x-kubernetes-validations:
+                    - message: source and sources are mutually exclusive, exactly
+                        one must be set
+                      rule: (has(self.source) && self.source != null) != (has(self.sources)
+                        && size(self.sources) > 0)
+                    - message: destination server and name are mutually exclusive,
+                        exactly one must be set
+                      rule: (has(self.destination.server) && self.destination.server.size()
+                        > 0) != (has(self.destination.name) && self.destination.name.size()
+                        > 0)
                 required:
                 - metadata
                 - spec

--- a/manifests/ha/install-with-hydrator.yaml
+++ b/manifests/ha/install-with-hydrator.yaml
@@ -2309,15 +2309,13 @@ spec:
             - project
             type: object
             x-kubernetes-validations:
-            - message: source and sources are mutually exclusive, exactly one must
-                be set
-              rule: (has(self.source) && self.source != null) != (has(self.sources)
-                && size(self.sources) > 0)
-            - message: destination server and name are mutually exclusive, exactly
-                one must be set
-              rule: (has(self.destination.server) && self.destination.server.size()
-                > 0) != (has(self.destination.name) && self.destination.name.size()
-                > 0)
+            - message: source and sources are mutually exclusive
+              rule: '!((has(self.source) && self.source != null) && (has(self.sources)
+                && size(self.sources) > 0))'
+            - message: destination server and name are mutually exclusive
+              rule: '!((has(self.destination.server) && self.destination.server.size()
+                > 0) && (has(self.destination.name) && self.destination.name.size()
+                > 0))'
           status:
             description: ApplicationStatus contains status information for the application
             properties:
@@ -7951,15 +7949,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -8869,15 +8866,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -9788,15 +9784,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -10685,15 +10680,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -11608,16 +11602,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -12528,16 +12522,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -13449,16 +13443,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -14348,16 +14342,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -15255,16 +15249,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -16389,16 +16383,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -17514,16 +17508,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -18429,15 +18423,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -19354,16 +19347,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -20274,16 +20267,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -21195,16 +21188,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -22094,16 +22087,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -23001,16 +22994,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -24135,16 +24128,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -25260,16 +25253,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -26179,15 +26172,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -27083,15 +27075,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -28215,15 +28206,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -29338,15 +29328,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -30329,15 +30318,13 @@ spec:
                     - project
                     type: object
                     x-kubernetes-validations:
-                    - message: source and sources are mutually exclusive, exactly
-                        one must be set
-                      rule: (has(self.source) && self.source != null) != (has(self.sources)
-                        && size(self.sources) > 0)
-                    - message: destination server and name are mutually exclusive,
-                        exactly one must be set
-                      rule: (has(self.destination.server) && self.destination.server.size()
-                        > 0) != (has(self.destination.name) && self.destination.name.size()
-                        > 0)
+                    - message: source and sources are mutually exclusive
+                      rule: '!((has(self.source) && self.source != null) && (has(self.sources)
+                        && size(self.sources) > 0))'
+                    - message: destination server and name are mutually exclusive
+                      rule: '!((has(self.destination.server) && self.destination.server.size()
+                        > 0) && (has(self.destination.name) && self.destination.name.size()
+                        > 0))'
                 required:
                 - metadata
                 - spec

--- a/manifests/ha/install-with-hydrator.yaml
+++ b/manifests/ha/install-with-hydrator.yaml
@@ -2309,10 +2309,12 @@ spec:
             - project
             type: object
             x-kubernetes-validations:
-            - message: source and sources are mutually exclusive
+            - message: application spec can't have both source and sources defined
               rule: '!((has(self.source) && self.source != null) && (has(self.sources)
                 && size(self.sources) > 0))'
-            - message: destination server and name are mutually exclusive
+            - message: application destination can't have both name and server defined
+              messageExpression: '''application destination can\''t have both name
+                and server defined: '' + self.destination.name + '' '' + self.destination.server'
               rule: '!((has(self.destination.server) && self.destination.server.size()
                 > 0) && (has(self.destination.name) && self.destination.name.size()
                 > 0))'
@@ -7949,11 +7951,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -8866,11 +8872,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -9784,11 +9794,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -10680,11 +10694,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -11601,13 +11619,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -12521,13 +12542,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -13442,13 +13466,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -14341,13 +14368,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -15248,13 +15278,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -16382,13 +16415,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -17507,13 +17543,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -18423,11 +18462,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -19346,13 +19389,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -20266,13 +20312,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -21187,13 +21236,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -22086,13 +22138,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -22993,13 +23048,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -24127,13 +24185,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -25252,13 +25313,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -26172,11 +26236,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -27075,11 +27143,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -28206,11 +28278,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -29328,11 +29404,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -30318,10 +30398,15 @@ spec:
                     - project
                     type: object
                     x-kubernetes-validations:
-                    - message: source and sources are mutually exclusive
+                    - message: application spec can't have both source and sources
+                        defined
                       rule: '!((has(self.source) && self.source != null) && (has(self.sources)
                         && size(self.sources) > 0))'
-                    - message: destination server and name are mutually exclusive
+                    - message: application destination can't have both name and server
+                        defined
+                      messageExpression: '''application destination can\''t have both
+                        name and server defined: '' + self.destination.name + '' ''
+                        + self.destination.server'
                       rule: '!((has(self.destination.server) && self.destination.server.size()
                         > 0) && (has(self.destination.name) && self.destination.name.size()
                         > 0))'

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -2308,6 +2308,16 @@ spec:
             - destination
             - project
             type: object
+            x-kubernetes-validations:
+            - message: source and sources are mutually exclusive, exactly one must
+                be set
+              rule: (has(self.source) && self.source != null) != (has(self.sources)
+                && size(self.sources) > 0)
+            - message: destination server and name are mutually exclusive, exactly
+                one must be set
+              rule: (has(self.destination.server) && self.destination.server.size()
+                > 0) != (has(self.destination.name) && self.destination.name.size()
+                > 0)
           status:
             description: ApplicationStatus contains status information for the application
             properties:
@@ -7940,6 +7950,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -8848,6 +8868,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -9757,6 +9787,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -10644,6 +10684,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -11556,6 +11606,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -12464,6 +12526,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -13373,6 +13447,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -14260,6 +14346,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -15155,6 +15253,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -16277,6 +16387,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -17390,6 +17512,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -18294,6 +18428,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -19208,6 +19352,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -20116,6 +20272,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -21025,6 +21193,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -21912,6 +22092,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -22807,6 +22999,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -23929,6 +24133,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -25042,6 +25258,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -25950,6 +26178,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -26844,6 +27082,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -27966,6 +28214,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -29079,6 +29337,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -30060,6 +30328,16 @@ spec:
                     - destination
                     - project
                     type: object
+                    x-kubernetes-validations:
+                    - message: source and sources are mutually exclusive, exactly
+                        one must be set
+                      rule: (has(self.source) && self.source != null) != (has(self.sources)
+                        && size(self.sources) > 0)
+                    - message: destination server and name are mutually exclusive,
+                        exactly one must be set
+                      rule: (has(self.destination.server) && self.destination.server.size()
+                        > 0) != (has(self.destination.name) && self.destination.name.size()
+                        > 0)
                 required:
                 - metadata
                 - spec

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -2309,15 +2309,13 @@ spec:
             - project
             type: object
             x-kubernetes-validations:
-            - message: source and sources are mutually exclusive, exactly one must
-                be set
-              rule: (has(self.source) && self.source != null) != (has(self.sources)
-                && size(self.sources) > 0)
-            - message: destination server and name are mutually exclusive, exactly
-                one must be set
-              rule: (has(self.destination.server) && self.destination.server.size()
-                > 0) != (has(self.destination.name) && self.destination.name.size()
-                > 0)
+            - message: source and sources are mutually exclusive
+              rule: '!((has(self.source) && self.source != null) && (has(self.sources)
+                && size(self.sources) > 0))'
+            - message: destination server and name are mutually exclusive
+              rule: '!((has(self.destination.server) && self.destination.server.size()
+                > 0) && (has(self.destination.name) && self.destination.name.size()
+                > 0))'
           status:
             description: ApplicationStatus contains status information for the application
             properties:
@@ -7951,15 +7949,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -8869,15 +8866,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -9788,15 +9784,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -10685,15 +10680,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -11608,16 +11602,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -12528,16 +12522,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -13449,16 +13443,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -14348,16 +14342,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -15255,16 +15249,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -16389,16 +16383,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -17514,16 +17508,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -18429,15 +18423,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -19354,16 +19347,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -20274,16 +20267,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -21195,16 +21188,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -22094,16 +22087,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -23001,16 +22994,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -24135,16 +24128,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -25260,16 +25253,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -26179,15 +26172,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -27083,15 +27075,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -28215,15 +28206,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -29338,15 +29328,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -30329,15 +30318,13 @@ spec:
                     - project
                     type: object
                     x-kubernetes-validations:
-                    - message: source and sources are mutually exclusive, exactly
-                        one must be set
-                      rule: (has(self.source) && self.source != null) != (has(self.sources)
-                        && size(self.sources) > 0)
-                    - message: destination server and name are mutually exclusive,
-                        exactly one must be set
-                      rule: (has(self.destination.server) && self.destination.server.size()
-                        > 0) != (has(self.destination.name) && self.destination.name.size()
-                        > 0)
+                    - message: source and sources are mutually exclusive
+                      rule: '!((has(self.source) && self.source != null) && (has(self.sources)
+                        && size(self.sources) > 0))'
+                    - message: destination server and name are mutually exclusive
+                      rule: '!((has(self.destination.server) && self.destination.server.size()
+                        > 0) && (has(self.destination.name) && self.destination.name.size()
+                        > 0))'
                 required:
                 - metadata
                 - spec

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -2309,10 +2309,12 @@ spec:
             - project
             type: object
             x-kubernetes-validations:
-            - message: source and sources are mutually exclusive
+            - message: application spec can't have both source and sources defined
               rule: '!((has(self.source) && self.source != null) && (has(self.sources)
                 && size(self.sources) > 0))'
-            - message: destination server and name are mutually exclusive
+            - message: application destination can't have both name and server defined
+              messageExpression: '''application destination can\''t have both name
+                and server defined: '' + self.destination.name + '' '' + self.destination.server'
               rule: '!((has(self.destination.server) && self.destination.server.size()
                 > 0) && (has(self.destination.name) && self.destination.name.size()
                 > 0))'
@@ -7949,11 +7951,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -8866,11 +8872,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -9784,11 +9794,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -10680,11 +10694,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -11601,13 +11619,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -12521,13 +12542,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -13442,13 +13466,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -14341,13 +14368,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -15248,13 +15278,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -16382,13 +16415,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -17507,13 +17543,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -18423,11 +18462,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -19346,13 +19389,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -20266,13 +20312,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -21187,13 +21236,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -22086,13 +22138,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -22993,13 +23048,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -24127,13 +24185,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -25252,13 +25313,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -26172,11 +26236,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -27075,11 +27143,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -28206,11 +28278,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -29328,11 +29404,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -30318,10 +30398,15 @@ spec:
                     - project
                     type: object
                     x-kubernetes-validations:
-                    - message: source and sources are mutually exclusive
+                    - message: application spec can't have both source and sources
+                        defined
                       rule: '!((has(self.source) && self.source != null) && (has(self.sources)
                         && size(self.sources) > 0))'
-                    - message: destination server and name are mutually exclusive
+                    - message: application destination can't have both name and server
+                        defined
+                      messageExpression: '''application destination can\''t have both
+                        name and server defined: '' + self.destination.name + '' ''
+                        + self.destination.server'
                       rule: '!((has(self.destination.server) && self.destination.server.size()
                         > 0) && (has(self.destination.name) && self.destination.name.size()
                         > 0))'

--- a/manifests/install-with-hydrator.yaml
+++ b/manifests/install-with-hydrator.yaml
@@ -2308,6 +2308,16 @@ spec:
             - destination
             - project
             type: object
+            x-kubernetes-validations:
+            - message: source and sources are mutually exclusive, exactly one must
+                be set
+              rule: (has(self.source) && self.source != null) != (has(self.sources)
+                && size(self.sources) > 0)
+            - message: destination server and name are mutually exclusive, exactly
+                one must be set
+              rule: (has(self.destination.server) && self.destination.server.size()
+                > 0) != (has(self.destination.name) && self.destination.name.size()
+                > 0)
           status:
             description: ApplicationStatus contains status information for the application
             properties:
@@ -7940,6 +7950,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -8848,6 +8868,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -9757,6 +9787,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -10644,6 +10684,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -11556,6 +11606,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -12464,6 +12526,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -13373,6 +13447,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -14260,6 +14346,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -15155,6 +15253,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -16277,6 +16387,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -17390,6 +17512,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -18294,6 +18428,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -19208,6 +19352,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -20116,6 +20272,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -21025,6 +21193,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -21912,6 +22092,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -22807,6 +22999,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -23929,6 +24133,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -25042,6 +25258,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -25950,6 +26178,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -26844,6 +27082,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -27966,6 +28214,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -29079,6 +29337,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -30060,6 +30328,16 @@ spec:
                     - destination
                     - project
                     type: object
+                    x-kubernetes-validations:
+                    - message: source and sources are mutually exclusive, exactly
+                        one must be set
+                      rule: (has(self.source) && self.source != null) != (has(self.sources)
+                        && size(self.sources) > 0)
+                    - message: destination server and name are mutually exclusive,
+                        exactly one must be set
+                      rule: (has(self.destination.server) && self.destination.server.size()
+                        > 0) != (has(self.destination.name) && self.destination.name.size()
+                        > 0)
                 required:
                 - metadata
                 - spec

--- a/manifests/install-with-hydrator.yaml
+++ b/manifests/install-with-hydrator.yaml
@@ -2309,15 +2309,13 @@ spec:
             - project
             type: object
             x-kubernetes-validations:
-            - message: source and sources are mutually exclusive, exactly one must
-                be set
-              rule: (has(self.source) && self.source != null) != (has(self.sources)
-                && size(self.sources) > 0)
-            - message: destination server and name are mutually exclusive, exactly
-                one must be set
-              rule: (has(self.destination.server) && self.destination.server.size()
-                > 0) != (has(self.destination.name) && self.destination.name.size()
-                > 0)
+            - message: source and sources are mutually exclusive
+              rule: '!((has(self.source) && self.source != null) && (has(self.sources)
+                && size(self.sources) > 0))'
+            - message: destination server and name are mutually exclusive
+              rule: '!((has(self.destination.server) && self.destination.server.size()
+                > 0) && (has(self.destination.name) && self.destination.name.size()
+                > 0))'
           status:
             description: ApplicationStatus contains status information for the application
             properties:
@@ -7951,15 +7949,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -8869,15 +8866,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -9788,15 +9784,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -10685,15 +10680,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -11608,16 +11602,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -12528,16 +12522,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -13449,16 +13443,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -14348,16 +14342,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -15255,16 +15249,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -16389,16 +16383,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -17514,16 +17508,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -18429,15 +18423,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -19354,16 +19347,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -20274,16 +20267,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -21195,16 +21188,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -22094,16 +22087,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -23001,16 +22994,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -24135,16 +24128,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -25260,16 +25253,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -26179,15 +26172,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -27083,15 +27075,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -28215,15 +28206,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -29338,15 +29328,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -30329,15 +30318,13 @@ spec:
                     - project
                     type: object
                     x-kubernetes-validations:
-                    - message: source and sources are mutually exclusive, exactly
-                        one must be set
-                      rule: (has(self.source) && self.source != null) != (has(self.sources)
-                        && size(self.sources) > 0)
-                    - message: destination server and name are mutually exclusive,
-                        exactly one must be set
-                      rule: (has(self.destination.server) && self.destination.server.size()
-                        > 0) != (has(self.destination.name) && self.destination.name.size()
-                        > 0)
+                    - message: source and sources are mutually exclusive
+                      rule: '!((has(self.source) && self.source != null) && (has(self.sources)
+                        && size(self.sources) > 0))'
+                    - message: destination server and name are mutually exclusive
+                      rule: '!((has(self.destination.server) && self.destination.server.size()
+                        > 0) && (has(self.destination.name) && self.destination.name.size()
+                        > 0))'
                 required:
                 - metadata
                 - spec

--- a/manifests/install-with-hydrator.yaml
+++ b/manifests/install-with-hydrator.yaml
@@ -2309,10 +2309,12 @@ spec:
             - project
             type: object
             x-kubernetes-validations:
-            - message: source and sources are mutually exclusive
+            - message: application spec can't have both source and sources defined
               rule: '!((has(self.source) && self.source != null) && (has(self.sources)
                 && size(self.sources) > 0))'
-            - message: destination server and name are mutually exclusive
+            - message: application destination can't have both name and server defined
+              messageExpression: '''application destination can\''t have both name
+                and server defined: '' + self.destination.name + '' '' + self.destination.server'
               rule: '!((has(self.destination.server) && self.destination.server.size()
                 > 0) && (has(self.destination.name) && self.destination.name.size()
                 > 0))'
@@ -7949,11 +7951,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -8866,11 +8872,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -9784,11 +9794,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -10680,11 +10694,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -11601,13 +11619,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -12521,13 +12542,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -13442,13 +13466,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -14341,13 +14368,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -15248,13 +15278,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -16382,13 +16415,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -17507,13 +17543,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -18423,11 +18462,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -19346,13 +19389,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -20266,13 +20312,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -21187,13 +21236,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -22086,13 +22138,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -22993,13 +23048,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -24127,13 +24185,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -25252,13 +25313,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -26172,11 +26236,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -27075,11 +27143,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -28206,11 +28278,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -29328,11 +29404,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -30318,10 +30398,15 @@ spec:
                     - project
                     type: object
                     x-kubernetes-validations:
-                    - message: source and sources are mutually exclusive
+                    - message: application spec can't have both source and sources
+                        defined
                       rule: '!((has(self.source) && self.source != null) && (has(self.sources)
                         && size(self.sources) > 0))'
-                    - message: destination server and name are mutually exclusive
+                    - message: application destination can't have both name and server
+                        defined
+                      messageExpression: '''application destination can\''t have both
+                        name and server defined: '' + self.destination.name + '' ''
+                        + self.destination.server'
                       rule: '!((has(self.destination.server) && self.destination.server.size()
                         > 0) && (has(self.destination.name) && self.destination.name.size()
                         > 0))'

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -2308,6 +2308,16 @@ spec:
             - destination
             - project
             type: object
+            x-kubernetes-validations:
+            - message: source and sources are mutually exclusive, exactly one must
+                be set
+              rule: (has(self.source) && self.source != null) != (has(self.sources)
+                && size(self.sources) > 0)
+            - message: destination server and name are mutually exclusive, exactly
+                one must be set
+              rule: (has(self.destination.server) && self.destination.server.size()
+                > 0) != (has(self.destination.name) && self.destination.name.size()
+                > 0)
           status:
             description: ApplicationStatus contains status information for the application
             properties:
@@ -7940,6 +7950,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -8848,6 +8868,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -9757,6 +9787,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -10644,6 +10684,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -11556,6 +11606,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -12464,6 +12526,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -13373,6 +13447,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -14260,6 +14346,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -15155,6 +15253,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -16277,6 +16387,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -17390,6 +17512,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -18294,6 +18428,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -19208,6 +19352,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -20116,6 +20272,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -21025,6 +21193,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -21912,6 +22092,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -22807,6 +22999,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -23929,6 +24133,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -25042,6 +25258,18 @@ spec:
                                         - destination
                                         - project
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: source and sources are mutually
+                                            exclusive, exactly one must be set
+                                          rule: (has(self.source) && self.source !=
+                                            null) != (has(self.sources) && size(self.sources)
+                                            > 0)
+                                        - message: destination server and name are
+                                            mutually exclusive, exactly one must be
+                                            set
+                                          rule: (has(self.destination.server) && self.destination.server.size()
+                                            > 0) != (has(self.destination.name) &&
+                                            self.destination.name.size() > 0)
                                     required:
                                     - metadata
                                     - spec
@@ -25950,6 +26178,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -26844,6 +27082,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -27966,6 +28214,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -29079,6 +29337,16 @@ spec:
                               - destination
                               - project
                               type: object
+                              x-kubernetes-validations:
+                              - message: source and sources are mutually exclusive,
+                                  exactly one must be set
+                                rule: (has(self.source) && self.source != null) !=
+                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: destination server and name are mutually
+                                  exclusive, exactly one must be set
+                                rule: (has(self.destination.server) && self.destination.server.size()
+                                  > 0) != (has(self.destination.name) && self.destination.name.size()
+                                  > 0)
                           required:
                           - metadata
                           - spec
@@ -30060,6 +30328,16 @@ spec:
                     - destination
                     - project
                     type: object
+                    x-kubernetes-validations:
+                    - message: source and sources are mutually exclusive, exactly
+                        one must be set
+                      rule: (has(self.source) && self.source != null) != (has(self.sources)
+                        && size(self.sources) > 0)
+                    - message: destination server and name are mutually exclusive,
+                        exactly one must be set
+                      rule: (has(self.destination.server) && self.destination.server.size()
+                        > 0) != (has(self.destination.name) && self.destination.name.size()
+                        > 0)
                 required:
                 - metadata
                 - spec

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -2309,15 +2309,13 @@ spec:
             - project
             type: object
             x-kubernetes-validations:
-            - message: source and sources are mutually exclusive, exactly one must
-                be set
-              rule: (has(self.source) && self.source != null) != (has(self.sources)
-                && size(self.sources) > 0)
-            - message: destination server and name are mutually exclusive, exactly
-                one must be set
-              rule: (has(self.destination.server) && self.destination.server.size()
-                > 0) != (has(self.destination.name) && self.destination.name.size()
-                > 0)
+            - message: source and sources are mutually exclusive
+              rule: '!((has(self.source) && self.source != null) && (has(self.sources)
+                && size(self.sources) > 0))'
+            - message: destination server and name are mutually exclusive
+              rule: '!((has(self.destination.server) && self.destination.server.size()
+                > 0) && (has(self.destination.name) && self.destination.name.size()
+                > 0))'
           status:
             description: ApplicationStatus contains status information for the application
             properties:
@@ -7951,15 +7949,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -8869,15 +8866,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -9788,15 +9784,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -10685,15 +10680,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -11608,16 +11602,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -12528,16 +12522,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -13449,16 +13443,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -14348,16 +14342,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -15255,16 +15249,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -16389,16 +16383,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -17514,16 +17508,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -18429,15 +18423,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -19354,16 +19347,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -20274,16 +20267,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -21195,16 +21188,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -22094,16 +22087,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -23001,16 +22994,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -24135,16 +24128,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -25260,16 +25253,16 @@ spec:
                                         type: object
                                         x-kubernetes-validations:
                                         - message: source and sources are mutually
-                                            exclusive, exactly one must be set
-                                          rule: (has(self.source) && self.source !=
-                                            null) != (has(self.sources) && size(self.sources)
-                                            > 0)
+                                            exclusive
+                                          rule: '!((has(self.source) && self.source
+                                            != null) && (has(self.sources) && size(self.sources)
+                                            > 0))'
                                         - message: destination server and name are
-                                            mutually exclusive, exactly one must be
-                                            set
-                                          rule: (has(self.destination.server) && self.destination.server.size()
-                                            > 0) != (has(self.destination.name) &&
-                                            self.destination.name.size() > 0)
+                                            mutually exclusive
+                                          rule: '!((has(self.destination.server) &&
+                                            self.destination.server.size() > 0) &&
+                                            (has(self.destination.name) && self.destination.name.size()
+                                            > 0))'
                                     required:
                                     - metadata
                                     - spec
@@ -26179,15 +26172,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -27083,15 +27075,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -28215,15 +28206,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -29338,15 +29328,14 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive,
-                                  exactly one must be set
-                                rule: (has(self.source) && self.source != null) !=
-                                  (has(self.sources) && size(self.sources) > 0)
+                              - message: source and sources are mutually exclusive
+                                rule: '!((has(self.source) && self.source != null)
+                                  && (has(self.sources) && size(self.sources) > 0))'
                               - message: destination server and name are mutually
-                                  exclusive, exactly one must be set
-                                rule: (has(self.destination.server) && self.destination.server.size()
-                                  > 0) != (has(self.destination.name) && self.destination.name.size()
-                                  > 0)
+                                  exclusive
+                                rule: '!((has(self.destination.server) && self.destination.server.size()
+                                  > 0) && (has(self.destination.name) && self.destination.name.size()
+                                  > 0))'
                           required:
                           - metadata
                           - spec
@@ -30329,15 +30318,13 @@ spec:
                     - project
                     type: object
                     x-kubernetes-validations:
-                    - message: source and sources are mutually exclusive, exactly
-                        one must be set
-                      rule: (has(self.source) && self.source != null) != (has(self.sources)
-                        && size(self.sources) > 0)
-                    - message: destination server and name are mutually exclusive,
-                        exactly one must be set
-                      rule: (has(self.destination.server) && self.destination.server.size()
-                        > 0) != (has(self.destination.name) && self.destination.name.size()
-                        > 0)
+                    - message: source and sources are mutually exclusive
+                      rule: '!((has(self.source) && self.source != null) && (has(self.sources)
+                        && size(self.sources) > 0))'
+                    - message: destination server and name are mutually exclusive
+                      rule: '!((has(self.destination.server) && self.destination.server.size()
+                        > 0) && (has(self.destination.name) && self.destination.name.size()
+                        > 0))'
                 required:
                 - metadata
                 - spec

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -2309,10 +2309,12 @@ spec:
             - project
             type: object
             x-kubernetes-validations:
-            - message: source and sources are mutually exclusive
+            - message: application spec can't have both source and sources defined
               rule: '!((has(self.source) && self.source != null) && (has(self.sources)
                 && size(self.sources) > 0))'
-            - message: destination server and name are mutually exclusive
+            - message: application destination can't have both name and server defined
+              messageExpression: '''application destination can\''t have both name
+                and server defined: '' + self.destination.name + '' '' + self.destination.server'
               rule: '!((has(self.destination.server) && self.destination.server.size()
                 > 0) && (has(self.destination.name) && self.destination.name.size()
                 > 0))'
@@ -7949,11 +7951,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -8866,11 +8872,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -9784,11 +9794,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -10680,11 +10694,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -11601,13 +11619,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -12521,13 +12542,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -13442,13 +13466,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -14341,13 +14368,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -15248,13 +15278,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -16382,13 +16415,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -17507,13 +17543,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -18423,11 +18462,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -19346,13 +19389,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -20266,13 +20312,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -21187,13 +21236,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -22086,13 +22138,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -22993,13 +23048,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -24127,13 +24185,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -25252,13 +25313,16 @@ spec:
                                         - project
                                         type: object
                                         x-kubernetes-validations:
-                                        - message: source and sources are mutually
-                                            exclusive
+                                        - message: application spec can't have both
+                                            source and sources defined
                                           rule: '!((has(self.source) && self.source
                                             != null) && (has(self.sources) && size(self.sources)
                                             > 0))'
-                                        - message: destination server and name are
-                                            mutually exclusive
+                                        - message: application destination can't have
+                                            both name and server defined
+                                          messageExpression: '''application destination
+                                            can\''t have both name and server defined:
+                                            '' + self.destination.name + '' '' + self.destination.server'
                                           rule: '!((has(self.destination.server) &&
                                             self.destination.server.size() > 0) &&
                                             (has(self.destination.name) && self.destination.name.size()
@@ -26172,11 +26236,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -27075,11 +27143,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -28206,11 +28278,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -29328,11 +29404,15 @@ spec:
                               - project
                               type: object
                               x-kubernetes-validations:
-                              - message: source and sources are mutually exclusive
+                              - message: application spec can't have both source and
+                                  sources defined
                                 rule: '!((has(self.source) && self.source != null)
                                   && (has(self.sources) && size(self.sources) > 0))'
-                              - message: destination server and name are mutually
-                                  exclusive
+                              - message: application destination can't have both name
+                                  and server defined
+                                messageExpression: '''application destination can\''t
+                                  have both name and server defined: '' + self.destination.name
+                                  + '' '' + self.destination.server'
                                 rule: '!((has(self.destination.server) && self.destination.server.size()
                                   > 0) && (has(self.destination.name) && self.destination.name.size()
                                   > 0))'
@@ -30318,10 +30398,15 @@ spec:
                     - project
                     type: object
                     x-kubernetes-validations:
-                    - message: source and sources are mutually exclusive
+                    - message: application spec can't have both source and sources
+                        defined
                       rule: '!((has(self.source) && self.source != null) && (has(self.sources)
                         && size(self.sources) > 0))'
-                    - message: destination server and name are mutually exclusive
+                    - message: application destination can't have both name and server
+                        defined
+                      messageExpression: '''application destination can\''t have both
+                        name and server defined: '' + self.destination.name + '' ''
+                        + self.destination.server'
                       rule: '!((has(self.destination.server) && self.destination.server.size()
                         > 0) && (has(self.destination.name) && self.destination.name.size()
                         > 0))'

--- a/pkg/apis/application/v1alpha1/generated.proto
+++ b/pkg/apis/application/v1alpha1/generated.proto
@@ -652,6 +652,8 @@ message ApplicationSourcePluginParameter {
 }
 
 // ApplicationSpec represents desired application state. Contains link to repository with application definition and additional parameters link definition revision.
+// +kubebuilder:validation:XValidation:rule="(has(self.source) && self.source != null) != (has(self.sources) && size(self.sources) > 0)",message="source and sources are mutually exclusive, exactly one must be set"
+// +kubebuilder:validation:XValidation:rule="(has(self.destination.server) && self.destination.server.size() > 0) != (has(self.destination.name) && self.destination.name.size() > 0)",message="destination server and name are mutually exclusive, exactly one must be set"
 message ApplicationSpec {
   // Source is a reference to the location of the application's manifests or chart
   optional ApplicationSource source = 1;

--- a/pkg/apis/application/v1alpha1/generated.proto
+++ b/pkg/apis/application/v1alpha1/generated.proto
@@ -652,8 +652,8 @@ message ApplicationSourcePluginParameter {
 }
 
 // ApplicationSpec represents desired application state. Contains link to repository with application definition and additional parameters link definition revision.
-// +kubebuilder:validation:XValidation:rule="(has(self.source) && self.source != null) != (has(self.sources) && size(self.sources) > 0)",message="source and sources are mutually exclusive, exactly one must be set"
-// +kubebuilder:validation:XValidation:rule="(has(self.destination.server) && self.destination.server.size() > 0) != (has(self.destination.name) && self.destination.name.size() > 0)",message="destination server and name are mutually exclusive, exactly one must be set"
+// +kubebuilder:validation:XValidation:rule="!((has(self.source) && self.source != null) && (has(self.sources) && size(self.sources) > 0))",message="source and sources are mutually exclusive"
+// +kubebuilder:validation:XValidation:rule="!((has(self.destination.server) && self.destination.server.size() > 0) && (has(self.destination.name) && self.destination.name.size() > 0))",message="destination server and name are mutually exclusive"
 message ApplicationSpec {
   // Source is a reference to the location of the application's manifests or chart
   optional ApplicationSource source = 1;

--- a/pkg/apis/application/v1alpha1/generated.proto
+++ b/pkg/apis/application/v1alpha1/generated.proto
@@ -652,8 +652,8 @@ message ApplicationSourcePluginParameter {
 }
 
 // ApplicationSpec represents desired application state. Contains link to repository with application definition and additional parameters link definition revision.
-// +kubebuilder:validation:XValidation:rule="!((has(self.source) && self.source != null) && (has(self.sources) && size(self.sources) > 0))",message="source and sources are mutually exclusive"
-// +kubebuilder:validation:XValidation:rule="!((has(self.destination.server) && self.destination.server.size() > 0) && (has(self.destination.name) && self.destination.name.size() > 0))",message="destination server and name are mutually exclusive"
+// +kubebuilder:validation:XValidation:rule="!((has(self.source) && self.source != null) && (has(self.sources) && size(self.sources) > 0))",message="application spec can't have both source and sources defined"
+// +kubebuilder:validation:XValidation:rule="!((has(self.destination.server) && self.destination.server.size() > 0) && (has(self.destination.name) && self.destination.name.size() > 0))",message="application destination can't have both name and server defined",messageExpression="'application destination can\\'t have both name and server defined: ' + self.destination.name + ' ' + self.destination.server"
 message ApplicationSpec {
   // Source is a reference to the location of the application's manifests or chart
   optional ApplicationSource source = 1;

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -73,8 +73,8 @@ type Application struct {
 }
 
 // ApplicationSpec represents desired application state. Contains link to repository with application definition and additional parameters link definition revision.
-// +kubebuilder:validation:XValidation:rule="(has(self.source) && self.source != null) != (has(self.sources) && size(self.sources) > 0)",message="source and sources are mutually exclusive, exactly one must be set"
-// +kubebuilder:validation:XValidation:rule="(has(self.destination.server) && self.destination.server.size() > 0) != (has(self.destination.name) && self.destination.name.size() > 0)",message="destination server and name are mutually exclusive, exactly one must be set"
+// +kubebuilder:validation:XValidation:rule="!((has(self.source) && self.source != null) && (has(self.sources) && size(self.sources) > 0))",message="source and sources are mutually exclusive"
+// +kubebuilder:validation:XValidation:rule="!((has(self.destination.server) && self.destination.server.size() > 0) && (has(self.destination.name) && self.destination.name.size() > 0))",message="destination server and name are mutually exclusive"
 type ApplicationSpec struct {
 	// Source is a reference to the location of the application's manifests or chart
 	Source *ApplicationSource `json:"source,omitempty" protobuf:"bytes,1,opt,name=source"`

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -73,6 +73,8 @@ type Application struct {
 }
 
 // ApplicationSpec represents desired application state. Contains link to repository with application definition and additional parameters link definition revision.
+// +kubebuilder:validation:XValidation:rule="(has(self.source) && self.source != null) != (has(self.sources) && size(self.sources) > 0)",message="source and sources are mutually exclusive, exactly one must be set"
+// +kubebuilder:validation:XValidation:rule="(has(self.destination.server) && self.destination.server.size() > 0) != (has(self.destination.name) && self.destination.name.size() > 0)",message="destination server and name are mutually exclusive, exactly one must be set"
 type ApplicationSpec struct {
 	// Source is a reference to the location of the application's manifests or chart
 	Source *ApplicationSource `json:"source,omitempty" protobuf:"bytes,1,opt,name=source"`

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -73,8 +73,8 @@ type Application struct {
 }
 
 // ApplicationSpec represents desired application state. Contains link to repository with application definition and additional parameters link definition revision.
-// +kubebuilder:validation:XValidation:rule="!((has(self.source) && self.source != null) && (has(self.sources) && size(self.sources) > 0))",message="source and sources are mutually exclusive"
-// +kubebuilder:validation:XValidation:rule="!((has(self.destination.server) && self.destination.server.size() > 0) && (has(self.destination.name) && self.destination.name.size() > 0))",message="destination server and name are mutually exclusive"
+// +kubebuilder:validation:XValidation:rule="!((has(self.source) && self.source != null) && (has(self.sources) && size(self.sources) > 0))",message="application spec can't have both source and sources defined"
+// +kubebuilder:validation:XValidation:rule="!((has(self.destination.server) && self.destination.server.size() > 0) && (has(self.destination.name) && self.destination.name.size() > 0))",message="application destination can't have both name and server defined",messageExpression="'application destination can\\'t have both name and server defined: ' + self.destination.name + ' ' + self.destination.server"
 type ApplicationSpec struct {
 	// Source is a reference to the location of the application's manifests or chart
 	Source *ApplicationSource `json:"source,omitempty" protobuf:"bytes,1,opt,name=source"`

--- a/server/application/application_test.go
+++ b/server/application/application_test.go
@@ -85,7 +85,7 @@ func (t *dryRunAwareTracker) Create(gvr schema.GroupVersionResource, obj runtime
 		if err != nil {
 			return err
 		}
-		_, err = t.ObjectTracker.Get(gvr, ns, meta.GetName())
+		_, err = t.Get(gvr, ns, meta.GetName())
 		if err == nil {
 			// Object already exists
 			return apierrors.NewAlreadyExists(gvr.GroupResource(), meta.GetName())
@@ -105,7 +105,7 @@ func (t *dryRunAwareTracker) Update(gvr schema.GroupVersionResource, obj runtime
 		if err != nil {
 			return err
 		}
-		_, err = t.ObjectTracker.Get(gvr, ns, meta.GetName())
+		_, err = t.Get(gvr, ns, meta.GetName())
 		if err != nil {
 			// Object doesn't exist
 			return err

--- a/test/e2e/crd_validation_test.go
+++ b/test/e2e/crd_validation_test.go
@@ -24,20 +24,19 @@ func TestApplicationDestinationValidation_BothServerAndName(t *testing.T) {
 		Expect(Error("", "mutually exclusive"))
 }
 
-// TestApplicationDestinationValidation_NeitherServerNorName verifies that the CRD validation
-// rejects an Application with neither server nor name set in the destination
+// TestApplicationDestinationValidation_NeitherServerNorName verifies that an Application
+// with neither server nor name is allowed (for ApplicationSet templates)
 func TestApplicationDestinationValidation_NeitherServerNorName(t *testing.T) {
 	Given(t).
 		Path(guestbookPath).
 		When().
-		IgnoreErrors().
 		CreateFromFile(func(app *Application) {
-			// Clear both server and name - this should be rejected by CEL validation
+			// Clear both server and name - this is valid for templates
 			app.Spec.Destination.Server = ""
 			app.Spec.Destination.Name = ""
 		}).
 		Then().
-		Expect(Error("", "mutually exclusive"))
+		Expect(Success(""))
 }
 
 // TestApplicationDestinationValidation_ValidServerOnly verifies that an Application
@@ -79,36 +78,34 @@ func TestApplicationSourceValidation_BothSourceAndSources(t *testing.T) {
 		Expect(Error("", "mutually exclusive"))
 }
 
-// TestApplicationSourceValidation_NeitherSourceNorSources verifies that the CRD validation
-// rejects an Application with neither source nor sources set
+// TestApplicationSourceValidation_NeitherSourceNorSources verifies that an Application
+// with neither source nor sources is allowed (for ApplicationSet templates)
 func TestApplicationSourceValidation_NeitherSourceNorSources(t *testing.T) {
 	Given(t).
 		Path(guestbookPath).
 		When().
-		IgnoreErrors().
 		CreateFromFile(func(app *Application) {
-			// Clear both source and sources - this should be rejected by CEL validation
+			// Clear both source and sources - this is valid for templates
 			app.Spec.Source = nil
 			app.Spec.Sources = nil
 		}).
 		Then().
-		Expect(Error("", "mutually exclusive"))
+		Expect(Success(""))
 }
 
-// TestApplicationSourceValidation_EmptySourcesArray verifies that the CRD validation
-// rejects an Application with an empty sources array
+// TestApplicationSourceValidation_EmptySourcesArray verifies that an Application
+// with an empty sources array is allowed (for ApplicationSet templates)
 func TestApplicationSourceValidation_EmptySourcesArray(t *testing.T) {
 	Given(t).
 		Path(guestbookPath).
 		When().
-		IgnoreErrors().
 		CreateFromFile(func(app *Application) {
-			// Set sources to empty array - this should be rejected by CEL validation
+			// Set sources to empty array - this is valid for templates
 			app.Spec.Source = nil
 			app.Spec.Sources = ApplicationSources{}
 		}).
 		Then().
-		Expect(Error("", "mutually exclusive"))
+		Expect(Success(""))
 }
 
 // TestApplicationSourceValidation_ValidSourceOnly verifies that an Application

--- a/test/e2e/crd_validation_test.go
+++ b/test/e2e/crd_validation_test.go
@@ -21,22 +21,7 @@ func TestApplicationDestinationValidationBothServerAndName(t *testing.T) {
 			app.Spec.Destination.Name = "in-cluster"
 		}).
 		Then().
-		Expect(Error("", "mutually exclusive"))
-}
-
-// TestApplicationDestinationValidationNeitherServerNorName verifies that an Application
-// with neither server nor name is allowed (for ApplicationSet templates)
-func TestApplicationDestinationValidationNeitherServerNorName(t *testing.T) {
-	Given(t).
-		Path(guestbookPath).
-		When().
-		CreateFromFile(func(app *Application) {
-			// Clear both server and name - this is valid for templates
-			app.Spec.Destination.Server = ""
-			app.Spec.Destination.Name = ""
-		}).
-		Then().
-		Expect(Success(""))
+		Expect(Error("", "can't have both name and server defined"))
 }
 
 // TestApplicationDestinationValidationValidServerOnly verifies that an Application
@@ -75,26 +60,8 @@ func TestApplicationValidationBothSourceAndSources(t *testing.T) {
 			}
 		}).
 		Then().
-		Expect(Error("", "mutually exclusive"))
+		Expect(Error("", "can't have both source and sources defined"))
 }
-
-// TestApplicationSourceValidationEmptySourcesArray verifies that an Application
-// with an empty sources array is allowed (for ApplicationSet templates)
-/*
-func TestApplicationSourceValidationEmptySourcesArray(t *testing.T) {
-	Given(t).
-		Path(guestbookPath).
-		When().
-		CreateFromFile(func(app *Application) {
-			// Set sources to empty array - this is valid for templates
-			app.Spec.Source = nil
-			app.Spec.Sources = ApplicationSources{}
-		}).
-		Then().
-		Expect(Success(""))
-}
-
-*/
 
 // TestApplicationSourceValidationValidSourceOnly verifies that an Application
 // with only source set is accepted
@@ -147,10 +114,9 @@ func TestApplicationSourceValidationValidMultipleSources(t *testing.T) {
 				{
 					RepoURL: RepoURL(RepoURLTypeFile),
 					Path:    guestbookPath,
-				},
-				{
+				}, {
 					RepoURL: RepoURL(RepoURLTypeFile),
-					Path:    "kustomize-guestbook",
+					Path:    "two-nice-pods",
 				},
 			}
 		}).

--- a/test/e2e/crd_validation_test.go
+++ b/test/e2e/crd_validation_test.go
@@ -8,9 +8,9 @@ import (
 	. "github.com/argoproj/argo-cd/v3/test/e2e/fixture/app"
 )
 
-// TestApplicationDestinationValidation_BothServerAndName verifies that the CRD validation
+// TestApplicationDestinationValidationBothServerAndName verifies that the CRD validation
 // rejects an Application with both server and name set in the destination
-func TestApplicationDestinationValidation_BothServerAndName(t *testing.T) {
+func TestApplicationDestinationValidationBothServerAndName(t *testing.T) {
 	Given(t).
 		Path(guestbookPath).
 		When().
@@ -24,9 +24,9 @@ func TestApplicationDestinationValidation_BothServerAndName(t *testing.T) {
 		Expect(Error("", "mutually exclusive"))
 }
 
-// TestApplicationDestinationValidation_NeitherServerNorName verifies that an Application
+// TestApplicationDestinationValidationNeitherServerNorName verifies that an Application
 // with neither server nor name is allowed (for ApplicationSet templates)
-func TestApplicationDestinationValidation_NeitherServerNorName(t *testing.T) {
+func TestApplicationDestinationValidationNeitherServerNorName(t *testing.T) {
 	Given(t).
 		Path(guestbookPath).
 		When().
@@ -39,9 +39,9 @@ func TestApplicationDestinationValidation_NeitherServerNorName(t *testing.T) {
 		Expect(Success(""))
 }
 
-// TestApplicationDestinationValidation_ValidServerOnly verifies that an Application
+// TestApplicationDestinationValidationValidServerOnly verifies that an Application
 // with only server set is accepted
-func TestApplicationDestinationValidation_ValidServerOnly(t *testing.T) {
+func TestApplicationDestinationValidationValidServerOnly(t *testing.T) {
 	Given(t).
 		Path(guestbookPath).
 		When().
@@ -54,9 +54,9 @@ func TestApplicationDestinationValidation_ValidServerOnly(t *testing.T) {
 		Expect(Success(""))
 }
 
-// TestApplicationSourceValidation_BothSourceAndSources verifies that the CRD validation
+// TestApplicationSourceValidationBothSourceAndSources verifies that the CRD validation
 // rejects an Application with both source and sources set
-func TestApplicationSourceValidation_BothSourceAndSources(t *testing.T) {
+func TestApplicationSourceValidationBothSourceAndSources(t *testing.T) {
 	Given(t).
 		Path(guestbookPath).
 		When().
@@ -78,9 +78,9 @@ func TestApplicationSourceValidation_BothSourceAndSources(t *testing.T) {
 		Expect(Error("", "mutually exclusive"))
 }
 
-// TestApplicationSourceValidation_NeitherSourceNorSources verifies that an Application
+// TestApplicationSourceValidationNeitherSourceNorSources verifies that an Application
 // with neither source nor sources is allowed (for ApplicationSet templates)
-func TestApplicationSourceValidation_NeitherSourceNorSources(t *testing.T) {
+func TestApplicationSourceValidationNeitherSourceNorSources(t *testing.T) {
 	Given(t).
 		Path(guestbookPath).
 		When().
@@ -93,9 +93,9 @@ func TestApplicationSourceValidation_NeitherSourceNorSources(t *testing.T) {
 		Expect(Success(""))
 }
 
-// TestApplicationSourceValidation_EmptySourcesArray verifies that an Application
+// TestApplicationSourceValidationEmptySourcesArray verifies that an Application
 // with an empty sources array is allowed (for ApplicationSet templates)
-func TestApplicationSourceValidation_EmptySourcesArray(t *testing.T) {
+func TestApplicationSourceValidationEmptySourcesArray(t *testing.T) {
 	Given(t).
 		Path(guestbookPath).
 		When().
@@ -108,9 +108,9 @@ func TestApplicationSourceValidation_EmptySourcesArray(t *testing.T) {
 		Expect(Success(""))
 }
 
-// TestApplicationSourceValidation_ValidSourceOnly verifies that an Application
+// TestApplicationSourceValidationValidSourceOnly verifies that an Application
 // with only source set is accepted
-func TestApplicationSourceValidation_ValidSourceOnly(t *testing.T) {
+func TestApplicationSourceValidationValidSourceOnly(t *testing.T) {
 	Given(t).
 		Path(guestbookPath).
 		When().
@@ -126,9 +126,9 @@ func TestApplicationSourceValidation_ValidSourceOnly(t *testing.T) {
 		Expect(Success(""))
 }
 
-// TestApplicationSourceValidation_ValidSourcesOnly verifies that an Application
+// TestApplicationSourceValidationValidSourcesOnly verifies that an Application
 // with only sources set is accepted
-func TestApplicationSourceValidation_ValidSourcesOnly(t *testing.T) {
+func TestApplicationSourceValidationValidSourcesOnly(t *testing.T) {
 	Given(t).
 		Path(guestbookPath).
 		When().
@@ -146,9 +146,9 @@ func TestApplicationSourceValidation_ValidSourcesOnly(t *testing.T) {
 		Expect(Success(""))
 }
 
-// TestApplicationSourceValidation_ValidMultipleSources verifies that an Application
+// TestApplicationSourceValidationValidMultipleSources verifies that an Application
 // with multiple sources is accepted
-func TestApplicationSourceValidation_ValidMultipleSources(t *testing.T) {
+func TestApplicationSourceValidationValidMultipleSources(t *testing.T) {
 	Given(t).
 		Path(guestbookPath).
 		When().

--- a/test/e2e/crd_validation_test.go
+++ b/test/e2e/crd_validation_test.go
@@ -1,0 +1,174 @@
+package e2e
+
+import (
+	"testing"
+
+	. "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	. "github.com/argoproj/argo-cd/v3/test/e2e/fixture"
+	. "github.com/argoproj/argo-cd/v3/test/e2e/fixture/app"
+)
+
+// TestApplicationDestinationValidation_BothServerAndName verifies that the CRD validation
+// rejects an Application with both server and name set in the destination
+func TestApplicationDestinationValidation_BothServerAndName(t *testing.T) {
+	Given(t).
+		Path(guestbookPath).
+		When().
+		IgnoreErrors().
+		CreateFromFile(func(app *Application) {
+			// Set both server and name - this should be rejected by CEL validation
+			app.Spec.Destination.Server = KubernetesInternalAPIServerAddr
+			app.Spec.Destination.Name = "in-cluster"
+		}).
+		Then().
+		Expect(Error("", "mutually exclusive"))
+}
+
+// TestApplicationDestinationValidation_NeitherServerNorName verifies that the CRD validation
+// rejects an Application with neither server nor name set in the destination
+func TestApplicationDestinationValidation_NeitherServerNorName(t *testing.T) {
+	Given(t).
+		Path(guestbookPath).
+		When().
+		IgnoreErrors().
+		CreateFromFile(func(app *Application) {
+			// Clear both server and name - this should be rejected by CEL validation
+			app.Spec.Destination.Server = ""
+			app.Spec.Destination.Name = ""
+		}).
+		Then().
+		Expect(Error("", "mutually exclusive"))
+}
+
+// TestApplicationDestinationValidation_ValidServerOnly verifies that an Application
+// with only server set is accepted
+func TestApplicationDestinationValidation_ValidServerOnly(t *testing.T) {
+	Given(t).
+		Path(guestbookPath).
+		When().
+		CreateFromFile(func(app *Application) {
+			// Only server is set - this should be valid
+			app.Spec.Destination.Server = KubernetesInternalAPIServerAddr
+			app.Spec.Destination.Name = ""
+		}).
+		Then().
+		Expect(Success(""))
+}
+
+// TestApplicationSourceValidation_BothSourceAndSources verifies that the CRD validation
+// rejects an Application with both source and sources set
+func TestApplicationSourceValidation_BothSourceAndSources(t *testing.T) {
+	Given(t).
+		Path(guestbookPath).
+		When().
+		IgnoreErrors().
+		CreateFromFile(func(app *Application) {
+			// Set both source and sources - this should be rejected by CEL validation
+			app.Spec.Source = &ApplicationSource{
+				RepoURL: RepoURL(RepoURLTypeFile),
+				Path:    guestbookPath,
+			}
+			app.Spec.Sources = ApplicationSources{
+				{
+					RepoURL: RepoURL(RepoURLTypeFile),
+					Path:    "helm-guestbook",
+				},
+			}
+		}).
+		Then().
+		Expect(Error("", "mutually exclusive"))
+}
+
+// TestApplicationSourceValidation_NeitherSourceNorSources verifies that the CRD validation
+// rejects an Application with neither source nor sources set
+func TestApplicationSourceValidation_NeitherSourceNorSources(t *testing.T) {
+	Given(t).
+		Path(guestbookPath).
+		When().
+		IgnoreErrors().
+		CreateFromFile(func(app *Application) {
+			// Clear both source and sources - this should be rejected by CEL validation
+			app.Spec.Source = nil
+			app.Spec.Sources = nil
+		}).
+		Then().
+		Expect(Error("", "mutually exclusive"))
+}
+
+// TestApplicationSourceValidation_EmptySourcesArray verifies that the CRD validation
+// rejects an Application with an empty sources array
+func TestApplicationSourceValidation_EmptySourcesArray(t *testing.T) {
+	Given(t).
+		Path(guestbookPath).
+		When().
+		IgnoreErrors().
+		CreateFromFile(func(app *Application) {
+			// Set sources to empty array - this should be rejected by CEL validation
+			app.Spec.Source = nil
+			app.Spec.Sources = ApplicationSources{}
+		}).
+		Then().
+		Expect(Error("", "mutually exclusive"))
+}
+
+// TestApplicationSourceValidation_ValidSourceOnly verifies that an Application
+// with only source set is accepted
+func TestApplicationSourceValidation_ValidSourceOnly(t *testing.T) {
+	Given(t).
+		Path(guestbookPath).
+		When().
+		CreateFromFile(func(app *Application) {
+			// Only source is set - this should be valid
+			app.Spec.Source = &ApplicationSource{
+				RepoURL: RepoURL(RepoURLTypeFile),
+				Path:    guestbookPath,
+			}
+			app.Spec.Sources = nil
+		}).
+		Then().
+		Expect(Success(""))
+}
+
+// TestApplicationSourceValidation_ValidSourcesOnly verifies that an Application
+// with only sources set is accepted
+func TestApplicationSourceValidation_ValidSourcesOnly(t *testing.T) {
+	Given(t).
+		Path(guestbookPath).
+		When().
+		CreateFromFile(func(app *Application) {
+			// Only sources is set - this should be valid
+			app.Spec.Source = nil
+			app.Spec.Sources = ApplicationSources{
+				{
+					RepoURL: RepoURL(RepoURLTypeFile),
+					Path:    guestbookPath,
+				},
+			}
+		}).
+		Then().
+		Expect(Success(""))
+}
+
+// TestApplicationSourceValidation_ValidMultipleSources verifies that an Application
+// with multiple sources is accepted
+func TestApplicationSourceValidation_ValidMultipleSources(t *testing.T) {
+	Given(t).
+		Path(guestbookPath).
+		When().
+		CreateFromFile(func(app *Application) {
+			// Multiple sources set - this should be valid
+			app.Spec.Source = nil
+			app.Spec.Sources = ApplicationSources{
+				{
+					RepoURL: RepoURL(RepoURLTypeFile),
+					Path:    guestbookPath,
+				},
+				{
+					RepoURL: RepoURL(RepoURLTypeFile),
+					Path:    "kustomize-guestbook",
+				},
+			}
+		}).
+		Then().
+		Expect(Success(""))
+}

--- a/test/e2e/crd_validation_test.go
+++ b/test/e2e/crd_validation_test.go
@@ -54,9 +54,9 @@ func TestApplicationDestinationValidationValidServerOnly(t *testing.T) {
 		Expect(Success(""))
 }
 
-// TestApplicationSourceValidationBothSourceAndSources verifies that the CRD validation
+// TestApplicationValidationBothSourceAndSources verifies that the CRD validation
 // rejects an Application with both source and sources set
-func TestApplicationSourceValidationBothSourceAndSources(t *testing.T) {
+func TestApplicationValidationBothSourceAndSources(t *testing.T) {
 	Given(t).
 		Path(guestbookPath).
 		When().
@@ -78,23 +78,9 @@ func TestApplicationSourceValidationBothSourceAndSources(t *testing.T) {
 		Expect(Error("", "mutually exclusive"))
 }
 
-// TestApplicationSourceValidationNeitherSourceNorSources verifies that an Application
-// with neither source nor sources is allowed (for ApplicationSet templates)
-func TestApplicationSourceValidationNeitherSourceNorSources(t *testing.T) {
-	Given(t).
-		Path(guestbookPath).
-		When().
-		CreateFromFile(func(app *Application) {
-			// Clear both source and sources - this is valid for templates
-			app.Spec.Source = nil
-			app.Spec.Sources = nil
-		}).
-		Then().
-		Expect(Success(""))
-}
-
 // TestApplicationSourceValidationEmptySourcesArray verifies that an Application
 // with an empty sources array is allowed (for ApplicationSet templates)
+/*
 func TestApplicationSourceValidationEmptySourcesArray(t *testing.T) {
 	Given(t).
 		Path(guestbookPath).
@@ -107,6 +93,8 @@ func TestApplicationSourceValidationEmptySourcesArray(t *testing.T) {
 		Then().
 		Expect(Success(""))
 }
+
+*/
 
 // TestApplicationSourceValidationValidSourceOnly verifies that an Application
 // with only source set is accepted


### PR DESCRIPTION
This has been available since k8s 1.25, and GA since 1.29. These are the two obvious ones I can come up with on the top of my head, but there are probably more we could implement.

* `source` and `sources` are mutually exclusive
* as is `name` and `server` for an app destination
* the imperative `argocd app create/update` commands will now first perform a dry-run to the k8s api server before proceeding with their normal validations

The idea here is to enable similar validations when doing `kubectl apply -f <app>.yaml` as when creating an app using the Argo CD CLI/UI

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
