### PR TITLE
fix: incorrect GitHub path in TestGitHubListReturnsRepositoryNotFoundError

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -316,6 +316,7 @@ Currently, the following organizations are **officially** using Argo CD:
 1. [Reenigne Cloud](https://reenigne.ca)
 1. [reev.com](https://www.reev.com/)
 1. [Relex Solutions](https://www.relexsolutions.com/)
+1. [remberg](https://remberg.com/)
 1. [RightRev](https://rightrev.com/)
 1. [Rijkswaterstaat](https://www.rijkswaterstaat.nl/en)
 1. Rise

--- a/USERS.md
+++ b/USERS.md
@@ -328,6 +328,7 @@ Currently, the following organizations are **officially** using Argo CD:
 1. [Reenigne Cloud](https://reenigne.ca)
 1. [reev.com](https://www.reev.com/)
 1. [Relex Solutions](https://www.relexsolutions.com/)
+1. [remberg](https://remberg.com/)
 1. [RightRev](https://rightrev.com/)
 1. [Rijkswaterstaat](https://www.rijkswaterstaat.nl/en)
 1. Rise

--- a/applicationset/services/pull_request/github_test.go
+++ b/applicationset/services/pull_request/github_test.go
@@ -95,7 +95,7 @@ func TestGitHubListReturnsRepositoryNotFoundError(t *testing.T) {
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	path := "/repos/nonexistent/nonexistent/pulls"
+	path := "/api/v3/repos/nonexistent/nonexistent/pulls"
 
 	mux.HandleFunc(path, func(w http.ResponseWriter, _ *http.Request) {
 		// Return 404 status to simulate repository not found

--- a/applicationset/services/pull_request/github_test.go
+++ b/applicationset/services/pull_request/github_test.go
@@ -96,7 +96,7 @@ func TestGitHubListReturnsRepositoryNotFoundError(t *testing.T) {
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	path := "/repos/nonexistent/nonexistent/pulls"
+	path := "/api/v3/repos/nonexistent/nonexistent/pulls"
 
 	mux.HandleFunc(path, func(w http.ResponseWriter, _ *http.Request) {
 		// Return 404 status to simulate repository not found


### PR DESCRIPTION
Before the fix: The handler was registered at /repos/... but the client requested /api/v3/repos/...

The test previously passed only due to a generic 404 status code.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
