### PR TITLE
feat: add Gateway API support to network view

### DIFF
--- a/controller/cache/info.go
+++ b/controller/cache/info.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -79,6 +80,13 @@ func populateNodeInfo(un *unstructured.Unstructured, res *ResourceInfo, customLa
 			populateIstioVirtualServiceInfo(un, res)
 		case "ServiceEntry":
 			populateIstioServiceEntryInfo(un, res)
+		}
+	case "gateway.networking.k8s.io":
+		switch gvk.Kind {
+		case "HTTPRoute", "GRPCRoute", "TCPRoute", "TLSRoute", "UDPRoute":
+			populateGatewayAPIRouteInfo(un, res)
+		case "Gateway":
+			populateGatewayInfo(un, res)
 		}
 	case "argoproj.io":
 		if gvk.Kind == "Application" {
@@ -318,6 +326,266 @@ func populateIstioServiceEntryInfo(un *unstructured.Unstructured, res *ResourceI
 		TargetRefs: []v1alpha1.ResourceRef{{
 			Kind: kube.PodKind,
 		}},
+	}
+}
+
+func getGatewayAddresses(un *unstructured.Unstructured) []corev1.LoadBalancerIngress {
+	addresses, ok, err := unstructured.NestedSlice(un.Object, "status", "addresses")
+	if !ok || err != nil {
+		if err != nil {
+			log.Warnf("Failed to get addresses for Gateway %s/%s: %v", un.GetNamespace(), un.GetName(), err)
+		}
+		return nil
+	}
+	res := make([]corev1.LoadBalancerIngress, 0)
+	for _, item := range addresses {
+		addr, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		addrType, _, errType := unstructured.NestedString(addr, "type")
+		if errType != nil {
+			log.Warnf("Failed to get address type for Gateway %s/%s: %v", un.GetNamespace(), un.GetName(), errType)
+		}
+		value, _, errValue := unstructured.NestedString(addr, "value")
+		if errValue != nil {
+			log.Warnf("Failed to get address value for Gateway %s/%s: %v", un.GetNamespace(), un.GetName(), errValue)
+		}
+		if value == "" {
+			continue
+		}
+		switch addrType {
+		case "Hostname":
+			res = append(res, corev1.LoadBalancerIngress{Hostname: value})
+		case "IPAddress", "":
+			// IPAddress is default per Gateway API spec
+			res = append(res, corev1.LoadBalancerIngress{IP: value})
+		}
+	}
+	return res
+}
+
+func generateGatewayURLs(un *unstructured.Unstructured, addresses []corev1.LoadBalancerIngress) []string {
+	urlsSet := make(map[string]bool)
+
+	listeners, ok, err := unstructured.NestedSlice(un.Object, "spec", "listeners")
+	if !ok || err != nil {
+		if err != nil {
+			log.Warnf("Failed to get listeners for Gateway %s/%s: %v", un.GetNamespace(), un.GetName(), err)
+		}
+		return nil
+	}
+
+	for _, listener := range listeners {
+		listenerMap, ok := listener.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		hostname, _, errHostname := unstructured.NestedString(listenerMap, "hostname")
+		if errHostname != nil {
+			log.Warnf("Failed to get hostname for Gateway %s/%s listener: %v", un.GetNamespace(), un.GetName(), errHostname)
+		}
+		protocol, _, errProtocol := unstructured.NestedString(listenerMap, "protocol")
+		if errProtocol != nil {
+			log.Warnf("Failed to get protocol for Gateway %s/%s listener: %v", un.GetNamespace(), un.GetName(), errProtocol)
+		}
+
+		// Port can come as int64 or float64 depending on parsing
+		var port int64
+		if portVal, exists := listenerMap["port"]; exists {
+			switch v := portVal.(type) {
+			case int64:
+				port = v
+			case float64:
+				port = int64(v)
+			case int:
+				port = int64(v)
+			default:
+				log.Warnf("Unsupported port type %T for Gateway %s/%s listener", portVal, un.GetNamespace(), un.GetName())
+			}
+		}
+
+		scheme := "http"
+		if protocol == "HTTPS" || protocol == "TLS" {
+			scheme = "https"
+		}
+
+		// Use listener hostname if specified, otherwise use addresses
+		hosts := []string{}
+		if hostname != "" && hostname != "*" {
+			hosts = append(hosts, hostname)
+		} else {
+			for _, addr := range addresses {
+				if addr.Hostname != "" {
+					hosts = append(hosts, addr.Hostname)
+				} else if addr.IP != "" {
+					hosts = append(hosts, addr.IP)
+				}
+			}
+		}
+
+		for _, host := range hosts {
+			urlStr := fmt.Sprintf("%s://%s", scheme, host)
+			// Add non-standard ports
+			if (scheme == "http" && port != 80) || (scheme == "https" && port != 443) {
+				urlStr = fmt.Sprintf("%s:%d", urlStr, port)
+			}
+			if err := settings.ValidateExternalURL(urlStr); err != nil {
+				log.Warnf("Invalid URL generated for Gateway %s/%s: %s", un.GetNamespace(), un.GetName(), urlStr)
+				continue
+			}
+			urlsSet[urlStr] = true
+		}
+	}
+
+	urls := make([]string, 0, len(urlsSet))
+	for u := range urlsSet {
+		urls = append(urls, u)
+	}
+	return urls
+}
+
+func populateGatewayInfo(un *unstructured.Unstructured, res *ResourceInfo) {
+	ingress := getGatewayAddresses(un)
+
+	var urls []string
+	if res.NetworkingInfo != nil {
+		urls = res.NetworkingInfo.ExternalURLs
+	}
+
+	// Check for ignore default links annotation
+	enableDefaultExternalURLs := true
+	if ignoreVal, ok := un.GetAnnotations()[common.AnnotationKeyIgnoreDefaultLinks]; ok {
+		if ignoreDefaultLinks, err := strconv.ParseBool(ignoreVal); err == nil {
+			enableDefaultExternalURLs = !ignoreDefaultLinks
+		}
+	}
+
+	if enableDefaultExternalURLs {
+		generatedURLs := generateGatewayURLs(un, ingress)
+		urls = append(urls, generatedURLs...)
+	}
+
+	res.NetworkingInfo = &v1alpha1.ResourceNetworkingInfo{
+		Ingress:      ingress,
+		ExternalURLs: urls,
+	}
+}
+
+func populateGatewayAPIRouteInfo(un *unstructured.Unstructured, res *ResourceInfo) {
+	targetsMap := make(map[v1alpha1.ResourceRef]bool)
+
+	// Extract parent refs (Gateway references)
+	parentRefs, ok, err := unstructured.NestedSlice(un.Object, "spec", "parentRefs")
+	if err != nil {
+		log.Warnf("Failed to get parentRefs for %s %s/%s: %v", un.GetKind(), un.GetNamespace(), un.GetName(), err)
+	}
+	if ok && err == nil {
+		for _, parentRef := range parentRefs {
+			parent, ok := parentRef.(map[string]any)
+			if !ok {
+				continue
+			}
+
+			name, _, errName := unstructured.NestedString(parent, "name")
+			if errName != nil {
+				log.Warnf("Failed to get parentRef name for %s %s/%s: %v", un.GetKind(), un.GetNamespace(), un.GetName(), errName)
+			}
+			if name == "" {
+				continue
+			}
+
+			// Namespace defaults to HTTPRoute's namespace
+			namespace, found, _ := unstructured.NestedString(parent, "namespace")
+			if !found || namespace == "" {
+				namespace = un.GetNamespace()
+			}
+
+			// Group defaults to "gateway.networking.k8s.io"
+			group, found, _ := unstructured.NestedString(parent, "group")
+			if !found || group == "" {
+				group = "gateway.networking.k8s.io"
+			}
+
+			// Kind defaults to "Gateway"
+			kind, found, _ := unstructured.NestedString(parent, "kind")
+			if !found || kind == "" {
+				kind = "Gateway"
+			}
+
+			targetsMap[v1alpha1.ResourceRef{
+				Group:     group,
+				Kind:      kind,
+				Namespace: namespace,
+				Name:      name,
+			}] = true
+		}
+	}
+
+	// Extract backend refs from all rules
+	rules, ok, err := unstructured.NestedSlice(un.Object, "spec", "rules")
+	if ok && err == nil {
+		for _, rule := range rules {
+			ruleMap, ok := rule.(map[string]any)
+			if !ok {
+				continue
+			}
+
+			backendRefs, ok, err := unstructured.NestedSlice(ruleMap, "backendRefs")
+			if !ok || err != nil {
+				continue
+			}
+
+			for _, backendRef := range backendRefs {
+				backend, ok := backendRef.(map[string]any)
+				if !ok {
+					continue
+				}
+
+				name, _, _ := unstructured.NestedString(backend, "name")
+				if name == "" {
+					continue
+				}
+
+				// Namespace defaults to HTTPRoute's namespace if not specified
+				namespace, found, _ := unstructured.NestedString(backend, "namespace")
+				if !found || namespace == "" {
+					namespace = un.GetNamespace()
+				}
+
+				// Group defaults to "" (core API) if not specified
+				group, _, _ := unstructured.NestedString(backend, "group")
+
+				// Kind defaults to "Service" if not specified
+				kind, found, _ := unstructured.NestedString(backend, "kind")
+				if !found || kind == "" {
+					kind = kube.ServiceKind
+				}
+
+				targetsMap[v1alpha1.ResourceRef{
+					Group:     group,
+					Kind:      kind,
+					Namespace: namespace,
+					Name:      name,
+				}] = true
+			}
+		}
+	}
+
+	targets := make([]v1alpha1.ResourceRef, 0, len(targetsMap))
+	for target := range targetsMap {
+		targets = append(targets, target)
+	}
+
+	var urls []string
+	if res.NetworkingInfo != nil {
+		urls = res.NetworkingInfo.ExternalURLs
+	}
+
+	res.NetworkingInfo = &v1alpha1.ResourceNetworkingInfo{
+		TargetRefs:   targets,
+		ExternalURLs: urls,
 	}
 }
 

--- a/controller/cache/info_test.go
+++ b/controller/cache/info_test.go
@@ -319,12 +319,239 @@ spec:
   - name: http
     number: 80
     protocol: HTTP
-    targetPort: 5678 
+    targetPort: 5678
   resolution: DNS
 
   workloadSelector:
     labels:
       app.kubernetes.io/name: echo-2
+`)
+
+	testHTTPRoute = strToUnstructured(`
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-route
+  namespace: default
+spec:
+  parentRefs:
+  - name: example-gateway
+    namespace: default
+  hostnames:
+  - example.com
+  rules:
+  - backendRefs:
+    - name: service-a
+      port: 8080
+    - name: service-b
+      port: 8080
+`)
+
+	testHTTPRouteCrossNamespace = strToUnstructured(`
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: cross-ns-route
+  namespace: default
+spec:
+  rules:
+  - backendRefs:
+    - name: service-other
+      namespace: other-ns
+      port: 8080
+`)
+
+	testHTTPRouteWithExternalLink = strToUnstructured(`
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: annotated-route
+  namespace: default
+  annotations:
+    link.argocd.argoproj.io/external-link: https://example.com
+spec:
+  rules:
+  - backendRefs:
+    - name: service-a
+      port: 8080
+`)
+
+	testHTTPRouteMultipleRules = strToUnstructured(`
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: multi-rule-route
+  namespace: default
+spec:
+  rules:
+  - matches:
+    - path:
+        value: /api
+    backendRefs:
+    - name: api-service
+      port: 8080
+  - matches:
+    - path:
+        value: /web
+    backendRefs:
+    - name: web-service
+      port: 80
+`)
+
+	testHTTPRouteCrossNamespaceParent = strToUnstructured(`
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: cross-ns-parent-route
+  namespace: default
+spec:
+  parentRefs:
+  - name: shared-gateway
+    namespace: gateway-ns
+  rules:
+  - backendRefs:
+    - name: my-service
+      port: 8080
+`)
+
+	testGRPCRoute = strToUnstructured(`
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: grpc-route
+  namespace: default
+spec:
+  parentRefs:
+  - name: grpc-gateway
+  rules:
+  - backendRefs:
+    - name: grpc-service
+      port: 50051
+`)
+
+	testGatewayWithIP = strToUnstructured(`
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+  namespace: default
+spec:
+  gatewayClassName: example-class
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+status:
+  addresses:
+  - type: IPAddress
+    value: 192.168.1.100
+`)
+
+	testGatewayWithHostname = strToUnstructured(`
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: hostname-gateway
+  namespace: default
+spec:
+  listeners:
+  - name: https
+    protocol: HTTPS
+    port: 443
+    hostname: api.example.com
+status:
+  addresses:
+  - type: Hostname
+    value: lb.example.com
+`)
+
+	testGatewayMultipleListeners = strToUnstructured(`
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: multi-gateway
+  namespace: default
+spec:
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+  - name: https
+    protocol: HTTPS
+    port: 443
+status:
+  addresses:
+  - type: IPAddress
+    value: 10.0.0.1
+`)
+
+	testGatewayNonStandardPort = strToUnstructured(`
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: custom-port-gateway
+  namespace: default
+spec:
+  listeners:
+  - name: http-alt
+    protocol: HTTP
+    port: 8080
+status:
+  addresses:
+  - type: IPAddress
+    value: 10.0.0.1
+`)
+
+	testGatewayNoAddresses = strToUnstructured(`
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: pending-gateway
+  namespace: default
+spec:
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+`)
+
+	testGatewayWithExternalLink = strToUnstructured(`
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: annotated-gateway
+  namespace: default
+  annotations:
+    link.argocd.argoproj.io/external-link: https://custom-link.example.com
+spec:
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+status:
+  addresses:
+  - type: IPAddress
+    value: 10.0.0.1
+`)
+
+	testGatewayIgnoreDefaultLinks = strToUnstructured(`
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: no-default-links-gateway
+  namespace: default
+  annotations:
+    link.argocd.argoproj.io/external-link: https://custom-link.example.com
+    argocd.argoproj.io/ignore-default-links: "true"
+spec:
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+status:
+  addresses:
+  - type: IPAddress
+    value: 10.0.0.1
 `)
 )
 
@@ -1209,6 +1436,180 @@ func TestGetIstioServiceEntryInfo(t *testing.T) {
 	assert.Equal(t, map[string]string{
 		"app.kubernetes.io/name": "echo-2",
 	}, info.NetworkingInfo.TargetLabels)
+}
+
+func TestGetHTTPRouteInfo(t *testing.T) {
+	info := &ResourceInfo{}
+	populateNodeInfo(testHTTPRoute, info, []string{})
+	assert.Empty(t, info.Info)
+	require.NotNil(t, info.NetworkingInfo)
+	// Should have Gateway (parentRef) + 2 Services (backendRefs)
+	assert.Len(t, info.NetworkingInfo.TargetRefs, 3)
+	// Check Gateway ref from parentRefs
+	assert.Contains(t, info.NetworkingInfo.TargetRefs, v1alpha1.ResourceRef{
+		Group:     "gateway.networking.k8s.io",
+		Kind:      "Gateway",
+		Namespace: "default",
+		Name:      "example-gateway",
+	})
+	// Check Service refs from backendRefs
+	assert.Contains(t, info.NetworkingInfo.TargetRefs, v1alpha1.ResourceRef{
+		Group:     "",
+		Kind:      kube.ServiceKind,
+		Namespace: "default",
+		Name:      "service-a",
+	})
+	assert.Contains(t, info.NetworkingInfo.TargetRefs, v1alpha1.ResourceRef{
+		Group:     "",
+		Kind:      kube.ServiceKind,
+		Namespace: "default",
+		Name:      "service-b",
+	})
+	assert.Empty(t, info.NetworkingInfo.Ingress)
+}
+
+func TestGetHTTPRouteCrossNamespaceInfo(t *testing.T) {
+	info := &ResourceInfo{}
+	populateNodeInfo(testHTTPRouteCrossNamespace, info, []string{})
+	require.NotNil(t, info.NetworkingInfo)
+	assert.Len(t, info.NetworkingInfo.TargetRefs, 1)
+	assert.Contains(t, info.NetworkingInfo.TargetRefs, v1alpha1.ResourceRef{
+		Group:     "",
+		Kind:      kube.ServiceKind,
+		Namespace: "other-ns",
+		Name:      "service-other",
+	})
+}
+
+func TestGetHTTPRouteWithExternalLinkAnnotation(t *testing.T) {
+	info := &ResourceInfo{}
+	populateNodeInfo(testHTTPRouteWithExternalLink, info, []string{})
+	require.NotNil(t, info.NetworkingInfo)
+	assert.Contains(t, info.NetworkingInfo.ExternalURLs, "https://example.com")
+}
+
+func TestGetHTTPRouteMultipleRules(t *testing.T) {
+	info := &ResourceInfo{}
+	populateNodeInfo(testHTTPRouteMultipleRules, info, []string{})
+	require.NotNil(t, info.NetworkingInfo)
+	assert.Len(t, info.NetworkingInfo.TargetRefs, 2)
+	serviceNames := make([]string, 0)
+	for _, ref := range info.NetworkingInfo.TargetRefs {
+		serviceNames = append(serviceNames, ref.Name)
+	}
+	assert.Contains(t, serviceNames, "api-service")
+	assert.Contains(t, serviceNames, "web-service")
+}
+
+func TestGetHTTPRouteCrossNamespaceParent(t *testing.T) {
+	info := &ResourceInfo{}
+	populateNodeInfo(testHTTPRouteCrossNamespaceParent, info, []string{})
+	require.NotNil(t, info.NetworkingInfo)
+	// Should have Gateway (cross-namespace parentRef) + Service (backendRef)
+	assert.Len(t, info.NetworkingInfo.TargetRefs, 2)
+	// Gateway should use explicit namespace from parentRef
+	assert.Contains(t, info.NetworkingInfo.TargetRefs, v1alpha1.ResourceRef{
+		Group:     "gateway.networking.k8s.io",
+		Kind:      "Gateway",
+		Namespace: "gateway-ns",
+		Name:      "shared-gateway",
+	})
+	// Service should use HTTPRoute's namespace (default)
+	assert.Contains(t, info.NetworkingInfo.TargetRefs, v1alpha1.ResourceRef{
+		Group:     "",
+		Kind:      kube.ServiceKind,
+		Namespace: "default",
+		Name:      "my-service",
+	})
+}
+
+func TestGetGRPCRoute(t *testing.T) {
+	info := &ResourceInfo{}
+	populateNodeInfo(testGRPCRoute, info, []string{})
+	require.NotNil(t, info.NetworkingInfo)
+	// Should have Gateway (parentRef) + Service (backendRef)
+	assert.Len(t, info.NetworkingInfo.TargetRefs, 2)
+	assert.Contains(t, info.NetworkingInfo.TargetRefs, v1alpha1.ResourceRef{
+		Group:     "gateway.networking.k8s.io",
+		Kind:      "Gateway",
+		Namespace: "default",
+		Name:      "grpc-gateway",
+	})
+	assert.Contains(t, info.NetworkingInfo.TargetRefs, v1alpha1.ResourceRef{
+		Group:     "",
+		Kind:      kube.ServiceKind,
+		Namespace: "default",
+		Name:      "grpc-service",
+	})
+}
+
+func TestGetGatewayInfoWithIP(t *testing.T) {
+	info := &ResourceInfo{}
+	populateNodeInfo(testGatewayWithIP, info, []string{})
+	assert.Empty(t, info.Info)
+	require.NotNil(t, info.NetworkingInfo)
+	assert.Len(t, info.NetworkingInfo.Ingress, 1)
+	assert.Equal(t, "192.168.1.100", info.NetworkingInfo.Ingress[0].IP)
+	assert.Contains(t, info.NetworkingInfo.ExternalURLs, "http://192.168.1.100")
+}
+
+func TestGetGatewayInfoWithHostname(t *testing.T) {
+	info := &ResourceInfo{}
+	populateNodeInfo(testGatewayWithHostname, info, []string{})
+	require.NotNil(t, info.NetworkingInfo)
+	assert.Len(t, info.NetworkingInfo.Ingress, 1)
+	assert.Equal(t, "lb.example.com", info.NetworkingInfo.Ingress[0].Hostname)
+	// Listener has explicit hostname, so URL should use that
+	assert.Contains(t, info.NetworkingInfo.ExternalURLs, "https://api.example.com")
+}
+
+func TestGetGatewayInfoMultipleListeners(t *testing.T) {
+	info := &ResourceInfo{}
+	populateNodeInfo(testGatewayMultipleListeners, info, []string{})
+	require.NotNil(t, info.NetworkingInfo)
+	assert.Len(t, info.NetworkingInfo.Ingress, 1)
+	assert.Equal(t, "10.0.0.1", info.NetworkingInfo.Ingress[0].IP)
+	// Should have both HTTP and HTTPS URLs
+	assert.Len(t, info.NetworkingInfo.ExternalURLs, 2)
+	assert.Contains(t, info.NetworkingInfo.ExternalURLs, "http://10.0.0.1")
+	assert.Contains(t, info.NetworkingInfo.ExternalURLs, "https://10.0.0.1")
+}
+
+func TestGetGatewayInfoNonStandardPort(t *testing.T) {
+	info := &ResourceInfo{}
+	populateNodeInfo(testGatewayNonStandardPort, info, []string{})
+	require.NotNil(t, info.NetworkingInfo)
+	assert.Len(t, info.NetworkingInfo.Ingress, 1)
+	// Non-standard port should be included in URL
+	assert.Contains(t, info.NetworkingInfo.ExternalURLs, "http://10.0.0.1:8080")
+}
+
+func TestGetGatewayInfoNoAddresses(t *testing.T) {
+	info := &ResourceInfo{}
+	populateNodeInfo(testGatewayNoAddresses, info, []string{})
+	require.NotNil(t, info.NetworkingInfo)
+	// Gateway with no addresses (e.g., pending) should have empty ingress
+	assert.Empty(t, info.NetworkingInfo.Ingress)
+	// No URLs since no addresses to use
+	assert.Empty(t, info.NetworkingInfo.ExternalURLs)
+}
+
+func TestGetGatewayInfoWithExternalLink(t *testing.T) {
+	info := &ResourceInfo{}
+	populateNodeInfo(testGatewayWithExternalLink, info, []string{})
+	require.NotNil(t, info.NetworkingInfo)
+	// Should have both custom link and generated URL
+	assert.Contains(t, info.NetworkingInfo.ExternalURLs, "https://custom-link.example.com")
+	assert.Contains(t, info.NetworkingInfo.ExternalURLs, "http://10.0.0.1")
+}
+
+func TestGetGatewayInfoIgnoreDefaultLinks(t *testing.T) {
+	info := &ResourceInfo{}
+	populateNodeInfo(testGatewayIgnoreDefaultLinks, info, []string{})
+	require.NotNil(t, info.NetworkingInfo)
+	// Should only have custom link, not generated URL
+	assert.Len(t, info.NetworkingInfo.ExternalURLs, 1)
+	assert.Contains(t, info.NetworkingInfo.ExternalURLs, "https://custom-link.example.com")
 }
 
 func TestGetIngressInfo(t *testing.T) {

--- a/ui/src/app/applications/components/application-resource-tree/application-resource-tree.tsx
+++ b/ui/src/app/applications/components/application-resource-tree/application-resource-tree.tsx
@@ -1093,6 +1093,12 @@ export const ApplicationResourceTree = (props: ApplicationResourceTreeProps) => 
         }
     }
 
+    // Helper to check if edge should be reversed for correct traffic flow visualization
+    // Gateway API routes reference Gateway via parentRefs, but traffic flows Gateway -> Route
+    const gatewayAPIRouteKinds = new Set(['HTTPRoute', 'GRPCRoute', 'TCPRoute', 'TLSRoute', 'UDPRoute']);
+    const shouldReverseEdge = (source: ResourceTreeNode, target: ResourceTreeNode): boolean =>
+        source.group === 'gateway.networking.k8s.io' && gatewayAPIRouteKinds.has(source.kind) && target.group === 'gateway.networking.k8s.io' && target.kind === 'Gateway';
+
     if (props.useNetworkingHierarchy) {
         // Network view
         const hasParents = new Set<string>();
@@ -1100,24 +1106,30 @@ export const ApplicationResourceTree = (props: ApplicationResourceTreeProps) => 
         const hiddenNodes: ResourceTreeNode[] = [];
         networkNodes.forEach(parent => {
             findNetworkTargets(networkNodes, parent.networkingInfo).forEach(child => {
-                const children = childrenByParentKey.get(treeNodeKey(parent)) || [];
-                hasParents.add(treeNodeKey(child));
-                const parentId = parent.uid;
+                // For HTTPRoute -> Gateway edges, reverse the relationship
+                // so Gateway appears as the parent (traffic flows Gateway -> HTTPRoute -> Service)
+                const reverseEdge = shouldReverseEdge(parent, child);
+                const actualParent = reverseEdge ? child : parent;
+                const actualChild = reverseEdge ? parent : child;
+
+                const children = childrenByParentKey.get(treeNodeKey(actualParent)) || [];
+                hasParents.add(treeNodeKey(actualChild));
+                const parentId = actualParent.uid;
                 if (nodesHavingChildren.has(parentId)) {
                     nodesHavingChildren.set(parentId, nodesHavingChildren.get(parentId) + children.length);
                 } else {
                     nodesHavingChildren.set(parentId, 1);
                 }
-                if (child.kind !== 'Pod' || !props.showCompactNodes) {
+                if (actualChild.kind !== 'Pod' || !props.showCompactNodes) {
                     if (props.getNodeExpansion(parentId)) {
-                        hasParents.add(treeNodeKey(child));
-                        children.push(child);
-                        childrenByParentKey.set(treeNodeKey(parent), children);
+                        hasParents.add(treeNodeKey(actualChild));
+                        children.push(actualChild);
+                        childrenByParentKey.set(treeNodeKey(actualParent), children);
                     } else {
-                        hiddenNodes.push(child);
+                        hiddenNodes.push(actualChild);
                     }
                 } else {
-                    processPodGroup(parent, child, props);
+                    processPodGroup(actualParent, actualChild, props);
                 }
             });
         });

--- a/ui/src/app/applications/components/application-resource-tree/application-resource-tree.tsx
+++ b/ui/src/app/applications/components/application-resource-tree/application-resource-tree.tsx
@@ -1151,6 +1151,12 @@ export const ApplicationResourceTree = (props: ApplicationResourceTreeProps) => 
         }
     }
 
+    // Helper to check if edge should be reversed for correct traffic flow visualization
+    // Gateway API routes reference Gateway via parentRefs, but traffic flows Gateway -> Route
+    const gatewayAPIRouteKinds = new Set(['HTTPRoute', 'GRPCRoute', 'TCPRoute', 'TLSRoute', 'UDPRoute']);
+    const shouldReverseEdge = (source: ResourceTreeNode, target: ResourceTreeNode): boolean =>
+        source.group === 'gateway.networking.k8s.io' && gatewayAPIRouteKinds.has(source.kind) && target.group === 'gateway.networking.k8s.io' && target.kind === 'Gateway';
+
     if (props.useNetworkingHierarchy) {
         // Network view
         const hasParents = new Set<string>();
@@ -1158,24 +1164,30 @@ export const ApplicationResourceTree = (props: ApplicationResourceTreeProps) => 
         const hiddenNodes: ResourceTreeNode[] = [];
         networkNodes.forEach(parent => {
             findNetworkTargets(networkNodes, parent.networkingInfo).forEach(child => {
-                const children = childrenByParentKey.get(treeNodeKey(parent)) || [];
-                hasParents.add(treeNodeKey(child));
-                const parentId = parent.uid;
+                // For HTTPRoute -> Gateway edges, reverse the relationship
+                // so Gateway appears as the parent (traffic flows Gateway -> HTTPRoute -> Service)
+                const reverseEdge = shouldReverseEdge(parent, child);
+                const actualParent = reverseEdge ? child : parent;
+                const actualChild = reverseEdge ? parent : child;
+
+                const children = childrenByParentKey.get(treeNodeKey(actualParent)) || [];
+                hasParents.add(treeNodeKey(actualChild));
+                const parentId = actualParent.uid;
                 if (nodesHavingChildren.has(parentId)) {
                     nodesHavingChildren.set(parentId, nodesHavingChildren.get(parentId) + children.length);
                 } else {
                     nodesHavingChildren.set(parentId, 1);
                 }
-                if (child.kind !== 'Pod' || !props.showCompactNodes) {
+                if (actualChild.kind !== 'Pod' || !props.showCompactNodes) {
                     if (props.getNodeExpansion(parentId)) {
-                        hasParents.add(treeNodeKey(child));
-                        children.push(child);
-                        childrenByParentKey.set(treeNodeKey(parent), children);
+                        hasParents.add(treeNodeKey(actualChild));
+                        children.push(actualChild);
+                        childrenByParentKey.set(treeNodeKey(actualParent), children);
                     } else {
-                        hiddenNodes.push(child);
+                        hiddenNodes.push(actualChild);
                     }
                 } else {
-                    processPodGroup(parent, child, props);
+                    processPodGroup(actualParent, actualChild, props);
                 }
             });
         });


### PR DESCRIPTION
## Summary

This PR adds support for Gateway API resources (Gateway and HTTPRoute) in the ArgoCD network view, enabling visualization of the complete traffic flow similar to existing Ingress support.

For HTTPRoute resources, the implementation extracts backend references from `spec.rules[].backendRefs[]` to create edges to Services. It also extracts parent references from `spec.parentRefs[]` to link HTTPRoutes to their parent Gateways.

For Gateway resources, the implementation extracts load balancer addresses from `status.addresses[]` and generates clickable external URLs based on the Gateway's listener configuration.

Since traffic flows from Gateway to HTTPRoute but the data model has HTTPRoute referencing Gateway via parentRefs, the UI reverses these specific edges during graph construction so arrows display the correct traffic flow direction.

The resulting network view displays:
```
Gateway → HTTPRoute → Service → Pod
```

<img width="1717" height="1245" alt="Captura desde 2026-01-30 14-28-19" src="https://github.com/user-attachments/assets/f48df9d9-ee7c-48f2-a9e2-070c22ca2ae1" />


Fixes #17087