### PR TITLE
fix: cert-manager Certificate health check for Ready=False with Issuing message

### DIFF
--- a/resource_customizations/cert-manager.io/Certificate/health.lua
+++ b/resource_customizations/cert-manager.io/Certificate/health.lua
@@ -13,6 +13,14 @@ if obj.status ~= nil then
 
     for i, condition in ipairs(obj.status.conditions) do
       if condition.type == "Ready" and condition.status == "False" then
+        -- Check if the message indicates issuing is in progress.
+        -- This handles a race condition where Ready=False is set before
+        -- the Issuing condition is added by cert-manager.
+        if condition.message ~= nil and string.find(condition.message, "Issuing") then
+          hs.status = "Progressing"
+          hs.message = condition.message
+          return hs
+        end
         hs.status = "Degraded"
         hs.message = condition.message
         return hs

--- a/resource_customizations/cert-manager.io/Certificate/health_test.yaml
+++ b/resource_customizations/cert-manager.io/Certificate/health_test.yaml
@@ -24,3 +24,7 @@ tests:
     status: Healthy
     message: 'Certificate renewed successfully'
   inputPath: testdata/healthy_renewed.yaml
+- healthStatus:
+    status: Progressing
+    message: Issuing certificate as Secret was previously issued
+  inputPath: testdata/progressing_issuing_message_only.yaml

--- a/resource_customizations/cert-manager.io/Certificate/testdata/progressing_issuing_message_only.yaml
+++ b/resource_customizations/cert-manager.io/Certificate/testdata/progressing_issuing_message_only.yaml
@@ -1,0 +1,27 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  creationTimestamp: '2018-11-07T00:06:12Z'
+  generation: 1
+  name: test-cert
+  namespace: argocd
+  resourceVersion: '64763033'
+  uid: e6cfba50-314d-11e9-be3f-42010a800011
+spec:
+  commonName: cd.apps.argoproj.io
+  dnsNames:
+    - cd.apps.argoproj.io
+  issuerRef:
+    kind: ClusterIssuer
+    name: letsencrypt-prod
+  secretName: test-secret
+status:
+  # This test case covers a race condition where cert-manager sets Ready=False
+  # with an "Issuing" message BEFORE adding the Issuing condition type.
+  # Without the fix, this would incorrectly show as Degraded instead of Progressing.
+  conditions:
+    - lastTransitionTime: '2021-09-15T02:10:00Z'
+      message: Issuing certificate as Secret was previously issued
+      reason: Issuing
+      status: 'False'
+      type: Ready


### PR DESCRIPTION
## Summary
Fixes cert-manager Certificate resources being incorrectly marked as "Degraded" during renewal/issuance when the Ready condition is False with an "Issuing" message, but before the separate Issuing condition type is added.

## Problem
When a cert-manager Certificate is being issued or renewed, there's a race condition in the condition updates:
1. cert-manager first sets `Ready=False` with a message containing "Issuing" (e.g., "Issuing certificate as Secret does not exist")
2. Only afterward does cert-manager add the separate `type: Issuing` condition

The existing health check (added in commit 888687452) only looks for the `Issuing` condition type, missing this transitional state. This causes certificates to briefly show as "Degraded" in ArgoCD during normal renewal operations.

## Solution
This PR adds an additional check: when `Ready=False`, also check if the message contains "Issuing". If so, return "Progressing" status instead of "Degraded".

This aligns with the existing behavior that already returns "Progressing" when the Issuing condition type is present.

## Changes
- Modified `resource_customizations/cert-manager.io/Certificate/health.lua` to check for "Issuing" in the Ready condition message
- Added test case `progressing_issuing_message_only.yaml` to cover this scenario

## Checklist
- [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [x] The title of the PR conforms to the [Conventional Commits spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I've updated documentation as required by this PR.
- [x] I have signed my commits with DCO (gpg sign alone is not enough).
- [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
- [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
- [ ] My new feature complies with the [feature contribution guidelines](https://github.com/argoproj/argo-cd/blob/main/CONTRIBUTING.md#feature-contribution-lifecycle).
- [ ] **If there are changes to the UI,** I've included screenshots or videos.