### PR TITLE
fix: error sending generate manifest metadata cmp server

### DIFF
--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -2162,7 +2162,9 @@ func generateManifestsCMP(ctx context.Context, appPath, rootPath string, env []s
 		cmp.WithTarDoneChan(tarDoneCh),
 	}
 
-	err = cmp.SendRepoStream(generateManifestStream.Context(), appPath, rootPath, generateManifestStream, env, tarExcludedGlobs, opts...)
+	// Use the request context (ctx) rather than stream.Context() to avoid prematurely sending into a stream whose
+	// context may have been canceled by the gRPC internals or server-side handling.
+	err = cmp.SendRepoStream(ctx, appPath, rootPath, generateManifestStream, env, tarExcludedGlobs, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("error sending file to cmp-server: %w", err)
 	}
@@ -2384,7 +2386,7 @@ func populatePluginAppDetails(ctx context.Context, res *apiclient.RepoAppDetails
 		return fmt.Errorf("error getting parametersAnnouncementStream: %w", err)
 	}
 
-	err = cmp.SendRepoStream(parametersAnnouncementStream.Context(), appPath, repoPath, parametersAnnouncementStream, env, tarExcludedGlobs)
+	err = cmp.SendRepoStream(ctx, appPath, repoPath, parametersAnnouncementStream, env, tarExcludedGlobs)
 	if err != nil {
 		return fmt.Errorf("error sending file to cmp-server: %w", err)
 	}

--- a/util/app/discovery/discovery.go
+++ b/util/app/discovery/discovery.go
@@ -92,6 +92,7 @@ func DetectConfigManagementPlugin(ctx context.Context, appPath, repoPath, plugin
 	var conn utilio.Closer
 	var cmpClient pluginclient.ConfigManagementPluginServiceClient
 	var connFound bool
+	var lastErr error
 
 	pluginSockFilePath := common.GetPluginSockFilePath()
 	log.WithFields(log.Fields{
@@ -101,8 +102,11 @@ func DetectConfigManagementPlugin(ctx context.Context, appPath, repoPath, plugin
 
 	if pluginName != "" {
 		// check if the given plugin supports the repo
-		conn, cmpClient, connFound = cmpSupports(ctx, pluginSockFilePath, appPath, repoPath, fmt.Sprintf("%v.sock", pluginName), env, tarExcludedGlobs, true)
+		conn, cmpClient, connFound, lastErr = cmpSupports(ctx, pluginSockFilePath, appPath, repoPath, fmt.Sprintf("%v.sock", pluginName), env, tarExcludedGlobs, true)
 		if !connFound {
+			if lastErr != nil {
+				return nil, nil, fmt.Errorf("could not find cmp-server plugin with name %q supporting the given repository: %w", pluginName, lastErr)
+			}
 			return nil, nil, fmt.Errorf("could not find cmp-server plugin with name %q supporting the given repository", pluginName)
 		}
 	} else {
@@ -112,13 +116,16 @@ func DetectConfigManagementPlugin(ctx context.Context, appPath, repoPath, plugin
 		}
 		for _, file := range fileList {
 			if file.Type() == os.ModeSocket {
-				conn, cmpClient, connFound = cmpSupports(ctx, pluginSockFilePath, appPath, repoPath, file.Name(), env, tarExcludedGlobs, false)
+				conn, cmpClient, connFound, lastErr = cmpSupports(ctx, pluginSockFilePath, appPath, repoPath, file.Name(), env, tarExcludedGlobs, false)
 				if connFound {
 					break
 				}
 			}
 		}
 		if !connFound {
+			if lastErr != nil {
+				return nil, nil, fmt.Errorf("could not find plugin supporting the given repository: %w", lastErr)
+			}
 			return nil, nil, errors.New("could not find plugin supporting the given repository")
 		}
 	}
@@ -145,16 +152,20 @@ func matchRepositoryCMP(ctx context.Context, appPath, repoPath string, client pl
 	return resp.GetIsSupported(), resp.GetIsDiscoveryEnabled(), nil
 }
 
-func cmpSupports(ctx context.Context, pluginSockFilePath, appPath, repoPath, fileName string, env []string, tarExcludedGlobs []string, namedPlugin bool) (utilio.Closer, pluginclient.ConfigManagementPluginServiceClient, bool) {
+// cmpSupports checks if the given plugin socket supports the repo. If namedPlugin is true
+// a plugin that is not discovery-configured will be considered a match.
+// Returns a utilio.Closer, the client, a bool indicating a match, and an error describing
+// any lower-level failure that occurred while probing the plugin.
+func cmpSupports(ctx context.Context, pluginSockFilePath, appPath, repoPath, fileName string, env []string, tarExcludedGlobs []string, namedPlugin bool) (utilio.Closer, pluginclient.ConfigManagementPluginServiceClient, bool, error) {
 	absPluginSockFilePath, err := filepath.Abs(pluginSockFilePath)
 	if err != nil {
 		log.Errorf("error getting absolute path for plugin socket dir %v, %v", pluginSockFilePath, err)
-		return nil, nil, false
+		return nil, nil, false, fmt.Errorf("error getting absolute path for plugin socket dir %q: %w", pluginSockFilePath, err)
 	}
 	address := filepath.Join(absPluginSockFilePath, fileName)
 	if !files.Inbound(address, absPluginSockFilePath) {
 		log.Errorf("invalid socket file path, %v is outside plugin socket dir %v", fileName, pluginSockFilePath)
-		return nil, nil, false
+		return nil, nil, false, fmt.Errorf("invalid socket file path, %q is outside plugin socket dir %q", fileName, pluginSockFilePath)
 	}
 
 	cmpclientset := pluginclient.NewConfigManagementPluginClientSet(address)
@@ -165,23 +176,23 @@ func cmpSupports(ctx context.Context, pluginSockFilePath, appPath, repoPath, fil
 			common.SecurityField:    common.SecurityMedium,
 			common.SecurityCWEField: common.SecurityCWEMissingReleaseOfFileDescriptor,
 		}).Errorf("error dialing to cmp-server for plugin %s, %v", fileName, err)
-		return nil, nil, false
+		return nil, nil, false, fmt.Errorf("error dialing to cmp-server for plugin %s: %w", fileName, err)
 	}
 
 	cfg, err := cmpClient.CheckPluginConfiguration(ctx, &empty.Empty{})
 	if err != nil {
 		log.Errorf("error checking plugin configuration %s, %v", fileName, err)
 		utilio.Close(conn)
-		return nil, nil, false
+		return nil, nil, false, fmt.Errorf("error checking plugin configuration %s: %w", fileName, err)
 	}
 
 	if !cfg.IsDiscoveryConfigured {
 		// If discovery isn't configured but the plugin is named, then the plugin supports the repo.
 		if namedPlugin {
-			return conn, cmpClient, true
+			return conn, cmpClient, true, nil
 		}
 		utilio.Close(conn)
-		return nil, nil, false
+		return nil, nil, false, nil
 	}
 
 	isSupported, isDiscoveryEnabled, err := matchRepositoryCMP(ctx, appPath, repoPath, cmpClient, env, tarExcludedGlobs)
@@ -191,20 +202,20 @@ func cmpSupports(ctx context.Context, pluginSockFilePath, appPath, repoPath, fil
 			common.SecurityCWEField: common.SecurityCWEMissingReleaseOfFileDescriptor,
 		}).Errorf("repository %s is not the match because %v", repoPath, err)
 		utilio.Close(conn)
-		return nil, nil, false
+		return nil, nil, false, fmt.Errorf("error checking repository support for plugin %s: %w", fileName, err)
 	}
 
 	if !isSupported {
 		// if discovery is not set and the plugin name is specified, let app use the plugin
 		if !isDiscoveryEnabled && namedPlugin {
-			return conn, cmpClient, true
+			return conn, cmpClient, true, nil
 		}
 		log.WithFields(log.Fields{
 			common.SecurityField:    common.SecurityLow,
 			common.SecurityCWEField: common.SecurityCWEMissingReleaseOfFileDescriptor,
 		}).Debugf("Response from socket file %s does not support %v", fileName, repoPath)
 		utilio.Close(conn)
-		return nil, nil, false
+		return nil, nil, false, nil
 	}
-	return conn, cmpClient, true
+	return conn, cmpClient, true, nil
 }

--- a/util/cmp/stream.go
+++ b/util/cmp/stream.go
@@ -98,7 +98,7 @@ func SendRepoStream(ctx context.Context, appPath, rootPath string, sender Stream
 	if err != nil {
 		// include ctx.Err() in the message to make cancellations/deadlines visible
 		if ctx != nil && ctx.Err() != nil {
-			return fmt.Errorf("error sending generate manifest metadata to cmp-server: %w (stream ctx err: %v)", err, ctx.Err())
+			return fmt.Errorf("error sending generate manifest metadata to cmp-server: %w (stream ctx err: %w)", err, ctx.Err())
 		}
 		return fmt.Errorf("error sending generate manifest metadata to cmp-server: %w", err)
 	}

--- a/util/cmp/stream.go
+++ b/util/cmp/stream.go
@@ -96,6 +96,10 @@ func SendRepoStream(ctx context.Context, appPath, rootPath string, sender Stream
 	defer tgzstream.CloseAndDelete(tgz)
 	err = sender.Send(mr)
 	if err != nil {
+		// include ctx.Err() in the message to make cancellations/deadlines visible
+		if ctx != nil && ctx.Err() != nil {
+			return fmt.Errorf("error sending generate manifest metadata to cmp-server: %w (stream ctx err: %v)", err, ctx.Err())
+		}
 		return fmt.Errorf("error sending generate manifest metadata to cmp-server: %w", err)
 	}
 


### PR DESCRIPTION
Closes #25511 

## This PR has a two-level fix 

### The first commit addresses the actual issue as described below
reposerver tries to detect the CMP sidecar (`DetectConfigManagementPlugin`). If the detection fails, it returns: "could not find cmp-server plugin with name %q supporting the given repository". That is exactly the message in the user's logs.

If detect succeeds, reposerver opens a GenerateManifest stream: 
`generateManifestStream, err := cmpClient.GenerateManifest(ctx, grpc_retry.Disable())`
It then calls `SendRepoStream` to send metadata, but the code currently passes this `generateManifestStream.Context()` as context. If this context is by any reason cancelled/closed early on the server-side (for any reason) the client-side will return an error (sometimes io.EOF), which is wrapped and logged as: "error sending generate manifest metadata to cmp-server: EOF". The PR now uses the original context. 

### The second commit improves the diagnostic/debugging level of `DetectConfigManagementPlugin` function as below
Currently, `DetectConfigManagementPlugin` returns a generic error when a named plugin is not found/usable: "could not find cmp-server plugin with name %q supporting the given repository". `cmpSupports` function logs detailed reasons but does not return the concrete error to the caller. 

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
