### PR TITLE
fix(server): update resourceVersion on Terminate retry

### DIFF
--- a/server/application/application.go
+++ b/server/application/application.go
@@ -2455,7 +2455,7 @@ func (s *Server) TerminateOperation(ctx context.Context, termOpReq *application.
 		}
 		log.Warnf("failed to set operation for app %q due to update conflict. retrying again...", *termOpReq.Name)
 		time.Sleep(100 * time.Millisecond)
-		_, err = s.appclientset.ArgoprojV1alpha1().Applications(appNs).Get(ctx, appName, metav1.GetOptions{})
+		a, err = s.appclientset.ArgoprojV1alpha1().Applications(appNs).Get(ctx, appName, metav1.GetOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("error getting application by name: %w", err)
 		}

--- a/server/application/application_test.go
+++ b/server/application/application_test.go
@@ -4591,7 +4591,7 @@ func TestServerSideDiff(t *testing.T) {
 // fetched from Get(), causing all retries to fail with stale resource versions.
 func TestTerminateOperationWithConflicts(t *testing.T) {
 	testApp := newTestApp()
-	testApp.ObjectMeta.ResourceVersion = "1"
+	testApp.ResourceVersion = "1"
 	testApp.Operation = &v1alpha1.Operation{
 		Sync: &v1alpha1.SyncOperation{},
 	}
@@ -4627,7 +4627,7 @@ func TestTerminateOperationWithConflicts(t *testing.T) {
 			return true, nil, apierrors.NewConflict(
 				schema.GroupResource{Group: "argoproj.io", Resource: "applications"},
 				app.Name,
-				fmt.Errorf("the object has been modified"),
+				stderrors.New("the object has been modified"),
 			)
 		}
 
@@ -4643,14 +4643,14 @@ func TestTerminateOperationWithConflicts(t *testing.T) {
 		return true, nil, apierrors.NewConflict(
 			schema.GroupResource{Group: "argoproj.io", Resource: "applications"},
 			app.Name,
-			fmt.Errorf("the object has been modified"),
+			stderrors.New("the object has been modified"),
 		)
 	})
 
 	// Mock Get to return a fresh app with incrementing version
 	// With the fix, this fresh app will be used in subsequent retries
 	// Without the fix, this fresh app is discarded
-	fakeAppCs.AddReactor("get", "applications", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+	fakeAppCs.AddReactor("get", "applications", func(_ kubetesting.Action) (handled bool, ret runtime.Object, err error) {
 		getCallCount++
 
 		freshApp := testApp.DeepCopy()


### PR DESCRIPTION
`TerminateOperation` has a retry loop to handle the case where an update hits an optimistic lock failure due to the resourceVersion having been updated.

These retry loops are common, and they only work if you update the app's resourceVersion before trying again.

Unfortunately, `TerminateOperation` doesn't currently update the resourceVersion on retries. So it's doomed to 10 attempts and 10 failures.

I think this bug is causing e2e test flakes occasionally.

The unit test is a bit gnarly, but I think it's worth it to make sure we don't accidentally reintroduce this bug.