### PR TITLE
fix: Revert "fix(ci): ensure cherry-pick commits include DCO sign-off" (#26124)

### DIFF
--- a/.github/workflows/cherry-pick-single.yml
+++ b/.github/workflows/cherry-pick-single.yml
@@ -69,7 +69,7 @@ jobs:
           git checkout -b "$CHERRY_PICK_BRANCH" "origin/$TARGET_BRANCH"
 
           # Perform cherry-pick
-          if git cherry-pick -s -m 1 "$MERGE_COMMIT"; then
+          if git cherry-pick -m 1 "$MERGE_COMMIT"; then
             echo "✅ Cherry-pick successful"
 
             # Extract Signed-off-by from the cherry-pick commit


### PR DESCRIPTION
Reverts argoproj/argo-cd#26124

https://github.com/argoproj/argo-cd/issues/26088#issuecomment-3843392469