### PR TITLE
fix: OpenTelemetryCollector health check shows 0/0 for mode: daemonset

### DIFF
--- a/resource_customizations/opentelemetry.io/OpenTelemetryCollector/health.lua
+++ b/resource_customizations/opentelemetry.io/OpenTelemetryCollector/health.lua
@@ -14,8 +14,13 @@ if obj.status ~= nil then
             total = tonumber(total)
 
             if ready == 0 then
-                hs.status = "Degraded"
-                hs.message = "No replicas are ready"
+                if obj.spec ~= nil and obj.spec.mode == "daemonset" and ready == 0 and total == 0 then
+                    hs.status = "Healthy"
+                    hs.message = "DaemonSet has no schedulable nodes (0/0)"
+                else
+                    hs.status = "Degraded"
+                    hs.message = "No replicas are ready"
+                end
             elseif ready == total then
                 hs.status = "Healthy"
                 hs.message = "All replicas are ready"

--- a/resource_customizations/opentelemetry.io/OpenTelemetryCollector/health.lua
+++ b/resource_customizations/opentelemetry.io/OpenTelemetryCollector/health.lua
@@ -19,7 +19,7 @@ if obj.status ~= nil then
                 -- https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/#how-daemon-pods-are-scheduled
                 if obj.spec ~= nil and obj.spec.mode == "daemonset" and total == 0 then
                     hs.status = "Healthy"
-                    hs.message = "DaemonSet has no schedulable nodes (0/0)"
+                    hs.message = "DaemonSet has no eligible nodes (0/0)"
                 else
                     hs.status = "Degraded"
                     hs.message = "No replicas are ready"

--- a/resource_customizations/opentelemetry.io/OpenTelemetryCollector/health.lua
+++ b/resource_customizations/opentelemetry.io/OpenTelemetryCollector/health.lua
@@ -14,7 +14,10 @@ if obj.status ~= nil then
             total = tonumber(total)
 
             if ready == 0 then
-                if obj.spec ~= nil and obj.spec.mode == "daemonset" and ready == 0 and total == 0 then
+                -- DaemonSet desiredNumberScheduled is based on eligible nodes.
+                -- 0/0 is valid when no nodes match; treat as Healthy.
+                -- https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/#how-daemon-pods-are-scheduled
+                if obj.spec ~= nil and obj.spec.mode == "daemonset" and total == 0 then
                     hs.status = "Healthy"
                     hs.message = "DaemonSet has no schedulable nodes (0/0)"
                 else

--- a/resource_customizations/opentelemetry.io/OpenTelemetryCollector/health_test.yaml
+++ b/resource_customizations/opentelemetry.io/OpenTelemetryCollector/health_test.yaml
@@ -4,6 +4,10 @@ tests:
       message: "All replicas are ready"
     inputPath: testdata/healthy.yaml
   - healthStatus:
+      status: Healthy
+      message: "DaemonSet has no schedulable nodes (0/0)"
+    inputPath: testdata/daemonset-no-schedulable-node.yaml
+  - healthStatus:
       status: Degraded
       message: "No replicas are ready"
     inputPath: testdata/degraded.yaml

--- a/resource_customizations/opentelemetry.io/OpenTelemetryCollector/health_test.yaml
+++ b/resource_customizations/opentelemetry.io/OpenTelemetryCollector/health_test.yaml
@@ -5,8 +5,8 @@ tests:
     inputPath: testdata/healthy.yaml
   - healthStatus:
       status: Healthy
-      message: "DaemonSet has no schedulable nodes (0/0)"
-    inputPath: testdata/daemonset-no-schedulable-node.yaml
+      message: "DaemonSet has no eligible nodes (0/0)"
+    inputPath: testdata/daemonset-no-eligible-node.yaml
   - healthStatus:
       status: Degraded
       message: "No replicas are ready"

--- a/resource_customizations/opentelemetry.io/OpenTelemetryCollector/testdata/daemonset-no-eligible-node.yaml
+++ b/resource_customizations/opentelemetry.io/OpenTelemetryCollector/testdata/daemonset-no-eligible-node.yaml
@@ -1,7 +1,7 @@
 apiVersion: opentelemetry.io/v1beta1
 kind: OpenTelemetryCollector
 metadata:
-  name: test-collector-daemonset-no-schedulable-node
+  name: test-collector-daemonset-no-eligible-node
   namespace: default
 spec:
   mode: daemonset

--- a/resource_customizations/opentelemetry.io/OpenTelemetryCollector/testdata/daemonset-no-schedulable-node.yaml
+++ b/resource_customizations/opentelemetry.io/OpenTelemetryCollector/testdata/daemonset-no-schedulable-node.yaml
@@ -1,7 +1,7 @@
 apiVersion: opentelemetry.io/v1beta1
 kind: OpenTelemetryCollector
 metadata:
-  name: test-collector-daemonset-zero
+  name: test-collector-daemonset-no-schedulable-node
   namespace: default
 spec:
   mode: daemonset

--- a/resource_customizations/opentelemetry.io/OpenTelemetryCollector/testdata/daemonset-no-schedulable-node.yaml
+++ b/resource_customizations/opentelemetry.io/OpenTelemetryCollector/testdata/daemonset-no-schedulable-node.yaml
@@ -1,0 +1,14 @@
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: test-collector-daemonset-zero
+  namespace: default
+spec:
+  mode: daemonset
+status:
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.124.1
+  scale:
+    replicas: 0
+    selector: app.kubernetes.io/component=opentelemetry-collector
+    statusReplicas: 0/0
+  version: 0.124.1


### PR DESCRIPTION
Opentelemetry collector deployed via Opentelemetry operator sets the status with the amount of replicas as expected whenever it's deployed in other modes, but when it's deployed as daemonset and there are no eligible nodes (e.g., toleration targets a taint that no node has), it reports replicas as 0/0. Argo CD interprets 0/0 as not ready and marks the resource as progressing/degraded, even though this is expected for DaemonSet scheduling semantics when the eligible node set is empty.

This PR updates the Lua health check script to reports Healthy when it's deployed as daemonset with 0/0 replicas due to zero eligible nodes, preventing Argo CD Applications from being stuck in a non-healthy state for an expected configuration.

fix: https://github.com/argoproj/argo-cd/issues/26390

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
