### PR TITLE
fix(ci): ensure cherry-pick commits include DCO sign-off

### DIFF
--- a/.github/workflows/cherry-pick-single.yml
+++ b/.github/workflows/cherry-pick-single.yml
@@ -69,7 +69,7 @@ jobs:
           git checkout -b "$CHERRY_PICK_BRANCH" "origin/$TARGET_BRANCH"
 
           # Perform cherry-pick
-          if git cherry-pick -m 1 "$MERGE_COMMIT"; then
+          if git cherry-pick -s -m 1 "$MERGE_COMMIT"; then
             echo "✅ Cherry-pick successful"
 
             # Extract Signed-off-by from the cherry-pick commit


### PR DESCRIPTION
Fixes #26088

This PR fixes an issue where pull requests created by the Argo CD cherry-pick
workflow fail the DCO check.

Cherry-pick commits were being created without a `Signed-off-by` line, which
causes the DCO check to fail and blocks release PRs until they are manually
fixed.

The workflow now uses `git cherry-pick -s` so the generated commit automatically
includes the required sign-off.

---

### Checklist

- [x] This is a bug fix.
- [x] The title of the PR states what changed and references the related issue.
- [x] The title of the PR conforms to the Argo CD PR title guidelines.
- [x] I've included "Fixes #26088" in the description.
- [ ] This PR requires CLI or UI changes.
- [ ] This PR requires documentation updates.
- [x] I have signed off all my commits as required by DCO.
- [x] I have written unit or e2e tests for this change. (CI workflow change only)
- [x] My build is green.
- [ ] This PR introduces a new feature. (not applicable)
- [ ] Optional items are not applicable.
