### PR TITLE
chore(ci): configure Renovate to bump Dex

### DIFF
--- a/.github/configs/renovate-config.js
+++ b/.github/configs/renovate-config.js
@@ -3,12 +3,13 @@ module.exports = {
     gitAuthor: 'renovate[bot] <renovate[bot]@users.noreply.github.com>',
     autodiscover: false,
     allowPostUpgradeCommandTemplating: true,
-    allowedPostUpgradeCommands: ["make mockgen"],
+    allowedPostUpgradeCommands: ["make mockgen", "make codegen-local"],
     binarySource: 'install',
     extends: [
         "github>argoproj/argo-cd//renovate-presets/commons.json5",
         "github>argoproj/argo-cd//renovate-presets/custom-managers/shell.json5",
         "github>argoproj/argo-cd//renovate-presets/custom-managers/yaml.json5",
+        "github>argoproj/argo-cd//renovate-presets/custom-managers/docker-pull.json5",
         "github>argoproj/argo-cd//renovate-presets/fix/disable-all-updates.json5",
         "github>argoproj/argo-cd//renovate-presets/devtool.json5",
         "github>argoproj/argo-cd//renovate-presets/docs.json5"

--- a/.github/configs/renovate-config.js
+++ b/.github/configs/renovate-config.js
@@ -3,7 +3,7 @@ module.exports = {
     gitAuthor: 'renovate[bot] <renovate[bot]@users.noreply.github.com>',
     autodiscover: false,
     allowPostUpgradeCommandTemplating: true,
-    allowedPostUpgradeCommands: ["make mockgen", "make codegen-local"],
+    allowedPostUpgradeCommands: ["make codegen-local"],
     binarySource: 'install',
     extends: [
         "github>argoproj/argo-cd//renovate-presets/commons.json5",

--- a/renovate-presets/custom-managers/docker-pull.json5
+++ b/renovate-presets/custom-managers/docker-pull.json5
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "customManagers": [
+    {
+      "description": "A custom manager for updating docker pull commands in CI workflows.",
+      "customType": "regex",
+      "fileMatch": [
+        ".github/workflows/.+\\.(?:yml|yaml)$"
+      ],
+      "matchStrings": [
+        "docker pull (?<depName>[^:\\s]+):v?(?<currentValue>[\\d]+\\.[\\d]+\\.[\\d]+)"
+      ],
+      "datasourceTemplate": "docker"
+    }
+  ]
+}

--- a/renovate-presets/devtool.json5
+++ b/renovate-presets/devtool.json5
@@ -52,9 +52,25 @@
       ],
       "matchPackageNames": [
         "docker.io/library/node",
-        "docker.io/library/golang"
+        "docker.io/library/golang",
+        "ghcr.io/dexidp/dex"
       ],
       "enabled": true
+    },
+    {
+      "description": "Group Dex updates and run codegen to update generated manifests",
+      "groupName": "dex",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "ghcr.io/dexidp/dex"
+      ],
+      "postUpgradeTasks": {
+        "commands": ["make codegen-local"],
+        "fileFilters": ["manifests/**"],
+        "executionMode": "branch"
+      }
     },
     {
       "description": "Group golang-version packages",


### PR DESCRIPTION
## Summary
- Configures Renovate to automatically open PRs when new Dex releases are available
- Adds `ghcr.io/dexidp/dex` to the enabled docker packages in the devtool preset
- Adds a custom regex manager for `docker pull` commands in CI workflows so the Dex image reference in `.github/workflows/ci-build.yaml` is also updated
- Runs `make codegen-local` as a post-upgrade task to regenerate manifests (`manifests/ha/install.yaml`, etc.) after the base Dex image is bumped
- Groups all Dex updates into a single PR

### How it works

Renovate will detect Dex image updates from two sources:
1. **Kubernetes manifests** (`manifests/base/dex/argocd-dex-server-deployment.yaml`) - detected by Renovate's built-in `kubernetes` manager
2. **CI workflow** (`.github/workflows/ci-build.yaml`) - detected by the new `docker-pull` custom regex manager

After updating both files, `make codegen-local` runs to regenerate the derived manifests.

Closes #23089

## Test plan
- [ ] Verify Renovate validates the config (check Renovate logs after merge)
- [ ] Verify automated PR is created on next Dex release