### PR TITLE
test: use unique app name per test

### DIFF
--- a/test/e2e/admin_test.go
+++ b/test/e2e/admin_test.go
@@ -21,6 +21,9 @@ func TestBackupExportImport(t *testing.T) {
 	// Create application in argocd namespace
 	appctx := appfixture.GivenWithSameState(t)
 
+	var appTestNamespace Application
+	var appOtherNamespace Application
+
 	// Create application in test namespace
 	appctx.
 		Path(guestbookPath).
@@ -29,8 +32,9 @@ func TestBackupExportImport(t *testing.T) {
 		CreateApp().
 		Then().
 		And(func(app *Application) {
-			assert.Equal(t, "exported-app1", app.Name)
-			assert.Equal(t, fixture.TestNamespace(), app.Namespace)
+			assert.Equal(t, appctx.AppName(), app.Name)
+			assert.Equal(t, appctx.AppNamespace(), app.Namespace)
+			appTestNamespace = *app
 		})
 
 	// Create app in other namespace
@@ -42,8 +46,9 @@ func TestBackupExportImport(t *testing.T) {
 		CreateApp().
 		Then().
 		And(func(app *Application) {
-			assert.Equal(t, "exported-app-other-namespace", app.Name)
-			assert.Equal(t, fixture.AppNamespace(), app.Namespace)
+			assert.Equal(t, appctx.AppName(), app.Name)
+			assert.Equal(t, appctx.AppNamespace(), app.Namespace)
+			appOtherNamespace = *app
 		})
 
 	ctx.
@@ -57,8 +62,8 @@ func TestBackupExportImport(t *testing.T) {
 		AndExportedResources(func(exportResources *ExportedResources, err error) {
 			require.NoError(t, err, "export format not valid")
 			assert.True(t, exportResources.HasResource(kube.NewResourceKey("", "ConfigMap", "", "argocd-cm")), "argocd-cm not found in export")
-			assert.True(t, exportResources.HasResource(kube.NewResourceKey(ApplicationSchemaGroupVersionKind.Group, ApplicationSchemaGroupVersionKind.Kind, "", "exported-app1")), "test namespace application not in export")
-			assert.True(t, exportResources.HasResource(kube.NewResourceKey(ApplicationSchemaGroupVersionKind.Group, ApplicationSchemaGroupVersionKind.Kind, fixture.AppNamespace(), "exported-app-other-namespace")), "app namespace application not in export")
+			assert.True(t, exportResources.HasResource(kube.NewResourceKey(ApplicationSchemaGroupVersionKind.Group, ApplicationSchemaGroupVersionKind.Kind, "", appTestNamespace.GetName())), "test namespace application not in export")
+			assert.True(t, exportResources.HasResource(kube.NewResourceKey(ApplicationSchemaGroupVersionKind.Group, ApplicationSchemaGroupVersionKind.Kind, appOtherNamespace.GetNamespace(), appOtherNamespace.GetName())), "app namespace application not in export")
 		})
 
 	// Test import - clean state
@@ -70,9 +75,9 @@ func TestBackupExportImport(t *testing.T) {
 		Then().
 		AndCLIOutput(func(_ string, err error) {
 			require.NoError(t, err, "import finished with error")
-			_, err = fixture.AppClientset.ArgoprojV1alpha1().Applications(fixture.TestNamespace()).Get(t.Context(), "exported-app1", metav1.GetOptions{})
+			_, err = fixture.AppClientset.ArgoprojV1alpha1().Applications(appTestNamespace.GetNamespace()).Get(t.Context(), appTestNamespace.GetName(), metav1.GetOptions{})
 			require.NoError(t, err, "failed getting test namespace application after import")
-			_, err = fixture.AppClientset.ArgoprojV1alpha1().Applications(fixture.AppNamespace()).Get(t.Context(), "exported-app-other-namespace", metav1.GetOptions{})
+			_, err = fixture.AppClientset.ArgoprojV1alpha1().Applications(appOtherNamespace.GetNamespace()).Get(t.Context(), appOtherNamespace.GetName(), metav1.GetOptions{})
 			require.NoError(t, err, "failed getting app namespace application after import")
 		})
 }

--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -845,7 +845,7 @@ func TestAppWithSecrets(t *testing.T) {
 			assert.Empty(t, diffOutput)
 
 			// make sure resource update error does not print secret details
-			_, err = fixture.RunCli("app", "patch-resource", "test-app-with-secrets", "--resource-name", "test-secret",
+			_, err = fixture.RunCli("app", "patch-resource", app.GetName(), "--resource-name", "test-secret",
 				"--kind", "Secret", "--patch", `{"op": "add", "path": "/data", "value": "hello"}'`,
 				"--patch-type", "application/json-patch+json")
 			require.ErrorContains(t, err, fmt.Sprintf("failed to patch Secret %s/test-secret", fixture.DeploymentNamespace()))
@@ -1571,10 +1571,9 @@ func assertResourceActions(t *testing.T, appName string, successful bool) {
 
 func TestPermissions(t *testing.T) {
 	appCtx := Given(t)
-	projName := "argo-project"
-	projActions := projectFixture.
-		GivenWithSameState(t).
-		Name(projName).
+	projCtx := projectFixture.GivenWithSameState(t)
+	projActions := projCtx.
+		Name("argo-project").
 		When().
 		Create()
 
@@ -1583,7 +1582,7 @@ func TestPermissions(t *testing.T) {
 
 	appCtx.
 		Path("guestbook-logs").
-		Project(projName).
+		Project(projCtx.GetName()).
 		When().
 		IgnoreErrors().
 		// ensure app is not created if project permissions are missing
@@ -1641,8 +1640,8 @@ func TestPermissions(t *testing.T) {
 		Refresh(RefreshTypeNormal).
 		Then().
 		// make sure application resource actions are failing
-		And(func(_ *Application) {
-			assertResourceActions(t, "test-permissions", false)
+		And(func(a *Application) {
+			assertResourceActions(t, a.GetName(), false)
 		})
 }
 

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -35,27 +35,27 @@ func createTestPlugin(t *testing.T, name, content string) string {
 
 // TestCliAppCommand verifies the basic Argo CD CLI commands for app synchronization and listing.
 func TestCliAppCommand(t *testing.T) {
-	Given(t).
-		Path("hook").
+	ctx := Given(t)
+	ctx.Path("hook").
 		When().
 		CreateApp().
 		And(func() {
-			output, err := RunCli("app", "sync", Name(), "--timeout", "90")
+			output, err := RunCli("app", "sync", ctx.AppName(), "--timeout", "90")
 			require.NoError(t, err)
-			vars := map[string]any{"Name": Name(), "Namespace": DeploymentNamespace()}
+			vars := map[string]any{"Name": ctx.AppName(), "Namespace": DeploymentNamespace()}
 			assert.Contains(t, NormalizeOutput(output), Tmpl(t, `Pod {{.Namespace}} pod Synced Progressing pod/pod created`, vars))
 			assert.Contains(t, NormalizeOutput(output), Tmpl(t, `Pod {{.Namespace}} hook Succeeded Sync pod/hook created`, vars))
 		}).
 		Then().
 		Expect(OperationPhaseIs(OperationSucceeded)).
 		Expect(HealthIs(health.HealthStatusHealthy)).
-		And(func(_ *Application) {
+		And(func(a *Application) {
 			output, err := RunCli("app", "list")
 			require.NoError(t, err)
 			expected := Tmpl(
 				t,
 				`{{.Name}} https://kubernetes.default.svc {{.Namespace}} default Synced Healthy Manual <none>`,
-				map[string]any{"Name": Name(), "Namespace": DeploymentNamespace()})
+				map[string]any{"Name": a.GetName(), "Namespace": DeploymentNamespace()})
 			assert.Contains(t, NormalizeOutput(output), expected)
 		})
 }
@@ -75,17 +75,18 @@ func TestNormalArgoCDCommandsExecuteOverPluginsWithSameName(t *testing.T) {
 	})
 	t.Setenv("PATH", filepath.Dir(pluginPath)+":"+origPath)
 
-	Given(t).
+	ctx := Given(t)
+	ctx.Path("hook").
 		Path("hook").
 		When().
 		CreateApp().
 		And(func() {
-			output, err := RunCli("app", "sync", Name(), "--timeout", "90")
+			output, err := RunCli("app", "sync", ctx.AppName(), "--timeout", "90")
 			require.NoError(t, err)
 
 			assert.NotContains(t, NormalizeOutput(output), "I am a plugin, not Argo CD!")
 
-			vars := map[string]any{"Name": Name(), "Namespace": DeploymentNamespace()}
+			vars := map[string]any{"Name": ctx.AppName(), "Namespace": DeploymentNamespace()}
 			assert.Contains(t, NormalizeOutput(output), Tmpl(t, `Pod {{.Namespace}} pod Synced Progressing pod/pod created`, vars))
 			assert.Contains(t, NormalizeOutput(output), Tmpl(t, `Pod {{.Namespace}} hook Succeeded Sync pod/hook created`, vars))
 		}).
@@ -101,7 +102,7 @@ func TestNormalArgoCDCommandsExecuteOverPluginsWithSameName(t *testing.T) {
 			expected := Tmpl(
 				t,
 				`{{.Name}} https://kubernetes.default.svc {{.Namespace}} default Synced Healthy Manual <none>`,
-				map[string]any{"Name": Name(), "Namespace": DeploymentNamespace()})
+				map[string]any{"Name": ctx.AppName(), "Namespace": DeploymentNamespace()})
 			assert.Contains(t, NormalizeOutput(output), expected)
 		})
 }

--- a/test/e2e/cluster_test.go
+++ b/test/e2e/cluster_test.go
@@ -56,9 +56,8 @@ https://kubernetes.default.svc  in-cluster  %v     Successful           `, fixtu
 }
 
 func TestClusterAdd(t *testing.T) {
-	clusterFixture.
-		Given(t).
-		Project(fixture.ProjectName).
+	ctx := clusterFixture.Given(t)
+	ctx.Project(fixture.ProjectName).
 		Upsert(true).
 		Server(KubernetesInternalAPIServerAddr).
 		When().
@@ -66,8 +65,7 @@ func TestClusterAdd(t *testing.T) {
 		List().
 		Then().
 		AndCLIOutput(func(output string, _ error) {
-			assert.Equal(t, fmt.Sprintf(`SERVER                          NAME              VERSION  STATUS      MESSAGE  PROJECT
-https://kubernetes.default.svc  test-cluster-add  %v     Successful           %s`, fixture.GetVersions(t).ServerVersion, fixture.ProjectName), output)
+			assert.Contains(t, fixture.NormalizeOutput(output), fmt.Sprintf(`https://kubernetes.default.svc %s %v Successful %s`, ctx.GetName(), fixture.GetVersions(t).ServerVersion, fixture.ProjectName))
 		})
 }
 
@@ -112,8 +110,8 @@ func TestClusterAddAllowed(t *testing.T) {
 			},
 		}, "org-admin")
 
-	clusterFixture.
-		GivenWithSameState(t).
+	ctx := clusterFixture.GivenWithSameState(t)
+	ctx.Project(fixture.ProjectName).
 		Project(fixture.ProjectName).
 		Upsert(true).
 		Server(KubernetesInternalAPIServerAddr).
@@ -122,8 +120,7 @@ func TestClusterAddAllowed(t *testing.T) {
 		List().
 		Then().
 		AndCLIOutput(func(output string, _ error) {
-			assert.Equal(t, fmt.Sprintf(`SERVER                          NAME                      VERSION  STATUS      MESSAGE  PROJECT
-https://kubernetes.default.svc  test-cluster-add-allowed  %v     Successful           argo-project`, fixture.GetVersions(t).ServerVersion), output)
+			assert.Contains(t, fixture.NormalizeOutput(output), fmt.Sprintf(`https://kubernetes.default.svc %s %v Successful %s`, ctx.GetName(), fixture.GetVersions(t).ServerVersion, fixture.ProjectName))
 		})
 }
 

--- a/test/e2e/fixture/app/context.go
+++ b/test/e2e/fixture/app/context.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -93,8 +94,15 @@ func GivenWithSameState(t *testing.T) *Context {
 	}
 }
 
+// AppName returns the unique application name for the test context.
+// Unique application names protects from potential conflicts between test run
+// caused by the tracking annotation on existing objects
 func (c *Context) AppName() string {
-	return c.name
+	suffix := "-" + fixture.ShortId()
+	if strings.HasSuffix(c.name, suffix) {
+		return c.name
+	}
+	return fixture.DnsFriendly(c.name, suffix)
 }
 
 func (c *Context) AppQualifiedName() string {

--- a/test/e2e/fixture/fixture.go
+++ b/test/e2e/fixture/fixture.go
@@ -90,6 +90,7 @@ const (
 
 var (
 	id                      string
+	shortId                 string
 	deploymentNamespace     string
 	name                    string
 	KubeClientset           kubernetes.Interface
@@ -299,6 +300,10 @@ func LoginAs(username string) error {
 
 func Name() string {
 	return name
+}
+
+func ShortId() string {
+	return shortId
 }
 
 func repoDirectory() string {
@@ -1056,10 +1061,11 @@ func EnsureCleanState(t *testing.T, opts ...TestOption) {
 			if err != nil {
 				return err
 			}
-			postFix := "-" + strings.ToLower(randString)
-			id = t.Name() + postFix
-			name = DnsFriendly(t.Name(), "")
-			deploymentNamespace = DnsFriendly("argocd-e2e-"+t.Name(), postFix)
+			shortId = strings.ToLower(randString)
+			id = fmt.Sprintf("%s-%s", t.Name(), shortId)
+			name = DnsFriendly(t.Name(), "-"+shortId)
+			deploymentNamespace = DnsFriendly("argocd-e2e-"+t.Name(), "-"+shortId)
+
 			// create namespace
 			_, err = Run("", "kubectl", "create", "ns", DeploymentNamespace())
 			if err != nil {


### PR DESCRIPTION
The main problem is with the resource tracking. When tests are run by a retry, or executed locally, it is possible that resources already exist in terminating state (done at the start of tests during the EnsureCleanState) and the tests will pick these up.

This change will increase stability, and is a small step towards parallelism. 
Related to https://github.com/argoproj/argo-cd/issues/24307



As a result, current e2e are updated if they were hardcoding the ApplicationName