### PR TITLE
fix(hydrator): race when pushing notes

### DIFF
--- a/commitserver/commit/addnote_race_test.go
+++ b/commitserver/commit/addnote_race_test.go
@@ -1,0 +1,248 @@
+package commit
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/argoproj/argo-cd/v3/util/git"
+)
+
+// TestAddNoteConcurrentStaggered tests that when multiple AddNote operations run
+// with slightly staggered timing, all notes persist correctly.
+// Each operation gets its own git clone, simulating multiple concurrent hydration requests.
+func TestAddNoteConcurrentStaggered(t *testing.T) {
+	t.Parallel()
+
+	// Create a bare repository to act as the "remote"
+	remoteDir := t.TempDir()
+	remotePath := filepath.Join(remoteDir, "remote.git")
+	err := os.MkdirAll(remotePath, 0755)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	_, err = runGitCmd(ctx, remotePath, "init", "--bare")
+	require.NoError(t, err)
+
+	// Create a local repository with some commits
+	localDir := t.TempDir()
+	localPath := filepath.Join(localDir, "local")
+	err = os.MkdirAll(localPath, 0755)
+	require.NoError(t, err)
+
+	// Initialize and create initial commits
+	_, err = runGitCmd(ctx, localPath, "init")
+	require.NoError(t, err)
+
+	_, err = runGitCmd(ctx, localPath, "config", "user.name", "Test User")
+	require.NoError(t, err)
+
+	_, err = runGitCmd(ctx, localPath, "config", "user.email", "test@example.com")
+	require.NoError(t, err)
+
+	_, err = runGitCmd(ctx, localPath, "remote", "add", "origin", remotePath)
+	require.NoError(t, err)
+
+	// Create 3 branches with commits (simulating different hydration targets)
+	branches := []string{"env/dev", "env/staging", "env/prod"}
+	commitSHAs := make([]string, 3)
+
+	for i, branch := range branches {
+		testFile := filepath.Join(localPath, fmt.Sprintf("file-%d.txt", i))
+		err = os.WriteFile(testFile, []byte(fmt.Sprintf("content %d", i)), 0644)
+		require.NoError(t, err)
+
+		_, err = runGitCmd(ctx, localPath, "add", ".")
+		require.NoError(t, err)
+		_, err = runGitCmd(ctx, localPath, "commit", "-m", fmt.Sprintf("commit %s", branch))
+		require.NoError(t, err)
+
+		sha, err := runGitCmd(ctx, localPath, "rev-parse", "HEAD")
+		require.NoError(t, err)
+		commitSHAs[i] = sha
+
+		_, err = runGitCmd(ctx, localPath, "branch", branch)
+		require.NoError(t, err)
+		_, err = runGitCmd(ctx, localPath, "push", "origin", branch)
+		require.NoError(t, err)
+	}
+
+	// Create separate clones for concurrent operations
+	gitClients := make([]git.Client, 3)
+
+	for i := 0; i < 3; i++ {
+		workDir := filepath.Join(localDir, fmt.Sprintf("work-%d", i))
+		err = os.MkdirAll(workDir, 0755)
+		require.NoError(t, err)
+
+		client, err := git.NewClientExt(remotePath, workDir, &git.NopCreds{}, false, false, "", "")
+		require.NoError(t, err)
+
+		err = client.Init()
+		require.NoError(t, err)
+		_, err = runGitCmd(ctx, workDir, "config", "user.name", "Test User")
+		require.NoError(t, err)
+		_, err = runGitCmd(ctx, workDir, "config", "user.email", "test@example.com")
+		require.NoError(t, err)
+		err = client.Fetch("", 0)
+		require.NoError(t, err)
+
+		gitClients[i] = client
+	}
+
+	// Add notes concurrently with slight stagger
+	var wg sync.WaitGroup
+	errors := make([]error, 3)
+
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			time.Sleep(time.Duration(idx*50) * time.Millisecond)
+			errors[idx] = AddNote(gitClients[idx], fmt.Sprintf("dry-sha-%d", idx), commitSHAs[idx])
+		}(i)
+	}
+	wg.Wait()
+
+	// Verify all notes persisted
+	verifyClient, err := git.NewClientExt(remotePath, t.TempDir(), &git.NopCreds{}, false, false, "", "")
+	require.NoError(t, err)
+	err = verifyClient.Init()
+	require.NoError(t, err)
+	err = verifyClient.Fetch("", 0)
+	require.NoError(t, err)
+
+	for i, commitSHA := range commitSHAs {
+		note, err := verifyClient.GetCommitNote(commitSHA, NoteNamespace)
+		assert.NoError(t, err, "Note should exist for commit %d", i)
+		if err == nil {
+			assert.Contains(t, note, fmt.Sprintf("dry-sha-%d", i))
+		}
+	}
+}
+
+// TestAddNoteConcurrentSimultaneous tests that when multiple AddNote operations run
+// simultaneously (without delays), all notes persist correctly.
+// Each operation gets its own git clone, simulating multiple concurrent hydration requests.
+func TestAddNoteConcurrentSimultaneous(t *testing.T) {
+	t.Parallel()
+
+	remoteDir := t.TempDir()
+	remotePath := filepath.Join(remoteDir, "remote.git")
+	err := os.MkdirAll(remotePath, 0755)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	_, err = runGitCmd(ctx, remotePath, "init", "--bare")
+	require.NoError(t, err)
+
+	localDir := t.TempDir()
+	localPath := filepath.Join(localDir, "local")
+	err = os.MkdirAll(localPath, 0755)
+	require.NoError(t, err)
+
+	_, err = runGitCmd(ctx, localPath, "init")
+	require.NoError(t, err)
+	_, err = runGitCmd(ctx, localPath, "config", "user.name", "Test User")
+	require.NoError(t, err)
+	_, err = runGitCmd(ctx, localPath, "config", "user.email", "test@example.com")
+	require.NoError(t, err)
+	_, err = runGitCmd(ctx, localPath, "remote", "add", "origin", remotePath)
+	require.NoError(t, err)
+
+	// Create 3 branches with commits (simulating different hydration targets)
+	branches := []string{"env/dev", "env/staging", "env/prod"}
+	commitSHAs := make([]string, 3)
+
+	for i, branch := range branches {
+		testFile := filepath.Join(localPath, fmt.Sprintf("file-%d.txt", i))
+		err = os.WriteFile(testFile, []byte(fmt.Sprintf("content %d", i)), 0644)
+		require.NoError(t, err)
+
+		_, err = runGitCmd(ctx, localPath, "add", ".")
+		require.NoError(t, err)
+		_, err = runGitCmd(ctx, localPath, "commit", "-m", fmt.Sprintf("commit %s", branch))
+		require.NoError(t, err)
+
+		sha, err := runGitCmd(ctx, localPath, "rev-parse", "HEAD")
+		require.NoError(t, err)
+		commitSHAs[i] = sha
+
+		_, err = runGitCmd(ctx, localPath, "branch", branch)
+		require.NoError(t, err)
+		_, err = runGitCmd(ctx, localPath, "push", "origin", branch)
+		require.NoError(t, err)
+	}
+
+	// Create separate clones for concurrent operations
+	gitClients := make([]git.Client, 3)
+
+	for i := 0; i < 3; i++ {
+		workDir := filepath.Join(localDir, fmt.Sprintf("work-%d", i))
+		err = os.MkdirAll(workDir, 0755)
+		require.NoError(t, err)
+
+		client, err := git.NewClientExt(remotePath, workDir, &git.NopCreds{}, false, false, "", "")
+		require.NoError(t, err)
+
+		err = client.Init()
+		require.NoError(t, err)
+		_, err = runGitCmd(ctx, workDir, "config", "user.name", "Test User")
+		require.NoError(t, err)
+		_, err = runGitCmd(ctx, workDir, "config", "user.email", "test@example.com")
+		require.NoError(t, err)
+		err = client.Fetch("", 0)
+		require.NoError(t, err)
+
+		gitClients[i] = client
+	}
+
+	// Add notes concurrently without delays
+	var wg sync.WaitGroup
+	startChan := make(chan struct{})
+
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-startChan
+			AddNote(gitClients[idx], fmt.Sprintf("dry-sha-%d", idx), commitSHAs[idx])
+		}(i)
+	}
+
+	close(startChan)
+	wg.Wait()
+
+	// Verify all notes persisted
+	verifyClient, err := git.NewClientExt(remotePath, t.TempDir(), &git.NopCreds{}, false, false, "", "")
+	require.NoError(t, err)
+	err = verifyClient.Init()
+	require.NoError(t, err)
+	err = verifyClient.Fetch("", 0)
+	require.NoError(t, err)
+
+	for i, commitSHA := range commitSHAs {
+		note, err := verifyClient.GetCommitNote(commitSHA, NoteNamespace)
+		assert.NoError(t, err, "Note should exist for commit %d", i)
+		if err == nil {
+			assert.Contains(t, note, fmt.Sprintf("dry-sha-%d", i))
+		}
+	}
+}
+
+// runGitCmd is a helper function to run git commands
+func runGitCmd(ctx context.Context, dir string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(output)), err
+}

--- a/go.mod
+++ b/go.mod
@@ -119,6 +119,8 @@ require (
 	sigs.k8s.io/yaml v1.6.0
 )
 
+require github.com/cenkalti/backoff/v5 v5.0.3
+
 require (
 	cloud.google.com/go/auth v0.15.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.7 // indirect
@@ -160,7 +162,6 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
-	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/chai2010/gettext-go v1.0.3 // indirect
 	github.com/clipperhouse/displaywidth v0.6.0 // indirect
 	github.com/clipperhouse/stringish v0.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.17.0
 	github.com/casbin/casbin/v2 v2.135.0
 	github.com/casbin/govaluate v1.10.0
+	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/chainguard-dev/git-urls v1.0.2
 	github.com/coreos/go-oidc/v3 v3.14.1
@@ -118,8 +119,6 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.1-0.20251003215857-446d8398e19c
 	sigs.k8s.io/yaml v1.6.0
 )
-
-require github.com/cenkalti/backoff/v5 v5.0.3
 
 require (
 	cloud.google.com/go/auth v0.15.0 // indirect

--- a/util/git/client.go
+++ b/util/git/client.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"math/rand"
 	"net/http"
 	"net/mail"
 	"net/url"
@@ -1157,8 +1158,10 @@ func (m *nativeGitClient) AddAndPushNote(sha string, namespace string, note stri
 
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		if attempt > 0 {
-			// Exponential backoff before retry: 100ms, 400ms
-			backoff := time.Duration(100*attempt*attempt) * time.Millisecond
+			// Exponential backoff with jitter to avoid thundering herd
+			baseBackoff := 100 * attempt * attempt // 100ms, 400ms in milliseconds
+			jitter := rand.Intn(baseBackoff/5 + 1) // Up to 20% jitter
+			backoff := time.Duration(baseBackoff+jitter) * time.Millisecond
 			time.Sleep(backoff)
 		}
 

--- a/util/git/client.go
+++ b/util/git/client.go
@@ -1195,7 +1195,7 @@ func (m *nativeGitClient) AddAndPushNote(sha string, namespace string, note stri
 		// Check if this is a retryable error
 		errStr := err.Error()
 		isRetryable := strings.Contains(errStr, "fetch first") || // Remote updated after our fetch (concurrent push completed between our fetch and push)
-			strings.Contains(errStr, "cannot lock ref") || // Another push is in progress right now (git server-side lock)
+			strings.Contains(errStr, "reference already exists") || // Concurrent push is holding the lock (git server-side lock)
 			strings.Contains(errStr, "failed to update ref") // Generic ref update failure that may include transient issues
 
 		if !isRetryable {

--- a/util/git/client.go
+++ b/util/git/client.go
@@ -1152,15 +1152,15 @@ func (m *nativeGitClient) AddAndPushNote(sha string, namespace string, note stri
 	ref := "--ref=" + namespace
 	notesRef := "refs/notes/" + namespace
 
-	// Retry up to 3 times to handle concurrent note updates
-	maxRetries := 3
+	// Retry up to 5 times to handle concurrent note updates
+	maxRetries := 5
 	var lastErr error
 
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		if attempt > 0 {
-			// Exponential backoff with jitter to avoid thundering herd
-			baseBackoff := 100 * attempt * attempt // 100ms, 400ms in milliseconds
-			jitter := rand.Intn(baseBackoff/5 + 1) // Up to 20% jitter
+			// Exponential backoff with aggressive jitter to avoid thundering herd
+			baseBackoff := 50 * attempt * attempt // 50ms, 200ms, 450ms, 800ms in milliseconds
+			jitter := rand.Intn(baseBackoff + 1) // Up to 100% jitter for maximum spread
 			backoff := time.Duration(baseBackoff+jitter) * time.Millisecond
 			time.Sleep(backoff)
 		}


### PR DESCRIPTION
Source Hydrator uses `ref/notes/hydrator.metadata` to keep track of hydration state.

That ref behaves a lot like a branch: if multiple concurrent processes have different state, those states have to be reconciled.

This PR adds retries to make sure we eventually push whatever note we're currently working on, regardless of other hydration processes that might also be pushing notes.

The tests are really aggressive and should ensure we successfully eliminate failures in real world scenarios.