### PR TITLE
fix(generator): skip merge when generator template is empty

### DIFF
--- a/applicationset/generators/generator_spec_processor.go
+++ b/applicationset/generators/generator_spec_processor.go
@@ -143,35 +143,13 @@ func mergeGeneratorTemplate(g Generator, requestedGenerator *argoprojiov1alpha1.
 	dest := g.GetTemplate(requestedGenerator).DeepCopy()
 
 	// If the generator template is empty, return the ApplicationSet template as is
-	if isEmptyTemplate(*dest) {
+	if dest.IsEmpty() {
 		return applicationSetTemplate, nil
 	}
 
 	// Merge the ApplicationSet template into the generator template
 	err := mergo.Merge(dest, applicationSetTemplate)
 	return *dest, err
-}
-
-func isEmptyTemplate(template argoprojiov1alpha1.ApplicationSetTemplate) bool {
-	meta := template.ApplicationSetTemplateMeta
-	spec := template.Spec
-
-	// Check if metadata is empty
-	metaEmpty := meta.Name == "" &&
-		meta.Namespace == "" &&
-		len(meta.Labels) == 0 &&
-		len(meta.Annotations) == 0 &&
-		len(meta.Finalizers) == 0
-
-	// Check if spec is empty
-	specEmpty := spec.Project == "" &&
-		spec.Source == nil &&
-		spec.Sources == nil &&
-		spec.Destination.Server == "" &&
-		spec.Destination.Namespace == "" &&
-		spec.Destination.Name == ""
-
-	return metaEmpty && specEmpty
 }
 
 // InterpolateGenerator allows interpolating the matrix's 2nd child generator with values from the 1st child generator

--- a/applicationset/generators/generator_spec_processor_test.go
+++ b/applicationset/generators/generator_spec_processor_test.go
@@ -683,9 +683,9 @@ func TestMergeGeneratorTemplate(t *testing.T) {
 			result, err := mergeGeneratorTemplate(gen, requestedGenerator, tt.applicationSetTemplate)
 
 			require.NoError(t, err)
-			assert.Equal(t, tt.expected.ApplicationSetTemplateMeta.Name, result.ApplicationSetTemplateMeta.Name)
-			assert.Equal(t, tt.expected.ApplicationSetTemplateMeta.Namespace, result.ApplicationSetTemplateMeta.Namespace)
-			assert.Equal(t, tt.expected.ApplicationSetTemplateMeta.Labels, result.ApplicationSetTemplateMeta.Labels)
+			assert.Equal(t, tt.expected.Name, result.Name)
+			assert.Equal(t, tt.expected.Namespace, result.Namespace)
+			assert.Equal(t, tt.expected.Labels, result.Labels)
 			assert.Equal(t, tt.expected.Spec.Project, result.Spec.Project)
 			assert.Equal(t, tt.expected.Spec.Destination, result.Spec.Destination)
 		})

--- a/applicationset/generators/generator_spec_processor_test.go
+++ b/applicationset/generators/generator_spec_processor_test.go
@@ -557,69 +557,6 @@ func TestInterpolateGeneratorError(t *testing.T) {
 	}
 }
 
-func TestIsEmptyTemplate(t *testing.T) {
-	tests := []struct {
-		name     string
-		template argov1alpha1.ApplicationSetTemplate
-		expected bool
-	}{
-		{
-			name: "empty template",
-			template: argov1alpha1.ApplicationSetTemplate{
-				ApplicationSetTemplateMeta: argov1alpha1.ApplicationSetTemplateMeta{},
-				Spec:                       argov1alpha1.ApplicationSpec{},
-			},
-			expected: true,
-		},
-		{
-			name: "template with metadata",
-			template: argov1alpha1.ApplicationSetTemplate{
-				ApplicationSetTemplateMeta: argov1alpha1.ApplicationSetTemplateMeta{
-					Name:   "my-app",
-					Labels: map[string]string{"app": "test"},
-				},
-				Spec: argov1alpha1.ApplicationSpec{},
-			},
-			expected: false,
-		},
-		{
-			name: "template with spec",
-			template: argov1alpha1.ApplicationSetTemplate{
-				ApplicationSetTemplateMeta: argov1alpha1.ApplicationSetTemplateMeta{},
-				Spec: argov1alpha1.ApplicationSpec{
-					Project: "default",
-					Source: &argov1alpha1.ApplicationSource{
-						RepoURL: "https://github.com/example/repo",
-					},
-					Destination: argov1alpha1.ApplicationDestination{
-						Server: "https://kubernetes.default.svc",
-					},
-				},
-			},
-			expected: false,
-		},
-		{
-			name: "template with both metadata and spec",
-			template: argov1alpha1.ApplicationSetTemplate{
-				ApplicationSetTemplateMeta: argov1alpha1.ApplicationSetTemplateMeta{
-					Name: "my-app",
-				},
-				Spec: argov1alpha1.ApplicationSpec{
-					Project: "default",
-				},
-			},
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := isEmptyTemplate(tt.template)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
 func TestMergeGeneratorTemplate(t *testing.T) {
 	tests := []struct {
 		name                   string

--- a/pkg/apis/application/v1alpha1/applicationset_types.go
+++ b/pkg/apis/application/v1alpha1/applicationset_types.go
@@ -182,6 +182,11 @@ type ApplicationSetTemplate struct {
 	Spec                       ApplicationSpec `json:"spec" protobuf:"bytes,2,name=spec"`
 }
 
+// IsEmpty returns true if the ApplicationSetTemplate is considered empty
+func (t *ApplicationSetTemplate) IsEmpty() bool {
+	return t.ApplicationSetTemplateMeta.IsEmpty() && t.Spec.IsEmpty()
+}
+
 // ApplicationSetTemplateMeta represents the Argo CD application fields that may
 // be used for Applications generated from the ApplicationSet (based on metav1.ObjectMeta)
 type ApplicationSetTemplateMeta struct {
@@ -190,6 +195,15 @@ type ApplicationSetTemplateMeta struct {
 	Labels      map[string]string `json:"labels,omitempty" protobuf:"bytes,3,name=labels"`
 	Annotations map[string]string `json:"annotations,omitempty" protobuf:"bytes,4,name=annotations"`
 	Finalizers  []string          `json:"finalizers,omitempty" protobuf:"bytes,5,name=finalizers"`
+}
+
+// IsEmpty returns true if the ApplicationSetTemplateMeta is considered empty
+func (a *ApplicationSetTemplateMeta) IsEmpty() bool {
+	return a.Name == "" &&
+		a.Namespace == "" &&
+		len(a.Labels) == 0 &&
+		len(a.Annotations) == 0 &&
+		len(a.Finalizers) == 0
 }
 
 // ApplicationSetGenerator represents a generator at the top level of an ApplicationSet.

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -102,6 +102,22 @@ type ApplicationSpec struct {
 	SourceHydrator *SourceHydrator `json:"sourceHydrator,omitempty" protobuf:"bytes,9,opt,name=sourceHydrator"`
 }
 
+// IsEmpty returns true if the ApplicationSpec is considered empty
+func (spec *ApplicationSpec) IsEmpty() bool {
+	return spec == nil ||
+		(spec.Source.IsZero() &&
+			spec.Sources.IsZero() &&
+			spec.Destination.Server == "" &&
+			spec.Destination.Namespace == "" &&
+			spec.Destination.Name == "" &&
+			spec.Project == "" &&
+			spec.SyncPolicy.IsZero() &&
+			len(spec.IgnoreDifferences) == 0 &&
+			len(spec.Info) == 0 &&
+			spec.RevisionHistoryLimit == nil &&
+			spec.SourceHydrator == nil)
+}
+
 type IgnoreDifferences []ResourceIgnoreDifferences
 
 func (id IgnoreDifferences) Equals(other IgnoreDifferences) bool {

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -1611,6 +1611,57 @@ func TestApplicationSource_IsZero(t *testing.T) {
 	}
 }
 
+func TestApplicationSpec_IsEmpty(t *testing.T) {
+	tests := []struct {
+		name string
+		spec *ApplicationSpec
+		want bool
+	}{
+		{
+			name: "nil spec returns true",
+			spec: nil,
+			want: true,
+		},
+		{
+			name: "empty spec returns true",
+			spec: &ApplicationSpec{},
+			want: true,
+		},
+		{
+			name: "spec with Source returns false",
+			spec: &ApplicationSpec{
+				Source: &ApplicationSource{
+					RepoURL: "https://github.com/argoproj/argocd-example-apps",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "spec with Destination returns false",
+			spec: &ApplicationSpec{
+				Destination: ApplicationDestination{
+					Server: "https://kubernetes.default.svc",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "spec with Project returns false",
+			spec: &ApplicationSpec{
+				Project: "default",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.spec.IsEmpty()
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
 func TestApplicationSourceHelm_AddParameter(t *testing.T) {
 	src := ApplicationSourceHelm{}
 	t.Run("Add", func(t *testing.T) {


### PR DESCRIPTION
## WHY

**The Problem**: Users have a generator in ApplicationSet without a generator-level template, but an empty template structure would be automatically added. 

This caused the system to go out of sync with the original manifest,  which in turn triggers a continuous OutOfSync cycle.

## What
This method always returns a template, even if the user has not defined a generator-level template.
https://github.com/argoproj/argo-cd/blob/9cc0c77eb5669942893b07ac913adb8c64be7600/applicationset/generators/pull_request.go#L55

**Problem flow**:
https://github.com/argoproj/argo-cd/blob/9cc0c77eb5669942893b07ac913adb8c64be7600/applicationset/generators/generator_spec_processor.go#L140-L148

1. `GetTemplate` returns an empty template, even if the user hasn't defined one.
2. The `mergeGeneratorTemplate` function unconditionally merges the empty template with the original Generator.
3. `selfHeal` detects the discrepancy and attempts to remove it.
4. It is re-added after the next Reconcile, leading to an infinite loop.


## How
In the `mergeGeneratorTemplate` function, add logic to check whether the value returned by GetTemplate() is empty.
The merge should only be performed when a template is explicitly defined.

Fix: #24647 
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [X] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
