### PR TITLE
feat: support file-based secret references ($file:) in config substitution

### DIFF
--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -12,6 +12,7 @@ import (
 	"math/big"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"reflect"
 	"strconv"
@@ -2275,11 +2276,31 @@ func replaceListSecrets(obj []any, secretValues map[string]string) []any {
 	return newObj
 }
 
-// ReplaceStringSecret checks if given string is a secret key reference ( starts with $ ) and returns corresponding value from provided map
+// ReplaceStringSecret checks if given string is a secret key reference (starts with $) and returns
+// the corresponding value from the provided map.
+//
+// Supported reference formats:
+//   - $key                  - resolves from argocd-secret
+//   - $secretName:key       - resolves from a labeled Kubernetes Secret
+//   - $file:/path/to/file   - resolves from a file on disk (e.g., mounted via Secrets Store CSI Driver)
 func ReplaceStringSecret(val string, secretValues map[string]string) string {
 	if val == "" || !strings.HasPrefix(val, "$") {
 		return val
 	}
+
+	// File-based secret reference: $file:/path/to/secret
+	// The prefix is "$file:/" (not "$file:") to avoid ambiguity with
+	// the $secretName:key format when a secret is named "file".
+	if strings.HasPrefix(val, "$file:/") {
+		filePath := val[len("$file:"):]
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			log.Warnf("config referenced file '%s', but could not read: %v", filePath, err)
+			return val
+		}
+		return strings.TrimSpace(string(data))
+	}
+
 	secretKey := val[1:]
 	secretVal, ok := secretValues[secretKey]
 	if !ok {

--- a/util/settings/settings_test.go
+++ b/util/settings/settings_test.go
@@ -1967,6 +1967,73 @@ func TestReplaceStringSecret(t *testing.T) {
 	assert.Equal(t, "my-value", result)
 }
 
+func TestReplaceStringSecretFromFile(t *testing.T) {
+	secretValues := map[string]string{"my-secret-key": "my-secret-value"}
+
+	t.Run("reads secret from file", func(t *testing.T) {
+		tmpFile := t.TempDir() + "/client-secret"
+		err := os.WriteFile(tmpFile, []byte("file-secret-value"), 0o600)
+		require.NoError(t, err)
+
+		result := ReplaceStringSecret("$file:"+tmpFile, secretValues)
+		assert.Equal(t, "file-secret-value", result)
+	})
+
+	t.Run("trims whitespace and trailing newline", func(t *testing.T) {
+		tmpFile := t.TempDir() + "/client-secret"
+		err := os.WriteFile(tmpFile, []byte("  file-secret-value\n"), 0o600)
+		require.NoError(t, err)
+
+		result := ReplaceStringSecret("$file:"+tmpFile, secretValues)
+		assert.Equal(t, "file-secret-value", result)
+	})
+
+	t.Run("returns original value when file does not exist", func(t *testing.T) {
+		ref := "$file:/nonexistent/path/secret"
+		result := ReplaceStringSecret(ref, secretValues)
+		assert.Equal(t, ref, result)
+	})
+
+	t.Run("returns empty string for empty file", func(t *testing.T) {
+		tmpFile := t.TempDir() + "/empty-secret"
+		err := os.WriteFile(tmpFile, []byte(""), 0o600)
+		require.NoError(t, err)
+
+		result := ReplaceStringSecret("$file:"+tmpFile, secretValues)
+		assert.Empty(t, result)
+	})
+
+	t.Run("file reference takes precedence over secret key with same name", func(t *testing.T) {
+		// Even if a secret key named "file:/some/path" existed, $file:/ should
+		// be treated as a file reference, not a secret key lookup.
+		tmpFile := t.TempDir() + "/secret"
+		err := os.WriteFile(tmpFile, []byte("from-file"), 0o600)
+		require.NoError(t, err)
+
+		vals := map[string]string{"file:" + tmpFile: "from-secret-map"}
+		result := ReplaceStringSecret("$file:"+tmpFile, vals)
+		assert.Equal(t, "from-file", result)
+	})
+
+	t.Run("$file:key without slash resolves as secret named file", func(t *testing.T) {
+		// $file:somekey should NOT be treated as a file reference — it should
+		// fall through to the $secretName:key lookup (secret named "file", key "somekey").
+		vals := map[string]string{"file:somekey": "from-secret-named-file"}
+		result := ReplaceStringSecret("$file:somekey", vals)
+		assert.Equal(t, "from-secret-named-file", result)
+	})
+
+	t.Run("existing secret key references still work", func(t *testing.T) {
+		result := ReplaceStringSecret("$my-secret-key", secretValues)
+		assert.Equal(t, "my-secret-value", result)
+	})
+
+	t.Run("literal string without $ prefix unchanged", func(t *testing.T) {
+		result := ReplaceStringSecret("file:/some/path", secretValues)
+		assert.Equal(t, "file:/some/path", result)
+	})
+}
+
 func TestRedirectURLForRequest(t *testing.T) {
 	testCases := []struct {
 		Name        string


### PR DESCRIPTION
Closes #26509

Adds `$file:/path/to/file` as a new reference format in `ReplaceStringSecret`. ~10 lines of logic, fully backwards compatible. See the issue for motivation and usage examples.