### PR TITLE
docs(operator-manual): fix typos and improve clarity

### DIFF
--- a/docs/operator-manual/high_availability.md
+++ b/docs/operator-manual/high_availability.md
@@ -1,13 +1,13 @@
 # High Availability
 
 Argo CD is largely stateless. All data is persisted as Kubernetes objects, which in turn is stored in Kubernetes' etcd.
-Redis is only used as a throw-away cache and can be lost. When lost, it will be rebuilt without loss of service.
+Redis is only used as a disposable cache and can be safely rebuilt without service disruption.
 
 A set of [HA manifests](https://github.com/argoproj/argo-cd/tree/stable/manifests/ha) are provided for users who wish to
 run Argo CD in a highly available manner. This runs more containers, and runs Redis in HA mode.
 
 > [!NOTE]
-> The HA installation will require at least three different nodes due to pod anti-affinity roles in the
+> The HA installation will require at least three different nodes due to pod anti-affinity rule in the
 > specs. Additionally, IPv6 only clusters are not supported.
 
 ## Scaling Up
@@ -19,17 +19,17 @@ run Argo CD in a highly available manner. This runs more containers, and runs Re
 The `argocd-repo-server` is responsible for cloning Git repository, keeping it up to date and generating manifests using
 the appropriate tool.
 
-* `argocd-repo-server` fork/exec config management tool to generate manifests. The fork can fail due to lack of memory
+* `argocd-repo-server` fork/exec config management tools to generate manifests. The fork can fail due to lack of memory
   or limit on the number of OS threads.
   The `--parallelismlimit` flag controls how many manifests generations are running concurrently and helps avoid OOM
   kills.
 
-* the `argocd-repo-server` ensures that repository is in the clean state during the manifest generation using config
+* The `argocd-repo-server` ensures that repository is in the clean state during the manifest generation using config
   management tools such as Kustomize, Helm
   or custom plugin. As a result Git repositories with multiple applications might affect repository server performance.
   Read [Monorepo Scaling Considerations](#monorepo-scaling-considerations) for more information.
 
-* `argocd-repo-server` clones the repository into `/tmp` (or the path specified in the `TMPDIR` env variable). The Pod
+* `argocd-repo-server` clones the repository into `/tmp` (or the path specified in the `TMPDIR` env variable). The pod
   might run out of disk space if it has too many repositories
   or if the repositories have a lot of files. To avoid this problem mount a persistent volume.
 
@@ -83,7 +83,7 @@ get the actual cluster state.
   syncing (seconds). The number of queue processors for each queue is controlled by
   `--status-processors` (20 by default) and `--operation-processors` (10 by default) flags. Increase the number of
   processors if your Argo CD instance manages too many applications.
-  For 1000 application we use 50 for `--status-processors` and 25 for `--operation-processors`
+  For 1000 applications, we use 50 for `--status-processors` and 25 for `--operation-processors`
 
 * The manifest generation typically takes the most time during reconciliation. The duration of manifest generation is
   limited to make sure the controller refresh queue does not overflow.
@@ -139,7 +139,7 @@ spec:
       and also reduces cluster or application reshuffling in case of additions or removals of shards or clusters.
 
 The `--sharding-method` parameter can also be overridden by setting the key `controller.sharding.algorithm` in the
-`argocd-cmd-params-cm` `configMap` (preferably) or by setting the `ARGOCD_CONTROLLER_SHARDING_ALGORITHM` environment
+`argocd-cmd-params-cm` `ConfigMap` (preferably) or by setting the `ARGOCD_CONTROLLER_SHARDING_ALGORITHM` environment
 variable and by specifying the same possible values.
 
 > [!WARNING]
@@ -148,7 +148,7 @@ variable and by specifying the same possible values.
 > The `round-robin` shard distribution algorithm is an experimental feature. Reshuffling is known to occur in certain
 > scenarios with cluster removal. If the cluster at rank-0 is removed, reshuffling all clusters across shards will occur
 > and may temporarily have negative performance impacts.
-> The `consistent-hashing` shard distribution algorithm is an experimental feature. Extensive benchmark have been
+> The `consistent-hashing` shard distribution algorithm is an experimental feature. Extensive benchmarks have been
 > documented on the [CNOE blog](https://cnoe.io/blog/argo-cd-application-scalability) with encouraging results.
 > Community
 > feedback is highly appreciated before moving this feature to a production ready state.
@@ -182,7 +182,7 @@ stringData:
   if you need to troubleshoot performance issues. Note: This metric is expensive to both query and store!
 
 * `ARGOCD_CLUSTER_CACHE_LIST_PAGE_BUFFER_SIZE` - environment variable controlling the number of pages the controller
-  buffers in memory when performing a list operation against the K8s api server while syncing the cluster cache. This
+  buffers in memory when performing a list operation against the K8s Api server while syncing the cluster cache. This
   is useful when the cluster contains a large number of resources and cluster sync times exceed the default etcd
   compaction interval timeout. In this scenario, when attempting to sync the cluster cache, the application controller
   may throw an error that the `continue parameter is too old to display a consistent list result`. Setting a higher
@@ -255,14 +255,14 @@ spec:
 
 ### argocd-dex-server, argocd-redis
 
-The `argocd-dex-server` uses an in-memory database, and two or more instances would have inconsistent data.
+The `argocd-dex-server` uses an in-memory database, and two or more instances may have inconsistent data.
 `argocd-redis` is pre-configured with the understanding of only three total redis servers/sentinels.
 
 ## Monorepo Scaling Considerations
 
 Argo CD repo server maintains one repository clone locally and uses it for application manifest generation. If the
 manifest generation requires to change a file in the local repository clone then only one concurrent manifest generation
-per server instance is allowed. This limitation might significantly slowdown Argo CD if you have a mono repository with
+per server instance is allowed. This limitation might significantly slow down Argo CD if you have a monorepo with
 multiple applications (50+).
 
 ### Enable Concurrent Processing
@@ -280,8 +280,8 @@ The following are known cases that might cause slowness and their workarounds:
   `.argocd-allow-concurrency` file in the app directory, or use the sidecar plugin option, which processes each
   application using a temporary copy of the repository.
 
-* **Multiple Kustomize applications in same repository with [parameter overrides](../user-guide/parameters.md):** sorry,
-  no workaround for now.
+* **Multiple Kustomize applications in same repository with [parameter overrides](../user-guide/parameters.md):** Currently,
+  there is no workaround for this limitation.
 
 ### Manifest Paths Annotation
 

--- a/docs/operator-manual/ingress.md
+++ b/docs/operator-manual/ingress.md
@@ -1,19 +1,21 @@
 # Ingress Configuration
 
-Argo CD API server runs both a gRPC server (used by the CLI), as well as a HTTP/HTTPS server (used by the UI).
+Argo CD API server runs both a gRPC server (used by the CLI), as well as an HTTP/HTTPS server (used by the UI).
 Both protocols are exposed by the argocd-server service object on the following ports:
 
 * 443 - gRPC/HTTPS
 * 80 - HTTP (redirects to HTTPS)
 
-There are several ways how Ingress can be configured.
+There are several ways to configure Ingress.
 
 ## [Ambassador](https://www.getambassador.io/)
 
 The Ambassador Edge Stack can be used as a Kubernetes ingress controller with [automatic TLS termination](https://www.getambassador.io/docs/latest/topics/running/tls/#host) and routing capabilities for both the CLI and the UI.
 
-The API server should be run with TLS disabled. Edit the `argocd-server` deployment to add the `--insecure` flag to the argocd-server command, or simply set `server.insecure: "true"` in the `argocd-cmd-params-cm` ConfigMap [as described here](server-commands/additional-configuration-method.md). Given the `argocd` CLI includes the port number in the request `host` header, 2 Mappings are required.
-Note: Disabling TLS is not required if you are using grpc-web
+The API server should be run with TLS disabled. Edit the `argocd-server` deployment to add the `--insecure` flag to the argocd-server command, or simply set `server.insecure: "true"` in the `argocd-cmd-params-cm` ConfigMap [as described here](server-commands/additional-configuration-method.md). Given the `argocd` CLI includes the port number in the request `host` header, two Mappings are required.
+
+> [!NOTE]
+> Disabling TLS is not required if you are using gRPC-Web.
 
 ### Option 1: Mapping CRD for Host-based Routing
 ```yaml
@@ -375,7 +377,7 @@ Traefik can be used as an edge router and provide [TLS](https://docs.traefik.io/
 
 It currently has an advantage over NGINX in that it can terminate both TCP and HTTP connections _on the same port_ meaning you do not require multiple hosts or paths.
 
-The API server should be run with TLS disabled. Edit the `argocd-server` deployment to add the `--insecure` flag to the argocd-server command or set `server.insecure: "true"` in the `argocd-cmd-params-cm` ConfigMap [as described here](server-commands/additional-configuration-method.md).
+Run the API server with TLS disabled. Edit the `argocd-server` deployment to add the `--insecure` flag to the argocd-server command or set `server.insecure: "true"` in the `argocd-cmd-params-cm` ConfigMap [as described here](server-commands/additional-configuration-method.md).
 
 ### IngressRoute CRD
 ```yaml
@@ -476,7 +478,7 @@ Also note that we can configure the health check to return the gRPC health statu
 ```
 
 ## [Istio](https://www.istio.io)
-You can put Argo CD behind Istio using following configurations. Here we will achieve both serving Argo CD behind istio and using subpath on Istio
+You can put Argo CD behind Istio using the following configuration. This example serves Argo CD behind Istio and uses a subpath (for example, `/argocd`).
 
 First we need to make sure that we can run Argo CD with subpath (ie /argocd). For this we have used install.yaml from argocd project as is
 
@@ -484,7 +486,7 @@ First we need to make sure that we can run Argo CD with subpath (ie /argocd). Fo
 curl -kLs -o install.yaml https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
 ```
 
-save following file as kustomization.yml
+Save the following file as `kustomization.yaml`:
 
 ```yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
@@ -528,7 +530,7 @@ spec:
          value: "0"
 ```
 
-After that install Argo CD  (there should be only 3 yml file defined above in current directory )
+Install Argo CD (there should be only the three YAML files defined above in the current directory):
 
 ```bash
 kubectl apply -k ./ -n argocd --wait=true
@@ -598,7 +600,7 @@ spec:
           number: 80
 ```
 
-And now we can browse http://{{ IP }}/argocd (it will be rewritten to https://{{ IP }}/argocd
+You can now browse to `http://<IP>/argocd` (it will be redirected to HTTPS).
 
 
 ## Google Cloud load balancers with Kubernetes Ingress
@@ -648,7 +650,7 @@ spec:
 
 ### Creating a BackendConfig
 
-See that previous service referencing a backend config called `argocd-backend-config`? So lets deploy it using this yaml:
+See that previous service referencing a backend config called `argocd-backend-config`? So let's deploy it using this YAML:
 
 ```yaml
 apiVersion: cloud.google.com/v1
@@ -777,7 +779,7 @@ Argo CD endpoints may be protected by one or more reverse proxies layers, in tha
 $ argocd login <host>:<port> --header 'x-token1:foo' --header 'x-token2:bar' # can be repeated multiple times
 $ argocd login <host>:<port> --header 'x-token1:foo,x-token2:bar' # headers can also be comma separated
 ```
-## ArgoCD Server and UI Root Path (v1.5.3)
+## Argo CD server and UI root path (v1.5.3)
 
 Argo CD server and UI can be configured to be available under a non-root path (e.g. `/argo-cd`).
 To do this, add the `--rootpath` flag into the `argocd-server` deployment command:
@@ -823,7 +825,7 @@ http {
     }
 }
 ```
-Flag ```--grpc-web-root-path ``` is used to provide a non-root path (e.g. /argo-cd)
+The `--grpc-web-root-path` flag is used to provide a non-root path (e.g. /argo-cd)
 
 ```shell
 $ argocd login <host>:<port> --grpc-web-root-path /argo-cd


### PR DESCRIPTION
### Summary
This PR improves operator manual documentation readability.

### Changes
- Fix grammar, typos, and capitalization issues
- Improve wording clarity and Markdown formatting

### Notes
- Docs-only change; no functional changes
- No release note required
