### PR TITLE
fix: compressedLayerExtracterStore+isCompressedLayer - allow tar.gzip suffixes

### DIFF
--- a/util/oci/client.go
+++ b/util/oci/client.go
@@ -518,7 +518,7 @@ func isContentLayer(mediaType string) bool {
 
 func isCompressedLayer(mediaType string) bool {
 	// TODO: Is zstd something which is used in the wild? For now let's stick to these suffixes
-	return strings.HasSuffix(mediaType, "tar+gzip") || strings.HasSuffix(mediaType, "tar")
+	return strings.HasSuffix(mediaType, "tar+gzip") || strings.HasSuffix(mediaType, "tar.gzip") || strings.HasSuffix(mediaType, "tar")
 }
 
 func createTarFile(from, to string) error {
@@ -625,7 +625,7 @@ func (s *compressedLayerExtracterStore) Push(ctx context.Context, desc imagev1.D
 		}
 		defer os.RemoveAll(srcDir)
 
-		if strings.HasSuffix(desc.MediaType, "tar+gzip") {
+		if strings.HasSuffix(desc.MediaType, "tar+gzip") || strings.HasSuffix(desc.MediaType, "tar.gzip") {
 			err = files.Untgz(srcDir, content, s.maxSize, false)
 		} else {
 			err = files.Untar(srcDir, content, s.maxSize, false)

--- a/util/oci/client_test.go
+++ b/util/oci/client_test.go
@@ -260,6 +260,31 @@ func Test_nativeOCIClient_Extract(t *testing.T) {
 			},
 		},
 		{
+			name: "extraction with docker rootfs tar.gzip layer",
+			fields: fields{
+				allowedMediaTypes: []string{"application/vnd.docker.image.rootfs.diff.tar.gzip"},
+			},
+			args: args{
+				digestFunc: func(store *memory.Store) string {
+					layerBlob := createGzippedTarWithContent(t, "foo.yaml", "some content")
+					return generateManifest(t, store, layerConf{content.NewDescriptorFromBytes("application/vnd.docker.image.rootfs.diff.tar.gzip", layerBlob), layerBlob})
+				},
+				postValidationFunc: func(_, path string, _ Client, _ fields, _ args) {
+					manifestDir, err := os.ReadDir(path)
+					require.NoError(t, err)
+					require.Len(t, manifestDir, 1)
+					require.Equal(t, "foo.yaml", manifestDir[0].Name())
+					f, err := os.Open(filepath.Join(path, manifestDir[0].Name()))
+					require.NoError(t, err)
+					contents, err := io.ReadAll(f)
+					require.NoError(t, err)
+					require.Equal(t, "some content", string(contents))
+				},
+				manifestMaxExtractedSize:        1000,
+				disableManifestMaxExtractedSize: false,
+			},
+		},
+		{
 			name: "extraction with standard gzip layer using cache",
 			fields: fields{
 				allowedMediaTypes: []string{imagev1.MediaTypeImageLayerGzip},


### PR DESCRIPTION
I'm doing weird things and am using single layer images built via a CI pipeline that uses Docker.

When I attempted to allow `application/vnd.docker.image.rootfs.diff.tar.gzip` as a layer extension for the ArgoCD repo server, I still encountered an issue where the layer does not properly parse as a compressed layer /  content layer due to the suffix being `tar.gzip` instead of the expected `tar+gzip`.

This MR adds the single line of duct tape and accompanying test case to patch this case + validate for the future.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, **(b) this is a bug fix**, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [X] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
