### PR TITLE
feat(reposerver): #25605 #12159 enable a multi-source application manifest to have same repoURL with different revision

### DIFF
--- a/docs/user-guide/multiple_sources.md
+++ b/docs/user-guide/multiple_sources.md
@@ -86,3 +86,35 @@ at that URL. If the `path` field is not set, Argo CD will use the repository sol
 
 > [!NOTE]
 > Even when the `ref` field is configured with the `path` field, `$value` still represents the root of sources with the `ref` field. Consequently, `valueFiles` must be specified as relative paths from the root of sources.
+
+## Same repository at different revisions
+
+A `ref` source may point at the *same* repository as the source that consumes it, at a different
+target revision. This allows pinning a chart to a stable revision while tracking value files on a
+moving branch:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+spec:
+  sources:
+    - repoURL: 'https://git.example.com/org/repo.git'
+      targetRevision: v1.2.3        # chart pinned to a tag
+      path: charts/my-chart
+      helm:
+        valueFiles:
+          - $values/charts/my-chart/values-dev.yaml
+    - repoURL: 'https://git.example.com/org/repo.git'
+      targetRevision: main          # value files follow a branch
+      ref: values
+```
+
+Argo CD checks the additional revision out in a git worktree alongside the primary checkout, sharing
+the repository's object database. Worktrees are transient: they are created for the request that
+needs them, shared between concurrent requests at the same commit, and removed afterwards.
+
+> [!WARNING]
+> Submodule and Git LFS content is not populated for a `ref` source that is served from a worktree
+> (that is, when it resolves to a different commit than the source consuming it). Value files that
+> live in a submodule, or that are stored in LFS, will not resolve. Keep such files in the
+> repository proper, or point the `ref` source at the same revision as the consuming source.

--- a/reposerver/cache/cache.go
+++ b/reposerver/cache/cache.go
@@ -108,9 +108,15 @@ func getRefTargetRevisionMappingForCacheKey(refTargetRevisionMapping appv1.RefTa
 	res := make(refTargetRevisionMappingForCacheKey)
 
 	for k, v := range refTargetRevisionMapping {
-		// forcefully update TargetRevision based on refSourceCommitSHAs so that the resolved revision is always stored in the cache
-		v.TargetRevision = refSourceCommitSHAs[git.NormalizeGitURL(v.Repo.Repo)]
-		res[k] = refTargetForCacheKeyFromRefTarget(v)
+		// Copy first: v points into the caller's request, and overwriting TargetRevision in place
+		// would change the revision they go on to check out.
+		refTarget := *v
+		// Worktree-backed refs are keyed "<url>@<sha>", so there is no plain-URL entry to substitute;
+		// their commits still reach the key through refSourceCommitSHAs.
+		if resolvedRevision, ok := refSourceCommitSHAs[git.NormalizeGitURL(refTarget.Repo.Repo)]; ok {
+			refTarget.TargetRevision = resolvedRevision
+		}
+		res[k] = refTargetForCacheKeyFromRefTarget(&refTarget)
 	}
 	return res
 }

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -85,13 +85,23 @@ var ErrExceededMaxCombinedManifestFileSize = errors.New("exceeded max combined m
 
 // Service implements ManifestService interface
 type Service struct {
-	gitCredsStore             git.CredsStore
-	rootDir                   string
-	gitRepoPaths              utilio.TempPaths
-	chartPaths                utilio.TempPaths
-	ociPaths                  utilio.TempPaths
-	gitRepoInitializer        func(rootPath string) goio.Closer
-	repoLock                  *repositoryLock
+	gitCredsStore git.CredsStore
+	rootDir       string
+	// worktreeRootDir holds transient git worktrees, a sibling of rootDir so Init's per-repo walk
+	// ignores it. Cleaned of orphans at startup. Lifecycle logic is in worktree.go.
+	worktreeRootDir    string
+	gitRepoPaths       utilio.TempPaths
+	chartPaths         utilio.TempPaths
+	ociPaths           utilio.TempPaths
+	gitRepoInitializer func(rootPath string) goio.Closer
+	repoLock           *repositoryLock
+	// gitWorktreeLock serializes worktree ops per repo root. repoLock can't be reused here: it is
+	// already held for the primary revision on the same root, so re-locking would deadlock.
+	gitWorktreeLock sync.KeyLock
+	// worktrees ref-counts active worktrees by "<normalizedRepoURL>@<commitSHA>"; worktreesMu guards
+	// the map across roots (gitWorktreeLock only serializes a single root).
+	worktrees                 map[string]*worktreeRef
+	worktreesMu               gosync.Mutex
 	cache                     *cache.Cache
 	parallelismLimitSemaphore *semaphore.Weighted
 	metricsServer             *metrics.MetricsServer
@@ -143,6 +153,8 @@ func NewService(metricsServer *metrics.MetricsServer, cache *cache.Cache, initCo
 	return &Service{
 		parallelismLimitSemaphore: parallelismLimitSemaphore,
 		repoLock:                  repoLock,
+		gitWorktreeLock:           sync.NewKeyLock(),
+		worktrees:                 map[string]*worktreeRef{},
 		cache:                     cache,
 		metricsServer:             metricsServer,
 		newGitClient:              git.NewClientExt,
@@ -162,11 +174,17 @@ func NewService(metricsServer *metrics.MetricsServer, cache *cache.Cache, initCo
 		ociPaths:           ociRandomizedPaths,
 		gitRepoInitializer: directoryPermissionInitializer,
 		rootDir:            rootDir,
+		worktreeRootDir:    filepath.Join(filepath.Dir(rootDir), "_argocd-worktrees"),
 		symlinksState:      gocache.New(12*time.Hour, time.Hour),
 	}
 }
 
 func (s *Service) Init() error {
+	// Remove worktrees orphaned by a previous process (e.g. a crash before cleanup ran).
+	if err := s.cleanupOrphanedWorktrees(); err != nil {
+		log.Warnf("Failed to clean up orphaned worktrees: %v", err)
+	}
+
 	_, err := os.Stat(s.rootDir)
 	if os.IsNotExist(err) {
 		return os.MkdirAll(s.rootDir, 0o300)
@@ -189,6 +207,7 @@ func (s *Service) Init() error {
 			continue
 		}
 		fullPath := filepath.Join(s.rootDir, file.Name())
+		pruneWorktreeAdminDir(fullPath)
 		closer := s.gitRepoInitializer(fullPath)
 		if repo, err := gogit.PlainOpen(fullPath); err == nil {
 			if remotes, err := repo.Remotes(); err == nil && len(remotes) > 0 && len(remotes[0].Config().URLs) > 0 {
@@ -406,19 +425,8 @@ func (s *Service) runRepoOperation(
 		defer utilio.Close(closer)
 
 		if !s.initConstants.AllowOutOfBoundsSymlinks {
-			err := s.checkOutOfBoundsSymlinks(ociPath, revision, settings.noCache)
-			if err != nil {
-				oobError := &apppathutil.OutOfBoundsSymlinkError{}
-				if errors.As(err, &oobError) {
-					log.WithFields(log.Fields{
-						common.SecurityField: common.SecurityHigh,
-						"repo":               repo.Repo,
-						"digest":             revision,
-						"file":               oobError.File,
-					}).Warn("oci image contains out-of-bounds symlink")
-					return fmt.Errorf("oci image contains out-of-bounds symlinks. file: %s", oobError.File)
-				}
-				return err
+			if err := s.checkOutOfBoundsSymlinks(ociPath, revision, settings.noCache); err != nil {
+				return outOfBoundsSymlinkError(err, "oci image", log.Fields{"repo": repo.Repo, "digest": revision})
 			}
 		}
 
@@ -447,19 +455,8 @@ func (s *Service) runRepoOperation(
 		}
 		defer utilio.Close(closer)
 		if !s.initConstants.AllowOutOfBoundsSymlinks {
-			err := s.checkOutOfBoundsSymlinks(chartPath, revision, settings.noCache)
-			if err != nil {
-				oobError := &apppathutil.OutOfBoundsSymlinkError{}
-				if errors.As(err, &oobError) {
-					log.WithFields(log.Fields{
-						common.SecurityField: common.SecurityHigh,
-						"chart":              source.Chart,
-						"revision":           revision,
-						"file":               oobError.File,
-					}).Warn("chart contains out-of-bounds symlink")
-					return fmt.Errorf("chart contains out-of-bounds symlinks. file: %s", oobError.File)
-				}
-				return err
+			if err := s.checkOutOfBoundsSymlinks(chartPath, revision, settings.noCache); err != nil {
+				return outOfBoundsSymlinkError(err, "chart", log.Fields{"chart": source.Chart, "revision": revision})
 			}
 		}
 		return operation(chartPath, revision, revision, func() (*operationContext, error) {
@@ -476,19 +473,8 @@ func (s *Service) runRepoOperation(
 	defer utilio.Close(closer)
 
 	if !s.initConstants.AllowOutOfBoundsSymlinks {
-		err := s.checkOutOfBoundsSymlinks(gitClient.Root(), revision, settings.noCache, ".git")
-		if err != nil {
-			oobError := &apppathutil.OutOfBoundsSymlinkError{}
-			if errors.As(err, &oobError) {
-				log.WithFields(log.Fields{
-					common.SecurityField: common.SecurityHigh,
-					"repo":               repo.Repo,
-					"revision":           revision,
-					"file":               oobError.File,
-				}).Warn("repository contains out-of-bounds symlink")
-				return fmt.Errorf("repository contains out-of-bounds symlinks. file: %s", oobError.File)
-			}
-			return err
+		if err := s.checkOutOfBoundsSymlinks(gitClient.Root(), revision, settings.noCache, ".git"); err != nil {
+			return outOfBoundsSymlinkError(err, "repository", log.Fields{"repo": repo.Repo, "revision": revision})
 		}
 	}
 
@@ -628,6 +614,20 @@ func (s *Service) checkOutOfBoundsSymlinks(rootPath string, version string, noCa
 	return checker.(func() error)()
 }
 
+// outOfBoundsSymlinkError logs and returns a user-facing error when err is an out-of-bounds symlink
+// error; otherwise it returns err unchanged. noun names the artifact (e.g. "repository", "chart")
+// and fields adds security-log context.
+func outOfBoundsSymlinkError(err error, noun string, fields log.Fields) error {
+	oobErr := &apppathutil.OutOfBoundsSymlinkError{}
+	if !errors.As(err, &oobErr) {
+		return err
+	}
+	fields[common.SecurityField] = common.SecurityHigh
+	fields["file"] = oobErr.File
+	log.WithFields(fields).Warnf("%s contains out-of-bounds symlink", noun)
+	return fmt.Errorf("%s contains out-of-bounds symlinks. file: %s", noun, oobErr.File)
+}
+
 func (s *Service) GenerateManifest(ctx context.Context, q *apiclient.ManifestRequest) (*apiclient.ManifestResponse, error) {
 	var res *apiclient.ManifestResponse
 	var err error
@@ -724,17 +724,8 @@ func (s *Service) GenerateManifestWithFiles(stream apiclient.RepoServerService_G
 	}
 
 	if !s.initConstants.AllowOutOfBoundsSymlinks {
-		err := apppathutil.CheckOutOfBoundsSymlinks(workDir)
-		if err != nil {
-			oobError := &apppathutil.OutOfBoundsSymlinkError{}
-			if errors.As(err, &oobError) {
-				log.WithFields(log.Fields{
-					common.SecurityField: common.SecurityHigh,
-					"file":               oobError.File,
-				}).Warn("streamed files contains out-of-bounds symlink")
-				return fmt.Errorf("streamed files contains out-of-bounds symlinks. file: %s", oobError.File)
-			}
-			return err
+		if err := apppathutil.CheckOutOfBoundsSymlinks(workDir); err != nil {
+			return outOfBoundsSymlinkError(err, "streamed files", log.Fields{})
 		}
 	}
 
@@ -836,6 +827,10 @@ func (s *Service) runManifestGenAsync(ctx context.Context, repoRoot, commitSHA, 
 	if err == nil {
 		// Much of the multi-source handling logic is duplicated in resolveReferencedSources. If making changes here,
 		// check whether they should be replicated in resolveReferencedSources.
+		// refVarCommitSHAs maps $refVar (e.g., "$values") to the resolved commit SHA.
+		// This is used to look up the exact worktree path when multiple worktrees exist
+		// for the same repository at different revisions.
+		refVarCommitSHAs := make(map[string]string)
 		if q.HasMultipleSources {
 			if q.ApplicationSource.Helm != nil {
 				refFileParams := make([]string, 0)
@@ -868,24 +863,49 @@ func (s *Service) runManifestGenAsync(ctx context.Context, repoRoot, commitSHA, 
 						return
 					}
 					normalizedRepoURL := git.NormalizeGitURL(refSourceMapping.Repo.Repo)
-					closer, ok := repoRefs[normalizedRepoURL]
-					if ok {
-						if closer.revision != refSourceMapping.TargetRevision {
-							ch.errCh <- fmt.Errorf("cannot reference multiple revisions for the same repository (%s references %q while %s references %q)", refVar, refSourceMapping.TargetRevision, closer.key, closer.revision)
+					existingRef, ok := repoRefs[normalizedRepoURL]
+					if ok && existingRef.revision == refSourceMapping.TargetRevision {
+						// Same repo and same revision already referenced - reuse existing checkout
+						// Record the commit SHA for this refVar so we can look up the correct path later
+						refVarCommitSHAs[refVar] = existingRef.commitSHA
+						continue
+					}
+
+					// Resolve the git client and commit SHA for this ref source
+					gitClient, referencedCommitSHA, err := s.newClientResolveRevision(&refSourceMapping.Repo, refSourceMapping.TargetRevision, git.WithCache(s.cache, !q.NoRevisionCache && !q.NoCache))
+					if err != nil {
+						ch.errCh <- fmt.Errorf("failed to get git client for repo %s: %w", refSourceMapping.Repo.Repo, err)
+						return
+					}
+
+					refVarCommitSHAs[refVar] = referencedCommitSHA
+
+					needsWorktree := ok || // already have a ref to this repo at a different revision
+						(git.NormalizeGitURL(q.ApplicationSource.RepoURL) == normalizedRepoURL && commitSHA != referencedCommitSHA) // same as primary source at a different revision
+
+					if needsWorktree {
+						worktreePath, cleanup, err := s.createAndRegisterWorktree(gitClient, normalizedRepoURL, referencedCommitSHA, q.Repo.Depth)
+						if err != nil {
+							ch.errCh <- fmt.Errorf("failed to create worktree for repo %s: %w", refSourceMapping.Repo.Repo, err)
 							return
 						}
-					} else {
-						gitClient, referencedCommitSHA, err := s.newClientResolveRevision(&refSourceMapping.Repo, refSourceMapping.TargetRevision, git.WithCache(s.cache, !q.NoRevisionCache && !q.NoCache))
-						if err != nil {
-							log.Errorf("Failed to get git client for repo %s: %v", refSourceMapping.Repo.Repo, err)
-							ch.errCh <- fmt.Errorf("failed to get git client for repo %s", refSourceMapping.Repo.Repo)
-							return
+						defer cleanup.cleanup()
+
+						if !s.initConstants.AllowOutOfBoundsSymlinks {
+							if err := s.checkOutOfBoundsSymlinks(worktreePath, referencedCommitSHA, q.NoCache, ".git"); err != nil {
+								ch.errCh <- outOfBoundsSymlinkError(err, "repository", log.Fields{"repo": refSourceMapping.Repo, "revision": refSourceMapping.TargetRevision})
+								return
+							}
 						}
 
-						if git.NormalizeGitURL(q.ApplicationSource.RepoURL) == normalizedRepoURL && commitSHA != referencedCommitSHA {
-							ch.errCh <- fmt.Errorf("cannot reference a different revision of the same repository (%s references %q which resolves to %q while the application references %q which resolves to %q)", refVar, refSourceMapping.TargetRevision, referencedCommitSHA, q.Revision, commitSHA)
-							return
+						// Key by commit SHA so each revision of the same repo contributes its own entry to
+						// the cache key (a plain repo-URL key would collapse to one revision).
+						repoRefs[normalizedRepoURL+"@"+referencedCommitSHA] = repoRef{
+							revision:  refSourceMapping.TargetRevision,
+							commitSHA: referencedCommitSHA,
 						}
+					} else {
+						// Different repo - use normal checkout flow
 						closer, err := s.repoLock.Lock(gitClient.Root(), referencedCommitSHA, true, func(clean bool) (goio.Closer, error) {
 							return s.checkoutRevision(gitClient, referencedCommitSHA, s.initConstants.SubmoduleEnabled, q.Repo.Depth, clean)
 						})
@@ -903,31 +923,19 @@ func (s *Service) runManifestGenAsync(ctx context.Context, repoRoot, commitSHA, 
 
 						// Symlink check must happen after acquiring lock.
 						if !s.initConstants.AllowOutOfBoundsSymlinks {
-							err := s.checkOutOfBoundsSymlinks(gitClient.Root(), commitSHA, q.NoCache, ".git")
-							if err != nil {
-								oobError := &apppathutil.OutOfBoundsSymlinkError{}
-								if errors.As(err, &oobError) {
-									log.WithFields(log.Fields{
-										common.SecurityField: common.SecurityHigh,
-										"repo":               refSourceMapping.Repo,
-										"revision":           refSourceMapping.TargetRevision,
-										"file":               oobError.File,
-									}).Warn("repository contains out-of-bounds symlink")
-									ch.errCh <- fmt.Errorf("repository contains out-of-bounds symlinks. file: %s", oobError.File)
-									return
-								}
-								ch.errCh <- err
+							if err := s.checkOutOfBoundsSymlinks(gitClient.Root(), commitSHA, q.NoCache, ".git"); err != nil {
+								ch.errCh <- outOfBoundsSymlinkError(err, "repository", log.Fields{"repo": refSourceMapping.Repo, "revision": refSourceMapping.TargetRevision})
 								return
 							}
 						}
 
-						repoRefs[normalizedRepoURL] = repoRef{revision: refSourceMapping.TargetRevision, commitSHA: referencedCommitSHA, key: refVar}
+						repoRefs[normalizedRepoURL] = repoRef{revision: refSourceMapping.TargetRevision, commitSHA: referencedCommitSHA}
 					}
 				}
 			}
 		}
 
-		manifestGenResult, err = GenerateManifests(ctx, opContext.appPath, repoRoot, commitSHA, q, false, s.gitCredsStore, s.initConstants.MaxCombinedDirectoryManifestsSize, s.gitRepoPaths, WithCMPTarDoneChannel(ch.tarDoneCh), WithCMPTarExcludedGlobs(s.initConstants.CMPTarExcludedGlobs), WithCMPUseManifestGeneratePaths(s.initConstants.CMPUseManifestGeneratePaths))
+		manifestGenResult, err = GenerateManifests(ctx, opContext.appPath, repoRoot, commitSHA, q, false, s.gitCredsStore, s.initConstants.MaxCombinedDirectoryManifestsSize, s.gitRepoPaths, WithCMPTarDoneChannel(ch.tarDoneCh), WithCMPTarExcludedGlobs(s.initConstants.CMPTarExcludedGlobs), WithCMPUseManifestGeneratePaths(s.initConstants.CMPUseManifestGeneratePaths), WithRefSourceCommitSHAs(refVarCommitSHAs))
 	}
 	refSourceCommitSHAs := make(map[string]string)
 	if len(repoRefs) > 0 {
@@ -1258,7 +1266,7 @@ func parseKubeVersion(version string) (string, error) {
 	return kubeVersion.String(), nil
 }
 
-func helmTemplate(appPath string, repoRoot string, env *v1alpha1.Env, q *apiclient.ManifestRequest, isLocal bool, gitRepoPaths utilio.TempPaths) ([]*unstructured.Unstructured, string, error) {
+func helmTemplate(appPath string, repoRoot string, env *v1alpha1.Env, q *apiclient.ManifestRequest, isLocal bool, gitRepoPaths utilio.TempPaths, refSourceCommitSHAs map[string]string) ([]*unstructured.Unstructured, string, error) {
 	// We use the app name as Helm's release name property, which must not
 	// contain any underscore characters and must not exceed 53 characters.
 	// We are not interested in the fully qualified application name while
@@ -1294,7 +1302,7 @@ func helmTemplate(appPath string, repoRoot string, env *v1alpha1.Env, q *apiclie
 			templateOpts.Namespace = appHelm.Namespace
 		}
 
-		resolvedValueFiles, err := getResolvedValueFiles(appPath, repoRoot, env, q.GetValuesFileSchemes(), appHelm.ValueFiles, q.RefSources, gitRepoPaths, appHelm.IgnoreMissingValueFiles)
+		resolvedValueFiles, err := getResolvedValueFiles(appPath, repoRoot, env, q.GetValuesFileSchemes(), appHelm.ValueFiles, q.RefSources, gitRepoPaths, appHelm.IgnoreMissingValueFiles, refSourceCommitSHAs)
 		if err != nil {
 			return nil, "", fmt.Errorf("error resolving helm value files: %w", err)
 		}
@@ -1332,7 +1340,7 @@ func helmTemplate(appPath string, repoRoot string, env *v1alpha1.Env, q *apiclie
 			referencedSource := getReferencedSource(p.Path, q.RefSources)
 			if referencedSource != nil {
 				// If the $-prefixed path appears to reference another source, do env substitution _after_ resolving the source
-				resolvedPath, err = getResolvedRefValueFile(p.Path, env, q.GetValuesFileSchemes(), referencedSource.Repo.Repo, gitRepoPaths)
+				resolvedPath, err = getResolvedRefValueFile(p.Path, env, q.GetValuesFileSchemes(), referencedSource.Repo.Repo, gitRepoPaths, refSourceCommitSHAs)
 				if err != nil {
 					return nil, "", fmt.Errorf("error resolving set-file path: %w", err)
 				}
@@ -1443,6 +1451,7 @@ func getResolvedValueFiles(
 	refSources map[string]*v1alpha1.RefTarget,
 	gitRepoPaths utilio.TempPaths,
 	ignoreMissingValueFiles bool,
+	refSourceCommitSHAs map[string]string,
 ) ([]pathutil.ResolvedFilePath, error) {
 	// Pre-collect resolved paths for all explicit (non-glob) entries. This allows glob
 	// expansion to skip files that also appear explicitly, so the explicit entry controls
@@ -1454,7 +1463,7 @@ func getResolvedValueFiles(
 		var resolved pathutil.ResolvedFilePath
 		var err error
 		if referencedSource != nil {
-			resolved, err = getResolvedRefValueFile(rawValueFile, env, allowedValueFilesSchemas, referencedSource.Repo.Repo, gitRepoPaths)
+			resolved, err = getResolvedRefValueFile(rawValueFile, env, allowedValueFilesSchemas, referencedSource.Repo.Repo, gitRepoPaths, refSourceCommitSHAs)
 		} else {
 			resolved, _, err = pathutil.ResolveValueFilePathOrUrl(appPath, repoRoot, env.Envsubst(rawValueFile), allowedValueFilesSchemas)
 		}
@@ -1486,11 +1495,14 @@ func getResolvedValueFiles(
 		effectiveRoot := repoRoot
 		if referencedSource != nil {
 			// If the $-prefixed path appears to reference another source, do env substitution _after_ resolving that source.
-			resolvedPath, err = getResolvedRefValueFile(rawValueFile, env, allowedValueFilesSchemas, referencedSource.Repo.Repo, gitRepoPaths)
+			resolvedPath, err = getResolvedRefValueFile(rawValueFile, env, allowedValueFilesSchemas, referencedSource.Repo.Repo, gitRepoPaths, refSourceCommitSHAs)
 			if err != nil {
 				return nil, fmt.Errorf("error resolving value file path: %w", err)
 			}
-			if refRepoPath := gitRepoPaths.GetPathIfExists(git.NormalizeGitURL(referencedSource.Repo.Repo)); refRepoPath != "" {
+			// Match the dir the value file resolved against (the worktree for same-repo/different-
+			// revision refs) so the glob boundary check below uses the right root.
+			refVar := strings.Split(rawValueFile, "/")[0]
+			if refRepoPath := resolveRefRepoRoot(referencedSource.Repo.Repo, refVar, gitRepoPaths, refSourceCommitSHAs); refRepoPath != "" {
 				effectiveRoot = refRepoPath
 			}
 		} else {
@@ -1549,15 +1561,39 @@ func getResolvedValueFiles(
 	return resolvedValueFiles, nil
 }
 
+// resolveRefRepoRoot returns the on-disk checkout directory for a referenced source. When a worktree
+// exists for the exact commit (same repo at a different revision), its path is preferred so callers
+// resolve against, and boundary-check within, the correct checkout. refVar is the $-prefixed
+// reference (e.g. "$values"). Returns "" if no path is registered for the repo.
+func resolveRefRepoRoot(refSourceRepo string, refVar string, gitRepoPaths utilio.TempPaths, refSourceCommitSHAs map[string]string) string {
+	normalizedRepoURL := git.NormalizeGitURL(refSourceRepo)
+
+	// Prefer the exact worktree for this commit (set when the repo is referenced at multiple revisions).
+	if refSourceCommitSHAs != nil {
+		if commitSHA, ok := refSourceCommitSHAs[refVar]; ok && commitSHA != "" {
+			if repoPath := gitRepoPaths.GetPathIfExists(normalizedRepoURL + "@" + commitSHA); repoPath != "" {
+				return repoPath
+			}
+		}
+	}
+
+	// Standard repo path (same-revision or non-worktree cases). newClientResolveRevision always
+	// registers this key, so it resolves whenever the ref has been checked out.
+	return gitRepoPaths.GetPathIfExists(normalizedRepoURL)
+}
+
 func getResolvedRefValueFile(
 	rawValueFile string,
 	env *v1alpha1.Env,
 	allowedValueFilesSchemas []string,
 	refSourceRepo string,
 	gitRepoPaths utilio.TempPaths,
+	refSourceCommitSHAs map[string]string,
 ) (pathutil.ResolvedFilePath, error) {
 	pathStrings := strings.Split(rawValueFile, "/")
-	repoPath := gitRepoPaths.GetPathIfExists(git.NormalizeGitURL(refSourceRepo))
+	refVar := pathStrings[0] // e.g. "$values"
+
+	repoPath := resolveRefRepoRoot(refSourceRepo, refVar, gitRepoPaths, refSourceCommitSHAs)
 	if repoPath == "" {
 		return "", fmt.Errorf("failed to find repo %q", refSourceRepo)
 	}
@@ -1676,6 +1712,10 @@ type (
 		cmpTarDoneCh                chan<- bool
 		cmpTarExcludedGlobs         []string
 		cmpUseManifestGeneratePaths bool
+		// refSourceCommitSHAs maps $refVar (e.g., "$values") to the resolved commit SHA.
+		// This is used to look up the exact worktree path when multiple worktrees exist
+		// for the same repository at different revisions.
+		refSourceCommitSHAs map[string]string
 	}
 )
 
@@ -1712,6 +1752,15 @@ func WithCMPUseManifestGeneratePaths(enabled bool) GenerateManifestOpt {
 	}
 }
 
+// WithRefSourceCommitSHAs provides a mapping from $refVar (e.g., "$values") to the resolved
+// commit SHA. This is used to look up the exact worktree path when multiple worktrees exist
+// for the same repository at different revisions.
+func WithRefSourceCommitSHAs(shas map[string]string) GenerateManifestOpt {
+	return func(o *generateManifestOpt) {
+		o.refSourceCommitSHAs = shas
+	}
+}
+
 // GenerateManifests generates manifests from a path. Overrides are applied as a side effect on the given ApplicationSource.
 func GenerateManifests(ctx context.Context, appPath, repoRoot, revision string, q *apiclient.ManifestRequest, isLocal bool, gitCredsStore git.CredsStore, maxCombinedManifestQuantity resource.Quantity, gitRepoPaths utilio.TempPaths, opts ...GenerateManifestOpt) (*apiclient.ManifestResponse, error) {
 	opt := newGenerateManifestOpt(opts...)
@@ -1735,7 +1784,7 @@ func GenerateManifests(ctx context.Context, appPath, repoRoot, revision string, 
 	switch appSourceType {
 	case v1alpha1.ApplicationSourceTypeHelm:
 		var command string
-		targetObjs, command, err = helmTemplate(appPath, repoRoot, env, q, isLocal, gitRepoPaths)
+		targetObjs, command, err = helmTemplate(appPath, repoRoot, env, q, isLocal, gitRepoPaths, opt.refSourceCommitSHAs)
 		commands = append(commands, command)
 	case v1alpha1.ApplicationSourceTypeKustomize:
 		var kustomizeBinary string
@@ -2546,7 +2595,7 @@ func (s *Service) populateHelmAppDetails(res *apiclient.RepoAppDetailsResponse, 
 	if q.Source.Helm != nil {
 		ignoreMissingValueFiles = q.Source.Helm.IgnoreMissingValueFiles
 	}
-	resolvedSelectedValueFiles, err := getResolvedValueFiles(appPath, repoRoot, &v1alpha1.Env{}, q.GetValuesFileSchemes(), selectedValueFiles, q.RefSources, gitRepoPaths, ignoreMissingValueFiles)
+	resolvedSelectedValueFiles, err := getResolvedValueFiles(appPath, repoRoot, &v1alpha1.Env{}, q.GetValuesFileSchemes(), selectedValueFiles, q.RefSources, gitRepoPaths, ignoreMissingValueFiles, nil)
 	if err != nil {
 		return fmt.Errorf("failed to resolve value files: %w", err)
 	}

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -367,7 +367,7 @@ func (s *Service) runRepoOperation(
 	source *v1alpha1.ApplicationSource,
 	sourceIntegrity *v1alpha1.SourceIntegrity,
 	cacheFn func(revision string, refSourceCommitSHAs cache.ResolvedRevisions, firstInvocation bool) (bool, error),
-	operation func(repoRoot, commitSHA, revision string, ctxSrc operationContextSrc) error,
+	operation func(repoRoot, commitSHA, revision string, refSourceCommitSHAs cache.ResolvedRevisions, ctxSrc operationContextSrc) error,
 	settings operationSettings,
 	hasMultipleSources bool,
 	refSources map[string]*v1alpha1.RefTarget,
@@ -449,7 +449,7 @@ func (s *Service) runRepoOperation(
 			return err
 		}
 
-		return operation(ociPath, revision, revision, func() (*operationContext, error) {
+		return operation(ociPath, revision, revision, repoRefs, func() (*operationContext, error) {
 			return &operationContext{appPath, "", nil}, nil
 		})
 	} else if source.IsHelm() {
@@ -473,7 +473,7 @@ func (s *Service) runRepoOperation(
 				return outOfBoundsSymlinkError(err, "chart", log.Fields{"chart": source.Chart, "revision": revision})
 			}
 		}
-		return operation(chartPath, revision, revision, func() (*operationContext, error) {
+		return operation(chartPath, revision, revision, repoRefs, func() (*operationContext, error) {
 			return &operationContext{chartPath, "", nil}, nil
 		})
 	}
@@ -512,7 +512,7 @@ func (s *Service) runRepoOperation(
 
 	// Here commitSHA refers to the SHA of the actual commit, whereas revision refers to the branch/tag name etc
 	// We use the commitSHA to generate manifests and store them in cache, and revision to retrieve them from cache
-	return operation(gitClient.Root(), commitSHA, revision, func() (*operationContext, error) {
+	return operation(gitClient.Root(), commitSHA, revision, repoRefs, func() (*operationContext, error) {
 		// Pass in the originalRevision to have access to the eventual tag name. Use resolved revision only if the originalRevision is unspecified.
 		var rev string
 		if unresolvedRevision != "" {
@@ -720,7 +720,9 @@ func (s *Service) GenerateManifest(ctx context.Context, q *apiclient.ManifestReq
 	tarConcluded := false
 	var promise *ManifestResponsePromise
 
-	operation := func(repoRoot, commitSHA, revision string, ctxSrc operationContextSrc) error {
+	// The resolved revisions are unused here: manifest generation rebuilds them as it checks out each
+	// ref, and TestGenerateManifests_SameRepoTwoRevisions_CacheHit asserts the two agree.
+	operation := func(repoRoot, commitSHA, revision string, _ cache.ResolvedRevisions, ctxSrc operationContextSrc) error {
 		// do not generate manifests if Path and Chart fields are not set for a source in Multiple Sources
 		if q.HasMultipleSources && q.ApplicationSource.Path == "" && q.ApplicationSource.Chart == "" {
 			log.WithFields(map[string]any{
@@ -2510,7 +2512,7 @@ func (s *Service) GetAppDetails(ctx context.Context, q *apiclient.RepoServerAppD
 	res := &apiclient.RepoAppDetailsResponse{}
 
 	cacheFn := s.createGetAppDetailsCacheHandler(res, q)
-	operation := func(repoRoot, commitSHA, revision string, ctxSrc operationContextSrc) error {
+	operation := func(repoRoot, commitSHA, revision string, refSourceCommitSHAs cache.ResolvedRevisions, ctxSrc operationContextSrc) error {
 		opContext, err := ctxSrc()
 		if err != nil {
 			return err
@@ -2539,7 +2541,8 @@ func (s *Service) GetAppDetails(ctx context.Context, q *apiclient.RepoServerAppD
 				return fmt.Errorf("failed to populate plugin app details: %w", err)
 			}
 		}
-		_ = s.cache.SetAppDetails(revision, q.Source, q.RefSources, res, v1alpha1.TrackingMethod(q.TrackingMethod), nil)
+		// Same map the lookup keyed on, so a commit to a referenced branch invalidates this entry.
+		_ = s.cache.SetAppDetails(revision, q.Source, q.RefSources, res, v1alpha1.TrackingMethod(q.TrackingMethod), refSourceCommitSHAs)
 		return nil
 	}
 
@@ -2566,9 +2569,9 @@ func toUserInputStatusError(err error) error {
 	return err
 }
 
-func (s *Service) createGetAppDetailsCacheHandler(res *apiclient.RepoAppDetailsResponse, q *apiclient.RepoServerAppDetailsQuery) func(revision string, _ cache.ResolvedRevisions, _ bool) (bool, error) {
-	return func(revision string, _ cache.ResolvedRevisions, _ bool) (bool, error) {
-		err := s.cache.GetAppDetails(revision, q.Source, q.RefSources, res, v1alpha1.TrackingMethod(q.TrackingMethod), nil)
+func (s *Service) createGetAppDetailsCacheHandler(res *apiclient.RepoAppDetailsResponse, q *apiclient.RepoServerAppDetailsQuery) func(revision string, refSourceCommitSHAs cache.ResolvedRevisions, _ bool) (bool, error) {
+	return func(revision string, refSourceCommitSHAs cache.ResolvedRevisions, _ bool) (bool, error) {
+		err := s.cache.GetAppDetails(revision, q.Source, q.RefSources, res, v1alpha1.TrackingMethod(q.TrackingMethod), refSourceCommitSHAs)
 		if err == nil {
 			log.Infof("app details cache hit: %s/%s", revision, q.Source.Path)
 			return true, nil

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -90,13 +90,21 @@ var tracer = otel.Tracer("github.com/argoproj/argo-cd/v3/reposerver/repository")
 
 // Service implements ManifestService interface
 type Service struct {
-	gitCredsStore             git.CredsStore
-	rootDir                   string
-	gitRepoPaths              utilio.TempPaths
-	chartPaths                utilio.TempPaths
-	ociPaths                  utilio.TempPaths
-	gitRepoInitializer        func(rootPath string) goio.Closer
-	repoLock                  *repositoryLock
+	gitCredsStore git.CredsStore
+	rootDir       string
+	// worktreeRootDir holds transient worktrees; a sibling of rootDir so Init's walk ignores it.
+	worktreeRootDir    string
+	gitRepoPaths       utilio.TempPaths
+	chartPaths         utilio.TempPaths
+	ociPaths           utilio.TempPaths
+	gitRepoInitializer func(rootPath string) goio.Closer
+	repoLock           *repositoryLock
+	// gitWorktreeLock serializes worktree ops per repo root. repoLock can't be reused: it is already
+	// held for the primary revision on that root.
+	gitWorktreeLock sync.KeyLock
+	// worktrees ref-counts live worktrees by "<url>@<sha>"; worktreesMu guards it across roots.
+	worktrees                 map[string]*worktreeRef
+	worktreesMu               gosync.Mutex
 	cache                     *cache.Cache
 	parallelismLimitSemaphore *semaphore.Weighted
 	metricsServer             *metrics.MetricsServer
@@ -149,6 +157,8 @@ func NewService(metricsServer *metrics.MetricsServer, cache *cache.Cache, initCo
 	return &Service{
 		parallelismLimitSemaphore: parallelismLimitSemaphore,
 		repoLock:                  repoLock,
+		gitWorktreeLock:           sync.NewKeyLock(),
+		worktrees:                 map[string]*worktreeRef{},
 		cache:                     cache,
 		metricsServer:             metricsServer,
 		newGitClient:              git.NewClientExt,
@@ -169,11 +179,17 @@ func NewService(metricsServer *metrics.MetricsServer, cache *cache.Cache, initCo
 		ociPaths:           ociRandomizedPaths,
 		gitRepoInitializer: directoryPermissionInitializer,
 		rootDir:            rootDir,
+		worktreeRootDir:    filepath.Join(filepath.Dir(rootDir), "_argocd-worktrees"),
 		symlinksState:      gocache.New(12*time.Hour, time.Hour),
 	}
 }
 
 func (s *Service) Init() error {
+	// Remove worktrees orphaned by a previous process (e.g. a crash before cleanup ran).
+	if err := s.cleanupOrphanedWorktrees(); err != nil {
+		log.Warnf("Failed to clean up orphaned worktrees: %v", err)
+	}
+
 	_, err := os.Stat(s.rootDir)
 	if os.IsNotExist(err) {
 		return os.MkdirAll(s.rootDir, 0o300)
@@ -196,6 +212,7 @@ func (s *Service) Init() error {
 			continue
 		}
 		fullPath := filepath.Join(s.rootDir, file.Name())
+		pruneWorktreeAdminDir(fullPath)
 		closer := s.gitRepoInitializer(fullPath)
 		if repo, err := gogit.PlainOpen(fullPath); err == nil {
 			if remotes, err := repo.Remotes(); err == nil && len(remotes) > 0 && len(remotes[0].Config().URLs) > 0 {
@@ -381,7 +398,9 @@ func (s *Service) runRepoOperation(
 		return err
 	}
 
-	repoRefs, err := resolveReferencedSources(hasMultipleSources, source.Helm, refSources, s.newClientResolveRevision, gitClientOpts)
+	// For multi-source apps this resolved revision is passed on as commitSHA, so it is the same
+	// primary commit runManifestGenAsync keys against.
+	repoRefs, err := resolveReferencedSources(hasMultipleSources, source.Helm, refSources, s.newClientResolveRevision, gitClientOpts, git.NormalizeGitURL(source.RepoURL), revision)
 	if err != nil {
 		return err
 	}
@@ -420,19 +439,8 @@ func (s *Service) runRepoOperation(
 		defer utilio.Close(closer)
 
 		if !s.initConstants.AllowOutOfBoundsSymlinks {
-			err := s.checkOutOfBoundsSymlinks(ociPath, revision, settings.noCache)
-			if err != nil {
-				oobError := &apppathutil.OutOfBoundsSymlinkError{}
-				if errors.As(err, &oobError) {
-					log.WithFields(log.Fields{
-						common.SecurityField: common.SecurityHigh,
-						"repo":               repo.Repo,
-						"digest":             revision,
-						"file":               oobError.File,
-					}).Warn("oci image contains out-of-bounds symlink")
-					return fmt.Errorf("oci image contains out-of-bounds symlinks. file: %s", oobError.File)
-				}
-				return err
+			if err := s.checkOutOfBoundsSymlinks(ociPath, revision, settings.noCache); err != nil {
+				return outOfBoundsSymlinkError(err, "oci image", log.Fields{"repo": repo.Repo, "digest": revision})
 			}
 		}
 
@@ -461,19 +469,8 @@ func (s *Service) runRepoOperation(
 		}
 		defer utilio.Close(closer)
 		if !s.initConstants.AllowOutOfBoundsSymlinks {
-			err := s.checkOutOfBoundsSymlinks(chartPath, revision, settings.noCache)
-			if err != nil {
-				oobError := &apppathutil.OutOfBoundsSymlinkError{}
-				if errors.As(err, &oobError) {
-					log.WithFields(log.Fields{
-						common.SecurityField: common.SecurityHigh,
-						"chart":              source.Chart,
-						"revision":           revision,
-						"file":               oobError.File,
-					}).Warn("chart contains out-of-bounds symlink")
-					return fmt.Errorf("chart contains out-of-bounds symlinks. file: %s", oobError.File)
-				}
-				return err
+			if err := s.checkOutOfBoundsSymlinks(chartPath, revision, settings.noCache); err != nil {
+				return outOfBoundsSymlinkError(err, "chart", log.Fields{"chart": source.Chart, "revision": revision})
 			}
 		}
 		return operation(chartPath, revision, revision, func() (*operationContext, error) {
@@ -490,19 +487,8 @@ func (s *Service) runRepoOperation(
 	defer utilio.Close(closer)
 
 	if !s.initConstants.AllowOutOfBoundsSymlinks {
-		err := s.checkOutOfBoundsSymlinks(gitClient.Root(), revision, settings.noCache, ".git")
-		if err != nil {
-			oobError := &apppathutil.OutOfBoundsSymlinkError{}
-			if errors.As(err, &oobError) {
-				log.WithFields(log.Fields{
-					common.SecurityField: common.SecurityHigh,
-					"repo":               repo.Repo,
-					"revision":           revision,
-					"file":               oobError.File,
-				}).Warn("repository contains out-of-bounds symlink")
-				return fmt.Errorf("repository contains out-of-bounds symlinks. file: %s", oobError.File)
-			}
-			return err
+		if err := s.checkOutOfBoundsSymlinks(gitClient.Root(), revision, settings.noCache, ".git"); err != nil {
+			return outOfBoundsSymlinkError(err, "repository", log.Fields{"repo": repo.Repo, "revision": revision})
 		}
 	}
 
@@ -571,16 +557,54 @@ func getRepoSanitizerRegex(rootDir string) *regexp.Regexp {
 
 type gitClientGetter func(repo *v1alpha1.Repository, revision string, opts ...git.ClientOpts) (git.Client, string, error)
 
+// refRevisionKeyer assigns the keys that referenced sources' resolved commits are recorded under in
+// the manifest cache key: the first revision of a repository takes its normalized URL, any further
+// revision takes "<url>@<sha>". Manifest generation and cache lookup must agree on these keys, or a
+// manifest is stored under a key that is never looked up.
+type refRevisionKeyer struct {
+	primaryRepoURL   string
+	primaryCommitSHA string
+	// ordinaryCheckout records, per repository, the commit held by its single ordinary checkout.
+	ordinaryCheckout map[string]string
+}
+
+func newRefRevisionKeyer(primaryRepoURL, primaryCommitSHA string) *refRevisionKeyer {
+	return &refRevisionKeyer{
+		primaryRepoURL:   primaryRepoURL,
+		primaryCommitSHA: primaryCommitSHA,
+		ordinaryCheckout: map[string]string{},
+	}
+}
+
+// key returns the cache key for a referenced source at commitSHA, and whether it needs a worktree
+// because the repository's ordinary checkout holds a different commit. Stable across repeat calls.
+func (k *refRevisionKeyer) key(normalizedRepoURL, commitSHA string) (string, bool) {
+	if held, ok := k.ordinaryCheckout[normalizedRepoURL]; ok {
+		if held == commitSHA {
+			return normalizedRepoURL, false
+		}
+		return normalizedRepoURL + "@" + commitSHA, true
+	}
+	if k.primaryRepoURL == normalizedRepoURL && k.primaryCommitSHA != commitSHA {
+		return normalizedRepoURL + "@" + commitSHA, true
+	}
+	k.ordinaryCheckout[normalizedRepoURL] = commitSHA
+	return normalizedRepoURL, false
+}
+
 // resolveReferencedSources resolves the revisions for the given referenced sources. This lets us invalidate the cached
 // when one or more referenced sources change.
 //
 // Much of this logic is duplicated in runManifestGenAsync. If making changes here, check whether runManifestGenAsync
-// should be updated.
-func resolveReferencedSources(hasMultipleSources bool, source *v1alpha1.ApplicationSourceHelm, refSources map[string]*v1alpha1.RefTarget, newClientResolveRevision gitClientGetter, gitClientOpts git.ClientOpts) (map[string]string, error) {
+// should be updated. Both must key through refRevisionKeyer, in the same order, so the two agree.
+func resolveReferencedSources(hasMultipleSources bool, source *v1alpha1.ApplicationSourceHelm, refSources map[string]*v1alpha1.RefTarget, newClientResolveRevision gitClientGetter, gitClientOpts git.ClientOpts, primaryRepoURL string, primaryCommitSHA string) (map[string]string, error) {
 	repoRefs := make(map[string]string)
 	if !hasMultipleSources || source == nil {
 		return repoRefs, nil
 	}
+	refKeyer := newRefRevisionKeyer(primaryRepoURL, primaryCommitSHA)
+	// Caches resolution per (repo, target revision) so repeated refs cost one lookup.
+	resolvedRevisions := make(map[string]string)
 
 	refFileParams := make([]string, 0)
 	for _, fileParam := range source.FileParameters {
@@ -609,16 +633,21 @@ func resolveReferencedSources(hasMultipleSources bool, source *v1alpha1.Applicat
 			return nil, errors.New("source has a 'chart' field defined, but Helm charts are not yet not supported for 'ref' sources")
 		}
 		normalizedRepoURL := git.NormalizeGitURL(refSourceMapping.Repo.Repo)
-		_, ok = repoRefs[normalizedRepoURL]
-		if !ok {
-			_, referencedCommitSHA, err := newClientResolveRevision(&refSourceMapping.Repo, refSourceMapping.TargetRevision, gitClientOpts)
+		revisionKey := normalizedRepoURL + "\x00" + refSourceMapping.TargetRevision
+		referencedCommitSHA, resolved := resolvedRevisions[revisionKey]
+		if !resolved {
+			var err error
+			_, referencedCommitSHA, err = newClientResolveRevision(&refSourceMapping.Repo, refSourceMapping.TargetRevision, gitClientOpts)
 			if err != nil {
 				log.Errorf("Failed to get git client for repo %s: %v", refSourceMapping.Repo.Repo, err)
 				return nil, fmt.Errorf("failed to get git client for repo %s", refSourceMapping.Repo.Repo)
 			}
-
-			repoRefs[normalizedRepoURL] = referencedCommitSHA
+			resolvedRevisions[revisionKey] = referencedCommitSHA
 		}
+
+		// Every referenced revision must appear, or commits on a second one never invalidate the entry.
+		cacheKey, _ := refKeyer.key(normalizedRepoURL, referencedCommitSHA)
+		repoRefs[cacheKey] = referencedCommitSHA
 	}
 	return repoRefs, nil
 }
@@ -640,6 +669,19 @@ func (s *Service) checkOutOfBoundsSymlinks(rootPath string, version string, noCa
 	}
 
 	return checker.(func() error)()
+}
+
+// outOfBoundsSymlinkError logs and rewrites an out-of-bounds symlink error, passing other errors
+// through. noun names the artifact (e.g. "repository"); fields adds security-log context.
+func outOfBoundsSymlinkError(err error, noun string, fields log.Fields) error {
+	oobErr := &apppathutil.OutOfBoundsSymlinkError{}
+	if !errors.As(err, &oobErr) {
+		return err
+	}
+	fields[common.SecurityField] = common.SecurityHigh
+	fields["file"] = oobErr.File
+	log.WithFields(fields).Warnf("%s contains out-of-bounds symlink", noun)
+	return fmt.Errorf("%s contains out-of-bounds symlinks. file: %s", noun, oobErr.File)
 }
 
 func (s *Service) GenerateManifest(ctx context.Context, q *apiclient.ManifestRequest) (res *apiclient.ManifestResponse, retErr error) {
@@ -751,17 +793,8 @@ func (s *Service) GenerateManifestWithFiles(stream apiclient.RepoServerService_G
 	}
 
 	if !s.initConstants.AllowOutOfBoundsSymlinks {
-		err := apppathutil.CheckOutOfBoundsSymlinks(workDir)
-		if err != nil {
-			oobError := &apppathutil.OutOfBoundsSymlinkError{}
-			if errors.As(err, &oobError) {
-				log.WithFields(log.Fields{
-					common.SecurityField: common.SecurityHigh,
-					"file":               oobError.File,
-				}).Warn("streamed files contains out-of-bounds symlink")
-				return fmt.Errorf("streamed files contains out-of-bounds symlinks. file: %s", oobError.File)
-			}
-			return err
+		if err := apppathutil.CheckOutOfBoundsSymlinks(workDir); err != nil {
+			return outOfBoundsSymlinkError(err, "streamed files", log.Fields{})
 		}
 	}
 
@@ -843,8 +876,6 @@ type repoRef struct {
 	revision string
 	// commitSHA is the actual commit to which revision refers.
 	commitSHA string
-	// key is the name of the key which was used to reference this repo.
-	key string
 }
 
 func (s *Service) runManifestGenAsync(ctx context.Context, repoRoot, commitSHA, revision string, opContextSrc operationContextSrc, q *apiclient.ManifestRequest, ch *generateManifestCh) {
@@ -863,6 +894,10 @@ func (s *Service) runManifestGenAsync(ctx context.Context, repoRoot, commitSHA, 
 	if err == nil {
 		// Much of the multi-source handling logic is duplicated in resolveReferencedSources. If making changes here,
 		// check whether they should be replicated in resolveReferencedSources.
+		// Worktree-backed refs only; see WithRefSourceCommitSHAs.
+		refVarCommitSHAs := make(map[string]string)
+		// Must key identically to resolveReferencedSources, which computes the lookup key.
+		refKeyer := newRefRevisionKeyer(git.NormalizeGitURL(q.ApplicationSource.RepoURL), commitSHA)
 		if q.HasMultipleSources {
 			if q.ApplicationSource.Helm != nil {
 				refFileParams := make([]string, 0)
@@ -895,24 +930,47 @@ func (s *Service) runManifestGenAsync(ctx context.Context, repoRoot, commitSHA, 
 						return
 					}
 					normalizedRepoURL := git.NormalizeGitURL(refSourceMapping.Repo.Repo)
-					closer, ok := repoRefs[normalizedRepoURL]
-					if ok {
-						if closer.revision != refSourceMapping.TargetRevision {
-							ch.errCh <- fmt.Errorf("cannot reference multiple revisions for the same repository (%s references %q while %s references %q)", refVar, refSourceMapping.TargetRevision, closer.key, closer.revision)
+					existingRef, ok := repoRefs[normalizedRepoURL]
+					if ok && existingRef.revision == refSourceMapping.TargetRevision {
+						// Already checked out at this revision, under the plain repo URL that value-file
+						// resolution falls back to, so no refVarCommitSHAs entry is needed.
+						continue
+					}
+
+					gitClient, referencedCommitSHA, err := s.newClientResolveRevision(&refSourceMapping.Repo, refSourceMapping.TargetRevision, git.WithCache(s.cache, !q.NoRevisionCache && !q.NoCache))
+					if err != nil {
+						ch.errCh <- fmt.Errorf("failed to get git client for repo %s: %w", refSourceMapping.Repo.Repo, err)
+						return
+					}
+
+					refCacheKey, needsWorktree := refKeyer.key(normalizedRepoURL, referencedCommitSHA)
+
+					if needsWorktree {
+						// Honor the referenced source's own depth, as the checkout path below does.
+						worktreePath, cleanup, err := s.createAndRegisterWorktree(ctx, gitClient, normalizedRepoURL, referencedCommitSHA, refSourceMapping.Repo.Depth)
+						if err != nil {
+							ch.errCh <- fmt.Errorf("failed to create worktree for repo %s: %w", refSourceMapping.Repo.Repo, err)
 							return
 						}
-					} else {
-						gitClient, referencedCommitSHA, err := s.newClientResolveRevision(&refSourceMapping.Repo, refSourceMapping.TargetRevision, git.WithCache(s.cache, !q.NoRevisionCache && !q.NoCache))
-						if err != nil {
-							log.Errorf("Failed to get git client for repo %s: %v", refSourceMapping.Repo.Repo, err)
-							ch.errCh <- fmt.Errorf("failed to get git client for repo %s", refSourceMapping.Repo.Repo)
-							return
+						defer cleanup.cleanup()
+
+						// Worktree-backed refs only: worktrees are ref-counted globally, so pointing at a
+						// "<url>@<sha>" this request doesn't hold could read one a concurrent request removes.
+						refVarCommitSHAs[refVar] = referencedCommitSHA
+
+						if !s.initConstants.AllowOutOfBoundsSymlinks {
+							if err := s.checkOutOfBoundsSymlinks(worktreePath, referencedCommitSHA, q.NoCache, ".git"); err != nil {
+								ch.errCh <- outOfBoundsSymlinkError(err, "repository", log.Fields{"repo": refSourceMapping.Repo.Repo, "revision": refSourceMapping.TargetRevision})
+								return
+							}
 						}
 
-						if git.NormalizeGitURL(q.ApplicationSource.RepoURL) == normalizedRepoURL && commitSHA != referencedCommitSHA {
-							ch.errCh <- fmt.Errorf("cannot reference a different revision of the same repository (%s references %q which resolves to %q while the application references %q which resolves to %q)", refVar, refSourceMapping.TargetRevision, referencedCommitSHA, q.Revision, commitSHA)
-							return
+						repoRefs[refCacheKey] = repoRef{
+							revision:  refSourceMapping.TargetRevision,
+							commitSHA: referencedCommitSHA,
 						}
+					} else {
+						// No other revision of this repo is in play; use the ordinary checkout.
 						closer, err := s.repoLock.Lock(gitClient.Root(), referencedCommitSHA, true, func(clean bool) (goio.Closer, error) {
 							// Use the referenced source's own depth instead of the primary source's depth.
 							// For multi-source Applications where the primary source is a Helm/OCI artifact,
@@ -934,31 +992,19 @@ func (s *Service) runManifestGenAsync(ctx context.Context, repoRoot, commitSHA, 
 
 						// Symlink check must happen after acquiring lock.
 						if !s.initConstants.AllowOutOfBoundsSymlinks {
-							err := s.checkOutOfBoundsSymlinks(gitClient.Root(), commitSHA, q.NoCache, ".git")
-							if err != nil {
-								oobError := &apppathutil.OutOfBoundsSymlinkError{}
-								if errors.As(err, &oobError) {
-									log.WithFields(log.Fields{
-										common.SecurityField: common.SecurityHigh,
-										"repo":               refSourceMapping.Repo,
-										"revision":           refSourceMapping.TargetRevision,
-										"file":               oobError.File,
-									}).Warn("repository contains out-of-bounds symlink")
-									ch.errCh <- fmt.Errorf("repository contains out-of-bounds symlinks. file: %s", oobError.File)
-									return
-								}
-								ch.errCh <- err
+							if err := s.checkOutOfBoundsSymlinks(gitClient.Root(), commitSHA, q.NoCache, ".git"); err != nil {
+								ch.errCh <- outOfBoundsSymlinkError(err, "repository", log.Fields{"repo": refSourceMapping.Repo.Repo, "revision": refSourceMapping.TargetRevision})
 								return
 							}
 						}
 
-						repoRefs[normalizedRepoURL] = repoRef{revision: refSourceMapping.TargetRevision, commitSHA: referencedCommitSHA, key: refVar}
+						repoRefs[refCacheKey] = repoRef{revision: refSourceMapping.TargetRevision, commitSHA: referencedCommitSHA}
 					}
 				}
 			}
 		}
 
-		manifestGenResult, err = GenerateManifests(ctx, opContext.appPath, repoRoot, commitSHA, q, false, s.gitCredsStore, s.initConstants.MaxCombinedDirectoryManifestsSize, s.gitRepoPaths, WithCMPTarDoneChannel(ch.tarDoneCh), WithCMPTarExcludedGlobs(s.initConstants.CMPTarExcludedGlobs), WithCMPUseManifestGeneratePaths(s.initConstants.CMPUseManifestGeneratePaths))
+		manifestGenResult, err = GenerateManifests(ctx, opContext.appPath, repoRoot, commitSHA, q, false, s.gitCredsStore, s.initConstants.MaxCombinedDirectoryManifestsSize, s.gitRepoPaths, WithCMPTarDoneChannel(ch.tarDoneCh), WithCMPTarExcludedGlobs(s.initConstants.CMPTarExcludedGlobs), WithCMPUseManifestGeneratePaths(s.initConstants.CMPUseManifestGeneratePaths), WithRefSourceCommitSHAs(refVarCommitSHAs))
 	}
 	refSourceCommitSHAs := make(map[string]string)
 	if len(repoRefs) > 0 {
@@ -1283,7 +1329,7 @@ func parseKubeVersion(version string) (string, error) {
 	return kubeVersion.String(), nil
 }
 
-func helmTemplate(ctx context.Context, appPath string, repoRoot string, env *v1alpha1.Env, q *apiclient.ManifestRequest, isLocal bool, gitRepoPaths utilio.TempPaths) ([]*unstructured.Unstructured, string, error) {
+func helmTemplate(ctx context.Context, appPath string, repoRoot string, env *v1alpha1.Env, q *apiclient.ManifestRequest, isLocal bool, gitRepoPaths utilio.TempPaths, refSourceCommitSHAs map[string]string) ([]*unstructured.Unstructured, string, error) {
 	// We use the app name as Helm's release name property, which must not
 	// contain any underscore characters and must not exceed 53 characters.
 	// We are not interested in the fully qualified application name while
@@ -1319,7 +1365,7 @@ func helmTemplate(ctx context.Context, appPath string, repoRoot string, env *v1a
 			templateOpts.Namespace = appHelm.Namespace
 		}
 
-		resolvedValueFiles, err := getResolvedValueFiles(appPath, repoRoot, env, q.GetValuesFileSchemes(), appHelm.ValueFiles, q.RefSources, gitRepoPaths, appHelm.IgnoreMissingValueFiles)
+		resolvedValueFiles, err := getResolvedValueFiles(appPath, repoRoot, env, q.GetValuesFileSchemes(), appHelm.ValueFiles, q.RefSources, gitRepoPaths, appHelm.IgnoreMissingValueFiles, refSourceCommitSHAs)
 		if err != nil {
 			return nil, "", fmt.Errorf("error resolving helm value files: %w", err)
 		}
@@ -1357,7 +1403,7 @@ func helmTemplate(ctx context.Context, appPath string, repoRoot string, env *v1a
 			referencedSource := getReferencedSource(p.Path, q.RefSources)
 			if referencedSource != nil {
 				// If the $-prefixed path appears to reference another source, do env substitution _after_ resolving the source
-				resolvedPath, err = getResolvedRefValueFile(p.Path, env, q.GetValuesFileSchemes(), referencedSource.Repo.Repo, gitRepoPaths)
+				resolvedPath, err = getResolvedRefValueFile(p.Path, env, q.GetValuesFileSchemes(), referencedSource.Repo.Repo, gitRepoPaths, refSourceCommitSHAs)
 				if err != nil {
 					return nil, "", fmt.Errorf("error resolving set-file path: %w", err)
 				}
@@ -1468,6 +1514,7 @@ func getResolvedValueFiles(
 	refSources map[string]*v1alpha1.RefTarget,
 	gitRepoPaths utilio.TempPaths,
 	ignoreMissingValueFiles bool,
+	refSourceCommitSHAs map[string]string,
 ) ([]pathutil.ResolvedFilePath, error) {
 	// Pre-collect resolved paths for all explicit (non-glob) entries. This allows glob
 	// expansion to skip files that also appear explicitly, so the explicit entry controls
@@ -1479,7 +1526,7 @@ func getResolvedValueFiles(
 		var resolved pathutil.ResolvedFilePath
 		var err error
 		if referencedSource != nil {
-			resolved, err = getResolvedRefValueFile(rawValueFile, env, allowedValueFilesSchemas, referencedSource.Repo.Repo, gitRepoPaths)
+			resolved, err = getResolvedRefValueFile(rawValueFile, env, allowedValueFilesSchemas, referencedSource.Repo.Repo, gitRepoPaths, refSourceCommitSHAs)
 		} else {
 			resolved, _, err = pathutil.ResolveValueFilePathOrUrl(appPath, repoRoot, env.Envsubst(rawValueFile), allowedValueFilesSchemas)
 		}
@@ -1511,11 +1558,13 @@ func getResolvedValueFiles(
 		effectiveRoot := repoRoot
 		if referencedSource != nil {
 			// If the $-prefixed path appears to reference another source, do env substitution _after_ resolving that source.
-			resolvedPath, err = getResolvedRefValueFile(rawValueFile, env, allowedValueFilesSchemas, referencedSource.Repo.Repo, gitRepoPaths)
+			resolvedPath, err = getResolvedRefValueFile(rawValueFile, env, allowedValueFilesSchemas, referencedSource.Repo.Repo, gitRepoPaths, refSourceCommitSHAs)
 			if err != nil {
 				return nil, fmt.Errorf("error resolving value file path: %w", err)
 			}
-			if refRepoPath := gitRepoPaths.GetPathIfExists(git.NormalizeGitURL(referencedSource.Repo.Repo)); refRepoPath != "" {
+			// Match the dir the value file resolved against, so the glob boundary check below agrees.
+			refVar := strings.Split(rawValueFile, "/")[0]
+			if refRepoPath := resolveRefRepoRoot(referencedSource.Repo.Repo, refVar, gitRepoPaths, refSourceCommitSHAs); refRepoPath != "" {
 				effectiveRoot = refRepoPath
 			}
 		} else {
@@ -1574,15 +1623,35 @@ func getResolvedValueFiles(
 	return resolvedValueFiles, nil
 }
 
+// resolveRefRepoRoot returns the on-disk checkout for a referenced source, preferring the worktree
+// holding that exact commit. refVar is the $-prefixed reference. Returns "" if nothing is registered.
+func resolveRefRepoRoot(refSourceRepo string, refVar string, gitRepoPaths utilio.TempPaths, refSourceCommitSHAs map[string]string) string {
+	normalizedRepoURL := git.NormalizeGitURL(refSourceRepo)
+
+	if refSourceCommitSHAs != nil {
+		if commitSHA, ok := refSourceCommitSHAs[refVar]; ok && commitSHA != "" {
+			if repoPath := gitRepoPaths.GetPathIfExists(normalizedRepoURL + "@" + commitSHA); repoPath != "" {
+				return repoPath
+			}
+		}
+	}
+
+	// newClientResolveRevision always registers this key, so it resolves once the ref is checked out.
+	return gitRepoPaths.GetPathIfExists(normalizedRepoURL)
+}
+
 func getResolvedRefValueFile(
 	rawValueFile string,
 	env *v1alpha1.Env,
 	allowedValueFilesSchemas []string,
 	refSourceRepo string,
 	gitRepoPaths utilio.TempPaths,
+	refSourceCommitSHAs map[string]string,
 ) (pathutil.ResolvedFilePath, error) {
 	pathStrings := strings.Split(rawValueFile, "/")
-	repoPath := gitRepoPaths.GetPathIfExists(git.NormalizeGitURL(refSourceRepo))
+	refVar := pathStrings[0] // e.g. "$values"
+
+	repoPath := resolveRefRepoRoot(refSourceRepo, refVar, gitRepoPaths, refSourceCommitSHAs)
 	if repoPath == "" {
 		return "", fmt.Errorf("failed to find repo %q", refSourceRepo)
 	}
@@ -1701,6 +1770,7 @@ type (
 		cmpTarDoneCh                chan<- bool
 		cmpTarExcludedGlobs         []string
 		cmpUseManifestGeneratePaths bool
+		refSourceCommitSHAs         map[string]string
 	}
 )
 
@@ -1737,6 +1807,14 @@ func WithCMPUseManifestGeneratePaths(enabled bool) GenerateManifestOpt {
 	}
 }
 
+// WithRefSourceCommitSHAs maps $refVar (e.g. "$values") to the commit it resolved to, for refs
+// served from a worktree, so their value files are read from that worktree.
+func WithRefSourceCommitSHAs(shas map[string]string) GenerateManifestOpt {
+	return func(o *generateManifestOpt) {
+		o.refSourceCommitSHAs = shas
+	}
+}
+
 // GenerateManifests generates manifests from a path. Overrides are applied as a side effect on the given ApplicationSource.
 func GenerateManifests(ctx context.Context, appPath, repoRoot, revision string, q *apiclient.ManifestRequest, isLocal bool, gitCredsStore git.CredsStore, maxCombinedManifestQuantity resource.Quantity, gitRepoPaths utilio.TempPaths, opts ...GenerateManifestOpt) (_ *apiclient.ManifestResponse, retErr error) {
 	ctx, span := tracer.Start(ctx, "reposerver.GenerateManifests")
@@ -1764,7 +1842,7 @@ func GenerateManifests(ctx context.Context, appPath, repoRoot, revision string, 
 	switch appSourceType {
 	case v1alpha1.ApplicationSourceTypeHelm:
 		var command string
-		targetObjs, command, err = helmTemplate(ctx, appPath, repoRoot, env, q, isLocal, gitRepoPaths)
+		targetObjs, command, err = helmTemplate(ctx, appPath, repoRoot, env, q, isLocal, gitRepoPaths, opt.refSourceCommitSHAs)
 		commands = append(commands, command)
 	case v1alpha1.ApplicationSourceTypeKustomize:
 		var kustomizeBinary string
@@ -2449,7 +2527,7 @@ func (s *Service) GetAppDetails(ctx context.Context, q *apiclient.RepoServerAppD
 
 		switch appSourceType {
 		case v1alpha1.ApplicationSourceTypeHelm:
-			if err := s.populateHelmAppDetails(ctx, res, opContext.appPath, repoRoot, commitSHA, revision, q, s.gitRepoPaths); err != nil {
+			if err := s.populateHelmAppDetails(ctx, res, opContext.appPath, repoRoot, commitSHA, q, s.gitRepoPaths); err != nil {
 				return err
 			}
 		case v1alpha1.ApplicationSourceTypeKustomize:
@@ -2505,7 +2583,13 @@ func (s *Service) createGetAppDetailsCacheHandler(res *apiclient.RepoAppDetailsR
 	}
 }
 
-func (s *Service) populateHelmAppDetails(ctx context.Context, res *apiclient.RepoAppDetailsResponse, appPath, repoRoot, commitSHA, revision string, q *apiclient.RepoServerAppDetailsQuery, gitRepoPaths utilio.TempPaths) error {
+// isGitRepo reports whether repo is a git repository. Repository.Type documents that git is assumed
+// when empty, and a repository with no repository secret arrives untyped.
+func isGitRepo(repo *v1alpha1.Repository) bool {
+	return repo != nil && (repo.Type == "" || repo.Type == "git")
+}
+
+func (s *Service) populateHelmAppDetails(ctx context.Context, res *apiclient.RepoAppDetailsResponse, appPath, repoRoot, commitSHA string, q *apiclient.RepoServerAppDetailsQuery, gitRepoPaths utilio.TempPaths) error {
 	var selectedValueFiles []string
 	var availableValueFiles []string
 
@@ -2537,10 +2621,14 @@ func (s *Service) populateHelmAppDetails(ctx context.Context, res *apiclient.Rep
 	}
 	defer h.Dispose()
 
+	// Worktree-backed refs only, as in runManifestGenAsync; see WithRefSourceCommitSHAs.
+	var refVarCommitSHAs map[string]string
+
 	if len(q.RefSources) > 0 {
+		refVarCommitSHAs = make(map[string]string, len(q.RefSources))
 		refSources := map[string]repoRef{}
 		var mainRepoURL string
-		if q.Repo.Type == "git" {
+		if isGitRepo(q.Repo) {
 			mainRepoURL = git.NormalizeGitURL(q.Repo.Repo)
 		}
 		refNames := []string{}
@@ -2550,7 +2638,7 @@ func (s *Service) populateHelmAppDetails(ctx context.Context, res *apiclient.Rep
 		sort.Strings(refNames)
 		for _, refName := range refNames {
 			refSource := q.RefSources[refName]
-			if refSource.Repo.Type != "git" {
+			if !isGitRepo(&refSource.Repo) {
 				continue
 			}
 			log.Debugf("Checking out repos for ref source %s  -> %s [%s]", refName, refSource.Repo.Repo, refSource.TargetRevision)
@@ -2559,20 +2647,28 @@ func (s *Service) populateHelmAppDetails(ctx context.Context, res *apiclient.Rep
 				return fmt.Errorf("error setting up git client for %s and resolving revision %s: %w", refSource.Repo.Repo, refSource.TargetRevision, err)
 			}
 			refNormalizedURL := git.NormalizeGitURL(refSource.Repo.Repo)
-			if mainRepoURL == refNormalizedURL && refSHA != commitSHA {
-				return fmt.Errorf("cannot reference a different revision of the same repository (%s references %q which resolves to %q while the application references %q which resolves to %q)", refName, refSource.TargetRevision, refSHA, revision, commitSHA)
-			}
+
 			prevRef, ok := refSources[refNormalizedURL]
-			if ok {
-				if prevRef.commitSHA != refSHA {
-					return fmt.Errorf("cannot reference multiple revisions for the same repository (%s references %q which resolves to %q while %s references %q which resolves to %q)", refName, refSource.TargetRevision, refSHA, prevRef.key, prevRef.revision, prevRef.commitSHA)
+			if ok && prevRef.commitSHA == refSHA {
+				continue // an earlier ref already checked this repo out at this commit
+			}
+
+			// Wanted at a second revision, so check it out in a worktree alongside the ordinary
+			// checkout, as manifest generation does.
+			if ok || (mainRepoURL == refNormalizedURL && refSHA != commitSHA) {
+				_, cleanup, err := s.createAndRegisterWorktree(ctx, gitClient, refNormalizedURL, refSHA, refSource.Repo.Depth)
+				if err != nil {
+					return fmt.Errorf("failed to create worktree for referenced repo %q at revision %q: %w", refSource.Repo.Repo, refSource.TargetRevision, err)
 				}
-			} else {
-				refSources[refNormalizedURL] = repoRef{
-					revision:  refSource.TargetRevision,
-					commitSHA: refSHA,
-					key:       refName,
-				}
+				defer cleanup.cleanup()
+				refVarCommitSHAs[refName] = refSHA
+				log.Debugf("Checked out referenced repo %s at %s in a worktree", refSource.Repo.Repo, refSHA)
+				continue
+			}
+
+			refSources[refNormalizedURL] = repoRef{
+				revision:  refSource.TargetRevision,
+				commitSHA: refSHA,
 			}
 			closer, err := s.repoLock.Lock(gitClient.Root(), refSHA, true, func(clean bool) (goio.Closer, error) {
 				return s.checkoutRevision(ctx, gitClient, refSHA, s.initConstants.SubmoduleEnabled, refSource.Repo.Depth, clean)
@@ -2598,7 +2694,7 @@ func (s *Service) populateHelmAppDetails(ctx context.Context, res *apiclient.Rep
 	if q.Source.Helm != nil {
 		ignoreMissingValueFiles = q.Source.Helm.IgnoreMissingValueFiles
 	}
-	resolvedSelectedValueFiles, err := getResolvedValueFiles(appPath, repoRoot, &v1alpha1.Env{}, q.GetValuesFileSchemes(), selectedValueFiles, q.RefSources, gitRepoPaths, ignoreMissingValueFiles)
+	resolvedSelectedValueFiles, err := getResolvedValueFiles(appPath, repoRoot, &v1alpha1.Env{}, q.GetValuesFileSchemes(), selectedValueFiles, q.RefSources, gitRepoPaths, ignoreMissingValueFiles, refVarCommitSHAs)
 	if err != nil {
 		return fmt.Errorf("failed to resolve value files: %w", err)
 	}

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -3566,7 +3566,7 @@ func Test_getResolvedValueFiles(t *testing.T) {
 		tcc := tc
 		t.Run(tcc.name, func(t *testing.T) {
 			t.Parallel()
-			resolvedPaths, err := getResolvedValueFiles(path.Join(tempDir, "main-repo"), path.Join(tempDir, "main-repo"), tcc.env, []string{}, []string{tcc.rawPath}, tcc.refSources, paths, false)
+			resolvedPaths, err := getResolvedValueFiles(path.Join(tempDir, "main-repo"), path.Join(tempDir, "main-repo"), tcc.env, []string{}, []string{tcc.rawPath}, tcc.refSources, paths, false, nil)
 			if !tcc.expectedErr {
 				require.NoError(t, err)
 				require.Len(t, resolvedPaths, 1)

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -30,6 +31,7 @@ import (
 
 	cacheutil "github.com/argoproj/argo-cd/v3/util/cache"
 
+	argosync "github.com/argoproj/pkg/v2/sync"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -3998,7 +4000,7 @@ func Test_getResolvedValueFiles(t *testing.T) {
 		tcc := tc
 		t.Run(tcc.name, func(t *testing.T) {
 			t.Parallel()
-			resolvedPaths, err := getResolvedValueFiles(path.Join(tempDir, "main-repo"), path.Join(tempDir, "main-repo"), tcc.env, []string{}, []string{tcc.rawPath}, tcc.refSources, paths, false)
+			resolvedPaths, err := getResolvedValueFiles(path.Join(tempDir, "main-repo"), path.Join(tempDir, "main-repo"), tcc.env, []string{}, []string{tcc.rawPath}, tcc.refSources, paths, false, nil)
 			if !tcc.expectedErr {
 				require.NoError(t, err)
 				require.Len(t, resolvedPaths, 1)
@@ -4221,7 +4223,7 @@ func Test_getResolvedValueFiles_glob(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			repoPath := path.Join(tempDir, "main-repo")
-			resolvedPaths, err := getResolvedValueFiles(repoPath, repoPath, tt.env, []string{}, []string{tt.rawPath}, tt.refSources, paths, tt.ignoreMissingValueFiles)
+			resolvedPaths, err := getResolvedValueFiles(repoPath, repoPath, tt.env, []string{}, []string{tt.rawPath}, tt.refSources, paths, tt.ignoreMissingValueFiles, nil)
 			if tt.expectedErr {
 				require.Error(t, err)
 				return
@@ -4248,7 +4250,7 @@ func Test_getResolvedValueFiles_glob(t *testing.T) {
 				"envs/*.yaml", // glob - z.yaml is explicit so skipped; only a.yaml added
 				"envs/z.yaml", // explicit - placed last, highest precedence
 			},
-			map[string]*v1alpha1.RefTarget{}, paths, false,
+			map[string]*v1alpha1.RefTarget{}, paths, false, nil,
 		)
 		require.NoError(t, err)
 		require.Len(t, resolvedPaths, 2)
@@ -4266,7 +4268,7 @@ func Test_getResolvedValueFiles_glob(t *testing.T) {
 				"prod/a.yaml", // explicit locks in position 0
 				"prod/*.yaml", // glob - a.yaml already seen, only b.yaml is new
 			},
-			map[string]*v1alpha1.RefTarget{}, paths, false,
+			map[string]*v1alpha1.RefTarget{}, paths, false, nil,
 		)
 		require.NoError(t, err)
 		require.Len(t, resolvedPaths, 2)
@@ -4284,7 +4286,7 @@ func Test_getResolvedValueFiles_glob(t *testing.T) {
 				"prod/*.yaml", // glob - a.yaml is explicit so skipped; only b.yaml added (pos 0)
 				"prod/a.yaml", // explicit - placed here at pos 1 (highest precedence)
 			},
-			map[string]*v1alpha1.RefTarget{}, paths, false,
+			map[string]*v1alpha1.RefTarget{}, paths, false, nil,
 		)
 		require.NoError(t, err)
 		require.Len(t, resolvedPaths, 2)
@@ -4302,7 +4304,7 @@ func Test_getResolvedValueFiles_glob(t *testing.T) {
 				"prod/*.yaml",    // adds a.yaml, b.yaml
 				"prod/**/*.yaml", // a.yaml, b.yaml already seen; adds nested/c.yaml, nested/d.yaml
 			},
-			map[string]*v1alpha1.RefTarget{}, paths, false,
+			map[string]*v1alpha1.RefTarget{}, paths, false, nil,
 		)
 		require.NoError(t, err)
 		require.Len(t, resolvedPaths, 4)
@@ -4325,7 +4327,7 @@ func Test_getResolvedValueFiles_glob(t *testing.T) {
 				"prod/**/*.yaml",     // a.yaml, b.yaml, nested/c.yaml all explicit and skipped; nested/d.yaml added - pos 2
 				"prod/nested/c.yaml", // explicit - pos 3
 			},
-			map[string]*v1alpha1.RefTarget{}, paths, false,
+			map[string]*v1alpha1.RefTarget{}, paths, false, nil,
 		)
 		require.NoError(t, err)
 		require.Len(t, resolvedPaths, 4)
@@ -4448,7 +4450,7 @@ func Test_getResolvedValueFiles_glob_symlink_escape(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(outsideDir, "secret.yaml"), []byte("password: hunter2"), 0o644))
 	require.NoError(t, os.Symlink(filepath.Join(outsideDir, "secret.yaml"), filepath.Join(repoDir, "values", "escape.yaml")))
 
-	_, err := getResolvedValueFiles(repoDir, repoDir, &v1alpha1.Env{}, []string{}, []string{"values/*.yaml"}, map[string]*v1alpha1.RefTarget{}, paths, false)
+	_, err := getResolvedValueFiles(repoDir, repoDir, &v1alpha1.Env{}, []string{}, []string{"values/*.yaml"}, map[string]*v1alpha1.RefTarget{}, paths, false, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "resolved to outside repository root")
 }
@@ -5931,4 +5933,454 @@ func TestGetHelmRepos_InsecureOCIForceHttpPropagatedFromRepoCreds(t *testing.T) 
 
 	require.Len(t, helmRepos, 1)
 	assert.True(t, helmRepos[0].InsecureOCIForceHttp)
+}
+
+func TestGenerateManifest_MultiSource_SameRepoWithDifferentRevisions(t *testing.T) {
+	// This test validates that multi-source applications can reference the same
+	// git repository with different target revisions by using git worktrees.
+	root, err := filepath.Abs("../../util/helm/testdata")
+	require.NoError(t, err)
+
+	primarySHA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	refSHA := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+	paths := &iomocks.TempPaths{}
+	helmClient := &helmmocks.Client{}
+	ociClient := &ocimocks.Client{}
+
+	// Create two separate git clients - one for primary, one for ref source
+	primaryGitClient := &gitmocks.Client{}
+	refGitClient := &gitmocks.Client{}
+
+	// Primary source checkout behavior
+	primaryGitClient.EXPECT().Init().Return(nil)
+	primaryGitClient.EXPECT().IsRevisionPresent(mock.Anything).Return(false)
+	primaryGitClient.EXPECT().Fetch(mock.Anything, mock.Anything).Return(nil)
+	primaryGitClient.EXPECT().Checkout(mock.Anything, mock.Anything, mock.Anything).Return("", nil)
+	primaryGitClient.EXPECT().LsRemote("main").Return(primarySHA, nil)
+	primaryGitClient.EXPECT().CommitSHA().Return(primarySHA, nil)
+	primaryGitClient.EXPECT().Root().Return(root)
+	primaryGitClient.EXPECT().IsAnnotatedTag(mock.Anything).Return(false)
+	primaryGitClient.EXPECT().VerifyCommitSignature(mock.Anything).Return("", nil)
+
+	// Ref source behavior - uses worktree since different revision
+	refGitClient.EXPECT().Init().Return(nil)
+	refGitClient.EXPECT().IsRevisionPresent(mock.Anything).Return(false)
+	refGitClient.EXPECT().Fetch(mock.Anything, mock.Anything).Return(nil)
+	refGitClient.EXPECT().LsRemote("v1.0.0").Return(refSHA, nil)
+	refGitClient.EXPECT().CommitSHA().Return(refSHA, nil)
+	refGitClient.EXPECT().CreateWorktree(refSHA, mock.AnythingOfType("string")).Return(nil)
+	refGitClient.EXPECT().RemoveWorktree(mock.AnythingOfType("string")).Return(nil).Maybe()
+	refGitClient.EXPECT().Root().Return(root)
+
+	// Track which client to return
+	callCount := 0
+
+	// Helm client setup
+	helmClient.EXPECT().GetIndex(mock.AnythingOfType("bool"), mock.Anything).Return(&helm.Index{Entries: map[string]helm.Entries{
+		"redis": {{Version: "1.0.0"}},
+	}}, nil)
+	helmClient.EXPECT().GetTags(mock.Anything, mock.Anything).Return(nil, nil)
+
+	// OCI client setup
+	ociClient.EXPECT().GetTags(mock.Anything, mock.Anything).Return(nil, nil)
+	ociClient.EXPECT().ResolveRevision(mock.Anything, mock.Anything, mock.Anything).Return("", nil)
+
+	// Paths mock - Add is called for both primary and worktree
+	paths.EXPECT().Add(mock.Anything, mock.Anything).Return()
+	paths.EXPECT().GetPath(mock.Anything).Return(root, nil)
+	paths.EXPECT().GetPathIfExists(mock.Anything).Return(root)
+	paths.EXPECT().GetPaths().Return(map[string]string{"fake-nonce": root})
+	paths.EXPECT().Remove(mock.Anything).Return()
+
+	cacheMocks := newCacheMocks()
+	t.Cleanup(cacheMocks.mockCache.StopRedisCallback)
+
+	service := NewService(metrics.NewMetricsServer(), cacheMocks.cache, RepoServerInitConstants{ParallelismLimit: 1}, &git.NoopCredsStore{}, root)
+	service.newGitClient = func(_, _ string, _ git.Creds, _, _ bool, _, _ string, _ ...git.ClientOpts) (git.Client, error) {
+		callCount++
+		if callCount == 1 {
+			return primaryGitClient, nil
+		}
+		return refGitClient, nil
+	}
+	service.newHelmClient = func(_ string, _ helm.Creds, _ bool, _, _ string, _ ...helm.ClientOpts) helm.Client {
+		return helmClient
+	}
+	service.newOCIClient = func(_ string, _ oci.Creds, _, _ string, _ []string, _ ...oci.ClientOpts) (oci.Client, error) {
+		return ociClient, nil
+	}
+	service.gitRepoInitializer = func(_ string) goio.Closer {
+		return utilio.NopCloser
+	}
+	service.gitRepoPaths = paths
+
+	// Create a request with same repo but different target revisions
+	req := &apiclient.ManifestRequest{
+		Repo: &v1alpha1.Repository{
+			Repo: "https://github.com/example/repo.git",
+		},
+		Revision: "main",
+		ApplicationSource: &v1alpha1.ApplicationSource{
+			RepoURL:        "https://github.com/example/repo.git",
+			Path:           "./redis",
+			TargetRevision: "main",
+			Helm: &v1alpha1.ApplicationSourceHelm{
+				ValueFiles: []string{"$values/redis/values-production.yaml"},
+			},
+		},
+		HasMultipleSources: true,
+		NoCache:            true,
+		ProjectName:        "test-project",
+		ProjectSourceRepos: []string{"*"},
+		// RefSources with same repo but different revision
+		RefSources: map[string]*v1alpha1.RefTarget{
+			"$values": {
+				TargetRevision: "v1.0.0", // Different revision than primary source
+				Repo: v1alpha1.Repository{
+					Repo: "https://github.com/example/repo.git", // Same repo as primary
+				},
+			},
+		},
+	}
+
+	// The test should succeed - worktree allows same repo with different revisions
+	_, err = service.GenerateManifest(t.Context(), req)
+	// We expect no error since worktrees should handle different revisions
+	// Note: The actual manifest generation may still fail due to missing files,
+	// but the key assertion is that we don't get the old
+	// "cannot reference the same repository multiple times when the" error
+	if err != nil {
+		assert.NotContains(t, err.Error(), "cannot reference the same repository multiple times")
+	}
+
+	// Verify that CreateWorktree was called on refGitClient
+	// RemoveWorktree is called via defer, which may happen after test assertions in some timing scenarios
+	refGitClient.AssertCalled(t, "CreateWorktree", refSHA, mock.AnythingOfType("string"))
+}
+
+// TestGenerateManifest_MultiSource_WorktreeOutOfBoundsSymlinkRejected verifies that the worktree
+// path runs the out-of-bounds symlink check: a worktree containing a symlink that escapes its root
+// must cause manifest generation to fail.
+func TestGenerateManifest_MultiSource_WorktreeOutOfBoundsSymlinkRejected(t *testing.T) {
+	// Real root so the primary source's app path (./redis) resolves; the worktree itself is created
+	// under a temp dir (service.worktreeRootDir override below).
+	root, err := filepath.Abs("../../util/helm/testdata")
+	require.NoError(t, err)
+
+	primarySHA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	refSHA := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+	// A file outside any worktree; the malicious symlink points here.
+	outsideFile := filepath.Join(t.TempDir(), "secret.yaml")
+	require.NoError(t, os.WriteFile(outsideFile, []byte("secret: true"), 0o600))
+
+	paths := &iomocks.TempPaths{}
+	helmClient := &helmmocks.Client{}
+	ociClient := &ocimocks.Client{}
+	primaryGitClient := &gitmocks.Client{}
+	refGitClient := &gitmocks.Client{}
+
+	primaryGitClient.EXPECT().Init().Return(nil)
+	primaryGitClient.EXPECT().IsRevisionPresent(mock.Anything).Return(false)
+	primaryGitClient.EXPECT().Fetch(mock.Anything, mock.Anything).Return(nil)
+	primaryGitClient.EXPECT().Checkout(mock.Anything, mock.Anything, mock.Anything).Return("", nil)
+	primaryGitClient.EXPECT().LsRemote("main").Return(primarySHA, nil)
+	primaryGitClient.EXPECT().CommitSHA().Return(primarySHA, nil)
+	primaryGitClient.EXPECT().Root().Return(root)
+	primaryGitClient.EXPECT().IsAnnotatedTag(mock.Anything).Return(false)
+	primaryGitClient.EXPECT().VerifyCommitSignature(mock.Anything).Return("", nil)
+
+	refGitClient.EXPECT().Init().Return(nil)
+	refGitClient.EXPECT().IsRevisionPresent(mock.Anything).Return(false)
+	refGitClient.EXPECT().Fetch(mock.Anything, mock.Anything).Return(nil)
+	refGitClient.EXPECT().LsRemote("v1.0.0").Return(refSHA, nil)
+	refGitClient.EXPECT().CommitSHA().Return(refSHA, nil)
+	refGitClient.EXPECT().Root().Return(root)
+	// Create a real worktree directory containing an out-of-bounds symlink.
+	refGitClient.EXPECT().CreateWorktree(refSHA, mock.AnythingOfType("string")).RunAndReturn(func(_, worktreePath string) error {
+		if err := os.MkdirAll(worktreePath, 0o700); err != nil {
+			return err
+		}
+		return os.Symlink(outsideFile, filepath.Join(worktreePath, "evil.yaml"))
+	})
+	refGitClient.EXPECT().RemoveWorktree(mock.AnythingOfType("string")).Return(nil).Maybe()
+
+	callCount := 0
+	helmClient.EXPECT().GetIndex(mock.AnythingOfType("bool"), mock.Anything).Return(&helm.Index{Entries: map[string]helm.Entries{
+		"redis": {{Version: "1.0.0"}},
+	}}, nil).Maybe()
+	helmClient.EXPECT().GetTags(mock.Anything, mock.Anything).Return(nil, nil).Maybe()
+	ociClient.EXPECT().GetTags(mock.Anything, mock.Anything).Return(nil, nil).Maybe()
+	ociClient.EXPECT().ResolveRevision(mock.Anything, mock.Anything, mock.Anything).Return("", nil).Maybe()
+
+	paths.EXPECT().Add(mock.Anything, mock.Anything).Return()
+	paths.EXPECT().GetPath(mock.Anything).Return(root, nil)
+	paths.EXPECT().GetPathIfExists(mock.Anything).Return(root)
+	paths.EXPECT().GetPaths().Return(map[string]string{"fake-nonce": root})
+	paths.EXPECT().Remove(mock.Anything).Return()
+
+	cacheMocks := newCacheMocks()
+	t.Cleanup(cacheMocks.mockCache.StopRedisCallback)
+
+	service := NewService(metrics.NewMetricsServer(), cacheMocks.cache, RepoServerInitConstants{ParallelismLimit: 1}, &git.NoopCredsStore{}, root)
+	service.newGitClient = func(_, _ string, _ git.Creds, _, _ bool, _, _ string, _ ...git.ClientOpts) (git.Client, error) {
+		callCount++
+		if callCount == 1 {
+			return primaryGitClient, nil
+		}
+		return refGitClient, nil
+	}
+	service.newHelmClient = func(_ string, _ helm.Creds, _ bool, _, _ string, _ ...helm.ClientOpts) helm.Client {
+		return helmClient
+	}
+	service.newOCIClient = func(_ string, _ oci.Creds, _, _ string, _ []string, _ ...oci.ClientOpts) (oci.Client, error) {
+		return ociClient, nil
+	}
+	service.gitRepoInitializer = func(_ string) goio.Closer {
+		return utilio.NopCloser
+	}
+	service.gitRepoPaths = paths
+	// Keep worktrees under a temp dir so they are cleaned up with the test.
+	service.worktreeRootDir = t.TempDir()
+
+	req := &apiclient.ManifestRequest{
+		Repo:     &v1alpha1.Repository{Repo: "https://github.com/example/repo.git"},
+		Revision: "main",
+		ApplicationSource: &v1alpha1.ApplicationSource{
+			RepoURL:        "https://github.com/example/repo.git",
+			Path:           "./redis",
+			TargetRevision: "main",
+			Helm: &v1alpha1.ApplicationSourceHelm{
+				ValueFiles: []string{"$values/redis/values-production.yaml"},
+			},
+		},
+		HasMultipleSources: true,
+		NoCache:            true,
+		ProjectName:        "test-project",
+		ProjectSourceRepos: []string{"*"},
+		RefSources: map[string]*v1alpha1.RefTarget{
+			"$values": {
+				TargetRevision: "v1.0.0",
+				Repo:           v1alpha1.Repository{Repo: "https://github.com/example/repo.git"},
+			},
+		},
+	}
+
+	_, err = service.GenerateManifest(t.Context(), req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "out-of-bounds symlinks")
+}
+
+// TestCreateAndRegisterWorktree_SerializesPerRoot verifies that concurrent worktree creations
+// against the same repository root are serialized by gitWorktreeLock, preventing the git fetch /
+// worktree-add races on the shared .git directory. Run with -race for full coverage.
+func TestCreateAndRegisterWorktree_SerializesPerRoot(t *testing.T) {
+	paths := &iomocks.TempPaths{}
+	paths.EXPECT().Add(mock.Anything, mock.Anything).Return()
+
+	gitClient := &gitmocks.Client{}
+	gitClient.EXPECT().Root().Return("/fake/repo/root")
+	// Revision already present locally, so Fetch is skipped; the worktree-add is the critical section.
+	gitClient.EXPECT().IsRevisionPresent(mock.Anything).Return(true)
+
+	var inFlight atomic.Int32
+	var maxInFlight atomic.Int32
+	gitClient.EXPECT().CreateWorktree(mock.Anything, mock.Anything).RunAndReturn(func(_, _ string) error {
+		cur := inFlight.Add(1)
+		for {
+			prev := maxInFlight.Load()
+			if cur <= prev || maxInFlight.CompareAndSwap(prev, cur) {
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond) // widen the window so an unserialized race would overlap
+		inFlight.Add(-1)
+		return nil
+	})
+
+	s := &Service{
+		gitWorktreeLock: argosync.NewKeyLock(),
+		gitRepoPaths:    paths,
+		worktrees:       map[string]*worktreeRef{},
+		worktreeRootDir: t.TempDir(),
+	}
+
+	const goroutines = 8
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := range goroutines {
+		go func(i int) {
+			defer wg.Done()
+			// Distinct commit SHAs so each registers a unique worktree path, but the same root.
+			_, _, err := s.createAndRegisterWorktree(gitClient, "https://github.com/example/repo.git", fmt.Sprintf("%040d", i), 0)
+			assert.NoError(t, err)
+		}(i)
+	}
+	wg.Wait()
+
+	assert.Equal(t, int32(1), maxInFlight.Load(), "worktree operations on the same repo root must be serialized")
+}
+
+// TestCreateAndRegisterWorktree_RefCountsSharedWorktree verifies that concurrent requests (and
+// repeated refs) for the same repo+commit share a single worktree, which is created once and
+// removed only when the last user releases it — preventing duplicate worktrees and a gitRepoPaths
+// registry collision where one request deletes another's still-active registration.
+func TestCreateAndRegisterWorktree_RefCountsSharedWorktree(t *testing.T) {
+	const repoURL = "https://github.com/example/repo.git"
+	const sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	// createAndRegisterWorktree takes an already-normalized repo URL (as the production caller does).
+	normalizedRepoURL := git.NormalizeGitURL(repoURL)
+	key := normalizedRepoURL + "@" + sha
+
+	registered := map[string]string{}
+	var registeredMu sync.Mutex
+	paths := &iomocks.TempPaths{}
+	paths.EXPECT().Add(mock.Anything, mock.Anything).Run(func(k, v string) {
+		registeredMu.Lock()
+		registered[k] = v
+		registeredMu.Unlock()
+	}).Return()
+	paths.EXPECT().Remove(mock.Anything).Run(func(k string) {
+		registeredMu.Lock()
+		delete(registered, k)
+		registeredMu.Unlock()
+	}).Return()
+
+	gitClient := &gitmocks.Client{}
+	gitClient.EXPECT().Root().Return("/fake/repo/root")
+	gitClient.EXPECT().IsRevisionPresent(mock.Anything).Return(true)
+	var createCalls, removeCalls atomic.Int32
+	gitClient.EXPECT().CreateWorktree(mock.Anything, mock.Anything).RunAndReturn(func(_, _ string) error {
+		createCalls.Add(1)
+		return nil
+	})
+	gitClient.EXPECT().RemoveWorktree(mock.Anything).RunAndReturn(func(_ string) error {
+		removeCalls.Add(1)
+		return nil
+	}).Maybe()
+
+	s := &Service{
+		gitWorktreeLock: argosync.NewKeyLock(),
+		gitRepoPaths:    paths,
+		worktrees:       map[string]*worktreeRef{},
+		worktreeRootDir: t.TempDir(),
+	}
+
+	const goroutines = 8
+	var wg sync.WaitGroup
+	paths1 := make([]string, goroutines)
+	cleanups := make([]*worktreeCleanup, goroutines)
+	wg.Add(goroutines)
+	for i := range goroutines {
+		go func(i int) {
+			defer wg.Done()
+			p, cleanup, err := s.createAndRegisterWorktree(gitClient, normalizedRepoURL, sha, 0)
+			assert.NoError(t, err)
+			paths1[i] = p
+			cleanups[i] = cleanup
+		}(i)
+	}
+	wg.Wait()
+
+	// One physical worktree created and shared by all callers.
+	assert.Equal(t, int32(1), createCalls.Load(), "same repo+commit must create exactly one worktree")
+	for i := 1; i < goroutines; i++ {
+		assert.Equal(t, paths1[0], paths1[i], "all callers must receive the same shared worktree path")
+	}
+	registeredMu.Lock()
+	assert.Equal(t, paths1[0], registered[key], "worktree path must be registered under repo@sha")
+	registeredMu.Unlock()
+
+	// Releasing all but the last reference must NOT remove the worktree.
+	for i := range goroutines - 1 {
+		cleanups[i].cleanup()
+	}
+	assert.Equal(t, int32(0), removeCalls.Load(), "worktree must stay while references remain")
+	registeredMu.Lock()
+	_, stillRegistered := registered[key]
+	registeredMu.Unlock()
+	assert.True(t, stillRegistered, "registration must persist while references remain")
+
+	// The final release removes it.
+	cleanups[goroutines-1].cleanup()
+	assert.Equal(t, int32(1), removeCalls.Load(), "worktree must be removed once after the last release")
+	registeredMu.Lock()
+	_, stillRegistered = registered[key]
+	registeredMu.Unlock()
+	assert.False(t, stillRegistered, "registration must be removed after the last release")
+}
+
+// TestGetResolvedValueFiles_GlobFromWorktreeUsesWorktreeRoot verifies that a globbed $ref value
+// file from a same-repo/different-revision source is boundary-checked against the worktree root
+// (where the files actually live), not the main checkout root. Before the fix, effectiveRoot was
+// derived from the plain repo key, so the glob matches resolved "outside repository root".
+func TestGetResolvedValueFiles_GlobFromWorktreeUsesWorktreeRoot(t *testing.T) {
+	const repoURL = "https://github.com/example/repo.git"
+	const sha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+	base := t.TempDir()
+	mainDir := filepath.Join(base, "main")   // plain repo key -> main checkout (no value files)
+	worktreeDir := filepath.Join(base, "wt") // repo@sha key -> worktree with the value files
+	require.NoError(t, os.MkdirAll(mainDir, 0o755))
+	require.NoError(t, os.MkdirAll(worktreeDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(worktreeDir, "a.yaml"), []byte("a: 1"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(worktreeDir, "b.yaml"), []byte("b: 2"), 0o644))
+
+	paths := utilio.NewRandomizedTempPaths(base)
+	paths.Add(git.NormalizeGitURL(repoURL), mainDir)
+	paths.Add(git.NormalizeGitURL(repoURL)+"@"+sha, worktreeDir)
+
+	refSources := map[string]*v1alpha1.RefTarget{
+		"$values": {Repo: v1alpha1.Repository{Repo: repoURL}},
+	}
+	refSourceCommitSHAs := map[string]string{"$values": sha}
+
+	resolved, err := getResolvedValueFiles(
+		mainDir, mainDir, &v1alpha1.Env{}, []string{},
+		[]string{"$values/*.yaml"},
+		refSources, paths, false, refSourceCommitSHAs,
+	)
+	require.NoError(t, err)
+	require.Len(t, resolved, 2)
+	assert.Equal(t, filepath.Join(worktreeDir, "a.yaml"), string(resolved[0]))
+	assert.Equal(t, filepath.Join(worktreeDir, "b.yaml"), string(resolved[1]))
+}
+
+// TestInit_RemovesOrphanedWorktrees verifies that startup cleanup removes worktree working
+// directories and stale .git/worktrees admin entries left behind by a previous process (e.g. a
+// crash), which would otherwise accumulate on the repo-server volume across restarts.
+func TestInit_RemovesOrphanedWorktrees(t *testing.T) {
+	base := t.TempDir()
+	rootDir := filepath.Join(base, "_argocd-repo")
+
+	cacheMocks := newCacheMocks()
+	t.Cleanup(cacheMocks.mockCache.StopRedisCallback)
+	s := NewService(metrics.NewMetricsServer(), cacheMocks.cache, RepoServerInitConstants{}, &git.NoopCredsStore{}, rootDir)
+
+	// Orphaned worktree working directory under the dedicated worktree root.
+	orphanWorktree := filepath.Join(s.worktreeRootDir, "argocd-worktree-orphan")
+	require.NoError(t, os.MkdirAll(orphanWorktree, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(orphanWorktree, "checkout.yaml"), []byte("x: 1"), 0o644))
+
+	// Stale worktree admin entry inside a previously cloned repo.
+	repoClone := filepath.Join(rootDir, "some-repo")
+	adminDir := filepath.Join(repoClone, ".git", "worktrees", "stale")
+	require.NoError(t, os.MkdirAll(adminDir, 0o700))
+
+	require.NoError(t, s.Init())
+
+	// The orphaned working directory is gone, but the (empty) worktree root remains.
+	_, err := os.Stat(orphanWorktree)
+	assert.True(t, os.IsNotExist(err), "orphaned worktree dir should be removed")
+	_, err = os.Stat(s.worktreeRootDir)
+	assert.NoError(t, err, "worktree root dir should be recreated")
+
+	// The stale admin entry is pruned. Init locks the clone down (0000), so restore read access first.
+	require.NoError(t, os.Chmod(repoClone, 0o700))
+	_, err = os.Stat(filepath.Join(repoClone, ".git", "worktrees"))
+	assert.True(t, os.IsNotExist(err), "stale .git/worktrees admin dir should be pruned")
+
+	// Init also locks rootDir to 0300; restore it so t.TempDir cleanup can remove the tree.
+	require.NoError(t, os.Chmod(rootDir, 0o700))
 }

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -6951,3 +6951,46 @@ func TestGenerateManifests_SameRepoTwoRevisions_CacheHit(t *testing.T) {
 	assert.Equal(t, setsAfterFirst, cacheSets(),
 		"second GenerateManifest should hit the manifest cache; a new cache write means the lookup and store keys diverged")
 }
+
+// TestGetAppDetailsCacheHandler_KeysOnResolvedRevisions covers the app-details half of ref-revision
+// invalidation: the handler must key on the commits its refs resolved to, or the Parameters pane
+// keeps serving a referenced branch's old values after someone pushes to it.
+func TestGetAppDetailsCacheHandler_KeysOnResolvedRevisions(t *testing.T) {
+	const (
+		revision  = "1c8c9a06f9400d899d8a3d790fb9a7a6ac554bf4"
+		refRepo   = "https://github.com/foo/bar"
+		oldRefSHA = "aaaa000000000000000000000000000000000000"
+		newRefSHA = "bbbb111111111111111111111111111111111111"
+	)
+
+	cacheMocks := newCacheMocks()
+	t.Cleanup(cacheMocks.mockCache.StopRedisCallback)
+	service := NewService(metrics.NewMetricsServer(), cacheMocks.cache, RepoServerInitConstants{ParallelismLimit: 1}, &git.NoopCredsStore{}, t.TempDir())
+
+	q := &apiclient.RepoServerAppDetailsQuery{
+		Repo:   &v1alpha1.Repository{Repo: refRepo},
+		Source: &v1alpha1.ApplicationSource{Path: "charts/foo"},
+		RefSources: map[string]*v1alpha1.RefTarget{
+			"$values": {Repo: v1alpha1.Repository{Repo: refRepo}, TargetRevision: "main"},
+		},
+	}
+
+	// Store an entry as the operation closure does, for the ref resolved to oldRefSHA.
+	stored := &apiclient.RepoAppDetailsResponse{Type: "Helm"}
+	require.NoError(t, service.cache.SetAppDetails(revision, q.Source, q.RefSources, stored, "", cache.ResolvedRevisions{refRepo: oldRefSHA}))
+
+	res := &apiclient.RepoAppDetailsResponse{}
+	handler := service.createGetAppDetailsCacheHandler(res, q)
+
+	// Same resolved revision: the entry is found.
+	ok, err := handler(revision, cache.ResolvedRevisions{refRepo: oldRefSHA}, true)
+	require.NoError(t, err)
+	assert.True(t, ok, "entry stored for this resolved revision should be found")
+	assert.Equal(t, "Helm", res.Type)
+
+	// The referenced branch moved: the old entry must not satisfy the lookup. Passing nil here (the
+	// previous behaviour) would make both calls key identically and this assertion would fail.
+	ok, err = handler(revision, cache.ResolvedRevisions{refRepo: newRefSHA}, true)
+	require.NoError(t, err)
+	assert.False(t, ok, "a commit on the referenced branch must invalidate the cached details")
+}

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -30,6 +31,7 @@ import (
 
 	cacheutil "github.com/argoproj/argo-cd/v3/util/cache"
 
+	argosync "github.com/argoproj/pkg/v2/sync"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -565,7 +567,11 @@ func TestGenerateManifestsHelmWithRefs_CachedNoLsRemote(t *testing.T) {
 	require.NoError(t, err)
 	cacheMocks.mockCache.AssertCacheCalledTimes(t, &repositorymocks.CacheCallCounts{
 		ExternalSets: 2,
-		ExternalGets: 4,
+		// Three git-refs reads and two manifest reads. The third git-refs read resolves the ref
+		// source's revision: it used to be skipped because building the cache key rewrote
+		// TargetRevision to a resolved SHA in this very request, which is a side effect the key
+		// builder no longer has. It is a cached read - LsRemote is still never called.
+		ExternalGets: 5,
 	})
 }
 
@@ -3564,7 +3570,7 @@ func Test_populateHelmAppDetails(t *testing.T) {
 	}
 	appPath, err := filepath.Abs("./testdata/values-files/")
 	require.NoError(t, err)
-	err = service.populateHelmAppDetails(t.Context(), &res, appPath, appPath, sha, "main", &q, emptyTempPaths)
+	err = service.populateHelmAppDetails(t.Context(), &res, appPath, appPath, sha, &q, emptyTempPaths)
 	require.NoError(t, err)
 	assert.Len(t, res.Helm.Parameters, 3)
 	assert.Len(t, res.Helm.ValueFiles, 5)
@@ -3676,7 +3682,10 @@ func Test_populateHelmAppDetailsWithRef(t *testing.T) {
 			},
 		},
 		{
-			name: "same_repo_diff_revision_error",
+			// A ref source pointing at the app's own repository at a different revision used to be
+			// rejected here. It is now served from a worktree, matching manifest generation, so the
+			// details pane stays usable for apps that sync fine.
+			name: "same_repo_diff_revision_uses_worktree",
 			makeQuery: func() apiclient.RepoServerAppDetailsQuery {
 				query := queryTemplate
 				query.RefSources = map[string]*v1alpha1.RefTarget{
@@ -3693,33 +3702,87 @@ func Test_populateHelmAppDetailsWithRef(t *testing.T) {
 
 			mockOpts: func(_ *gitmocks.Client, _ *helmmocks.Client, _ *ocimocks.Client, paths *iomocks.TempPaths) {
 				paths.EXPECT().GetPath(repoURL).Return(repoRoot, nil)
+				paths.EXPECT().Add(repoURL+"@"+refSha, mock.AnythingOfType("string")).Return()
+				paths.EXPECT().Remove(repoURL + "@" + refSha).Return()
+				// Keyed by commit, not by repo URL: resolving the value file against the plain repo
+				// URL would read the primary checkout instead of the worktree. A regression there
+				// calls GetPathIfExists(repoURL), which has no expectation and fails the test.
+				paths.EXPECT().GetPathIfExists(repoURL + "@" + refSha).Return(refRoot)
 			},
 			newGitClient: func(_ string, _ string, _ git.Creds, _ bool, _ bool, _ string, _ string, _ ...git.ClientOpts) (gitClient git.Client, e error) {
 				client := gitmocks.Client{}
 				client.EXPECT().LsRemote(refTargetRevision2).Return(refSha, nil)
+				client.EXPECT().Root().Return(repoRoot)
+				client.EXPECT().IsRevisionPresent(mock.Anything, refSha).Return(true)
+				client.EXPECT().CreateWorktree(mock.Anything, refSha, mock.AnythingOfType("string")).Return(nil)
+				client.EXPECT().RemoveWorktree(mock.Anything, mock.AnythingOfType("string")).Return(nil)
 				return &client, nil
 			},
 
 			testResults: func(t *testing.T) {
 				t.Helper()
-				expMsg := fmt.Sprintf("cannot reference a different revision of the same repository (%s references %q which resolves to %q while the application references %q which resolves to %q", refName, refTargetRevision2, refSha, targetRevision, sha)
-				require.Error(t, err)
-				require.ErrorContains(t, err, expMsg)
+				require.NoError(t, err)
+				assert.Len(t, res.Helm.Parameters, 1)
+				for _, v := range res.Helm.Parameters {
+					require.NotNil(t, v)
+					assert.Equal(t, v1alpha1.HelmParameter{Name: "values", Value: "yaml", ForceString: false}, *v)
+				}
 			},
 		},
 		{
-			name: "same_ref_repo_diff_revision_error",
+			// A repository with no repository secret arrives untyped, and Repository.Type documents
+			// that an empty type means git. Treating untyped as non-git skipped the ref entirely, so
+			// its value files silently resolved against the primary checkout - the wrong revision.
+			name: "untyped_repo_is_treated_as_git",
+			makeQuery: func() apiclient.RepoServerAppDetailsQuery {
+				query := queryTemplate
+				query.Repo = &v1alpha1.Repository{Repo: repoURL} // no Type, as for an unregistered repo
+				query.RefSources = map[string]*v1alpha1.RefTarget{
+					refName: {
+						Repo:           v1alpha1.Repository{Repo: repoURL},
+						TargetRevision: refTargetRevision2,
+					},
+				}
+				return query
+			},
+
+			mockOpts: func(_ *gitmocks.Client, _ *helmmocks.Client, _ *ocimocks.Client, paths *iomocks.TempPaths) {
+				paths.EXPECT().GetPath(repoURL).Return(repoRoot, nil)
+				paths.EXPECT().Add(repoURL+"@"+refSha, mock.AnythingOfType("string")).Return()
+				paths.EXPECT().Remove(repoURL + "@" + refSha).Return()
+				paths.EXPECT().GetPathIfExists(repoURL + "@" + refSha).Return(refRoot)
+			},
+			newGitClient: func(_ string, _ string, _ git.Creds, _ bool, _ bool, _ string, _ string, _ ...git.ClientOpts) (gitClient git.Client, e error) {
+				client := gitmocks.Client{}
+				client.EXPECT().LsRemote(refTargetRevision2).Return(refSha, nil)
+				client.EXPECT().Root().Return(repoRoot)
+				client.EXPECT().IsRevisionPresent(mock.Anything, refSha).Return(true)
+				client.EXPECT().CreateWorktree(mock.Anything, refSha, mock.AnythingOfType("string")).Return(nil)
+				client.EXPECT().RemoveWorktree(mock.Anything, mock.AnythingOfType("string")).Return(nil)
+				return &client, nil
+			},
+
+			testResults: func(t *testing.T) {
+				t.Helper()
+				require.NoError(t, err)
+				assert.Len(t, res.Helm.Parameters, 1)
+			},
+		},
+		{
+			// Two refs to the same repository at different revisions used to be rejected. The second
+			// revision now gets a worktree alongside the first ref's checkout.
+			name: "same_ref_repo_diff_revision_uses_worktree",
 			makeQuery: func() apiclient.RepoServerAppDetailsQuery {
 				query := queryTemplate
 				delete(query.RefSources, "$values")
-				query.RefSources["$valuesA"] = &v1alpha1.RefTarget{
+				query.RefSources[refNameA] = &v1alpha1.RefTarget{
 					Repo: v1alpha1.Repository{
 						Type: "git",
 						Repo: refRepoURL,
 					},
 					TargetRevision: refTargetRevision,
 				}
-				query.RefSources["$valuesB"] = &v1alpha1.RefTarget{
+				query.RefSources[refNameB] = &v1alpha1.RefTarget{
 					Repo: v1alpha1.Repository{
 						Type: "git",
 						Repo: refRepoURL,
@@ -3733,7 +3796,11 @@ func Test_populateHelmAppDetailsWithRef(t *testing.T) {
 			mockOpts: func(_ *gitmocks.Client, _ *helmmocks.Client, _ *ocimocks.Client, paths *iomocks.TempPaths) {
 				paths.EXPECT().GetPath(repoURL).Return(repoRoot, nil)
 				paths.EXPECT().GetPath(refRepoURL).Return(refRoot, nil)
-				paths.EXPECT().GetPath(refRepoURL).Return(refRoot, nil)
+				// $valuesA holds the ordinary checkout; $valuesB resolves through its worktree.
+				paths.EXPECT().GetPathIfExists(refRepoURL).Return(refRoot)
+				paths.EXPECT().Add(refRepoURL+"@"+refSha2, mock.AnythingOfType("string")).Return()
+				paths.EXPECT().Remove(refRepoURL + "@" + refSha2).Return()
+				paths.EXPECT().GetPathIfExists(refRepoURL + "@" + refSha2).Return(refRoot)
 			},
 			newGitClient: func(_ string, _ string, _ git.Creds, _ bool, _ bool, _ string, _ string, _ ...git.ClientOpts) (gitClient git.Client, e error) {
 				client := gitmocks.Client{}
@@ -3744,15 +3811,15 @@ func Test_populateHelmAppDetailsWithRef(t *testing.T) {
 				client.EXPECT().IsRevisionPresent(mock.Anything, refSha).Return(true)
 				client.EXPECT().IsRevisionPresent(mock.Anything, refSha2).Return(true)
 				client.EXPECT().Checkout(mock.Anything, refSha, false, true).Return("", nil)
-				client.EXPECT().Checkout(mock.Anything, refSha2, false, true).Return("", nil)
+				client.EXPECT().CreateWorktree(mock.Anything, refSha2, mock.AnythingOfType("string")).Return(nil)
+				client.EXPECT().RemoveWorktree(mock.Anything, mock.AnythingOfType("string")).Return(nil)
 				return &client, nil
 			},
 
 			testResults: func(t *testing.T) {
 				t.Helper()
-				expMsg := fmt.Sprintf("cannot reference multiple revisions for the same repository (%s references %q which resolves to %q while %s references %q which resolves to %q", refNameB, refTargetRevision2, refSha2, refNameA, refTargetRevision, refSha)
-				require.Error(t, err)
-				require.ErrorContains(t, err, expMsg)
+				require.NoError(t, err)
+				assert.Len(t, res.Helm.Parameters, 1)
 			},
 		},
 		{
@@ -3861,10 +3928,12 @@ func Test_populateHelmAppDetailsWithRef(t *testing.T) {
 			query := tc.makeQuery()
 			service, _, _ := newServiceWithOpt(t, tc.mockOpts, ".")
 			service.newGitClient = tc.newGitClient
+			// Keep worktrees out of the source tree; NewService derives this from the "." root.
+			service.worktreeRootDir = t.TempDir()
 			appPath, err = filepath.Abs(repoRoot)
 			require.NoError(t, err)
 			res = apiclient.RepoAppDetailsResponse{}
-			err = service.populateHelmAppDetails(t.Context(), &res, appPath, appPath, sha, "main", &query, service.gitRepoPaths)
+			err = service.populateHelmAppDetails(t.Context(), &res, appPath, appPath, sha, &query, service.gitRepoPaths)
 			tc.testResults(t)
 		})
 	}
@@ -3877,7 +3946,7 @@ func Test_populateHelmAppDetails_values_symlinks(t *testing.T) {
 	t.Run("inbound", func(t *testing.T) {
 		res := apiclient.RepoAppDetailsResponse{}
 		q := apiclient.RepoServerAppDetailsQuery{Repo: &v1alpha1.Repository{}, Source: &v1alpha1.ApplicationSource{}}
-		err := service.populateHelmAppDetails(t.Context(), &res, "./testdata/in-bounds-values-file-link/", "./testdata/in-bounds-values-file-link/", "dummy_sha", "main", &q, emptyTempPaths)
+		err := service.populateHelmAppDetails(t.Context(), &res, "./testdata/in-bounds-values-file-link/", "./testdata/in-bounds-values-file-link/", "dummy_sha", &q, emptyTempPaths)
 		require.NoError(t, err)
 		assert.NotEmpty(t, res.Helm.Values)
 		assert.NotEmpty(t, res.Helm.Parameters)
@@ -3886,7 +3955,7 @@ func Test_populateHelmAppDetails_values_symlinks(t *testing.T) {
 	t.Run("out of bounds", func(t *testing.T) {
 		res := apiclient.RepoAppDetailsResponse{}
 		q := apiclient.RepoServerAppDetailsQuery{Repo: &v1alpha1.Repository{}, Source: &v1alpha1.ApplicationSource{}}
-		err := service.populateHelmAppDetails(t.Context(), &res, "./testdata/out-of-bounds-values-file-link/", "./testdata/out-of-bounds-values-file-link/", sha, "main", &q, emptyTempPaths)
+		err := service.populateHelmAppDetails(t.Context(), &res, "./testdata/out-of-bounds-values-file-link/", "./testdata/out-of-bounds-values-file-link/", sha, &q, emptyTempPaths)
 		require.NoError(t, err)
 		assert.Empty(t, res.Helm.Values)
 		assert.Empty(t, res.Helm.Parameters)
@@ -4125,7 +4194,7 @@ func Test_getResolvedValueFiles(t *testing.T) {
 		tcc := tc
 		t.Run(tcc.name, func(t *testing.T) {
 			t.Parallel()
-			resolvedPaths, err := getResolvedValueFiles(path.Join(tempDir, "main-repo"), path.Join(tempDir, "main-repo"), tcc.env, []string{}, []string{tcc.rawPath}, tcc.refSources, paths, false)
+			resolvedPaths, err := getResolvedValueFiles(path.Join(tempDir, "main-repo"), path.Join(tempDir, "main-repo"), tcc.env, []string{}, []string{tcc.rawPath}, tcc.refSources, paths, false, nil)
 			if !tcc.expectedErr {
 				require.NoError(t, err)
 				require.Len(t, resolvedPaths, 1)
@@ -4348,7 +4417,7 @@ func Test_getResolvedValueFiles_glob(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			repoPath := path.Join(tempDir, "main-repo")
-			resolvedPaths, err := getResolvedValueFiles(repoPath, repoPath, tt.env, []string{}, []string{tt.rawPath}, tt.refSources, paths, tt.ignoreMissingValueFiles)
+			resolvedPaths, err := getResolvedValueFiles(repoPath, repoPath, tt.env, []string{}, []string{tt.rawPath}, tt.refSources, paths, tt.ignoreMissingValueFiles, nil)
 			if tt.expectedErr {
 				require.Error(t, err)
 				return
@@ -4375,7 +4444,7 @@ func Test_getResolvedValueFiles_glob(t *testing.T) {
 				"envs/*.yaml", // glob - z.yaml is explicit so skipped; only a.yaml added
 				"envs/z.yaml", // explicit - placed last, highest precedence
 			},
-			map[string]*v1alpha1.RefTarget{}, paths, false,
+			map[string]*v1alpha1.RefTarget{}, paths, false, nil,
 		)
 		require.NoError(t, err)
 		require.Len(t, resolvedPaths, 2)
@@ -4393,7 +4462,7 @@ func Test_getResolvedValueFiles_glob(t *testing.T) {
 				"prod/a.yaml", // explicit locks in position 0
 				"prod/*.yaml", // glob - a.yaml already seen, only b.yaml is new
 			},
-			map[string]*v1alpha1.RefTarget{}, paths, false,
+			map[string]*v1alpha1.RefTarget{}, paths, false, nil,
 		)
 		require.NoError(t, err)
 		require.Len(t, resolvedPaths, 2)
@@ -4411,7 +4480,7 @@ func Test_getResolvedValueFiles_glob(t *testing.T) {
 				"prod/*.yaml", // glob - a.yaml is explicit so skipped; only b.yaml added (pos 0)
 				"prod/a.yaml", // explicit - placed here at pos 1 (highest precedence)
 			},
-			map[string]*v1alpha1.RefTarget{}, paths, false,
+			map[string]*v1alpha1.RefTarget{}, paths, false, nil,
 		)
 		require.NoError(t, err)
 		require.Len(t, resolvedPaths, 2)
@@ -4429,7 +4498,7 @@ func Test_getResolvedValueFiles_glob(t *testing.T) {
 				"prod/*.yaml",    // adds a.yaml, b.yaml
 				"prod/**/*.yaml", // a.yaml, b.yaml already seen; adds nested/c.yaml, nested/d.yaml
 			},
-			map[string]*v1alpha1.RefTarget{}, paths, false,
+			map[string]*v1alpha1.RefTarget{}, paths, false, nil,
 		)
 		require.NoError(t, err)
 		require.Len(t, resolvedPaths, 4)
@@ -4452,7 +4521,7 @@ func Test_getResolvedValueFiles_glob(t *testing.T) {
 				"prod/**/*.yaml",     // a.yaml, b.yaml, nested/c.yaml all explicit and skipped; nested/d.yaml added - pos 2
 				"prod/nested/c.yaml", // explicit - pos 3
 			},
-			map[string]*v1alpha1.RefTarget{}, paths, false,
+			map[string]*v1alpha1.RefTarget{}, paths, false, nil,
 		)
 		require.NoError(t, err)
 		require.Len(t, resolvedPaths, 4)
@@ -4575,7 +4644,7 @@ func Test_getResolvedValueFiles_glob_symlink_escape(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(outsideDir, "secret.yaml"), []byte("password: hunter2"), 0o644))
 	require.NoError(t, os.Symlink(filepath.Join(outsideDir, "secret.yaml"), filepath.Join(repoDir, "values", "escape.yaml")))
 
-	_, err := getResolvedValueFiles(repoDir, repoDir, &v1alpha1.Env{}, []string{}, []string{"values/*.yaml"}, map[string]*v1alpha1.RefTarget{}, paths, false)
+	_, err := getResolvedValueFiles(repoDir, repoDir, &v1alpha1.Env{}, []string{}, []string{"values/*.yaml"}, map[string]*v1alpha1.RefTarget{}, paths, false, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "resolved to outside repository root")
 }
@@ -6194,4 +6263,691 @@ func TestGetHelmRepos_InsecureOCIForceHttpPropagatedFromRepoCreds(t *testing.T) 
 
 	require.Len(t, helmRepos, 1)
 	assert.True(t, helmRepos[0].InsecureOCIForceHttp)
+}
+
+func TestGenerateManifest_MultiSource_SameRepoWithDifferentRevisions(t *testing.T) {
+	// This test validates that multi-source applications can reference the same
+	// git repository with different target revisions by using git worktrees.
+	root, err := filepath.Abs("../../util/helm/testdata")
+	require.NoError(t, err)
+
+	primarySHA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	refSHA := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+	paths := &iomocks.TempPaths{}
+	helmClient := &helmmocks.Client{}
+	ociClient := &ocimocks.Client{}
+
+	// Create two separate git clients - one for primary, one for ref source
+	primaryGitClient := &gitmocks.Client{}
+	refGitClient := &gitmocks.Client{}
+
+	// Primary source checkout behavior
+	primaryGitClient.EXPECT().Init().Return(nil)
+	primaryGitClient.EXPECT().IsRevisionPresent(mock.Anything, mock.Anything).Return(false)
+	primaryGitClient.EXPECT().Fetch(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	primaryGitClient.EXPECT().Checkout(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
+	primaryGitClient.EXPECT().LsRemote("main").Return(primarySHA, nil)
+	primaryGitClient.EXPECT().CommitSHA(mock.Anything).Return(primarySHA, nil)
+	primaryGitClient.EXPECT().Root().Return(root)
+	primaryGitClient.EXPECT().IsAnnotatedTag(mock.Anything, mock.Anything).Return(false)
+	primaryGitClient.EXPECT().VerifyCommitSignature(mock.Anything, mock.Anything).Return("", nil)
+
+	// Ref source behavior - uses worktree since different revision
+	refGitClient.EXPECT().Init().Return(nil)
+	refGitClient.EXPECT().IsRevisionPresent(mock.Anything, mock.Anything).Return(false)
+	refGitClient.EXPECT().Fetch(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	refGitClient.EXPECT().LsRemote("v1.0.0").Return(refSHA, nil)
+	refGitClient.EXPECT().CommitSHA(mock.Anything).Return(refSHA, nil)
+	refGitClient.EXPECT().CreateWorktree(mock.Anything, refSHA, mock.AnythingOfType("string")).Return(nil)
+	refGitClient.EXPECT().RemoveWorktree(mock.Anything, mock.AnythingOfType("string")).Return(nil).Maybe()
+	refGitClient.EXPECT().Root().Return(root)
+
+	// Track which client to return
+	callCount := 0
+
+	// Helm client setup
+	helmClient.EXPECT().GetIndex(mock.Anything, mock.AnythingOfType("bool"), mock.Anything).Return(&helm.Index{Entries: map[string]helm.Entries{
+		"redis": {{Version: "1.0.0"}},
+	}}, nil)
+	helmClient.EXPECT().GetTags(mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+
+	// OCI client setup
+	ociClient.EXPECT().GetTags(mock.Anything, mock.Anything).Return(nil, nil)
+	ociClient.EXPECT().ResolveRevision(mock.Anything, mock.Anything, mock.Anything).Return("", nil)
+
+	// Paths mock - Add is called for both primary and worktree
+	paths.EXPECT().Add(mock.Anything, mock.Anything).Return()
+	paths.EXPECT().GetPath(mock.Anything).Return(root, nil)
+	paths.EXPECT().GetPathIfExists(mock.Anything).Return(root)
+	paths.EXPECT().GetPaths().Return(map[string]string{"fake-nonce": root})
+	paths.EXPECT().Remove(mock.Anything).Return()
+
+	cacheMocks := newCacheMocks()
+	t.Cleanup(cacheMocks.mockCache.StopRedisCallback)
+
+	service := NewService(metrics.NewMetricsServer(), cacheMocks.cache, RepoServerInitConstants{ParallelismLimit: 1}, &git.NoopCredsStore{}, root)
+	service.newGitClient = func(_, _ string, _ git.Creds, _, _ bool, _, _ string, _ ...git.ClientOpts) (git.Client, error) {
+		callCount++
+		if callCount == 1 {
+			return primaryGitClient, nil
+		}
+		return refGitClient, nil
+	}
+	service.newHelmClient = func(_ string, _ helm.Creds, _ bool, _, _ string, _ ...helm.ClientOpts) helm.Client {
+		return helmClient
+	}
+	service.newOCIClient = func(_ string, _ oci.Creds, _, _ string, _ []string, _ ...oci.ClientOpts) (oci.Client, error) {
+		return ociClient, nil
+	}
+	service.gitRepoInitializer = func(_ string) goio.Closer {
+		return utilio.NopCloser
+	}
+	service.gitRepoPaths = paths
+
+	// Create a request with same repo but different target revisions
+	req := &apiclient.ManifestRequest{
+		Repo: &v1alpha1.Repository{
+			Repo: "https://github.com/example/repo.git",
+		},
+		Revision: "main",
+		ApplicationSource: &v1alpha1.ApplicationSource{
+			RepoURL:        "https://github.com/example/repo.git",
+			Path:           "./redis",
+			TargetRevision: "main",
+			Helm: &v1alpha1.ApplicationSourceHelm{
+				ValueFiles: []string{"$values/redis/values-production.yaml"},
+			},
+		},
+		HasMultipleSources: true,
+		NoCache:            true,
+		ProjectName:        "test-project",
+		ProjectSourceRepos: []string{"*"},
+		// RefSources with same repo but different revision
+		RefSources: map[string]*v1alpha1.RefTarget{
+			"$values": {
+				TargetRevision: "v1.0.0", // Different revision than primary source
+				Repo: v1alpha1.Repository{
+					Repo: "https://github.com/example/repo.git", // Same repo as primary
+				},
+			},
+		},
+	}
+
+	// The test should succeed - worktree allows same repo with different revisions
+	_, err = service.GenerateManifest(t.Context(), req)
+	// We expect no error since worktrees should handle different revisions
+	// Note: The actual manifest generation may still fail due to missing files,
+	// but the key assertion is that we don't get the old
+	// "cannot reference the same repository multiple times when the" error
+	if err != nil {
+		assert.NotContains(t, err.Error(), "cannot reference the same repository multiple times")
+	}
+
+	// Verify that CreateWorktree was called on refGitClient
+	// RemoveWorktree is called via defer, which may happen after test assertions in some timing scenarios
+	refGitClient.AssertCalled(t, "CreateWorktree", mock.Anything, refSHA, mock.AnythingOfType("string"))
+}
+
+// TestGenerateManifest_MultiSource_WorktreeOutOfBoundsSymlinkRejected verifies that the worktree
+// path runs the out-of-bounds symlink check: a worktree containing a symlink that escapes its root
+// must cause manifest generation to fail.
+func TestGenerateManifest_MultiSource_WorktreeOutOfBoundsSymlinkRejected(t *testing.T) {
+	// Real root so the primary source's app path (./redis) resolves; the worktree itself is created
+	// under a temp dir (service.worktreeRootDir override below).
+	root, err := filepath.Abs("../../util/helm/testdata")
+	require.NoError(t, err)
+
+	primarySHA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	refSHA := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+	// A file outside any worktree; the malicious symlink points here.
+	outsideFile := filepath.Join(t.TempDir(), "secret.yaml")
+	require.NoError(t, os.WriteFile(outsideFile, []byte("secret: true"), 0o600))
+
+	paths := &iomocks.TempPaths{}
+	helmClient := &helmmocks.Client{}
+	ociClient := &ocimocks.Client{}
+	primaryGitClient := &gitmocks.Client{}
+	refGitClient := &gitmocks.Client{}
+
+	primaryGitClient.EXPECT().Init().Return(nil)
+	primaryGitClient.EXPECT().IsRevisionPresent(mock.Anything, mock.Anything).Return(false)
+	primaryGitClient.EXPECT().Fetch(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	primaryGitClient.EXPECT().Checkout(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
+	primaryGitClient.EXPECT().LsRemote("main").Return(primarySHA, nil)
+	primaryGitClient.EXPECT().CommitSHA(mock.Anything).Return(primarySHA, nil)
+	primaryGitClient.EXPECT().Root().Return(root)
+	primaryGitClient.EXPECT().IsAnnotatedTag(mock.Anything, mock.Anything).Return(false)
+	primaryGitClient.EXPECT().VerifyCommitSignature(mock.Anything, mock.Anything).Return("", nil)
+
+	refGitClient.EXPECT().Init().Return(nil)
+	refGitClient.EXPECT().IsRevisionPresent(mock.Anything, mock.Anything).Return(false)
+	refGitClient.EXPECT().Fetch(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	refGitClient.EXPECT().LsRemote("v1.0.0").Return(refSHA, nil)
+	refGitClient.EXPECT().CommitSHA(mock.Anything).Return(refSHA, nil)
+	refGitClient.EXPECT().Root().Return(root)
+	// Create a real worktree directory containing an out-of-bounds symlink.
+	refGitClient.EXPECT().CreateWorktree(mock.Anything, refSHA, mock.AnythingOfType("string")).RunAndReturn(func(_ context.Context, _ string, worktreePath string) error {
+		if err := os.MkdirAll(worktreePath, 0o700); err != nil {
+			return err
+		}
+		return os.Symlink(outsideFile, filepath.Join(worktreePath, "evil.yaml"))
+	})
+	refGitClient.EXPECT().RemoveWorktree(mock.Anything, mock.AnythingOfType("string")).Return(nil).Maybe()
+
+	callCount := 0
+	helmClient.EXPECT().GetIndex(mock.Anything, mock.AnythingOfType("bool"), mock.Anything).Return(&helm.Index{Entries: map[string]helm.Entries{
+		"redis": {{Version: "1.0.0"}},
+	}}, nil).Maybe()
+	helmClient.EXPECT().GetTags(mock.Anything, mock.Anything, mock.Anything).Return(nil, nil).Maybe()
+	ociClient.EXPECT().GetTags(mock.Anything, mock.Anything).Return(nil, nil).Maybe()
+	ociClient.EXPECT().ResolveRevision(mock.Anything, mock.Anything, mock.Anything).Return("", nil).Maybe()
+
+	paths.EXPECT().Add(mock.Anything, mock.Anything).Return()
+	paths.EXPECT().GetPath(mock.Anything).Return(root, nil)
+	paths.EXPECT().GetPathIfExists(mock.Anything).Return(root)
+	paths.EXPECT().GetPaths().Return(map[string]string{"fake-nonce": root})
+	paths.EXPECT().Remove(mock.Anything).Return()
+
+	cacheMocks := newCacheMocks()
+	t.Cleanup(cacheMocks.mockCache.StopRedisCallback)
+
+	service := NewService(metrics.NewMetricsServer(), cacheMocks.cache, RepoServerInitConstants{ParallelismLimit: 1}, &git.NoopCredsStore{}, root)
+	service.newGitClient = func(_, _ string, _ git.Creds, _, _ bool, _, _ string, _ ...git.ClientOpts) (git.Client, error) {
+		callCount++
+		if callCount == 1 {
+			return primaryGitClient, nil
+		}
+		return refGitClient, nil
+	}
+	service.newHelmClient = func(_ string, _ helm.Creds, _ bool, _, _ string, _ ...helm.ClientOpts) helm.Client {
+		return helmClient
+	}
+	service.newOCIClient = func(_ string, _ oci.Creds, _, _ string, _ []string, _ ...oci.ClientOpts) (oci.Client, error) {
+		return ociClient, nil
+	}
+	service.gitRepoInitializer = func(_ string) goio.Closer {
+		return utilio.NopCloser
+	}
+	service.gitRepoPaths = paths
+	// Keep worktrees under a temp dir so they are cleaned up with the test.
+	service.worktreeRootDir = t.TempDir()
+
+	req := &apiclient.ManifestRequest{
+		Repo:     &v1alpha1.Repository{Repo: "https://github.com/example/repo.git"},
+		Revision: "main",
+		ApplicationSource: &v1alpha1.ApplicationSource{
+			RepoURL:        "https://github.com/example/repo.git",
+			Path:           "./redis",
+			TargetRevision: "main",
+			Helm: &v1alpha1.ApplicationSourceHelm{
+				ValueFiles: []string{"$values/redis/values-production.yaml"},
+			},
+		},
+		HasMultipleSources: true,
+		NoCache:            true,
+		ProjectName:        "test-project",
+		ProjectSourceRepos: []string{"*"},
+		RefSources: map[string]*v1alpha1.RefTarget{
+			"$values": {
+				TargetRevision: "v1.0.0",
+				Repo:           v1alpha1.Repository{Repo: "https://github.com/example/repo.git"},
+			},
+		},
+	}
+
+	_, err = service.GenerateManifest(t.Context(), req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "out-of-bounds symlinks")
+}
+
+// TestCreateAndRegisterWorktree_SerializesPerRoot verifies that concurrent worktree creations
+// against the same repository root are serialized by gitWorktreeLock, preventing the git fetch /
+// worktree-add races on the shared .git directory. Run with -race for full coverage.
+func TestCreateAndRegisterWorktree_SerializesPerRoot(t *testing.T) {
+	paths := &iomocks.TempPaths{}
+	paths.EXPECT().Add(mock.Anything, mock.Anything).Return()
+
+	gitClient := &gitmocks.Client{}
+	gitClient.EXPECT().Root().Return("/fake/repo/root")
+	// Revision already present locally, so Fetch is skipped; the worktree-add is the critical section.
+	gitClient.EXPECT().IsRevisionPresent(mock.Anything, mock.Anything).Return(true)
+
+	var inFlight atomic.Int32
+	var maxInFlight atomic.Int32
+	gitClient.EXPECT().CreateWorktree(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, _ string, _ string) error {
+		cur := inFlight.Add(1)
+		for {
+			prev := maxInFlight.Load()
+			if cur <= prev || maxInFlight.CompareAndSwap(prev, cur) {
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond) // widen the window so an unserialized race would overlap
+		inFlight.Add(-1)
+		return nil
+	})
+
+	s := &Service{
+		gitWorktreeLock: argosync.NewKeyLock(),
+		gitRepoPaths:    paths,
+		worktrees:       map[string]*worktreeRef{},
+		worktreeRootDir: t.TempDir(),
+	}
+
+	const goroutines = 8
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := range goroutines {
+		go func(i int) {
+			defer wg.Done()
+			// Distinct commit SHAs so each registers a unique worktree path, but the same root.
+			_, _, err := s.createAndRegisterWorktree(t.Context(), gitClient, "https://github.com/example/repo.git", fmt.Sprintf("%040d", i), 0)
+			assert.NoError(t, err)
+		}(i)
+	}
+	wg.Wait()
+
+	assert.Equal(t, int32(1), maxInFlight.Load(), "worktree operations on the same repo root must be serialized")
+}
+
+// TestCreateAndRegisterWorktree_RefCountsSharedWorktree verifies that concurrent requests (and
+// repeated refs) for the same repo+commit share a single worktree, which is created once and
+// removed only when the last user releases it — preventing duplicate worktrees and a gitRepoPaths
+// registry collision where one request deletes another's still-active registration.
+func TestCreateAndRegisterWorktree_RefCountsSharedWorktree(t *testing.T) {
+	const repoURL = "https://github.com/example/repo.git"
+	const sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	// createAndRegisterWorktree takes an already-normalized repo URL (as the production caller does).
+	normalizedRepoURL := git.NormalizeGitURL(repoURL)
+	key := normalizedRepoURL + "@" + sha
+
+	registered := map[string]string{}
+	var registeredMu sync.Mutex
+	paths := &iomocks.TempPaths{}
+	paths.EXPECT().Add(mock.Anything, mock.Anything).Run(func(k, v string) {
+		registeredMu.Lock()
+		registered[k] = v
+		registeredMu.Unlock()
+	}).Return()
+	paths.EXPECT().Remove(mock.Anything).Run(func(k string) {
+		registeredMu.Lock()
+		delete(registered, k)
+		registeredMu.Unlock()
+	}).Return()
+
+	gitClient := &gitmocks.Client{}
+	gitClient.EXPECT().Root().Return("/fake/repo/root")
+	gitClient.EXPECT().IsRevisionPresent(mock.Anything, mock.Anything).Return(true)
+	var createCalls, removeCalls atomic.Int32
+	gitClient.EXPECT().CreateWorktree(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, _ string, _ string) error {
+		createCalls.Add(1)
+		return nil
+	})
+	gitClient.EXPECT().RemoveWorktree(mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, _ string) error {
+		removeCalls.Add(1)
+		return nil
+	}).Maybe()
+
+	s := &Service{
+		gitWorktreeLock: argosync.NewKeyLock(),
+		gitRepoPaths:    paths,
+		worktrees:       map[string]*worktreeRef{},
+		worktreeRootDir: t.TempDir(),
+	}
+
+	const goroutines = 8
+	var wg sync.WaitGroup
+	paths1 := make([]string, goroutines)
+	cleanups := make([]*worktreeCleanup, goroutines)
+	wg.Add(goroutines)
+	for i := range goroutines {
+		go func(i int) {
+			defer wg.Done()
+			p, cleanup, err := s.createAndRegisterWorktree(t.Context(), gitClient, normalizedRepoURL, sha, 0)
+			assert.NoError(t, err)
+			paths1[i] = p
+			cleanups[i] = cleanup
+		}(i)
+	}
+	wg.Wait()
+
+	// One physical worktree created and shared by all callers.
+	assert.Equal(t, int32(1), createCalls.Load(), "same repo+commit must create exactly one worktree")
+	for i := 1; i < goroutines; i++ {
+		assert.Equal(t, paths1[0], paths1[i], "all callers must receive the same shared worktree path")
+	}
+	registeredMu.Lock()
+	assert.Equal(t, paths1[0], registered[key], "worktree path must be registered under repo@sha")
+	registeredMu.Unlock()
+
+	// Releasing all but the last reference must NOT remove the worktree.
+	for i := range goroutines - 1 {
+		cleanups[i].cleanup()
+	}
+	assert.Equal(t, int32(0), removeCalls.Load(), "worktree must stay while references remain")
+	registeredMu.Lock()
+	_, stillRegistered := registered[key]
+	registeredMu.Unlock()
+	assert.True(t, stillRegistered, "registration must persist while references remain")
+
+	// The final release removes it.
+	cleanups[goroutines-1].cleanup()
+	assert.Equal(t, int32(1), removeCalls.Load(), "worktree must be removed once after the last release")
+	registeredMu.Lock()
+	_, stillRegistered = registered[key]
+	registeredMu.Unlock()
+	assert.False(t, stillRegistered, "registration must be removed after the last release")
+}
+
+// TestGetResolvedValueFiles_GlobFromWorktreeUsesWorktreeRoot verifies that a globbed $ref value
+// file from a same-repo/different-revision source is boundary-checked against the worktree root
+// (where the files actually live), not the main checkout root. Before the fix, effectiveRoot was
+// derived from the plain repo key, so the glob matches resolved "outside repository root".
+func TestGetResolvedValueFiles_GlobFromWorktreeUsesWorktreeRoot(t *testing.T) {
+	const repoURL = "https://github.com/example/repo.git"
+	const sha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+	base := t.TempDir()
+	mainDir := filepath.Join(base, "main")   // plain repo key -> main checkout (no value files)
+	worktreeDir := filepath.Join(base, "wt") // repo@sha key -> worktree with the value files
+	require.NoError(t, os.MkdirAll(mainDir, 0o755))
+	require.NoError(t, os.MkdirAll(worktreeDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(worktreeDir, "a.yaml"), []byte("a: 1"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(worktreeDir, "b.yaml"), []byte("b: 2"), 0o644))
+
+	paths := utilio.NewRandomizedTempPaths(base)
+	paths.Add(git.NormalizeGitURL(repoURL), mainDir)
+	paths.Add(git.NormalizeGitURL(repoURL)+"@"+sha, worktreeDir)
+
+	refSources := map[string]*v1alpha1.RefTarget{
+		"$values": {Repo: v1alpha1.Repository{Repo: repoURL}},
+	}
+	refSourceCommitSHAs := map[string]string{"$values": sha}
+
+	resolved, err := getResolvedValueFiles(
+		mainDir, mainDir, &v1alpha1.Env{}, []string{},
+		[]string{"$values/*.yaml"},
+		refSources, paths, false, refSourceCommitSHAs,
+	)
+	require.NoError(t, err)
+	require.Len(t, resolved, 2)
+	assert.Equal(t, filepath.Join(worktreeDir, "a.yaml"), string(resolved[0]))
+	assert.Equal(t, filepath.Join(worktreeDir, "b.yaml"), string(resolved[1]))
+}
+
+// TestInit_RemovesOrphanedWorktrees verifies that startup cleanup removes worktree working
+// directories and stale .git/worktrees admin entries left behind by a previous process (e.g. a
+// crash), which would otherwise accumulate on the repo-server volume across restarts.
+func TestInit_RemovesOrphanedWorktrees(t *testing.T) {
+	base := t.TempDir()
+	rootDir := filepath.Join(base, "_argocd-repo")
+
+	cacheMocks := newCacheMocks()
+	t.Cleanup(cacheMocks.mockCache.StopRedisCallback)
+	s := NewService(metrics.NewMetricsServer(), cacheMocks.cache, RepoServerInitConstants{}, &git.NoopCredsStore{}, rootDir)
+
+	// Orphaned worktree working directory under the dedicated worktree root.
+	orphanWorktree := filepath.Join(s.worktreeRootDir, "argocd-worktree-orphan")
+	require.NoError(t, os.MkdirAll(orphanWorktree, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(orphanWorktree, "checkout.yaml"), []byte("x: 1"), 0o644))
+
+	// Stale worktree admin entry inside a previously cloned repo.
+	repoClone := filepath.Join(rootDir, "some-repo")
+	adminDir := filepath.Join(repoClone, ".git", "worktrees", "stale")
+	require.NoError(t, os.MkdirAll(adminDir, 0o700))
+
+	require.NoError(t, s.Init())
+
+	// The orphaned working directory is gone, but the (empty) worktree root remains.
+	_, err := os.Stat(orphanWorktree)
+	assert.True(t, os.IsNotExist(err), "orphaned worktree dir should be removed")
+	_, err = os.Stat(s.worktreeRootDir)
+	assert.NoError(t, err, "worktree root dir should be recreated")
+
+	// The stale admin entry is pruned. Init locks the clone down (0000), so restore read access first.
+	require.NoError(t, os.Chmod(repoClone, 0o700))
+	_, err = os.Stat(filepath.Join(repoClone, ".git", "worktrees"))
+	assert.True(t, os.IsNotExist(err), "stale .git/worktrees admin dir should be pruned")
+
+	// Init also locks rootDir to 0300; restore it so t.TempDir cleanup can remove the tree.
+	require.NoError(t, os.Chmod(rootDir, 0o700))
+}
+
+func TestRefRevisionKeyer(t *testing.T) {
+	const (
+		primaryURL = "https://github.com/foo/primary"
+		otherURL   = "https://github.com/foo/other"
+		shaX       = "aaaa000000000000000000000000000000000000"
+		shaY       = "bbbb111111111111111111111111111111111111"
+		shaZ       = "cccc222222222222222222222222222222222222"
+	)
+
+	type call struct {
+		repoURL      string
+		commitSHA    string
+		wantKey      string
+		wantWorktree bool
+	}
+
+	testCases := []struct {
+		name  string
+		calls []call
+	}{
+		{
+			name:  "first revision of an unrelated repo takes the plain URL",
+			calls: []call{{otherURL, shaY, otherURL, false}},
+		},
+		{
+			name:  "ref matching the primary source's commit shares its checkout",
+			calls: []call{{primaryURL, shaX, primaryURL, false}},
+		},
+		{
+			name:  "ref on the primary repo at another commit needs a worktree",
+			calls: []call{{primaryURL, shaY, primaryURL + "@" + shaY, true}},
+		},
+		{
+			name: "second revision of the same repo is keyed separately",
+			calls: []call{
+				{otherURL, shaY, otherURL, false},
+				{otherURL, shaZ, otherURL + "@" + shaZ, true},
+			},
+		},
+		{
+			// Otherwise a repeated ref would create a redundant worktree at a commit the ordinary
+			// checkout already holds.
+			name: "repeat of an already-checked-out commit reuses the plain URL",
+			calls: []call{
+				{otherURL, shaY, otherURL, false},
+				{otherURL, shaY, otherURL, false},
+			},
+		},
+		{
+			name: "three revisions of the same repo each get a key",
+			calls: []call{
+				{primaryURL, shaX, primaryURL, false},
+				{primaryURL, shaY, primaryURL + "@" + shaY, true},
+				{primaryURL, shaZ, primaryURL + "@" + shaZ, true},
+				{primaryURL, shaY, primaryURL + "@" + shaY, true},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			keyer := newRefRevisionKeyer(primaryURL, shaX)
+			for i, c := range tc.calls {
+				key, needsWorktree := keyer.key(c.repoURL, c.commitSHA)
+				assert.Equal(t, c.wantKey, key, "call %d key", i)
+				assert.Equal(t, c.wantWorktree, needsWorktree, "call %d worktree", i)
+			}
+		})
+	}
+}
+
+// Test_resolveReferencedSources_recordsEveryRevision covers the cache-invalidation half of the
+// worktree feature: the manifest cache key has to carry every referenced revision. Recording only
+// the first commit per repository (the previous behaviour) meant a commit on a second referenced
+// revision left the key unchanged.
+func Test_resolveReferencedSources_recordsEveryRevision(t *testing.T) {
+	const (
+		primaryURL = "https://github.com/foo/primary"
+		otherURL   = "https://github.com/foo/other"
+		primarySHA = "aaaa000000000000000000000000000000000000"
+		shaStable  = "bbbb111111111111111111111111111111111111"
+		shaDev     = "cccc222222222222222222222222222222222222"
+	)
+
+	// Resolves each target revision to a distinct commit, and counts lookups so we can assert
+	// repeated references to one revision are not re-resolved.
+	revisions := map[string]string{"stable": shaStable, "dev": shaDev, "main": primarySHA}
+	var lookups int
+	resolver := func(_ *v1alpha1.Repository, revision string, _ ...git.ClientOpts) (git.Client, string, error) {
+		lookups++
+		sha, ok := revisions[revision]
+		if !ok {
+			return nil, "", fmt.Errorf("unexpected revision %q", revision)
+		}
+		return nil, sha, nil
+	}
+
+	testCases := []struct {
+		name        string
+		source      *v1alpha1.ApplicationSourceHelm
+		refSources  map[string]*v1alpha1.RefTarget
+		want        map[string]string
+		wantLookups int
+	}{
+		{
+			name:   "two revisions of the same repo are both recorded",
+			source: &v1alpha1.ApplicationSourceHelm{ValueFiles: []string{"$a/v.yaml", "$b/v.yaml"}},
+			refSources: map[string]*v1alpha1.RefTarget{
+				"$a": {Repo: v1alpha1.Repository{Repo: otherURL}, TargetRevision: "stable"},
+				"$b": {Repo: v1alpha1.Repository{Repo: otherURL}, TargetRevision: "dev"},
+			},
+			want: map[string]string{
+				otherURL:                shaStable,
+				otherURL + "@" + shaDev: shaDev,
+			},
+			wantLookups: 2,
+		},
+		{
+			name:   "ref on the app's own repo at another revision is keyed by commit",
+			source: &v1alpha1.ApplicationSourceHelm{ValueFiles: []string{"$a/v.yaml"}},
+			refSources: map[string]*v1alpha1.RefTarget{
+				"$a": {Repo: v1alpha1.Repository{Repo: primaryURL}, TargetRevision: "stable"},
+			},
+			want:        map[string]string{primaryURL + "@" + shaStable: shaStable},
+			wantLookups: 1,
+		},
+		{
+			name:   "ref resolving to the primary commit keeps the plain URL key",
+			source: &v1alpha1.ApplicationSourceHelm{ValueFiles: []string{"$a/v.yaml"}},
+			refSources: map[string]*v1alpha1.RefTarget{
+				"$a": {Repo: v1alpha1.Repository{Repo: primaryURL}, TargetRevision: "main"},
+			},
+			want:        map[string]string{primaryURL: primarySHA},
+			wantLookups: 1,
+		},
+		{
+			name: "repeated references to one revision resolve once",
+			source: &v1alpha1.ApplicationSourceHelm{
+				ValueFiles:     []string{"$a/v.yaml", "$a/other.yaml"},
+				FileParameters: []v1alpha1.HelmFileParameter{{Name: "p", Path: "$a/p.txt"}},
+			},
+			refSources: map[string]*v1alpha1.RefTarget{
+				"$a": {Repo: v1alpha1.Repository{Repo: otherURL}, TargetRevision: "stable"},
+			},
+			want:        map[string]string{otherURL: shaStable},
+			wantLookups: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			lookups = 0
+			got, err := resolveReferencedSources(true, tc.source, tc.refSources, resolver, git.ClientOpts(nil), primaryURL, primarySHA)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+			assert.Equal(t, tc.wantLookups, lookups, "revision resolutions")
+		})
+	}
+}
+
+// TestGenerateManifests_SameRepoTwoRevisions_CacheHit is the regression test for the manifest cache
+// key of a multi-revision app. Manifest generation records worktree-backed refs under
+// "<url>@<sha>", so the lookup side (resolveReferencedSources) has to derive the same key. When the
+// two disagreed, the entry written was never the entry read and these apps re-generated manifests
+// on every reconcile.
+func TestGenerateManifests_SameRepoTwoRevisions_CacheHit(t *testing.T) {
+	// os.MkdirTemp rather than t.TempDir(): the async goroutine in runManifestGenAsync chmods the
+	// directory to 0o000 after GenerateManifest returns, racing t.TempDir()'s cleanup.
+	dir, err := os.MkdirTemp("", "TestGenerateManifests_SameRepoTwoRevisions_CacheHit")
+	require.NoError(t, err)
+	repopath := dir + "/tmprepo"
+
+	cacheMocks := newCacheMocks()
+	t.Cleanup(cacheMocks.mockCache.StopRedisCallback)
+	service := NewService(metrics.NewMetricsServer(), cacheMocks.cache, RepoServerInitConstants{ParallelismLimit: 1}, &git.NoopCredsStore{}, repopath)
+	service.newGitClient = git.NewClientExt
+
+	repoRemote := "file://" + repopath
+	// The pinned revision the $ref source points at.
+	pinnedRevision := initGitRepo(t, newGitRepoOptions{
+		path:       repopath,
+		createPath: true,
+		remote:     repoRemote,
+		helmChartOptions: newGitRepoHelmChartOptions{
+			chartName:   "my-chart",
+			valuesFiles: map[string]map[string]string{"test.yaml": {"testval": "pinned"}},
+		},
+	})
+	// Move HEAD on, so the primary source and the $ref source resolve to different commits and the
+	// generation path has to use a worktree.
+	require.NoError(t, os.WriteFile(filepath.Join(repopath, "test.yaml"), []byte("testval: head\n"), 0o644))
+	for _, args := range [][]string{{"add", "-A"}, {"commit", "-m", "move head"}} {
+		cmd := exec.CommandContext(t.Context(), "git", args...)
+		cmd.Dir = repopath
+		require.NoError(t, cmd.Run())
+	}
+
+	repo := &v1alpha1.Repository{Repo: repoRemote}
+	// A fresh request per call: GenerateManifests applies overrides to the ApplicationSource it is
+	// given as a documented side effect, so reusing one would change the cache key by itself.
+	newQuery := func() *apiclient.ManifestRequest {
+		return &apiclient.ManifestRequest{
+			Repo:               repo,
+			Revision:           "HEAD",
+			HasMultipleSources: true,
+			ApplicationSource: &v1alpha1.ApplicationSource{
+				RepoURL: repoRemote, Path: ".", TargetRevision: "HEAD",
+				Helm: &v1alpha1.ApplicationSourceHelm{ValueFiles: []string{"$ref/test.yaml"}},
+			},
+			ProjectName:        "default",
+			ProjectSourceRepos: []string{"*"},
+			RefSources:         map[string]*v1alpha1.RefTarget{"$ref": {TargetRevision: pinnedRevision, Repo: *repo}},
+		}
+	}
+	cacheSets := func() int {
+		sets := 0
+		for _, call := range cacheMocks.mockCache.RedisClient.Calls {
+			if call.Method == "Set" {
+				sets++
+			}
+		}
+		return sets
+	}
+
+	_, err = service.GenerateManifest(t.Context(), newQuery())
+	require.NoError(t, err)
+	setsAfterFirst := cacheSets()
+
+	_, err = service.GenerateManifest(t.Context(), newQuery())
+	require.NoError(t, err)
+
+	// The second identical request must be served from the manifest cache, so it stores nothing new.
+	// A fresh Set means the lookup key did not match the key the first call stored under.
+	assert.Equal(t, setsAfterFirst, cacheSets(),
+		"second GenerateManifest should hit the manifest cache; a new cache write means the lookup and store keys diverged")
 }

--- a/reposerver/repository/worktree.go
+++ b/reposerver/repository/worktree.go
@@ -1,0 +1,130 @@
+package repository
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/argoproj/argo-cd/v3/util/git"
+)
+
+type worktreeRef struct {
+	path  string
+	count int
+}
+
+// worktreeCleanup releases one reference to a shared worktree; the caller should defer it.
+type worktreeCleanup struct {
+	s      *Service
+	client git.Client
+	key    string
+}
+
+func (w *worktreeCleanup) cleanup() {
+	w.s.releaseWorktree(w.client, w.key)
+}
+
+// createAndRegisterWorktree returns a worktree for the given commit, creating one if needed.
+// Worktrees are ref-counted by "<normalizedRepoURL>@<commitSHA>", so concurrent requests and
+// repeated refs at the same commit share one checkout. The caller must defer the returned cleanup.
+func (s *Service) createAndRegisterWorktree(
+	gitClient git.Client,
+	normalizedRepoURL string,
+	commitSHA string,
+	depth int64,
+) (string, *worktreeCleanup, error) {
+	key := normalizedRepoURL + "@" + commitSHA
+	root := gitClient.Root()
+
+	// Serialize git ops per root (they race on shared .git lock files) and make the reuse check atomic.
+	s.gitWorktreeLock.Lock(root)
+	defer s.gitWorktreeLock.Unlock(root)
+
+	s.worktreesMu.Lock()
+	if ref, ok := s.worktrees[key]; ok {
+		ref.count++
+		path := ref.path
+		s.worktreesMu.Unlock()
+		return path, &worktreeCleanup{s: s, client: gitClient, key: key}, nil
+	}
+	s.worktreesMu.Unlock()
+
+	// Init creates worktreeRootDir, but may not have run (e.g. in tests).
+	if err := os.MkdirAll(s.worktreeRootDir, 0o700); err != nil {
+		return "", nil, fmt.Errorf("failed to create worktree root dir %s: %w", s.worktreeRootDir, err)
+	}
+	worktreePath := filepath.Join(s.worktreeRootDir, "argocd-worktree-"+uuid.New().String())
+
+	// ls-remote resolved the SHA but didn't fetch objects.
+	if !gitClient.IsRevisionPresent(commitSHA) {
+		if err := gitClient.Fetch(commitSHA, depth); err != nil {
+			return "", nil, fmt.Errorf("failed to fetch revision %s: %w", commitSHA, err)
+		}
+	}
+
+	if err := gitClient.CreateWorktree(commitSHA, worktreePath); err != nil {
+		return "", nil, fmt.Errorf("failed to create worktree at revision %s: %w", commitSHA, err)
+	}
+
+	// Register so getResolvedRefValueFile can resolve value files from this worktree.
+	s.gitRepoPaths.Add(key, worktreePath)
+	s.worktreesMu.Lock()
+	s.worktrees[key] = &worktreeRef{path: worktreePath, count: 1}
+	s.worktreesMu.Unlock()
+
+	return worktreePath, &worktreeCleanup{s: s, client: gitClient, key: key}, nil
+}
+
+// releaseWorktree drops one reference to a shared worktree, removing it once no users remain.
+func (s *Service) releaseWorktree(gitClient git.Client, key string) {
+	root := gitClient.Root()
+	s.gitWorktreeLock.Lock(root)
+	defer s.gitWorktreeLock.Unlock(root)
+
+	s.worktreesMu.Lock()
+	ref, ok := s.worktrees[key]
+	if !ok {
+		s.worktreesMu.Unlock()
+		return
+	}
+	ref.count--
+	if ref.count > 0 {
+		s.worktreesMu.Unlock()
+		return
+	}
+	delete(s.worktrees, key)
+	worktreePath := ref.path
+	s.worktreesMu.Unlock()
+
+	// `git worktree remove` deletes both the working dir and its .git/worktrees admin entry. If it
+	// fails, fall back to deleting just the working dir so it doesn't leak; the stale admin entry is
+	// pruned at the next startup.
+	if err := gitClient.RemoveWorktree(worktreePath); err != nil {
+		log.Warnf("Failed to remove worktree at %s: %v; removing directory directly", worktreePath, err)
+		if rmErr := os.RemoveAll(worktreePath); rmErr != nil {
+			log.Warnf("Failed to remove worktree directory %s: %v", worktreePath, rmErr)
+		}
+	}
+	s.gitRepoPaths.Remove(key)
+}
+
+// cleanupOrphanedWorktrees clears worktreeRootDir at startup. Worktrees are ref-counted in memory,
+// so none are live then: anything present was orphaned by a crash and would otherwise accumulate.
+func (s *Service) cleanupOrphanedWorktrees() error {
+	if err := os.RemoveAll(s.worktreeRootDir); err != nil {
+		return fmt.Errorf("failed to remove orphaned worktrees at %s: %w", s.worktreeRootDir, err)
+	}
+	return os.MkdirAll(s.worktreeRootDir, 0o700)
+}
+
+// pruneWorktreeAdminDir removes a repo clone's stale .git/worktrees entries (left by crashed
+// worktrees). Safe at startup; git recreates the directory on the next worktree add.
+func pruneWorktreeAdminDir(repoPath string) {
+	adminDir := filepath.Join(repoPath, ".git", "worktrees")
+	if err := os.RemoveAll(adminDir); err != nil {
+		log.Warnf("Failed to prune worktree admin dir %s: %v", adminDir, err)
+	}
+}

--- a/reposerver/repository/worktree.go
+++ b/reposerver/repository/worktree.go
@@ -1,0 +1,132 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/argoproj/argo-cd/v3/util/git"
+)
+
+type worktreeRef struct {
+	path  string
+	count int
+}
+
+// worktreeCleanup releases one reference to a shared worktree; the caller should defer it.
+type worktreeCleanup struct {
+	s      *Service
+	ctx    context.Context
+	client git.Client
+	key    string
+}
+
+func (w *worktreeCleanup) cleanup() {
+	w.s.releaseWorktree(w.ctx, w.client, w.key)
+}
+
+// createAndRegisterWorktree returns a worktree for the given commit, creating one if needed.
+// Worktrees are ref-counted by "<normalizedRepoURL>@<commitSHA>". The caller must defer the cleanup.
+func (s *Service) createAndRegisterWorktree(
+	ctx context.Context,
+	gitClient git.Client,
+	normalizedRepoURL string,
+	commitSHA string,
+	depth int64,
+) (string, *worktreeCleanup, error) {
+	key := normalizedRepoURL + "@" + commitSHA
+	root := gitClient.Root()
+	// Removal must still run if the request is canceled, or the worktree leaks until the next sweep.
+	cleanupCtx := context.WithoutCancel(ctx)
+
+	// Serialize per root: git ops race on shared .git lock files, and this makes reuse atomic.
+	s.gitWorktreeLock.Lock(root)
+	defer s.gitWorktreeLock.Unlock(root)
+
+	s.worktreesMu.Lock()
+	if ref, ok := s.worktrees[key]; ok {
+		ref.count++
+		path := ref.path
+		s.worktreesMu.Unlock()
+		return path, &worktreeCleanup{s: s, ctx: cleanupCtx, client: gitClient, key: key}, nil
+	}
+	s.worktreesMu.Unlock()
+
+	// Init creates worktreeRootDir, but may not have run (e.g. in tests).
+	if err := os.MkdirAll(s.worktreeRootDir, 0o700); err != nil {
+		return "", nil, fmt.Errorf("failed to create worktree root dir %s: %w", s.worktreeRootDir, err)
+	}
+	worktreePath := filepath.Join(s.worktreeRootDir, "argocd-worktree-"+uuid.New().String())
+
+	// ls-remote resolved the SHA but didn't fetch objects. Use the shared helper, not gitClient.Fetch:
+	// at the default depth of 0 it avoids fetching by explicit SHA, which bloats the repo (#8845).
+	if err := s.fetch(ctx, gitClient, []string{commitSHA}, depth); err != nil {
+		return "", nil, fmt.Errorf("failed to fetch revision %s: %w", commitSHA, err)
+	}
+
+	if err := gitClient.CreateWorktree(ctx, commitSHA, worktreePath); err != nil {
+		return "", nil, fmt.Errorf("failed to create worktree at revision %s: %w", commitSHA, err)
+	}
+
+	// Register so getResolvedRefValueFile can resolve value files from this worktree.
+	s.gitRepoPaths.Add(key, worktreePath)
+	s.worktreesMu.Lock()
+	s.worktrees[key] = &worktreeRef{path: worktreePath, count: 1}
+	s.worktreesMu.Unlock()
+
+	return worktreePath, &worktreeCleanup{s: s, ctx: cleanupCtx, client: gitClient, key: key}, nil
+}
+
+// releaseWorktree drops one reference to a shared worktree, removing it once no users remain.
+func (s *Service) releaseWorktree(ctx context.Context, gitClient git.Client, key string) {
+	root := gitClient.Root()
+	s.gitWorktreeLock.Lock(root)
+	defer s.gitWorktreeLock.Unlock(root)
+
+	s.worktreesMu.Lock()
+	ref, ok := s.worktrees[key]
+	if !ok {
+		s.worktreesMu.Unlock()
+		return
+	}
+	ref.count--
+	if ref.count > 0 {
+		s.worktreesMu.Unlock()
+		return
+	}
+	delete(s.worktrees, key)
+	worktreePath := ref.path
+	s.worktreesMu.Unlock()
+
+	// `git worktree remove` deletes the working dir and its admin entry. On failure, drop the dir so
+	// it doesn't leak; the stale admin entry is pruned at the next startup.
+	if err := gitClient.RemoveWorktree(ctx, worktreePath); err != nil {
+		log.Warnf("Failed to remove worktree at %s: %v; removing directory directly", worktreePath, err)
+		if rmErr := os.RemoveAll(worktreePath); rmErr != nil {
+			log.Warnf("Failed to remove worktree directory %s: %v", worktreePath, rmErr)
+		}
+	}
+	s.gitRepoPaths.Remove(key)
+}
+
+// cleanupOrphanedWorktrees clears worktreeRootDir at startup. Ref-counts live in memory, so nothing
+// present at startup is in use: it was orphaned by a crash.
+func (s *Service) cleanupOrphanedWorktrees() error {
+	if err := os.RemoveAll(s.worktreeRootDir); err != nil {
+		return fmt.Errorf("failed to remove orphaned worktrees at %s: %w", s.worktreeRootDir, err)
+	}
+	return os.MkdirAll(s.worktreeRootDir, 0o700)
+}
+
+// pruneWorktreeAdminDir removes stale .git/worktrees entries left by crashed worktrees. Startup
+// only; git recreates the directory on the next worktree add.
+func pruneWorktreeAdminDir(repoPath string) {
+	adminDir := filepath.Join(repoPath, ".git", "worktrees")
+	if err := os.RemoveAll(adminDir); err != nil {
+		log.Warnf("Failed to prune worktree admin dir %s: %v", adminDir, err)
+	}
+}

--- a/test/e2e/app_multiple_sources_test.go
+++ b/test/e2e/app_multiple_sources_test.go
@@ -297,3 +297,60 @@ func TestMultiSourceAppErrorWhenSourceNameAndSourcePosition(t *testing.T) {
 			assert.ErrorContains(t, err, "Only one of source-positions and source-names can be specified.")
 		})
 }
+
+// TestMultiSourceAppWithWorktreeSameRepoMultipleRevisions tests the scenario where
+// a multi-source application uses the same git repository with different target revisions.
+// This validates that git worktrees are properly used to checkout different revisions
+// simultaneously and that value files are correctly resolved from the appropriate worktree.
+func TestMultiSourceAppWithWorktreeSameRepoMultipleRevisions(t *testing.T) {
+	sources := []ApplicationSource{{
+		RepoURL:        RepoURL(RepoURLTypeFile),
+		TargetRevision: "HEAD",
+		Ref:            "values",
+	}, {
+		RepoURL:        RepoURL(RepoURLTypeFile),
+		TargetRevision: "HEAD",
+		Path:           "helm-guestbook",
+		Helm: &ApplicationSourceHelm{
+			ReleaseName: "helm-guestbook",
+			ValueFiles: []string{
+				"$values/multiple-source-values/values.yaml",
+			},
+		},
+	}}
+	ctx := Given(t)
+	ctx.
+		Sources(sources).
+		When().
+		CreateMultiSourceAppFromFile(func(_ *Application) {}).
+		Then().
+		And(func(app *Application) {
+			assert.Equal(t, ctx.GetName(), app.Name)
+			assert.Len(t, app.Spec.GetSources(), 2)
+			assert.Equal(t, ctx.DeploymentNamespace(), app.Spec.Destination.Namespace)
+		}).
+		Expect(Event(EventReasonResourceCreated, "create")).
+		And(func(_ *Application) {
+			output, err := RunCli("app", "list")
+			require.NoError(t, err)
+			assert.Contains(t, output, ctx.GetName())
+		}).
+		Expect(Success("")).
+		Given().Timeout(60).
+		When().Wait().Then().
+		Expect(Success("")).
+		And(func(app *Application) {
+			statusByName := map[string]SyncStatusCode{}
+			for _, r := range app.Status.Resources {
+				statusByName[r.Name] = r.Status
+			}
+			// The helm-guestbook should be synced with values from the ref source
+			assert.Equal(t, SyncStatusCodeSynced, statusByName["guestbook-ui"])
+
+			// Confirm that the deployment has the expected replicas from the values file.
+			// The values.yaml in multiple-source-values sets replicas to 3.
+			output, err := Run("", "kubectl", "get", "deployment", "guestbook-ui", "-n", ctx.DeploymentNamespace(), "-o", "jsonpath={.spec.replicas}")
+			require.NoError(t, err)
+			assert.Equal(t, "3", output, "Expected 3 replicas from the external values file (worktree scenario)")
+		})
+}

--- a/test/e2e/app_multiple_sources_test.go
+++ b/test/e2e/app_multiple_sources_test.go
@@ -297,3 +297,79 @@ func TestMultiSourceAppErrorWhenSourceNameAndSourcePosition(t *testing.T) {
 			assert.ErrorContains(t, err, "Only one of source-positions and source-names can be specified.")
 		})
 }
+
+// TestMultiSourceAppWithWorktreeSameRepoMultipleRevisions tests the scenario where
+// a multi-source application uses the same git repository with different target revisions.
+// This validates that git worktrees are properly used to checkout different revisions
+// simultaneously and that value files are correctly resolved from the appropriate worktree.
+//
+// The revisions must actually differ for this to exercise the worktree path: the reposerver
+// only creates a worktree when the ref source resolves the repository to a different commit
+// than the primary source (see needsWorktree in reposerver/repository/repository.go). If both
+// sources tracked HEAD they would resolve to the same commit and the ordinary single-checkout
+// path would handle the app, which is legal on any release and would prove nothing.
+func TestMultiSourceAppWithWorktreeSameRepoMultipleRevisions(t *testing.T) {
+	// Tags the initial commit, where multiple-source-values/values.yaml is `replicas: 3`.
+	const pinnedValuesTag = "pinned-values"
+	// Committed on top of the tag, so HEAD carries a different value than the pinned revision.
+	const headValuesFile = "replicas: 5\n"
+
+	sources := []ApplicationSource{{
+		RepoURL:        RepoURL(RepoURLTypeFile),
+		TargetRevision: pinnedValuesTag,
+		Ref:            "values",
+	}, {
+		RepoURL:        RepoURL(RepoURLTypeFile),
+		TargetRevision: "HEAD",
+		Path:           "helm-guestbook",
+		Helm: &ApplicationSourceHelm{
+			ReleaseName: "helm-guestbook",
+			ValueFiles: []string{
+				"$values/multiple-source-values/values.yaml",
+			},
+		},
+	}}
+	ctx := Given(t)
+	ctx.
+		Sources(sources).
+		When().
+		// Pin the tag to the current values, then move HEAD past it. The ref source stays on the
+		// tag while the chart source follows HEAD, so the two sources need separate checkouts of
+		// the same repository at once.
+		AddTag(pinnedValuesTag).
+		AddFile("multiple-source-values/values.yaml", headValuesFile).
+		CreateMultiSourceAppFromFile(func(_ *Application) {}).
+		Then().
+		And(func(app *Application) {
+			assert.Equal(t, ctx.GetName(), app.Name)
+			assert.Len(t, app.Spec.GetSources(), 2)
+			assert.Equal(t, ctx.DeploymentNamespace(), app.Spec.Destination.Namespace)
+		}).
+		Expect(Event(EventReasonResourceCreated, "create")).
+		And(func(_ *Application) {
+			output, err := RunCli("app", "list")
+			require.NoError(t, err)
+			assert.Contains(t, output, ctx.GetName())
+		}).
+		Expect(Success("")).
+		Given().Timeout(60).
+		When().Wait().Then().
+		Expect(Success("")).
+		And(func(app *Application) {
+			statusByName := map[string]SyncStatusCode{}
+			for _, r := range app.Status.Resources {
+				statusByName[r.Name] = r.Status
+			}
+			// The helm-guestbook should be synced with values from the ref source
+			assert.Equal(t, SyncStatusCodeSynced, statusByName["guestbook-ui"])
+
+			// Confirm the values file was read from the worktree checked out at the pinned tag.
+			// The three candidate sources of this value are distinct, so the assertion pins down
+			// which checkout was used: 3 = the pinned worktree (correct), 5 = the primary HEAD
+			// checkout (worktree ignored/misresolved), 1 = the chart's own values.yaml default
+			// (the $values ref was dropped entirely).
+			output, err := Run("", "kubectl", "get", "deployment", "guestbook-ui", "-n", ctx.DeploymentNamespace(), "-o", "jsonpath={.spec.replicas}")
+			require.NoError(t, err)
+			assert.Equal(t, "3", output, "expected 3 replicas from the values file at %q; 5 means the primary HEAD checkout was used instead of the worktree, 1 means the $values ref was not applied", pinnedValuesTag)
+		})
+}

--- a/util/git/client.go
+++ b/util/git/client.go
@@ -166,6 +166,10 @@ type Client interface {
 	AddAndPushNote(sha string, namespace string, note string) error
 	// HasFileChanged returns the outout of git diff considering whether it is tracked or un-tracked
 	HasFileChanged(filePath string) (bool, error)
+	// CreateWorktree adds a detached git worktree at path for the given revision.
+	CreateWorktree(revision string, path string) error
+	// RemoveWorktree removes the git worktree at path.
+	RemoveWorktree(path string) error
 }
 
 type EventHandlers struct {
@@ -712,6 +716,25 @@ func (m *nativeGitClient) Checkout(revision string, submoduleEnabled bool, clean
 		}
 	}
 	return "", nil
+}
+
+// CreateWorktree adds a detached git worktree at path for the given revision. The worktree shares
+// the main repository's object database.
+func (m *nativeGitClient) CreateWorktree(revision string, path string) error {
+	ctx := context.Background()
+	if out, err := m.runCmd(ctx, "worktree", "add", "--detach", path, revision); err != nil {
+		return fmt.Errorf("failed to create worktree at %s for revision %s: %s, %w", path, revision, out, err)
+	}
+	return nil
+}
+
+// RemoveWorktree removes the git worktree at path. --force handles untracked or modified files.
+func (m *nativeGitClient) RemoveWorktree(path string) error {
+	ctx := context.Background()
+	if out, err := m.runCmd(ctx, "worktree", "remove", "--force", path); err != nil {
+		return fmt.Errorf("failed to remove worktree at %s: %s, %w", path, out, err)
+	}
+	return nil
 }
 
 func (m *nativeGitClient) getRefs() ([]*plumbing.Reference, error) {

--- a/util/git/client.go
+++ b/util/git/client.go
@@ -167,6 +167,10 @@ type Client interface {
 	AddAndPushNote(ctx context.Context, sha string, namespace string, note string) error
 	// HasFileChanged returns the outout of git diff considering whether it is tracked or un-tracked
 	HasFileChanged(ctx context.Context, filePath string) (bool, error)
+	// CreateWorktree adds a detached git worktree at path for the given revision.
+	CreateWorktree(ctx context.Context, revision string, path string) error
+	// RemoveWorktree removes the git worktree at path.
+	RemoveWorktree(ctx context.Context, path string) error
 }
 
 type EventHandlers struct {
@@ -805,6 +809,23 @@ func (m *nativeGitClient) Checkout(ctx context.Context, revision string, submodu
 		}
 	}
 	return "", nil
+}
+
+// CreateWorktree adds a detached git worktree at path for the given revision. The worktree shares
+// the main repository's object database.
+func (m *nativeGitClient) CreateWorktree(ctx context.Context, revision string, path string) error {
+	if out, err := m.runCmd(ctx, "worktree", "add", "--detach", path, revision); err != nil {
+		return fmt.Errorf("failed to create worktree at %s for revision %s: %s, %w", path, revision, out, err)
+	}
+	return nil
+}
+
+// RemoveWorktree removes the git worktree at path. --force handles untracked or modified files.
+func (m *nativeGitClient) RemoveWorktree(ctx context.Context, path string) error {
+	if out, err := m.runCmd(ctx, "worktree", "remove", "--force", path); err != nil {
+		return fmt.Errorf("failed to remove worktree at %s: %s, %w", path, out, err)
+	}
+	return nil
 }
 
 func (m *nativeGitClient) getRefs() ([]*plumbing.Reference, error) {

--- a/util/git/client_test.go
+++ b/util/git/client_test.go
@@ -1658,3 +1658,126 @@ func Test_LsSignatures_Error(t *testing.T) {
 		assert.Empty(t, legacy)
 	}
 }
+
+func Test_nativeGitClient_CreateWorktree(t *testing.T) {
+	ctx := t.Context()
+	tempDir, err := _createEmptyGitRepo(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(tempDir) })
+
+	client, err := NewClientExt("file://"+tempDir, tempDir, NopCreds{}, true, false, "", "")
+	require.NoError(t, err)
+
+	// Get the current commit SHA
+	commitSHA, err := outputCmd(ctx, tempDir, "git", "rev-parse", "HEAD")
+	require.NoError(t, err)
+	sha := strings.TrimSpace(string(commitSHA))
+
+	// Create a worktree
+	worktreePath := filepath.Join(os.TempDir(), fmt.Sprintf("test-worktree-%d", time.Now().UnixNano()))
+	t.Cleanup(func() {
+		// Clean up worktree
+		_ = client.RemoveWorktree(worktreePath)
+		os.RemoveAll(worktreePath)
+	})
+
+	err = client.CreateWorktree(sha, worktreePath)
+	require.NoError(t, err)
+
+	// Verify worktree was created
+	_, err = os.Stat(worktreePath)
+	require.NoError(t, err, "worktree directory should exist")
+
+	// Verify it's a valid git worktree by checking for .git file
+	gitFile := filepath.Join(worktreePath, ".git")
+	_, err = os.Stat(gitFile)
+	require.NoError(t, err, ".git file should exist in worktree")
+}
+
+func Test_nativeGitClient_RemoveWorktree(t *testing.T) {
+	ctx := t.Context()
+	tempDir, err := _createEmptyGitRepo(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(tempDir) })
+
+	client, err := NewClientExt("file://"+tempDir, tempDir, NopCreds{}, true, false, "", "")
+	require.NoError(t, err)
+
+	// Get the current commit SHA
+	commitSHA, err := outputCmd(ctx, tempDir, "git", "rev-parse", "HEAD")
+	require.NoError(t, err)
+	sha := strings.TrimSpace(string(commitSHA))
+
+	// Create a worktree
+	worktreePath := filepath.Join(os.TempDir(), fmt.Sprintf("test-worktree-%d", time.Now().UnixNano()))
+
+	err = client.CreateWorktree(sha, worktreePath)
+	require.NoError(t, err)
+
+	// Verify worktree exists
+	_, err = os.Stat(worktreePath)
+	require.NoError(t, err)
+
+	// Remove the worktree
+	err = client.RemoveWorktree(worktreePath)
+	require.NoError(t, err)
+
+	// Verify worktree directory is gone
+	_, err = os.Stat(worktreePath)
+	require.True(t, os.IsNotExist(err), "worktree directory should be removed")
+}
+
+func Test_nativeGitClient_CreateWorktree_DifferentRevisions(t *testing.T) {
+	ctx := t.Context()
+	tempDir, err := _createEmptyGitRepo(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(tempDir) })
+
+	// Create a second commit
+	err = runCmd(ctx, tempDir, "git", "commit", "-m", "Second commit", "--allow-empty")
+	require.NoError(t, err)
+
+	// Get both commit SHAs
+	firstCommit, err := outputCmd(ctx, tempDir, "git", "rev-parse", "HEAD~1")
+	require.NoError(t, err)
+	firstSHA := strings.TrimSpace(string(firstCommit))
+
+	secondCommit, err := outputCmd(ctx, tempDir, "git", "rev-parse", "HEAD")
+	require.NoError(t, err)
+	secondSHA := strings.TrimSpace(string(secondCommit))
+
+	client, err := NewClientExt("file://"+tempDir, tempDir, NopCreds{}, true, false, "", "")
+	require.NoError(t, err)
+
+	// Create worktrees for both revisions
+	worktree1 := filepath.Join(os.TempDir(), fmt.Sprintf("test-worktree-1-%d", time.Now().UnixNano()))
+	worktree2 := filepath.Join(os.TempDir(), fmt.Sprintf("test-worktree-2-%d", time.Now().UnixNano()))
+	t.Cleanup(func() {
+		_ = client.RemoveWorktree(worktree1)
+		_ = client.RemoveWorktree(worktree2)
+		os.RemoveAll(worktree1)
+		os.RemoveAll(worktree2)
+	})
+
+	err = client.CreateWorktree(firstSHA, worktree1)
+	require.NoError(t, err)
+
+	err = client.CreateWorktree(secondSHA, worktree2)
+	require.NoError(t, err)
+
+	// Verify both worktrees exist
+	_, err = os.Stat(worktree1)
+	require.NoError(t, err, "first worktree should exist")
+
+	_, err = os.Stat(worktree2)
+	require.NoError(t, err, "second worktree should exist")
+
+	// Verify they have different HEADs
+	head1, err := outputCmd(ctx, worktree1, "git", "rev-parse", "HEAD")
+	require.NoError(t, err)
+	head2, err := outputCmd(ctx, worktree2, "git", "rev-parse", "HEAD")
+	require.NoError(t, err)
+
+	assert.Equal(t, firstSHA, strings.TrimSpace(string(head1)))
+	assert.Equal(t, secondSHA, strings.TrimSpace(string(head2)))
+}

--- a/util/git/client_test.go
+++ b/util/git/client_test.go
@@ -2183,3 +2183,126 @@ func Test_fetch_authPromptRewrite(t *testing.T) {
 	// ... and the fix surfaces it as an actionable authentication error (the fix).
 	assert.Contains(t, err.Error(), "failed to authenticate to git repository", "expected the humanized authentication error")
 }
+
+func Test_nativeGitClient_CreateWorktree(t *testing.T) {
+	ctx := t.Context()
+	tempDir, err := _createEmptyGitRepo(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(tempDir) })
+
+	client, err := NewClientExt("file://"+tempDir, tempDir, NopCreds{}, true, false, "", "")
+	require.NoError(t, err)
+
+	// Get the current commit SHA
+	commitSHA, err := outputCmd(ctx, tempDir, "git", "rev-parse", "HEAD")
+	require.NoError(t, err)
+	sha := strings.TrimSpace(string(commitSHA))
+
+	// Create a worktree
+	worktreePath := filepath.Join(os.TempDir(), fmt.Sprintf("test-worktree-%d", time.Now().UnixNano()))
+	t.Cleanup(func() {
+		// Clean up worktree
+		_ = client.RemoveWorktree(ctx, worktreePath)
+		os.RemoveAll(worktreePath)
+	})
+
+	err = client.CreateWorktree(ctx, sha, worktreePath)
+	require.NoError(t, err)
+
+	// Verify worktree was created
+	_, err = os.Stat(worktreePath)
+	require.NoError(t, err, "worktree directory should exist")
+
+	// Verify it's a valid git worktree by checking for .git file
+	gitFile := filepath.Join(worktreePath, ".git")
+	_, err = os.Stat(gitFile)
+	require.NoError(t, err, ".git file should exist in worktree")
+}
+
+func Test_nativeGitClient_RemoveWorktree(t *testing.T) {
+	ctx := t.Context()
+	tempDir, err := _createEmptyGitRepo(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(tempDir) })
+
+	client, err := NewClientExt("file://"+tempDir, tempDir, NopCreds{}, true, false, "", "")
+	require.NoError(t, err)
+
+	// Get the current commit SHA
+	commitSHA, err := outputCmd(ctx, tempDir, "git", "rev-parse", "HEAD")
+	require.NoError(t, err)
+	sha := strings.TrimSpace(string(commitSHA))
+
+	// Create a worktree
+	worktreePath := filepath.Join(os.TempDir(), fmt.Sprintf("test-worktree-%d", time.Now().UnixNano()))
+
+	err = client.CreateWorktree(ctx, sha, worktreePath)
+	require.NoError(t, err)
+
+	// Verify worktree exists
+	_, err = os.Stat(worktreePath)
+	require.NoError(t, err)
+
+	// Remove the worktree
+	err = client.RemoveWorktree(ctx, worktreePath)
+	require.NoError(t, err)
+
+	// Verify worktree directory is gone
+	_, err = os.Stat(worktreePath)
+	require.True(t, os.IsNotExist(err), "worktree directory should be removed")
+}
+
+func Test_nativeGitClient_CreateWorktree_DifferentRevisions(t *testing.T) {
+	ctx := t.Context()
+	tempDir, err := _createEmptyGitRepo(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(tempDir) })
+
+	// Create a second commit
+	err = runCmd(ctx, tempDir, "git", "commit", "-m", "Second commit", "--allow-empty")
+	require.NoError(t, err)
+
+	// Get both commit SHAs
+	firstCommit, err := outputCmd(ctx, tempDir, "git", "rev-parse", "HEAD~1")
+	require.NoError(t, err)
+	firstSHA := strings.TrimSpace(string(firstCommit))
+
+	secondCommit, err := outputCmd(ctx, tempDir, "git", "rev-parse", "HEAD")
+	require.NoError(t, err)
+	secondSHA := strings.TrimSpace(string(secondCommit))
+
+	client, err := NewClientExt("file://"+tempDir, tempDir, NopCreds{}, true, false, "", "")
+	require.NoError(t, err)
+
+	// Create worktrees for both revisions
+	worktree1 := filepath.Join(os.TempDir(), fmt.Sprintf("test-worktree-1-%d", time.Now().UnixNano()))
+	worktree2 := filepath.Join(os.TempDir(), fmt.Sprintf("test-worktree-2-%d", time.Now().UnixNano()))
+	t.Cleanup(func() {
+		_ = client.RemoveWorktree(ctx, worktree1)
+		_ = client.RemoveWorktree(ctx, worktree2)
+		os.RemoveAll(worktree1)
+		os.RemoveAll(worktree2)
+	})
+
+	err = client.CreateWorktree(ctx, firstSHA, worktree1)
+	require.NoError(t, err)
+
+	err = client.CreateWorktree(ctx, secondSHA, worktree2)
+	require.NoError(t, err)
+
+	// Verify both worktrees exist
+	_, err = os.Stat(worktree1)
+	require.NoError(t, err, "first worktree should exist")
+
+	_, err = os.Stat(worktree2)
+	require.NoError(t, err, "second worktree should exist")
+
+	// Verify they have different HEADs
+	head1, err := outputCmd(ctx, worktree1, "git", "rev-parse", "HEAD")
+	require.NoError(t, err)
+	head2, err := outputCmd(ctx, worktree2, "git", "rev-parse", "HEAD")
+	require.NoError(t, err)
+
+	assert.Equal(t, firstSHA, strings.TrimSpace(string(head1)))
+	assert.Equal(t, secondSHA, strings.TrimSpace(string(head2)))
+}

--- a/util/git/mocks/Client.go
+++ b/util/git/mocks/Client.go
@@ -490,6 +490,63 @@ func (_c *Client_CommitSHA_Call) RunAndReturn(run func() (string, error)) *Clien
 	return _c
 }
 
+// CreateWorktree provides a mock function for the type Client
+func (_mock *Client) CreateWorktree(revision string, path string) error {
+	ret := _mock.Called(revision, path)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateWorktree")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, string) error); ok {
+		r0 = returnFunc(revision, path)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// Client_CreateWorktree_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateWorktree'
+type Client_CreateWorktree_Call struct {
+	*mock.Call
+}
+
+// CreateWorktree is a helper method to define mock.On call
+//   - revision string
+//   - path string
+func (_e *Client_Expecter) CreateWorktree(revision interface{}, path interface{}) *Client_CreateWorktree_Call {
+	return &Client_CreateWorktree_Call{Call: _e.mock.On("CreateWorktree", revision, path)}
+}
+
+func (_c *Client_CreateWorktree_Call) Run(run func(revision string, path string)) *Client_CreateWorktree_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *Client_CreateWorktree_Call) Return(err error) *Client_CreateWorktree_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *Client_CreateWorktree_Call) RunAndReturn(run func(revision string, path string) error) *Client_CreateWorktree_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Fetch provides a mock function for the type Client
 func (_mock *Client) Fetch(revision string, depth int64) error {
 	ret := _mock.Called(revision, depth)
@@ -1113,6 +1170,57 @@ func (_c *Client_RemoveContents_Call) Return(s string, err error) *Client_Remove
 }
 
 func (_c *Client_RemoveContents_Call) RunAndReturn(run func(paths []string) (string, error)) *Client_RemoveContents_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// RemoveWorktree provides a mock function for the type Client
+func (_mock *Client) RemoveWorktree(path string) error {
+	ret := _mock.Called(path)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveWorktree")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
+		r0 = returnFunc(path)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// Client_RemoveWorktree_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemoveWorktree'
+type Client_RemoveWorktree_Call struct {
+	*mock.Call
+}
+
+// RemoveWorktree is a helper method to define mock.On call
+//   - path string
+func (_e *Client_Expecter) RemoveWorktree(path interface{}) *Client_RemoveWorktree_Call {
+	return &Client_RemoveWorktree_Call{Call: _e.mock.On("RemoveWorktree", path)}
+}
+
+func (_c *Client_RemoveWorktree_Call) Run(run func(path string)) *Client_RemoveWorktree_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Client_RemoveWorktree_Call) Return(err error) *Client_RemoveWorktree_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *Client_RemoveWorktree_Call) RunAndReturn(run func(path string) error) *Client_RemoveWorktree_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/util/git/mocks/Client.go
+++ b/util/git/mocks/Client.go
@@ -496,6 +496,63 @@ func (_c *Client_CommitSHA_Call) RunAndReturn(run func() (string, error)) *Clien
 	return _c
 }
 
+// CreateWorktree provides a mock function for the type Client
+func (_mock *Client) CreateWorktree(revision string, path string) error {
+	ret := _mock.Called(revision, path)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateWorktree")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, string) error); ok {
+		r0 = returnFunc(revision, path)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// Client_CreateWorktree_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateWorktree'
+type Client_CreateWorktree_Call struct {
+	*mock.Call
+}
+
+// CreateWorktree is a helper method to define mock.On call
+//   - revision string
+//   - path string
+func (_e *Client_Expecter) CreateWorktree(revision interface{}, path interface{}) *Client_CreateWorktree_Call {
+	return &Client_CreateWorktree_Call{Call: _e.mock.On("CreateWorktree", revision, path)}
+}
+
+func (_c *Client_CreateWorktree_Call) Run(run func(revision string, path string)) *Client_CreateWorktree_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *Client_CreateWorktree_Call) Return(err error) *Client_CreateWorktree_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *Client_CreateWorktree_Call) RunAndReturn(run func(revision string, path string) error) *Client_CreateWorktree_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Fetch provides a mock function for the type Client
 func (_mock *Client) Fetch(revision string, depth int64) error {
 	ret := _mock.Called(revision, depth)
@@ -1193,6 +1250,57 @@ func (_c *Client_RemoveContents_Call) Return(s string, err error) *Client_Remove
 }
 
 func (_c *Client_RemoveContents_Call) RunAndReturn(run func(paths []string) (string, error)) *Client_RemoveContents_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// RemoveWorktree provides a mock function for the type Client
+func (_mock *Client) RemoveWorktree(path string) error {
+	ret := _mock.Called(path)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveWorktree")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
+		r0 = returnFunc(path)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// Client_RemoveWorktree_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemoveWorktree'
+type Client_RemoveWorktree_Call struct {
+	*mock.Call
+}
+
+// RemoveWorktree is a helper method to define mock.On call
+//   - path string
+func (_e *Client_Expecter) RemoveWorktree(path interface{}) *Client_RemoveWorktree_Call {
+	return &Client_RemoveWorktree_Call{Call: _e.mock.On("RemoveWorktree", path)}
+}
+
+func (_c *Client_RemoveWorktree_Call) Run(run func(path string)) *Client_RemoveWorktree_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Client_RemoveWorktree_Call) Return(err error) *Client_RemoveWorktree_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *Client_RemoveWorktree_Call) RunAndReturn(run func(path string) error) *Client_RemoveWorktree_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/util/git/mocks/Client.go
+++ b/util/git/mocks/Client.go
@@ -541,6 +541,69 @@ func (_c *Client_CommitSHA_Call) RunAndReturn(run func(ctx context.Context) (str
 	return _c
 }
 
+// CreateWorktree provides a mock function for the type Client
+func (_mock *Client) CreateWorktree(ctx context.Context, revision string, path string) error {
+	ret := _mock.Called(ctx, revision, path)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateWorktree")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = returnFunc(ctx, revision, path)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// Client_CreateWorktree_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateWorktree'
+type Client_CreateWorktree_Call struct {
+	*mock.Call
+}
+
+// CreateWorktree is a helper method to define mock.On call
+//   - ctx context.Context
+//   - revision string
+//   - path string
+func (_e *Client_Expecter) CreateWorktree(ctx any, revision any, path any) *Client_CreateWorktree_Call {
+	return &Client_CreateWorktree_Call{Call: _e.mock.On("CreateWorktree", ctx, revision, path)}
+}
+
+func (_c *Client_CreateWorktree_Call) Run(run func(ctx context.Context, revision string, path string)) *Client_CreateWorktree_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *Client_CreateWorktree_Call) Return(err error) *Client_CreateWorktree_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *Client_CreateWorktree_Call) RunAndReturn(run func(ctx context.Context, revision string, path string) error) *Client_CreateWorktree_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Fetch provides a mock function for the type Client
 func (_mock *Client) Fetch(ctx context.Context, revision string, depth int64) error {
 	ret := _mock.Called(ctx, revision, depth)
@@ -1293,6 +1356,63 @@ func (_c *Client_RemoveContents_Call) Return(s string, err error) *Client_Remove
 }
 
 func (_c *Client_RemoveContents_Call) RunAndReturn(run func(ctx context.Context, paths []string) (string, error)) *Client_RemoveContents_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// RemoveWorktree provides a mock function for the type Client
+func (_mock *Client) RemoveWorktree(ctx context.Context, path string) error {
+	ret := _mock.Called(ctx, path)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveWorktree")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = returnFunc(ctx, path)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// Client_RemoveWorktree_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemoveWorktree'
+type Client_RemoveWorktree_Call struct {
+	*mock.Call
+}
+
+// RemoveWorktree is a helper method to define mock.On call
+//   - ctx context.Context
+//   - path string
+func (_e *Client_Expecter) RemoveWorktree(ctx any, path any) *Client_RemoveWorktree_Call {
+	return &Client_RemoveWorktree_Call{Call: _e.mock.On("RemoveWorktree", ctx, path)}
+}
+
+func (_c *Client_RemoveWorktree_Call) Run(run func(ctx context.Context, path string)) *Client_RemoveWorktree_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *Client_RemoveWorktree_Call) Return(err error) *Client_RemoveWorktree_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *Client_RemoveWorktree_Call) RunAndReturn(run func(ctx context.Context, path string) error) *Client_RemoveWorktree_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/util/io/mocks/TempPaths.go
+++ b/util/io/mocks/TempPaths.go
@@ -237,3 +237,43 @@ func (_c *TempPaths_GetPaths_Call) RunAndReturn(run func() map[string]string) *T
 	_c.Call.Return(run)
 	return _c
 }
+
+// Remove provides a mock function for the type TempPaths
+func (_mock *TempPaths) Remove(key string) {
+	_mock.Called(key)
+	return
+}
+
+// TempPaths_Remove_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Remove'
+type TempPaths_Remove_Call struct {
+	*mock.Call
+}
+
+// Remove is a helper method to define mock.On call
+//   - key string
+func (_e *TempPaths_Expecter) Remove(key interface{}) *TempPaths_Remove_Call {
+	return &TempPaths_Remove_Call{Call: _e.mock.On("Remove", key)}
+}
+
+func (_c *TempPaths_Remove_Call) Run(run func(key string)) *TempPaths_Remove_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *TempPaths_Remove_Call) Return() *TempPaths_Remove_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *TempPaths_Remove_Call) RunAndReturn(run func(key string)) *TempPaths_Remove_Call {
+	_c.Run(run)
+	return _c
+}

--- a/util/io/mocks/TempPaths.go
+++ b/util/io/mocks/TempPaths.go
@@ -237,3 +237,43 @@ func (_c *TempPaths_GetPaths_Call) RunAndReturn(run func() map[string]string) *T
 	_c.Call.Return(run)
 	return _c
 }
+
+// Remove provides a mock function for the type TempPaths
+func (_mock *TempPaths) Remove(key string) {
+	_mock.Called(key)
+	return
+}
+
+// TempPaths_Remove_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Remove'
+type TempPaths_Remove_Call struct {
+	*mock.Call
+}
+
+// Remove is a helper method to define mock.On call
+//   - key string
+func (_e *TempPaths_Expecter) Remove(key any) *TempPaths_Remove_Call {
+	return &TempPaths_Remove_Call{Call: _e.mock.On("Remove", key)}
+}
+
+func (_c *TempPaths_Remove_Call) Run(run func(key string)) *TempPaths_Remove_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *TempPaths_Remove_Call) Return() *TempPaths_Remove_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *TempPaths_Remove_Call) RunAndReturn(run func(key string)) *TempPaths_Remove_Call {
+	_c.Run(run)
+	return _c
+}

--- a/util/io/paths.go
+++ b/util/io/paths.go
@@ -12,6 +12,9 @@ type TempPaths interface {
 	GetPath(key string) (string, error)
 	GetPathIfExists(key string) string
 	GetPaths() map[string]string
+	// Remove removes a path mapping for the given key. This is useful for cleaning up
+	// temporary paths like git worktrees that are no longer needed.
+	Remove(key string)
 }
 
 // RandomizedTempPaths allows generating and memoizing random paths, each path being mapped to a specific key.
@@ -69,4 +72,11 @@ func (p *RandomizedTempPaths) GetPaths() map[string]string {
 		paths[k] = v
 	}
 	return paths
+}
+
+// Remove removes a path mapping for the given key.
+func (p *RandomizedTempPaths) Remove(key string) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	delete(p.paths, key)
 }

--- a/util/io/paths.go
+++ b/util/io/paths.go
@@ -13,6 +13,9 @@ type TempPaths interface {
 	GetPath(key string) (string, error)
 	GetPathIfExists(key string) string
 	GetPaths() map[string]string
+	// Remove removes a path mapping for the given key. This is useful for cleaning up
+	// temporary paths like git worktrees that are no longer needed.
+	Remove(key string)
 }
 
 // RandomizedTempPaths allows generating and memoizing random paths, each path being mapped to a specific key.
@@ -68,4 +71,11 @@ func (p *RandomizedTempPaths) GetPaths() map[string]string {
 	paths := map[string]string{}
 	maps.Copy(paths, p.paths)
 	return paths
+}
+
+// Remove removes a path mapping for the given key.
+func (p *RandomizedTempPaths) Remove(key string) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	delete(p.paths, key)
 }

--- a/util/io/paths_test.go
+++ b/util/io/paths_test.go
@@ -73,3 +73,49 @@ func TestGetPaths_no_race(t *testing.T) {
 		paths.GetPaths()
 	}()
 }
+
+func TestRemove(t *testing.T) {
+	paths := NewRandomizedTempPaths(os.TempDir())
+
+	// Add a path
+	key := "https://localhost/test.txt"
+	path, err := paths.GetPath(key)
+	require.NoError(t, err)
+	assert.NotEmpty(t, path)
+
+	// Verify it exists
+	existingPath := paths.GetPathIfExists(key)
+	assert.Equal(t, path, existingPath)
+
+	// Remove it
+	paths.Remove(key)
+
+	// Verify it's gone
+	removedPath := paths.GetPathIfExists(key)
+	assert.Empty(t, removedPath)
+}
+
+func TestRemove_NonExistent(t *testing.T) {
+	paths := NewRandomizedTempPaths(os.TempDir())
+
+	// Removing a non-existent key should not panic
+	paths.Remove("https://localhost/does-not-exist.txt")
+
+	// Verify it still doesn't exist
+	path := paths.GetPathIfExists("https://localhost/does-not-exist.txt")
+	assert.Empty(t, path)
+}
+
+func TestRemove_no_race(t *testing.T) {
+	paths := NewRandomizedTempPaths(os.TempDir())
+	key := "https://localhost/test.txt"
+	_, err := paths.GetPath(key)
+	require.NoError(t, err)
+
+	go func() {
+		paths.Remove(key)
+	}()
+	go func() {
+		paths.GetPathIfExists(key)
+	}()
+}


### PR DESCRIPTION
## What

Enables a multi-source Application to reference the **same** git repository at **different** target revisions. Previously the reposerver rejected this with `cannot reference a different revision of the same repository`.

Closes #25605
Closes #12159

## Why

A common pattern is pinning a chart/source to a stable revision while pulling value files (via a `$ref` source) from a moving branch of the *same* repo. There's only one on-disk checkout per repo, so two revisions couldn't be checked out at once.

## How

Uses **git worktrees** to check out the additional revision(s) alongside the primary checkout, sharing the repo's object database. `$ref` value files resolve against — and are boundary-checked within — the correct worktree.

- Worktrees are **ref-counted** by `<normalizedRepoURL>@<commitSHA>`, so concurrent requests and repeated refs at the same.
- All worktree git operations (fetch / add / remove) are **serialized per repo root** to avoid racing on the shared `.git`
- Worktrees **orphaned by a crash are cleaned up at startup**, along with stale `.git/worktrees` admin entries.
- Worktree fetches go through the **same fetch helper as the primary checkout**, so the default `depth: 0` doesn't fetch b, #8845). Verified working against shallow (`depth > 0`) repositories.

### Why git worktrees

Argo CD keeps one clone per repository, and this feature needs a second *working tree* of that clone — which is what `git ives considered:

- **A second clone keyed by revision** — re-downloads and duplicates the object database per revision, and splits the one-that `Service.Init`, the repo permission initializer, and orphaned-packfile cleanup all rely on.
- **Tree extraction (`git archive | tar -x`)** — produces an identical tree (same symlinks preserved, same unpopulated subunds symlink scan is still required either way. It removes only the admin-entry pruning while adding tar extraction to
review, and it rules out ever supporting submodules/LFS here.
- **Extracting individual value files** — `valueFiles` support globs, `$ref` also feeds `fileParameters`, and value files  all three would have to be reimplemented over `git ls-tree`, forking behaviour from local sources.

Worktrees also share the object database (one fetch of missing objects, not a clone) and materialize trees with the same semantics as the `git checkout` used for primary sources.

### Cache correctness

The manifest cache key recorded one resolved revision per repo URL, which collapsed two revisions of the same repo into a evisions are now keyed `<url>@<sha>` when a repository is referenced at more than one revision, and manifest generation and cache lookup derive that key through the same helper, so the key a manifest is stored under is the key looked up. Apps referencing a single revision keep their existing keys.

This also fixes `getRefTargetRevisionMappingForCacheKey` mutating the caller's `RefSources` in place: with per-revision kenked `TargetRevision`, causing the ref source to resolve to `HEAD` instead of the pinned revision.

## Known limitations

- Submodule and LFS content is not populated in worktree-backed `$ref` sources. This is unchanged from any of the alternatives above; it can be added later by reusing the existing checkout logic in the worktree.

## Addressing review feedback

Thanks @pjiang-dev and @aali309 for the review.

**First round:**

- **Concurrency:** worktree fetch/add/remove now run under a dedicated per-root lock. (Reusing `repoLock` deadlocks — it'sary revision on the same root.) Concurrent same-commit requests share one ref-counted worktree.
- **Orphan cleanup:** worktrees moved to a dedicated directory and swept at startup in `Service.Init`; stale admin entries
- **Exact-SHA matching:** worktrees are keyed and resolved by commit SHA, so multiple revisions of the same repo resolve c

**Second round:**

- **E2E didn't exercise the feature:** both sources used `HEAD` and so resolved to the same commit, taking the ordinary chld have passed on `master`. The ref source is now pinned to a tag whose values differ from `HEAD`, so the assertiondistinguishes the worktree from the primary checkout.
- **`GetAppDetails` still rejected same-repo/different-revision:** `populateHelmAppDetails` now uses the same worktree logers pane works for apps that sync. It was also passing `nil` for the resolved commits, which would have read value filesfrom the primary checkout.
- **Cache invalidation:** `resolveReferencedSources` records every referenced revision, not just the first per repository
- **Log hygiene:** out-of-bounds symlink logs now record the repo URL rather than the `Repository` struct, which carries credentials.

## Testing

- **Unit:** per-root serialization (under `-race`), shared/ref-counted worktrees, worktree-aware glob boundary check, star-bounds symlink rejection from a worktree, ref-revision key assignment, and an end-to-end regression test that a secondidentical `GenerateManifest` hits the cache (i.e. generation and lookup agree on the key).
- **E2E:** `test/e2e/app_multiple_sources_test.go`.
- **Manual:**  verified locally (Tilt): a same-repo/two-revision Application syncs, worktrees are created/cleaned per request, and orphaned worktrees are removed on repo-server restart.

---

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submi)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. <!-- multi-source is already exposed in CLI/UI; this only removes a backend limitation -->
* [x] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR. <!-- TODO: note in multiple_sources.md that same-repo/different-r->
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may nk/complexity).