### PR TITLE
fix(session,oidc): defer transport TLS config to avoid race with late DexConfig

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -334,7 +334,7 @@ func NewServer(ctx context.Context, opts ArgoCDServerOpts, appsetOpts Applicatio
 	appsetLister := appFactory.Argoproj().V1alpha1().ApplicationSets().Lister()
 
 	userStateStorage := util_session.NewUserStateStorage(opts.RedisClient)
-	ssoClientApp, err := oidc.NewClientApp(settings, opts.DexServerAddr, opts.DexTLSConfig, opts.BaseHRef, cacheutil.NewRedisCache(opts.RedisClient, settings.UserInfoCacheExpiration(), cacheutil.RedisCompressionNone))
+	ssoClientApp, err := oidc.NewClientApp(settingsMgr, settings, opts.DexServerAddr, opts.DexTLSConfig, opts.BaseHRef, cacheutil.NewRedisCache(opts.RedisClient, settings.UserInfoCacheExpiration(), cacheutil.RedisCompressionNone))
 	errorsutil.CheckError(err)
 	sessionMgr := util_session.NewSessionManager(settingsMgr, projLister, opts.DexServerAddr, opts.DexTLSConfig, userStateStorage)
 	enf := rbac.NewEnforcer(opts.KubeClientset, opts.Namespace, common.ArgoCDRBACConfigMapName, nil)

--- a/server/server.go
+++ b/server/server.go
@@ -587,7 +587,7 @@ func (server *ArgoCDServer) Run(ctx context.Context, listeners *Listeners) {
 		cacheutil.CollectMetrics(server.RedisClient, metricsServ, server.userStateStorage.GetLockObject())
 	}
 	// OIDC config needs to be refreshed at each server restart
-	ssoClientApp, err := oidc.NewClientApp(server.settings, server.DexServerAddr, server.DexTLSConfig, server.BaseHRef, cacheutil.NewRedisCache(server.RedisClient, server.settings.UserInfoCacheExpiration(), cacheutil.RedisCompressionNone))
+	ssoClientApp, err := oidc.NewClientApp(server.settingsMgr, server.settings, server.DexServerAddr, server.DexTLSConfig, server.BaseHRef, cacheutil.NewRedisCache(server.RedisClient, server.settings.UserInfoCacheExpiration(), cacheutil.RedisCompressionNone))
 	errorsutil.CheckError(err)
 	server.ssoClientApp = ssoClientApp
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -667,7 +667,7 @@ connectors:
 	}
 	argocd = NewServer(t.Context(), argoCDOpts, ApplicationSetOpts{})
 	var err error
-	argocd.ssoClientApp, err = oidc.NewClientApp(argocd.settings, argocd.DexServerAddr, argocd.DexTLSConfig, argocd.BaseHRef, cache.NewInMemoryCache(24*time.Hour))
+	argocd.ssoClientApp, err = oidc.NewClientApp(argocd.settingsMgr, argocd.settings, argocd.DexServerAddr, argocd.DexTLSConfig, argocd.BaseHRef, cache.NewInMemoryCache(24*time.Hour))
 	require.NoError(t, err)
 	return argocd, oidcServer.URL
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -777,7 +777,7 @@ connectors:
 	}
 	argocd = NewServer(t.Context(), argoCDOpts, ApplicationSetOpts{})
 	var err error
-	argocd.ssoClientApp, err = oidc.NewClientApp(argocd.settings, argocd.DexServerAddr, argocd.DexTLSConfig, argocd.BaseHRef, cache.NewInMemoryCache(24*time.Hour))
+	argocd.ssoClientApp, err = oidc.NewClientApp(argocd.settingsMgr, argocd.settings, argocd.DexServerAddr, argocd.DexTLSConfig, argocd.BaseHRef, cache.NewInMemoryCache(24*time.Hour))
 	require.NoError(t, err)
 	return argocd, oidcServer.URL
 }

--- a/util/oidc/oidc.go
+++ b/util/oidc/oidc.go
@@ -94,6 +94,16 @@ type ClientApp struct {
 	secureCookie bool
 	// settings holds Argo CD settings
 	settings *settings.ArgoCDSettings
+	// settingsMgr is used to lazily read the current settings at transport-config time
+	settingsMgr *settings.SettingsManager
+	// transport is the underlying HTTP transport (TLS configured lazily)
+	transport *http.Transport
+	// dexTLSConfig holds the dex TLS configuration for lazy transport setup
+	dexTLSConfig *dex.DexTLSConfig
+	// dexServerAddr holds the dex server address for lazy transport setup
+	dexServerAddr string
+	// transportOnce ensures configureTransport runs exactly once
+	transportOnce sync.Once
 	// encryptionKey holds server encryption key
 	encryptionKey []byte
 	// provider is the OIDC provider
@@ -194,7 +204,7 @@ func getDomainHint(settings *settings.ArgoCDSettings) string {
 
 // NewClientApp will register the Argo CD client app (either via Dex or external OIDC) and return an
 // object which has HTTP handlers for handling the HTTP responses for login and callback
-func NewClientApp(settings *settings.ArgoCDSettings, dexServerAddr string, dexTLSConfig *dex.DexTLSConfig, baseHRef string, cacheClient cache.CacheClient) (*ClientApp, error) {
+func NewClientApp(settingsMgr *settings.SettingsManager, settings *settings.ArgoCDSettings, dexServerAddr string, dexTLSConfig *dex.DexTLSConfig, baseHRef string, cacheClient cache.CacheClient) (*ClientApp, error) {
 	redirectURL, err := settings.RedirectURL()
 	if err != nil {
 		return nil, err
@@ -204,25 +214,6 @@ func NewClientApp(settings *settings.ArgoCDSettings, dexServerAddr string, dexTL
 		return nil, err
 	}
 	domainHint := getDomainHint(settings)
-	a := ClientApp{
-		clientID:                 settings.OAuth2ClientID(),
-		clientSecret:             settings.OAuth2ClientSecret(),
-		usePKCE:                  settings.OAuth2UsePKCE(),
-		useAzureWorkloadIdentity: settings.UseAzureWorkloadIdentity(),
-		redirectURI:              redirectURL,
-		issuerURL:                settings.IssuerURL(),
-		baseHRef:                 baseHRef,
-		encryptionKey:            encryptionKey,
-		clientCache:              cacheClient,
-		azure:                    azureApp{mtx: &sync.RWMutex{}},
-		domainHint:               domainHint,
-		refreshTokenThreshold:    settings.RefreshTokenThreshold(),
-	}
-	log.Infof("Creating client app (%s)", a.clientID)
-	u, err := url.Parse(settings.URL)
-	if err != nil {
-		return nil, fmt.Errorf("parse redirect-uri: %w", err)
-	}
 
 	transport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
@@ -241,26 +232,74 @@ func NewClientApp(settings *settings.ArgoCDSettings, dexServerAddr string, dexTL
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 	}
+
+	a := ClientApp{
+		clientID:                 settings.OAuth2ClientID(),
+		clientSecret:             settings.OAuth2ClientSecret(),
+		usePKCE:                  settings.OAuth2UsePKCE(),
+		useAzureWorkloadIdentity: settings.UseAzureWorkloadIdentity(),
+		redirectURI:              redirectURL,
+		issuerURL:                settings.IssuerURL(),
+		baseHRef:                 baseHRef,
+		encryptionKey:            encryptionKey,
+		clientCache:              cacheClient,
+		azure:                    azureApp{mtx: &sync.RWMutex{}},
+		domainHint:               domainHint,
+		refreshTokenThreshold:    settings.RefreshTokenThreshold(),
+		settingsMgr:              settingsMgr,
+		transport:                transport,
+		dexTLSConfig:             dexTLSConfig,
+		dexServerAddr:            dexServerAddr,
+	}
+	log.Infof("Creating client app (%s)", a.clientID)
+	u, err := url.Parse(settings.URL)
+	if err != nil {
+		return nil, fmt.Errorf("parse redirect-uri: %w", err)
+	}
+
 	a.client = &http.Client{
 		Transport: transport,
 	}
-
-	if settings.DexConfig != "" && settings.OIDCConfigRAW == "" {
-		transport.TLSClientConfig = dex.TLSConfig(dexTLSConfig)
-		addrWithProto := dex.DexServerAddressWithProtocol(dexServerAddr, dexTLSConfig)
-		a.client.Transport = dex.NewDexRewriteURLRoundTripper(addrWithProto, a.client.Transport)
-	} else {
-		transport.TLSClientConfig = settings.OIDCTLSConfig()
-	}
-	if os.Getenv(common.EnvVarSSODebug) == "1" {
-		a.client.Transport = httputil.DebugTransport{T: a.client.Transport}
-	}
+	// Transport TLS is configured lazily in configureTransport() to avoid a
+	// race where DexConfig is not yet present in argocd-cm at startup but
+	// arrives later via a settings update / graceful restart.
 
 	a.provider = NewOIDCProvider(a.issuerURL, a.client)
 	// NOTE: if we ever have replicas of Argo CD, this needs to switch to Redis cache
 	a.secureCookie = bool(u.Scheme == "https")
 	a.settings = settings
 	return &a, nil
+}
+
+// configureTransport sets up TLS and (optionally) Dex rewrite transport on the
+// ClientApp's http.Transport. It is called lazily via sync.Once so that the
+// settings (e.g. DexConfig) can arrive after the ClientApp has been constructed.
+// When settingsMgr is available the latest settings are read from the
+// Kubernetes ConfigMap; otherwise the settings snapshot captured at
+// construction time is used as a fallback.
+func (a *ClientApp) configureTransport() {
+	if a.transport == nil {
+		return
+	}
+	currentSettings := a.settings
+	if a.settingsMgr != nil {
+		s, err := a.settingsMgr.GetSettings()
+		if err != nil {
+			log.Warnf("Failed to read settings for transport configuration: %v", err)
+		} else {
+			currentSettings = s
+		}
+	}
+	if currentSettings.DexConfig != "" && currentSettings.OIDCConfigRAW == "" {
+		a.transport.TLSClientConfig = dex.TLSConfig(a.dexTLSConfig)
+		addrWithProto := dex.DexServerAddressWithProtocol(a.dexServerAddr, a.dexTLSConfig)
+		a.client.Transport = dex.NewDexRewriteURLRoundTripper(addrWithProto, a.transport)
+	} else {
+		a.transport.TLSClientConfig = currentSettings.OIDCTLSConfig()
+	}
+	if os.Getenv(common.EnvVarSSODebug) == "1" {
+		a.client.Transport = httputil.DebugTransport{T: a.client.Transport}
+	}
 }
 
 func (a *ClientApp) getRedirectURIForRequest(req *http.Request) string {
@@ -412,6 +451,7 @@ func isValidRedirectURL(redirectURL string, allowedURLs []string) bool {
 // HandleLogin formulates the proper OAuth2 URL (auth code or implicit) and redirects the user to
 // the IDp login & consent page
 func (a *ClientApp) HandleLogin(w http.ResponseWriter, r *http.Request) {
+	a.transportOnce.Do(a.configureTransport)
 	oidcConf, err := a.provider.ParseConfig()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -507,6 +547,7 @@ func (a *azureApp) getFederatedServiceAccountToken(context.Context) (string, err
 
 // HandleCallback is the callback handler for an OAuth2 login flow
 func (a *ClientApp) HandleCallback(w http.ResponseWriter, r *http.Request) {
+	a.transportOnce.Do(a.configureTransport)
 	oauth2Config, err := a.getOauth2ConfigForRedirectURI(a.getRedirectURIForRequest(r))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -731,6 +772,7 @@ func (a *ClientApp) GetUpdatedOidcTokenFromCache(ctx context.Context, subject st
 	ctx, span = tracer.Start(ctx, "oidc.ClientApp.GetUpdatedOidcTokenFromCache")
 	defer span.End()
 
+	a.transportOnce.Do(a.configureTransport)
 	ctx = gooidc.ClientContext(ctx, a.client)
 	span.SetAttributes(
 		attribute.String("subject", subject),
@@ -949,6 +991,7 @@ func (a *ClientApp) GetUserInfo(ctx context.Context, actualClaims jwt.MapClaims,
 	var span trace.Span
 	ctx, span = tracer.Start(ctx, "oidc.ClientApp.GetUserInfo")
 	defer span.End()
+	a.transportOnce.Do(a.configureTransport)
 	sub := jwtutil.StringField(actualClaims, "sub")
 	var claims jwt.MapClaims
 	var encClaims []byte

--- a/util/oidc/oidc_azure_test.go
+++ b/util/oidc/oidc_azure_test.go
@@ -279,7 +279,7 @@ func TestGetUserGroupsFromAzureOverageClaim(t *testing.T) {
 			require.NoError(t, err)
 
 			testCache := cache.NewInMemoryCache(24 * time.Hour)
-			a, err := NewClientApp(cdSettings, "", nil, "/argo-cd", testCache)
+			a, err := NewClientApp(nil, cdSettings, "", nil, "/argo-cd", testCache)
 			require.NoError(t, err)
 
 			for key, value := range tt.cacheItems {
@@ -331,7 +331,7 @@ func TestCacheAzureGroupsOverageResponse(t *testing.T) {
 		require.NoError(t, err)
 
 		testCache := cache.NewInMemoryCache(24 * time.Hour)
-		a, err := NewClientApp(cdSettings, "", nil, "/argo-cd", testCache)
+		a, err := NewClientApp(nil, cdSettings, "", nil, "/argo-cd", testCache)
 		require.NoError(t, err)
 
 		groups := []string{"group-1", "group-2"}
@@ -360,7 +360,7 @@ func TestCacheAzureGroupsOverageResponse(t *testing.T) {
 		}
 
 		testCache := cache.NewInMemoryCache(24 * time.Hour)
-		a, err := NewClientApp(cdSettings, "", nil, "/argo-cd", testCache)
+		a, err := NewClientApp(nil, cdSettings, "", nil, "/argo-cd", testCache)
 		require.NoError(t, err)
 
 		groups := []string{"group-a"}
@@ -384,7 +384,7 @@ func TestCacheAzureGroupsOverageResponse(t *testing.T) {
 		}
 
 		testCache := cache.NewInMemoryCache(24 * time.Hour)
-		a, err := NewClientApp(cdSettings, "", nil, "/argo-cd", testCache)
+		a, err := NewClientApp(nil, cdSettings, "", nil, "/argo-cd", testCache)
 		require.NoError(t, err)
 
 		groups := []string{"group-b"}
@@ -433,7 +433,7 @@ func TestGetUserGroupsFromAzureOverageClaim_CacheHitAfterFetch(t *testing.T) {
 	require.NoError(t, err)
 
 	testCache := cache.NewInMemoryCache(24 * time.Hour)
-	a, err := NewClientApp(cdSettings, "", nil, "/argo-cd", testCache)
+	a, err := NewClientApp(nil, cdSettings, "", nil, "/argo-cd", testCache)
 	require.NoError(t, err)
 
 	accessToken := createTestJWT(t, jwt.MapClaims{"scp": "User.Read profile email"})
@@ -490,7 +490,7 @@ func TestGetUserGroupsFromAzureOverageClaim_CorruptCacheCallsAPI(t *testing.T) {
 	require.NoError(t, err)
 
 	testCache := cache.NewInMemoryCache(24 * time.Hour)
-	a, err := NewClientApp(cdSettings, "", nil, "/argo-cd", testCache)
+	a, err := NewClientApp(nil, cdSettings, "", nil, "/argo-cd", testCache)
 	require.NoError(t, err)
 
 	// Populate cache with corrupt (non-JSON) data that is still validly encrypted.

--- a/util/oidc/oidc_test.go
+++ b/util/oidc/oidc_test.go
@@ -24,6 +24,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/yaml"
 
 	"github.com/argoproj/argo-cd/v3/common"
@@ -176,7 +179,7 @@ clientSecret: test-client-secret
 domainHint: example.com
 requestedScopes: ["openid", "profile", "email", "groups"]`, oidcTestServer.URL),
 	}
-	app, err := NewClientApp(cdSettings, "", nil, "https://argocd.example.com", cache.NewInMemoryCache(24*time.Hour))
+	app, err := NewClientApp(nil, cdSettings, "", nil, "https://argocd.example.com", cache.NewInMemoryCache(24*time.Hour))
 	require.NoError(t, err)
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://argocd.example.com/auth/login", http.NoBody)
@@ -239,7 +242,7 @@ clientID: xxx
 clientSecret: yyy
 requestedScopes: ["oidc"]`, oidcTestServer.URL),
 		}
-		app, err := NewClientApp(cdSettings, dexTestServer.URL, nil, "https://argocd.example.com", cache.NewInMemoryCache(24*time.Hour))
+		app, err := NewClientApp(nil, cdSettings, dexTestServer.URL, nil, "https://argocd.example.com", cache.NewInMemoryCache(24*time.Hour))
 		require.NoError(t, err)
 
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://argocd.example.com/auth/login", http.NoBody)
@@ -252,7 +255,7 @@ requestedScopes: ["oidc"]`, oidcTestServer.URL),
 
 		cdSettings.OIDCTLSInsecureSkipVerify = true
 
-		app, err = NewClientApp(cdSettings, dexTestServer.URL, nil, "https://argocd.example.com", cache.NewInMemoryCache(24*time.Hour))
+		app, err = NewClientApp(nil, cdSettings, dexTestServer.URL, nil, "https://argocd.example.com", cache.NewInMemoryCache(24*time.Hour))
 		require.NoError(t, err)
 
 		w = httptest.NewRecorder()
@@ -276,7 +279,7 @@ requestedScopes: ["oidc"]`, oidcTestServer.URL),
 		cert, err := tls.X509KeyPair(test.Cert, test.PrivateKey)
 		require.NoError(t, err)
 		cdSettings.Certificate = &cert
-		app, err := NewClientApp(cdSettings, dexTestServer.URL, nil, "https://argocd.example.com", cache.NewInMemoryCache(24*time.Hour))
+		app, err := NewClientApp(nil, cdSettings, dexTestServer.URL, nil, "https://argocd.example.com", cache.NewInMemoryCache(24*time.Hour))
 		require.NoError(t, err)
 
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://argocd.example.com/auth/login", http.NoBody)
@@ -289,7 +292,7 @@ requestedScopes: ["oidc"]`, oidcTestServer.URL),
 			t.Fatal("did not receive expected certificate verification failure error")
 		}
 
-		app, err = NewClientApp(cdSettings, dexTestServer.URL, &dex.DexTLSConfig{StrictValidation: false}, "https://argocd.example.com", cache.NewInMemoryCache(24*time.Hour))
+		app, err = NewClientApp(nil, cdSettings, dexTestServer.URL, &dex.DexTLSConfig{StrictValidation: false}, "https://argocd.example.com", cache.NewInMemoryCache(24*time.Hour))
 		require.NoError(t, err)
 
 		w = httptest.NewRecorder()
@@ -315,7 +318,7 @@ requestedScopes: ["oidc"]`, oidcTestServer.URL),
 		require.NoError(t, err)
 		cdSettings.OIDCConfigRAW = string(oidcConfigRaw)
 
-		app, err := NewClientApp(cdSettings, dexTestServer.URL, &dex.DexTLSConfig{StrictValidation: false}, "https://argocd.example.com", cache.NewInMemoryCache(24*time.Hour))
+		app, err := NewClientApp(nil, cdSettings, dexTestServer.URL, &dex.DexTLSConfig{StrictValidation: false}, "https://argocd.example.com", cache.NewInMemoryCache(24*time.Hour))
 		require.NoError(t, err)
 
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://argocd.example.com/auth/login", http.NoBody)
@@ -348,7 +351,7 @@ requestedScopes: ["oidc"]`, oidcTestServer.URL),
 		require.NoError(t, err)
 		cdSettings.OIDCConfigRAW = string(oidcConfigRaw)
 
-		app, err := NewClientApp(cdSettings, dexTestServer.URL, &dex.DexTLSConfig{StrictValidation: false}, "https://argocd.example.com", cache.NewInMemoryCache(24*time.Hour))
+		app, err := NewClientApp(nil, cdSettings, dexTestServer.URL, &dex.DexTLSConfig{StrictValidation: false}, "https://argocd.example.com", cache.NewInMemoryCache(24*time.Hour))
 		require.NoError(t, err)
 
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://argocd.example.com/auth/login", http.NoBody)
@@ -385,7 +388,7 @@ requestedScopes: ["oidc"]`, oidcTestServer.URL),
 		require.NoError(t, err)
 		cdSettings.DexConfig = string(dexConfigRaw)
 
-		app, err := NewClientApp(cdSettings, dexTestServer.URL, &dex.DexTLSConfig{StrictValidation: false}, "https://argocd.example.com", cache.NewInMemoryCache(24*time.Hour))
+		app, err := NewClientApp(nil, cdSettings, dexTestServer.URL, &dex.DexTLSConfig{StrictValidation: false}, "https://argocd.example.com", cache.NewInMemoryCache(24*time.Hour))
 		require.NoError(t, err)
 
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://argocd.example.com/auth/login", http.NoBody)
@@ -423,7 +426,7 @@ requestedScopes: ["oidc"]`, oidcTestServer.URL),
 		cert, err := tls.X509KeyPair(test.Cert, test.PrivateKey)
 		require.NoError(t, err)
 		cdSettings.Certificate = &cert
-		app, err := NewClientApp(cdSettings, dexTestServer.URL, &dex.DexTLSConfig{StrictValidation: false}, "https://argocd.example.com", cache.NewInMemoryCache(24*time.Hour))
+		app, err := NewClientApp(nil, cdSettings, dexTestServer.URL, &dex.DexTLSConfig{StrictValidation: false}, "https://argocd.example.com", cache.NewInMemoryCache(24*time.Hour))
 		require.NoError(t, err)
 
 		t.Run("should accept login redirecting on the main domain", func(t *testing.T) {
@@ -519,7 +522,7 @@ requestedScopes: ["oidc"]`, oidcTestServer.URL),
 	}
 	// The base href (the last argument for NewClientApp) is what HandleLogin will fall back to when no explicit
 	// redirect URL is given.
-	app, err := NewClientApp(cdSettings, "", nil, "/", cache.NewInMemoryCache(24*time.Hour))
+	app, err := NewClientApp(nil, cdSettings, "", nil, "/", cache.NewInMemoryCache(24*time.Hour))
 	require.NoError(t, err)
 
 	w := httptest.NewRecorder()
@@ -567,7 +570,7 @@ requestedScopes: ["oidc"]
 enablePKCEAuthentication: true`, oidcTestServer.URL),
 		OIDCTLSInsecureSkipVerify: true,
 	}
-	app, err := NewClientApp(cdSettings, "", nil, "/", cache.NewInMemoryCache(24*time.Hour))
+	app, err := NewClientApp(nil, cdSettings, "", nil, "/", cache.NewInMemoryCache(24*time.Hour))
 	require.NoError(t, err)
 
 	w := httptest.NewRecorder()
@@ -616,7 +619,7 @@ clientID: xxx
 clientSecret: yyy
 requestedScopes: ["oidc"]`, oidcTestServer.URL),
 		}
-		app, err := NewClientApp(cdSettings, dexTestServer.URL, nil, "https://argocd.example.com", cache.NewInMemoryCache(24*time.Hour))
+		app, err := NewClientApp(nil, cdSettings, dexTestServer.URL, nil, "https://argocd.example.com", cache.NewInMemoryCache(24*time.Hour))
 		require.NoError(t, err)
 
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://argocd.example.com/auth/callback", http.NoBody)
@@ -631,7 +634,7 @@ requestedScopes: ["oidc"]`, oidcTestServer.URL),
 
 		cdSettings.OIDCTLSInsecureSkipVerify = true
 
-		app, err = NewClientApp(cdSettings, dexTestServer.URL, nil, "https://argocd.example.com", cache.NewInMemoryCache(24*time.Hour))
+		app, err = NewClientApp(nil, cdSettings, dexTestServer.URL, nil, "https://argocd.example.com", cache.NewInMemoryCache(24*time.Hour))
 		require.NoError(t, err)
 
 		w = httptest.NewRecorder()
@@ -655,7 +658,7 @@ requestedScopes: ["oidc"]`, oidcTestServer.URL),
 		cert, err := tls.X509KeyPair(test.Cert, test.PrivateKey)
 		require.NoError(t, err)
 		cdSettings.Certificate = &cert
-		app, err := NewClientApp(cdSettings, dexTestServer.URL, nil, "https://argocd.example.com", cache.NewInMemoryCache(24*time.Hour))
+		app, err := NewClientApp(nil, cdSettings, dexTestServer.URL, nil, "https://argocd.example.com", cache.NewInMemoryCache(24*time.Hour))
 		require.NoError(t, err)
 
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://argocd.example.com/auth/callback", http.NoBody)
@@ -668,7 +671,7 @@ requestedScopes: ["oidc"]`, oidcTestServer.URL),
 			t.Fatal("did not receive expected certificate verification failure error")
 		}
 
-		app, err = NewClientApp(cdSettings, dexTestServer.URL, &dex.DexTLSConfig{StrictValidation: false}, "https://argocd.example.com", cache.NewInMemoryCache(24*time.Hour))
+		app, err = NewClientApp(nil, cdSettings, dexTestServer.URL, &dex.DexTLSConfig{StrictValidation: false}, "https://argocd.example.com", cache.NewInMemoryCache(24*time.Hour))
 		require.NoError(t, err)
 
 		w = httptest.NewRecorder()
@@ -783,7 +786,7 @@ skipAudienceCheckWhenTokenHasNoAudience: true
 requestedScopes: ["oidc"]`, oidcTestServer.URL),
 		}
 
-		app, err := NewClientApp(cdSettings, dexTestServer.URL, nil, "https://argocd.example.com", cache.NewInMemoryCache(24*time.Hour))
+		app, err := NewClientApp(nil, cdSettings, dexTestServer.URL, nil, "https://argocd.example.com", cache.NewInMemoryCache(24*time.Hour))
 		require.NoError(t, err)
 
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://argocd.example.com/auth/callback", http.NoBody)
@@ -801,7 +804,7 @@ requestedScopes: ["oidc"]`, oidcTestServer.URL),
 
 		cdSettings.OIDCTLSInsecureSkipVerify = true
 
-		app, err = NewClientApp(cdSettings, dexTestServer.URL, nil, "https://argocd.example.com", cache.NewInMemoryCache(24*time.Hour))
+		app, err = NewClientApp(nil, cdSettings, dexTestServer.URL, nil, "https://argocd.example.com", cache.NewInMemoryCache(24*time.Hour))
 		require.NoError(t, err)
 
 		w = httptest.NewRecorder()
@@ -905,7 +908,7 @@ func TestGenerateAppState(t *testing.T) {
 	signature, err := util.MakeSignature(32)
 	require.NoError(t, err)
 	expectedReturnURL := "http://argocd.example.com/"
-	app, err := NewClientApp(&settings.ArgoCDSettings{ServerSignature: signature, URL: expectedReturnURL}, "", nil, "", cache.NewInMemoryCache(24*time.Hour))
+	app, err := NewClientApp(nil, &settings.ArgoCDSettings{ServerSignature: signature, URL: expectedReturnURL}, "", nil, "", cache.NewInMemoryCache(24*time.Hour))
 	require.NoError(t, err)
 	generateResponse := httptest.NewRecorder()
 	expectedPKCEVerifier := oauth2.GenerateVerifier()
@@ -939,6 +942,7 @@ func TestGenerateAppState_XSS(t *testing.T) {
 	signature, err := util.MakeSignature(32)
 	require.NoError(t, err)
 	app, err := NewClientApp(
+		nil,
 		&settings.ArgoCDSettings{
 			// Only return URLs starting with this base should be allowed.
 			URL:             "https://argocd.example.com",
@@ -995,7 +999,7 @@ func TestGenerateAppState_NoReturnURL(t *testing.T) {
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", http.NoBody)
 	encrypted, err := crypto.Encrypt([]byte("123"), key)
 	require.NoError(t, err)
-	app, err := NewClientApp(cdSettings, "", nil, "/argo-cd", cache.NewInMemoryCache(24*time.Hour))
+	app, err := NewClientApp(nil, cdSettings, "", nil, "/argo-cd", cache.NewInMemoryCache(24*time.Hour))
 	require.NoError(t, err)
 
 	req.AddCookie(&http.Cookie{Name: common.StateCookieName, Value: hex.EncodeToString(encrypted)})
@@ -1294,7 +1298,7 @@ func TestGetUserInfo(t *testing.T) {
 			cdSettings := &settings.ArgoCDSettings{ServerSignature: signature}
 			encryptionKey, err := cdSettings.GetServerEncryptionKey()
 			require.NoError(t, err)
-			a, _ := NewClientApp(cdSettings, "", nil, "/argo-cd", tt.cache)
+			a, _ := NewClientApp(nil, cdSettings, "", nil, "/argo-cd", tt.cache)
 
 			for _, item := range tt.cacheItems {
 				var newValue []byte
@@ -1387,7 +1391,7 @@ issuer: http://localhost:63231
 enableUserInfoGroups: true
 userInfoPath: /`,
 			}
-			a, err := NewClientApp(cdSettings, "", nil, "/argo-cd", userInfoCache)
+			a, err := NewClientApp(nil, cdSettings, "", nil, "/argo-cd", userInfoCache)
 			require.NoError(t, err, "failed creating clientapp")
 
 			// prepoluate cache to predict what the GetUserInfo function will return to the SetGroupsClaimFromEndpoint function (without having to mock the userinfo response)
@@ -1566,7 +1570,7 @@ clientSecret: test-client-secret
 requestedScopes: ["oidc"]`, oidcTestServer.URL),
 				OIDCTLSInsecureSkipVerify: true,
 			}
-			app, err := NewClientApp(cdSettings, "", nil, "/", cache.NewInMemoryCache(24*time.Hour))
+			app, err := NewClientApp(nil, cdSettings, "", nil, "/", cache.NewInMemoryCache(24*time.Hour))
 			require.NoError(t, err)
 			if tt.insertIntoCache {
 				oidcTokenCacheJSON, err := json.Marshal(tt.oidcTokenCache)
@@ -1652,7 +1656,7 @@ requestedScopes: ["oidc"]`, oidcTestServer.URL, tt.refreshTokenThreshold),
 			}
 			// The base href (the last argument for NewClientApp) is what HandleLogin will fall back to when no explicit
 			// redirect URL is given.
-			app, err := NewClientApp(cdSettings, "", nil, "/", cache.NewInMemoryCache(24*time.Hour))
+			app, err := NewClientApp(nil, cdSettings, "", nil, "/", cache.NewInMemoryCache(24*time.Hour))
 			require.NoError(t, err)
 			oidcTokenCacheJSON, err := json.Marshal(&OidcTokenCache{Token: &oauth2.Token{
 				RefreshToken: "not empty",
@@ -1722,4 +1726,201 @@ func TestClientApp_getRedirectURIForRequest(t *testing.T) {
 			assert.Equal(t, expectedRedirectURI, redirectURI, "expected URI")
 		})
 	}
+}
+
+// TestClientApp_LazyTransportConfig verifies that the ClientApp correctly
+// configures its HTTP transport even when DexConfig is not present at
+// construction time but arrives later via a settings update.
+func TestClientApp_LazyTransportConfig(t *testing.T) {
+	dexTestServer := test.GetDexTestServer(t)
+	t.Cleanup(dexTestServer.Close)
+
+	dexTLSConfig := &dex.DexTLSConfig{
+		DisableTLS:       false,
+		StrictValidation: false,
+	}
+
+	t.Run("transport configured for dex when DexConfig arrives after construction", func(t *testing.T) {
+		// Phase 1: Create ClientApp with NO DexConfig (simulates first
+		// startup where argocd-cm hasn't been populated yet).
+		kubeClient := fake.NewClientset(
+			&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "argocd-cm",
+					Namespace: "argocd",
+					Labels: map[string]string{
+						"app.kubernetes.io/part-of": "argocd",
+					},
+				},
+				Data: map[string]string{
+					"url": dexTestServer.URL,
+				},
+			},
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "argocd-secret",
+					Namespace: "argocd",
+				},
+				Data: map[string][]byte{
+					"server.secretkey": []byte("Hello, world!"),
+				},
+			},
+		)
+		settingsMgr := settings.NewSettingsManager(t.Context(), kubeClient, "argocd")
+		cdSettings, err := settingsMgr.GetSettings()
+		require.NoError(t, err)
+
+		a, err := NewClientApp(settingsMgr, cdSettings, dexTestServer.URL, dexTLSConfig, "/", cache.NewInMemoryCache(24*time.Hour))
+		require.NoError(t, err)
+
+		// At this point the transport should NOT be configured for dex.
+		assert.Nil(t, a.transport.TLSClientConfig,
+			"transport TLS should not be configured at construction when DexConfig is empty")
+
+		// Phase 2: Update the configmap to include DexConfig.
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "argocd-cm",
+				Namespace: "argocd",
+				Labels: map[string]string{
+					"app.kubernetes.io/part-of": "argocd",
+				},
+			},
+			Data: map[string]string{
+				"url": dexTestServer.URL,
+				"dex.config": `connectors:
+- type: github
+  name: GitHub
+  config:
+    clientID: aabbccddeeff00112233
+    clientSecret: aabbccddeeff00112233`,
+			},
+		}
+		_, err = kubeClient.CoreV1().ConfigMaps("argocd").Update(t.Context(), cm, metav1.UpdateOptions{})
+		require.NoError(t, err)
+
+		// Invalidate settings cache so the manager re-reads the configmap.
+		err = settingsMgr.ResyncInformers()
+		require.NoError(t, err)
+
+		// Phase 3: Trigger configureTransport via sync.Once.
+		a.transportOnce.Do(a.configureTransport)
+
+		// Verify the transport was configured for dex:
+		// 1. TLS should have InsecureSkipVerify (non-strict dex mode)
+		require.NotNil(t, a.transport.TLSClientConfig,
+			"transport TLS should be configured after configureTransport runs")
+		assert.True(t, a.transport.TLSClientConfig.InsecureSkipVerify,
+			"transport should have InsecureSkipVerify=true for non-strict dex")
+
+		// 2. The client transport should be a DexRewriteURLRoundTripper
+		_, isDexRewriter := a.client.Transport.(dex.DexRewriteURLRoundTripper)
+		assert.True(t, isDexRewriter,
+			"client transport should be DexRewriteURLRoundTripper when DexConfig is set")
+	})
+
+	t.Run("transport configured for external OIDC when no DexConfig", func(t *testing.T) {
+		oidcTestServer := test.GetOIDCTestServer(t, nil)
+		t.Cleanup(oidcTestServer.Close)
+
+		kubeClient := fake.NewClientset(
+			&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "argocd-cm",
+					Namespace: "argocd",
+					Labels: map[string]string{
+						"app.kubernetes.io/part-of": "argocd",
+					},
+				},
+				Data: map[string]string{
+					"url": "https://argocd.example.com",
+					"oidc.config": fmt.Sprintf(`
+name: Test
+issuer: %s
+clientID: xxx
+clientSecret: yyy`, oidcTestServer.URL),
+				},
+			},
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "argocd-secret",
+					Namespace: "argocd",
+				},
+				Data: map[string][]byte{
+					"server.secretkey": []byte("Hello, world!"),
+				},
+			},
+		)
+		settingsMgr := settings.NewSettingsManager(t.Context(), kubeClient, "argocd")
+		cdSettings, err := settingsMgr.GetSettings()
+		require.NoError(t, err)
+
+		a, err := NewClientApp(settingsMgr, cdSettings, dexTestServer.URL, dexTLSConfig, "/", cache.NewInMemoryCache(24*time.Hour))
+		require.NoError(t, err)
+
+		// Trigger configureTransport.
+		a.transportOnce.Do(a.configureTransport)
+
+		// Should NOT have InsecureSkipVerify (external OIDC mode)
+		require.NotNil(t, a.transport.TLSClientConfig)
+		assert.False(t, a.transport.TLSClientConfig.InsecureSkipVerify,
+			"transport should verify certs for external OIDC")
+
+		// Should NOT be a DexRewriteURLRoundTripper
+		_, isDexRewriter := a.client.Transport.(dex.DexRewriteURLRoundTripper)
+		assert.False(t, isDexRewriter,
+			"client transport should not be DexRewriteURLRoundTripper for external OIDC")
+	})
+
+	t.Run("transport configured for dex when DexConfig present at construction", func(t *testing.T) {
+		kubeClient := fake.NewClientset(
+			&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "argocd-cm",
+					Namespace: "argocd",
+					Labels: map[string]string{
+						"app.kubernetes.io/part-of": "argocd",
+					},
+				},
+				Data: map[string]string{
+					"url": dexTestServer.URL,
+					"dex.config": `connectors:
+- type: github
+  name: GitHub
+  config:
+    clientID: aabbccddeeff00112233
+    clientSecret: aabbccddeeff00112233`,
+				},
+			},
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "argocd-secret",
+					Namespace: "argocd",
+				},
+				Data: map[string][]byte{
+					"server.secretkey": []byte("Hello, world!"),
+				},
+			},
+		)
+		settingsMgr := settings.NewSettingsManager(t.Context(), kubeClient, "argocd")
+		cdSettings, err := settingsMgr.GetSettings()
+		require.NoError(t, err)
+
+		a, err := NewClientApp(settingsMgr, cdSettings, dexTestServer.URL, dexTLSConfig, "/", cache.NewInMemoryCache(24*time.Hour))
+		require.NoError(t, err)
+
+		// Transport not configured yet - lazy.
+		assert.Nil(t, a.transport.TLSClientConfig)
+
+		// Trigger configureTransport.
+		a.transportOnce.Do(a.configureTransport)
+
+		// Should be configured for dex.
+		require.NotNil(t, a.transport.TLSClientConfig)
+		assert.True(t, a.transport.TLSClientConfig.InsecureSkipVerify,
+			"transport should have InsecureSkipVerify=true for dex")
+		_, isDexRewriter := a.client.Transport.(dex.DexRewriteURLRoundTripper)
+		assert.True(t, isDexRewriter,
+			"client transport should be DexRewriteURLRoundTripper")
+	})
 }

--- a/util/session/sessionmanager.go
+++ b/util/session/sessionmanager.go
@@ -43,11 +43,15 @@ type SessionManager struct {
 	settingsMgr                   *settings.SettingsManager
 	projectsLister                v1alpha1.AppProjectNamespaceLister
 	client                        *http.Client
+	transport                     *http.Transport
+	dexTLSConfig                  *dex.DexTLSConfig
+	dexServerAddr                 string
 	prov                          oidcutil.Provider
 	storage                       UserStateStorage
 	sleep                         func(d time.Duration)
 	verificationDelayNoiseEnabled bool
 	failedLock                    sync.RWMutex
+	transportOnce                 sync.Once
 	metricsRegistry               MetricsRegistry
 }
 
@@ -129,18 +133,6 @@ func getLoginFailureWindow() time.Duration {
 
 // NewSessionManager creates a new session manager from Argo CD settings
 func NewSessionManager(settingsMgr *settings.SettingsManager, projectsLister v1alpha1.AppProjectNamespaceLister, dexServerAddr string, dexTLSConfig *dex.DexTLSConfig, storage UserStateStorage) *SessionManager {
-	s := SessionManager{
-		settingsMgr:                   settingsMgr,
-		storage:                       storage,
-		sleep:                         time.Sleep,
-		projectsLister:                projectsLister,
-		verificationDelayNoiseEnabled: true,
-	}
-	settings, err := settingsMgr.GetSettings()
-	if err != nil {
-		panic(err)
-	}
-
 	transport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		Dial: (&net.Dialer{
@@ -151,22 +143,37 @@ func NewSessionManager(settingsMgr *settings.SettingsManager, projectsLister v1a
 		ExpectContinueTimeout: 1 * time.Second,
 	}
 
-	s.client = &http.Client{
-		Transport: transport,
+	s := SessionManager{
+		settingsMgr:                   settingsMgr,
+		storage:                       storage,
+		sleep:                         time.Sleep,
+		projectsLister:                projectsLister,
+		verificationDelayNoiseEnabled: true,
+		client:                        &http.Client{Transport: transport},
+		transport:                     transport,
+		dexTLSConfig:                  dexTLSConfig,
+		dexServerAddr:                 dexServerAddr,
 	}
-
-	if settings.DexConfig != "" {
-		transport.TLSClientConfig = dex.TLSConfig(dexTLSConfig)
-		addrWithProto := dex.DexServerAddressWithProtocol(dexServerAddr, dexTLSConfig)
-		s.client.Transport = dex.NewDexRewriteURLRoundTripper(addrWithProto, s.client.Transport)
-	} else {
-		transport.TLSClientConfig = settings.OIDCTLSConfig()
-	}
-	if os.Getenv(common.EnvVarSSODebug) == "1" {
-		s.client.Transport = httputil.DebugTransport{T: s.client.Transport}
-	}
+	// Transport TLS is configured lazily in configureTransport() to avoid a
+	// race where DexConfig is not yet present in argocd-cm at startup but
+	// arrives later via a settings update / graceful restart.
 
 	return &s
+}
+
+// configureTransport sets up the HTTP transport TLS and URL-rewriting based on
+// the given settings.  Called once via sync.Once from provider().
+func (mgr *SessionManager) configureTransport(settings *settings.ArgoCDSettings) {
+	if settings.DexConfig != "" {
+		mgr.transport.TLSClientConfig = dex.TLSConfig(mgr.dexTLSConfig)
+		addrWithProto := dex.DexServerAddressWithProtocol(mgr.dexServerAddr, mgr.dexTLSConfig)
+		mgr.client.Transport = dex.NewDexRewriteURLRoundTripper(addrWithProto, mgr.transport)
+	} else {
+		mgr.transport.TLSClientConfig = settings.OIDCTLSConfig()
+	}
+	if os.Getenv(common.EnvVarSSODebug) == "1" {
+		mgr.client.Transport = httputil.DebugTransport{T: mgr.client.Transport}
+	}
 }
 
 // Create creates a new token for a given subject (user) and returns it as a string.
@@ -635,6 +642,7 @@ func (mgr *SessionManager) provider() (oidcutil.Provider, error) {
 	if !settings.IsSSOConfigured() {
 		return nil, errors.New("SSO is not configured")
 	}
+	mgr.transportOnce.Do(func() { mgr.configureTransport(settings) })
 	mgr.prov = oidcutil.NewOIDCProvider(settings.IssuerURL(), mgr.client)
 	return mgr.prov, nil
 }

--- a/util/session/sessionmanager_test.go
+++ b/util/session/sessionmanager_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/argoproj/argo-cd/v3/util"
 	"github.com/argoproj/argo-cd/v3/util/cache"
 	"github.com/argoproj/argo-cd/v3/util/crypto"
+	"github.com/argoproj/argo-cd/v3/util/dex"
 	jwtutil "github.com/argoproj/argo-cd/v3/util/jwt"
 	"github.com/argoproj/argo-cd/v3/util/oidc"
 	"github.com/argoproj/argo-cd/v3/util/password"
@@ -1329,5 +1330,161 @@ func Test_PickFailureAttemptWhenOverflowed(t *testing.T) {
 			user := pickRandomNonAdminLoginFailure(failures, "test")
 			assert.Equal(t, "test2", *user)
 		}
+	})
+}
+
+// TestSessionManager_LazyTransportConfig verifies that the SessionManager
+// correctly configures its HTTP transport for dex even when DexConfig is not
+// present at construction time but arrives later via a settings update.
+// This reproduces https://github.com/argoproj/argo-cd/issues/26345.
+func TestSessionManager_LazyTransportConfig(t *testing.T) {
+	dexTestServer := utiltest.GetDexTestServer(t)
+	t.Cleanup(dexTestServer.Close)
+
+	dexAddr := dexTestServer.URL
+	dexTLSConfig := &dex.DexTLSConfig{
+		DisableTLS:       false,
+		StrictValidation: false,
+	}
+
+	t.Run("transport configured for dex when DexConfig arrives after construction", func(t *testing.T) {
+		// Phase 1: Create SessionManager with NO DexConfig (simulates first
+		// startup where argocd-cm hasn't been populated yet).
+		kubeClient := getKubeClientWithConfig(map[string]string{}, nil)
+		settingsMgr := settings.NewSettingsManager(t.Context(), kubeClient, "argocd")
+		mgr := NewSessionManager(settingsMgr, getProjLister(), dexAddr, dexTLSConfig, NewUserStateStorage(nil))
+
+		// At this point the transport should NOT be configured for dex.
+		assert.Nil(t, mgr.transport.TLSClientConfig,
+			"transport TLS should not be configured at construction when DexConfig is empty")
+
+		// provider() should fail — SSO is not configured yet.
+		_, err := mgr.provider()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "SSO is not configured")
+		// Transport must still be nil — configureTransport was NOT called.
+		assert.Nil(t, mgr.transport.TLSClientConfig,
+			"transport TLS should remain nil when SSO is not configured")
+
+		// Phase 2: Update the configmap to include DexConfig and URL
+		// (simulates argocd-config delivering the full argocd-cm).
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "argocd-cm",
+				Namespace: "argocd",
+				Labels: map[string]string{
+					"app.kubernetes.io/part-of": "argocd",
+				},
+			},
+			Data: map[string]string{
+				"url": dexTestServer.URL,
+				"dex.config": `connectors:
+- type: github
+  name: GitHub
+  config:
+    clientID: aabbccddeeff00112233
+    clientSecret: aabbccddeeff00112233`,
+			},
+		}
+		_, err = kubeClient.CoreV1().ConfigMaps("argocd").Update(t.Context(), cm, metav1.UpdateOptions{})
+		require.NoError(t, err)
+
+		// Invalidate settings cache so the manager re-reads the configmap.
+		err = settingsMgr.ResyncInformers()
+		require.NoError(t, err)
+
+		// Phase 3: Call provider() — SSO is now configured, so
+		// configureTransport runs via sync.Once before the provider is created.
+		// The provider itself may fail (test dex server doesn't serve OIDC
+		// discovery), but configureTransport must have executed.
+		_, _ = mgr.provider()
+
+		// Verify the transport was configured for dex:
+		// 1. TLS should have InsecureSkipVerify (non-strict dex mode)
+		require.NotNil(t, mgr.transport.TLSClientConfig,
+			"transport TLS should be configured after provider() triggers lazy init")
+		assert.True(t, mgr.transport.TLSClientConfig.InsecureSkipVerify,
+			"transport should have InsecureSkipVerify=true for non-strict dex")
+
+		// 2. The client transport should be a DexRewriteURLRoundTripper
+		_, isDexRewriter := mgr.client.Transport.(dex.DexRewriteURLRoundTripper)
+		assert.True(t, isDexRewriter,
+			"client transport should be DexRewriteURLRoundTripper when DexConfig is set")
+	})
+
+	t.Run("transport configured for external OIDC when no DexConfig", func(t *testing.T) {
+		// SessionManager with external OIDC (no dex).
+		kubeClient := getKubeClientWithConfig(map[string]string{
+			"url": "https://argocd.example.com",
+			"oidc.config": fmt.Sprintf(`
+name: Test
+issuer: %s
+clientID: xxx
+clientSecret: yyy`, dexTestServer.URL),
+		}, nil)
+		settingsMgr := settings.NewSettingsManager(t.Context(), kubeClient, "argocd")
+		mgr := NewSessionManager(settingsMgr, getProjLister(), dexAddr, dexTLSConfig, NewUserStateStorage(nil))
+
+		// Call provider() to trigger lazy transport config.
+		_, _ = mgr.provider()
+
+		// Should NOT have InsecureSkipVerify (external OIDC mode)
+		require.NotNil(t, mgr.transport.TLSClientConfig)
+		assert.False(t, mgr.transport.TLSClientConfig.InsecureSkipVerify,
+			"transport should verify certs for external OIDC")
+
+		// Should NOT be a DexRewriteURLRoundTripper
+		_, isDexRewriter := mgr.client.Transport.(dex.DexRewriteURLRoundTripper)
+		assert.False(t, isDexRewriter,
+			"client transport should not be DexRewriteURLRoundTripper for external OIDC")
+	})
+
+	t.Run("transport not configured when SSO is never configured", func(t *testing.T) {
+		// SessionManager created with completely empty settings — no dex, no OIDC.
+		kubeClient := getKubeClientWithConfig(map[string]string{}, nil)
+		settingsMgr := settings.NewSettingsManager(t.Context(), kubeClient, "argocd")
+		mgr := NewSessionManager(settingsMgr, getProjLister(), dexAddr, dexTLSConfig, NewUserStateStorage(nil))
+
+		// Transport should have no TLS config at construction.
+		assert.Nil(t, mgr.transport.TLSClientConfig)
+
+		// provider() should return error since SSO is not configured.
+		_, err := mgr.provider()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "SSO is not configured")
+
+		// Transport should still be unconfigured — configureTransport was not called
+		// because provider() returned before reaching the sync.Once.
+		assert.Nil(t, mgr.transport.TLSClientConfig,
+			"transport TLS should remain nil when SSO is never configured")
+	})
+
+	t.Run("transport configured for dex when DexConfig present at construction", func(t *testing.T) {
+		// Normal case: DexConfig is available at startup (no race).
+		kubeClient := getKubeClientWithConfig(map[string]string{
+			"url": dexTestServer.URL,
+			"dex.config": `connectors:
+- type: github
+  name: GitHub
+  config:
+    clientID: aabbccddeeff00112233
+    clientSecret: aabbccddeeff00112233`,
+		}, nil)
+		settingsMgr := settings.NewSettingsManager(t.Context(), kubeClient, "argocd")
+		mgr := NewSessionManager(settingsMgr, getProjLister(), dexAddr, dexTLSConfig, NewUserStateStorage(nil))
+
+		// Transport not configured yet — lazy.
+		assert.Nil(t, mgr.transport.TLSClientConfig)
+
+		// Call provider() to trigger lazy config.
+		_, _ = mgr.provider()
+
+		// Should be configured for dex.
+		require.NotNil(t, mgr.transport.TLSClientConfig)
+		assert.True(t, mgr.transport.TLSClientConfig.InsecureSkipVerify,
+			"transport should have InsecureSkipVerify=true for dex")
+		_, isDexRewriter := mgr.client.Transport.(dex.DexRewriteURLRoundTripper)
+		assert.True(t, isDexRewriter,
+			"client transport should be DexRewriteURLRoundTripper")
 	})
 }

--- a/util/session/sessionmanager_test.go
+++ b/util/session/sessionmanager_test.go
@@ -380,7 +380,7 @@ issuer: http://localhost:63231
 enableUserInfoGroups: true
 userInfoPath: /`,
 				}
-				clientApp, err = oidc.NewClientApp(cdSettings, "", nil, "/argo-cd", userInfoCache)
+				clientApp, err = oidc.NewClientApp(nil, cdSettings, "", nil, "/argo-cd", userInfoCache)
 				require.NoError(t, err, "failed creating clientapp")
 
 				// prepopulate the cache with claims to return for a userinfo call

--- a/util/session/sessionmanager_test.go
+++ b/util/session/sessionmanager_test.go
@@ -435,7 +435,7 @@ issuer: http://localhost:63231
 enableUserInfoGroups: true
 userInfoPath: /`,
 				}
-				clientApp, err = oidc.NewClientApp(cdSettings, "", nil, "/argo-cd", userInfoCache)
+				clientApp, err = oidc.NewClientApp(nil, cdSettings, "", nil, "/argo-cd", userInfoCache)
 				require.NoError(t, err, "failed creating clientapp")
 
 				// prepopulate the cache with claims to return for a userinfo call

--- a/util/session/sessionmanager_test.go
+++ b/util/session/sessionmanager_test.go
@@ -1565,3 +1565,159 @@ func Test_PickFailureAttemptWhenOverflowed(t *testing.T) {
 		}
 	})
 }
+
+// TestSessionManager_LazyTransportConfig verifies that the SessionManager
+// correctly configures its HTTP transport for dex even when DexConfig is not
+// present at construction time but arrives later via a settings update.
+// This reproduces https://github.com/argoproj/argo-cd/issues/26345.
+func TestSessionManager_LazyTransportConfig(t *testing.T) {
+	dexTestServer := utiltest.GetDexTestServer(t)
+	t.Cleanup(dexTestServer.Close)
+
+	dexAddr := dexTestServer.URL
+	dexTLSConfig := &dex.DexTLSConfig{
+		DisableTLS:       false,
+		StrictValidation: false,
+	}
+
+	t.Run("transport configured for dex when DexConfig arrives after construction", func(t *testing.T) {
+		// Phase 1: Create SessionManager with NO DexConfig (simulates first
+		// startup where argocd-cm hasn't been populated yet).
+		kubeClient := getKubeClientWithConfig(map[string]string{}, nil)
+		settingsMgr := settings.NewSettingsManager(t.Context(), kubeClient, "argocd")
+		mgr := NewSessionManager(settingsMgr, getProjLister(), dexAddr, dexTLSConfig, NewUserStateStorage(nil))
+
+		// At this point the transport should NOT be configured for dex.
+		assert.Nil(t, mgr.transport.TLSClientConfig,
+			"transport TLS should not be configured at construction when DexConfig is empty")
+
+		// provider() should fail — SSO is not configured yet.
+		_, err := mgr.provider()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "SSO is not configured")
+		// Transport must still be nil — configureTransport was NOT called.
+		assert.Nil(t, mgr.transport.TLSClientConfig,
+			"transport TLS should remain nil when SSO is not configured")
+
+		// Phase 2: Update the configmap to include DexConfig and URL
+		// (simulates argocd-config delivering the full argocd-cm).
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "argocd-cm",
+				Namespace: "argocd",
+				Labels: map[string]string{
+					"app.kubernetes.io/part-of": "argocd",
+				},
+			},
+			Data: map[string]string{
+				"url": dexTestServer.URL,
+				"dex.config": `connectors:
+- type: github
+  name: GitHub
+  config:
+    clientID: aabbccddeeff00112233
+    clientSecret: aabbccddeeff00112233`,
+			},
+		}
+		_, err = kubeClient.CoreV1().ConfigMaps("argocd").Update(t.Context(), cm, metav1.UpdateOptions{})
+		require.NoError(t, err)
+
+		// Invalidate settings cache so the manager re-reads the configmap.
+		err = settingsMgr.ResyncInformers()
+		require.NoError(t, err)
+
+		// Phase 3: Call provider() — SSO is now configured, so
+		// configureTransport runs via sync.Once before the provider is created.
+		// The provider itself may fail (test dex server doesn't serve OIDC
+		// discovery), but configureTransport must have executed.
+		_, _ = mgr.provider()
+
+		// Verify the transport was configured for dex:
+		// 1. TLS should have InsecureSkipVerify (non-strict dex mode)
+		require.NotNil(t, mgr.transport.TLSClientConfig,
+			"transport TLS should be configured after provider() triggers lazy init")
+		assert.True(t, mgr.transport.TLSClientConfig.InsecureSkipVerify,
+			"transport should have InsecureSkipVerify=true for non-strict dex")
+
+		// 2. The client transport should be a DexRewriteURLRoundTripper
+		_, isDexRewriter := mgr.client.Transport.(dex.DexRewriteURLRoundTripper)
+		assert.True(t, isDexRewriter,
+			"client transport should be DexRewriteURLRoundTripper when DexConfig is set")
+	})
+
+	t.Run("transport configured for external OIDC when no DexConfig", func(t *testing.T) {
+		// SessionManager with external OIDC (no dex).
+		kubeClient := getKubeClientWithConfig(map[string]string{
+			"url": "https://argocd.example.com",
+			"oidc.config": fmt.Sprintf(`
+name: Test
+issuer: %s
+clientID: xxx
+clientSecret: yyy`, dexTestServer.URL),
+		}, nil)
+		settingsMgr := settings.NewSettingsManager(t.Context(), kubeClient, "argocd")
+		mgr := NewSessionManager(settingsMgr, getProjLister(), dexAddr, dexTLSConfig, NewUserStateStorage(nil))
+
+		// Call provider() to trigger lazy transport config.
+		_, _ = mgr.provider()
+
+		// Should NOT have InsecureSkipVerify (external OIDC mode)
+		require.NotNil(t, mgr.transport.TLSClientConfig)
+		assert.False(t, mgr.transport.TLSClientConfig.InsecureSkipVerify,
+			"transport should verify certs for external OIDC")
+
+		// Should NOT be a DexRewriteURLRoundTripper
+		_, isDexRewriter := mgr.client.Transport.(dex.DexRewriteURLRoundTripper)
+		assert.False(t, isDexRewriter,
+			"client transport should not be DexRewriteURLRoundTripper for external OIDC")
+	})
+
+	t.Run("transport not configured when SSO is never configured", func(t *testing.T) {
+		// SessionManager created with completely empty settings — no dex, no OIDC.
+		kubeClient := getKubeClientWithConfig(map[string]string{}, nil)
+		settingsMgr := settings.NewSettingsManager(t.Context(), kubeClient, "argocd")
+		mgr := NewSessionManager(settingsMgr, getProjLister(), dexAddr, dexTLSConfig, NewUserStateStorage(nil))
+
+		// Transport should have no TLS config at construction.
+		assert.Nil(t, mgr.transport.TLSClientConfig)
+
+		// provider() should return error since SSO is not configured.
+		_, err := mgr.provider()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "SSO is not configured")
+
+		// Transport should still be unconfigured — configureTransport was not called
+		// because provider() returned before reaching the sync.Once.
+		assert.Nil(t, mgr.transport.TLSClientConfig,
+			"transport TLS should remain nil when SSO is never configured")
+	})
+
+	t.Run("transport configured for dex when DexConfig present at construction", func(t *testing.T) {
+		// Normal case: DexConfig is available at startup (no race).
+		kubeClient := getKubeClientWithConfig(map[string]string{
+			"url": dexTestServer.URL,
+			"dex.config": `connectors:
+- type: github
+  name: GitHub
+  config:
+    clientID: aabbccddeeff00112233
+    clientSecret: aabbccddeeff00112233`,
+		}, nil)
+		settingsMgr := settings.NewSettingsManager(t.Context(), kubeClient, "argocd")
+		mgr := NewSessionManager(settingsMgr, getProjLister(), dexAddr, dexTLSConfig, NewUserStateStorage(nil))
+
+		// Transport not configured yet — lazy.
+		assert.Nil(t, mgr.transport.TLSClientConfig)
+
+		// Call provider() to trigger lazy config.
+		_, _ = mgr.provider()
+
+		// Should be configured for dex.
+		require.NotNil(t, mgr.transport.TLSClientConfig)
+		assert.True(t, mgr.transport.TLSClientConfig.InsecureSkipVerify,
+			"transport should have InsecureSkipVerify=true for dex")
+		_, isDexRewriter := mgr.client.Transport.(dex.DexRewriteURLRoundTripper)
+		assert.True(t, isDexRewriter,
+			"client transport should be DexRewriteURLRoundTripper")
+	})
+}


### PR DESCRIPTION
## Summary

When `argocd-server` starts, both `SessionManager` and `ClientApp` configure their HTTP transport based on whether `dex.config` is present in `argocd-cm` at construction time. This determines whether OIDC requests are routed internally to dex (with `InsecureSkipVerify` and `DexRewriteURLRoundTripper`) or externally with strict TLS verification.

If the configmap or its `dex.config` field is delivered after the server starts (e.g. by a GitOps controller), the transport is permanently misconfigured: OIDC discovery requests go to the external URL with strict TLS instead of to the internal dex address. Token verifications fail with `x509: certificate signed by unknown authority`. The graceful restart mechanism only re-runs `Run()`, not `NewServer()`, so the clients are never rebuilt. Only a full pod restart fixes it.

This may also address https://github.com/argoproj/argo-cd/issues/26345.

### Root cause

`NewSessionManager()` and `NewClientApp()` read `settings.DexConfig` at construction time to decide the TLS branch. If `DexConfig` is empty (configmap not yet reconciled), they take the external-OIDC branch with strict TLS and no URL rewriting. When the configmap arrives later and triggers a graceful restart, `NewServer()` is not re-called (`cmd/argocd-server/commands/argocd_server.go:265-286`), so both keep their misconfigured clients.

### Fix

Transport configuration is deferred from the constructors to first use via `sync.Once`:

- **`SessionManager`**: Transport is configured in `provider()`, which already gates on `IsSSOConfigured()` — guaranteeing that both URL and `DexConfig` are present when the configuration runs.
- **`ClientApp`**: Transport is configured before the first HTTP request in `HandleLogin`, `HandleCallback`, `GetUserInfo`, and `GetUpdatedOidcTokenFromCache`. `NewClientApp` now accepts a `SettingsManager` to read fresh settings at configuration time.

Both read fresh settings from `SettingsManager` at configuration time, so the correct TLS branch is always taken regardless of startup ordering.

### Changes

| File | Change |
|---|---|
| `util/session/sessionmanager.go` | Defer transport config from `NewSessionManager()` to `provider()` via `sync.Once` |
| `util/oidc/oidc.go` | Defer transport config from `NewClientApp()` to first HTTP use via `sync.Once`. Add `settingsMgr` parameter. |
| `server/server.go` | Pass `settingsMgr` to `NewClientApp` |
| `server/server_test.go` | Pass `settingsMgr` to `NewClientApp` |
| `util/session/sessionmanager_test.go` | New `TestSessionManager_LazyTransportConfig` (4 subtests) + update `NewClientApp` call |
| `util/oidc/oidc_test.go` | New `TestClientApp_LazyTransportConfig` (3 subtests) + update all `NewClientApp` calls |

## Test plan

- [x] `TestSessionManager_LazyTransportConfig` — 4 subtests covering: DexConfig late arrival, external OIDC, SSO never configured, DexConfig at startup
- [x] `TestClientApp_LazyTransportConfig` — 3 subtests covering: DexConfig late arrival, external OIDC, DexConfig at startup
- [x] All existing `TestSessionManager_VerifyToken` subtests pass (17/17)
- [x] Full `util/session` test suite passes
- [x] Full `util/oidc` test suite passes
- [x] `server` package builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)