### PR TITLE
fix(swagger): apply server security headers to Swagger UI endpoints

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1243,7 +1243,7 @@ func (server *ArgoCDServer) newHTTPServer(ctx context.Context, port int, grpcWeb
 	mustRegisterGWHandler(ctx, gpgkeypkg.RegisterGPGKeyServiceHandler, gwmux, conn)
 
 	// Swagger UI
-	swagger.ServeSwaggerUI(mux, assets.SwaggerJSON, "/swagger-ui", server.RootPath)
+	swagger.ServeSwaggerUI(mux, assets.SwaggerJSON, "/swagger-ui", server.RootPath, server.XFrameOptions, server.ContentSecurityPolicy)
 	healthz.ServeHealthCheck(mux, server.healthCheck)
 
 	// Dex reverse proxy and OAuth2 login/callback

--- a/util/swagger/swagger.go
+++ b/util/swagger/swagger.go
@@ -12,19 +12,34 @@ import (
 const redocScriptName = "redoc.standalone.js"
 
 // ServeSwaggerUI serves the Swagger UI and JSON spec.
-func ServeSwaggerUI(mux *http.ServeMux, swaggerJSON string, uiPath string, rootPath string) {
+// xFrameOptions and contentSecurityPolicy are applied to all swagger responses
+// when non-empty, consistent with how the static assets handler treats them.
+func ServeSwaggerUI(mux *http.ServeMux, swaggerJSON string, uiPath string, rootPath string, xFrameOptions string, contentSecurityPolicy string) {
+	setSecurityHeaders := func(w http.ResponseWriter) {
+		if xFrameOptions != "" {
+			w.Header().Set("X-Frame-Options", xFrameOptions)
+		}
+		if contentSecurityPolicy != "" {
+			w.Header().Set("Content-Security-Policy", contentSecurityPolicy)
+		}
+	}
+
 	prefix := path.Dir(uiPath)
 	swaggerPath := path.Join(prefix, "swagger.json")
 	mux.HandleFunc(swaggerPath, func(w http.ResponseWriter, _ *http.Request) {
+		setSecurityHeaders(w)
 		_, _ = fmt.Fprint(w, swaggerJSON)
 	})
 
 	specURL := path.Join(prefix, rootPath, "swagger.json")
 	scriptURL := path.Join(prefix, rootPath, "assets", "scripts", redocScriptName)
-	mux.Handle(uiPath, middleware.Redoc(middleware.RedocOpts{
-		BasePath: prefix,
-		SpecURL:  specURL,
-		Path:     path.Base(uiPath),
-		RedocURL: scriptURL,
-	}, http.NotFoundHandler()))
+	mux.Handle(uiPath, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		setSecurityHeaders(w)
+		middleware.Redoc(middleware.RedocOpts{
+			BasePath: prefix,
+			SpecURL:  specURL,
+			Path:     path.Base(uiPath),
+			RedocURL: scriptURL,
+		}, http.NotFoundHandler()).ServeHTTP(w, r)
+	}))
 }

--- a/util/swagger/swagger_test.go
+++ b/util/swagger/swagger_test.go
@@ -7,37 +7,28 @@ import (
 	"testing"
 
 	"github.com/go-openapi/loads"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/argoproj/argo-cd/v3/util/assets"
 )
 
-func TestSwaggerUI(t *testing.T) {
+func serveTestSwagger(t *testing.T, xFrameOptions, contentSecurityPolicy string) string {
+	t.Helper()
 	lc := &net.ListenConfig{}
-	serve := func(c chan<- string) {
-		// listen on first available dynamic (unprivileged) port
-		listener, err := lc.Listen(t.Context(), "tcp", ":0")
-		if err != nil {
-			panic(err)
-		}
+	listener, err := lc.Listen(t.Context(), "tcp", ":0")
+	require.NoError(t, err)
 
-		// send back the address so that it can be used
-		c <- listener.Addr().String()
+	addr := listener.Addr().String()
+	mux := http.NewServeMux()
+	ServeSwaggerUI(mux, assets.SwaggerJSON, "/swagger-ui", "", xFrameOptions, contentSecurityPolicy)
+	go func() { _ = http.Serve(listener, mux) }()
 
-		mux := http.NewServeMux()
-		ServeSwaggerUI(mux, assets.SwaggerJSON, "/swagger-ui", "")
-		panic(http.Serve(listener, mux))
-	}
+	return "http://" + addr
+}
 
-	c := make(chan string, 1)
-
-	// run a local webserver to test data retrieval
-	go serve(c)
-
-	address := <-c
-	t.Logf("Listening at address: %s", address)
-
-	server := "http://" + address
+func TestSwaggerUI(t *testing.T) {
+	server := serveTestSwagger(t, "", "")
 
 	specDoc, err := loads.Spec(server + "/swagger.json")
 	require.NoError(t, err)
@@ -52,4 +43,57 @@ func TestSwaggerUI(t *testing.T) {
 	require.NoError(t, err)
 	require.Equalf(t, http.StatusOK, resp.StatusCode, "Was expecting status code 200 from swagger-ui, but got %d instead", resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
+}
+
+func TestSwaggerUIPage(t *testing.T) {
+	server := serveTestSwagger(t, "", "")
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server+"/swagger-ui", http.NoBody)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	// Redoc serves the UI page; any non-error response confirms the handler is wired correctly.
+	assert.Less(t, resp.StatusCode, http.StatusInternalServerError)
+}
+
+func TestSwaggerUISecurityHeaders(t *testing.T) {
+	endpoints := []string{"/swagger.json", "/swagger-ui"}
+
+	t.Run("headers set when configured", func(t *testing.T) {
+		server := serveTestSwagger(t, "DENY", "frame-ancestors 'none'")
+
+		for _, endpoint := range endpoints {
+			t.Run(endpoint, func(t *testing.T) {
+				req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server+endpoint, http.NoBody)
+				require.NoError(t, err)
+
+				resp, err := http.DefaultClient.Do(req)
+				require.NoError(t, err)
+				require.NoError(t, resp.Body.Close())
+
+				assert.Equal(t, "DENY", resp.Header.Get("X-Frame-Options"))
+				assert.Equal(t, "frame-ancestors 'none'", resp.Header.Get("Content-Security-Policy"))
+			})
+		}
+	})
+
+	t.Run("headers absent when not configured", func(t *testing.T) {
+		server := serveTestSwagger(t, "", "")
+
+		for _, endpoint := range endpoints {
+			t.Run(endpoint, func(t *testing.T) {
+				req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server+endpoint, http.NoBody)
+				require.NoError(t, err)
+
+				resp, err := http.DefaultClient.Do(req)
+				require.NoError(t, err)
+				require.NoError(t, resp.Body.Close())
+
+				assert.Empty(t, resp.Header.Get("X-Frame-Options"))
+				assert.Empty(t, resp.Header.Get("Content-Security-Policy"))
+			})
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Fixes #22877.

The `/swagger-ui` and `/swagger.json` endpoints did not set `X-Frame-Options` or `Content-Security-Policy` headers, leaving them exposed to clickjacking while the rest of the server's static asset responses were already protected.

Rather than hardcoding a value, this PR threads the existing `--x-frame-options` and `--content-security-policy` server flags through to `ServeSwaggerUI`, so the Swagger endpoints honour the same operator-configured security policy that `newStaticAssetsHandler` already applies to all other responses.

## Changes

- **`util/swagger/swagger.go`** — `ServeSwaggerUI` accepts two new string parameters (`xFrameOptions`, `contentSecurityPolicy`) and sets them as response headers for both the `/swagger.json` and `/swagger-ui` handlers when non-empty.
- **`server/server.go`** — call site updated to forward `server.XFrameOptions` and `server.ContentSecurityPolicy`.
- **`util/swagger/swagger_test.go`** — existing test updated for the new signature; two new sub-tests added to assert headers are present when configured and absent when not configured.

## Why this approach

Previous PRs (#23082, #25634, #25760) hardcoded `X-Frame-Options: DENY`. This PR reuses the existing configurable flags instead, so operators who set `--x-frame-options=SAMEORIGIN` (or any other value) get consistent behaviour across all server endpoints without any special-casing for Swagger.

No default values are introduced; if neither flag is set the behaviour is identical to before, preserving backward compatibility.

## Test plan

- [x] `TestSwaggerUI` — existing test continues to pass
- [x] `TestSwaggerUISecurityHeaders/headers_set_when_configured` — asserts `X-Frame-Options` and `Content-Security-Policy` are present when values are provided
- [x] `TestSwaggerUISecurityHeaders/headers_absent_when_not_configured` — asserts headers are absent when values are empty (backward-compatible default)