### PR TITLE
docs: Remove references to no longer used tls-server-name flag

### DIFF
--- a/docs/operator-manual/notifications/troubleshooting-commands.md
+++ b/docs/operator-manual/notifications/troubleshooting-commands.md
@@ -48,7 +48,6 @@ argocd admin notifications template get app-sync-succeeded -o=yaml
       --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --secret string                   argocd-notifications-secret.yaml file path. Use empty secret if provided value is ':empty'
       --server string                   The address and port of the Kubernetes API server
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                    Bearer token for authentication to the API server
       --user string                     The name of the kubeconfig user to use
       --username string                 Username for basic authentication to the API server
@@ -105,7 +104,6 @@ argocd admin notifications template notify app-sync-succeeded guestbook
       --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --secret string                   argocd-notifications-secret.yaml file path. Use empty secret if provided value is ':empty'
       --server string                   The address and port of the Kubernetes API server
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                    Bearer token for authentication to the API server
       --user string                     The name of the kubeconfig user to use
       --username string                 Username for basic authentication to the API server
@@ -161,7 +159,6 @@ argocd admin notifications trigger get on-sync-failed -o=yaml
       --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --secret string                   argocd-notifications-secret.yaml file path. Use empty secret if provided value is ':empty'
       --server string                   The address and port of the Kubernetes API server
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                    Bearer token for authentication to the API server
       --user string                     The name of the kubeconfig user to use
       --username string                 Username for basic authentication to the API server
@@ -217,7 +214,6 @@ argocd admin notifications trigger run on-sync-status-unknown ./sample-app.yaml 
       --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --secret string                   argocd-notifications-secret.yaml file path. Use empty secret if provided value is ':empty'
       --server string                   The address and port of the Kubernetes API server
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                    Bearer token for authentication to the API server
       --user string                     The name of the kubeconfig user to use
       --username string                 Username for basic authentication to the API server

--- a/docs/operator-manual/server-commands/argocd-application-controller.md
+++ b/docs/operator-manual/server-commands/argocd-application-controller.md
@@ -81,7 +81,6 @@ argocd-application-controller [flags]
       --sharding-method string                                    Enables choice of sharding method. Supported sharding methods are : [legacy, round-robin, consistent-hashing]  (default "legacy")
       --status-processors int                                     Number of application status processors (default 20)
       --sync-timeout int                                          Specifies the timeout after which a sync would be terminated. 0 means no timeout (default 0).
-      --tls-server-name string                                    If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                                              Bearer token for authentication to the API server
       --user string                                               The name of the kubeconfig user to use
       --username string                                           Username for basic authentication to the API server

--- a/docs/operator-manual/server-commands/argocd-applicationset-controller.md
+++ b/docs/operator-manual/server-commands/argocd-applicationset-controller.md
@@ -53,7 +53,6 @@ argocd-applicationset-controller [flags]
       --request-timeout string                  The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --scm-root-ca-path string                 Provide Root CA Path for self-signed TLS Certificates
       --server string                           The address and port of the Kubernetes API server
-      --tls-server-name string                  If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                            Bearer token for authentication to the API server
       --token-ref-strict-mode                   Set to true to require secrets referenced by SCM providers to have the argocd.argoproj.io/secret-type=scm-creds label set (Default: false)
       --user string                             The name of the kubeconfig user to use

--- a/docs/operator-manual/server-commands/argocd-dex_gendexcfg.md
+++ b/docs/operator-manual/server-commands/argocd-dex_gendexcfg.md
@@ -32,7 +32,6 @@ argocd-dex gendexcfg [flags]
       --proxy-url string               If provided, this URL will be used to connect via proxy
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                  The address and port of the Kubernetes API server
-      --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use
       --username string                Username for basic authentication to the API server

--- a/docs/operator-manual/server-commands/argocd-dex_rundex.md
+++ b/docs/operator-manual/server-commands/argocd-dex_rundex.md
@@ -31,7 +31,6 @@ argocd-dex rundex [flags]
       --proxy-url string               If provided, this URL will be used to connect via proxy
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                  The address and port of the Kubernetes API server
-      --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use
       --username string                Username for basic authentication to the API server

--- a/docs/operator-manual/server-commands/argocd-server.md
+++ b/docs/operator-manual/server-commands/argocd-server.md
@@ -107,7 +107,6 @@ argocd-server [flags]
       --server string                                   The address and port of the Kubernetes API server
       --staticassets string                             Directory path that contains additional static assets (default "/shared/app")
       --sync-with-replace-allowed                       Whether to allow users to select replace for syncs from UI/CLI (default true)
-      --tls-server-name string                          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --tlsciphers string                               The list of acceptable ciphers to be used when establishing TLS connections. Use 'list' to list available ciphers. (default "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384")
       --tlsmaxversion string                            The maximum SSL/TLS version that is acceptable (one of: 1.0|1.1|1.2|1.3) (default "1.3")
       --tlsminversion string                            The minimum SSL/TLS version that is acceptable (one of: 1.0|1.1|1.2|1.3) (default "1.2")

--- a/docs/operator-manual/server-commands/argocd-server_version.md
+++ b/docs/operator-manual/server-commands/argocd-server_version.md
@@ -34,7 +34,6 @@ argocd-server version [flags]
       --proxy-url string               If provided, this URL will be used to connect via proxy
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                  The address and port of the Kubernetes API server
-      --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use
       --username string                Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_account.md
+++ b/docs/user-guide/commands/argocd_account.md
@@ -43,7 +43,6 @@ argocd account [flags]
       --password string                Password for basic authentication to the API server
       --proxy-url string               If provided, this URL will be used to connect via proxy
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use
       --username string                Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_app_get-reconcile-results.md
+++ b/docs/user-guide/commands/argocd_admin_app_get-reconcile-results.md
@@ -34,7 +34,6 @@ argocd admin app get-reconcile-results PATH [flags]
       --request-timeout string                            The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                                     The address and port of the Kubernetes API server
       --server-side-diff                                  If set to "true" will use server-side diff while comparing resources. Default ("false")
-      --tls-server-name string                            If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                                      Bearer token for authentication to the API server
       --user string                                       The name of the kubeconfig user to use
       --username string                                   Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_cluster_kubeconfig.md
+++ b/docs/user-guide/commands/argocd_admin_cluster_kubeconfig.md
@@ -45,7 +45,6 @@ argocd admin cluster kubeconfig https://cluster-api-url:6443 /path/to/output/kub
       --proxy-url string               If provided, this URL will be used to connect via proxy
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                  The address and port of the Kubernetes API server
-      --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use
       --username string                Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_cluster_namespaces.md
+++ b/docs/user-guide/commands/argocd_admin_cluster_namespaces.md
@@ -28,7 +28,6 @@ argocd admin cluster namespaces [flags]
       --proxy-url string               If provided, this URL will be used to connect via proxy
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                  The address and port of the Kubernetes API server
-      --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use
       --username string                Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_cluster_namespaces_disable-namespaced-mode.md
+++ b/docs/user-guide/commands/argocd_admin_cluster_namespaces_disable-namespaced-mode.md
@@ -29,7 +29,6 @@ argocd admin cluster namespaces disable-namespaced-mode PATTERN [flags]
       --proxy-url string               If provided, this URL will be used to connect via proxy
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                  The address and port of the Kubernetes API server
-      --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use
       --username string                Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_cluster_namespaces_enable-namespaced-mode.md
+++ b/docs/user-guide/commands/argocd_admin_cluster_namespaces_enable-namespaced-mode.md
@@ -31,7 +31,6 @@ argocd admin cluster namespaces enable-namespaced-mode PATTERN [flags]
       --proxy-url string               If provided, this URL will be used to connect via proxy
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                  The address and port of the Kubernetes API server
-      --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use
       --username string                Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_cluster_shards.md
+++ b/docs/user-guide/commands/argocd_admin_cluster_shards.md
@@ -44,7 +44,6 @@ argocd admin cluster shards [flags]
       --server string                         The address and port of the Kubernetes API server
       --shard int                             Cluster shard filter (default -1)
       --sharding-method string                Sharding method. Defaults: legacy. Supported sharding methods are : [legacy, round-robin, consistent-hashing]  (default "legacy")
-      --tls-server-name string                If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                          Bearer token for authentication to the API server
       --user string                           The name of the kubeconfig user to use
       --username string                       Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_cluster_stats.md
+++ b/docs/user-guide/commands/argocd_admin_cluster_stats.md
@@ -58,7 +58,6 @@ argocd admin cluster stats target-cluster
       --server string                         The address and port of the Kubernetes API server
       --shard int                             Cluster shard filter (default -1)
       --sharding-method string                Sharding method. Defaults: legacy. Supported sharding methods are : [legacy, round-robin, consistent-hashing]  (default "legacy")
-      --tls-server-name string                If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                          Bearer token for authentication to the API server
       --user string                           The name of the kubeconfig user to use
       --username string                       Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_dashboard.md
+++ b/docs/user-guide/commands/argocd_admin_dashboard.md
@@ -44,7 +44,6 @@ $ argocd admin dashboard --redis-compress gzip
       --proxy-url string               If provided, this URL will be used to connect via proxy
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                  The address and port of the Kubernetes API server
-      --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use
       --username string                Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_export.md
+++ b/docs/user-guide/commands/argocd_admin_export.md
@@ -31,7 +31,6 @@ argocd admin export [flags]
       --proxy-url string                    If provided, this URL will be used to connect via proxy
       --request-timeout string              The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                       The address and port of the Kubernetes API server
-      --tls-server-name string              If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                        Bearer token for authentication to the API server
       --user string                         The name of the kubeconfig user to use
       --username string                     Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_import.md
+++ b/docs/user-guide/commands/argocd_admin_import.md
@@ -37,7 +37,6 @@ argocd admin import SOURCE [flags]
       --server string                       The address and port of the Kubernetes API server
       --skip-resources-with-label string    Skip importing resources based on the label e.g. '--skip-resources-with-label my-label/example.io=true'
       --stop-operation                      Stop any existing operations
-      --tls-server-name string              If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                        Bearer token for authentication to the API server
       --user string                         The name of the kubeconfig user to use
       --username string                     Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_initial-password.md
+++ b/docs/user-guide/commands/argocd_admin_initial-password.md
@@ -28,7 +28,6 @@ argocd admin initial-password [flags]
       --proxy-url string               If provided, this URL will be used to connect via proxy
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                  The address and port of the Kubernetes API server
-      --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use
       --username string                Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_notifications.md
+++ b/docs/user-guide/commands/argocd_admin_notifications.md
@@ -33,7 +33,6 @@ argocd admin notifications [flags]
       --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --secret string                   argocd-notifications-secret.yaml file path. Use empty secret if provided value is ':empty'
       --server string                   The address and port of the Kubernetes API server
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                    Bearer token for authentication to the API server
       --user string                     The name of the kubeconfig user to use
       --username string                 Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_notifications_template.md
+++ b/docs/user-guide/commands/argocd_admin_notifications_template.md
@@ -63,7 +63,6 @@ argocd admin notifications template [flags]
       --server string                   The address and port of the Kubernetes API server
       --server-crt string               Server certificate file
       --server-name string              Name of the Argo CD API server; set this or the ARGOCD_SERVER_NAME environment variable when the server's name label differs from the default, for example when installing via the Helm chart (default "argocd-server")
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                    Bearer token for authentication to the API server
       --user string                     The name of the kubeconfig user to use
       --username string                 Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_notifications_template_get.md
+++ b/docs/user-guide/commands/argocd_admin_notifications_template_get.md
@@ -75,7 +75,6 @@ argocd admin notifications template get app-sync-succeeded -o=yaml
       --server string                   The address and port of the Kubernetes API server
       --server-crt string               Server certificate file
       --server-name string              Name of the Argo CD API server; set this or the ARGOCD_SERVER_NAME environment variable when the server's name label differs from the default, for example when installing via the Helm chart (default "argocd-server")
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                    Bearer token for authentication to the API server
       --user string                     The name of the kubeconfig user to use
       --username string                 Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_notifications_template_notify.md
+++ b/docs/user-guide/commands/argocd_admin_notifications_template_notify.md
@@ -76,7 +76,6 @@ argocd admin notifications template notify app-sync-succeeded guestbook
       --server string                   The address and port of the Kubernetes API server
       --server-crt string               Server certificate file
       --server-name string              Name of the Argo CD API server; set this or the ARGOCD_SERVER_NAME environment variable when the server's name label differs from the default, for example when installing via the Helm chart (default "argocd-server")
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                    Bearer token for authentication to the API server
       --user string                     The name of the kubeconfig user to use
       --username string                 Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_notifications_trigger.md
+++ b/docs/user-guide/commands/argocd_admin_notifications_trigger.md
@@ -63,7 +63,6 @@ argocd admin notifications trigger [flags]
       --server string                   The address and port of the Kubernetes API server
       --server-crt string               Server certificate file
       --server-name string              Name of the Argo CD API server; set this or the ARGOCD_SERVER_NAME environment variable when the server's name label differs from the default, for example when installing via the Helm chart (default "argocd-server")
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                    Bearer token for authentication to the API server
       --user string                     The name of the kubeconfig user to use
       --username string                 Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_notifications_trigger_get.md
+++ b/docs/user-guide/commands/argocd_admin_notifications_trigger_get.md
@@ -75,7 +75,6 @@ argocd admin notifications trigger get on-sync-failed -o=yaml
       --server string                   The address and port of the Kubernetes API server
       --server-crt string               Server certificate file
       --server-name string              Name of the Argo CD API server; set this or the ARGOCD_SERVER_NAME environment variable when the server's name label differs from the default, for example when installing via the Helm chart (default "argocd-server")
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                    Bearer token for authentication to the API server
       --user string                     The name of the kubeconfig user to use
       --username string                 Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_notifications_trigger_run.md
+++ b/docs/user-guide/commands/argocd_admin_notifications_trigger_run.md
@@ -75,7 +75,6 @@ argocd admin notifications trigger run on-sync-status-unknown ./sample-app.yaml 
       --server string                   The address and port of the Kubernetes API server
       --server-crt string               Server certificate file
       --server-name string              Name of the Argo CD API server; set this or the ARGOCD_SERVER_NAME environment variable when the server's name label differs from the default, for example when installing via the Helm chart (default "argocd-server")
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                    Bearer token for authentication to the API server
       --user string                     The name of the kubeconfig user to use
       --username string                 Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_proj_generate-allow-list.md
+++ b/docs/user-guide/commands/argocd_admin_proj_generate-allow-list.md
@@ -36,7 +36,6 @@ argocd admin proj generate-allow-list /path/to/clusterrole.yaml my-project
       --proxy-url string               If provided, this URL will be used to connect via proxy
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                  The address and port of the Kubernetes API server
-      --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use
       --username string                Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_proj_update-role-policy.md
+++ b/docs/user-guide/commands/argocd_admin_proj_update-role-policy.md
@@ -44,7 +44,6 @@ argocd admin proj update-role-policy PROJECT_GLOB MODIFICATION ACTION [flags]
       --role string                    Role name pattern e.g. '*deployer*' (default "*")
       --scope string                   Resource scope e.g. '*'
       --server string                  The address and port of the Kubernetes API server
-      --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use
       --username string                Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_redis-initial-password.md
+++ b/docs/user-guide/commands/argocd_admin_redis-initial-password.md
@@ -28,7 +28,6 @@ argocd admin redis-initial-password [flags]
       --proxy-url string               If provided, this URL will be used to connect via proxy
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                  The address and port of the Kubernetes API server
-      --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use
       --username string                Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_settings.md
+++ b/docs/user-guide/commands/argocd_admin_settings.md
@@ -31,7 +31,6 @@ argocd admin settings [flags]
       --proxy-url string               If provided, this URL will be used to connect via proxy
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                  The address and port of the Kubernetes API server
-      --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use
       --username string                Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_settings_rbac.md
+++ b/docs/user-guide/commands/argocd_admin_settings_rbac.md
@@ -61,7 +61,6 @@ argocd admin settings rbac [flags]
       --server string                   The address and port of the Kubernetes API server
       --server-crt string               Server certificate file
       --server-name string              Name of the Argo CD API server; set this or the ARGOCD_SERVER_NAME environment variable when the server's name label differs from the default, for example when installing via the Helm chart (default "argocd-server")
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                    Bearer token for authentication to the API server
       --user string                     The name of the kubeconfig user to use
       --username string                 Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_settings_rbac_can.md
+++ b/docs/user-guide/commands/argocd_admin_settings_rbac_can.md
@@ -62,7 +62,6 @@ argocd admin settings rbac can someuser create application 'default/app' --defau
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                  The address and port of the Kubernetes API server
       --strict                         whether to perform strict check on action and resource names (default true)
-      --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server
       --use-builtin-policy             whether to also use builtin-policy (default true)
       --user string                    The name of the kubeconfig user to use

--- a/docs/user-guide/commands/argocd_admin_settings_rbac_validate.md
+++ b/docs/user-guide/commands/argocd_admin_settings_rbac_validate.md
@@ -55,7 +55,6 @@ argocd admin settings rbac validate --namespace argocd
       --proxy-url string               If provided, this URL will be used to connect via proxy
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                  The address and port of the Kubernetes API server
-      --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use
       --username string                Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_settings_resource-overrides.md
+++ b/docs/user-guide/commands/argocd_admin_settings_resource-overrides.md
@@ -61,7 +61,6 @@ argocd admin settings resource-overrides [flags]
       --server string                   The address and port of the Kubernetes API server
       --server-crt string               Server certificate file
       --server-name string              Name of the Argo CD API server; set this or the ARGOCD_SERVER_NAME environment variable when the server's name label differs from the default, for example when installing via the Helm chart (default "argocd-server")
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                    Bearer token for authentication to the API server
       --user string                     The name of the kubeconfig user to use
       --username string                 Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_settings_resource-overrides_health.md
+++ b/docs/user-guide/commands/argocd_admin_settings_resource-overrides_health.md
@@ -72,7 +72,6 @@ argocd admin settings resource-overrides health ./deploy.yaml --argocd-cm-path .
       --server string                   The address and port of the Kubernetes API server
       --server-crt string               Server certificate file
       --server-name string              Name of the Argo CD API server; set this or the ARGOCD_SERVER_NAME environment variable when the server's name label differs from the default, for example when installing via the Helm chart (default "argocd-server")
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                    Bearer token for authentication to the API server
       --user string                     The name of the kubeconfig user to use
       --username string                 Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_settings_resource-overrides_ignore-differences.md
+++ b/docs/user-guide/commands/argocd_admin_settings_resource-overrides_ignore-differences.md
@@ -72,7 +72,6 @@ argocd admin settings resource-overrides ignore-differences ./deploy.yaml --argo
       --server string                   The address and port of the Kubernetes API server
       --server-crt string               Server certificate file
       --server-name string              Name of the Argo CD API server; set this or the ARGOCD_SERVER_NAME environment variable when the server's name label differs from the default, for example when installing via the Helm chart (default "argocd-server")
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                    Bearer token for authentication to the API server
       --user string                     The name of the kubeconfig user to use
       --username string                 Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_settings_resource-overrides_ignore-resource-updates.md
+++ b/docs/user-guide/commands/argocd_admin_settings_resource-overrides_ignore-resource-updates.md
@@ -73,7 +73,6 @@ argocd admin settings resource-overrides ignore-resource-updates ./deploy.yaml -
       --server string                   The address and port of the Kubernetes API server
       --server-crt string               Server certificate file
       --server-name string              Name of the Argo CD API server; set this or the ARGOCD_SERVER_NAME environment variable when the server's name label differs from the default, for example when installing via the Helm chart (default "argocd-server")
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                    Bearer token for authentication to the API server
       --user string                     The name of the kubeconfig user to use
       --username string                 Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_settings_resource-overrides_list-actions.md
+++ b/docs/user-guide/commands/argocd_admin_settings_resource-overrides_list-actions.md
@@ -72,7 +72,6 @@ argocd admin settings resource-overrides action list /tmp/deploy.yaml --argocd-c
       --server string                   The address and port of the Kubernetes API server
       --server-crt string               Server certificate file
       --server-name string              Name of the Argo CD API server; set this or the ARGOCD_SERVER_NAME environment variable when the server's name label differs from the default, for example when installing via the Helm chart (default "argocd-server")
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                    Bearer token for authentication to the API server
       --user string                     The name of the kubeconfig user to use
       --username string                 Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_settings_resource-overrides_run-action.md
+++ b/docs/user-guide/commands/argocd_admin_settings_resource-overrides_run-action.md
@@ -73,7 +73,6 @@ argocd admin settings resource-overrides action /tmp/deploy.yaml restart --argoc
       --server string                   The address and port of the Kubernetes API server
       --server-crt string               Server certificate file
       --server-name string              Name of the Argo CD API server; set this or the ARGOCD_SERVER_NAME environment variable when the server's name label differs from the default, for example when installing via the Helm chart (default "argocd-server")
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                    Bearer token for authentication to the API server
       --user string                     The name of the kubeconfig user to use
       --username string                 Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_settings_validate.md
+++ b/docs/user-guide/commands/argocd_admin_settings_validate.md
@@ -77,7 +77,6 @@ argocd admin settings validate --group accounts --group plugins --load-cluster-s
       --server string                   The address and port of the Kubernetes API server
       --server-crt string               Server certificate file
       --server-name string              Name of the Argo CD API server; set this or the ARGOCD_SERVER_NAME environment variable when the server's name label differs from the default, for example when installing via the Helm chart (default "argocd-server")
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                    Bearer token for authentication to the API server
       --user string                     The name of the kubeconfig user to use
       --username string                 Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_app.md
+++ b/docs/user-guide/commands/argocd_app.md
@@ -40,7 +40,6 @@ argocd app [flags]
       --password string                Password for basic authentication to the API server
       --proxy-url string               If provided, this URL will be used to connect via proxy
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use
       --username string                Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_appset.md
+++ b/docs/user-guide/commands/argocd_appset.md
@@ -43,7 +43,6 @@ argocd appset [flags]
       --password string                Password for basic authentication to the API server
       --proxy-url string               If provided, this URL will be used to connect via proxy
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use
       --username string                Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_cert.md
+++ b/docs/user-guide/commands/argocd_cert.md
@@ -50,7 +50,6 @@ argocd cert [flags]
       --password string                Password for basic authentication to the API server
       --proxy-url string               If provided, this URL will be used to connect via proxy
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use
       --username string                Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_cluster.md
+++ b/docs/user-guide/commands/argocd_cluster.md
@@ -47,7 +47,6 @@ argocd cluster [flags]
       --password string                Password for basic authentication to the API server
       --proxy-url string               If provided, this URL will be used to connect via proxy
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use
       --username string                Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_configure.md
+++ b/docs/user-guide/commands/argocd_configure.md
@@ -39,7 +39,6 @@ argocd configure --prompts-enabled=false
       --prompts-enabled                Enable (or disable) optional interactive prompts
       --proxy-url string               If provided, this URL will be used to connect via proxy
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use
       --username string                Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_gpg.md
+++ b/docs/user-guide/commands/argocd_gpg.md
@@ -27,7 +27,6 @@ argocd gpg [flags]
       --password string                Password for basic authentication to the API server
       --proxy-url string               If provided, this URL will be used to connect via proxy
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use
       --username string                Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_proj.md
+++ b/docs/user-guide/commands/argocd_proj.md
@@ -43,7 +43,6 @@ argocd proj [flags]
       --password string                Password for basic authentication to the API server
       --proxy-url string               If provided, this URL will be used to connect via proxy
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use
       --username string                Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_repo.md
+++ b/docs/user-guide/commands/argocd_repo.md
@@ -45,7 +45,6 @@ argocd repo rm https://github.com/yourusername/your-repo.git
       --password string                Password for basic authentication to the API server
       --proxy-url string               If provided, this URL will be used to connect via proxy
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use
       --username string                Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_repocreds.md
+++ b/docs/user-guide/commands/argocd_repocreds.md
@@ -40,7 +40,6 @@ argocd repocreds [flags]
       --password string                Password for basic authentication to the API server
       --proxy-url string               If provided, this URL will be used to connect via proxy
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use
       --username string                Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_version.md
+++ b/docs/user-guide/commands/argocd_version.md
@@ -47,7 +47,6 @@ argocd version [flags]
       --proxy-url string               If provided, this URL will be used to connect via proxy
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --short                          print just the version number
-      --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use
       --username string                Username for basic authentication to the API server


### PR DESCRIPTION
The `--tls-server-name` flag is documented, but no longer used.

Remove all remaining references:
```
$ find docs/ -name '*.md' -execdir sed -i /--tls-server-name/d {} +
$ git grep tls-server-name || echo No matches
No matches
```