### PR TITLE
feat(repo-server): add resolved Git reference caching to optimize concurrent app syncs (#26428)

### DIFF
--- a/cmd/argocd/commands/headless/headless.go
+++ b/cmd/argocd/commands/headless/headless.go
@@ -100,6 +100,12 @@ func (c *forwardCacheClient) Delete(key string) error {
 	})
 }
 
+func (c *forwardCacheClient) DeleteByPattern(key string) error {
+	return c.doLazy(func(client cache.CacheClient) error {
+		return client.DeleteByPattern(key)
+	})
+}
+
 func (c *forwardCacheClient) OnUpdated(ctx context.Context, key string, callback func() error) error {
 	return c.doLazy(func(client cache.CacheClient) error {
 		return client.OnUpdated(ctx, key, callback)

--- a/reposerver/cache/cache_test.go
+++ b/reposerver/cache/cache_test.go
@@ -365,7 +365,7 @@ func TestGetGitReferences(t *testing.T) {
 		assert.Len(t, references, 1)
 		assert.Equal(t, "test", (references)[0].Target().String())
 		assert.Equal(t, "test-repo", (references)[0].Name().String())
-		fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalSets: 1, ExternalGets: 1})
+		fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalSets: 1, ExternalGets: 1, ExternalDeletesByPattern: 1})
 	})
 
 	t.Run("cache error", func(t *testing.T) {
@@ -472,7 +472,7 @@ func TestGetOrLockGitReferences(t *testing.T) {
 		assert.Empty(t, lockId, "Lock id should not be set")
 		assert.Equal(t, "test-repo", references[0].Name().String())
 		assert.Equal(t, "test", references[0].Target().String())
-		fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalSets: 1, ExternalGets: 1})
+		fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalSets: 1, ExternalGets: 1, ExternalDeletesByPattern: 1})
 	})
 
 	t.Run("Test cache lock, cache hit remote", func(t *testing.T) {
@@ -512,7 +512,7 @@ func TestGetOrLockGitReferences(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotEqual(t, "test-lock-id", lockId)
 		assert.Empty(t, lockId, "Lock id should not be set")
-		fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalSets: 2, ExternalGets: 2})
+		fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalSets: 2, ExternalGets: 2, ExternalDeletesByPattern: 1})
 	})
 
 	t.Run("Test cache lock timeout", func(t *testing.T) {
@@ -529,7 +529,7 @@ func TestGetOrLockGitReferences(t *testing.T) {
 		assert.Equal(t, "test-lock-id", lockId)
 		assert.NotEmpty(t, lockId, "Lock id should be set")
 		cache.revisionCacheLockTimeout = 10 * time.Second
-		fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalSets: 1})
+		fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalSets: 1, ExternalDeletesByPattern: 1})
 	})
 
 	t.Run("Test cache lock error", func(t *testing.T) {
@@ -571,6 +571,32 @@ func TestGetResolvedGitReference(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "test-sha", sha)
 		fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalSets: 1, ExternalGets: 1})
+	})
+}
+
+func TestCleanResolvedGitReference(t *testing.T) {
+	t.Run("Resolved references are cleaned as part of the SetGitReferences flow", func(t *testing.T) {
+		fixtures := newFixtures()
+		t.Cleanup(fixtures.mockCache.StopRedisCallback)
+		cache := fixtures.cache
+
+		// Set a resolved reference, and confirm it's there
+		err := cache.SetResolvedGitReference("test-repo", "main", "test-sha")
+		require.NoError(t, err)
+		sha, err := cache.GetResolvedGitReference("test-repo", "main")
+		require.NoError(t, err)
+		assert.Equal(t, "test-sha", sha)
+
+		// Set git references, which should clear the resolved reference
+		err = cache.SetGitReferences("test-repo", *GitRefCacheItemToReferences([][2]string{{"test-repo", "ref: test"}}))
+		require.NoError(t, err)
+
+		// After setting git references, the resolved reference should be gone, even if there was a value before
+		sha, err = cache.GetResolvedGitReference("test-repo", "main")
+		require.NoError(t, err)
+		assert.Empty(t, sha)
+
+		fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalSets: 2, ExternalGets: 2, ExternalDeletesByPattern: 1})
 	})
 }
 

--- a/reposerver/cache/cache_test.go
+++ b/reposerver/cache/cache_test.go
@@ -550,6 +550,30 @@ func TestGetOrLockGitReferences(t *testing.T) {
 	})
 }
 
+func TestGetResolvedGitReference(t *testing.T) {
+	t.Run("Test cache miss", func(t *testing.T) {
+		fixtures := newFixtures()
+		t.Cleanup(fixtures.mockCache.StopRedisCallback)
+		cache := fixtures.cache
+		sha, err := cache.GetResolvedGitReference("test-repo", "main")
+		require.NoError(t, err)
+		assert.Empty(t, sha)
+		fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalSets: 0, ExternalGets: 1})
+	})
+
+	t.Run("Test cache set and hit", func(t *testing.T) {
+		fixtures := newFixtures()
+		t.Cleanup(fixtures.mockCache.StopRedisCallback)
+		cache := fixtures.cache
+		err := cache.SetResolvedGitReference("test-repo", "main", "test-sha")
+		require.NoError(t, err)
+		sha, err := cache.GetResolvedGitReference("test-repo", "main")
+		require.NoError(t, err)
+		assert.Equal(t, "test-sha", sha)
+		fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalSets: 1, ExternalGets: 1})
+	})
+}
+
 func TestUnlockGitReferences(t *testing.T) {
 	fixtures := newFixtures()
 	t.Cleanup(fixtures.mockCache.StopRedisCallback)

--- a/reposerver/cache/mocks/reposervercache.go
+++ b/reposerver/cache/mocks/reposervercache.go
@@ -33,10 +33,11 @@ type MockCacheOptions struct {
 }
 
 type CacheCallCounts struct {
-	ExternalSets    int
-	ExternalGets    int
-	ExternalDeletes int
-	ExternalRenames int
+	ExternalSets             int
+	ExternalGets             int
+	ExternalDeletes          int
+	ExternalRenames          int
+	ExternalDeletesByPattern int
 }
 
 // Checks that the cache was called the expected number of times
@@ -46,6 +47,7 @@ func (mockCache *MockRepoCache) AssertCacheCalledTimes(t *testing.T, calls *Cach
 	mockCache.RedisClient.AssertNumberOfCalls(t, "Set", calls.ExternalSets)
 	mockCache.RedisClient.AssertNumberOfCalls(t, "Delete", calls.ExternalDeletes)
 	mockCache.RedisClient.AssertNumberOfCalls(t, "Rename", calls.ExternalRenames)
+	mockCache.RedisClient.AssertNumberOfCalls(t, "DeleteByPattern", calls.ExternalDeletesByPattern)
 }
 
 func (mockCache *MockRepoCache) ConfigureDefaultCallbacks() {
@@ -53,6 +55,7 @@ func (mockCache *MockRepoCache) ConfigureDefaultCallbacks() {
 	mockCache.RedisClient.On("Set", mock.Anything).Return(nil)
 	mockCache.RedisClient.On("Delete", mock.Anything).Return(nil)
 	mockCache.RedisClient.On("Rename", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockCache.RedisClient.On("DeleteByPattern", mock.Anything).Return(nil)
 }
 
 func NewInMemoryRedis() (*redis.Client, func()) {

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -450,8 +450,8 @@ func TestGenerateManifest_RefOnlyShortCircuit(t *testing.T) {
 	_, err := service.GenerateManifest(t.Context(), &q)
 	require.NoError(t, err)
 	cacheMocks.mockCache.AssertCacheCalledTimes(t, &repositorymocks.CacheCallCounts{
-		ExternalSets: 2,
-		ExternalGets: 2,
+		ExternalSets: 3,
+		ExternalGets: 3,
 	})
 	assert.True(t, lsremoteCalled, "ls-remote should be called when the source is ref only")
 	var revisions [][2]string
@@ -520,8 +520,8 @@ func TestGenerateManifestsHelmWithRefs_CachedNoLsRemote(t *testing.T) {
 	_, err = service.GenerateManifest(t.Context(), &q)
 	require.NoError(t, err)
 	cacheMocks.mockCache.AssertCacheCalledTimes(t, &repositorymocks.CacheCallCounts{
-		ExternalSets: 2,
-		ExternalGets: 4,
+		ExternalSets: 3,
+		ExternalGets: 5,
 	})
 }
 

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -450,8 +450,9 @@ func TestGenerateManifest_RefOnlyShortCircuit(t *testing.T) {
 	_, err := service.GenerateManifest(t.Context(), &q)
 	require.NoError(t, err)
 	cacheMocks.mockCache.AssertCacheCalledTimes(t, &repositorymocks.CacheCallCounts{
-		ExternalSets: 3,
-		ExternalGets: 3,
+		ExternalSets:             3,
+		ExternalGets:             3,
+		ExternalDeletesByPattern: 1,
 	})
 	assert.True(t, lsremoteCalled, "ls-remote should be called when the source is ref only")
 	var revisions [][2]string

--- a/util/cache/cache.go
+++ b/util/cache/cache.go
@@ -352,6 +352,11 @@ func (c *Cache) SetItem(key string, item any, opts *CacheActionOpts) error {
 	if opts.Delete {
 		return client.Delete(fullKey)
 	}
+	if opts.KeyPatternToDelete != "" {
+		if err := client.DeleteByPattern(opts.KeyPatternToDelete); err != nil {
+			return fmt.Errorf("failed to delete cache items by pattern %s: %w", opts.KeyPatternToDelete, err)
+		}
+	}
 	return client.Set(&Item{Key: fullKey, Object: item, CacheActionOpts: *opts})
 }
 

--- a/util/cache/client.go
+++ b/util/cache/client.go
@@ -25,6 +25,8 @@ type CacheActionOpts struct {
 	DisableOverwrite bool
 	// Expiration is the cache expiration time.
 	Expiration time.Duration
+	// KeyPatternToDelete is the pattern of keys to delete when the item is set. It can be used to invalidate related cache entries.
+	KeyPatternToDelete string
 }
 
 type CacheClient interface {
@@ -32,6 +34,7 @@ type CacheClient interface {
 	Rename(oldKey string, newKey string, expiration time.Duration) error
 	Get(key string, obj any) error
 	Delete(key string) error
+	DeleteByPattern(key string) error
 	OnUpdated(ctx context.Context, key string, callback func() error) error
 	NotifyUpdated(key string) error
 }

--- a/util/cache/inmemory.go
+++ b/util/cache/inmemory.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/gob"
 	"fmt"
+	"strings"
 	"time"
 
 	gocache "github.com/patrickmn/go-cache"
@@ -82,6 +83,18 @@ func (i *InMemoryCache) Get(key string, obj any) error {
 
 func (i *InMemoryCache) Delete(key string) error {
 	i.memCache.Delete(key)
+	return nil
+}
+
+func (i *InMemoryCache) DeleteByPattern(key string) error {
+	for k := range i.memCache.Items() {
+		if strings.HasPrefix(k, key) {
+			err := i.Delete(k)
+			if err != nil {
+				return err
+			}
+		}
+	}
 	return nil
 }
 

--- a/util/cache/inmemory_test.go
+++ b/util/cache/inmemory_test.go
@@ -26,3 +26,37 @@ func TestInMemoryCache(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, &foo{Bar: "bar"}, obj)
 }
+
+func TestInMemoryCacheDeleteByPattern(t *testing.T) {
+	cache := NewInMemoryCache(1 * time.Hour)
+	obj := &foo{}
+	// cache miss
+	err := cache.Get("my-key:1", obj)
+	assert.Equal(t, ErrCacheMiss, err)
+	err = cache.Get("my-key:2", obj)
+	assert.Equal(t, ErrCacheMiss, err)
+	// cache hit
+	err = cache.Set(&Item{Key: "my-key:1", Object: &foo{Bar: "bar"}})
+	require.NoError(t, err)
+	err = cache.Set(&Item{Key: "my-key:2", Object: &foo{Bar: "bar"}})
+	require.NoError(t, err)
+	err = cache.Set(&Item{Key: "other-key:1", Object: &foo{Bar: "bar"}})
+	require.NoError(t, err)
+	err = cache.Get("my-key:1", obj)
+	require.NoError(t, err)
+	err = cache.Get("my-key:2", obj)
+	require.NoError(t, err)
+	err = cache.Get("other-key:1", obj)
+	require.NoError(t, err)
+	// clear cache by pattern
+	err = cache.DeleteByPattern("my-key:")
+	require.NoError(t, err)
+	// cache miss after deletion
+	err = cache.Get("my-key:1", obj)
+	assert.Equal(t, ErrCacheMiss, err)
+	err = cache.Get("my-key:2", obj)
+	assert.Equal(t, ErrCacheMiss, err)
+	// other key should not be deleted
+	err = cache.Get("other-key:1", obj)
+	require.NoError(t, err)
+}

--- a/util/cache/mocks/cacheclient.go
+++ b/util/cache/mocks/cacheclient.go
@@ -57,6 +57,17 @@ func (c *MockCacheClient) Delete(key string) error {
 	return c.BaseCache.Delete(key)
 }
 
+func (c *MockCacheClient) DeleteByPattern(key string) error {
+	args := c.Called(key)
+	if len(args) > 0 && args.Get(0) != nil {
+		return args.Get(0).(error)
+	}
+	if c.WriteDelay > 0 {
+		time.Sleep(c.WriteDelay)
+	}
+	return c.BaseCache.DeleteByPattern(key)
+}
+
 func (c *MockCacheClient) OnUpdated(ctx context.Context, key string, callback func() error) error {
 	args := c.Called(ctx, key, callback)
 	if len(args) > 0 && args.Get(0) != nil {

--- a/util/cache/redis.go
+++ b/util/cache/redis.go
@@ -64,6 +64,15 @@ func (r *redisCache) getKey(key string) string {
 	}
 }
 
+func (r *redisCache) getKeyPattern(key string) string {
+	switch r.redisCompressionType {
+	case RedisCompressionGZip:
+		return key + "*" + ".gz"
+	default:
+		return key + "*"
+	}
+}
+
 func (r *redisCache) marshal(obj any) ([]byte, error) {
 	buf := bytes.NewBuffer([]byte{})
 	var w io.Writer = buf
@@ -146,6 +155,22 @@ func (r *redisCache) Get(key string, obj any) error {
 
 func (r *redisCache) Delete(key string) error {
 	return r.cache.Delete(context.TODO(), r.getKey(key))
+}
+
+func (r *redisCache) DeleteByPattern(key string) error {
+	// we are using go-redis/cache/v9 which doesn't support pattern-based deletion, so we need to do it ourselves
+	iter := r.client.Scan(context.TODO(), 0, r.getKeyPattern(key), 0).Iterator()
+	var keysToDelete []string
+	for iter.Next(context.TODO()) {
+		keysToDelete = append(keysToDelete, iter.Val())
+	}
+	if err := iter.Err(); err != nil {
+		return err
+	}
+	if len(keysToDelete) == 0 {
+		return nil
+	}
+	return r.client.Del(context.TODO(), keysToDelete...).Err()
 }
 
 func (r *redisCache) OnUpdated(ctx context.Context, key string, callback func() error) error {

--- a/util/cache/redis.go
+++ b/util/cache/redis.go
@@ -159,9 +159,10 @@ func (r *redisCache) Delete(key string) error {
 
 func (r *redisCache) DeleteByPattern(key string) error {
 	// we are using go-redis/cache/v9 which doesn't support pattern-based deletion, so we need to do it ourselves
-	iter := r.client.Scan(context.TODO(), 0, r.getKeyPattern(key), 0).Iterator()
+	ctx := context.TODO()
+	iter := r.client.Scan(ctx, 0, r.getKeyPattern(key), 0).Iterator()
 	var keysToDelete []string
-	for iter.Next(context.TODO()) {
+	for iter.Next(ctx) {
 		keysToDelete = append(keysToDelete, iter.Val())
 	}
 	if err := iter.Err(); err != nil {
@@ -170,7 +171,7 @@ func (r *redisCache) DeleteByPattern(key string) error {
 	if len(keysToDelete) == 0 {
 		return nil
 	}
-	return r.client.Del(context.TODO(), keysToDelete...).Err()
+	return r.client.Unlink(ctx, keysToDelete...).Err()
 }
 
 func (r *redisCache) OnUpdated(ctx context.Context, key string, callback func() error) error {

--- a/util/cache/twolevelclient.go
+++ b/util/cache/twolevelclient.go
@@ -67,6 +67,14 @@ func (c *twoLevelClient) Delete(key string) error {
 	return c.externalCache.Delete(key)
 }
 
+func (c *twoLevelClient) DeleteByPattern(key string) error {
+	err := c.inMemoryCache.DeleteByPattern(key)
+	if err != nil {
+		return err
+	}
+	return c.externalCache.DeleteByPattern(key)
+}
+
 func (c *twoLevelClient) OnUpdated(ctx context.Context, key string, callback func() error) error {
 	return c.externalCache.OnUpdated(ctx, key, callback)
 }


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Fixes: #26428 

### Summary and Motivation
This change adds a second-layer cache for resolved Git references (revision → SHA) to significantly reduce repo-server CPU and memory load when multiple applications pointing to the same repository sync within the same cache window. 
Many ArgoCD users adopt monorepo setups where thousands of applications are managed from a single Git repository. In large-scale environments, concurrent sync operations cause excessive load on the repo-server because each revision resolution (e.g., main → SHA) requires loading the entire list of Git references (all branches and tags) from cache.

### Solution

This PR introduces a resolved reference cache that stores individual revision-to-SHA mappings (`repo:revision → SHA`) alongside the existing full ref list cache.

How it works:
1. First request: When resolving "main" → SHA, if not found in resolved ref cache:
  - Load full ref list from cache (existing behavior)
  - Resolve "main" to its commit SHA
  - Store the resolved mapping: "repo|main" → "abc123" in cache
2. Subsequent requests: When resolving "main" → SHA again:
  - Check resolved ref cache before loading full ref list
  - Return cached SHA immediately (O(1) lookup)
  - Skip loading and iterating through 515k refs

### Changes

This PR includes two optimization layers:
- Add resolved reference cache (new in this PR):
  - Cache individual revision → SHA mappings
  - Skip loading full ref list for repeated revision lookups
  - Provides O(1) lookup for cached resolutions

### Cache Invalidation Fix

E2e testing revealed that hard refresh operations (refresh: `hard`) were not invalidating the new resolved reference cache, causing stale data to be returned. The cache is now properly cleared during hard refresh to ensure fresh data is fetched from Git remote as expected, while normal refresh operations continue to benefit from caching. Additionally, the cache interfaces were updated to support mass invalidation to enable this fix, contributing to the larger scope of this PR.

### Performance Results
Real production testing with 1,500 applications pointing to a large monorepo shows dramatic CPU reduction:

<img width="3444" height="1346" alt="image" src="https://github.com/user-attachments/assets/ed2f08e7-0af9-4c6a-9541-b0a94a2f8838" />

Graph breakdown:
1. Baseline (~2 CPU cores): ArgoCD staging environment without applications
2. 1500 apps created (~22.5 CPU cores): CPU usage spikes as apps sync and resolve Git references
3. First optimization deployed (~7.5 CPU cores): `ref.Name().Short()` optimization reduces CPU by ~67% - **Covered by #26456**
4. Final optimization deployed (~0.5 CPU cores): Resolved reference caching reduces CPU to baseline levels (~99% total reduction) - **covered by this PR**

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
