### PR TITLE
feat(cli): allow unsetting annotations on cluster

### DIFF
--- a/cmd/argocd/commands/cluster.go
+++ b/cmd/argocd/commands/cluster.go
@@ -264,14 +264,14 @@ func NewClusterSetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command
 				namespaces[0] = ""
 			}
 			// parse the labels you're receiving from the label flag
-			labelsMap, err := label.ParseLabelMap(labels)
+			labelsMap, err := label.ParseMap(labels)
 			errors.CheckError(err)
 			// parse the annotations you're receiving from the annotation flag
-			annotationsMap, err := label.ParseLabelMap(annotations)
+			annotationsMap, err := label.ParseMap(annotations)
 			errors.CheckError(err)
 
 			// fetch existing cluster to merge labels/annotations
-			if labelsMap.Updates != nil || annotationsMap.Updates != nil {
+			if len(labelsMap) > 0 || len(annotationsMap) > 0 {
 				existing, err := clusterIf.Get(ctx, getQueryBySelector(clusterName))
 				errors.CheckError(err)
 				if labelsMap != nil {

--- a/cmd/argocd/commands/cluster.go
+++ b/cmd/argocd/commands/cluster.go
@@ -274,12 +274,8 @@ func NewClusterSetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command
 			if len(labelsMap) > 0 || len(annotationsMap) > 0 {
 				existing, err := clusterIf.Get(ctx, getQueryBySelector(clusterName))
 				errors.CheckError(err)
-				if labelsMap != nil {
-					mergedLabels = labelsMap.Merge(existing.Labels)
-				}
-				if annotationsMap != nil {
-					mergedAnnotations = annotationsMap.Merge(existing.Annotations)
-				}
+				mergedLabels = labelsMap.Merge(existing.Labels)
+				mergedAnnotations = annotationsMap.Merge(existing.Annotations)
 			}
 			if updatedFields != nil {
 				clusterUpdateRequest := clusterpkg.ClusterUpdateRequest{

--- a/docs/user-guide/commands/argocd_cluster_set.md
+++ b/docs/user-guide/commands/argocd_cluster_set.md
@@ -19,9 +19,9 @@ argocd cluster set NAME [flags]
 ### Options
 
 ```
-      --annotation stringArray   Set metadata annotations (e.g. --annotation key=value)
+      --annotation stringArray   Set metadata annotations (e.g. --annotation key=value) or unset them (e.g. --annotation key-)
   -h, --help                     help for set
-      --label stringArray        Set metadata labels (e.g. --label key=value)
+      --label stringArray        Set metadata labels (e.g. --label key=value) or unset them (e.g. --label key-)
       --name string              Overwrite the cluster name
       --namespace stringArray    List of namespaces which are allowed to manage. Specify '*' to manage all namespaces
 ```

--- a/util/text/label/label.go
+++ b/util/text/label/label.go
@@ -5,19 +5,45 @@ import (
 	"strings"
 )
 
-const labelFieldDelimiter = "="
+const (
+	labelFieldDelimiter = "="
+	deletionMarker      = "\x00DELETE\x00"
+)
 
 func Parse(labels []string) (map[string]string, error) {
 	var selectedLabels map[string]string
 	if labels != nil {
 		selectedLabels = map[string]string{}
 		for _, r := range labels {
-			fields := strings.Split(r, labelFieldDelimiter)
-			if len(fields) != 2 {
-				return nil, fmt.Errorf("labels should have key%svalue, but instead got: %s", labelFieldDelimiter, r)
+			if strings.HasSuffix(r, "-") {
+				key := strings.TrimSuffix(r, "-")
+				if key == "" {
+					return nil, fmt.Errorf("invalid label deletion syntax: %s", r)
+				}
+				selectedLabels[key] = deletionMarker
+			} else {
+				fields := strings.Split(r, labelFieldDelimiter)
+				if len(fields) != 2 {
+					return nil, fmt.Errorf("labels should have key%svalue, but instead got: %s", labelFieldDelimiter, r)
+				}
+				selectedLabels[fields[0]] = fields[1]
 			}
-			selectedLabels[fields[0]] = fields[1]
 		}
 	}
 	return selectedLabels, nil
+}
+
+func Merge(existing, updates map[string]string) map[string]string {
+	result := make(map[string]string)
+	for k, v := range existing {
+		result[k] = v
+	}
+	for k, v := range updates {
+		if v == deletionMarker {
+			delete(result, k)
+		} else {
+			result[k] = v
+		}
+	}
+	return result
 }

--- a/util/text/label/label.go
+++ b/util/text/label/label.go
@@ -1,49 +1,105 @@
 package label
 
 import (
+	"errors"
 	"fmt"
+	"maps"
 	"strings"
 )
 
-const (
-	labelFieldDelimiter = "="
-	deletionMarker      = "\x00DELETE\x00"
-)
+const labelFieldDelimiter = "="
 
+// LabelUpdate represents a single label update with value and deletion flag.
+type LabelUpdate struct {
+	Value  string
+	Delete bool
+}
+
+// LabelMap holds label updates that can include deletions.
+type LabelMap struct {
+	Updates map[string]LabelUpdate
+}
+
+func NewLabelMap() *LabelMap {
+	return &LabelMap{Updates: make(map[string]LabelUpdate)}
+}
+
+// Plain returns a simple map[string]string with only non-deleted labels.
+func (lm *LabelMap) Plain() map[string]string {
+	result := make(map[string]string)
+	for k, v := range lm.Updates {
+		if !v.Delete {
+			result[k] = v.Value
+		}
+	}
+	return result
+}
+
+// Parse populates the LabelMap from a slice of label strings.
+// Supports deletion syntax (e.g., "key-").
+func (lm *LabelMap) Parse(labels []string) error {
+	if labels != nil {
+		lm.Updates = make(map[string]LabelUpdate)
+		for _, r := range labels {
+			if strings.HasSuffix(r, "-") {
+				key := strings.TrimSuffix(r, "-")
+				if key == "" {
+					return fmt.Errorf("invalid label deletion syntax: %s", r)
+				}
+				lm.Updates[key] = LabelUpdate{Value: "", Delete: true}
+			} else {
+				fields := strings.Split(r, labelFieldDelimiter)
+				if len(fields) != 2 {
+					return fmt.Errorf("labels should have key%svalue, but instead got: %s", labelFieldDelimiter, r)
+				}
+				lm.Updates[fields[0]] = LabelUpdate{Value: fields[1], Delete: false}
+			}
+		}
+	}
+	return nil
+}
+
+// Merge merges the updates in this LabelMap with existing labels, handling deletions.
+func (lm *LabelMap) Merge(existing map[string]string) map[string]string {
+	result := make(map[string]string)
+	maps.Copy(result, existing)
+	for k, v := range lm.Updates {
+		if v.Delete {
+			delete(result, k)
+		} else {
+			result[k] = v.Value
+		}
+	}
+	return result
+}
+
+// Parse parses a slice of label strings into a simple map.
+// For deletion support, use ParseToMap instead.
 func Parse(labels []string) (map[string]string, error) {
 	var selectedLabels map[string]string
 	if labels != nil {
 		selectedLabels = map[string]string{}
 		for _, r := range labels {
 			if strings.HasSuffix(r, "-") {
-				key := strings.TrimSuffix(r, "-")
-				if key == "" {
-					return nil, fmt.Errorf("invalid label deletion syntax: %s", r)
-				}
-				selectedLabels[key] = deletionMarker
-			} else {
-				fields := strings.Split(r, labelFieldDelimiter)
-				if len(fields) != 2 {
-					return nil, fmt.Errorf("labels should have key%svalue, but instead got: %s", labelFieldDelimiter, r)
-				}
-				selectedLabels[fields[0]] = fields[1]
+				return nil, errors.New("deletion syntax not supported in Parse(), use ParseToMap() instead")
 			}
+			fields := strings.Split(r, labelFieldDelimiter)
+			if len(fields) != 2 {
+				return nil, fmt.Errorf("labels should have key%svalue, but instead got: %s", labelFieldDelimiter, r)
+			}
+			selectedLabels[fields[0]] = fields[1]
 		}
 	}
 	return selectedLabels, nil
 }
 
-func Merge(existing, updates map[string]string) map[string]string {
-	result := make(map[string]string)
-	for k, v := range existing {
-		result[k] = v
+// ParseLabelMap parses a slice of label strings into a LabelMap.
+// Supports deletion syntax (e.g., "key-").
+func ParseLabelMap(labels []string) (*LabelMap, error) {
+	lm := NewLabelMap()
+	err := lm.Parse(labels)
+	if err != nil {
+		return nil, err
 	}
-	for k, v := range updates {
-		if v == deletionMarker {
-			delete(result, k)
-		} else {
-			result[k] = v
-		}
-	}
-	return result
+	return lm, nil
 }

--- a/util/text/label/label.go
+++ b/util/text/label/label.go
@@ -22,17 +22,6 @@ func NewMap() Map {
 	return make(Map)
 }
 
-// Plain returns a simple map[string]string with only non-deleted labels.
-func (lm Map) Plain() map[string]string {
-	result := make(map[string]string)
-	for k, v := range lm {
-		if !v.Delete {
-			result[k] = v.Value
-		}
-	}
-	return result
-}
-
 // Parse populates the Map from a slice of label strings.
 // Supports deletion syntax (e.g., "key-").
 func (lm Map) Parse(labels []string) error {

--- a/util/text/label/label.go
+++ b/util/text/label/label.go
@@ -26,8 +26,8 @@ func NewMap() Map {
 // Supports deletion syntax (e.g., "key-").
 func (lm Map) Parse(labels []string) error {
 	for _, r := range labels {
-		if strings.HasSuffix(r, "-") {
-			key := strings.TrimSuffix(r, "-")
+		key, found := strings.CutSuffix(r, "-")
+		if found {
 			if key == "" {
 				return fmt.Errorf("invalid label deletion syntax: %s", r)
 			}

--- a/util/text/label/label.go
+++ b/util/text/label/label.go
@@ -26,8 +26,8 @@ func NewMap() Map {
 // Supports deletion syntax (e.g., "key-").
 func (lm Map) Parse(labels []string) error {
 	for _, r := range labels {
-		key, found := strings.CutSuffix(r, "-")
-		if found {
+		if !strings.Contains(r, labelFieldDelimiter) && strings.HasSuffix(r, "-") {
+			key := strings.TrimSuffix(r, "-")
 			if key == "" {
 				return fmt.Errorf("invalid label deletion syntax: %s", r)
 			}
@@ -63,7 +63,7 @@ func (lm Map) Merge(existing map[string]string) map[string]string {
 func Parse(labels []string) (map[string]string, error) {
 	selectedLabels := map[string]string{}
 	for _, r := range labels {
-		if strings.HasSuffix(r, "-") {
+		if !strings.Contains(r, labelFieldDelimiter) && strings.HasSuffix(r, "-") {
 			return nil, errors.New("deletion syntax not supported in Parse(), use ParseMap() instead")
 		}
 		fields := strings.Split(r, labelFieldDelimiter)

--- a/util/text/label/label_test.go
+++ b/util/text/label/label_test.go
@@ -23,3 +23,31 @@ func TestParseLabels(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, result)
 }
+
+func TestParseDeletion(t *testing.T) {
+	result, err := Parse([]string{"x-"})
+	require.NoError(t, err)
+	assert.Equal(t, deletionMarker, result["x"])
+
+	result, err = Parse([]string{"x=5", "y-"})
+	require.NoError(t, err)
+	assert.Equal(t, "5", result["x"])
+	assert.Equal(t, deletionMarker, result["y"])
+
+	_, err = Parse([]string{"-"})
+	require.Error(t, err)
+}
+
+func TestMerge(t *testing.T) {
+	result := Merge(map[string]string{"x": "5", "y": "10"}, map[string]string{"x": deletionMarker})
+	assert.Len(t, result, 1)
+	assert.Equal(t, "10", result["y"])
+
+	result = Merge(map[string]string{"x": "5", "y": "10"}, map[string]string{"x": "6", "y": deletionMarker})
+	assert.Len(t, result, 1)
+	assert.Equal(t, "6", result["x"])
+
+	result = Merge(map[string]string{"x": "5"}, map[string]string{"y": deletionMarker})
+	assert.Len(t, result, 1)
+	assert.Equal(t, "5", result["x"])
+}

--- a/util/text/label/label_test.go
+++ b/util/text/label/label_test.go
@@ -13,6 +13,9 @@ func TestParseLabels(t *testing.T) {
 	result, err := Parse(validLabels)
 	require.NoError(t, err)
 	assert.Len(t, result, 3)
+	assert.Equal(t, "value", result["key"])
+	assert.Equal(t, "bar", result["foo"])
+	assert.Equal(t, "inc", result["intuit"])
 
 	invalidLabels := []string{"key=value", "too=many=equals"}
 	_, err = Parse(invalidLabels)
@@ -24,30 +27,93 @@ func TestParseLabels(t *testing.T) {
 	assert.Empty(t, result)
 }
 
-func TestParseDeletion(t *testing.T) {
-	result, err := Parse([]string{"x-"})
-	require.NoError(t, err)
-	assert.Equal(t, deletionMarker, result["x"])
-
-	result, err = Parse([]string{"x=5", "y-"})
-	require.NoError(t, err)
-	assert.Equal(t, "5", result["x"])
-	assert.Equal(t, deletionMarker, result["y"])
-
-	_, err = Parse([]string{"-"})
+func TestParseRejectsDeletionSyntax(t *testing.T) {
+	// Original Parse() should reject deletion syntax
+	_, err := Parse([]string{"x-"})
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "deletion syntax not supported")
+
+	_, err = Parse([]string{"x=5", "y-"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "deletion syntax not supported")
+
+	// ParseLabelMap should accept deletion syntax
+	lm, err := ParseLabelMap([]string{"x-"})
+	require.NoError(t, err)
+	assert.True(t, lm.Updates["x"].Delete)
 }
 
-func TestMerge(t *testing.T) {
-	result := Merge(map[string]string{"x": "5", "y": "10"}, map[string]string{"x": deletionMarker})
+func TestParseLabelMap(t *testing.T) {
+	// Test basic parsing
+	result, err := ParseLabelMap([]string{"x=5", "y=10"})
+	require.NoError(t, err)
+	assert.Len(t, result.Updates, 2)
+	assert.Equal(t, "5", result.Updates["x"].Value)
+	assert.False(t, result.Updates["x"].Delete)
+	assert.Equal(t, "10", result.Updates["y"].Value)
+	assert.False(t, result.Updates["y"].Delete)
+
+	// Test deletion syntax
+	result, err = ParseLabelMap([]string{"x-"})
+	require.NoError(t, err)
+	assert.Len(t, result.Updates, 1)
+	assert.True(t, result.Updates["x"].Delete)
+
+	// Test mixed syntax
+	result, err = ParseLabelMap([]string{"x=5", "y-"})
+	require.NoError(t, err)
+	assert.Len(t, result.Updates, 2)
+	assert.Equal(t, "5", result.Updates["x"].Value)
+	assert.False(t, result.Updates["x"].Delete)
+	assert.True(t, result.Updates["y"].Delete)
+
+	// Test invalid deletion syntax
+	_, err = ParseLabelMap([]string{"-"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid label deletion syntax")
+}
+
+func TestLabelMapMerge(t *testing.T) {
+	// Test deletion
+	lm, _ := ParseLabelMap([]string{"x-"})
+	result := lm.Merge(map[string]string{"x": "5", "y": "10"})
 	assert.Len(t, result, 1)
 	assert.Equal(t, "10", result["y"])
+	assert.NotContains(t, result, "x")
 
-	result = Merge(map[string]string{"x": "5", "y": "10"}, map[string]string{"x": "6", "y": deletionMarker})
+	// Test update and deletion
+	lm, _ = ParseLabelMap([]string{"x=6", "y-"})
+	result = lm.Merge(map[string]string{"x": "5", "y": "10"})
 	assert.Len(t, result, 1)
 	assert.Equal(t, "6", result["x"])
 
-	result = Merge(map[string]string{"x": "5"}, map[string]string{"y": deletionMarker})
+	// Test deletion of non-existing key
+	lm, _ = ParseLabelMap([]string{"z-"})
+	result = lm.Merge(map[string]string{"x": "5"})
 	assert.Len(t, result, 1)
 	assert.Equal(t, "5", result["x"])
+
+	// Test update only
+	lm, _ = ParseLabelMap([]string{"x=6"})
+	result = lm.Merge(map[string]string{"x": "5", "y": "10"})
+	assert.Len(t, result, 2)
+	assert.Equal(t, "6", result["x"])
+	assert.Equal(t, "10", result["y"])
+}
+
+func TestLabelMapPlain(t *testing.T) {
+	lm, _ := ParseLabelMap([]string{"x=5", "y-", "z=10"})
+
+	result := lm.Plain()
+	assert.Len(t, result, 2)
+	assert.Equal(t, "5", result["x"])
+	assert.Equal(t, "10", result["z"])
+	assert.NotContains(t, result, "y")
+}
+
+func TestNewLabelMap(t *testing.T) {
+	lm := NewLabelMap()
+	assert.NotNil(t, lm)
+	assert.NotNil(t, lm.Updates)
+	assert.Empty(t, lm.Updates)
 }

--- a/util/text/label/label_test.go
+++ b/util/text/label/label_test.go
@@ -113,16 +113,6 @@ func TestMapMerge(t *testing.T) {
 	assert.Equal(t, "10", result["y"])
 }
 
-func TestMapPlain(t *testing.T) {
-	lm, _ := ParseMap([]string{"x=5", "y-", "z=10"})
-
-	result := lm.Plain()
-	assert.Len(t, result, 2)
-	assert.Equal(t, "5", result["x"])
-	assert.Equal(t, "10", result["z"])
-	assert.NotContains(t, result, "y")
-}
-
 func TestNewMap(t *testing.T) {
 	lm := NewMap()
 	assert.NotNil(t, lm)

--- a/util/text/label/label_test.go
+++ b/util/text/label/label_test.go
@@ -17,6 +17,12 @@ func TestParseLabels(t *testing.T) {
 	assert.Equal(t, "bar", result["foo"])
 	assert.Equal(t, "inc", result["intuit"])
 
+	// Values ending with a hyphen are valid assignments, not deletions.
+	hyphenValue := []string{"key=value-"}
+	result, err = Parse(hyphenValue)
+	require.NoError(t, err)
+	assert.Equal(t, "value-", result["key"])
+
 	invalidLabels := []string{"key=value", "too=many=equals"}
 	_, err = Parse(invalidLabels)
 	require.Error(t, err)
@@ -36,6 +42,10 @@ func TestParseRejectsDeletionSyntax(t *testing.T) {
 	_, err = Parse([]string{"x=5", "y-"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "deletion syntax not supported")
+
+	// key=value- is an assignment, not deletion syntax
+	_, err = Parse([]string{"key=value-"})
+	require.NoError(t, err)
 
 	// ParseMap should accept deletion syntax
 	lm, err := ParseMap([]string{"x-"})
@@ -66,6 +76,12 @@ func TestParseMap(t *testing.T) {
 	assert.Equal(t, "5", result["x"].Value)
 	assert.False(t, result["x"].Delete)
 	assert.True(t, result["y"].Delete)
+
+	// Test that key=value- is treated as assignment, not deletion
+	result, err = ParseMap([]string{"key=value-"})
+	require.NoError(t, err)
+	assert.Equal(t, "value-", result["key"].Value)
+	assert.False(t, result["key"].Delete)
 
 	// Test invalid deletion syntax
 	_, err = ParseMap([]string{"-"})


### PR DESCRIPTION
This allows users to unset cluster annotations by using a special syntax that is equivalent of "kubectl annotate".

The same functionality is currently available through the UI.

Example usage:

```shell
## Possible today
$ argocd cluster set mycluster --annotation unwanted=12345
Cluster 'mycluster' updated.

$ argocd cluster get mycluster | yq .annotations
argocd.argoproj.io/refresh: "2025-08-04T14:39:55Z"
unwanted: '12345'
$

## new
$ argocd cluster set mycluster --annotation unwanted-
Cluster 'mycluster' updated.

$ argocd cluster get mycluster | yq .annotations
argocd.argoproj.io/refresh: "2025-08-04T14:39:55Z"
$
```

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI ~and UI~ to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
