### PR TITLE
fix: Remove default BeforeHookCreation hook deletion policy

### DIFF
--- a/controller/hook.go
+++ b/controller/hook.go
@@ -226,17 +226,12 @@ func (ctrl *ApplicationController) cleanupHooks(hookType HookType, liveObjs map[
 		deletePolicies := hook.DeletePolicies(obj)
 		shouldDelete := false
 
-		if len(deletePolicies) == 0 {
-			// If no delete policy is specified, always delete hooks during cleanup phase
-			shouldDelete = true
-		} else {
-			// Check if any delete policy matches the current hook state
-			for _, policy := range deletePolicies {
-				if (policy == common.HookDeletePolicyHookFailed && aggregatedHealth == health.HealthStatusDegraded) ||
-					(policy == common.HookDeletePolicyHookSucceeded && aggregatedHealth == health.HealthStatusHealthy) {
-					shouldDelete = true
-					break
-				}
+		// Only delete hooks if they have an explicit deletion policy that matches the current state
+		for _, policy := range deletePolicies {
+			if (policy == common.HookDeletePolicyHookFailed && aggregatedHealth == health.HealthStatusDegraded) ||
+				(policy == common.HookDeletePolicyHookSucceeded && aggregatedHealth == health.HealthStatusHealthy) {
+				shouldDelete = true
+				break
 			}
 		}
 

--- a/gitops-engine/pkg/sync/doc.go
+++ b/gitops-engine/pkg/sync/doc.go
@@ -37,8 +37,9 @@ The annotation value indicates the sync operation phase:
   - SyncFail - executes when the sync operation fails.
   - Sync - executes after all PreSync hooks completed and were successful, at the same time as the apply of the manifests.
 
-Named hooks (i.e. ones with /metadata/name) will only be created once. If you want a hook to be re-created each time
-either use BeforeHookCreation policy (see below) or /metadata/generateName.
+Named hooks (i.e. ones with /metadata/name) will only be created once and will persist across syncs unless explicitly
+deleted using a hook deletion policy (see below). If you want a hook to be re-created each time, use /metadata/generateName
+or the BeforeHookCreation deletion policy.
 
 The same resource hook might be executed in several sync phases:
 
@@ -59,12 +60,16 @@ Hooks can be deleted in an automatic fashion using the annotation: argocd.argopr
 	    argocd.argoproj.io/hook: PostSync
 	    argocd.argoproj.io/hook-delete-policy: HookSucceeded
 
-Hook deletion policies are governed by sync success and failure. A successful sync operation requires all hooks to complete successfully. A sync will fail if _any_ hooks fail.
-The following policies define when the hook will be deleted.
+By default, hook resources are NOT automatically deleted and will persist in the cluster. Hook deletion policies allow
+you to control when hooks should be automatically deleted. Policies are governed by sync success and failure. A successful
+sync operation requires all hooks to complete successfully. A sync will fail if _any_ hooks fail.
+The following policies define when the hook will be deleted:
 
   - HookSucceeded - the hook resource is deleted if the sync succeeds
   - HookFailed - the hook resource is deleted if the sync fails.
   - BeforeHookCreation - the hook resource is deleted if it exist at the start of the sync.
+
+Note: If no deletion policy is specified, hooks will persist and must be manually deleted or pruned.
 
 # Sync Waves
 

--- a/gitops-engine/pkg/sync/hook/delete_policy.go
+++ b/gitops-engine/pkg/sync/hook/delete_policy.go
@@ -19,8 +19,6 @@ func DeletePolicies(obj *unstructured.Unstructured) []common.HookDeletePolicy {
 	for _, p := range helmhook.DeletePolicies(obj) {
 		policies = append(policies, p.DeletePolicy())
 	}
-	if len(policies) == 0 {
-		policies = append(policies, common.HookDeletePolicyBeforeHookCreation)
-	}
+	// No default deletion policy - hooks should only be deleted when explicitly configured
 	return policies
 }

--- a/gitops-engine/pkg/sync/hook/delete_policy_test.go
+++ b/gitops-engine/pkg/sync/hook/delete_policy_test.go
@@ -10,8 +10,9 @@ import (
 )
 
 func TestDeletePolicies(t *testing.T) {
-	assert.Equal(t, []common.HookDeletePolicy{common.HookDeletePolicyBeforeHookCreation}, DeletePolicies(testingutils.NewPod()))
-	assert.Equal(t, []common.HookDeletePolicy{common.HookDeletePolicyBeforeHookCreation}, DeletePolicies(testingutils.Annotate(testingutils.NewPod(), "argocd.argoproj.io/hook-delete-policy", "garbage")))
+	// No default deletion policy - hooks are only deleted when explicitly configured
+	assert.Empty(t, DeletePolicies(testingutils.NewPod()))
+	assert.Empty(t, DeletePolicies(testingutils.Annotate(testingutils.NewPod(), "argocd.argoproj.io/hook-delete-policy", "garbage")))
 	assert.Equal(t, []common.HookDeletePolicy{common.HookDeletePolicyBeforeHookCreation}, DeletePolicies(testingutils.Annotate(testingutils.NewPod(), "argocd.argoproj.io/hook-delete-policy", "BeforeHookCreation")))
 	assert.Equal(t, []common.HookDeletePolicy{common.HookDeletePolicyHookSucceeded}, DeletePolicies(testingutils.Annotate(testingutils.NewPod(), "argocd.argoproj.io/hook-delete-policy", "HookSucceeded")))
 	assert.Equal(t, []common.HookDeletePolicy{common.HookDeletePolicyHookFailed}, DeletePolicies(testingutils.Annotate(testingutils.NewPod(), "argocd.argoproj.io/hook-delete-policy", "HookFailed")))


### PR DESCRIPTION
## Summary

This PR removes the default deletion policy for resources with hook annotations. Resources with hook annotations should not be automatically deleted when only the hook phase annotation is specified.

## Motivation

Previously, **resources with hook annotations** would be automatically deleted due to two different mechanisms:

1. **Resources with sync hook annotations** (PreSync, PostSync, Sync, SyncFail) had an automatic `BeforeHookCreation` deletion policy applied in the gitops-engine
2. **Resources with delete hook annotations** (PreDelete, PostDelete) were automatically deleted during the cleanup phase in the controller

This was unexpected behavior because:
- The hook annotation primarily controls **when** resources are synced (timing/phase), not their lifecycle
- Automatic deletion should be explicit, not default
- It caused confusion and loss of state for resources with hook annotations
- Users expected these resources to persist unless explicitly configured otherwise

## Changes

### 1. gitops-engine/pkg/sync/hook/delete_policy.go
Removed the automatic assignment of `BeforeHookCreation` deletion policy when no policy is specified:

**Before:**
```go
if len(policies) == 0 {
    policies = append(policies, common.HookDeletePolicyBeforeHookCreation)
}
```

**After:**
```go
// No default deletion policy - hook resources should only be deleted when explicitly configured
return policies
```

### 2. controller/hook.go
Removed the auto-deletion logic in the `cleanupHooks` function for resources with PreDelete/PostDelete hook annotations:

**Before:**
```go
if len(deletePolicies) == 0 {
    // If no delete policy is specified, always delete hooks during cleanup phase
    shouldDelete = true
}
```

**After:**
```go
// Only delete hook resources if they have an explicit deletion policy that matches the current state
for _, policy := range deletePolicies {
    if (policy == common.HookDeletePolicyHookFailed && aggregatedHealth == health.HealthStatusDegraded) ||
        (policy == common.HookDeletePolicyHookSucceeded && aggregatedHealth == health.HealthStatusHealthy) {
        shouldDelete = true
        break
    }
}
```

### 3. Updated Tests and Documentation
- Updated unit tests in `gitops-engine/pkg/sync/hook/delete_policy_test.go`
- Updated documentation in `gitops-engine/pkg/sync/doc.go` to clarify that resources with hook annotations are NOT deleted by default

## Behavior Changes

### Before this PR:
```yaml
apiVersion: batch/v1
kind: Job
metadata:
  annotations:
    argocd.argoproj.io/hook: PreSync
```
☠️ This **Job resource** would be **automatically deleted and recreated** on every sync

### After this PR:
```yaml
apiVersion: batch/v1
kind: Job
metadata:
  annotations:
    argocd.argoproj.io/hook: PreSync
```
✅ This **Job resource** will **persist** across syncs

### To get the old auto-delete behavior:
```yaml
apiVersion: batch/v1
kind: Job
metadata:
  annotations:
    argocd.argoproj.io/hook: PreSync
    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation  # Explicit deletion policy
```

## Testing

- ✅ All unit tests in `gitops-engine/pkg/sync/hook` pass
- ✅ All unit tests in `gitops-engine/pkg/sync` pass
- ✅ All controller tests pass
- ✅ No linter errors

## Migration Guide

For users who relied on the old default behavior and want resources with hook annotations to be deleted before recreation, add an explicit deletion policy:

```yaml
apiVersion: batch/v1
kind: Job
metadata:
  annotations:
    argocd.argoproj.io/hook: PreSync
    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation  # Add this
```

Available deletion policies:
- `BeforeHookCreation` - Delete the resource before creating it (old default behavior)
- `HookSucceeded` - Delete the resource after it succeeds
- `HookFailed` - Delete the resource after it fails

## Impact

This is a **behavior change** that makes ArgoCD more intuitive:
- Resources with hook annotations are treated like any other resource - they persist by default
- Deletion must be explicitly configured via the hook-delete-policy annotation
- Aligns with user expectations
- Reduces surprise and confusion

## Related Issues

Fixes #25956

## Checklist

- [x] Code changes made
- [x] Tests updated
- [x] Documentation updated
- [x] All tests passing
- [x] No linter errors
- [x] Commits signed-off (DCO)