### PR TITLE
fix: project edit to not persist globalProjects-inherited spec

### DIFF
--- a/server/project/project.go
+++ b/server/project/project.go
@@ -372,7 +372,20 @@ func (s *Server) Update(ctx context.Context, q *project.ProjectUpdateRequest) (*
 	// then sent it back via Update, which persists inherited/global entries into the AppProject CR.
 	// Since global merge is append-based, that results in duplicates on every subsequent edit.
 	// Strip inherited entries here to make the API safe for all clients.
-	globalProjects := argo.GetGlobalProjects(q.Project, listersv1alpha1.NewAppProjectLister(s.projInformer.GetIndexer()), s.settingsMgr)
+	//
+	// Clients may legitimately omit metadata.namespace and/or metadata.labels in the update payload.
+	// GetGlobalProjects matches via labels and looks up the global project in proj.Namespace, so we
+	// fall back to the server's namespace and to the stored project's labels before computing matches.
+	projLister := listersv1alpha1.NewAppProjectLister(s.projInformer.GetIndexer())
+	if q.Project.Namespace == "" {
+		q.Project.Namespace = s.ns
+	}
+	if q.Project.Labels == nil {
+		if existing, err := projLister.AppProjects(s.ns).Get(q.Project.Name); err == nil && existing != nil {
+			q.Project.Labels = existing.Labels
+		}
+	}
+	globalProjects := argo.GetGlobalProjects(q.Project, projLister, s.settingsMgr)
 	argo.StripInheritedGlobalProjectSpec(q.Project, globalProjects)
 
 	err := validateProject(q.Project)

--- a/server/project/project.go
+++ b/server/project/project.go
@@ -366,6 +366,15 @@ func (s *Server) Update(ctx context.Context, q *project.ProjectUpdateRequest) (*
 	}
 	q.Project.NormalizePolicies()
 	q.Project.NormalizeJWTTokens()
+
+	// NOTE: `/projects/:name/detailed` returns a virtual project (global project specs appended).
+	// Some clients (notably the UI) historically used that virtual project as the edit source and
+	// then sent it back via Update, which persists inherited/global entries into the AppProject CR.
+	// Since global merge is append-based, that results in duplicates on every subsequent edit.
+	// Strip inherited entries here to make the API safe for all clients.
+	globalProjects := argo.GetGlobalProjects(q.Project, listersv1alpha1.NewAppProjectLister(s.projInformer.GetIndexer()), s.settingsMgr)
+	argo.StripInheritedGlobalProjectSpec(q.Project, globalProjects)
+
 	err := validateProject(q.Project)
 	if err != nil {
 		return nil, err

--- a/server/project/project_test.go
+++ b/server/project/project_test.go
@@ -953,3 +953,118 @@ func TestListEvents(t *testing.T) {
 		assert.Equal(t, codes.PermissionDenied, statusErr.Code())
 	})
 }
+
+// TestUpdateStripsInheritedGlobalProjectSpec verifies that Server.Update does not persist
+// spec entries inherited from a globalProject back into the AppProject CR. This is the core
+// scenario that motivated the fix: clients (notably the UI) historically PUT the virtual
+// project (which has globalProject specs appended) and we must defensively strip inherited
+// entries server-side to avoid duplication on every subsequent edit.
+func TestUpdateStripsInheritedGlobalProjectSpec(t *testing.T) {
+	const ns = testNamespace
+
+	kubeclientset := fake.NewClientset(
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns,
+				Name:      "argocd-cm",
+				Labels:    map[string]string{"app.kubernetes.io/part-of": "argocd"},
+			},
+			Data: map[string]string{
+				"globalProjects": `
+- projectName: global-project
+  labelSelector:
+    matchLabels:
+      inherits-global: "true"
+`,
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "argocd-secret", Namespace: ns},
+			Data: map[string][]byte{
+				"admin.password":   []byte("test"),
+				"server.secretkey": []byte("test"),
+			},
+		},
+	)
+	settingsMgr := settings.NewSettingsManager(t.Context(), kubeclientset, ns)
+	enforcer := newEnforcer(kubeclientset)
+	enforcer.SetDefaultRole("role:admin")
+	_ = enforcer.SetBuiltinPolicy(assets.BuiltinPolicyCSV)
+
+	globalProj := &v1alpha1.AppProject{
+		ObjectMeta: metav1.ObjectMeta{Name: "global-project", Namespace: ns},
+		Spec: v1alpha1.AppProjectSpec{
+			SourceRepos: []string{"https://global.example.com/repo.git"},
+			Destinations: []v1alpha1.ApplicationDestination{
+				{Server: "*", Namespace: "global-ns"},
+			},
+			ClusterResourceBlacklist: []v1alpha1.ClusterResourceRestrictionItem{
+				{Group: "*", Kind: "Volume"},
+			},
+			NamespaceResourceBlacklist: []metav1.GroupKind{
+				{Group: "", Kind: "LimitRange"},
+			},
+		},
+	}
+	storedProj := &v1alpha1.AppProject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-project",
+			Namespace: ns,
+			Labels:    map[string]string{"inherits-global": "true"},
+		},
+		Spec: v1alpha1.AppProjectSpec{
+			SourceRepos:  []string{"https://local.example.com/repo.git"},
+			Destinations: []v1alpha1.ApplicationDestination{{Server: "*", Namespace: "local-ns"}},
+		},
+	}
+
+	appsClientset := apps.NewSimpleClientset(globalProj, storedProj)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	factory := informer.NewSharedInformerFactoryWithOptions(appsClientset, 0, informer.WithNamespace(""))
+	projInformer := factory.Argoproj().V1alpha1().AppProjects().Informer()
+	go projInformer.Run(ctx.Done())
+	if !k8scache.WaitForCacheSync(ctx.Done(), projInformer.HasSynced) {
+		t.Fatal("Timed out waiting for caches to sync")
+	}
+
+	argoDB := db.NewDB(ns, settingsMgr, kubeclientset)
+	projectServer := NewServer(ns, kubeclientset, appsClientset, enforcer, sync.NewKeyLock(), nil, nil, projInformer, settingsMgr, argoDB, testEnableEventList)
+
+	// Simulate what clients (UI) historically did: PUT the *virtual* project (with global entries appended),
+	// possibly multiple times resulting in duplicates.
+	virtualProj := storedProj.DeepCopy()
+	virtualProj.Spec.SourceRepos = append(virtualProj.Spec.SourceRepos,
+		"https://global.example.com/repo.git", "https://global.example.com/repo.git")
+	virtualProj.Spec.Destinations = append(virtualProj.Spec.Destinations,
+		v1alpha1.ApplicationDestination{Server: "*", Namespace: "global-ns"},
+		v1alpha1.ApplicationDestination{Server: "*", Namespace: "global-ns"},
+	)
+	virtualProj.Spec.ClusterResourceBlacklist = append(virtualProj.Spec.ClusterResourceBlacklist,
+		v1alpha1.ClusterResourceRestrictionItem{Group: "*", Kind: "Volume"},
+	)
+	virtualProj.Spec.NamespaceResourceBlacklist = append(virtualProj.Spec.NamespaceResourceBlacklist,
+		metav1.GroupKind{Group: "", Kind: "LimitRange"},
+	)
+
+	updated, err := projectServer.Update(t.Context(), &project.ProjectUpdateRequest{Project: virtualProj})
+	require.NoError(t, err)
+
+	// Inherited entries must be stripped; only locally-owned entries remain.
+	assert.Equal(t, []string{"https://local.example.com/repo.git"}, updated.Spec.SourceRepos)
+	assert.Equal(t,
+		[]v1alpha1.ApplicationDestination{{Server: "*", Namespace: "local-ns"}},
+		updated.Spec.Destinations,
+	)
+	assert.Empty(t, updated.Spec.ClusterResourceBlacklist)
+	assert.Empty(t, updated.Spec.NamespaceResourceBlacklist)
+
+	// Persisted CR matches what Update returned.
+	persisted, err := appsClientset.ArgoprojV1alpha1().AppProjects(ns).Get(t.Context(), "test-project", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"https://local.example.com/repo.git"}, persisted.Spec.SourceRepos)
+	assert.Equal(t,
+		[]v1alpha1.ApplicationDestination{{Server: "*", Namespace: "local-ns"}},
+		persisted.Spec.Destinations,
+	)
+}

--- a/ui/src/app/settings/components/project-details/project-details.tsx
+++ b/ui/src/app/settings/components/project-details/project-details.tsx
@@ -192,8 +192,14 @@ function stripInheritedGlobalSpec(virtualSpec: ProjectSpec, globalProjects: Proj
             (virtualSpec.namespaceResourceWhitelist || []).filter(i => !inheritedNamespaceWhitelist.has(groupKindKey(i))),
             groupKindKey
         ),
-        sourceRepos: uniqueByKey((virtualSpec.sourceRepos || []).filter(r => !inheritedSourceRepos.has(r || '')), r => r || ''),
-        destinations: uniqueByKey((virtualSpec.destinations || []).filter(d => !inheritedDestinations.has(destKey(d))), destKey)
+        sourceRepos: uniqueByKey(
+            (virtualSpec.sourceRepos || []).filter(r => !inheritedSourceRepos.has(r || '')),
+            r => r || ''
+        ),
+        destinations: uniqueByKey(
+            (virtualSpec.destinations || []).filter(d => !inheritedDestinations.has(destKey(d))),
+            destKey
+        )
     };
 }
 

--- a/ui/src/app/settings/components/project-details/project-details.tsx
+++ b/ui/src/app/settings/components/project-details/project-details.tsx
@@ -193,8 +193,14 @@ function stripInheritedGlobalSpec(virtualSpec: ProjectSpec, globalProjects: Proj
             (virtualSpec.namespaceResourceWhitelist || []).filter(i => !inheritedNamespaceWhitelist.has(groupKindKey(i))),
             groupKindKey
         ),
-        sourceRepos: uniqueByKey((virtualSpec.sourceRepos || []).filter(r => !inheritedSourceRepos.has(r || '')), r => r || ''),
-        destinations: uniqueByKey((virtualSpec.destinations || []).filter(d => !inheritedDestinations.has(destKey(d))), destKey)
+        sourceRepos: uniqueByKey(
+            (virtualSpec.sourceRepos || []).filter(r => !inheritedSourceRepos.has(r || '')),
+            r => r || ''
+        ),
+        destinations: uniqueByKey(
+            (virtualSpec.destinations || []).filter(d => !inheritedDestinations.has(destKey(d))),
+            destKey
+        )
     };
 }
 

--- a/ui/src/app/settings/components/project-details/project-details.tsx
+++ b/ui/src/app/settings/components/project-details/project-details.tsx
@@ -163,9 +163,7 @@ function stripInheritedGlobalSpec(virtualSpec: ProjectSpec, globalProjects: Proj
     // can lose inherited destinations that use cluster-name (empty `server`) or that differ only by `name`.
     // Build the inherited destination key set directly from the global projects using the same identity
     // (server+name+namespace) used for filtering below.
-    const inheritedDestinations = new Set(
-        (globalProjects || []).flatMap(gp => (gp.spec?.destinations || []).map(destKey))
-    );
+    const inheritedDestinations = new Set((globalProjects || []).flatMap(gp => (gp.spec?.destinations || []).map(destKey)));
 
     const uniqueByKey = <T,>(items: T[], keyFn: (t: T) => string): T[] => {
         const seen = new Set<string>();

--- a/ui/src/app/settings/components/project-details/project-details.tsx
+++ b/ui/src/app/settings/components/project-details/project-details.tsx
@@ -159,7 +159,13 @@ function stripInheritedGlobalSpec(virtualSpec: ProjectSpec, globalProjects: Proj
     const inheritedNamespaceBlacklist = new Set((inherited.namespaceResourceBlacklist || []).map(groupKindKey));
     const inheritedNamespaceWhitelist = new Set((inherited.namespaceResourceWhitelist || []).map(groupKindKey));
     const inheritedSourceRepos = new Set((inherited.sourceRepos || []).map(r => r || ''));
-    const inheritedDestinations = new Set((inherited.destinations || []).map(destKey));
+    // NOTE: `reduceGlobal` dedupes destinations by `server+namespace` and drops the `name` field, so it
+    // can lose inherited destinations that use cluster-name (empty `server`) or that differ only by `name`.
+    // Build the inherited destination key set directly from the global projects using the same identity
+    // (server+name+namespace) used for filtering below.
+    const inheritedDestinations = new Set(
+        (globalProjects || []).flatMap(gp => (gp.spec?.destinations || []).map(destKey))
+    );
 
     const uniqueByKey = <T,>(items: T[], keyFn: (t: T) => string): T[] => {
         const seen = new Set<string>();

--- a/ui/src/app/settings/components/project-details/project-details.tsx
+++ b/ui/src/app/settings/components/project-details/project-details.tsx
@@ -143,6 +143,61 @@ function reduceGlobal(projs: Project[]): ProjectSpec & {count: number} {
     );
 }
 
+function stripInheritedGlobalSpec(virtualSpec: ProjectSpec, globalProjects: Project[] | undefined): ProjectSpec {
+    if (!globalProjects || globalProjects.length === 0) {
+        return virtualSpec;
+    }
+
+    const inherited = reduceGlobal(globalProjects);
+
+    const clusterResKey = (i: ClusterResourceRestrictionItem) => `${i.group || ''}::${i.kind || ''}::${i.name || ''}`;
+    const groupKindKey = (i: GroupKind) => `${i.group || ''}::${i.kind || ''}`;
+    const destKey = (d: any) => `${d.server || ''}::${d.name || ''}::${d.namespace || ''}`;
+
+    const inheritedClusterBlacklist = new Set((inherited.clusterResourceBlacklist || []).map(clusterResKey));
+    const inheritedClusterWhitelist = new Set((inherited.clusterResourceWhitelist || []).map(clusterResKey));
+    const inheritedNamespaceBlacklist = new Set((inherited.namespaceResourceBlacklist || []).map(groupKindKey));
+    const inheritedNamespaceWhitelist = new Set((inherited.namespaceResourceWhitelist || []).map(groupKindKey));
+    const inheritedSourceRepos = new Set((inherited.sourceRepos || []).map(r => r || ''));
+    const inheritedDestinations = new Set((inherited.destinations || []).map(destKey));
+
+    const uniqueByKey = <T,>(items: T[], keyFn: (t: T) => string): T[] => {
+        const seen = new Set<string>();
+        const res: T[] = [];
+        for (const item of items || []) {
+            const k = keyFn(item);
+            if (seen.has(k)) {
+                continue;
+            }
+            seen.add(k);
+            res.push(item);
+        }
+        return res;
+    };
+
+    return {
+        ...virtualSpec,
+        clusterResourceBlacklist: uniqueByKey(
+            (virtualSpec.clusterResourceBlacklist || []).filter(i => !inheritedClusterBlacklist.has(clusterResKey(i))),
+            clusterResKey
+        ),
+        clusterResourceWhitelist: uniqueByKey(
+            (virtualSpec.clusterResourceWhitelist || []).filter(i => !inheritedClusterWhitelist.has(clusterResKey(i))),
+            clusterResKey
+        ),
+        namespaceResourceBlacklist: uniqueByKey(
+            (virtualSpec.namespaceResourceBlacklist || []).filter(i => !inheritedNamespaceBlacklist.has(groupKindKey(i))),
+            groupKindKey
+        ),
+        namespaceResourceWhitelist: uniqueByKey(
+            (virtualSpec.namespaceResourceWhitelist || []).filter(i => !inheritedNamespaceWhitelist.has(groupKindKey(i))),
+            groupKindKey
+        ),
+        sourceRepos: uniqueByKey((virtualSpec.sourceRepos || []).filter(r => !inheritedSourceRepos.has(r || '')), r => r || ''),
+        destinations: uniqueByKey((virtualSpec.destinations || []).filter(d => !inheritedDestinations.has(destKey(d))), destKey)
+    };
+}
+
 export const ProjectDetails: React.FC<RouteComponentProps<{name: string}> & {objectListKind?: string}> = props => {
     const [token, setToken] = React.useState('');
     const projectRoleFormApi = React.useRef<FormApi>(null);
@@ -308,11 +363,14 @@ export const ProjectDetails: React.FC<RouteComponentProps<{name: string}> & {obj
         );
     };
 
-    const saveProject = async (updatedProj: Project) => {
+    const saveProject = async (updatedProj: Project, globalProjects?: Project[]) => {
         try {
             const proj = await services.projects.get(updatedProj.metadata.name);
             proj.metadata.labels = updatedProj.metadata.labels;
-            proj.spec = updatedProj.spec;
+            // NOTE: `/projects/:name/detailed` returns a *virtual* project (globalProjects are appended).
+            // We must never persist inherited/global spec entries back into the real AppProject CR,
+            // otherwise each subsequent edit will append the inherited entries again and create duplicates.
+            proj.spec = stripInheritedGlobalSpec(updatedProj.spec, globalProjects);
 
             await services.projects.update(proj);
             const scopedProj = await services.projects.getDetailed(props.match.params.name);
@@ -329,7 +387,7 @@ export const ProjectDetails: React.FC<RouteComponentProps<{name: string}> & {obj
         return (
             <div className='argo-container'>
                 <EditablePanel
-                    save={item => saveProject(item)}
+                    save={item => saveProject(item, scopedProj.globalProjects)}
                     validate={input => ({
                         'metadata.name': !input.metadata.name && 'Project name is required'
                     })}
@@ -375,7 +433,7 @@ export const ProjectDetails: React.FC<RouteComponentProps<{name: string}> & {obj
                 />
 
                 <EditablePanel
-                    save={item => saveProject(item)}
+                    save={item => saveProject(item, scopedProj.globalProjects)}
                     values={proj}
                     title={<React.Fragment>SOURCE REPOSITORIES {helpTip('Git repositories where application manifests are permitted to be retrieved from')}</React.Fragment>}
                     view={
@@ -438,7 +496,7 @@ export const ProjectDetails: React.FC<RouteComponentProps<{name: string}> & {obj
                     {authCtx =>
                         authCtx?.appsInAnyNamespaceEnabled && (
                             <EditablePanel
-                                save={item => saveProject(item)}
+                                save={item => saveProject(item, scopedProj.globalProjects)}
                                 values={proj}
                                 title={
                                     <React.Fragment>SOURCE NAMESPACES {helpTip('Kubernetes namespaces where application resources are allowed to be created in')}</React.Fragment>
@@ -480,7 +538,7 @@ export const ProjectDetails: React.FC<RouteComponentProps<{name: string}> & {obj
                     }
                 </AuthSettingsCtx.Consumer>
                 <EditablePanel
-                    save={item => saveProject(item)}
+                    save={item => saveProject(item, scopedProj.globalProjects)}
                     values={proj}
                     title={<React.Fragment>DESTINATIONS {helpTip('Cluster and namespaces where applications are permitted to be deployed to')}</React.Fragment>}
                     view={
@@ -577,7 +635,7 @@ export const ProjectDetails: React.FC<RouteComponentProps<{name: string}> & {obj
                 />
 
                 <EditablePanel
-                    save={item => saveProject(item)}
+                    save={item => saveProject(item, scopedProj.globalProjects)}
                     values={proj}
                     title={
                         <React.Fragment>
@@ -667,7 +725,7 @@ export const ProjectDetails: React.FC<RouteComponentProps<{name: string}> & {obj
                     items={[]}
                 />
 
-                <ResourceListsPanel proj={proj} saveProject={item => saveProject(item)} />
+                <ResourceListsPanel proj={proj} saveProject={item => saveProject(item, scopedProj.globalProjects)} />
                 {globalProj.count > 0 && (
                     <ResourceListsPanel
                         title={<p>INHERITED FROM GLOBAL PROJECTS {helpTip('Global projects provide configurations that other projects can inherit from.')}</p>}
@@ -676,7 +734,7 @@ export const ProjectDetails: React.FC<RouteComponentProps<{name: string}> & {obj
                 )}
 
                 <EditablePanel
-                    save={item => saveProject(item)}
+                    save={item => saveProject(item, scopedProj.globalProjects)}
                     values={proj}
                     title={<React.Fragment>GPG SIGNATURE KEYS {helpTip('IDs of GnuPG keys that commits must be signed with in order to be allowed to sync to')}</React.Fragment>}
                     view={
@@ -727,7 +785,7 @@ export const ProjectDetails: React.FC<RouteComponentProps<{name: string}> & {obj
                 />
 
                 <EditablePanel
-                    save={item => saveProject(item)}
+                    save={item => saveProject(item, scopedProj.globalProjects)}
                     values={proj}
                     title={<React.Fragment>RESOURCE MONITORING {helpTip('Enables monitoring of top level resources in the application target namespace')}</React.Fragment>}
                     view={

--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -21,6 +21,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -1103,19 +1104,9 @@ func GetGlobalProjects(proj *argoappv1.AppProject, projLister applicationsv1.App
 		if err != nil {
 			break
 		}
-		// Get projects which match the label selector, then see if proj is a match
-		projList, err := projLister.AppProjects(proj.Namespace).List(selector)
-		if err != nil {
-			break
-		}
-		var matchMe bool
-		for _, item := range projList {
-			if item.Name == proj.Name {
-				matchMe = true
-				break
-			}
-		}
-		if !matchMe {
+		// Use the project's labels directly (instead of listing projects) so callers can pass an
+		// updated project object and get correct matches even before informer cache updates.
+		if !selector.Matches(labels.Set(proj.Labels)) {
 			continue
 		}
 		// If proj is a match for this global project setting, then it is its global project
@@ -1135,6 +1126,7 @@ func GetAppVirtualProject(proj *argoappv1.AppProject, projLister applicationsv1.
 	for _, gp := range globalProjects {
 		virtualProj = mergeVirtualProject(virtualProj, gp)
 	}
+	dedupVirtualProjectSpec(virtualProj)
 	return virtualProj, nil
 }
 
@@ -1155,6 +1147,255 @@ func mergeVirtualProject(proj *argoappv1.AppProject, globalProj *argoappv1.AppPr
 	proj.Spec.Destinations = append(proj.Spec.Destinations, globalProj.Spec.Destinations...)
 
 	return proj
+}
+
+// StripInheritedGlobalProjectSpec removes spec entries inherited from global projects from proj.Spec.
+// This prevents clients (e.g. UI) from persisting inherited/global settings back into the AppProject CR,
+// which would otherwise cause duplicated entries on subsequent edits because virtual project merge is append-based.
+func StripInheritedGlobalProjectSpec(proj *argoappv1.AppProject, globalProjects []*argoappv1.AppProject) {
+	if proj == nil || len(globalProjects) == 0 {
+		return
+	}
+
+	clusterResKey := func(i argoappv1.ClusterResourceRestrictionItem) string {
+		return i.Group + "||" + i.Kind + "||" + i.Name
+	}
+	groupKindKey := func(i metav1.GroupKind) string {
+		return i.Group + "||" + i.Kind
+	}
+	destKey := func(d argoappv1.ApplicationDestination) string {
+		return d.Server + "||" + d.Name + "||" + d.Namespace
+	}
+
+	inheritedClusterWhitelist := make(map[string]struct{})
+	inheritedClusterBlacklist := make(map[string]struct{})
+	inheritedNamespaceWhitelist := make(map[string]struct{})
+	inheritedNamespaceBlacklist := make(map[string]struct{})
+	inheritedSourceRepos := make(map[string]struct{})
+	inheritedDestinations := make(map[string]struct{})
+	inheritedSyncWindows := make(map[uint64]struct{})
+
+	for _, gp := range globalProjects {
+		if gp == nil {
+			continue
+		}
+		for _, i := range gp.Spec.ClusterResourceWhitelist {
+			inheritedClusterWhitelist[clusterResKey(i)] = struct{}{}
+		}
+		for _, i := range gp.Spec.ClusterResourceBlacklist {
+			inheritedClusterBlacklist[clusterResKey(i)] = struct{}{}
+		}
+		for _, i := range gp.Spec.NamespaceResourceWhitelist {
+			inheritedNamespaceWhitelist[groupKindKey(i)] = struct{}{}
+		}
+		for _, i := range gp.Spec.NamespaceResourceBlacklist {
+			inheritedNamespaceBlacklist[groupKindKey(i)] = struct{}{}
+		}
+		for _, r := range gp.Spec.SourceRepos {
+			inheritedSourceRepos[r] = struct{}{}
+		}
+		for _, d := range gp.Spec.Destinations {
+			inheritedDestinations[destKey(d)] = struct{}{}
+		}
+		for _, w := range gp.Spec.SyncWindows {
+			if w == nil {
+				continue
+			}
+			h, err := w.HashIdentity()
+			if err != nil {
+				continue
+			}
+			inheritedSyncWindows[h] = struct{}{}
+		}
+	}
+
+	filterCluster := func(items []argoappv1.ClusterResourceRestrictionItem, inherited map[string]struct{}) []argoappv1.ClusterResourceRestrictionItem {
+		seen := make(map[string]struct{})
+		var res []argoappv1.ClusterResourceRestrictionItem
+		for _, i := range items {
+			k := clusterResKey(i)
+			if _, ok := inherited[k]; ok {
+				continue
+			}
+			if _, ok := seen[k]; ok {
+				continue
+			}
+			seen[k] = struct{}{}
+			res = append(res, i)
+		}
+		return res
+	}
+	filterGroupKind := func(items []metav1.GroupKind, inherited map[string]struct{}) []metav1.GroupKind {
+		seen := make(map[string]struct{})
+		var res []metav1.GroupKind
+		for _, i := range items {
+			k := groupKindKey(i)
+			if _, ok := inherited[k]; ok {
+				continue
+			}
+			if _, ok := seen[k]; ok {
+				continue
+			}
+			seen[k] = struct{}{}
+			res = append(res, i)
+		}
+		return res
+	}
+	filterString := func(items []string, inherited map[string]struct{}) []string {
+		seen := make(map[string]struct{})
+		var res []string
+		for _, s := range items {
+			if _, ok := inherited[s]; ok {
+				continue
+			}
+			if _, ok := seen[s]; ok {
+				continue
+			}
+			seen[s] = struct{}{}
+			res = append(res, s)
+		}
+		return res
+	}
+	filterDest := func(items []argoappv1.ApplicationDestination, inherited map[string]struct{}) []argoappv1.ApplicationDestination {
+		seen := make(map[string]struct{})
+		var res []argoappv1.ApplicationDestination
+		for _, d := range items {
+			k := destKey(d)
+			if _, ok := inherited[k]; ok {
+				continue
+			}
+			if _, ok := seen[k]; ok {
+				continue
+			}
+			seen[k] = struct{}{}
+			res = append(res, d)
+		}
+		return res
+	}
+	filterWindows := func(items argoappv1.SyncWindows, inherited map[uint64]struct{}) argoappv1.SyncWindows {
+		seen := make(map[uint64]struct{})
+		var res argoappv1.SyncWindows
+		for _, w := range items {
+			if w == nil {
+				continue
+			}
+			h, err := w.HashIdentity()
+			if err != nil {
+				// If we can't hash identity, keep it (validation will handle bad windows elsewhere).
+				res = append(res, w)
+				continue
+			}
+			if _, ok := inherited[h]; ok {
+				continue
+			}
+			if _, ok := seen[h]; ok {
+				continue
+			}
+			seen[h] = struct{}{}
+			res = append(res, w)
+		}
+		return res
+	}
+
+	proj.Spec.ClusterResourceWhitelist = filterCluster(proj.Spec.ClusterResourceWhitelist, inheritedClusterWhitelist)
+	proj.Spec.ClusterResourceBlacklist = filterCluster(proj.Spec.ClusterResourceBlacklist, inheritedClusterBlacklist)
+	proj.Spec.NamespaceResourceWhitelist = filterGroupKind(proj.Spec.NamespaceResourceWhitelist, inheritedNamespaceWhitelist)
+	proj.Spec.NamespaceResourceBlacklist = filterGroupKind(proj.Spec.NamespaceResourceBlacklist, inheritedNamespaceBlacklist)
+	proj.Spec.SourceRepos = filterString(proj.Spec.SourceRepos, inheritedSourceRepos)
+	proj.Spec.Destinations = filterDest(proj.Spec.Destinations, inheritedDestinations)
+	proj.Spec.SyncWindows = filterWindows(proj.Spec.SyncWindows, inheritedSyncWindows)
+}
+
+func dedupVirtualProjectSpec(proj *argoappv1.AppProject) {
+	if proj == nil {
+		return
+	}
+
+	clusterResKey := func(i argoappv1.ClusterResourceRestrictionItem) string {
+		return i.Group + "||" + i.Kind + "||" + i.Name
+	}
+	groupKindKey := func(i metav1.GroupKind) string { return i.Group + "||" + i.Kind }
+	destKey := func(d argoappv1.ApplicationDestination) string { return d.Server + "||" + d.Name + "||" + d.Namespace }
+
+	dedupCluster := func(items []argoappv1.ClusterResourceRestrictionItem) []argoappv1.ClusterResourceRestrictionItem {
+		seen := make(map[string]struct{})
+		var res []argoappv1.ClusterResourceRestrictionItem
+		for _, i := range items {
+			k := clusterResKey(i)
+			if _, ok := seen[k]; ok {
+				continue
+			}
+			seen[k] = struct{}{}
+			res = append(res, i)
+		}
+		return res
+	}
+	dedupGroupKind := func(items []metav1.GroupKind) []metav1.GroupKind {
+		seen := make(map[string]struct{})
+		var res []metav1.GroupKind
+		for _, i := range items {
+			k := groupKindKey(i)
+			if _, ok := seen[k]; ok {
+				continue
+			}
+			seen[k] = struct{}{}
+			res = append(res, i)
+		}
+		return res
+	}
+	dedupString := func(items []string) []string {
+		seen := make(map[string]struct{})
+		var res []string
+		for _, s := range items {
+			if _, ok := seen[s]; ok {
+				continue
+			}
+			seen[s] = struct{}{}
+			res = append(res, s)
+		}
+		return res
+	}
+	dedupDest := func(items []argoappv1.ApplicationDestination) []argoappv1.ApplicationDestination {
+		seen := make(map[string]struct{})
+		var res []argoappv1.ApplicationDestination
+		for _, d := range items {
+			k := destKey(d)
+			if _, ok := seen[k]; ok {
+				continue
+			}
+			seen[k] = struct{}{}
+			res = append(res, d)
+		}
+		return res
+	}
+	dedupWindows := func(items argoappv1.SyncWindows) argoappv1.SyncWindows {
+		seen := make(map[uint64]struct{})
+		var res argoappv1.SyncWindows
+		for _, w := range items {
+			if w == nil {
+				continue
+			}
+			h, err := w.HashIdentity()
+			if err != nil {
+				res = append(res, w)
+				continue
+			}
+			if _, ok := seen[h]; ok {
+				continue
+			}
+			seen[h] = struct{}{}
+			res = append(res, w)
+		}
+		return res
+	}
+
+	proj.Spec.ClusterResourceWhitelist = dedupCluster(proj.Spec.ClusterResourceWhitelist)
+	proj.Spec.ClusterResourceBlacklist = dedupCluster(proj.Spec.ClusterResourceBlacklist)
+	proj.Spec.NamespaceResourceWhitelist = dedupGroupKind(proj.Spec.NamespaceResourceWhitelist)
+	proj.Spec.NamespaceResourceBlacklist = dedupGroupKind(proj.Spec.NamespaceResourceBlacklist)
+	proj.Spec.SourceRepos = dedupString(proj.Spec.SourceRepos)
+	proj.Spec.Destinations = dedupDest(proj.Spec.Destinations)
+	proj.Spec.SyncWindows = dedupWindows(proj.Spec.SyncWindows)
 }
 
 func GenerateSpecIsDifferentErrorMessage(entity string, a, b any) string {

--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -1292,7 +1292,10 @@ func filterSyncWindows(items argoappv1.SyncWindows, inherited map[uint64]struct{
 	for _, w := range items {
 		h, ok := syncWindowIdentityHash(w)
 		if !ok {
-			// If we can't hash identity, keep it (validation will handle bad windows elsewhere).
+			// HashIdentity only fails on a gob.Encode error, which is not expected for valid SyncWindows
+			// in practice. Keep the item rather than dropping it: validation elsewhere will catch
+			// genuinely malformed windows. The trade-off is that a theoretically un-hashable window will
+			// not participate in dedupe; this is preferable to silently dropping user data.
 			res = append(res, w)
 			continue
 		}

--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -20,6 +20,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -1148,19 +1149,9 @@ func GetGlobalProjects(proj *argoappv1.AppProject, projLister applicationsv1.App
 		if err != nil {
 			break
 		}
-		// Get projects which match the label selector, then see if proj is a match
-		projList, err := projLister.AppProjects(proj.Namespace).List(selector)
-		if err != nil {
-			break
-		}
-		var matchMe bool
-		for _, item := range projList {
-			if item.Name == proj.Name {
-				matchMe = true
-				break
-			}
-		}
-		if !matchMe {
+		// Use the project's labels directly (instead of listing projects) so callers can pass an
+		// updated project object and get correct matches even before informer cache updates.
+		if !selector.Matches(labels.Set(proj.Labels)) {
 			continue
 		}
 		// If proj is a match for this global project setting, then it is its global project
@@ -1180,6 +1171,7 @@ func GetAppVirtualProject(proj *argoappv1.AppProject, projLister applicationsv1.
 	for _, gp := range globalProjects {
 		virtualProj = mergeVirtualProject(virtualProj, gp)
 	}
+	dedupVirtualProjectSpec(virtualProj)
 	return virtualProj, nil
 }
 
@@ -1202,6 +1194,255 @@ func mergeVirtualProject(proj *argoappv1.AppProject, globalProj *argoappv1.AppPr
 	proj.Spec.DestinationServiceAccounts = append(proj.Spec.DestinationServiceAccounts, globalProj.Spec.DestinationServiceAccounts...)
 
 	return proj
+}
+
+// StripInheritedGlobalProjectSpec removes spec entries inherited from global projects from proj.Spec.
+// This prevents clients (e.g. UI) from persisting inherited/global settings back into the AppProject CR,
+// which would otherwise cause duplicated entries on subsequent edits because virtual project merge is append-based.
+func StripInheritedGlobalProjectSpec(proj *argoappv1.AppProject, globalProjects []*argoappv1.AppProject) {
+	if proj == nil || len(globalProjects) == 0 {
+		return
+	}
+
+	clusterResKey := func(i argoappv1.ClusterResourceRestrictionItem) string {
+		return i.Group + "||" + i.Kind + "||" + i.Name
+	}
+	groupKindKey := func(i metav1.GroupKind) string {
+		return i.Group + "||" + i.Kind
+	}
+	destKey := func(d argoappv1.ApplicationDestination) string {
+		return d.Server + "||" + d.Name + "||" + d.Namespace
+	}
+
+	inheritedClusterWhitelist := make(map[string]struct{})
+	inheritedClusterBlacklist := make(map[string]struct{})
+	inheritedNamespaceWhitelist := make(map[string]struct{})
+	inheritedNamespaceBlacklist := make(map[string]struct{})
+	inheritedSourceRepos := make(map[string]struct{})
+	inheritedDestinations := make(map[string]struct{})
+	inheritedSyncWindows := make(map[uint64]struct{})
+
+	for _, gp := range globalProjects {
+		if gp == nil {
+			continue
+		}
+		for _, i := range gp.Spec.ClusterResourceWhitelist {
+			inheritedClusterWhitelist[clusterResKey(i)] = struct{}{}
+		}
+		for _, i := range gp.Spec.ClusterResourceBlacklist {
+			inheritedClusterBlacklist[clusterResKey(i)] = struct{}{}
+		}
+		for _, i := range gp.Spec.NamespaceResourceWhitelist {
+			inheritedNamespaceWhitelist[groupKindKey(i)] = struct{}{}
+		}
+		for _, i := range gp.Spec.NamespaceResourceBlacklist {
+			inheritedNamespaceBlacklist[groupKindKey(i)] = struct{}{}
+		}
+		for _, r := range gp.Spec.SourceRepos {
+			inheritedSourceRepos[r] = struct{}{}
+		}
+		for _, d := range gp.Spec.Destinations {
+			inheritedDestinations[destKey(d)] = struct{}{}
+		}
+		for _, w := range gp.Spec.SyncWindows {
+			if w == nil {
+				continue
+			}
+			h, err := w.HashIdentity()
+			if err != nil {
+				continue
+			}
+			inheritedSyncWindows[h] = struct{}{}
+		}
+	}
+
+	filterCluster := func(items []argoappv1.ClusterResourceRestrictionItem, inherited map[string]struct{}) []argoappv1.ClusterResourceRestrictionItem {
+		seen := make(map[string]struct{})
+		var res []argoappv1.ClusterResourceRestrictionItem
+		for _, i := range items {
+			k := clusterResKey(i)
+			if _, ok := inherited[k]; ok {
+				continue
+			}
+			if _, ok := seen[k]; ok {
+				continue
+			}
+			seen[k] = struct{}{}
+			res = append(res, i)
+		}
+		return res
+	}
+	filterGroupKind := func(items []metav1.GroupKind, inherited map[string]struct{}) []metav1.GroupKind {
+		seen := make(map[string]struct{})
+		var res []metav1.GroupKind
+		for _, i := range items {
+			k := groupKindKey(i)
+			if _, ok := inherited[k]; ok {
+				continue
+			}
+			if _, ok := seen[k]; ok {
+				continue
+			}
+			seen[k] = struct{}{}
+			res = append(res, i)
+		}
+		return res
+	}
+	filterString := func(items []string, inherited map[string]struct{}) []string {
+		seen := make(map[string]struct{})
+		var res []string
+		for _, s := range items {
+			if _, ok := inherited[s]; ok {
+				continue
+			}
+			if _, ok := seen[s]; ok {
+				continue
+			}
+			seen[s] = struct{}{}
+			res = append(res, s)
+		}
+		return res
+	}
+	filterDest := func(items []argoappv1.ApplicationDestination, inherited map[string]struct{}) []argoappv1.ApplicationDestination {
+		seen := make(map[string]struct{})
+		var res []argoappv1.ApplicationDestination
+		for _, d := range items {
+			k := destKey(d)
+			if _, ok := inherited[k]; ok {
+				continue
+			}
+			if _, ok := seen[k]; ok {
+				continue
+			}
+			seen[k] = struct{}{}
+			res = append(res, d)
+		}
+		return res
+	}
+	filterWindows := func(items argoappv1.SyncWindows, inherited map[uint64]struct{}) argoappv1.SyncWindows {
+		seen := make(map[uint64]struct{})
+		var res argoappv1.SyncWindows
+		for _, w := range items {
+			if w == nil {
+				continue
+			}
+			h, err := w.HashIdentity()
+			if err != nil {
+				// If we can't hash identity, keep it (validation will handle bad windows elsewhere).
+				res = append(res, w)
+				continue
+			}
+			if _, ok := inherited[h]; ok {
+				continue
+			}
+			if _, ok := seen[h]; ok {
+				continue
+			}
+			seen[h] = struct{}{}
+			res = append(res, w)
+		}
+		return res
+	}
+
+	proj.Spec.ClusterResourceWhitelist = filterCluster(proj.Spec.ClusterResourceWhitelist, inheritedClusterWhitelist)
+	proj.Spec.ClusterResourceBlacklist = filterCluster(proj.Spec.ClusterResourceBlacklist, inheritedClusterBlacklist)
+	proj.Spec.NamespaceResourceWhitelist = filterGroupKind(proj.Spec.NamespaceResourceWhitelist, inheritedNamespaceWhitelist)
+	proj.Spec.NamespaceResourceBlacklist = filterGroupKind(proj.Spec.NamespaceResourceBlacklist, inheritedNamespaceBlacklist)
+	proj.Spec.SourceRepos = filterString(proj.Spec.SourceRepos, inheritedSourceRepos)
+	proj.Spec.Destinations = filterDest(proj.Spec.Destinations, inheritedDestinations)
+	proj.Spec.SyncWindows = filterWindows(proj.Spec.SyncWindows, inheritedSyncWindows)
+}
+
+func dedupVirtualProjectSpec(proj *argoappv1.AppProject) {
+	if proj == nil {
+		return
+	}
+
+	clusterResKey := func(i argoappv1.ClusterResourceRestrictionItem) string {
+		return i.Group + "||" + i.Kind + "||" + i.Name
+	}
+	groupKindKey := func(i metav1.GroupKind) string { return i.Group + "||" + i.Kind }
+	destKey := func(d argoappv1.ApplicationDestination) string { return d.Server + "||" + d.Name + "||" + d.Namespace }
+
+	dedupCluster := func(items []argoappv1.ClusterResourceRestrictionItem) []argoappv1.ClusterResourceRestrictionItem {
+		seen := make(map[string]struct{})
+		var res []argoappv1.ClusterResourceRestrictionItem
+		for _, i := range items {
+			k := clusterResKey(i)
+			if _, ok := seen[k]; ok {
+				continue
+			}
+			seen[k] = struct{}{}
+			res = append(res, i)
+		}
+		return res
+	}
+	dedupGroupKind := func(items []metav1.GroupKind) []metav1.GroupKind {
+		seen := make(map[string]struct{})
+		var res []metav1.GroupKind
+		for _, i := range items {
+			k := groupKindKey(i)
+			if _, ok := seen[k]; ok {
+				continue
+			}
+			seen[k] = struct{}{}
+			res = append(res, i)
+		}
+		return res
+	}
+	dedupString := func(items []string) []string {
+		seen := make(map[string]struct{})
+		var res []string
+		for _, s := range items {
+			if _, ok := seen[s]; ok {
+				continue
+			}
+			seen[s] = struct{}{}
+			res = append(res, s)
+		}
+		return res
+	}
+	dedupDest := func(items []argoappv1.ApplicationDestination) []argoappv1.ApplicationDestination {
+		seen := make(map[string]struct{})
+		var res []argoappv1.ApplicationDestination
+		for _, d := range items {
+			k := destKey(d)
+			if _, ok := seen[k]; ok {
+				continue
+			}
+			seen[k] = struct{}{}
+			res = append(res, d)
+		}
+		return res
+	}
+	dedupWindows := func(items argoappv1.SyncWindows) argoappv1.SyncWindows {
+		seen := make(map[uint64]struct{})
+		var res argoappv1.SyncWindows
+		for _, w := range items {
+			if w == nil {
+				continue
+			}
+			h, err := w.HashIdentity()
+			if err != nil {
+				res = append(res, w)
+				continue
+			}
+			if _, ok := seen[h]; ok {
+				continue
+			}
+			seen[h] = struct{}{}
+			res = append(res, w)
+		}
+		return res
+	}
+
+	proj.Spec.ClusterResourceWhitelist = dedupCluster(proj.Spec.ClusterResourceWhitelist)
+	proj.Spec.ClusterResourceBlacklist = dedupCluster(proj.Spec.ClusterResourceBlacklist)
+	proj.Spec.NamespaceResourceWhitelist = dedupGroupKind(proj.Spec.NamespaceResourceWhitelist)
+	proj.Spec.NamespaceResourceBlacklist = dedupGroupKind(proj.Spec.NamespaceResourceBlacklist)
+	proj.Spec.SourceRepos = dedupString(proj.Spec.SourceRepos)
+	proj.Spec.Destinations = dedupDest(proj.Spec.Destinations)
+	proj.Spec.SyncWindows = dedupWindows(proj.Spec.SyncWindows)
 }
 
 func GenerateSpecIsDifferentErrorMessage(entity string, a, b any) string {

--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -1196,22 +1196,124 @@ func mergeVirtualProject(proj *argoappv1.AppProject, globalProj *argoappv1.AppPr
 	return proj
 }
 
+func clusterResourceRestrictionItemKey(i argoappv1.ClusterResourceRestrictionItem) string {
+	return i.Group + "||" + i.Kind + "||" + i.Name
+}
+
+func groupKindKey(i metav1.GroupKind) string {
+	return i.Group + "||" + i.Kind
+}
+
+func applicationDestinationKey(d argoappv1.ApplicationDestination) string {
+	return d.Server + "||" + d.Name + "||" + d.Namespace
+}
+
+func syncWindowIdentityHash(w *argoappv1.SyncWindow) (uint64, bool) {
+	if w == nil {
+		return 0, false
+	}
+	h, err := w.HashIdentity()
+	if err != nil {
+		return 0, false
+	}
+	return h, true
+}
+
+func filterClusterResourceRestrictionItems(items []argoappv1.ClusterResourceRestrictionItem, inherited map[string]struct{}) []argoappv1.ClusterResourceRestrictionItem {
+	seen := make(map[string]struct{})
+	var res []argoappv1.ClusterResourceRestrictionItem
+	for _, i := range items {
+		k := clusterResourceRestrictionItemKey(i)
+		if _, ok := inherited[k]; ok {
+			continue
+		}
+		if _, ok := seen[k]; ok {
+			continue
+		}
+		seen[k] = struct{}{}
+		res = append(res, i)
+	}
+	return res
+}
+
+func filterGroupKinds(items []metav1.GroupKind, inherited map[string]struct{}) []metav1.GroupKind {
+	seen := make(map[string]struct{})
+	var res []metav1.GroupKind
+	for _, i := range items {
+		k := groupKindKey(i)
+		if _, ok := inherited[k]; ok {
+			continue
+		}
+		if _, ok := seen[k]; ok {
+			continue
+		}
+		seen[k] = struct{}{}
+		res = append(res, i)
+	}
+	return res
+}
+
+func filterStrings(items []string, inherited map[string]struct{}) []string {
+	seen := make(map[string]struct{})
+	var res []string
+	for _, s := range items {
+		if _, ok := inherited[s]; ok {
+			continue
+		}
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		res = append(res, s)
+	}
+	return res
+}
+
+func filterDestinations(items []argoappv1.ApplicationDestination, inherited map[string]struct{}) []argoappv1.ApplicationDestination {
+	seen := make(map[string]struct{})
+	var res []argoappv1.ApplicationDestination
+	for _, d := range items {
+		k := applicationDestinationKey(d)
+		if _, ok := inherited[k]; ok {
+			continue
+		}
+		if _, ok := seen[k]; ok {
+			continue
+		}
+		seen[k] = struct{}{}
+		res = append(res, d)
+	}
+	return res
+}
+
+func filterSyncWindows(items argoappv1.SyncWindows, inherited map[uint64]struct{}) argoappv1.SyncWindows {
+	seen := make(map[uint64]struct{})
+	var res argoappv1.SyncWindows
+	for _, w := range items {
+		h, ok := syncWindowIdentityHash(w)
+		if !ok {
+			// If we can't hash identity, keep it (validation will handle bad windows elsewhere).
+			res = append(res, w)
+			continue
+		}
+		if _, ok := inherited[h]; ok {
+			continue
+		}
+		if _, ok := seen[h]; ok {
+			continue
+		}
+		seen[h] = struct{}{}
+		res = append(res, w)
+	}
+	return res
+}
+
 // StripInheritedGlobalProjectSpec removes spec entries inherited from global projects from proj.Spec.
 // This prevents clients (e.g. UI) from persisting inherited/global settings back into the AppProject CR,
 // which would otherwise cause duplicated entries on subsequent edits because virtual project merge is append-based.
 func StripInheritedGlobalProjectSpec(proj *argoappv1.AppProject, globalProjects []*argoappv1.AppProject) {
 	if proj == nil || len(globalProjects) == 0 {
 		return
-	}
-
-	clusterResKey := func(i argoappv1.ClusterResourceRestrictionItem) string {
-		return i.Group + "||" + i.Kind + "||" + i.Name
-	}
-	groupKindKey := func(i metav1.GroupKind) string {
-		return i.Group + "||" + i.Kind
-	}
-	destKey := func(d argoappv1.ApplicationDestination) string {
-		return d.Server + "||" + d.Name + "||" + d.Namespace
 	}
 
 	inheritedClusterWhitelist := make(map[string]struct{})
@@ -1227,10 +1329,10 @@ func StripInheritedGlobalProjectSpec(proj *argoappv1.AppProject, globalProjects 
 			continue
 		}
 		for _, i := range gp.Spec.ClusterResourceWhitelist {
-			inheritedClusterWhitelist[clusterResKey(i)] = struct{}{}
+			inheritedClusterWhitelist[clusterResourceRestrictionItemKey(i)] = struct{}{}
 		}
 		for _, i := range gp.Spec.ClusterResourceBlacklist {
-			inheritedClusterBlacklist[clusterResKey(i)] = struct{}{}
+			inheritedClusterBlacklist[clusterResourceRestrictionItemKey(i)] = struct{}{}
 		}
 		for _, i := range gp.Spec.NamespaceResourceWhitelist {
 			inheritedNamespaceWhitelist[groupKindKey(i)] = struct{}{}
@@ -1242,115 +1344,22 @@ func StripInheritedGlobalProjectSpec(proj *argoappv1.AppProject, globalProjects 
 			inheritedSourceRepos[r] = struct{}{}
 		}
 		for _, d := range gp.Spec.Destinations {
-			inheritedDestinations[destKey(d)] = struct{}{}
+			inheritedDestinations[applicationDestinationKey(d)] = struct{}{}
 		}
 		for _, w := range gp.Spec.SyncWindows {
-			if w == nil {
-				continue
+			if h, ok := syncWindowIdentityHash(w); ok {
+				inheritedSyncWindows[h] = struct{}{}
 			}
-			h, err := w.HashIdentity()
-			if err != nil {
-				continue
-			}
-			inheritedSyncWindows[h] = struct{}{}
 		}
 	}
 
-	filterCluster := func(items []argoappv1.ClusterResourceRestrictionItem, inherited map[string]struct{}) []argoappv1.ClusterResourceRestrictionItem {
-		seen := make(map[string]struct{})
-		var res []argoappv1.ClusterResourceRestrictionItem
-		for _, i := range items {
-			k := clusterResKey(i)
-			if _, ok := inherited[k]; ok {
-				continue
-			}
-			if _, ok := seen[k]; ok {
-				continue
-			}
-			seen[k] = struct{}{}
-			res = append(res, i)
-		}
-		return res
-	}
-	filterGroupKind := func(items []metav1.GroupKind, inherited map[string]struct{}) []metav1.GroupKind {
-		seen := make(map[string]struct{})
-		var res []metav1.GroupKind
-		for _, i := range items {
-			k := groupKindKey(i)
-			if _, ok := inherited[k]; ok {
-				continue
-			}
-			if _, ok := seen[k]; ok {
-				continue
-			}
-			seen[k] = struct{}{}
-			res = append(res, i)
-		}
-		return res
-	}
-	filterString := func(items []string, inherited map[string]struct{}) []string {
-		seen := make(map[string]struct{})
-		var res []string
-		for _, s := range items {
-			if _, ok := inherited[s]; ok {
-				continue
-			}
-			if _, ok := seen[s]; ok {
-				continue
-			}
-			seen[s] = struct{}{}
-			res = append(res, s)
-		}
-		return res
-	}
-	filterDest := func(items []argoappv1.ApplicationDestination, inherited map[string]struct{}) []argoappv1.ApplicationDestination {
-		seen := make(map[string]struct{})
-		var res []argoappv1.ApplicationDestination
-		for _, d := range items {
-			k := destKey(d)
-			if _, ok := inherited[k]; ok {
-				continue
-			}
-			if _, ok := seen[k]; ok {
-				continue
-			}
-			seen[k] = struct{}{}
-			res = append(res, d)
-		}
-		return res
-	}
-	filterWindows := func(items argoappv1.SyncWindows, inherited map[uint64]struct{}) argoappv1.SyncWindows {
-		seen := make(map[uint64]struct{})
-		var res argoappv1.SyncWindows
-		for _, w := range items {
-			if w == nil {
-				continue
-			}
-			h, err := w.HashIdentity()
-			if err != nil {
-				// If we can't hash identity, keep it (validation will handle bad windows elsewhere).
-				res = append(res, w)
-				continue
-			}
-			if _, ok := inherited[h]; ok {
-				continue
-			}
-			if _, ok := seen[h]; ok {
-				continue
-			}
-			seen[h] = struct{}{}
-			res = append(res, w)
-		}
-		return res
-	}
-
-	proj.Spec.ClusterResourceWhitelist = filterCluster(proj.Spec.ClusterResourceWhitelist, inheritedClusterWhitelist)
-	proj.Spec.ClusterResourceBlacklist = filterCluster(proj.Spec.ClusterResourceBlacklist, inheritedClusterBlacklist)
-	proj.Spec.NamespaceResourceWhitelist = filterGroupKind(proj.Spec.NamespaceResourceWhitelist, inheritedNamespaceWhitelist)
-	proj.Spec.NamespaceResourceBlacklist = filterGroupKind(proj.Spec.NamespaceResourceBlacklist, inheritedNamespaceBlacklist)
-	proj.Spec.SourceRepos = filterString(proj.Spec.SourceRepos, inheritedSourceRepos)
-	proj.Spec.Destinations = filterDest(proj.Spec.Destinations, inheritedDestinations)
-	proj.Spec.SyncWindows = filterWindows(proj.Spec.SyncWindows, inheritedSyncWindows)
+	proj.Spec.ClusterResourceWhitelist = filterClusterResourceRestrictionItems(proj.Spec.ClusterResourceWhitelist, inheritedClusterWhitelist)
+	proj.Spec.ClusterResourceBlacklist = filterClusterResourceRestrictionItems(proj.Spec.ClusterResourceBlacklist, inheritedClusterBlacklist)
+	proj.Spec.NamespaceResourceWhitelist = filterGroupKinds(proj.Spec.NamespaceResourceWhitelist, inheritedNamespaceWhitelist)
+	proj.Spec.NamespaceResourceBlacklist = filterGroupKinds(proj.Spec.NamespaceResourceBlacklist, inheritedNamespaceBlacklist)
+	proj.Spec.SourceRepos = filterStrings(proj.Spec.SourceRepos, inheritedSourceRepos)
+	proj.Spec.Destinations = filterDestinations(proj.Spec.Destinations, inheritedDestinations)
+	proj.Spec.SyncWindows = filterSyncWindows(proj.Spec.SyncWindows, inheritedSyncWindows)
 }
 
 func dedupVirtualProjectSpec(proj *argoappv1.AppProject) {
@@ -1358,91 +1367,14 @@ func dedupVirtualProjectSpec(proj *argoappv1.AppProject) {
 		return
 	}
 
-	clusterResKey := func(i argoappv1.ClusterResourceRestrictionItem) string {
-		return i.Group + "||" + i.Kind + "||" + i.Name
-	}
-	groupKindKey := func(i metav1.GroupKind) string { return i.Group + "||" + i.Kind }
-	destKey := func(d argoappv1.ApplicationDestination) string { return d.Server + "||" + d.Name + "||" + d.Namespace }
-
-	dedupCluster := func(items []argoappv1.ClusterResourceRestrictionItem) []argoappv1.ClusterResourceRestrictionItem {
-		seen := make(map[string]struct{})
-		var res []argoappv1.ClusterResourceRestrictionItem
-		for _, i := range items {
-			k := clusterResKey(i)
-			if _, ok := seen[k]; ok {
-				continue
-			}
-			seen[k] = struct{}{}
-			res = append(res, i)
-		}
-		return res
-	}
-	dedupGroupKind := func(items []metav1.GroupKind) []metav1.GroupKind {
-		seen := make(map[string]struct{})
-		var res []metav1.GroupKind
-		for _, i := range items {
-			k := groupKindKey(i)
-			if _, ok := seen[k]; ok {
-				continue
-			}
-			seen[k] = struct{}{}
-			res = append(res, i)
-		}
-		return res
-	}
-	dedupString := func(items []string) []string {
-		seen := make(map[string]struct{})
-		var res []string
-		for _, s := range items {
-			if _, ok := seen[s]; ok {
-				continue
-			}
-			seen[s] = struct{}{}
-			res = append(res, s)
-		}
-		return res
-	}
-	dedupDest := func(items []argoappv1.ApplicationDestination) []argoappv1.ApplicationDestination {
-		seen := make(map[string]struct{})
-		var res []argoappv1.ApplicationDestination
-		for _, d := range items {
-			k := destKey(d)
-			if _, ok := seen[k]; ok {
-				continue
-			}
-			seen[k] = struct{}{}
-			res = append(res, d)
-		}
-		return res
-	}
-	dedupWindows := func(items argoappv1.SyncWindows) argoappv1.SyncWindows {
-		seen := make(map[uint64]struct{})
-		var res argoappv1.SyncWindows
-		for _, w := range items {
-			if w == nil {
-				continue
-			}
-			h, err := w.HashIdentity()
-			if err != nil {
-				res = append(res, w)
-				continue
-			}
-			if _, ok := seen[h]; ok {
-				continue
-			}
-			seen[h] = struct{}{}
-			res = append(res, w)
-		}
-		return res
-	}
-
-	proj.Spec.ClusterResourceWhitelist = dedupCluster(proj.Spec.ClusterResourceWhitelist)
-	proj.Spec.ClusterResourceBlacklist = dedupCluster(proj.Spec.ClusterResourceBlacklist)
-	proj.Spec.NamespaceResourceWhitelist = dedupGroupKind(proj.Spec.NamespaceResourceWhitelist)
-	proj.Spec.NamespaceResourceBlacklist = dedupGroupKind(proj.Spec.NamespaceResourceBlacklist)
-	proj.Spec.SourceRepos = dedupString(proj.Spec.SourceRepos)
-	proj.Spec.Destinations = dedupDest(proj.Spec.Destinations)
-	proj.Spec.SyncWindows = dedupWindows(proj.Spec.SyncWindows)
+	// Passing empty "inherited" maps deduplicates by key while keeping all items.
+	proj.Spec.ClusterResourceWhitelist = filterClusterResourceRestrictionItems(proj.Spec.ClusterResourceWhitelist, map[string]struct{}{})
+	proj.Spec.ClusterResourceBlacklist = filterClusterResourceRestrictionItems(proj.Spec.ClusterResourceBlacklist, map[string]struct{}{})
+	proj.Spec.NamespaceResourceWhitelist = filterGroupKinds(proj.Spec.NamespaceResourceWhitelist, map[string]struct{}{})
+	proj.Spec.NamespaceResourceBlacklist = filterGroupKinds(proj.Spec.NamespaceResourceBlacklist, map[string]struct{}{})
+	proj.Spec.SourceRepos = filterStrings(proj.Spec.SourceRepos, map[string]struct{}{})
+	proj.Spec.Destinations = filterDestinations(proj.Spec.Destinations, map[string]struct{}{})
+	proj.Spec.SyncWindows = filterSyncWindows(proj.Spec.SyncWindows, map[uint64]struct{}{})
 }
 
 func GenerateSpecIsDifferentErrorMessage(entity string, a, b any) string {

--- a/util/argo/argo_test.go
+++ b/util/argo/argo_test.go
@@ -957,6 +957,71 @@ func TestFilterSyncWindows(t *testing.T) {
 	assert.Equal(t, argoappv1.SyncWindows{w2}, got)
 }
 
+func TestDedupVirtualProjectSpec(t *testing.T) {
+	w := &argoappv1.SyncWindow{
+		Kind:         "allow",
+		Schedule:     "* * * * *",
+		Duration:     "1h",
+		Applications: []string{"*"},
+		TimeZone:     "UTC",
+	}
+	wDup := &argoappv1.SyncWindow{
+		Kind:         "allow",
+		Schedule:     "* * * * *",
+		Duration:     "1h",
+		Applications: []string{"*"},
+		TimeZone:     "UTC",
+	}
+
+	proj := &argoappv1.AppProject{
+		Spec: argoappv1.AppProjectSpec{
+			ClusterResourceWhitelist: []argoappv1.ClusterResourceRestrictionItem{
+				{Group: "*", Kind: "*"},
+				{Group: "*", Kind: "*"},
+			},
+			ClusterResourceBlacklist: []argoappv1.ClusterResourceRestrictionItem{
+				{Group: "", Kind: "Volume"},
+				{Group: "", Kind: "Volume"},
+			},
+			NamespaceResourceWhitelist: []metav1.GroupKind{
+				{Group: "", Kind: "ConfigMap"},
+				{Group: "", Kind: "ConfigMap"},
+			},
+			NamespaceResourceBlacklist: []metav1.GroupKind{
+				{Group: "", Kind: "Secret"},
+				{Group: "", Kind: "Secret"},
+			},
+			SourceRepos: []string{
+				"https://example.com/a.git",
+				"https://example.com/a.git",
+				"https://example.com/b.git",
+			},
+			Destinations: []argoappv1.ApplicationDestination{
+				{Server: "*", Namespace: "team-a"},
+				{Server: "*", Namespace: "team-a"},
+				{Server: "*", Namespace: "team-b"},
+			},
+			SyncWindows: argoappv1.SyncWindows{w, wDup},
+		},
+	}
+
+	dedupVirtualProjectSpec(proj)
+
+	assert.Equal(t, []argoappv1.ClusterResourceRestrictionItem{{Group: "*", Kind: "*"}}, proj.Spec.ClusterResourceWhitelist)
+	assert.Equal(t, []argoappv1.ClusterResourceRestrictionItem{{Group: "", Kind: "Volume"}}, proj.Spec.ClusterResourceBlacklist)
+	assert.Equal(t, []metav1.GroupKind{{Group: "", Kind: "ConfigMap"}}, proj.Spec.NamespaceResourceWhitelist)
+	assert.Equal(t, []metav1.GroupKind{{Group: "", Kind: "Secret"}}, proj.Spec.NamespaceResourceBlacklist)
+	assert.Equal(t, []string{"https://example.com/a.git", "https://example.com/b.git"}, proj.Spec.SourceRepos)
+	assert.Equal(t,
+		[]argoappv1.ApplicationDestination{
+			{Server: "*", Namespace: "team-a"},
+			{Server: "*", Namespace: "team-b"},
+		},
+		proj.Spec.Destinations,
+	)
+	assert.Len(t, proj.Spec.SyncWindows, 1)
+}
+
 func TestFilterByRepo(t *testing.T) {
 	apps := []argoappv1.Application{
 		{
@@ -1712,6 +1777,20 @@ func TestGetGlobalProjects(t *testing.T) {
 		nonXGlobalProjects := GetGlobalProjects(isNoX, projLister, settingsMgr)
 		assert.Len(t, nonXGlobalProjects, 1)
 		assert.Equal(t, "default-non-x", nonXGlobalProjects[0].Name)
+
+		// Regression: a proj object whose labels match a global project's selector should match
+		// even if it is not yet present in the lister/informer cache (e.g. a freshly received
+		// update payload). Only the proj's labels should drive matching.
+		notInCache := &argoappv1.AppProject{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "not-in-cache",
+				Namespace: namespace,
+				Labels:    map[string]string{"is-x": "yep"},
+			},
+		}
+		notInCacheGlobalProjects := GetGlobalProjects(notInCache, projLister, settingsMgr)
+		assert.Len(t, notInCacheGlobalProjects, 1)
+		assert.Equal(t, "default-x", notInCacheGlobalProjects[0].Name)
 	})
 }
 

--- a/util/argo/argo_test.go
+++ b/util/argo/argo_test.go
@@ -691,7 +691,7 @@ func TestFilterAppSetsByProjects(t *testing.T) {
 
 func TestStripInheritedGlobalProjectSpec(t *testing.T) {
 	global := &argoappv1.AppProject{
-		ObjectMeta: metav1.ObjectMeta{Name: "global-common", Namespace: "argocd"},
+		ObjectMeta: metav1.ObjectMeta{Name: "global-project", Namespace: "argocd"},
 		Spec: argoappv1.AppProjectSpec{
 			ClusterResourceBlacklist: []argoappv1.ClusterResourceRestrictionItem{
 				{Group: "*", Kind: "*"},
@@ -701,14 +701,14 @@ func TestStripInheritedGlobalProjectSpec(t *testing.T) {
 			},
 			SourceRepos: []string{"https://example.com/global.git"},
 			Destinations: []argoappv1.ApplicationDestination{
-				{Server: "*", Namespace: "debman"},
+				{Server: "*", Namespace: "team-a"},
 			},
 		},
 	}
 
 	// Simulate a "virtual" project spec which already contains inherited entries (possibly multiple times).
 	proj := &argoappv1.AppProject{
-		ObjectMeta: metav1.ObjectMeta{Name: "debman", Namespace: "argocd"},
+		ObjectMeta: metav1.ObjectMeta{Name: "project-a", Namespace: "argocd"},
 		Spec: argoappv1.AppProjectSpec{
 			ClusterResourceBlacklist: []argoappv1.ClusterResourceRestrictionItem{
 				{Group: "*", Kind: "*"},
@@ -726,9 +726,9 @@ func TestStripInheritedGlobalProjectSpec(t *testing.T) {
 				"https://example.com/project.git",
 			},
 			Destinations: []argoappv1.ApplicationDestination{
-				{Server: "*", Namespace: "debman"},
-				{Server: "*", Namespace: "debman"},
-				{Server: "*", Namespace: "test3"},
+				{Server: "*", Namespace: "team-a"},
+				{Server: "*", Namespace: "team-a"},
+				{Server: "*", Namespace: "team-b"},
 			},
 		},
 	}
@@ -750,10 +750,52 @@ func TestStripInheritedGlobalProjectSpec(t *testing.T) {
 	assert.Equal(t, []string{"https://example.com/project.git"}, proj.Spec.SourceRepos)
 	assert.Equal(t,
 		[]argoappv1.ApplicationDestination{
-			{Server: "*", Namespace: "test3"},
+			{Server: "*", Namespace: "team-b"},
 		},
 		proj.Spec.Destinations,
 	)
+}
+
+func TestFilterClusterResourceRestrictionItems(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		items     []argoappv1.ClusterResourceRestrictionItem
+		inherited map[string]struct{}
+		want      []argoappv1.ClusterResourceRestrictionItem
+	}{
+		{
+			name: "filters inherited and dedupes remaining",
+			items: []argoappv1.ClusterResourceRestrictionItem{
+				{Group: "*", Kind: "*"},
+				{Group: "*", Kind: "*"},
+				{Group: "", Kind: "ConfigMap"},
+				{Group: "", Kind: "ConfigMap"},
+				{Group: "", Kind: "Secret"},
+			},
+			inherited: map[string]struct{}{
+				clusterResourceRestrictionItemKey(argoappv1.ClusterResourceRestrictionItem{Group: "*", Kind: "*"}): {},
+			},
+			want: []argoappv1.ClusterResourceRestrictionItem{
+				{Group: "", Kind: "ConfigMap"},
+				{Group: "", Kind: "Secret"},
+			},
+		},
+		{
+			name:      "no inherited -> only dedupe",
+			items:     []argoappv1.ClusterResourceRestrictionItem{{Group: "*", Kind: "*"}, {Group: "*", Kind: "*"}},
+			inherited: map[string]struct{}{},
+			want:      []argoappv1.ClusterResourceRestrictionItem{{Group: "*", Kind: "*"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterClusterResourceRestrictionItems(tt.items, tt.inherited)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func TestFilterByRepo(t *testing.T) {

--- a/util/argo/argo_test.go
+++ b/util/argo/argo_test.go
@@ -791,7 +791,6 @@ func TestFilterClusterResourceRestrictionItems(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := filterClusterResourceRestrictionItems(tt.items, tt.inherited)
@@ -833,7 +832,6 @@ func TestFilterGroupKinds(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := filterGroupKinds(tt.items, tt.inherited)
@@ -873,7 +871,6 @@ func TestFilterStrings(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := filterStrings(tt.items, tt.inherited)
@@ -915,7 +912,6 @@ func TestFilterDestinations(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := filterDestinations(tt.items, tt.inherited)

--- a/util/argo/argo_test.go
+++ b/util/argo/argo_test.go
@@ -791,11 +791,170 @@ func TestFilterClusterResourceRestrictionItems(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := filterClusterResourceRestrictionItems(tt.items, tt.inherited)
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestFilterGroupKinds(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		items     []metav1.GroupKind
+		inherited map[string]struct{}
+		want      []metav1.GroupKind
+	}{
+		{
+			name: "filters inherited and dedupes remaining",
+			items: []metav1.GroupKind{
+				{Group: "", Kind: "LimitRange"},
+				{Group: "", Kind: "LimitRange"},
+				{Group: "", Kind: "Secret"},
+				{Group: "", Kind: "Secret"},
+			},
+			inherited: map[string]struct{}{
+				groupKindKey(metav1.GroupKind{Group: "", Kind: "LimitRange"}): {},
+			},
+			want: []metav1.GroupKind{
+				{Group: "", Kind: "Secret"},
+			},
+		},
+		{
+			name:      "no inherited -> only dedupe",
+			items:     []metav1.GroupKind{{Group: "", Kind: "Secret"}, {Group: "", Kind: "Secret"}},
+			inherited: map[string]struct{}{},
+			want:      []metav1.GroupKind{{Group: "", Kind: "Secret"}},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := filterGroupKinds(tt.items, tt.inherited)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestFilterStrings(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		items     []string
+		inherited map[string]struct{}
+		want      []string
+	}{
+		{
+			name: "filters inherited and dedupes remaining",
+			items: []string{
+				"https://example.com/global.git",
+				"https://example.com/global.git",
+				"https://example.com/project.git",
+				"https://example.com/project.git",
+			},
+			inherited: map[string]struct{}{
+				"https://example.com/global.git": {},
+			},
+			want: []string{"https://example.com/project.git"},
+		},
+		{
+			name:      "no inherited -> only dedupe",
+			items:     []string{"a", "a", "b", "b"},
+			inherited: map[string]struct{}{},
+			want:      []string{"a", "b"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := filterStrings(tt.items, tt.inherited)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestFilterDestinations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		items     []argoappv1.ApplicationDestination
+		inherited map[string]struct{}
+		want      []argoappv1.ApplicationDestination
+	}{
+		{
+			name: "filters inherited and dedupes remaining",
+			items: []argoappv1.ApplicationDestination{
+				{Server: "*", Namespace: "team-a"},
+				{Server: "*", Namespace: "team-a"},
+				{Server: "*", Namespace: "team-b"},
+				{Server: "*", Namespace: "team-b"},
+			},
+			inherited: map[string]struct{}{
+				applicationDestinationKey(argoappv1.ApplicationDestination{Server: "*", Namespace: "team-a"}): {},
+			},
+			want: []argoappv1.ApplicationDestination{
+				{Server: "*", Namespace: "team-b"},
+			},
+		},
+		{
+			name:      "no inherited -> only dedupe",
+			items:     []argoappv1.ApplicationDestination{{Server: "*", Namespace: "team-a"}, {Server: "*", Namespace: "team-a"}},
+			inherited: map[string]struct{}{},
+			want:      []argoappv1.ApplicationDestination{{Server: "*", Namespace: "team-a"}},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := filterDestinations(tt.items, tt.inherited)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestFilterSyncWindows(t *testing.T) {
+	t.Parallel()
+
+	w1 := &argoappv1.SyncWindow{
+		Kind:         "allow",
+		Schedule:     "* * * * *",
+		Duration:     "1h",
+		Applications: []string{"*"},
+		TimeZone:     "UTC",
+	}
+	// Same identity as w1 (should be deduped)
+	w1dup := &argoappv1.SyncWindow{
+		Kind:         "allow",
+		Schedule:     "* * * * *",
+		Duration:     "1h",
+		Applications: []string{"*"},
+		TimeZone:     "UTC",
+	}
+	w2 := &argoappv1.SyncWindow{
+		Kind:         "deny",
+		Schedule:     "* * * * *",
+		Duration:     "1h",
+		Applications: []string{"*"},
+		TimeZone:     "UTC",
+	}
+
+	h1, ok := syncWindowIdentityHash(w1)
+	require.True(t, ok)
+
+	got := filterSyncWindows(argoappv1.SyncWindows{w1, w1dup, w2}, map[uint64]struct{}{h1: {}})
+	assert.Equal(t, argoappv1.SyncWindows{w2}, got)
 }
 
 func TestFilterByRepo(t *testing.T) {

--- a/util/argo/argo_test.go
+++ b/util/argo/argo_test.go
@@ -689,6 +689,73 @@ func TestFilterAppSetsByProjects(t *testing.T) {
 	})
 }
 
+func TestStripInheritedGlobalProjectSpec(t *testing.T) {
+	global := &argoappv1.AppProject{
+		ObjectMeta: metav1.ObjectMeta{Name: "global-common", Namespace: "argocd"},
+		Spec: argoappv1.AppProjectSpec{
+			ClusterResourceBlacklist: []argoappv1.ClusterResourceRestrictionItem{
+				{Group: "*", Kind: "*"},
+			},
+			NamespaceResourceBlacklist: []metav1.GroupKind{
+				{Group: "", Kind: "LimitRange"},
+			},
+			SourceRepos: []string{"https://example.com/global.git"},
+			Destinations: []argoappv1.ApplicationDestination{
+				{Server: "*", Namespace: "debman"},
+			},
+		},
+	}
+
+	// Simulate a "virtual" project spec which already contains inherited entries (possibly multiple times).
+	proj := &argoappv1.AppProject{
+		ObjectMeta: metav1.ObjectMeta{Name: "debman", Namespace: "argocd"},
+		Spec: argoappv1.AppProjectSpec{
+			ClusterResourceBlacklist: []argoappv1.ClusterResourceRestrictionItem{
+				{Group: "*", Kind: "*"},
+				{Group: "*", Kind: "*"},
+				{Group: "", Kind: "ConfigMap"},
+			},
+			NamespaceResourceBlacklist: []metav1.GroupKind{
+				{Group: "", Kind: "LimitRange"},
+				{Group: "", Kind: "LimitRange"},
+				{Group: "", Kind: "Secret"},
+			},
+			SourceRepos: []string{
+				"https://example.com/global.git",
+				"https://example.com/global.git",
+				"https://example.com/project.git",
+			},
+			Destinations: []argoappv1.ApplicationDestination{
+				{Server: "*", Namespace: "debman"},
+				{Server: "*", Namespace: "debman"},
+				{Server: "*", Namespace: "test3"},
+			},
+		},
+	}
+
+	StripInheritedGlobalProjectSpec(proj, []*argoappv1.AppProject{global})
+
+	assert.Equal(t,
+		[]argoappv1.ClusterResourceRestrictionItem{
+			{Group: "", Kind: "ConfigMap"},
+		},
+		proj.Spec.ClusterResourceBlacklist,
+	)
+	assert.Equal(t,
+		[]metav1.GroupKind{
+			{Group: "", Kind: "Secret"},
+		},
+		proj.Spec.NamespaceResourceBlacklist,
+	)
+	assert.Equal(t, []string{"https://example.com/project.git"}, proj.Spec.SourceRepos)
+	assert.Equal(t,
+		[]argoappv1.ApplicationDestination{
+			{Server: "*", Namespace: "test3"},
+		},
+		proj.Spec.Destinations,
+	)
+}
+
 func TestFilterByRepo(t *testing.T) {
 	apps := []argoappv1.Application{
 		{


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Closes #25830 

This PR fixes an issue where editing an AppProject in the UI while globalProjects is configured in `argocd-cm` causes inherited spec fields to be duplicated on every save.

GET `/projects/:name/detailed` returns a virtual project where specs from matching globalProjects are merged into the project (append-based). The UI used this virtual project as the edit source and sent it back via PUT `/projects/:name`, which persisted inherited/global entries into the real AppProject CR. Since the merge is append-based, every subsequent edit appended the same inherited entries again, leading to duplicates (and failures such as “already exists” for fields like sourceRepos).

- **UI**: When saving a project, strip spec entries that are inherited from matching global projects so we only persist the project’s own spec (also dedupe local entries).
- **Server**: Add a defensive guard in ProjectService. Update to strip inherited/global spec entries before validating and persisting, making the API safe for any client (not just the UI).
- **Virtual project display**: Deduplicate the merged virtual project spec so inherited views don’t show repeated entries even if the CR was previously polluted.

Inherited values from global projects are still visible in the UI, but they are not persisted back to the AppProject CR, preventing duplicate accumulation across edits.
I’ve attached the test manifests and results from validating this fix.

#### manifests
```
apiVersion: argoproj.io/v1alpha1
kind: AppProject
metadata:
  name: global-common
spec:
  clusterResourceBlacklist:
  - group: '*'
    kind: '*'
  namespaceResourceBlacklist:
  - group: ""
    kind: LimitRange
```

```
apiVersion: argoproj.io/v1alpha1
kind: AppProject
metadata:
  name: jw-test
spec:
  destinations:
  - namespace: default
    server: '*'
  - namespace: jw-test
    server: '*'
```

#### test results
Edit project spec in UI with globalProjects enabled.
<img width="1118" height="460" alt="스크린샷 2026-01-01 오후 1 41 06" src="https://github.com/user-attachments/assets/80408ba3-c08d-4a73-8473-8e475892727b" />
After saving multiple times, no duplicated inherited specs are written to the `AppProject`.
<img width="1089" height="556" alt="스크린샷 2026-01-01 오후 1 41 19" src="https://github.com/user-attachments/assets/e3c1ec29-0b5a-4bad-a085-26078d2ed910" />


Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
