### PR TITLE
test(e2e): CMP test fails locally on Mac

### DIFF
--- a/test/e2e/testdata/cmp-gitsshcreds-disable-provide/generate.sh
+++ b/test/e2e/testdata/cmp-gitsshcreds-disable-provide/generate.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
-FILE=$(echo "$GIT_SSH_COMMAND" | grep -oP '\-i \K[/\w]+')
+# Extract the file path after -i from GIT_SSH_COMMAND
+FILE=$(echo "$GIT_SSH_COMMAND" | sed -n 's/.*-i \([^ ]*\).*/\1/p')
 GIT_SSH_CRED_FILE_SHA=$(sha256sum "${FILE}")
 echo "{\"kind\": \"ConfigMap\", \"apiVersion\": \"v1\", \"metadata\": { \"name\": \"$ARGOCD_APP_NAME\", \"namespace\": \"$ARGOCD_APP_NAMESPACE\", \"annotations\": {\"GitSSHCommand\":\"$GIT_SSH_COMMAND\", \"GitSSHCredsFileSHA\":\"$GIT_SSH_CRED_FILE_SHA\"}}}"

--- a/test/e2e/testdata/cmp-gitsshcreds/generate.sh
+++ b/test/e2e/testdata/cmp-gitsshcreds/generate.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
-FILE=$(echo "$GIT_SSH_COMMAND" | grep -oP '\-i \K[/\w]+')
+# Extract the file path after -i from GIT_SSH_COMMAND
+FILE=$(echo "$GIT_SSH_COMMAND" | sed -n 's/.*-i \([^ ]*\).*/\1/p')
 GIT_SSH_CRED_FILE_SHA=$(sha256sum "${FILE}")
 echo "{\"kind\": \"ConfigMap\", \"apiVersion\": \"v1\", \"metadata\": { \"name\": \"$ARGOCD_APP_NAME\", \"namespace\": \"$ARGOCD_APP_NAMESPACE\", \"annotations\": {\"GitSSHCommand\":\"$GIT_SSH_COMMAND\", \"GitSSHCredsFileSHA\":\"$GIT_SSH_CRED_FILE_SHA\"}}}"


### PR DESCRIPTION
on MacOS

```
echo "" | grep -oP '\-i \K[/\w]+' 

grep: invalid option -- P
usage: grep [-abcdDEFGHhIiJLlMmnOopqRSsUVvwXxZz] [-A num] [-B num] [-C[num]]
        [-e pattern] [-f file] [--binary-files=value] [--color=when]
        [--context[=num]] [--directories=action] [--label] [--line-buffered]
        [--null] [pattern] [file ...]
```