### PR TITLE
fix(ci): Inconsistent use of IMAGE_REGISTRY and IMAGE_NAMESPACE Makefile variables (#25846)

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -291,7 +291,6 @@ jobs:
           set -x
           export GOPATH=$(go env GOPATH)
           git checkout -- go.mod go.sum
-          #make IMAGE_NAMESPACE=${{ env.IMAGE_NAMESPACE }} IMAGE_REGISTRY=${{ env.IMAGE_REGISTRY }} IMAGE_REPOSITORY=${{ env.IMAGE_REPOSITORY }} codegen-local
           make codegen-local
         # generalizing repo name for forks:  ${{ github.event.repository.name }}
         working-directory: /home/runner/go/src/github.com/argoproj/${{ github.event.repository.name }}

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -15,6 +15,9 @@ env:
   # Golang version to use across CI steps
   # renovate: datasource=golang-version packageName=golang
   GOLANG_VERSION: '1.25.5'
+  IMAGE_REGISTRY: ${{ vars.IMAGE_REGISTRY || 'quay.io' }}
+  IMAGE_NAMESPACE: ${{ vars.IMAGE_NAMESPACE || 'argoproj' }}
+  IMAGE_REPOSITORY: ${{ vars.IMAGE_REPOSITORY || 'argocd' }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -288,7 +291,8 @@ jobs:
           set -x
           export GOPATH=$(go env GOPATH)
           git checkout -- go.mod go.sum
-          make IMAGE_NAMESPACE=${{ env.IMAGE_NAMESPACE }} IMAGE_REGISTRY=${{ env.IMAGE_REGISTRY }} IMAGE_REPOSITORY=${{ env.IMAGE_REPOSITORY }} codegen-local
+          #make IMAGE_NAMESPACE=${{ env.IMAGE_NAMESPACE }} IMAGE_REGISTRY=${{ env.IMAGE_REGISTRY }} IMAGE_REPOSITORY=${{ env.IMAGE_REPOSITORY }} codegen-local
+          make codegen-local
         # generalizing repo name for forks:  ${{ github.event.repository.name }}
         working-directory: /home/runner/go/src/github.com/argoproj/${{ github.event.repository.name }}
       - name: Check nothing has changed

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -288,7 +288,7 @@ jobs:
           set -x
           export GOPATH=$(go env GOPATH)
           git checkout -- go.mod go.sum
-          make codegen-local
+          make IMAGE_NAMESPACE=${{ env.IMAGE_NAMESPACE }} IMAGE_REGISTRY=${{ env.IMAGE_REGISTRY }} IMAGE_REPOSITORY=${{ env.IMAGE_REPOSITORY }} codegen-local
         # generalizing repo name for forks:  ${{ github.event.repository.name }}
         working-directory: /home/runner/go/src/github.com/argoproj/${{ github.event.repository.name }}
       - name: Check nothing has changed

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -15,9 +15,6 @@ env:
   # Golang version to use across CI steps
   # renovate: datasource=golang-version packageName=golang
   GOLANG_VERSION: '1.25.5'
-  IMAGE_REGISTRY: ${{ vars.IMAGE_REGISTRY || 'quay.io' }}
-  IMAGE_NAMESPACE: ${{ vars.IMAGE_NAMESPACE || 'argoproj' }}
-  IMAGE_REPOSITORY: ${{ vars.IMAGE_REPOSITORY || 'argocd' }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/Makefile
+++ b/Makefile
@@ -219,9 +219,14 @@ else
 $(error IMAGE_NAMESPACE must be set when IMAGE_REGISTRY is set (e.g. IMAGE_NAMESPACE=argoproj))
 endif
 else
-# for backwards compatibility with the old way like IMAGE_NAMESPACE='quay.io/argoproj' 
 ifdef IMAGE_NAMESPACE
+# for backwards compatibility with the old way like IMAGE_NAMESPACE='quay.io/argoproj' 
 IMAGE_PREFIX=${IMAGE_NAMESPACE}/
+else
+# Neither namespace nor registry given - apply the default values
+IMAGE_REGISTRY="quay.io"
+IMAGE_NAMESPACE="argoproj"
+IMAGE_PREFIX=${IMAGE_REGISTRY}/${IMAGE_NAMESPACE}/
 endif
 endif
 

--- a/hack/update-manifests.sh
+++ b/hack/update-manifests.sh
@@ -13,13 +13,25 @@ KUSTOMIZE=kustomize
 cd "${SRCROOT}/manifests/ha/base/redis-ha" && ./generate.sh
 
 # Image repository configuration - can be overridden in forks
-IMAGE_REGISTRY="${IMAGE_REGISTRY:-quay.io}"
-IMAGE_NAMESPACE="${IMAGE_NAMESPACE:-argoproj}"
+IMAGE_REGISTRY="${IMAGE_REGISTRY:-}"
+IMAGE_NAMESPACE="${IMAGE_NAMESPACE:-}"
 IMAGE_REPOSITORY="${IMAGE_REPOSITORY:-argocd}"
 IMAGE_TAG="${IMAGE_TAG:-}"
 
 # Construct full image name
-FULL_IMAGE_NAME="${IMAGE_REGISTRY}/${IMAGE_NAMESPACE}/${IMAGE_REPOSITORY}"
+# Note: keeping same logic as in Makefile for docker images
+FULL_IMAGE_NAME="${IMAGE_REPOSITORY}"
+if [[ -n $IMAGE_NAMESPACE ]]; then
+    # for backwards compatibility with the old way like IMAGE_NAMESPACE='quay.io/argoproj' 
+    FULL_IMAGE_NAME="${IMAGE_NAMESPACE}/${FULL_IMAGE_NAME}"
+fi
+if [[ -n $IMAGE_REGISTRY ]]; then
+    if [[ -z $IMAGE_NAMESPACE ]]; then
+	echo "IMAGE_NAMESPACE must be set when IMAGE_REGISTRY is set (e.g. IMAGE_NAMESPACE=argoproj)" >&2
+	exit 1
+    fi
+    FULL_IMAGE_NAME="${IMAGE_REGISTRY}/${FULL_IMAGE_NAME}"
+fi
 
 # Auto-detect current image in manifests for release workflows
 detect_current_image() {


### PR DESCRIPTION
Fixes #25846

This PR implements the same logic for creating full image tag in both the
`Makefile` (for building docker images) and `hack/update-manifests.sh` script:

`IMAGE_REGISTRY` is used for FQDN of the container registry. If it is not set,  the full tag won't have the registry part. It means that the default registry for the container engine will be used (it's docker.io unless configured otherwise).  If `IMAGE_REGISTRY` is configured while IMAGE_NAMESPACE is not (which does not have much sense) an error is generated.

`IMAGE_NAMESPACE` contains name of user account in the container registry. 
For backward compatibility it can provide both container registry and user account (like `quay.io/johnsmith`). If it not set, the full tag won't have the account part.

`IMAGE_REPOSITORY` contains name of the image (`argocd` by default). Now this parameter is supported for building docker images as well.

The default image parameters for the standard image tag are specified in the Makefile
and the hacks/update-manifests.sh. ArgoCD forks may override those values using the 
GithHub Actions variables.


Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [X] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

