### PR TITLE
chore(hydrator): improve error message

### DIFF
--- a/commitserver/commit/hydratorhelper.go
+++ b/commitserver/commit/hydratorhelper.go
@@ -249,7 +249,7 @@ func AddNote(gitClient git.Client, drySha, commitSha string) error {
 	}
 	err = gitClient.AddAndPushNote(commitSha, NoteNamespace, string(jsonBytes))
 	if err != nil {
-		return fmt.Errorf("failed to add commit note: %w", err)
+		return err // nolint:wrapcheck // wrapping wouldn't add any information that the caller doesn't already have
 	}
 	return nil
 }

--- a/commitserver/commit/hydratorhelper.go
+++ b/commitserver/commit/hydratorhelper.go
@@ -247,9 +247,5 @@ func AddNote(gitClient git.Client, drySha, commitSha string) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal commit note: %w", err)
 	}
-	err = gitClient.AddAndPushNote(commitSha, NoteNamespace, string(jsonBytes))
-	if err != nil {
-		return err // nolint:wrapcheck // wrapping wouldn't add any information that the caller doesn't already have
-	}
-	return nil
+	return gitClient.AddAndPushNote(commitSha, NoteNamespace, string(jsonBytes)) // nolint:wrapcheck // wrapping the error wouldn't add any information
 }


### PR DESCRIPTION
Relates to: https://github.com/argoproj/argo-cd/issues/25736

The error message currently duplicates "failed to add commit note". This simplifies to let the caller wrap the error.