### PR TITLE
docs: Set installation to match the quick-start guide in the installation section

### DIFF
--- a/docs/operator-manual/installation.md
+++ b/docs/operator-manual/installation.md
@@ -42,7 +42,7 @@ Not recommended for production use. This type of installation is typically used 
 > and have to be installed separately. The CRD manifests are located in the [manifests/crds](https://github.com/argoproj/argo-cd/blob/stable/manifests/crds) directory.
 > Use the following command to install them:
 > ```
-> kubectl apply -k https://github.com/argoproj/argo-cd/manifests/crds\?ref\=stable
+> kubectl apply --server-side --force-conflicts -k https://github.com/argoproj/argo-cd/manifests/crds\?ref\=stable
 > ```
 
 ### High Availability:


### PR DESCRIPTION
We modified the quick start guide, but forgot to modify this kubectl apply command here

This is required in 3.3, see the quick start  https://argo-cd.readthedocs.io/en/stable/#quick-start
