### PR TITLE
fix: skip namespace check on cluster scoped rbac resources for auth reconcile

### DIFF
--- a/gitops-engine/pkg/utils/kube/resource_ops.go
+++ b/gitops-engine/pkg/utils/kube/resource_ops.go
@@ -603,11 +603,14 @@ func (k *kubectlResourceOperations) authReconcile(ctx context.Context, obj *unst
 	if err != nil {
 		return "", fmt.Errorf("error creating kube client: %w", err)
 	}
+
+	clusterScoped := obj.GetKind() == "ClusterRole" || obj.GetKind() == "ClusterRoleBinding"
+
 	// `kubectl auth reconcile` has a side effect of auto-creating namespaces if it doesn't exist.
 	// See: https://github.com/kubernetes/kubernetes/issues/71185. This is behavior which we do
 	// not want. We need to check if the namespace exists, before know if it is safe to run this
 	// command. Skip this for dryRuns.
-	if dryRunStrategy == cmdutil.DryRunNone && obj.GetNamespace() != "" {
+	if dryRunStrategy == cmdutil.DryRunNone && obj.GetNamespace() != "" && !clusterScoped {
 		_, err = kubeClient.CoreV1().Namespaces().Get(ctx, obj.GetNamespace(), metav1.GetOptions{})
 		if err != nil {
 			return "", fmt.Errorf("error getting namespace %s: %w", obj.GetNamespace(), err)

--- a/gitops-engine/pkg/utils/kube/resource_ops_test.go
+++ b/gitops-engine/pkg/utils/kube/resource_ops_test.go
@@ -70,6 +70,6 @@ func TestAuthReconcileWithMissingNamespace(t *testing.T) {
 	clusterRoleBinding := testingutils.NewClusterRoleBinding()
 	clusterRoleBinding.SetNamespace(namespace)
 
-	_, err = k.authReconcile(context.Background(), clusterRole, "/dev/null", cmdutil.DryRunNone)
+	_, err = k.authReconcile(context.Background(), clusterRoleBinding, "/dev/null", cmdutil.DryRunNone)
 	assert.NoError(t, err)
 }

--- a/gitops-engine/pkg/utils/kube/resource_ops_test.go
+++ b/gitops-engine/pkg/utils/kube/resource_ops_test.go
@@ -1,0 +1,75 @@
+package kube
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	testingutils "github.com/argoproj/argo-cd/gitops-engine/pkg/utils/testing"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/rest"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+)
+
+func TestAuthReconcileWithMissingNamespace(t *testing.T) {
+	namespace := "test-ns"
+	fakeBearer := "fake-bearer"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		status := &metav1.Status{
+			Status:  "Failure",
+			Message: fmt.Sprintf("namespace \"%s\" not found", namespace),
+			Reason:  metav1.StatusReasonNotFound,
+			Code:    http.StatusNotFound,
+		}
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(status)
+	}))
+	defer server.Close()
+
+	kubeConfigFlags := genericclioptions.NewConfigFlags(true)
+	kubeConfigFlags.Namespace = &namespace
+	kubeConfigFlags.APIServer = &server.URL
+	kubeConfigFlags.BearerToken = &fakeBearer
+	matchFlags := cmdutil.NewMatchVersionFlags(kubeConfigFlags)
+	fact := cmdutil.NewFactory(matchFlags)
+
+	config := &rest.Config{Host: server.URL}
+	k := &kubectlResourceOperations{
+		config: config,
+		fact:   fact,
+	}
+
+	role := testingutils.NewRole()
+	role.SetNamespace(namespace)
+
+	_, err := k.authReconcile(context.Background(), role, "/dev/null", cmdutil.DryRunNone)
+	assert.Error(t, err)
+	assert.True(t, errors.IsNotFound(err), "returned error wasn't not found")
+
+	roleBinding := testingutils.NewRoleBinding()
+	roleBinding.SetNamespace(namespace)
+
+	_, err = k.authReconcile(context.Background(), roleBinding, "/dev/null", cmdutil.DryRunNone)
+	assert.Error(t, err)
+	assert.True(t, errors.IsNotFound(err), "returned error wasn't not found")
+
+	clusterRole := testingutils.NewClusterRole()
+	clusterRole.SetNamespace(namespace)
+
+	_, err = k.authReconcile(context.Background(), clusterRole, "/dev/null", cmdutil.DryRunNone)
+	assert.NoError(t, err)
+
+	clusterRoleBinding := testingutils.NewClusterRoleBinding()
+	clusterRoleBinding.SetNamespace(namespace)
+
+	_, err = k.authReconcile(context.Background(), clusterRole, "/dev/null", cmdutil.DryRunNone)
+	assert.NoError(t, err)
+}

--- a/gitops-engine/pkg/utils/testing/testdata.go
+++ b/gitops-engine/pkg/utils/testing/testdata.go
@@ -97,3 +97,55 @@ metadata:
   name: testnamespace
 spec:`)
 }
+
+func NewRole() *unstructured.Unstructured {
+	return Unstructured(`apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: my-role
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "watch", "list"]`)
+}
+
+func NewRoleBinding() *unstructured.Unstructured {
+	return Unstructured(`apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: my-role-binding
+subjects:
+- kind: User
+  name: user
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: my-role
+  apiGroup: rbac.authorization.k8s.io`)
+}
+
+func NewClusterRole() *unstructured.Unstructured {
+	return Unstructured(`apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: my-cluster-role
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "watch", "list"]`)
+}
+
+func NewClusterRoleBinding() *unstructured.Unstructured {
+	return Unstructured(`apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: my-cluster-role-binding
+subjects:
+- kind: Group
+  name: group
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: my-cluster-role
+  apiGroup: rbac.authorization.k8s.io`)
+}


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Closes: #24833 

The linked above issue describes that if a namespace is specified in the destination of an application's spec and that namespace does not exist, cluster scoped RBAC resources will fail to apply.

This is due to the auth reconcile operation that is performed doing a namespace check before hand due to a side effect where it creates namespaces that do not exist. This fix adds a check to see if the kind of the RBAC object is a ClusterRole or ClusterRoleBinding then skips the namespace check if it is.

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [N/A] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [N/A] Does this PR require documentation updates?
* [N/A] I've updated documentation as required by this PR.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [N/A] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [X] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [N/A] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [X] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
