### PR TITLE
fix: use 127.0.0.1 instead of localhost in health checks to avoid DNS lookups

### DIFF
--- a/cmd/argocd-commit-server/commands/argocd_commit_server.go
+++ b/cmd/argocd-commit-server/commands/argocd_commit_server.go
@@ -67,9 +67,11 @@ func NewCommand() *cobra.Command {
 
 			healthz.ServeHealthCheck(http.DefaultServeMux, func(r *http.Request) error {
 				if val, ok := r.URL.Query()["full"]; ok && len(val) > 0 && val[0] == "true" {
-					// connect to itself to make sure commit server is able to serve connection
-					// used by liveness probe to auto restart commit server
-					conn, err := apiclient.NewConnection(fmt.Sprintf("localhost:%d", listenPort))
+					// Connect to itself to verify commit server is able to serve connections.
+					// Used by liveness probe to auto-restart unhealthy commit server pods.
+					// Use 127.0.0.1 instead of localhost to bypass DNS resolution and avoid
+					// unnecessary gRPC service config lookups (see issue #24991).
+					conn, err := apiclient.NewConnection(fmt.Sprintf("127.0.0.1:%d", listenPort))
 					if err != nil {
 						return err
 					}


### PR DESCRIPTION
  ## Summary

  Changes health check connections in `argocd-repo-server` and `argocd-commit-server` from `localhost` to `127.0.0.1` to bypass DNS resolution and avoid unnecessary gRPC service config lookups.

  ## Problem

  In dual-stack IPv6 environments, health checks using `localhost` trigger:
  1. DNS resolution for both IPv4 and IPv6 addresses
  2. gRPC service discovery queries for `_grpc_config.localhost` (SRV/TXT records)
  3. NXDOMAIN responses that add latency
  4. Health check timeouts leading to pod crashes

  This issue is documented in #24991.

  ## Solution

  Using the IP address `127.0.0.1` directly:
  - Bypasses DNS resolution completely
  - Eliminates unnecessary service discovery lookups
  - Reduces health check latency from 30-40s to <1s
  - Prevents CrashLoopBackOff in dual-stack environments

  ## Changes

  - `cmd/argocd-repo-server/commands/argocd_repo_server.go`: Changed connection address from `localhost` to `127.0.0.1`
  - `cmd/argocd-commit-server/commands/argocd_commit_server.go`: Changed connection address from `localhost` to `127.0.0.1`
  - Updated comments to explain the rationale and reference issue #24991

  ## Testing

  Tested in a production dual-stack IPv6 Kubernetes cluster:
  - **Before**: repo-server pods in CrashLoopBackOff with liveness probe failures
  - **After**: repo-server pods stable, health checks complete successfully in <1s

  Fixes #24991

  ---

  **Checklist:**

  * [x] Either (a) I've created an enhancement proposal and discussed it with the community, **(b) this is a bug fix**, or (c) this does not need to be in the release notes.
  * [x] The title of the PR states what changed and the related issues number (used for the release note).
  * [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
  * [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
  * [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. *(N/A - internal fix)*
  * [x] Does this PR require documentation updates? *(No - internal change)*
  * [x] I've updated documentation as required by this PR. *(N/A)*
  * [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal) *(Will sign off if needed)*
  * [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged. *(Tested in production cluster; can add unit tests if requested)*
  * [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). *(Will check after CI runs)*
  * [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines. *(Bug fix, not a new feature)*
  * [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
  * [ ] Optional. My organization is added to USERS.md.
  * [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity). *(Could be cherry-picked to v3.0, v3.1, v3.2 release branches)*