### PR TITLE
fix: Some resources' live manifests can't be viewed in the UI sin

### DIFF
--- a/manifests/cluster-rbac/server/argocd-server-clusterrole.yaml
+++ b/manifests/cluster-rbac/server/argocd-server-clusterrole.yaml
@@ -14,6 +14,7 @@ rules:
   verbs:
   - delete  # supports deletion a live object in UI
   - get     # supports viewing live object manifest in UI
+  - list    # supports viewing live object manifest in UI for resources that require list
   - patch   # supports `argocd app patch`
 - apiGroups:
   - ""

--- a/manifests/ha/install-with-hydrator.yaml
+++ b/manifests/ha/install-with-hydrator.yaml
@@ -31025,6 +31025,7 @@ rules:
   verbs:
   - delete
   - get
+  - list
   - patch
 - apiGroups:
   - ""

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -31016,6 +31016,7 @@ rules:
   verbs:
   - delete
   - get
+  - list
   - patch
 - apiGroups:
   - ""

--- a/manifests/install-with-hydrator.yaml
+++ b/manifests/install-with-hydrator.yaml
@@ -30992,6 +30992,7 @@ rules:
   verbs:
   - delete
   - get
+  - list
   - patch
 - apiGroups:
   - ""

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -30983,6 +30983,7 @@ rules:
   verbs:
   - delete
   - get
+  - list
   - patch
 - apiGroups:
   - ""


### PR DESCRIPTION
## Summary

Addresses #18853.

## Changes

```
a5c87e3 fix: address issue #18853 - Some resources' live manifests can't be viewed in
 manifests/cluster-rbac/server/argocd-server-clusterrole.yaml | 1 +
 1 file changed, 1 insertion(+)
```
