### PR TITLE
docs: Update upgrade instructions for Argo CD for some known issues

### DIFF
--- a/docs/operator-manual/upgrading/3.2-3.3.md
+++ b/docs/operator-manual/upgrading/3.2-3.3.md
@@ -18,9 +18,6 @@ If you have already changed to v3.3 without having first changed to ServerSideAp
 
 1. Disable the [client-side migration](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#client-side-apply-migration), `ClientSideApplyMigration=false`
 2. Sync the application managing ArgoCD and make sure it succeeds
-3. Make sure the field managers of the manager `manager: argocd-controller` covers all the fields mentioned by `manager: kubectl-client-side-apply`. `kubectl get customresourcedefinitions.apiextensions.k8s.io applicationsets.argoproj.io -o yaml --show-managed-fields`
-4. Remove the `kubectl-client-side-apply` manually from the managedFields
-5. Enable again `ClientSideApplyMigration` and let the application managing ArgoCD to sync again.
 
 See [more detailed instructions in the relevant PR](https://github.com/argoproj/argo-cd/pull/26257#issuecomment-3849005839)
 

--- a/docs/operator-manual/upgrading/3.2-3.3.md
+++ b/docs/operator-manual/upgrading/3.2-3.3.md
@@ -4,16 +4,25 @@
 
 ### ApplicationSet CRD exceeds the size limit for client-side apply
 
+> [!WARNING]
+> If ArgoCD is managing itself, Make sure to change the application to Server Side Apply *before* you go through with the migration, since the `last-applied` annotation gets used one last time as part of the client-side apply migration to SSA.
+
+
 In this version, the ApplicationSet CRD exceeds the size limit for client-side apply, meaning that the previous upgrade methods will result in `The CustomResourceDefinition "applicationsets.argoproj.io" is invalid: metadata.annotations: Too long: may not be more than 262144 bytes`
 
 In order to avoid this issue, it is now required to upgrade Argo CD using Server Side Apply (SSA) along with `resolve conflicts`.
 SSA does not store the ApplicationSet fields in `last-applied` annotation, thus not impacted by the annotation size limitation.
 The `--force-conflicts` flag allows the apply operation to take ownership of fields that may have been previously managed by other tools (such as Helm or a previous `kubectl apply`). This is necessary for upgrades. Note that any custom modifications you've made to fields that are defined in the Argo CD manifests (like `affinity`, `env`, or `probes`) will be overwritten. However, fields not specified in the manifests (like `resources` limits/requests or `tolerations`) will be preserved.
 
-Make sure to change the application to Server Side Apply *before* you go through with the migration, since the `last-applied` annotation gets used one last time as part of the client-side apply migration to SSA. If you have already changed to v3.3 and the application managing ArgoCD itself is now on a stuck state, unable to process, you can do the following to get unstuck
+If you have already changed to v3.3 without having first changed to ServerSideApply on a previous version and the application managing ArgoCD itself is now on an error state. reporting `Failed to perform client-side apply migration: ...`, you can take the following steps
 
 1. Disable the [client-side migration](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#client-side-apply-migration), `ClientSideApplyMigration=false`
-2. Remove the last applied annotation manually from the relevant CRDs.
+2. Sync the application managing ArgoCD and make sure it succeeds
+3. Make sure the field managers of the manager `manager: argocd-controller` covers all the fields mentioned by `manager: kubectl-client-side-apply`. `kubectl get customresourcedefinitions.apiextensions.k8s.io applicationsets.argoproj.io -o yaml --show-managed-fields`
+4. Remove the `kubectl-client-side-apply` manually from the managedFields
+5. Enable again `ClientSideApplyMigration` and let the application managing ArgoCD to sync again.
+
+See [more detailed instructions in the relevant PR](https://github.com/argoproj/argo-cd/pull/26257#issuecomment-3849005839)
 
 #### Upgrading Argo CD which is managing itself 
 

--- a/docs/operator-manual/upgrading/3.2-3.3.md
+++ b/docs/operator-manual/upgrading/3.2-3.3.md
@@ -13,7 +13,7 @@ The `--force-conflicts` flag allows the apply operation to take ownership of fie
 Make sure to change the application to Server Side Apply *before* you go through with the migration, since the `last-applied` annotation gets used one last time as part of the client-side apply migration to SSA. If you have already changed to v3.3 and the application managing ArgoCD itself is now on a stuck state, unable to process, you can do the following to get unstuck
 
 1. Disable the [client-side migration](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#client-side-apply-migration), `ClientSideApplyMigration=false`
-2. Remove the last applied annotation manually for the CRDs.
+2. Remove the last applied annotation manually from the relevant CRDs.
 
 #### Upgrading Argo CD which is managing itself 
 

--- a/docs/operator-manual/upgrading/3.2-3.3.md
+++ b/docs/operator-manual/upgrading/3.2-3.3.md
@@ -14,7 +14,7 @@ In order to avoid this issue, it is now required to upgrade Argo CD using Server
 SSA does not store the ApplicationSet fields in `last-applied` annotation, thus not impacted by the annotation size limitation.
 The `--force-conflicts` flag allows the apply operation to take ownership of fields that may have been previously managed by other tools (such as Helm or a previous `kubectl apply`). This is necessary for upgrades. Note that any custom modifications you've made to fields that are defined in the Argo CD manifests (like `affinity`, `env`, or `probes`) will be overwritten. However, fields not specified in the manifests (like `resources` limits/requests or `tolerations`) will be preserved.
 
-If you have already changed to v3.3 without having first changed to ServerSideApply on a previous version and the application managing ArgoCD itself is now on an error state. reporting `Failed to perform client-side apply migration: ...`, you can take the following steps
+If you have already changed to v3.3 without having first changed to ServerSideApply on a previous version and the application managing ArgoCD itself is now on an error state, i.e. reporting `Failed to perform client-side apply migration: ...`, you can take the following steps
 
 1. Disable the [client-side migration](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#client-side-apply-migration), `ClientSideApplyMigration=false`
 2. Sync the application managing ArgoCD and make sure it succeeds

--- a/docs/operator-manual/upgrading/3.2-3.3.md
+++ b/docs/operator-manual/upgrading/3.2-3.3.md
@@ -10,6 +10,11 @@ In order to avoid this issue, it is now required to upgrade Argo CD using Server
 SSA does not store the ApplicationSet fields in `last-applied` annotation, thus not impacted by the annotation size limitation.
 The `--force-conflicts` flag allows the apply operation to take ownership of fields that may have been previously managed by other tools (such as Helm or a previous `kubectl apply`). This is necessary for upgrades. Note that any custom modifications you've made to fields that are defined in the Argo CD manifests (like `affinity`, `env`, or `probes`) will be overwritten. However, fields not specified in the manifests (like `resources` limits/requests or `tolerations`) will be preserved.
 
+Make sure to change the application to Server Side Apply *before* you go through with the migration, since the `last-applied` annotation gets used one last time as part of the client-side apply migration to SSA. If you have already changed to v3.3 and the application managing ArgoCD itself is now on a stuck state, unable to process, you can do the following to get unstuck
+
+1. Disable the [client-side migration](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#client-side-apply-migration), `ClientSideApplyMigration=false`
+2. Remove the last applied annotation manually for the CRDs.
+
 #### Upgrading Argo CD which is managing itself 
 
 When Argo CD is upgraded using an Argo CD Application, it is required to enable Server-Side Apply in the Application spec: 


### PR DESCRIPTION
Added instructions for migrating to Server Side Apply before upgrading Argo CD, including steps to resolve issues if stuck.

When migrating directly and doing the change to SSA all at once, it can get the application stuck, some reports in slack have reported this, (And I made the same mistake as well)

I would appreciate if someone can verify that these steps also unstuck you.