### PR TITLE
test(e2e): fix TestDeletionConfirmation flakiness

### DIFF
--- a/test/e2e/fixture/app/actions.go
+++ b/test/e2e/fixture/app/actions.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"slices"
 	"strconv"
+	"time"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 
@@ -439,6 +440,10 @@ func (a *Actions) ConfirmDeletion() *Actions {
 	a.context.t.Helper()
 
 	a.runCli("app", "confirm-deletion", a.context.AppQualifiedName())
+
+	// Always sleep more than a second after the confirmation so the timestamp
+	// is not valid for immediate subsequent operations
+	time.Sleep(1500 * time.Millisecond)
 
 	return a
 }

--- a/test/e2e/fixture/app/expectation.go
+++ b/test/e2e/fixture/app/expectation.go
@@ -272,6 +272,16 @@ func DoesNotExistNow() Expectation {
 	}
 }
 
+func App(predicate func(app *v1alpha1.Application) bool) Expectation {
+	return func(c *Consequences) (state, string) {
+		app := c.app().DeepCopy()
+		if predicate(app) {
+			return succeeded, "app predicate matches"
+		}
+		return pending, "app predicate does not match"
+	}
+}
+
 func Pod(predicate func(p corev1.Pod) bool) Expectation {
 	return func(_ *Consequences) (state, string) {
 		pods, err := pods()


### PR DESCRIPTION
Seems like the problem is because argocd.argoproj.io/deletion-approved: <timestamp> is used for both pruning and app deletion. Since we confirm the pruning just before deleting the application, the confirmed deletion executed for the pruning will still be valid for the delete, causing the app to be deleted without confirmation