### PR TITLE
feat: Add basic support for git tag path prefixes

### DIFF
--- a/util/versions/tags.go
+++ b/util/versions/tags.go
@@ -3,12 +3,78 @@ package versions
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"slices"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 
 	"github.com/Masterminds/semver/v3"
 )
+
+// tagTokenRegex matches tag-like tokens with an optional path prefix (group 1) and version (group 2).
+// The prefix must end with "/" and may contain path segments. The version part cannot contain "/",
+// which structurally prevents nested prefix confusion (e.g., "prod/" matching inside "prod/prod/").
+var tagTokenRegex = regexp.MustCompile(`([a-zA-Z0-9-_./]+/)?([a-zA-Z0-9-_./*]+)`)
+
+// extractPrefixes extracts a common path prefix from a semver revision/constraint string.
+// The prefix must end with "/" and be consistent across all version segments in the constraint.
+//
+// Examples:
+//   - "prod/v1.0.*" → ("prod/", "v1.0.*")
+//   - "> prod/v1.0.0 < prod/v2.0.0" → ("prod/", "> v1.0.0 < v2.0.0")
+//   - "> prod/v1.0.0 < dev/v2.0.0" → ("", "> prod/v1.0.0 < dev/v2.0.0") - mixed prefixes, no extraction
+//   - "v1.0.*" → ("", "v1.0.*") - no prefix
+func extractPrefixes(revision string) (prefix string, stripped string) {
+	matches := tagTokenRegex.FindAllStringSubmatch(revision, -1)
+	if len(matches) == 0 {
+		return "", revision
+	}
+
+	// No prefix found in revision.
+	prefix = matches[0][1]
+	if prefix == "" {
+		return "", revision
+	}
+
+	// Verify every tag-like token shares the same prefix.
+	for _, match := range matches {
+		if match[1] != prefix {
+			return "", revision
+		}
+	}
+	return prefix, strings.ReplaceAll(revision, prefix, "")
+}
+
+// filterTagsByPrefix returns only tags that have the specified prefix.
+// If prefix is empty, returns all tags unchanged.
+func filterTagsByPrefix(tags []string, prefix string) []string {
+	if prefix == "" {
+		return tags
+	}
+
+	var filtered []string
+	for _, tag := range tags {
+		if strings.HasPrefix(tag, prefix) {
+			filtered = append(filtered, tag)
+		}
+	}
+	return filtered
+}
+
+// stripPrefixFromTags removes the prefix from each tag.
+// If prefix is empty, returns tags unchanged.
+func stripPrefixFromTags(tags []string, prefix string) []string {
+	if prefix == "" {
+		return tags
+	}
+
+	stripped := make([]string, len(tags))
+	for i, tag := range tags {
+		stripped[i] = strings.TrimPrefix(tag, prefix)
+	}
+	return stripped
+}
 
 // MaxVersion takes a revision and a list of tags.
 // If the revision is a version, it returns that version, even if it is not in the list of tags.
@@ -16,28 +82,39 @@ import (
 // If the revision is a constraint, it iterates over the list of tags to find the "maximum" tag which satisfies that
 // constraint.
 // If the revision is a constraint, but no tag satisfies that constraint, then it returns an error.
+//
+// Supports hierarchical tag prefixes (e.g., "prod/v1.0.*" will match tags like "prod/v1.0.0", "prod/v1.0.1").
+// The prefix must be consistent across all version segments in the constraint.
 func MaxVersion(revision string, tags []string) (string, error) {
-	if v, err := semver.NewVersion(revision); err == nil {
+	// Extract prefix from revision (e.g., "prod/v1.0.*" -> prefix: "prod/", stripped: "v1.0.*")
+	constraintPrefix, constraintStripped := extractPrefixes(revision)
+
+	if v, err := semver.NewVersion(constraintStripped); err == nil {
 		// If the revision is a valid version, then we know it isn't a constraint; it's just a pin.
 		// In which case, we should use standard tag resolution mechanisms and return the original value.
 		// For example, the following are considered valid versions, and therefore should match an exact tag:
 		// - "v1.0.0"/"1.0.0"
 		// - "v1.0"/"1.0"
-		return v.Original(), nil
+		return constraintPrefix + v.Original(), nil
 	}
 
-	constraints, err := semver.NewConstraint(revision)
+	constraints, err := semver.NewConstraint(constraintStripped)
+
+	// Filter tags to only those matching the prefix, then strip prefix for version comparison
+	filteredTags := filterTagsByPrefix(tags, constraintPrefix)
+	strippedTags := stripPrefixFromTags(filteredTags, constraintPrefix)
+
 	if err != nil {
 		log.Debugf("Revision '%s' is not a valid semver constraint, resolving via basic string equality.", revision)
 		// If this is also an invalid constraint, we just iterate over available tags to determine if it is valid/invalid.
-		if slices.Contains(tags, revision) {
-			return revision, nil
+		if slices.Contains(strippedTags, constraintStripped) {
+			return constraintPrefix + constraintStripped, nil
 		}
 		return "", fmt.Errorf("failed to determine semver constraint: %w", err)
 	}
 
 	var maxVersion *semver.Version
-	for _, tag := range tags {
+	for _, tag := range strippedTags {
 		v, err := semver.NewVersion(tag)
 
 		// Invalid semantic version ignored
@@ -55,11 +132,11 @@ func MaxVersion(revision string, tags []string) (string, error) {
 		}
 	}
 	if maxVersion == nil {
-		return "", fmt.Errorf("version matching constraint not found in %d tags", len(tags))
+		return "", fmt.Errorf("version matching constraint not found in %d tags", len(filteredTags))
 	}
 
-	log.Debugf("Semver constraint '%s' resolved to version '%s'", constraints.String(), maxVersion.Original())
-	return maxVersion.Original(), nil
+	log.Debugf("Semver constraint '%s' resolved to version '%s'", constraints.String(), constraintPrefix+maxVersion.Original())
+	return constraintPrefix + maxVersion.Original(), nil
 }
 
 // Returns true if the given revision is not an exact semver and can be parsed as a semver constraint

--- a/util/versions/tags.go
+++ b/util/versions/tags.go
@@ -15,7 +15,7 @@ import (
 // tagTokenRegex matches tag-like tokens with an optional path prefix (group 1) and version (group 2).
 // The prefix must end with "/" and may contain path segments. The version part cannot contain "/",
 // which structurally prevents nested prefix confusion (e.g., "prod/" matching inside "prod/prod/").
-var tagTokenRegex = regexp.MustCompile(`([a-zA-Z0-9-_./]+/)?([a-zA-Z0-9-_./*]+)`)
+var tagTokenRegex = regexp.MustCompile(`([a-zA-Z0-9-_./]+/)?([a-zA-Z0-9-_.*]+)`)
 
 // extractPrefixes extracts a common path prefix from a semver revision/constraint string.
 // The prefix must end with "/" and be consistent across all version segments in the constraint.

--- a/util/versions/tags_test.go
+++ b/util/versions/tags_test.go
@@ -89,3 +89,207 @@ func TestTags_IsConstraint(t *testing.T) {
 		assert.True(t, IsConstraint("*"))
 	})
 }
+
+func TestExtractPrefix(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          string
+		expectedPrefix string
+		expectedStrip  string
+	}{
+		{
+			name:           "no prefix",
+			input:          "v1.0.0",
+			expectedPrefix: "",
+			expectedStrip:  "v1.0.0",
+		},
+		{
+			name:           "simple prefix",
+			input:          "prod/v1.0.0",
+			expectedPrefix: "prod/",
+			expectedStrip:  "v1.0.0",
+		},
+		{
+			name:           "prefix with wildcard",
+			input:          "prod/v1.0.*",
+			expectedPrefix: "prod/",
+			expectedStrip:  "v1.0.*",
+		},
+		{
+			name:           "prefix with star only",
+			input:          "prod/*",
+			expectedPrefix: "prod/",
+			expectedStrip:  "*",
+		},
+		{
+			name:           "prefix with gt constraint",
+			input:          "> prod/v1.0.0",
+			expectedPrefix: "prod/",
+			expectedStrip:  "> v1.0.0",
+		},
+		{
+			name:           "prefix with gte constraint",
+			input:          ">= prod/v1.0.0",
+			expectedPrefix: "prod/",
+			expectedStrip:  ">= v1.0.0",
+		},
+		{
+			name:           "consistent prefix in range",
+			input:          ">= prod/v1.0.0 < prod/v2.0.0",
+			expectedPrefix: "prod/",
+			expectedStrip:  ">= v1.0.0 < v2.0.0",
+		},
+		{
+			name:           "mixed prefixes - no extraction",
+			input:          "> prod/v1.0.0 < dev/v2.0.0",
+			expectedPrefix: "",
+			expectedStrip:  "> prod/v1.0.0 < dev/v2.0.0",
+		},
+		{
+			name:           "deep nested prefix",
+			input:          "foo/bar/baz/v1.0.0",
+			expectedPrefix: "foo/bar/baz/",
+			expectedStrip:  "v1.0.0",
+		},
+		{
+			name:           "deep nested prefix with constraint",
+			input:          "> foo/bar/v1.0.0 < foo/bar/v2.0.0",
+			expectedPrefix: "foo/bar/",
+			expectedStrip:  "> v1.0.0 < v2.0.0",
+		},
+		{
+			name:           "inconsistent - one has prefix one doesn't",
+			input:          "> prod/v1.0.0 < v2.0.0",
+			expectedPrefix: "",
+			expectedStrip:  "> prod/v1.0.0 < v2.0.0",
+		},
+		{
+			name:           "tilde constraint with prefix",
+			input:          "~prod/v1.0.0",
+			expectedPrefix: "prod/",
+			expectedStrip:  "~v1.0.0",
+		},
+		{
+			name:           "caret constraint with prefix",
+			input:          "^prod/v1.0.0",
+			expectedPrefix: "prod/",
+			expectedStrip:  "^v1.0.0",
+		},
+		{
+			name:           "empty string",
+			input:          "",
+			expectedPrefix: "",
+			expectedStrip:  "",
+		},
+		{
+			name:           "just operators",
+			input:          "> < >=",
+			expectedPrefix: "",
+			expectedStrip:  "> < >=",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			prefix, stripped := extractPrefixes(tc.input)
+			assert.Equal(t, tc.expectedPrefix, prefix, "prefix mismatch")
+			assert.Equal(t, tc.expectedStrip, stripped, "stripped mismatch")
+		})
+	}
+}
+
+func TestMaxVersion_WithPrefix(t *testing.T) {
+	prefixedTags := []string{
+		"prod/v1.0.0",
+		"prod/v1.0.1",
+		"prod/v1.1.0",
+		"staging/v1.0.0",
+		"staging/v2.0.0",
+		"v3.0.0",
+	}
+
+	t.Run("patch wildcard with prefix", func(t *testing.T) {
+		version, err := MaxVersion("prod/v1.0.*", prefixedTags)
+		require.NoError(t, err)
+		assert.Equal(t, "prod/v1.0.1", version)
+	})
+
+	t.Run("minor wildcard with prefix", func(t *testing.T) {
+		version, err := MaxVersion("prod/v1.*", prefixedTags)
+		require.NoError(t, err)
+		assert.Equal(t, "prod/v1.1.0", version)
+	})
+
+	t.Run("star wildcard with prefix - matches all versions in prefix", func(t *testing.T) {
+		version, err := MaxVersion("prod/*", prefixedTags)
+		require.NoError(t, err)
+		assert.Equal(t, "prod/v1.1.0", version)
+	})
+
+	t.Run("x.x.x wildcard syntax with prefix", func(t *testing.T) {
+		// 1.x.x is equivalent to 1.* - matches any 1.x.x version
+		version, err := MaxVersion("prod/v1.x.x", prefixedTags)
+		require.NoError(t, err)
+		assert.Equal(t, "prod/v1.1.0", version)
+	})
+
+	t.Run("x.x wildcard syntax with prefix", func(t *testing.T) {
+		// 1.0.x is equivalent to 1.0.* - matches any 1.0.x version
+		version, err := MaxVersion("prod/v1.0.x", prefixedTags)
+		require.NoError(t, err)
+		assert.Equal(t, "prod/v1.0.1", version)
+	})
+
+	t.Run("two-segment version with prefix is exact match", func(t *testing.T) {
+		// Two-segment versions like 1.0 are treated as exact versions, not constraints
+		// They must match a tag exactly (semver interprets 1.0 as 1.0.0)
+		tagsWithTwoSegment := []string{
+			"prod/1.0",
+			"prod/1.0.0",
+			"prod/1.0.1",
+		}
+		version, err := MaxVersion("prod/1.0", tagsWithTwoSegment)
+		require.NoError(t, err)
+		assert.Equal(t, "prod/1.0", version)
+	})
+
+	t.Run("gt constraint with prefix", func(t *testing.T) {
+		version, err := MaxVersion("> staging/v1.0.0", prefixedTags)
+		require.NoError(t, err)
+		assert.Equal(t, "staging/v2.0.0", version)
+	})
+
+	t.Run("range constraint with prefix", func(t *testing.T) {
+		version, err := MaxVersion(">= prod/v1.0.0 < prod/v1.1.0", prefixedTags)
+		require.NoError(t, err)
+		assert.Equal(t, "prod/v1.0.1", version)
+	})
+
+	t.Run("no prefix still works", func(t *testing.T) {
+		version, err := MaxVersion("v3.*", prefixedTags)
+		require.NoError(t, err)
+		assert.Equal(t, "v3.0.0", version)
+	})
+
+	t.Run("exact version with prefix", func(t *testing.T) {
+		version, err := MaxVersion("prod/v1.0.0", prefixedTags)
+		require.NoError(t, err)
+		assert.Equal(t, "prod/v1.0.0", version)
+	})
+
+	t.Run("non-matching prefix returns error", func(t *testing.T) {
+		_, err := MaxVersion("dev/v1.0.*", prefixedTags)
+		require.Error(t, err)
+	})
+
+	t.Run("deep nested prefix", func(t *testing.T) {
+		nestedTags := []string{
+			"foo/bar/v1.0.0",
+			"foo/bar/v1.0.1",
+			"foo/baz/v1.0.0",
+		}
+		version, err := MaxVersion("foo/bar/v1.0.*", nestedTags)
+		require.NoError(t, err)
+		assert.Equal(t, "foo/bar/v1.0.1", version)
+	})
+}

--- a/util/versions/tags_test.go
+++ b/util/versions/tags_test.go
@@ -187,6 +187,18 @@ func TestExtractPrefix(t *testing.T) {
 			expectedPrefix: "",
 			expectedStrip:  "> < >=",
 		},
+		{
+			name:           "nested prefix mismatch - prod vs prod/prod",
+			input:          "> prod/v1.0.0 < prod/prod/v2.0.0",
+			expectedPrefix: "",
+			expectedStrip:  "> prod/v1.0.0 < prod/prod/v2.0.0",
+		},
+		{
+			name:           "consistent nested prefix",
+			input:          "> prod/prod/v1.0.0 < prod/prod/v2.0.0",
+			expectedPrefix: "prod/prod/",
+			expectedStrip:  "> v1.0.0 < v2.0.0",
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
This PR adapts #20948 to reflect the refactor in #20216.
> TL;DR This PR changes the resolveSemverRevision() function to tolerate a path prefix before the semantic version.
> ```
> # example
> targetRevision: '>=foo/bar/v0.0.0-rc0'
> ```
> This change is useful for teams that:
> - want to use hierarchical tags - useful for monorepos (app1/v0.0.0, app2/v1.0.0)
> - want to use a hierarchical namespace to route argo deployments using generators (app1/cluster1/prod/v0.0.0, > app1/cluster2/dev/v0.0.0)
> - use git flow or other tag based workflows with path prefixes

Closes https://github.com/argoproj/argo-cd/issues/20949

As well as the added tests I've sanity-checked this in my own environment with a test repo and it seems to behave as expected.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
