### PR TITLE
fix(ui): standard resource icons are not displayed properly.#26216

### DIFF
--- a/ui/src/app/applications/components/resource-icon.test.tsx
+++ b/ui/src/app/applications/components/resource-icon.test.tsx
@@ -1,0 +1,137 @@
+import * as React from 'react';
+import * as renderer from 'react-test-renderer';
+import {ResourceIcon} from './resource-icon';
+
+// Mock the resourceIcons and resourceCustomizations
+jest.mock('./resources', () => ({
+    resourceIcons: new Map([
+        ['Ingress', 'ing'],
+        ['ConfigMap', 'cm'],
+        ['Deployment', 'deploy'],
+        ['Service', 'svc']
+    ])
+}));
+
+jest.mock('./resource-customizations', () => ({
+    resourceIconGroups: {
+        '*.crossplane.io': true,
+        '*.fluxcd.io': true,
+        'cert-manager.io': true
+    }
+}));
+
+describe('ResourceIcon', () => {
+    describe('kind-based icons (no group)', () => {
+        it('should show kind-based icon for ConfigMap without group', () => {
+            const testRenderer = renderer.create(<ResourceIcon group='' kind='ConfigMap' />);
+            const testInstance = testRenderer.root;
+            const imgs = testInstance.findAllByType('img');
+            expect(imgs.length).toBeGreaterThan(0);
+            expect(imgs[0].props.src).toBe('assets/images/resources/cm.svg');
+        });
+
+        it('should show kind-based icon for Deployment without group', () => {
+            const testRenderer = renderer.create(<ResourceIcon group='' kind='Deployment' />);
+            const testInstance = testRenderer.root;
+            const imgs = testInstance.findAllByType('img');
+            expect(imgs.length).toBeGreaterThan(0);
+            expect(imgs[0].props.src).toBe('assets/images/resources/deploy.svg');
+        });
+    });
+
+    describe('group-based icons (with matching group)', () => {
+        it('should show group-based icon for exact group match', () => {
+            const testRenderer = renderer.create(<ResourceIcon group='cert-manager.io' kind='Certificate' />);
+            const testInstance = testRenderer.root;
+            const imgs = testInstance.findAllByType('img');
+            expect(imgs.length).toBeGreaterThan(0);
+            expect(imgs[0].props.src).toBe('assets/images/resources/cert-manager.io/icon.svg');
+        });
+
+        it('should show group-based icon for wildcard group match (crossplane)', () => {
+            const testRenderer = renderer.create(<ResourceIcon group='pkg.crossplane.io' kind='Provider' />);
+            const testInstance = testRenderer.root;
+            const imgs = testInstance.findAllByType('img');
+            expect(imgs.length).toBeGreaterThan(0);
+            // Wildcard '*' should be replaced with '_' in the path
+            expect(imgs[0].props.src).toBe('assets/images/resources/_.crossplane.io/icon.svg');
+
+            const complexTestRenderer = renderer.create(<ResourceIcon group='identify.provider.crossplane.io' kind='Provider' />);
+            const complexTestInstance = complexTestRenderer.root;
+            const complexImgs = complexTestInstance.findAllByType('img');
+            expect(complexImgs.length).toBeGreaterThan(0);
+            // Wildcard '*' should be replaced with '_' in the path
+            expect(complexImgs[0].props.src).toBe('assets/images/resources/_.crossplane.io/icon.svg');
+        });
+
+        it('should show group-based icon for wildcard group match (fluxcd)', () => {
+            const testRenderer = renderer.create(<ResourceIcon group='source.fluxcd.io' kind='GitRepository' />);
+            const testInstance = testRenderer.root;
+            const imgs = testInstance.findAllByType('img');
+            expect(imgs.length).toBeGreaterThan(0);
+            expect(imgs[0].props.src).toBe('assets/images/resources/_.fluxcd.io/icon.svg');
+        });
+    });
+
+    describe('fallback to kind-based icons (with non-matching group) - THIS IS THE BUG FIX', () => {
+        it('should fallback to kind-based icon for Ingress with networking.k8s.io group', () => {
+            // This is the main bug fix test case
+            // Ingress has group 'networking.k8s.io' which is NOT in resourceCustomizations
+            // But Ingress IS in resourceIcons, so it should still show the icon
+            const testRenderer = renderer.create(<ResourceIcon group='networking.k8s.io' kind='Ingress' />);
+            const testInstance = testRenderer.root;
+            const imgs = testInstance.findAllByType('img');
+            expect(imgs.length).toBeGreaterThan(0);
+            expect(imgs[0].props.src).toBe('assets/images/resources/ing.svg');
+        });
+
+        it('should fallback to kind-based icon for Service with core group', () => {
+            const testRenderer = renderer.create(<ResourceIcon group='' kind='Service' />);
+            const testInstance = testRenderer.root;
+            const imgs = testInstance.findAllByType('img');
+            expect(imgs.length).toBeGreaterThan(0);
+            expect(imgs[0].props.src).toBe('assets/images/resources/svc.svg');
+        });
+    });
+
+    describe('fallback to initials (no matching group or kind)', () => {
+        it('should show initials for unknown resource with unknown group', () => {
+            const testRenderer = renderer.create(<ResourceIcon group='unknown.example.io' kind='UnknownResource' />);
+            const testInstance = testRenderer.root;
+            const imgs = testInstance.findAllByType('img');
+            expect(imgs.length).toBe(0);
+            // Should show initials "UR" (uppercase letters from UnknownResource)
+            const spans = testInstance.findAllByType('span');
+            const textSpan = spans.find(s => s.children.includes('UR'));
+            expect(textSpan).toBeTruthy();
+        });
+
+        it('should show initials for MyCustomKind', () => {
+            const testRenderer = renderer.create(<ResourceIcon group='' kind='MyCustomKind' />);
+            const testInstance = testRenderer.root;
+            const imgs = testInstance.findAllByType('img');
+            expect(imgs.length).toBe(0);
+            // Should show initials "MCK"
+            const spans = testInstance.findAllByType('span');
+            const textSpan = spans.find(s => s.children.includes('MCK'));
+            expect(textSpan).toBeTruthy();
+        });
+    });
+
+    describe('special cases', () => {
+        it('should show node icon for kind=node', () => {
+            const testRenderer = renderer.create(<ResourceIcon group='' kind='node' />);
+            const testInstance = testRenderer.root;
+            const imgs = testInstance.findAllByType('img');
+            expect(imgs.length).toBeGreaterThan(0);
+            expect(imgs[0].props.src).toBe('assets/images/infrastructure_components/node.svg');
+        });
+
+        it('should show application icon for kind=Application', () => {
+            const testRenderer = renderer.create(<ResourceIcon group='' kind='Application' />);
+            const testInstance = testRenderer.root;
+            const icons = testInstance.findAll(node => node.type === 'i' && typeof node.props.className === 'string' && node.props.className.includes('argo-icon-application'));
+            expect(icons.length).toBeGreaterThan(0);
+        });
+    });
+});

--- a/ui/src/app/applications/components/resource-icon.tsx
+++ b/ui/src/app/applications/components/resource-icon.tsx
@@ -10,16 +10,17 @@ export const ResourceIcon = ({group, kind, customStyle}: {group: string; kind: s
     if (kind === 'Application') {
         return <i title={kind} className={`icon argo-icon-application`} style={customStyle} />;
     }
-    if (!group) {
-        const i = resourceIcons.get(kind);
-        if (i !== undefined) {
-            return <img src={'assets/images/resources/' + i + '.svg'} alt={kind} style={{padding: '2px', width: '40px', height: '32px', ...customStyle}} />;
-        }
-    } else {
+    // First, check for group-based custom icons
+    if (group) {
         const matchedGroup = matchGroupToResource(group);
         if (matchedGroup) {
             return <img src={`assets/images/resources/${matchedGroup}/icon.svg`} alt={kind} style={{paddingBottom: '2px', width: '40px', height: '32px', ...customStyle}} />;
         }
+    }
+    // Fallback to kind-based icons (works for both empty group and non-matching groups)
+    const i = resourceIcons.get(kind);
+    if (i !== undefined) {
+        return <img src={'assets/images/resources/' + i + '.svg'} alt={kind} style={{padding: '2px', width: '40px', height: '32px', ...customStyle}} />;
     }
     const initials = kind.replace(/[a-z]/g, '');
     const n = initials.length;


### PR DESCRIPTION


<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

## Summary

Partial Fixes #26216 - standard resource icons (like `Ingress`) are not displayed properly.

## What this PR solves

In the current implementation, when a resource has a non-empty `group` (e.g., `Ingress` with group `networking.k8s.io`), the icon resolution logic only checks `resourceCustomizations` for a matching group. If no match is found, it falls through to showing initials instead of falling back to check `resourceIcons` for a kind-based icon.

This causes resources like `Ingress` to show initials ("I") instead of their proper icons, even though `Ingress` is defined in `resourceIcons` with the **ing.svg** icon.

## Changes

Modified the icon resolution logic in **resource-icon.tsx** to:
1. First check for group-based custom icons if `group` is not empty
2. **Always** fall back to check `resourceIcons` for kind-based icons, regardless of whether the group matched
3. Only show initials if neither group customization nor kind icon is found

| Resource | Group | Before | After |
|----------|-------|--------|-------|
| Ingress | `networking.k8s.io` | ❌ Shows "I" | ✅ Shows **ing.svg** |
| Crossplane resources | `*.crossplane.io` | ✅ Works | ✅ Works |
| ConfigMap | (empty) | ✅ Works | ✅ Works |

**Before:**
<img width="2514" height="992" alt="image" src="https://github.com/user-attachments/assets/add60849-61ff-4e45-a691-233fc9d56734" />

** After **
<img width="2738" height="1182" alt="image" src="https://github.com/user-attachments/assets/9c3a6c60-632b-468b-9992-144f69492be1" />


Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
