### PR TITLE
chore:logging improved in apptest

### DIFF
--- a/cmd/util/app_test.go
+++ b/cmd/util/app_test.go
@@ -215,19 +215,19 @@ type appOptionsFixture struct {
 func (f *appOptionsFixture) SetFlag(key, value string) error {
 	err := f.command.Flags().Set(key, value)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to set flag %q to %q: %w", key, value, err)
 	}
 	_ = SetAppSpecOptions(f.command.Flags(), f.spec, f.options, 0)
-	return err
+	return fmt.Errorf("failed to apply app spec options after setting flag %q: %w", key, err)
 }
 
 func (f *appOptionsFixture) SetFlagWithSourcePosition(key, value string, sourcePosition int) error {
 	err := f.command.Flags().Set(key, value)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to set flag %q to %q for source position %d: %w", key, value, sourcePosition, err)
 	}
 	_ = SetAppSpecOptions(f.command.Flags(), f.spec, f.options, sourcePosition)
-	return err
+	return fmt.Errorf("failed to apply app spec options after setting flag %q for source position %d: %w", key, sourcePosition, err)
 }
 
 func newAppOptionsFixture() *appOptionsFixture {


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
