### PR TITLE
fix: include Depth field in Repository.Sanitized() response

### DIFF
--- a/pkg/apis/application/v1alpha1/repository_types.go
+++ b/pkg/apis/application/v1alpha1/repository_types.go
@@ -362,6 +362,7 @@ func (repo *Repository) Sanitized() *Repository {
 		GithubAppInstallationId:    repo.GithubAppInstallationId,
 		GitHubAppEnterpriseBaseURL: repo.GitHubAppEnterpriseBaseURL,
 		UseAzureWorkloadIdentity:   repo.UseAzureWorkloadIdentity,
+		Depth:                      repo.Depth,
 	}
 }
 


### PR DESCRIPTION
## Summary

The `Sanitized()` method on the `Repository` type strips sensitive fields (passwords, SSH keys, tokens, etc.) and returns a safe-to-display copy. However, the `Depth` field (shallow clone depth) was not included in the sanitized output, causing it to always return as `0` when retrieved via the API.

This means that running `argocd repo get --output json` would not show the configured `depth` value, even though it is correctly stored in the repository secret and used during clone operations.

## Root Cause

The `Sanitized()` method in `pkg/apis/application/v1alpha1/repository_types.go` constructs a new `Repository` struct with only non-sensitive fields copied over. The `Depth` field was simply missing from this list, despite being a non-sensitive configuration value.

## Changes

- **`repository_types.go`**: Added `Depth: repo.Depth` to the `Sanitized()` method's return struct
- **`repository_types_test.go`**: Added comprehensive test `TestSanitizedRepository` that verifies:
  - All non-sensitive fields are preserved after sanitization
  - All sensitive fields (passwords, keys, tokens) are stripped
  - `Depth` is included in the preserved fields
  - A zero `Depth` value (full clone) is correctly preserved

## Design Reasoning

- `Depth` is not sensitive information — it only controls how many commits are fetched during a shallow clone
- This is consistent with how `Depth` is already handled in `CopySettingsFrom()` (line 335)
- The fix follows the existing pattern of explicitly listing non-sensitive fields in `Sanitized()`
- No breaking changes — this only adds a previously-missing field to the API response

Fixes #26559

Signed-off-by: Harshil Garg <harshil562@users.noreply.github.com>
