### PR TITLE
docs: fix description of argocd_oci_request_duration_seconds metric

### DIFF
--- a/docs/operator-manual/metrics.md
+++ b/docs/operator-manual/metrics.md
@@ -264,7 +264,7 @@ Scraped at the `argocd-repo-server:8084/metrics` endpoint.
 | `argocd_redis_request_total`             |  counter   | Number of Kubernetes requests executed during application reconciliation. |
 | `argocd_repo_pending_request_total`      |   gauge    | Number of pending requests requiring repository lock                      |
 | `argocd_oci_request_total`               |  counter   | Number of OCI requests performed by repo server                           |
-| `argocd_oci_request_duration_seconds`    | histogram  | Number of OCI fetch requests failures by repo server                      |
+| `argocd_oci_request_duration_seconds`    | histogram  | Duration of OCI requests performed by the repo server.                      |
 | `argocd_oci_test_repo_fail_total`        |  counter   | Number of OCI test repo requests failures by repo server                  |
 | `argocd_oci_get_tags_fail_total`         |  counter   | Number of OCI get tags requests failures by repo server                   |
 | `argocd_oci_digest_metadata_fail_total`  |  counter   | Number of OCI digest metadata failures by repo server                     |


### PR DESCRIPTION
This PR fixes a documentation inconsistency in the metrics reference.

`argocd_oci_request_duration_seconds` is defined as a histogram and represents request latency, but the documentation previously described it as a failure count. Failure-related metrics already exist as `*_fail_total`.

This change updates the description to accurately reflect the metric semantics.

Fixes #25912
