### PR TITLE
fix: trim whitespaces when retrieving source refresh paths

### DIFF
--- a/util/app/path/path.go
+++ b/util/app/path/path.go
@@ -117,6 +117,11 @@ func GetSourceRefreshPaths(app *v1alpha1.Application, source v1alpha1.Applicatio
 	var paths []string
 	if hasAnnotation && annotationPaths != "" {
 		for item := range strings.SplitSeq(annotationPaths, ";") {
+			// Trim whitespace because annotation values may contain spaces around
+			// separators (e.g. ".; /path"). Without trimming, paths like " /path"
+			// are not treated as absolute and empty/space-only entries may result
+			// in duplicate or incorrect refresh paths.
+			item = strings.TrimSpace(item)
 			// skip empty paths
 			if item == "" {
 				continue

--- a/util/app/path/path_test.go
+++ b/util/app/path/path_test.go
@@ -192,6 +192,43 @@ func Test_GetAppRefreshPaths(t *testing.T) {
 			source:        v1alpha1.ApplicationSource{Path: "dry/path"},
 			expectedPaths: []string{"dry/path/deploy"},
 		},
+		{
+			name:   "annotation paths with spaces after semicolon",
+			app:    getApp(ptr.To(".; dev/deploy; other/path"), ptr.To("source/path")),
+			source: v1alpha1.ApplicationSource{Path: "source/path"},
+			expectedPaths: []string{
+				"source/path",
+				"source/path/dev/deploy",
+				"source/path/other/path",
+			},
+		},
+		{
+			name:   "annotation paths with spaces before semicolon",
+			app:    getApp(ptr.To(". ;dev/deploy ;other/path"), ptr.To("source/path")),
+			source: v1alpha1.ApplicationSource{Path: "source/path"},
+			expectedPaths: []string{
+				"source/path",
+				"source/path/dev/deploy",
+				"source/path/other/path",
+			},
+		},
+		{
+			name:   "annotation paths with spaces around absolute path",
+			app:    getApp(ptr.To(" /fullpath/deploy ; other/path "), ptr.To("source/path")),
+			source: v1alpha1.ApplicationSource{Path: "source/path"},
+			expectedPaths: []string{
+				"fullpath/deploy",
+				"source/path/other/path",
+			},
+		},
+		{
+			name:   "annotation paths only spaces and separators",
+			app:    getApp(ptr.To(" ; ; . ; "), ptr.To("source/path")),
+			source: v1alpha1.ApplicationSource{Path: "source/path"},
+			expectedPaths: []string{
+				"source/path",
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Closes https://github.com/argoproj/argo-cd/issues/26381

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
