### PR TITLE
test: Add unit test for admin export CLI

### DIFF
--- a/cmd/argocd/commands/admin/backup.go
+++ b/cmd/argocd/commands/admin/backup.go
@@ -556,11 +556,10 @@ func exportData(ctx context.Context, client dynamic.Interface, acdClients *argoC
 	}
 	applicationSets, err := acdClients.applicationSets.List(ctx, metav1.ListOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
-		if apierrors.IsForbidden(err) {
-			log.Warn(err)
-		} else {
+		if !apierrors.IsForbidden(err) {
 			return err
 		}
+		log.Warn(err)
 	}
 	if applicationSets != nil {
 		for _, appSet := range applicationSets.Items {

--- a/cmd/argocd/commands/admin/backup_test.go
+++ b/cmd/argocd/commands/admin/backup_test.go
@@ -2,23 +2,21 @@ package admin
 
 import (
 	"bytes"
+	"context"
 	"testing"
-
-	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
-	"github.com/argoproj/argo-cd/v3/util/security"
 
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
-	"github.com/argoproj/argo-cd/v3/common"
-
-	"context"
-
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic/fake"
+
+	"github.com/argoproj/argo-cd/v3/common"
+	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v3/util/security"
 )
 
 func newBackupObject(trackingValue string, trackingLabel bool, trackingAnnotation bool) *unstructured.Unstructured {
@@ -591,7 +589,7 @@ func TestExportData(t *testing.T) {
 	var buf bytes.Buffer
 	// Call exportData with the fake client
 	err := exportData(context.Background(), fakeDyn, acdClients, &buf, "argocd", nil, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	output := buf.String()
 


### PR DESCRIPTION
Refactors `export` command logic to `exportData` function and adds `TestExportData` unit test.

Closes #21895

Description of changes:
This PR refactors the `argocd admin export` command logic by extracting the main export workflow from the `Run` closure into a separate, testable `exportData` function. This enables Dependency Injection of `dynamic.Interface` and `argoCDClientsets`.

Added `TestExportData` in `backup_test.go` which:
1. Creates a fake dynamic client populated with mock resources (ConfigMaps, Secrets, Applications, AppProjects).
2. Executes `exportData` using these fake clients.
3. Asserts that the output YAML contains the expected exported resources.

This satisfies the requirement to unit test the admin export CLI logic without relying on integration tests or real clusters.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).
