### PR TITLE
fix(hydrator): git fetch needs creds (#25727)

### DIFF
--- a/test/e2e/fixture/fixture.go
+++ b/test/e2e/fixture/fixture.go
@@ -957,7 +957,15 @@ func EnsureCleanState(t *testing.T, opts ...TestOption) {
 			return err
 		},
 		func() error {
-			err := os.RemoveAll(TmpDir)
+			// Try to chmod the directory tree before removing to handle permission issues
+			// that can occur when git notes are created by processes with different permissions.
+			// When git push operations write to file:// repositories, they may create files
+			// with restrictive permissions that prevent cleanup.
+			_, err := Run("", "chmod", "-R", "u+w", TmpDir)
+			if err != nil {
+				return err
+			}
+			err = os.RemoveAll(TmpDir)
 			if err != nil {
 				return err
 			}

--- a/test/e2e/fixture/fixture.go
+++ b/test/e2e/fixture/fixture.go
@@ -957,15 +957,7 @@ func EnsureCleanState(t *testing.T, opts ...TestOption) {
 			return err
 		},
 		func() error {
-			// Try to chmod the directory tree before removing to handle permission issues
-			// that can occur when git notes are created by processes with different permissions.
-			// When git push operations write to file:// repositories, they may create files
-			// with restrictive permissions that prevent cleanup.
-			_, err := Run("", "chmod", "-R", "u+w", TmpDir)
-			if err != nil {
-				return err
-			}
-			err = os.RemoveAll(TmpDir)
+			err := os.RemoveAll(TmpDir)
 			if err != nil {
 				return err
 			}
@@ -1039,6 +1031,12 @@ func EnsureCleanState(t *testing.T, opts ...TestOption) {
 				return err
 			}
 			_, err = Run(repoDirectory(), "git", "init", "-b", "master")
+			if err != nil {
+				return err
+			}
+			// Configure git to create files with more permissive permissions to avoid
+			// issues when cleaning up. By default git creates object files as 0444.
+			_, err = Run(repoDirectory(), "git", "config", "core.sharedRepository", "0666")
 			if err != nil {
 				return err
 			}

--- a/test/e2e/fixture/repos/repos.go
+++ b/test/e2e/fixture/repos/repos.go
@@ -1,6 +1,7 @@
 package repos
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -8,7 +9,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/argoproj/argo-cd/v3/common"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-cd/v3/test/e2e/fixture"
 	"github.com/argoproj/argo-cd/v3/util/errors"
@@ -314,4 +318,43 @@ func PushImageToAuthenticatedOCIRegistry(t *testing.T, pathName, tag string) {
 		fmt.Sprintf("%s:%s", fmt.Sprintf("%s/%s", strings.TrimPrefix(fixture.AuthenticatedOCIHostURL, "oci://"), filepath.Base(pathName)), tag),
 		".",
 	))
+}
+
+// AddHTTPSWriteCredentials adds write credentials for an HTTPS repository.
+// Write credentials are used by the commit-server to push hydrated manifests back to the repository.
+// TODO: add CLI support for managing write credentials and use that here instead.
+func AddHTTPSWriteCredentials(t *testing.T, insecure bool, repoURLType fixture.RepoURLType) {
+	t.Helper()
+	repoURL := fixture.RepoURL(repoURLType)
+
+	// Create a Kubernetes secret with the repository-write label
+	// Replace invalid characters for secret name
+	secretName := "write-creds-" + fixture.Name()
+
+	// Delete existing secret if it exists (ignore error if not found)
+	_ = fixture.KubeClientset.CoreV1().Secrets(fixture.ArgoCDNamespace).Delete(
+		context.Background(),
+		secretName,
+		metav1.DeleteOptions{},
+	)
+
+	_, err := fixture.KubeClientset.CoreV1().Secrets(fixture.ArgoCDNamespace).Create(
+		context.Background(),
+		&v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: secretName,
+				Labels: map[string]string{
+					common.LabelKeySecretType: common.LabelValueSecretTypeRepositoryWrite,
+				},
+			},
+			StringData: map[string]string{
+				"url":      repoURL,
+				"username": fixture.GitUsername,
+				"password": fixture.GitPassword,
+				"insecure": strconv.FormatBool(insecure),
+			},
+		},
+		metav1.CreateOptions{},
+	)
+	require.NoError(t, err)
 }

--- a/test/e2e/fixture/repos/repos.go
+++ b/test/e2e/fixture/repos/repos.go
@@ -9,11 +9,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/argoproj/argo-cd/v3/common"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/argoproj/argo-cd/v3/common"
 	"github.com/argoproj/argo-cd/v3/test/e2e/fixture"
 	"github.com/argoproj/argo-cd/v3/util/errors"
 )
@@ -340,7 +340,7 @@ func AddHTTPSWriteCredentials(t *testing.T, insecure bool, repoURLType fixture.R
 
 	_, err := fixture.KubeClientset.CoreV1().Secrets(fixture.ArgoCDNamespace).Create(
 		context.Background(),
-		&v1.Secret{
+		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: secretName,
 				Labels: map[string]string{

--- a/util/git/client.go
+++ b/util/git/client.go
@@ -1129,7 +1129,7 @@ func (m *nativeGitClient) GetCommitNote(sha string, namespace string) (string, e
 	// fetch first
 	// cli command: git fetch origin refs/notes/source-hydrator:refs/notes/source-hydrator
 	notesRef := "refs/notes/" + namespace
-	_, _ = m.runCmd(ctx, "fetch", "origin", fmt.Sprintf("%s:%s", notesRef, notesRef)) // Ignore fetch error for best effort
+	_ = m.runCredentialedCmd(ctx, "fetch", "origin", fmt.Sprintf("%s:%s", notesRef, notesRef)) // Ignore fetch error for best effort
 
 	ref := "--ref=" + namespace
 	out, err := m.runCmd(ctx, "notes", ref, "show", sha)
@@ -1163,7 +1163,7 @@ func (m *nativeGitClient) AddAndPushNote(sha string, namespace string, note stri
 
 		// Fetch the latest notes BEFORE adding to merge concurrent updates
 		// Use + prefix to force update local ref (safe because we want latest remote notes)
-		_, fetchErr := m.runCmd(ctx, "fetch", "origin", fmt.Sprintf("+%s:%s", notesRef, notesRef))
+		fetchErr := m.runCredentialedCmd(ctx, "fetch", "origin", fmt.Sprintf("+%s:%s", notesRef, notesRef))
 		// Ignore "couldn't find remote ref" errors (notes don't exist yet - first time)
 		if fetchErr != nil && !strings.Contains(fetchErr.Error(), "couldn't find remote ref") {
 			log.Debugf("Failed to fetch notes (will continue): %v", fetchErr)


### PR DESCRIPTION
Fixes #25727

Use credentials when doing git fetches.

I confirmed that the e2e test failed before applying the fix and that it passes now.