### PR TITLE
fix: Improve rendering of unschedulable nodes

### DIFF
--- a/ui/src/app/applications/components/application-pod-view/pod-view.tsx
+++ b/ui/src/app/applications/components/application-pod-view/pod-view.tsx
@@ -159,14 +159,16 @@ export function PodView(props: PodViewProps) {
                                                 {group.type === 'node' ? (
                                                     <div>
                                                         <div className='pod-view__node__info--large'>
-                                                            {(group.info || []).map(item => (
-                                                                <Tooltip content={`${item.name}: ${item.value}`} key={item.name}>
-                                                                    <div className='pod-view__node__info--large__item'>
-                                                                        <div className='pod-view__node__info--large__item__name'>{item.name}:</div>
-                                                                        <div className='pod-view__node__info--large__item__value'>{item.value}</div>
-                                                                    </div>
-                                                                </Tooltip>
-                                                            ))}
+                                                            {(group.info || [])
+                                                                .filter(item => item.value !== 'N/A')
+                                                                .map(item => (
+                                                                    <Tooltip content={`${item.name}: ${item.value}`} key={item.name}>
+                                                                        <div className='pod-view__node__info--large__item'>
+                                                                            <div className='pod-view__node__info--large__item__name'>{item.name}:</div>
+                                                                            <div className='pod-view__node__info--large__item__value'>{item.value}</div>
+                                                                        </div>
+                                                                    </Tooltip>
+                                                                ))}
                                                         </div>
                                                         {group.hostLabels && Object.keys(group.hostLabels).length > 0 ? (
                                                             <div className='pod-view__node__info--large'>
@@ -392,10 +394,7 @@ function processTree(
                         kind: 'node',
                         name: 'Unschedulable',
                         pods: [p],
-                        info: [
-                            {name: 'Kernel Version', value: 'N/A'},
-                            {name: 'OS/Arch', value: 'N/A'}
-                        ],
+                        info: [],
                         hostResourcesInfo: [],
                         hostLabels: {}
                     };


### PR DESCRIPTION
## Summary

Addresses #19870.

**File changed:** `ui/src/app/applications/components/application-pod-view/pod-view.tsx`

**Two changes made:**

1. **`processTree` function (line ~392):** Removed the hardcoded `info` array with `{name: 'Kernel Version', value: 'N/A'}` and `{name: 'OS/Arch', value: 'N/A'}` from the `Unschedulable` group creation. Replaced with an empty `info: []`. Kernel version cannot be known for a node that doesn't exist, and OS/Arch from image manifests isn't available in the current data.

2. **Rendering (

## Changes

```
e51d81d fix(ui): hide N/A fields for unschedulable nodes in pod view (#19870)
 .../app/applications/components/application-pod-view/pod-view.tsx  | 7 ++-----
 1 file changed, 2 insertions(+), 5 deletions(-)
```
