### PR TITLE
fix: invalid error message on health check failure (#26040)

### DIFF
--- a/util/healthz/healthz.go
+++ b/util/healthz/healthz.go
@@ -15,7 +15,7 @@ func ServeHealthCheck(mux *http.ServeMux, f func(r *http.Request) error) {
 		startTs := time.Now()
 		if err := f(r); err != nil {
 			w.WriteHeader(http.StatusServiceUnavailable)
-			log.WithField("duration", time.Since(startTs)).Errorf("Error serving healh check request: %v", err);
+			log.WithField("duration", time.Since(startTs)).Errorf("Error serving healh check request: %v", err)
 		} else {
 			fmt.Fprintln(w, "ok")
 		}

--- a/util/healthz/healthz.go
+++ b/util/healthz/healthz.go
@@ -3,6 +3,7 @@ package healthz
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -11,9 +12,10 @@ import (
 // ServeHealthCheck relies on the provided function to return an error if unhealthy and nil otherwise.
 func ServeHealthCheck(mux *http.ServeMux, f func(r *http.Request) error) {
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		startTs := time.Now()
 		if err := f(r); err != nil {
 			w.WriteHeader(http.StatusServiceUnavailable)
-			log.Errorln(w, err)
+			log.WithField("duration", time.Since(startTs)).Errorf("Error serving healh check request: %v", err);
 		} else {
 			fmt.Fprintln(w, "ok")
 		}

--- a/util/healthz/healthz.go
+++ b/util/healthz/healthz.go
@@ -15,7 +15,10 @@ func ServeHealthCheck(mux *http.ServeMux, f func(r *http.Request) error) {
 		startTs := time.Now()
 		if err := f(r); err != nil {
 			w.WriteHeader(http.StatusServiceUnavailable)
-			log.WithField("duration", time.Since(startTs)).Errorf("Error serving healh check request: %v", err)
+			log.WithFields(log.Fields{
+				"duration":  time.Since(startTs),
+				"component": "healthcheck",
+			}).WithError(err).Error("Error serving health check request")
 		} else {
 			fmt.Fprintln(w, "ok")
 		}

--- a/util/healthz/healthz_test.go
+++ b/util/healthz/healthz_test.go
@@ -73,8 +73,9 @@ func TestHealthCheck(t *testing.T) {
 			break
 		}
 	}
-	assert.NotNil(t, foundEntry, "Expected an error message '%s', but it was't found", expectedMsg)
-	actualErrMsg := foundEntry.Data["error"].(error).Error()
-	assert.Equal(t, svcErrMsg, actualErrMsg, "expected original error message '"+svcErrMsg+"', but got '"+actualErrMsg+"'")
+	require.NotEmpty(t, foundEntry, "Expected an error message '%s', but it was't found", expectedMsg)
+	actualErr, ok := foundEntry.Data["error"].(error)
+	require.Truef(t, ok, "Expected error field to contain an error, but got %v", actualErr)
+	assert.Equal(t, svcErrMsg, actualErr.Error(), "expected original error message '"+svcErrMsg+"', but got '"+actualErr.Error()+"'")
 	assert.Greater(t, foundEntry.Data["duration"].(time.Duration), time.Duration(0))
 }

--- a/util/healthz/healthz_test.go
+++ b/util/healthz/healthz_test.go
@@ -5,7 +5,11 @@ import (
 	"net"
 	"net/http"
 	"testing"
+	"strings"
 
+	logrus "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -13,7 +17,7 @@ func TestHealthCheck(t *testing.T) {
 	sentinel := false
 	lc := &net.ListenConfig{}
 	ctx := t.Context()
-
+	svcErrMsg := "This is a dummy error"
 	serve := func(c chan<- string) {
 		// listen on first available dynamic (unprivileged) port
 		listener, err := lc.Listen(ctx, "tcp", ":0")
@@ -27,7 +31,7 @@ func TestHealthCheck(t *testing.T) {
 		mux := http.NewServeMux()
 		ServeHealthCheck(mux, func(_ *http.Request) error {
 			if sentinel {
-				return errors.New("This is a dummy error")
+				return errors.New(svcErrMsg)
 			}
 			return nil
 		})
@@ -52,10 +56,23 @@ func TestHealthCheck(t *testing.T) {
 	require.Equalf(t, http.StatusOK, resp.StatusCode, "Was expecting status code 200 from health check, but got %d instead", resp.StatusCode)
 
 	sentinel = true
+	hook := test.NewGlobal()
 
 	req, err = http.NewRequestWithContext(ctx, http.MethodGet, server+"/healthz", http.NoBody)
 	require.NoError(t, err)
 	resp, err = http.DefaultClient.Do(req)
 	require.NoError(t, err)
 	require.Equalf(t, http.StatusServiceUnavailable, resp.StatusCode, "Was expecting status code 503 from health check, but got %d instead", resp.StatusCode)
+	assert.Greater(t, len(hook.Entries), 0, "Was expecting at least one log entry from health check, but got none")
+	expectedMsg := "Error serving healh check request: " + svcErrMsg
+	assert.Condition(t,
+		func() bool {
+			for _, entry := range hook.Entries {
+				if entry.Level == logrus.ErrorLevel &&
+					strings.HasPrefix(entry.Message, expectedMsg) {
+					return true
+				}
+			}
+			return false
+		}, "Was expecting and error message like '%s' but it wan't found", expectedMsg)
 }

--- a/util/healthz/healthz_test.go
+++ b/util/healthz/healthz_test.go
@@ -77,5 +77,4 @@ func TestHealthCheck(t *testing.T) {
 	actualErrMsg := foundEntry.Data["error"].(error).Error()
 	assert.Equal(t, svcErrMsg, actualErrMsg, "expected original error message '"+svcErrMsg+"', but got '"+actualErrMsg+"'")
 	assert.Greater(t, foundEntry.Data["duration"].(time.Duration), time.Duration(0))
-
 }

--- a/util/healthz/healthz_test.go
+++ b/util/healthz/healthz_test.go
@@ -75,7 +75,7 @@ func TestHealthCheck(t *testing.T) {
 	}
 	require.NotEmpty(t, foundEntry, "Expected an error message '%s', but it was't found", expectedMsg)
 	actualErr, ok := foundEntry.Data["error"].(error)
-	require.Truef(t, ok, "Expected error field to contain an error, but got %v", actualErr)
+	require.True(t, ok, "Expected 'error' field to contain an error, but it doesn't")
 	assert.Equal(t, svcErrMsg, actualErr.Error(), "expected original error message '"+svcErrMsg+"', but got '"+actualErr.Error()+"'")
 	assert.Greater(t, foundEntry.Data["duration"].(time.Duration), time.Duration(0))
 }

--- a/util/healthz/healthz_test.go
+++ b/util/healthz/healthz_test.go
@@ -4,10 +4,10 @@ import (
 	"errors"
 	"net"
 	"net/http"
-	"testing"
 	"strings"
+	"testing"
 
-	logrus "github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -63,12 +63,12 @@ func TestHealthCheck(t *testing.T) {
 	resp, err = http.DefaultClient.Do(req)
 	require.NoError(t, err)
 	require.Equalf(t, http.StatusServiceUnavailable, resp.StatusCode, "Was expecting status code 503 from health check, but got %d instead", resp.StatusCode)
-	assert.Greater(t, len(hook.Entries), 0, "Was expecting at least one log entry from health check, but got none")
+	assert.NotEmpty(t, hook.Entries, "Was expecting at least one log entry from health check, but got none")
 	expectedMsg := "Error serving healh check request: " + svcErrMsg
 	assert.Condition(t,
 		func() bool {
 			for _, entry := range hook.Entries {
-				if entry.Level == logrus.ErrorLevel &&
+				if entry.Level == log.ErrorLevel &&
 					strings.HasPrefix(entry.Message, expectedMsg) {
 					return true
 				}


### PR DESCRIPTION
Fixes #26040

This PR fixes the error message and, additionally,
it adds the "duration" field to the message that prints duration
of the failed healthcheck: this can be useful for troubleshooting
healthcheck failures. 

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
