### PR TITLE
docs: remove link to resource_hooks.md from sync-waves.md

### DIFF
--- a/docs/user-guide/sync-waves.md
+++ b/docs/user-guide/sync-waves.md
@@ -138,8 +138,6 @@ metadata:
     argocd.argoproj.io/hook: PreSync
 ```
 
-[Read more about hooks](resource_hooks.md).
-
 ## How Do I Configure Waves?
 
 Specify the wave using the following annotation:


### PR DESCRIPTION
resource_hooks.md is deprecated and redirects here
 