### PR TITLE
docs: fix garbled text in cluster bootstrapping helm example

### DIFF
--- a/docs/operator-manual/cluster-bootstrapping.md
+++ b/docs/operator-manual/cluster-bootstrapping.md
@@ -56,9 +56,12 @@ spec:
     path: guestbook
     repoURL: https://github.com/argoproj/argocd-example-apps
     targetRevision: HEAD
-``` 
+  syncPolicy:
+    automated:
+      prune: true
+```
 
-The sync policy to automated + prune, so that child apps are automatically created, synced, and deleted when the manifest is changed, but you may wish to disable this. I've also added the finalizer, which will ensure that your apps are deleted correctly.
+This example sets the sync policy to automated with pruning enabled, so child apps are automatically created, synced, and deleted when the parent app's manifest changes. You may wish to disable automated sync for more control over when changes are applied. The finalizer ensures that child app resources are properly cleaned up on deletion.
 
 Fix the revision to a specific Git commit SHA to make sure that, even if the child apps repo changes, the app will only change when the parent app change that revision. Alternatively, you can set it to HEAD or a branch name.
 


### PR DESCRIPTION
## Summary
- Add missing `syncPolicy` section to the Helm example YAML
- Rewrite explanatory paragraph for clarity (was missing verb, used informal language)
- Align documentation with what the text describes

## Motivation
The current text says "The sync policy to automated + prune..." which is missing a verb and references a syncPolicy that isn't shown in the example YAML.

**Before:**
> The sync policy to automated + prune, so that child apps are automatically created, synced, and deleted when the manifest is changed, but you may wish to disable this. I've also added the finalizer...

**After:**
> This example sets the sync policy to automated with pruning enabled, so child apps are automatically created, synced, and deleted when the parent app's manifest changes. You may wish to disable automated sync for more control over when changes are applied. The finalizer ensures that child app resources are properly cleaned up on deletion.

Fixes #25648

## Checklist
- [x] The title of the PR states what changed and the related issues number (if any)
- [x] Does this PR require documentation updates? N/A (this IS documentation)
- [x] I've updated documentation as required by this PR
- [x] I have signed off all my commits as required ([DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal))