### PR TITLE
fix: add client address to session token verification errors

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1178,7 +1178,8 @@ func (server *ArgoCDServer) newHTTPServer(ctx context.Context, port int, grpcWeb
 	// we use our own Marshaler
 	gwMuxOpts := runtime.WithMarshalerOption(runtime.MIMEWildcard, new(grpc_util.JSONMarshaler))
 	gwCookieOpts := runtime.WithForwardResponseOption(server.translateGrpcCookieHeader)
-	gwmux := runtime.NewServeMux(gwMuxOpts, gwCookieOpts)
+	gwClientAddrOpts := grpc_util.WithClientAddrMetadata()
+	gwmux := runtime.NewServeMux(gwMuxOpts, gwCookieOpts, gwClientAddrOpts)
 
 	var handler http.Handler = gwmux
 	if server.EnableGZip {

--- a/util/grpc/grpc.go
+++ b/util/grpc/grpc.go
@@ -190,8 +190,8 @@ func ClientIPFromHTTPRequest(r *http.Request) string {
 	// Check X-Forwarded-For header (can contain multiple IPs, first is the client)
 	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
 		// X-Forwarded-For can be a comma-separated list; take the first one
-		if idx := strings.Index(xff, ","); idx != -1 {
-			return strings.TrimSpace(xff[:idx])
+		if first, _, found := strings.Cut(xff, ","); found {
+			return strings.TrimSpace(first)
 		}
 		return strings.TrimSpace(xff)
 	}

--- a/util/grpc/grpc_test.go
+++ b/util/grpc/grpc_test.go
@@ -2,11 +2,13 @@ package grpc
 
 import (
 	"context"
+	"net"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/peer"
 )
 
 var proxyEnvKeys = []string{"ALL_PROXY", "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"}
@@ -102,6 +104,111 @@ func TestBlockingDial_ProxyEnvironmentHandling(t *testing.T) {
 				assert.NotNil(t, conn)
 				require.NoError(t, conn.Close())
 			}
+		})
+	}
+}
+
+func TestClientAddrFromContext(t *testing.T) {
+	tests := []struct {
+		name     string
+		setupCtx func() context.Context
+		expected string
+	}{
+		{
+			name: "Context with peer info",
+			setupCtx: func() context.Context {
+				addr, _ := net.ResolveTCPAddr("tcp", "192.168.1.100:54321")
+				p := &peer.Peer{Addr: addr}
+				return peer.NewContext(context.Background(), p)
+			},
+			expected: "192.168.1.100:54321",
+		},
+		{
+			name:     "Context without peer info",
+			setupCtx: context.Background,
+			expected: "unknown",
+		},
+		{
+			name: "Context with nil peer address",
+			setupCtx: func() context.Context {
+				p := &peer.Peer{Addr: nil}
+				return peer.NewContext(context.Background(), p)
+			},
+			expected: "unknown",
+		},
+		{
+			name: "Context with IPv6 address",
+			setupCtx: func() context.Context {
+				addr, _ := net.ResolveTCPAddr("tcp", "[::1]:8080")
+				p := &peer.Peer{Addr: addr}
+				return peer.NewContext(context.Background(), p)
+			},
+			expected: "[::1]:8080",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := tt.setupCtx()
+			result := ClientAddrFromContext(ctx)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestClientIPFromContext(t *testing.T) {
+	tests := []struct {
+		name     string
+		setupCtx func() context.Context
+		expected string
+	}{
+		{
+			name: "Context with IPv4 peer info",
+			setupCtx: func() context.Context {
+				addr, _ := net.ResolveTCPAddr("tcp", "192.168.1.100:54321")
+				p := &peer.Peer{Addr: addr}
+				return peer.NewContext(context.Background(), p)
+			},
+			expected: "192.168.1.100",
+		},
+		{
+			name:     "Context without peer info",
+			setupCtx: context.Background,
+			expected: "unknown",
+		},
+		{
+			name: "Context with nil peer address",
+			setupCtx: func() context.Context {
+				p := &peer.Peer{Addr: nil}
+				return peer.NewContext(context.Background(), p)
+			},
+			expected: "unknown",
+		},
+		{
+			name: "Context with IPv6 address",
+			setupCtx: func() context.Context {
+				addr, _ := net.ResolveTCPAddr("tcp", "[::1]:8080")
+				p := &peer.Peer{Addr: addr}
+				return peer.NewContext(context.Background(), p)
+			},
+			expected: "::1",
+		},
+		{
+			name: "Context with localhost",
+			setupCtx: func() context.Context {
+				addr, _ := net.ResolveTCPAddr("tcp", "127.0.0.1:12345")
+				p := &peer.Peer{Addr: addr}
+				return peer.NewContext(context.Background(), p)
+			},
+			expected: "127.0.0.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := tt.setupCtx()
+			result := ClientIPFromContext(ctx)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/util/grpc/grpc_test.go
+++ b/util/grpc/grpc_test.go
@@ -251,7 +251,7 @@ func TestClientIPFromHTTPRequest(t *testing.T) {
 		{
 			name: "X-Forwarded-For header with single IP",
 			setupReq: func() *http.Request {
-				req, _ := http.NewRequest("GET", "/", nil)
+				req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/", http.NoBody)
 				req.Header.Set("X-Forwarded-For", "203.0.113.195")
 				req.RemoteAddr = "10.0.0.1:12345"
 				return req
@@ -261,7 +261,7 @@ func TestClientIPFromHTTPRequest(t *testing.T) {
 		{
 			name: "X-Forwarded-For header with multiple IPs",
 			setupReq: func() *http.Request {
-				req, _ := http.NewRequest("GET", "/", nil)
+				req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/", http.NoBody)
 				req.Header.Set("X-Forwarded-For", "203.0.113.195, 70.41.3.18, 150.172.238.178")
 				req.RemoteAddr = "10.0.0.1:12345"
 				return req
@@ -271,7 +271,7 @@ func TestClientIPFromHTTPRequest(t *testing.T) {
 		{
 			name: "X-Real-IP header",
 			setupReq: func() *http.Request {
-				req, _ := http.NewRequest("GET", "/", nil)
+				req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/", http.NoBody)
 				req.Header.Set("X-Real-IP", "203.0.113.195")
 				req.RemoteAddr = "10.0.0.1:12345"
 				return req
@@ -281,7 +281,7 @@ func TestClientIPFromHTTPRequest(t *testing.T) {
 		{
 			name: "X-Forwarded-For takes precedence over X-Real-IP",
 			setupReq: func() *http.Request {
-				req, _ := http.NewRequest("GET", "/", nil)
+				req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/", http.NoBody)
 				req.Header.Set("X-Forwarded-For", "203.0.113.195")
 				req.Header.Set("X-Real-IP", "70.41.3.18")
 				req.RemoteAddr = "10.0.0.1:12345"
@@ -292,7 +292,7 @@ func TestClientIPFromHTTPRequest(t *testing.T) {
 		{
 			name: "Fallback to RemoteAddr",
 			setupReq: func() *http.Request {
-				req, _ := http.NewRequest("GET", "/", nil)
+				req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/", http.NoBody)
 				req.RemoteAddr = "10.0.0.1:12345"
 				return req
 			},
@@ -301,7 +301,7 @@ func TestClientIPFromHTTPRequest(t *testing.T) {
 		{
 			name: "X-Forwarded-For with spaces",
 			setupReq: func() *http.Request {
-				req, _ := http.NewRequest("GET", "/", nil)
+				req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/", http.NoBody)
 				req.Header.Set("X-Forwarded-For", "  203.0.113.195  ")
 				req.RemoteAddr = "10.0.0.1:12345"
 				return req

--- a/util/grpc/grpc_test.go
+++ b/util/grpc/grpc_test.go
@@ -3,11 +3,13 @@ package grpc
 import (
 	"context"
 	"net"
+	"net/http"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 )
 
@@ -145,6 +147,25 @@ func TestClientAddrFromContext(t *testing.T) {
 			},
 			expected: "[::1]:8080",
 		},
+		{
+			name: "Context with metadata (HTTP via grpc-gateway)",
+			setupCtx: func() context.Context {
+				md := metadata.Pairs(MetadataKeyClientAddr, "10.0.0.1:12345")
+				return metadata.NewIncomingContext(context.Background(), md)
+			},
+			expected: "10.0.0.1:12345",
+		},
+		{
+			name: "Context with both peer and metadata (peer takes precedence)",
+			setupCtx: func() context.Context {
+				addr, _ := net.ResolveTCPAddr("tcp", "192.168.1.100:54321")
+				p := &peer.Peer{Addr: addr}
+				ctx := peer.NewContext(context.Background(), p)
+				md := metadata.Pairs(MetadataKeyClientAddr, "10.0.0.1:12345")
+				return metadata.NewIncomingContext(ctx, md)
+			},
+			expected: "192.168.1.100:54321",
+		},
 	}
 
 	for _, tt := range tests {
@@ -202,12 +223,97 @@ func TestClientIPFromContext(t *testing.T) {
 			},
 			expected: "127.0.0.1",
 		},
+		{
+			name: "Context with metadata (HTTP via grpc-gateway)",
+			setupCtx: func() context.Context {
+				md := metadata.Pairs(MetadataKeyClientAddr, "10.0.0.1:12345")
+				return metadata.NewIncomingContext(context.Background(), md)
+			},
+			expected: "10.0.0.1",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := tt.setupCtx()
 			result := ClientIPFromContext(ctx)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestClientIPFromHTTPRequest(t *testing.T) {
+	tests := []struct {
+		name     string
+		setupReq func() *http.Request
+		expected string
+	}{
+		{
+			name: "X-Forwarded-For header with single IP",
+			setupReq: func() *http.Request {
+				req, _ := http.NewRequest("GET", "/", nil)
+				req.Header.Set("X-Forwarded-For", "203.0.113.195")
+				req.RemoteAddr = "10.0.0.1:12345"
+				return req
+			},
+			expected: "203.0.113.195",
+		},
+		{
+			name: "X-Forwarded-For header with multiple IPs",
+			setupReq: func() *http.Request {
+				req, _ := http.NewRequest("GET", "/", nil)
+				req.Header.Set("X-Forwarded-For", "203.0.113.195, 70.41.3.18, 150.172.238.178")
+				req.RemoteAddr = "10.0.0.1:12345"
+				return req
+			},
+			expected: "203.0.113.195",
+		},
+		{
+			name: "X-Real-IP header",
+			setupReq: func() *http.Request {
+				req, _ := http.NewRequest("GET", "/", nil)
+				req.Header.Set("X-Real-IP", "203.0.113.195")
+				req.RemoteAddr = "10.0.0.1:12345"
+				return req
+			},
+			expected: "203.0.113.195",
+		},
+		{
+			name: "X-Forwarded-For takes precedence over X-Real-IP",
+			setupReq: func() *http.Request {
+				req, _ := http.NewRequest("GET", "/", nil)
+				req.Header.Set("X-Forwarded-For", "203.0.113.195")
+				req.Header.Set("X-Real-IP", "70.41.3.18")
+				req.RemoteAddr = "10.0.0.1:12345"
+				return req
+			},
+			expected: "203.0.113.195",
+		},
+		{
+			name: "Fallback to RemoteAddr",
+			setupReq: func() *http.Request {
+				req, _ := http.NewRequest("GET", "/", nil)
+				req.RemoteAddr = "10.0.0.1:12345"
+				return req
+			},
+			expected: "10.0.0.1:12345",
+		},
+		{
+			name: "X-Forwarded-For with spaces",
+			setupReq: func() *http.Request {
+				req, _ := http.NewRequest("GET", "/", nil)
+				req.Header.Set("X-Forwarded-For", "  203.0.113.195  ")
+				req.RemoteAddr = "10.0.0.1:12345"
+				return req
+			},
+			expected: "203.0.113.195",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := tt.setupReq()
+			result := ClientIPFromHTTPRequest(req)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/util/oidc/provider.go
+++ b/util/oidc/provider.go
@@ -141,8 +141,6 @@ func (p *providerImpl) Verify(ctx context.Context, tokenString string, argoSetti
 				break
 			}
 			// We store the error for each audience so that we can return a more detailed error message to the user.
-			// If this gets merged, we'll be able to detect failures unrelated to audiences and short-circuit this loop
-			// to avoid logging irrelevant warnings: https://github.com/coreos/go-oidc/pull/406
 			tokenVerificationErrors[aud] = err
 		}
 		// If the most recent attempt encountered an error, and if we have collected multiple errors, switch to the

--- a/util/session/sessionmanager.go
+++ b/util/session/sessionmanager.go
@@ -31,6 +31,7 @@ import (
 	"github.com/argoproj/argo-cd/v3/pkg/client/listers/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v3/util/dex"
 	"github.com/argoproj/argo-cd/v3/util/env"
+	grpcutil "github.com/argoproj/argo-cd/v3/util/grpc"
 	httputil "github.com/argoproj/argo-cd/v3/util/http"
 	jwtutil "github.com/argoproj/argo-cd/v3/util/jwt"
 	oidcutil "github.com/argoproj/argo-cd/v3/util/oidc"
@@ -588,7 +589,8 @@ func (mgr *SessionManager) VerifyToken(ctx context.Context, tokenString string) 
 		// return a dummy claims only containing a value for the issuer, so the
 		// UI can handle expired tokens appropriately.
 		if err != nil {
-			errorMsg := "Failed to verify session token: " + err.Error()
+			clientAddr := grpcutil.ClientAddrFromContext(ctx)
+			errorMsg := fmt.Sprintf("Failed to verify session token (client: %s): %s", clientAddr, err)
 			span.SetStatus(otel_codes.Error, errorMsg)
 			log.Warn(errorMsg)
 			tokenExpiredError := &oidc.TokenExpiredError{}


### PR DESCRIPTION
## Summary

Include the client IP address in token verification error logs so operators can identify which clients trigger authentication failures.

## Motivation

Before:
```
level=warning msg="Failed to verify session token: ..."
```

After:
```
level=warning msg="Failed to verify session token (client: 192.168.1.100:54321): ..."
```

Fixes #20388

## Checklist

- [x] I have read the [contributing guidelines](https://argo-cd.readthedocs.io/en/latest/developer-guide/contributing/)
- [x] My changes follow the existing code style
- [x] I have added tests that prove my fix is effective
- [x] I have verified my changes don't break any existing tests
- [x] My change requires no updates to the documentation