### PR TITLE
fix: remove check for running hooks to resolve deadlock on termination

### DIFF
--- a/gitops-engine/pkg/sync/sync_context.go
+++ b/gitops-engine/pkg/sync/sync_context.go
@@ -714,7 +714,7 @@ func (sc *syncContext) getNamespaceCreationTask(tasks syncTasks) *syncTask {
 func (sc *syncContext) terminateHooksPreemptively(tasks syncTasks) bool {
 	terminateSuccessful := true
 	for _, task := range tasks {
-		if !task.isHook() || !task.running() {
+		if !task.isHook() {
 			continue
 		}
 

--- a/gitops-engine/pkg/sync/sync_context.go
+++ b/gitops-engine/pkg/sync/sync_context.go
@@ -927,7 +927,10 @@ func (sc *syncContext) getSyncTasks() (_ syncTasks, successful bool) {
 					targetObj.SetName(fmt.Sprintf("%s%s", generateName, postfix))
 				}
 				if !hook.HasHookFinalizer(targetObj) {
-					targetObj.SetFinalizers(append(targetObj.GetFinalizers(), hook.HookFinalizer))
+					liveObj := sc.liveObj(targetObj)
+					if liveObj == nil || liveObj.GetDeletionTimestamp() == nil {
+						targetObj.SetFinalizers(append(targetObj.GetFinalizers(), hook.HookFinalizer))
+					}
 				}
 				hookTasks = append(hookTasks, &syncTask{phase: phase, targetObj: targetObj})
 			}

--- a/gitops-engine/pkg/sync/sync_context_deadlock_test.go
+++ b/gitops-engine/pkg/sync/sync_context_deadlock_test.go
@@ -1,0 +1,125 @@
+package sync
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"k8s.io/klog/v2/textlogger"
+
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/argoproj/gitops-engine/pkg/sync/common"
+	"github.com/argoproj/gitops-engine/pkg/sync/hook"
+	"github.com/argoproj/gitops-engine/pkg/utils/kube"
+	testingutils "github.com/argoproj/gitops-engine/pkg/utils/testing"
+)
+
+func TestGetSyncTasks_TerminatingHookNoFinalizer(t *testing.T) {
+	// Setup a hook that is terminating (has DeletionTimestamp)
+	terminatingHook := testingutils.NewPod()
+	terminatingHook.SetName("terminating-hook")
+	terminatingHook.SetAnnotations(map[string]string{common.AnnotationKeyHook: "PreSync"})
+	
+	now := metav1.NewTime(time.Now())
+	terminatingHook.SetDeletionTimestamp(&now)
+
+	// Mock discovery client
+	fakeDisco := &fakediscovery.FakeDiscovery{Fake: &fake.NewSimpleClientset().Fake}
+	fakeDisco.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{
+					Name:       "pods",
+					Namespaced: true,
+					Kind:       "Pod",
+					Group:      "",
+					Version:    "v1",
+					Verbs:      []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+				},
+			},
+		},
+	}
+
+	syncCtx := &syncContext{
+		hooks:     []*unstructured.Unstructured{terminatingHook},
+		resources: make(map[kube.ResourceKey]reconciledResource),
+		log:       textlogger.NewLogger(textlogger.NewConfig()),
+		disco:     fakeDisco,
+		permissionValidator: func(_ *unstructured.Unstructured, _ *metav1.APIResource) error {
+			return nil
+		},
+		syncRes:   make(map[string]common.ResourceSyncResult),
+		startedAt: time.Now(),
+	}
+	
+	// Mock liveObj to return the terminating hook
+	syncCtx.resources = groupResources(ReconciliationResult{
+		Live:   []*unstructured.Unstructured{terminatingHook},
+		Target: []*unstructured.Unstructured{nil},
+	})
+
+	tasks, successful := syncCtx.getSyncTasks()
+	assert.True(t, successful)
+	assert.Len(t, tasks, 1)
+	
+	// The target object in the task should NOT have the hook finalizer
+	task := tasks[0]
+	assert.False(t, hook.HasHookFinalizer(task.targetObj), "Terminating hook should NOT have the hook finalizer added")
+}
+
+func TestGetSyncTasks_ActiveHookHasFinalizer(t *testing.T) {
+	// Setup a hook that is active (no DeletionTimestamp)
+	activeHook := testingutils.NewPod()
+	activeHook.SetName("active-hook")
+	activeHook.SetAnnotations(map[string]string{common.AnnotationKeyHook: "PreSync"})
+
+	// Mock discovery client
+	fakeDisco := &fakediscovery.FakeDiscovery{Fake: &fake.NewSimpleClientset().Fake}
+	fakeDisco.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{
+					Name:       "pods",
+					Namespaced: true,
+					Kind:       "Pod",
+					Group:      "",
+					Version:    "v1",
+					Verbs:      []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+				},
+			},
+		},
+	}
+
+	syncCtx := &syncContext{
+		hooks:     []*unstructured.Unstructured{activeHook},
+		resources: make(map[kube.ResourceKey]reconciledResource),
+		log:       textlogger.NewLogger(textlogger.NewConfig()),
+		disco:     fakeDisco,
+		permissionValidator: func(_ *unstructured.Unstructured, _ *metav1.APIResource) error {
+			return nil
+		},
+		syncRes:   make(map[string]common.ResourceSyncResult),
+		startedAt: time.Now(),
+	}
+	
+	// Mock liveObj to return the active hook (or nil, either way it should get the finalizer)
+	syncCtx.resources = groupResources(ReconciliationResult{
+		Live:   []*unstructured.Unstructured{activeHook},
+		Target: []*unstructured.Unstructured{nil},
+	})
+
+	tasks, successful := syncCtx.getSyncTasks()
+	assert.True(t, successful)
+	assert.Len(t, tasks, 1)
+	
+	// The target object in the task SHOULD have the hook finalizer
+	task := tasks[0]
+	assert.True(t, hook.HasHookFinalizer(task.targetObj), "Active hook SHOULD have the hook finalizer added")
+}


### PR DESCRIPTION
Fixes a deadlock where terminating hooks with external finalizers would effectively block sync because they were ignored by [terminateHooksPreemptively](https://github.com/argoproj/argo-cd/blob/72085781dcecc4fc1d69430bb89c4f1395948e64/gitops-engine/pkg/sync/sync_context.go#L710-L770) for not being in a 'running' state.

Fixes argoproj/argo-cd#26180

Detailed root cause analysis and verification report have been posted in https://github.com/argoproj/argo-cd/issues/26180#issuecomment-3825502430

Signed-off-by: Giulio Chessa <giuliohome@gmail.com>

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).