### PR TITLE
fix(hydrator): empty links for failed operation (#25025)

### DIFF
--- a/ui/src/app/applications/components/application-hydrate-operation-state/application-hydrate-operation-state.tsx
+++ b/ui/src/app/applications/components/application-hydrate-operation-state/application-hydrate-operation-state.tsx
@@ -37,15 +37,17 @@ export const ApplicationHydrateOperationState: React.FunctionComponent<Props> = 
     if (hydrateOperationState.finishedAt && hydrateOperationState.phase !== 'Hydrating') {
         operationAttributes.push({title: 'FINISHED AT', value: <Timestamp date={hydrateOperationState.finishedAt} />});
     }
-    operationAttributes.push({
-        title: 'DRY REVISION',
-        value: (
-            <div>
-                <Revision repoUrl={hydrateOperationState.sourceHydrator.drySource.repoURL} revision={hydrateOperationState.drySHA} />
-            </div>
-        )
-    });
-    if (hydrateOperationState.finishedAt) {
+    if (hydrateOperationState.drySHA) {
+        operationAttributes.push({
+            title: 'DRY REVISION',
+            value: (
+                <div>
+                    <Revision repoUrl={hydrateOperationState.sourceHydrator.drySource.repoURL} revision={hydrateOperationState.drySHA} />
+                </div>
+            )
+        });
+    }
+    if (hydrateOperationState.finishedAt && hydrateOperationState.hydratedSHA) {
         operationAttributes.push({
             title: 'HYDRATED REVISION',
             value: (

--- a/ui/src/app/shared/models.ts
+++ b/ui/src/app/shared/models.ts
@@ -543,7 +543,9 @@ export interface HydrateOperation {
     finishedAt?: models.Time;
     phase: HydrateOperationPhase;
     message: string;
+    // drySHA is the sha of the DRY commit being hydrated. This will be empty if the operation is not successful.
     drySHA: string;
+    // hydratedSHA is the sha of the hydrated commit. This will be empty if the operation is not successful.
     hydratedSHA: string;
     sourceHydrator: SourceHydrator;
 }


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-cd/issues/25025

Before (last two rows are problematic):

<img width="2320" height="470" alt="Screenshot 2026-01-15 at 4 05 54 PM" src="https://github.com/user-attachments/assets/99c344d9-99dc-489b-afdd-91b1071f6ffa" />

After (rows hidden):

<img width="2320" height="470" alt="Screenshot 2026-01-15 at 4 05 41 PM" src="https://github.com/user-attachments/assets/0c965bc9-fd7a-43b1-8c9b-786b539cf3fc" />

Happy path still works w/ new code:

<img width="2320" height="470" alt="Screenshot 2026-01-15 at 4 06 29 PM" src="https://github.com/user-attachments/assets/39237033-ed50-4307-b0d4-966bafa3f9cb" />
