### PR TITLE
feat(argocd-k8s-auth): add logging flags and version command

### DIFF
--- a/cmd/argocd-k8s-auth/commands/argocd_k8s_auth.go
+++ b/cmd/argocd-k8s-auth/commands/argocd_k8s_auth.go
@@ -2,25 +2,45 @@ package commands
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/argoproj/argo-cd/v3/util/cli"
 )
 
 const (
 	cliName = "argocd-k8s-auth"
 )
 
+var (
+	logFormat string
+	logLevel  string
+)
+
+func init() {
+	cobra.OnInitialize(initConfig)
+}
+
+func initConfig() {
+	cli.SetLogFormat(logFormat)
+	cli.SetLogLevel(logLevel)
+}
+
 func NewCommand() *cobra.Command {
 	command := &cobra.Command{
 		Use:               cliName,
-		Short:             "argocd-k8s-auth a set of commands to generate k8s auth token",
+		Short:             "argocd-k8s-auth tools used for generating authentication tokens",
 		DisableAutoGenTag: true,
 		Run: func(c *cobra.Command, args []string) {
 			c.HelpFunc()(c, args)
 		},
 	}
 
+	command.PersistentFlags().StringVar(&logFormat, "logformat", "text", "Set the logging format. One of: text|json")
+	command.PersistentFlags().StringVar(&logLevel, "loglevel", "info", "Set the logging level. One of: debug|info|warn|error")
+
 	command.AddCommand(newAWSCommand())
 	command.AddCommand(newGCPCommand())
 	command.AddCommand(newAzureCommand())
+	command.AddCommand(cli.NewVersionCmd(cliName))
 
 	return command
 }

--- a/cmd/argocd-k8s-auth/commands/argocd_k8s_auth_test.go
+++ b/cmd/argocd-k8s-auth/commands/argocd_k8s_auth_test.go
@@ -1,0 +1,45 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCommand(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewCommand()
+
+	t.Run("has correct name and description", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, "argocd-k8s-auth", cmd.Use)
+		assert.NotEmpty(t, cmd.Short)
+	})
+
+	t.Run("has logging flags", func(t *testing.T) {
+		t.Parallel()
+		logformatFlag := cmd.PersistentFlags().Lookup("logformat")
+		assert.NotNil(t, logformatFlag)
+		assert.Equal(t, "text", logformatFlag.DefValue)
+
+		loglevelFlag := cmd.PersistentFlags().Lookup("loglevel")
+		assert.NotNil(t, loglevelFlag)
+		assert.Equal(t, "info", loglevelFlag.DefValue)
+	})
+
+	t.Run("has expected subcommands", func(t *testing.T) {
+		t.Parallel()
+		subcommands := cmd.Commands()
+
+		var subcommandNames []string
+		for _, c := range subcommands {
+			subcommandNames = append(subcommandNames, c.Use)
+		}
+
+		assert.Contains(t, subcommandNames, "aws")
+		assert.Contains(t, subcommandNames, "gcp")
+		assert.Contains(t, subcommandNames, "azure")
+		assert.Contains(t, subcommandNames, "version")
+	})
+}


### PR DESCRIPTION
Fixes #20582

## Changes
- Add `--logformat` and `--loglevel` flags for configurable logging
- Add `version` subcommand for version information
- Show help when run without subcommand
- Add unit tests for new functionality