### PR TITLE
fix(Hydrator): prevent hydration skip when apps share drySha but have different paths (#26154)

### DIFF
--- a/commitserver/commit/commit.go
+++ b/commitserver/commit/commit.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -164,8 +165,15 @@ func (s *Service) handleCommitRequest(ctx context.Context, logCtx *log.Entry, r 
 	}
 	// short-circuit if already hydrated
 	if isHydrated {
-		logCtx.Debugf("this dry sha %s is already hydrated", r.DrySha)
-		return "", hydratedSha, nil
+		// Check if all requested paths are present in the existing hydrated commit
+		// If a new app is created with a path that was not part of the previous hydration, we need to proceed to full WriteForPaths
+		allPresent, err := allHydratedManifestsUnchanged(gitClient, r.Paths)
+		if err != nil {
+			logCtx.WithError(err).Warn("Failed to perform path existence check; will proceed to full WriteForPaths")
+		} else if allPresent {
+			logCtx.Debugf("this dry sha %s is already hydrated", r.DrySha)
+			return "", hydratedSha, nil
+		}
 	}
 
 	logCtx.Debug("Writing manifests")
@@ -270,4 +278,24 @@ func (s *Service) initGitClient(ctx context.Context, logCtx *log.Entry, r *apicl
 	}
 
 	return gitClient, dirPath, cleanupOrLog, nil
+}
+
+// allHydratedManifestsUnchanged checks whether all requested paths already have
+// an unchanged `manifest.yaml` in the current working tree (i.e. the hydrated commit).
+// It returns true when all hydrated manifests exist and are unchanged, false if any
+// are missing or changed, or an error if the git client failed to query the tree.
+func allHydratedManifestsUnchanged(gitClient git.Client, paths []*apiclient.PathDetails) (bool, error) {
+	for _, p := range paths {
+		manifestPath := filepath.Join(p.Path, ManifestYaml)
+		changed, err := gitClient.HasFileChanged(manifestPath)
+		if err != nil {
+			return false, err
+		}
+		// HasFileChanged returns true when the file is new or changed; if any
+		// manifest is new/changed, we must run the full WriteForPaths flow.
+		if changed {
+			return false, nil
+		}
+	}
+	return true, nil
 }

--- a/commitserver/commit/commit.go
+++ b/commitserver/commit/commit.go
@@ -167,7 +167,7 @@ func (s *Service) handleCommitRequest(ctx context.Context, logCtx *log.Entry, r 
 	if isHydrated {
 		// Check if all requested paths are present in the existing hydrated commit
 		// If a new app is created with a path that was not part of the previous hydration, we need to proceed to full WriteForPaths
-		allPresent, err := allHydratedManifestsUnchanged(gitClient, r.Paths)
+		allPresent, err := allHydratedManifestsUnchanged(ctx, gitClient, r.Paths)
 		if err != nil {
 			logCtx.WithError(err).Warn("Failed to perform path existence check; will proceed to full WriteForPaths")
 		} else if allPresent {
@@ -284,10 +284,10 @@ func (s *Service) initGitClient(ctx context.Context, logCtx *log.Entry, r *apicl
 // an unchanged `manifest.yaml` in the current working tree (i.e. the hydrated commit).
 // It returns true when all hydrated manifests exist and are unchanged, false if any
 // are missing or changed, or an error if the git client failed to query the tree.
-func allHydratedManifestsUnchanged(gitClient git.Client, paths []*apiclient.PathDetails) (bool, error) {
+func allHydratedManifestsUnchanged(ctx context.Context, gitClient git.Client, paths []*apiclient.PathDetails) (bool, error) {
 	for _, p := range paths {
 		manifestPath := filepath.Join(p.Path, ManifestYaml)
-		changed, err := gitClient.HasFileChanged(manifestPath)
+		changed, err := gitClient.HasFileChanged(ctx, manifestPath)
 		if err != nil {
 			return false, err
 		}

--- a/commitserver/commit/commit_test.go
+++ b/commitserver/commit/commit_test.go
@@ -372,6 +372,7 @@ func Test_CommitHydratedManifests(t *testing.T) {
 		mockGitClient.EXPECT().CheckoutOrNew(mock.Anything, "main", "env/test", false).Return("", nil).Once()
 		mockGitClient.EXPECT().GetCommitNote(mock.Anything, mock.Anything, mock.Anything).Return(strnote, nil).Once()
 		mockGitClient.EXPECT().CommitSHA(mock.Anything).Return("dupe-test-sha", nil).Once()
+		mockGitClient.EXPECT().HasFileChanged(mock.Anything, "manifest.yaml").Return(false, nil).Once()
 		mockRepoClientFactory.EXPECT().NewClient(mock.Anything, mock.Anything).Return(mockGitClient, nil).Once()
 
 		request := &apiclient.CommitHydratedManifestsRequest{
@@ -398,6 +399,65 @@ func Test_CommitHydratedManifests(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		assert.Equal(t, "dupe-test-sha", resp.HydratedSha, "Should return existing hydrated SHA when already hydrated")
+	})
+
+	t.Run("already hydrated but new path added - should proceed with full hydration", func(t *testing.T) {
+		t.Parallel()
+
+		strnote := "{\"drySha\":\"abc123\"}"
+		service, mockRepoClientFactory := newServiceWithMocks(t)
+		mockGitClient := gitmocks.NewClient(t)
+		mockGitClient.EXPECT().Init().Return(nil).Once()
+		mockGitClient.EXPECT().Fetch(mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+		mockGitClient.EXPECT().SetAuthor(mock.Anything, "Argo CD", "argo-cd@example.com").Return("", nil).Once()
+		mockGitClient.EXPECT().CheckoutOrOrphan(mock.Anything, "env/test", false).Return("", nil).Once()
+		mockGitClient.EXPECT().CheckoutOrNew(mock.Anything, "main", "env/test", false).Return("", nil).Once()
+		mockGitClient.EXPECT().GetCommitNote(mock.Anything, mock.Anything, mock.Anything).Return(strnote, nil).Once()
+		mockGitClient.EXPECT().CommitSHA(mock.Anything).Return("hydrated-sha-before-new-path", nil).Once()
+		// Check first path - exists and unchanged
+		mockGitClient.EXPECT().HasFileChanged(mock.Anything, "app1/manifest.yaml").Return(false, nil).Once()
+		// Check second path - new path (file changed = true means new or modified)
+		mockGitClient.EXPECT().HasFileChanged(mock.Anything, "app2/manifest.yaml").Return(true, nil).Once()
+		// Since a new path is detected, proceed with full WriteForPaths
+		mockGitClient.EXPECT().HasFileChanged(mock.Anything, "app1/manifest.yaml").Return(false, nil).Once()
+		mockGitClient.EXPECT().HasFileChanged(mock.Anything, "app2/manifest.yaml").Return(true, nil).Once()
+		mockGitClient.EXPECT().CommitAndPush(mock.Anything, "main", "test commit message").Return("", nil).Once()
+		mockGitClient.EXPECT().CommitSHA(mock.Anything).Return("new-hydrated-sha", nil).Once()
+		mockGitClient.EXPECT().AddAndPushNote(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+		mockRepoClientFactory.EXPECT().NewClient(mock.Anything, mock.Anything).Return(mockGitClient, nil).Once()
+
+		request := &apiclient.CommitHydratedManifestsRequest{
+			Repo: &v1alpha1.Repository{
+				Repo: "https://github.com/argoproj/argocd-example-apps.git",
+			},
+			TargetBranch:  "main",
+			SyncBranch:    "env/test",
+			DrySha:        "abc123",
+			CommitMessage: "test commit message",
+			Paths: []*apiclient.PathDetails{
+				{
+					Path: "app1",
+					Manifests: []*apiclient.HydratedManifestDetails{
+						{
+							ManifestJSON: `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"app1"}}`,
+						},
+					},
+				},
+				{
+					Path: "app2",
+					Manifests: []*apiclient.HydratedManifestDetails{
+						{
+							ManifestJSON: `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"app2"}}`,
+						},
+					},
+				},
+			},
+		}
+
+		resp, err := service.CommitHydratedManifests(t.Context(), request)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, "new-hydrated-sha", resp.HydratedSha, "Should create new commit when new path is added")
 	})
 
 	t.Run("root path with dot - no changes to manifest - should commit note only", func(t *testing.T) {
@@ -454,4 +514,15 @@ func newServiceWithMocks(t *testing.T) (*Service, *mocks.RepoClientFactory) {
 	service.repoClientFactory = mockRepoClientFactory
 
 	return service, mockRepoClientFactory
+}
+
+func Test_allHydratedManifestsUnchanged(t *testing.T) {
+	t.Run("empty paths list", func(t *testing.T) {
+		mockGitClient := gitmocks.NewClient(t)
+		paths := []*apiclient.PathDetails{}
+
+		result, err := allHydratedManifestsUnchanged(mockGitClient, paths)
+		require.NoError(t, err)
+		assert.True(t, result, "Should return true when paths list is empty")
+	})
 }

--- a/commitserver/commit/commit_test.go
+++ b/commitserver/commit/commit_test.go
@@ -521,7 +521,7 @@ func Test_allHydratedManifestsUnchanged(t *testing.T) {
 		mockGitClient := gitmocks.NewClient(t)
 		paths := []*apiclient.PathDetails{}
 
-		result, err := allHydratedManifestsUnchanged(mockGitClient, paths)
+		result, err := allHydratedManifestsUnchanged(t.Context(), mockGitClient, paths)
 		require.NoError(t, err)
 		assert.True(t, result, "Should return true when paths list is empty")
 	})

--- a/controller/hydrator/hydrator.go
+++ b/controller/hydrator/hydrator.go
@@ -373,11 +373,33 @@ func (h *Hydrator) hydrate(logCtx *log.Entry, apps []*appv1.Application, project
 	}
 	paths := []*commitclient.PathDetails{pathDetails}
 	logCtx = logCtx.WithFields(log.Fields{"drySha": targetRevision})
-	// De-dupe, if the drySha was already hydrated log a debug and return using the data from the last successful hydration run.
-	// We only inspect one app. If apps have been added/removed, that will be handled on the next DRY commit.
-	if apps[0].Status.SourceHydrator.LastSuccessfulOperation != nil && targetRevision == apps[0].Status.SourceHydrator.LastSuccessfulOperation.DrySHA {
-		logCtx.Debug("Skipping hydration since the DRY commit was already hydrated")
-		return targetRevision, apps[0].Status.SourceHydrator.LastSuccessfulOperation.HydratedSHA, nil, nil
+
+	// De-dupe check: Skip hydration only if all apps have already been hydrated with this drySha at their respective paths.
+	// We must check every app individually - if any app needs hydration, we must proceed.
+	if len(apps) > 0 {
+		allAppsAlreadyHydrated := true
+
+		for _, app := range apps {
+			if app.Status.SourceHydrator.LastSuccessfulOperation == nil {
+				allAppsAlreadyHydrated = false
+				break
+			}
+
+			lastDrySHA := app.Status.SourceHydrator.LastSuccessfulOperation.DrySHA
+			lastPath := app.Status.SourceHydrator.LastSuccessfulOperation.SourceHydrator.SyncSource.Path
+			currentPath := app.Spec.GetHydrateToSource().Path
+
+			// This app needs hydration if either drySha or path changed
+			if targetRevision != lastDrySHA || currentPath != lastPath {
+				allAppsAlreadyHydrated = false
+				break
+			}
+		}
+
+		if allAppsAlreadyHydrated {
+			// All apps already hydrated - return the hydratedSHA from the first app (all should have the same value)
+			return targetRevision, apps[0].Status.SourceHydrator.LastSuccessfulOperation.HydratedSHA, nil, nil
+		}
 	}
 
 	eg, ctx := errgroup.WithContext(context.Background())

--- a/controller/hydrator/hydrator.go
+++ b/controller/hydrator/hydrator.go
@@ -440,11 +440,33 @@ func (h *Hydrator) hydrate(ctx context.Context, logCtx *log.Entry, apps []*appv1
 	}
 	paths := []*commitclient.PathDetails{pathDetails}
 	logCtx = logCtx.WithFields(log.Fields{"drySha": targetRevision})
-	// De-dupe, if the drySha was already hydrated log a debug and return using the data from the last successful hydration run.
-	// We only inspect one app. If apps have been added/removed, that will be handled on the next DRY commit.
-	if apps[0].Status.SourceHydrator.LastSuccessfulOperation != nil && targetRevision == apps[0].Status.SourceHydrator.LastSuccessfulOperation.DrySHA {
-		logCtx.Debug("Skipping hydration since the DRY commit was already hydrated")
-		return targetRevision, apps[0].Status.SourceHydrator.LastSuccessfulOperation.HydratedSHA, nil, nil
+
+	// De-dupe check: Skip hydration only if all apps have already been hydrated with this drySha at their respective paths.
+	// We must check every app individually - if any app needs hydration, we must proceed.
+	if len(apps) > 0 {
+		allAppsAlreadyHydrated := true
+
+		for _, app := range apps {
+			if app.Status.SourceHydrator.LastSuccessfulOperation == nil {
+				allAppsAlreadyHydrated = false
+				break
+			}
+
+			lastDrySHA := app.Status.SourceHydrator.LastSuccessfulOperation.DrySHA
+			lastPath := app.Status.SourceHydrator.LastSuccessfulOperation.SourceHydrator.SyncSource.Path
+			currentPath := app.Spec.GetHydrateToSource().Path
+
+			// This app needs hydration if either drySha or path changed
+			if targetRevision != lastDrySHA || currentPath != lastPath {
+				allAppsAlreadyHydrated = false
+				break
+			}
+		}
+
+		if allAppsAlreadyHydrated {
+			// All apps already hydrated - return the hydratedSHA from the first app (all should have the same value)
+			return targetRevision, apps[0].Status.SourceHydrator.LastSuccessfulOperation.HydratedSHA, nil, nil
+		}
 	}
 
 	// NB: use a distinct name for the errgroup-derived context. errgroup cancels it as soon as

--- a/controller/hydrator/hydrator_test.go
+++ b/controller/hydrator/hydrator_test.go
@@ -1110,10 +1110,14 @@ func TestHydrator_hydrate_DeDupe_Success(t *testing.T) {
 	app1 := newTestApp("app1")
 	app2 := newTestApp("app2")
 	lastSuccessfulOperation := &v1alpha1.SuccessfulHydrateOperation{
-		DrySHA:      "sha123",
-		HydratedSHA: "hydrated123",
+		DrySHA:         "sha123",
+		HydratedSHA:    "hydrated123",
+		SourceHydrator: *app1.Spec.SourceHydrator,
 	}
 	app1.Status.SourceHydrator = v1alpha1.SourceHydratorStatus{
+		LastSuccessfulOperation: lastSuccessfulOperation,
+	}
+	app2.Status.SourceHydrator = v1alpha1.SourceHydratorStatus{
 		LastSuccessfulOperation: lastSuccessfulOperation,
 	}
 

--- a/controller/hydrator/hydrator_test.go
+++ b/controller/hydrator/hydrator_test.go
@@ -1542,10 +1542,14 @@ func TestHydrator_hydrate_DeDupe_Success(t *testing.T) {
 	app1 := newTestApp("app1")
 	app2 := newTestApp("app2")
 	lastSuccessfulOperation := &v1alpha1.SuccessfulHydrateOperation{
-		DrySHA:      "sha123",
-		HydratedSHA: "hydrated123",
+		DrySHA:         "sha123",
+		HydratedSHA:    "hydrated123",
+		SourceHydrator: *app1.Spec.SourceHydrator,
 	}
 	app1.Status.SourceHydrator = v1alpha1.SourceHydratorStatus{
+		LastSuccessfulOperation: lastSuccessfulOperation,
+	}
+	app2.Status.SourceHydrator = v1alpha1.SourceHydratorStatus{
 		LastSuccessfulOperation: lastSuccessfulOperation,
 	}
 


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->
Closes #26154

Issue: When multiple applications shared the same DRY source repository/branch and hydrated to the same destination branch, but used different paths, the second app would fail to hydrate. It would incorrectly skip hydration because the first app had already been hydrated.

If the first app was hydrated in the batch, it assumed all apps were done
 and it was only comparing drySha to decide whether to hydarte or not, ignored the condition that apps might write to different paths in the same repo

Changes:
Looped through all apps and check every  app  by comparing both drySha and path, only skip if all apps passes the condition

Checklist:

* -[x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* -[x] The title of the PR states what changed and the related issues number (used for the release note).
* -[x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* -[x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* -[x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* -[x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* -[x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
