### PR TITLE
chore(deps): update notifications-engine to fix GitHub PR comments nil panic (cherry-pick #26065 for 3.2)

### DIFF
--- a/docs/operator-manual/notifications/services/pagerduty_v2.md
+++ b/docs/operator-manual/notifications/services/pagerduty_v2.md
@@ -62,6 +62,8 @@ The parameters for the PagerDuty configuration in the template generally match w
 * `group` - Logical grouping of components of a service.
 * `class` - The class/type of the event.
 * `url` - The URL that should be used for the link "View in ArgoCD" in PagerDuty.
+* `dedupKey` - A string used by PagerDuty to deduplicate and correlate events. Events with the same `dedupKey` will be grouped into the same incident. If omitted, PagerDuty will create a new incident for each event.
+
 
 The `timestamp` and `custom_details` parameters are not currently supported.
 

--- a/docs/operator-manual/notifications/services/webhook.md
+++ b/docs/operator-manual/notifications/services/webhook.md
@@ -78,6 +78,29 @@ metadata:
     notifications.argoproj.io/subscribe.<trigger-name>.<webhook-name>: ""
 ```
 
+4. TLS configuration (optional)
+
+If your webhook server uses a custom TLS certificate, you can configure the notification service to trust it by adding the certificate to the `argocd-tls-certs-cm` ConfigMap as shown below:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-tls-certs-cm
+data:
+  <hostname>: |
+    -----BEGIN CERTIFICATE-----
+    <TLS DATA>
+    -----END CERTIFICATE-----
+```
+
+*NOTE:*
+*If the custom certificate is not trusted, you may encounter errors such as:*
+```
+Put \"https://...\": x509: certificate signed by unknown authority
+```
+*Adding the server's certificate to `argocd-tls-certs-cm` resolves this issue.*
+
 ## Examples
 
 ### Set GitHub commit status

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/TomOnTime/utfutil v1.0.0
 	github.com/alicebob/miniredis/v2 v2.35.0
 	github.com/argoproj/gitops-engine v0.7.1-0.20251217140045-5baed5604d2d
-	github.com/argoproj/notifications-engine v0.5.1-0.20251223091026-8c0c96d8d530
+	github.com/argoproj/notifications-engine v0.5.1-0.20260119155007-a23b5827d630
 	github.com/argoproj/pkg v0.13.6
 	github.com/argoproj/pkg/v2 v2.0.1
 	github.com/aws/aws-sdk-go v1.55.7

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/appscode/go v0.0.0-20191119085241-0887d8ec2ecc/go.mod h1:OawnOmAL4ZX3YaPdN+8HTNwBveT1jMsqP74moa9XUbE=
 github.com/argoproj/gitops-engine v0.7.1-0.20251217140045-5baed5604d2d h1:iUJYrbSvpV9n8vyl1sBt1GceM60HhHfnHxuzcm5apDg=
 github.com/argoproj/gitops-engine v0.7.1-0.20251217140045-5baed5604d2d/go.mod h1:PauXVUVcfiTgC+34lDdWzPS101g4NpsUtDAjFBnWf94=
-github.com/argoproj/notifications-engine v0.5.1-0.20251223091026-8c0c96d8d530 h1:l8CrIDgqJBRyR1TVC1aKq2XdeQlLkgP60LxoYkOY7BI=
-github.com/argoproj/notifications-engine v0.5.1-0.20251223091026-8c0c96d8d530/go.mod h1:d1RazGXWvKRFv9//rg4MRRR7rbvbE7XLgTSMT5fITTE=
+github.com/argoproj/notifications-engine v0.5.1-0.20260119155007-a23b5827d630 h1:naE5KNRTOALjF5nVIGUHrHU5xjlB8QJJiCu+aISIlSs=
+github.com/argoproj/notifications-engine v0.5.1-0.20260119155007-a23b5827d630/go.mod h1:d1RazGXWvKRFv9//rg4MRRR7rbvbE7XLgTSMT5fITTE=
 github.com/argoproj/pkg v0.13.6 h1:36WPD9MNYECHcO1/R1pj6teYspiK7uMQLCgLGft2abM=
 github.com/argoproj/pkg v0.13.6/go.mod h1:I698DoJBKuvNFaixh4vFl2C88cNIT1WS7KCbz5ewyF8=
 github.com/argoproj/pkg/v2 v2.0.1 h1:O/gCETzB/3+/hyFL/7d/VM/6pSOIRWIiBOTb2xqAHvc=


### PR DESCRIPTION
Cherry-picked chore(deps): update notifications-engine to fix GitHub PR comments nil panic (#26065)

Signed-off-by: John Soutar <john@tella.com>