### PR TITLE
docs: link to source hydrator

### DIFF
--- a/docs/operator-manual/upgrading/3.1-3.2.md
+++ b/docs/operator-manual/upgrading/3.1-3.2.md
@@ -6,7 +6,7 @@
 
 ### Hydration paths must now be non-root
 
-Source hydration now requires that every application specify a non-root path.
+Source hydration (with [Source Hydrator](../../../user-guide/source-hydrator/)) now requires that every application specify a non-root path.
 Using the repository root (for example, "" or ".") is no longer supported. This change ensures
 that hydration outputs are isolated to a dedicated subdirectory and prevents accidental overwrites
 or deletions of important files stored at the root, such as CI pipelines, documentation, or configuration files.


### PR DESCRIPTION
There's no obvious explanation about what `source hydration` is on https://argo-cd.readthedocs.io/en/stable/operator-manual/upgrading/3.1-3.2/ and searching for it was frustrating.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
