### PR TITLE
feat: add HTTPRoute to the network view (which also adds external url auto generate) (#17087)

### DIFF
--- a/controller/cache/info.go
+++ b/controller/cache/info.go
@@ -63,7 +63,7 @@ func populateNodeInfo(un *unstructured.Unstructured, res *ResourceInfo, customLa
 		}
 	case "gateway.networking.k8s.io":
 		if gvk.Kind == "HTTPRoute" {
-			populateHttpRouteInfo(un, res)
+			populateHTTPRouteInfo(un, res)
 		}
 	case "networking.istio.io":
 		switch gvk.Kind {
@@ -245,7 +245,7 @@ func populateIngressInfo(un *unstructured.Unstructured, res *ResourceInfo) {
 	res.NetworkingInfo = &v1alpha1.ResourceNetworkingInfo{TargetRefs: targets, Ingress: ingress, ExternalURLs: urls}
 }
 
-func populateHttpRouteInfo(un *unstructured.Unstructured, res *ResourceInfo) {
+func populateHTTPRouteInfo(un *unstructured.Unstructured, res *ResourceInfo) {
 	targetsMap := make(map[v1alpha1.ResourceRef]bool)
 	if rules, ok, err := unstructured.NestedSlice(un.Object, "spec", "rules"); ok && err == nil {
 		for i := range rules {
@@ -296,11 +296,11 @@ func populateHttpRouteInfo(un *unstructured.Unstructured, res *ResourceInfo) {
 				continue
 			}
 			stringPort := "https" // since we can't get the information from the referenced gateway resource here, we assume https
-			externalUrlBase := fmt.Sprintf("%s://%s", stringPort, hostname)
+			externalURLBase := fmt.Sprintf("%s://%s", stringPort, hostname)
 
 			if rules, ok, err := unstructured.NestedSlice(un.Object, "spec", "rules"); ok && err == nil {
 				if len(rules) == 0 {
-					urlsSet[externalUrlBase] = true
+					urlsSet[externalURLBase] = true
 					continue
 				}
 				for i := range rules {
@@ -313,7 +313,7 @@ func populateHttpRouteInfo(un *unstructured.Unstructured, res *ResourceInfo) {
 						continue
 					}
 					if len(matches) == 0 {
-						urlsSet[externalUrlBase] = true
+						urlsSet[externalURLBase] = true
 						continue
 					}
 					for j := range matches {
@@ -329,8 +329,8 @@ func populateHttpRouteInfo(un *unstructured.Unstructured, res *ResourceInfo) {
 						if pathValue, ok, err := unstructured.NestedString(matchPath, "value"); ok && err == nil {
 							subPath = strings.TrimSuffix(pathValue, "*")
 						}
-						externalUrl := externalUrlBase + subPath
-						urlsSet[externalUrl] = true
+						externalURL := externalURLBase + subPath
+						urlsSet[externalURL] = true
 					}
 				}
 			}

--- a/controller/cache/info_test.go
+++ b/controller/cache/info_test.go
@@ -1684,15 +1684,14 @@ func TestGetHTTPRouteInfo(t *testing.T) {
 
 		info := &ResourceInfo{}
 		populateNodeInfo(httpRoute, info, []string{})
-		assert.Equal(t, &v1alpha1.ResourceNetworkingInfo{
-			TargetRefs: []v1alpha1.ResourceRef{{
-				Namespace: "default",
-				Group:     "",
-				Kind:      kube.ServiceKind,
-				Name:      "helm-guestbook",
-			}},
-			ExternalURLs: []string{"https://helm-guestbook.example.com/", "https://helm-guestbook-2.example.com/", "https://helm-guestbook-3.example.com/"},
-		}, info.NetworkingInfo)
+		assert.ElementsMatch(t, info.NetworkingInfo.ExternalURLs, []string{"https://helm-guestbook.example.com/", "https://helm-guestbook-2.example.com/", "https://helm-guestbook-3.example.com/"})
+		assert.Equal(t, []v1alpha1.ResourceRef{{
+			Namespace: "default",
+			Group:     "",
+			Kind:      kube.ServiceKind,
+			Name:      "helm-guestbook",
+		},
+		}, info.NetworkingInfo.TargetRefs)
 	})
 
 	t.Run("TestGetHTTPRouteInfoWithMultipleHostsAndRulesAndPaths", func(t *testing.T) {
@@ -1739,19 +1738,19 @@ func TestGetHTTPRouteInfo(t *testing.T) {
 
 		info := &ResourceInfo{}
 		populateNodeInfo(httpRoute, info, []string{})
-		assert.Equal(t, &v1alpha1.ResourceNetworkingInfo{
-			TargetRefs: []v1alpha1.ResourceRef{{
-				Namespace: "default",
-				Group:     "",
-				Kind:      kube.ServiceKind,
-				Name:      "helm-guestbook",
-			}, {
-				Namespace: "default",
-				Group:     "",
-				Kind:      kube.ServiceKind,
-				Name:      "helm-guestbook-2",
-			}},
-			ExternalURLs: []string{"https://helm-guestbook.example.com/api", "https://helm-guestbook.example.com/api-v2", "https://helm-guestbook.example.com/apu", "https://helm-guestbook-2.example.com/api", "https://helm-guestbook-2.example.com/api-v2", "https://helm-guestbook-2.example.com/apu"},
-		}, info.NetworkingInfo)
+		assert.ElementsMatch(t, info.NetworkingInfo.ExternalURLs, []string{"https://helm-guestbook.example.com/api", "https://helm-guestbook.example.com/api-v2", "https://helm-guestbook.example.com/apu", "https://helm-guestbook-2.example.com/api", "https://helm-guestbook-2.example.com/api-v2", "https://helm-guestbook-2.example.com/apu"})
+		assert.Len(t, info.NetworkingInfo.TargetRefs, 2)
+		assert.Contains(t, info.NetworkingInfo.TargetRefs, v1alpha1.ResourceRef{
+			Namespace: "default",
+			Group:     "",
+			Kind:      kube.ServiceKind,
+			Name:      "helm-guestbook",
+		})
+		assert.Contains(t, info.NetworkingInfo.TargetRefs, v1alpha1.ResourceRef{
+			Namespace: "default",
+			Group:     "",
+			Kind:      kube.ServiceKind,
+			Name:      "helm-guestbook-2",
+		})
 	})
 }

--- a/controller/cache/info_test.go
+++ b/controller/cache/info_test.go
@@ -1685,12 +1685,13 @@ func TestGetHTTPRouteInfo(t *testing.T) {
 		info := &ResourceInfo{}
 		populateNodeInfo(httpRoute, info, []string{})
 		assert.ElementsMatch(t, info.NetworkingInfo.ExternalURLs, []string{"https://helm-guestbook.example.com/", "https://helm-guestbook-2.example.com/", "https://helm-guestbook-3.example.com/"})
-		assert.Equal(t, []v1alpha1.ResourceRef{{
-			Namespace: "default",
-			Group:     "",
-			Kind:      kube.ServiceKind,
-			Name:      "helm-guestbook",
-		},
+		assert.Equal(t, []v1alpha1.ResourceRef{
+			{
+				Namespace: "default",
+				Group:     "",
+				Kind:      kube.ServiceKind,
+				Name:      "helm-guestbook",
+			},
 		}, info.NetworkingInfo.TargetRefs)
 	})
 


### PR DESCRIPTION
This implements that the `HTTPRoute` of `gateway.networking.k8s.io/v1` is picked up in the network view of the ArgoCD UI and also adds auto generation of external links to the resource (so the clickable links in the UI, similar to what is done for `Ingress`).

Implementation details and open questions:

1. `HTTPRoute` fits generally into the implementation schema. The only downside is that we cannot determine wether its http or https, since that information is only present in the referenced `Gateway` resource. My assumption is that accessing another resource can / should not be done? I did not try it but I'm not sure how it would work with the permissions even. Also the referenced `Gateway` could be in another namespace.
So in the implementation I just assume https. A user could add another links using the general external-link annotation.

2. `Gateway` is not added here since, at least to my understanding, it needs more refactoring or discussion. The `HTTPRoute` references a `Gateway` which does not fit into the `TargetRefs`.
`TargetLabels` and `Labels` is for the connection between `Service` and `Pod`.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->

closes #17087 at least partially depending on the scope (`HTTPRoute` is added, `Gateway` is not)

Screenshot:
<img width="1712" height="802" alt="screenshot-network-view" src="https://github.com/user-attachments/assets/d9cd2ced-912a-4e8b-a27d-d2b3213d27e7" />
