### PR TITLE
fix: Don't mark CRD degraded while 'Installing'

### DIFF
--- a/resource_customizations/apiextensions.k8s.io/CustomResourceDefinition/health.lua
+++ b/resource_customizations/apiextensions.k8s.io/CustomResourceDefinition/health.lua
@@ -46,9 +46,15 @@ for _, condition in pairs(obj.status.conditions) do
     end
 
     -- Checking if CRD is established
-    if condition.type == "Established" and condition.status == "True" then
-        isEstablished = true
-        conditionMsg = condition.message
+    if condition.type == "Established" then
+        if condition.status == "True" then
+            isEstablished = true
+            conditionMsg = condition.message
+        elseif condition.reason == "Installing" then
+            hs.status = "Progressing"
+            hs.message = "CRD is being installed"
+            return hs
+        end
     end
 end
 

--- a/resource_customizations/apiextensions.k8s.io/CustomResourceDefinition/health_test.yaml
+++ b/resource_customizations/apiextensions.k8s.io/CustomResourceDefinition/health_test.yaml
@@ -27,3 +27,7 @@ tests:
     status: Progressing
     message: "Status conditions not found"
   inputPath: testdata/crd-v1-no-conditions-progressing.yaml
+- healthStatus:
+    status: Progressing
+    message: "CRD is being installed"
+  inputPath: testdata/crd-v1-installing-progressing.yaml

--- a/resource_customizations/apiextensions.k8s.io/CustomResourceDefinition/testdata/crd-v1-installing-progressing.yaml
+++ b/resource_customizations/apiextensions.k8s.io/CustomResourceDefinition/testdata/crd-v1-installing-progressing.yaml
@@ -1,0 +1,56 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: examples.example.io
+spec:
+  conversion:
+    strategy: None
+  group: example.io
+  names:
+    kind: Example
+    listKind: ExampleList
+    plural: examples
+    shortNames:
+      - ex
+    singular: example
+  preserveUnknownFields: true
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: >-
+            CreationTimestamp is a timestamp representing the server time when
+            this object was created. It is not guaranteed to be set in
+            happens-before order across separate operations. Clients may not set
+            this value. It is represented in RFC3339 form and is in UTC.
+
+
+            Populated by the system. Read-only. Null for lists. More info:
+            https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      served: true
+      storage: true
+      subresources: {}
+status:
+  acceptedNames:
+    kind: Example
+    listKind: ExampleList
+    plural: examples
+    shortNames:
+      - ex
+    singular: example
+  conditions:
+    - lastTransitionTime: '2024-05-19T23:35:28Z'
+      message: no conflicts found
+      reason: NoConflicts
+      status: 'True'
+      type: NamesAccepted
+    - lastTransitionTime: '2024-05-19T23:35:28Z'
+      message: the initial names have not been accepted
+      reason: Installing
+      status: 'False'
+      type: Established
+  storedVersions:
+    - v1alpha1


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->
This fix updates the CRD health check to be aware of the "not Estabilshed yet but currently Installing" state.

During syncs of existing applications we were getting notifications about degraded applications but the state was very fleeting. We'd check the UI and everything was synced and healthy. After combing the logs and doing some troubleshooting, we found that the CRD health check was causing the ArgoApp to report degraded for a short amount of time when the application was applying new CRDs during its sync.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
