### PR TITLE
feat(security): add X-Frame-Options header to prevent clickjacking

### DIFF
--- a/util/swagger/swagger.go
+++ b/util/swagger/swagger.go
@@ -15,7 +15,7 @@ const redocScriptName = "redoc.standalone.js"
 func ServeSwaggerUI(mux *http.ServeMux, swaggerJSON string, uiPath string, rootPath string) {
 	prefix := path.Dir(uiPath)
 	swaggerPath := path.Join(prefix, "swagger.json")
-	mux.HandleFunc(swaggerPath, func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(swaggerPath, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("X-Frame-Options", "DENY")
 		_, _ = fmt.Fprint(w, swaggerJSON)
 	})

--- a/util/swagger/swagger.go
+++ b/util/swagger/swagger.go
@@ -16,6 +16,7 @@ func ServeSwaggerUI(mux *http.ServeMux, swaggerJSON string, uiPath string, rootP
 	prefix := path.Dir(uiPath)
 	swaggerPath := path.Join(prefix, "swagger.json")
 	mux.HandleFunc(swaggerPath, func(w http.ResponseWriter, _ *http.Request) {
+         w.Header().Set("X-Frame-Options", "DENY")
 		_, _ = fmt.Fprint(w, swaggerJSON)
 	})
 

--- a/util/swagger/swagger.go
+++ b/util/swagger/swagger.go
@@ -16,7 +16,7 @@ func ServeSwaggerUI(mux *http.ServeMux, swaggerJSON string, uiPath string, rootP
 	prefix := path.Dir(uiPath)
 	swaggerPath := path.Join(prefix, "swagger.json")
 	mux.HandleFunc(swaggerPath, func(w http.ResponseWriter, _ *http.Request) {
-         w.Header().Set("X-Frame-Options", "DENY")
+		w.Header().Set("X-Frame-Options", "DENY")
 		_, _ = fmt.Fprint(w, swaggerJSON)
 	})
 

--- a/util/swagger/swagger.go
+++ b/util/swagger/swagger.go
@@ -15,7 +15,7 @@ const redocScriptName = "redoc.standalone.js"
 func ServeSwaggerUI(mux *http.ServeMux, swaggerJSON string, uiPath string, rootPath string) {
 	prefix := path.Dir(uiPath)
 	swaggerPath := path.Join(prefix, "swagger.json")
-	mux.HandleFunc(swaggerPath, func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc(swaggerPath, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Frame-Options", "DENY")
 		_, _ = fmt.Fprint(w, swaggerJSON)
 	})


### PR DESCRIPTION
## Description

Add the `X-Frame-Options: DENY` header to Swagger UI responses to prevent
clickjacking attacks, as requested in #22877.

## Changes

- Add `X-Frame-Options: DENY` header to Swagger UI responses
- Prevents clickjacking attacks by blocking iframe embedding
- Fixes #22877

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

## Checklist

* [x] Either (a) I've created an enhancement proposal and discussed it with the community,
      (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the Title of the PR guidelines.
* [x] I've included `Fixes #22877` in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. (not applicable)
* [ ] Does this PR require documentation updates? (likely no)
* [ ] I've updated documentation as required by this PR. (if not needed, leave unchecked)
* [ ] I have signed off all my commits as required by DCO.
* [ ] I have written unit and/or e2e tests for my change.
* [ ] My build is green.
* [x] I have added a brief description of why this PR is necessary and what it solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into.
