### PR TITLE
fix(webhook): support paths in API URL regex for enterprise setups

### DIFF
--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -485,10 +485,10 @@ func GetWebURLRegex(webURL string) (*regexp.Regexp, error) {
 func GetAPIURLRegex(apiURL string) (*regexp.Regexp, error) {
 	// 1. Optional: protocol (`http` or `https`) followed by `://`
 	// 2. Optional: username followed by `@`
-	// 3. Required: hostname parsed from `webURL`
+	// 3. Required: hostname parsed from `apiURL`
 	// 4. Optional: `:` followed by port number
-	// 5. Optional: `/` followed by path parsed from `webURL`
-	return getURLRegex(apiURL, `(?i)^(https?://)?(%[1]s@)?%[2]s(:\d+)?(/[\w.%/-]*)?$`)
+	// 5. Optional: `/` followed by path parsed from `apiURL` or any sub-path
+	return getURLRegex(apiURL, `(?i)^(https?://)?(%[1]s@)?%[2]s(:\d+)?(?:/%[3]s)?(?:/[\w.%/-]*)?$`)
 }
 
 func getURLRegex(originalURL string, regexpFormat string) (*regexp.Regexp, error) {

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -487,8 +487,8 @@ func GetAPIURLRegex(apiURL string) (*regexp.Regexp, error) {
 	// 2. Optional: username followed by `@`
 	// 3. Required: hostname parsed from `webURL`
 	// 4. Optional: `:` followed by port number
-	// 5. Optional: `/`
-	return getURLRegex(apiURL, `(?i)^(https?://)?(%[1]s@)?%[2]s(:\d+)?/?$`)
+	// 5. Optional: `/` followed by path parsed from `webURL`
+	return getURLRegex(apiURL, `(?i)^(https?://)?(%[1]s@)?%[2]s(:\d+)?(/[\w.%/-]*)?$`)
 }
 
 func getURLRegex(originalURL string, regexpFormat string) (*regexp.Regexp, error) {

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -737,6 +737,7 @@ func Test_GetAPIURLRegex(t *testing.T) {
 		{true, "https://user@example.com/", "https://example.com/", "https+username should match https"},
 		{true, "http://example.com/", "https://user@example.com/", "http should match https+username"},
 		{true, "https://example.com/", "https://user@example.com/", "https should match https+username"},
+		{true, "https://git.ourenterprise.com/", "https://git.ourenterprise.com/api/v3", "enterprise API URL with path should match base repo URL"},
 	}
 
 	for _, testCase := range tests {

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -738,6 +738,8 @@ func Test_GetAPIURLRegex(t *testing.T) {
 		{true, "http://example.com/", "https://user@example.com/", "http should match https+username"},
 		{true, "https://example.com/", "https://user@example.com/", "https should match https+username"},
 		{true, "https://git.ourenterprise.com/", "https://git.ourenterprise.com/api/v3", "enterprise API URL with path should match base repo URL"},
+		{true, "https://git.ourenterprise.com/api/v3/repos/org/repo", "https://git.ourenterprise.com/api/v3", "entreprise API URL with path and /repos should match base repo URL"},
+		{true, "https://api.github.com/repos/owner/repo", "https://api.github.com/", "public API URL with /repos should match base repo URL"},
 	}
 
 	for _, testCase := range tests {


### PR DESCRIPTION
## WHY
Using GitHub Enterprise (or similar self-hosted Git platforms) often have API URLs with paths like https://git.company.com/api/v3 . 

Since PR #21227, these setups have been failing because our webhook validator only expected URLs without paths.

## HOW
Update the regex pattern in GetAPIURLRegex() to accept optional path segments.

The key change is replacing the overly strict /?$ (which only allowed a single trailing slash) with (/[\w.%/-]*)?$.

## What
Files Modified:
- `util/webhook/webhook.go` - Updated regex to support paths in API URLs
- `util/webhook/webhook_test.go` - Added test case for enterprise API URL pattern

**Fixes:** #25095



<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [X] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
