### PR TITLE
fix: consider Replace/Force sync option on live resource annotations

### DIFF
--- a/gitops-engine/pkg/sync/sync_context.go
+++ b/gitops-engine/pkg/sync/sync_context.go
@@ -1272,8 +1272,8 @@ func (sc *syncContext) applyObject(t *syncTask, dryRun, validate bool) (common.R
 
 	var err error
 	var message string
-	shouldReplace := sc.replace || resourceutil.HasAnnotationOption(t.targetObj, common.AnnotationSyncOptions, common.SyncOptionReplace)
-	force := sc.force || resourceutil.HasAnnotationOption(t.targetObj, common.AnnotationSyncOptions, common.SyncOptionForce)
+	shouldReplace := sc.replace || resourceutil.HasAnnotationOption(t.targetObj, common.AnnotationSyncOptions, common.SyncOptionReplace) || (t.liveObj != nil && resourceutil.HasAnnotationOption(t.liveObj, common.AnnotationSyncOptions, common.SyncOptionReplace))
+	force := sc.force || resourceutil.HasAnnotationOption(t.targetObj, common.AnnotationSyncOptions, common.SyncOptionForce) || (t.liveObj != nil && resourceutil.HasAnnotationOption(t.liveObj, common.AnnotationSyncOptions, common.SyncOptionForce))
 	serverSideApply := sc.shouldUseServerSideApply(t.targetObj, dryRun)
 
 	// Check if we need to perform client-side apply migration for server-side apply

--- a/gitops-engine/pkg/sync/sync_context_test.go
+++ b/gitops-engine/pkg/sync/sync_context_test.go
@@ -890,6 +890,7 @@ func TestSync_Replace(t *testing.T) {
 	}{
 		{"NoAnnotation", testingutils.NewPod(), testingutils.NewPod(), "apply"},
 		{"AnnotationIsSet", withReplaceAnnotation(testingutils.NewPod()), testingutils.NewPod(), "replace"},
+		{"AnnotationIsSetOnLive", testingutils.NewPod(), withReplaceAnnotation(testingutils.NewPod()), "replace"},
 		{"LiveObjectMissing", withReplaceAnnotation(testingutils.NewPod()), nil, "create"},
 	}
 
@@ -1031,6 +1032,7 @@ func TestSync_Force(t *testing.T) {
 		{"NoAnnotation", testingutils.NewPod(), testingutils.NewPod(), "apply", false},
 		{"ForceApplyAnnotationIsSet", withForceAnnotation(testingutils.NewPod()), testingutils.NewPod(), "apply", true},
 		{"ForceReplaceAnnotationIsSet", withForceAndReplaceAnnotations(testingutils.NewPod()), testingutils.NewPod(), "replace", true},
+		{"ForceReplaceAnnotationIsSetOnLive", testingutils.NewPod(), withForceAndReplaceAnnotations(testingutils.NewPod()), "replace", true},
 		{"LiveObjectMissing", withReplaceAnnotation(testingutils.NewPod()), nil, "create", false},
 	}
 


### PR DESCRIPTION
With the change to https://github.com/argoproj/argo-cd/pull/22073 and https://github.com/argoproj/argo-cd/pull/22647, if replace option is disabled globally, users require a PR to modify the target object to add the `argocd.argoproj.io/sync-options: Force=true,Replace=true` annotation.

Considering an applciation with autosync, the user may only want to perform a "replace+force" operation on the resource once. Adding it to the target object means that every change to this resource will cause a "replace+force", which is not desired.

To prevent this, the user will now be able to add the annotation `argocd.argoproj.io/sync-options: Force=true,Replace=true` to the live resource by any means (such as using the edit in the Argo UI), and on the next sync of this resource, it will be "force+replace", and the annotation will be restored to what is defined in Git.