### PR TITLE
fix(hydrator): hydrated sha missing on no-ops (#25694)

### DIFF
--- a/commitserver/commit/commit_test.go
+++ b/commitserver/commit/commit_test.go
@@ -108,7 +108,7 @@ func Test_CommitHydratedManifests(t *testing.T) {
 		resp, err := service.CommitHydratedManifests(t.Context(), validRequest)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
-		assert.Empty(t, resp.HydratedSha) // changes introduced by commit note. hydration won't happen if there are no new manifest|s to commit
+		assert.Equal(t, "it-worked!", resp.HydratedSha, "Should return existing hydrated SHA for no-op")
 	})
 
 	t.Run("root path with dot and blank - no directory removal", func(t *testing.T) {
@@ -283,12 +283,13 @@ func Test_CommitHydratedManifests(t *testing.T) {
 			TargetBranch:  "main",
 			SyncBranch:    "env/test",
 			CommitMessage: "test commit message",
+			DrySha:        "dry-sha-456",
 		}
 
 		resp, err := service.CommitHydratedManifests(t.Context(), requestWithEmptyPaths)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
-		assert.Empty(t, resp.HydratedSha) // changes introduced by commit note. hydration won't happen if there are no new manifest|s to commit
+		assert.Equal(t, "empty-paths-sha", resp.HydratedSha, "Should return existing hydrated SHA for no-op")
 	})
 
 	t.Run("duplicate request already hydrated", func(t *testing.T) {
@@ -329,7 +330,7 @@ func Test_CommitHydratedManifests(t *testing.T) {
 		resp, err := service.CommitHydratedManifests(t.Context(), request)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
-		assert.Empty(t, resp.HydratedSha) // changes introduced by commit note. hydration won't happen if there are no new manifest|s to commit
+		assert.Equal(t, "dupe-test-sha", resp.HydratedSha, "Should return existing hydrated SHA when already hydrated")
 	})
 
 	t.Run("root path with dot - no changes to manifest - should commit note only", func(t *testing.T) {
@@ -355,6 +356,7 @@ func Test_CommitHydratedManifests(t *testing.T) {
 			TargetBranch:  "main",
 			SyncBranch:    "env/test",
 			CommitMessage: "test commit message",
+			DrySha:        "dry-sha-123",
 			Paths: []*apiclient.PathDetails{
 				{
 					Path: ".",
@@ -370,7 +372,8 @@ func Test_CommitHydratedManifests(t *testing.T) {
 		resp, err := service.CommitHydratedManifests(t.Context(), requestWithRootAndBlank)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
-		assert.Empty(t, resp.HydratedSha)
+		// BUG FIX: When manifests don't change (no-op), the existing hydrated SHA should be returned.
+		assert.Equal(t, "root-and-blank-sha", resp.HydratedSha, "Should return existing hydrated SHA for no-op")
 	})
 }
 

--- a/test/e2e/hydrator_test.go
+++ b/test/e2e/hydrator_test.go
@@ -325,17 +325,14 @@ func TestHydratorNoOp(t *testing.T) {
 		}).
 		When().
 		// Make a change to the dry source that doesn't affect the generated manifests.
-		// Adding a README.md file that's not listed in kustomization.yaml resources.
 		AddFile("guestbook/README.md", "# Guestbook\n\nThis is documentation.").
 		Refresh(RefreshTypeNormal).
 		Wait("--hydrated").
 		Then().
 		Expect(HydrationPhaseIs(HydrateOperationPhaseHydrated)).
 		And(func(app *Application) {
-			// BUG FIX: The hydrated SHA must be non-empty.
-			// Before the fix, when manifests didn't change, an empty string was returned.
 			require.NotEmpty(t, app.Status.SourceHydrator.CurrentOperation.HydratedSHA,
-				"BUG FIX: Hydrated SHA must not be empty - this was the bug")
+				"Hydrated SHA must not be empty")
 			require.NotEmpty(t, app.Status.SourceHydrator.CurrentOperation.DrySHA)
 
 			// The dry SHA should be different (new commit in the dry source)
@@ -346,9 +343,7 @@ func TestHydratorNoOp(t *testing.T) {
 				app.Status.SourceHydrator.CurrentOperation.DrySHA,
 				app.Status.SourceHydrator.CurrentOperation.HydratedSHA)
 
-			// BUG FIX: The hydrated SHA should remain the same since manifests didn't change.
-			// No new hydrated commit should be created for a no-op.
 			require.Equal(t, firstHydratedSHA, app.Status.SourceHydrator.CurrentOperation.HydratedSHA,
-				"BUG FIX: Hydrated SHA should remain the same for no-op hydration")
+				"Hydrated SHA should remain the same for no-op hydration")
 		})
 }

--- a/test/e2e/hydrator_test.go
+++ b/test/e2e/hydrator_test.go
@@ -345,5 +345,10 @@ func TestHydratorNoOp(t *testing.T) {
 			t.Logf("Second hydration - drySHA: %s, hydratedSHA: %s",
 				app.Status.SourceHydrator.CurrentOperation.DrySHA,
 				app.Status.SourceHydrator.CurrentOperation.HydratedSHA)
+
+			// BUG FIX: The hydrated SHA should remain the same since manifests didn't change.
+			// No new hydrated commit should be created for a no-op.
+			require.Equal(t, firstHydratedSHA, app.Status.SourceHydrator.CurrentOperation.HydratedSHA,
+				"BUG FIX: Hydrated SHA should remain the same for no-op hydration")
 		})
 }


### PR DESCRIPTION
Fixes #25694

Starting in 3.3, the commit-server short circuits commits where it detects that there's nothing to commit and instead pushes a note (or skips pushing if the note is already there and up to date). In these cases, the commit-server wasn't returning a hydrated SHA, so the UI had an empty string where the SHA should have been. This change makes sure the SHA appears even when the commit gets short-circuited.