### PR TITLE
fix: remove auto generated field from mockery

### DIFF
--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -1,6 +1,5 @@
 dir: '{{.InterfaceDir}}/mocks'
 filename: '{{.InterfaceName}}.go'
-include-auto-generated: true # Needed since mockery 3.6.1
 packages:
   github.com/argoproj/argo-cd/v3/applicationset/generators:
     interfaces:


### PR DESCRIPTION
Running `make codegen-local` currently gives the following error:

```
+ mockery version
v3.3.6
+ mockery --config /Users/nitishkumar/Documents/Work/Open-Source/argo-cd/.mockery.yaml
2026-02-05T10:29:22.635017000+09:00 FTL app failed error="getting config: unmarshalling config: decoding failed due to the following error(s):\n\n'' has invalid keys: include-auto-generated" version=v3.3.6
make: *** [mockgen] Error 1
```

Reading the [mockery docs](https://vektra.github.io/mockery/latest/include-auto-generated/), it doesn't seem to be a hard requirement to use the `include-auto-generated` field. Running the codegen checks after this works well.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
