### PR TITLE
fix(cli): show child resources with argo app resources --output tree

### DIFF
--- a/cmd/argocd/commands/tree.go
+++ b/cmd/argocd/commands/tree.go
@@ -75,9 +75,7 @@ func detailedTreeViewAppGet(prefix string, uidToNodeMap map[string]v1alpha1.Reso
 }
 
 func treeViewAppResourcesNotOrphaned(prefix string, uidToNodeMap map[string]v1alpha1.ResourceNode, parentChildMap map[string][]string, parent v1alpha1.ResourceNode, w *tabwriter.Writer) {
-	if len(parent.ParentRefs) == 0 {
-		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", parent.Group, parent.Kind, parent.Namespace, parent.Name, "No")
-	}
+	_, _ = fmt.Fprintf(w, "%s%s\t%s\t%s\t%s\t%s\n", printPrefix(prefix), parent.Group, parent.Kind, parent.Namespace, parent.Name, "No")
 	chs := parentChildMap[parent.UID]
 	for i, child := range chs {
 		var p string
@@ -107,14 +105,12 @@ func treeViewAppResourcesOrphaned(prefix string, uidToNodeMap map[string]v1alpha
 }
 
 func detailedTreeViewAppResourcesNotOrphaned(prefix string, uidToNodeMap map[string]v1alpha1.ResourceNode, parentChildMap map[string][]string, parent v1alpha1.ResourceNode, w *tabwriter.Writer) {
-	if len(parent.ParentRefs) == 0 {
-		healthStatus, reason := extractHealthStatusAndReason(parent)
-		age := "<unknown>"
-		if parent.CreatedAt != nil {
-			age = duration.HumanDuration(time.Since(parent.CreatedAt.Time))
-		}
-		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n", parent.Group, parent.Kind, parent.Namespace, parent.Name, "No", age, healthStatus, reason)
+	healthStatus, reason := extractHealthStatusAndReason(parent)
+	age := "<unknown>"
+	if parent.CreatedAt != nil {
+		age = duration.HumanDuration(time.Since(parent.CreatedAt.Time))
 	}
+	_, _ = fmt.Fprintf(w, "%s%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n", printPrefix(prefix), parent.Group, parent.Kind, parent.Namespace, parent.Name, "No", age, healthStatus, reason)
 	chs := parentChildMap[parent.UID]
 	for i, child := range chs {
 		var p string


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->
fixes https://github.com/argoproj/argo-cd/issues/26158
closes https://github.com/argoproj/argo-cd/issues/13370
Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->

Previously `argocd app resources my-app --output tree` does not show child resources and only prints 'root'/parent nodes.

Before:
```
argocd app resources my-app --output tree
GROUP  KIND     NAMESPACE  NAME           ORPHANED
batch  CronJob  my-ns      my-cronjob     No
apps   Deployment  my-ns   my-deployment  No
```

After
```
argocd app resources my-app --output tree
GROUP  KIND        NAMESPACE  NAME                    ORPHANED
batch  CronJob     my-ns      my-cronjob              No
└─batch  Job       my-ns      my-cronjob-29491560     No
  └─     Pod       my-ns      my-cronjob-29491560-abc No
apps   Deployment  my-ns      my-deployment           No
└─apps ReplicaSet  my-ns      my-deployment-abc123    No
  └─   Pod         my-ns      my-deployment-abc123-x  No
```