### PR TITLE
fix(engine): correctly set prune confirmation message in setRunningPhase

### DIFF
--- a/gitops-engine/pkg/sync/sync_context.go
+++ b/gitops-engine/pkg/sync/sync_context.go
@@ -422,9 +422,22 @@ func (sc *syncContext) setRunningPhase(tasks syncTasks, isPendingDeletion bool) 
 	} else {
 		firstTask = resources[0]
 	}
+	nbAdditionalTask := tasks.Len() - 1
+
+	if !sc.pruneConfirmed {
+		tasksToPrune := tasks.Filter(func(task *syncTask) bool {
+			return task.isPrune() && resourceutil.HasAnnotationOption(task.liveObj, common.AnnotationSyncOptions, common.SyncOptionPruneRequireConfirm)
+		})
+
+		if len(tasksToPrune) > 0 {
+			reason = "pruning confirmation of"
+			firstTask = tasksToPrune[0]
+			nbAdditionalTask = len(tasksToPrune) - 1
+		}
+	}
 
 	message := fmt.Sprintf("waiting for %s %s/%s/%s", reason, firstTask.group(), firstTask.kind(), firstTask.name())
-	if nbAdditionalTask := len(tasks) - 1; nbAdditionalTask > 0 {
+	if nbAdditionalTask > 0 {
 		message = fmt.Sprintf("%s and %d more %s", message, nbAdditionalTask, taskType)
 	}
 	sc.setOperationPhase(common.OperationRunning, message)
@@ -1487,20 +1500,11 @@ func (sc *syncContext) runTasks(tasks syncTasks, dryRun bool) runState {
 	// prune first
 	{
 		if !sc.pruneConfirmed {
-			var resources []string
 			for _, task := range pruneTasks {
 				if resourceutil.HasAnnotationOption(task.liveObj, common.AnnotationSyncOptions, common.SyncOptionPruneRequireConfirm) {
-					resources = append(resources, fmt.Sprintf("%s/%s/%s", task.obj().GetAPIVersion(), task.obj().GetKind(), task.name()))
+					sc.log.WithValues("task", task).Info("Prune requires confirmation")
+					return pending
 				}
-			}
-			if len(resources) > 0 {
-				sc.log.WithValues("resources", resources).Info("Prune requires confirmation")
-				andMessage := ""
-				if len(resources) > 1 {
-					andMessage = fmt.Sprintf(" and %d more resources", len(resources)-1)
-				}
-				sc.message = fmt.Sprintf("Waiting for pruning confirmation of %s%s", resources[0], andMessage)
-				return pending
 			}
 		}
 

--- a/gitops-engine/pkg/sync/sync_context_test.go
+++ b/gitops-engine/pkg/sync/sync_context_test.go
@@ -850,6 +850,33 @@ func TestDoNotPrunePruneFalse(t *testing.T) {
 	assert.Equal(t, synccommon.OperationSucceeded, phase)
 }
 
+func TestPruneConfirm(t *testing.T) {
+	syncCtx := newTestSyncCtx(nil, WithOperationSettings(false, true, false, false))
+	pod := testingutils.NewPod()
+	pod.SetAnnotations(map[string]string{synccommon.AnnotationSyncOptions: "Prune=confirm"})
+	pod.SetNamespace(testingutils.FakeArgoCDNamespace)
+	syncCtx.resources = groupResources(ReconciliationResult{
+		Live:   []*unstructured.Unstructured{pod},
+		Target: []*unstructured.Unstructured{nil},
+	})
+
+	syncCtx.Sync()
+	phase, msg, resources := syncCtx.GetState()
+
+	assert.Equal(t, synccommon.OperationRunning, phase)
+	assert.Empty(t, resources)
+	assert.Equal(t, "waiting for pruning confirmation of /Pod/my-pod", msg)
+
+	syncCtx.pruneConfirmed = true
+	syncCtx.Sync()
+
+	phase, _, resources = syncCtx.GetState()
+	assert.Equal(t, synccommon.OperationSucceeded, phase)
+	assert.Len(t, resources, 1)
+	assert.Equal(t, synccommon.ResultCodePruned, resources[0].Status)
+	assert.Equal(t, "pruned", resources[0].Message)
+}
+
 // // make sure Validate=false means we don't validate
 func TestSyncOptionValidate(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION


<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->

Restore the behavior before commit 95d19f2ed to not force the message to an empty string if the tasks slice is empty. This broke the Prune=confirm features that set a message but get overwritten here. Also add a Prune=confirm unit test to prevent further regression.