### PR TITLE
fix: Restrict cache to managed namespaces to avoid cluster-wide access (#26467)

### DIFF
--- a/cmd/argocd-applicationset-controller/commands/applicationset_controller.go
+++ b/cmd/argocd-applicationset-controller/commands/applicationset_controller.go
@@ -28,6 +28,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -130,22 +131,36 @@ func NewCommand() *cobra.Command {
 				os.Exit(1)
 			}
 
-			// By default, watch all namespaces
-			var watchedNamespace string
-			// If the applicationset-namespaces contains only one namespace it corresponds to the current namespace
-			if len(applicationSetNamespaces) == 1 {
-				watchedNamespace = (applicationSetNamespaces)[0]
-			} else if enableScmProviders && len(allowedScmProviders) == 0 {
+			if len(applicationSetNamespaces) > 1 && enableScmProviders && len(allowedScmProviders) == 0 {
 				log.Error("When enabling applicationset in any namespace using applicationset-namespaces, you must either set --enable-scm-providers=false or specify --allowed-scm-providers")
 				os.Exit(1)
 			}
 
-			cacheOpt := ctrlcache.Options{SyncPeriod: &cacheSyncPeriod}
-
-			if watchedNamespace != "" {
-				cacheOpt.DefaultNamespaces = map[string]ctrlcache.Config{
-					watchedNamespace: {},
+			// If the wildcard "*" is present we cannot restrict the Secret cache to specific
+			// namespaces — fall back to the previous cluster-wide cache behaviour so that
+			// controller-runtime does not attempt to watch a namespace literally named "*".
+			hasWildcard := false
+			for _, ns := range applicationSetNamespaces {
+				if ns == "*" {
+					hasWildcard = true
+					break
 				}
+			}
+
+			cacheOpt := ctrlcache.Options{SyncPeriod: &cacheSyncPeriod}
+			if !hasWildcard {
+				appSetNsConfig := make(map[string]ctrlcache.Config, len(applicationSetNamespaces))
+				for _, ns := range applicationSetNamespaces {
+					appSetNsConfig[ns] = ctrlcache.Config{}
+				}
+				cacheOpt.ByObject = map[ctrlclient.Object]ctrlcache.ByObject{
+					&corev1.Secret{}: {
+						Namespaces: appSetNsConfig,
+					},
+				}
+			} else {
+				log.Warn("applicationset-namespaces contains '*': Secret cache will be cluster-wide. " +
+					"Ensure the controller ServiceAccount has a ClusterRole with secrets list/watch permission.")
 			}
 
 			cfg := ctrl.GetConfigOrDie()

--- a/cmd/argocd-applicationset-controller/commands/applicationset_controller.go
+++ b/cmd/argocd-applicationset-controller/commands/applicationset_controller.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"os"
 	"runtime/debug"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/argoproj/pkg/v2/stats"
@@ -136,19 +138,15 @@ func NewCommand() *cobra.Command {
 				os.Exit(1)
 			}
 
-			// If the wildcard "*" is present we cannot restrict the Secret cache to specific
-			// namespaces — fall back to the previous cluster-wide cache behaviour so that
-			// controller-runtime does not attempt to watch a namespace literally named "*".
-			hasWildcard := false
-			for _, ns := range applicationSetNamespaces {
-				if ns == "*" {
-					hasWildcard = true
-					break
-				}
-			}
-
+			// Restrict the cache to only the namespaces managed by this controller.
+			// If applicationSetNamespaces contains any glob/regex pattern, ByObject cannot be used
+			// In that case we fall back to the cluster-wide cache. 
 			cacheOpt := ctrlcache.Options{SyncPeriod: &cacheSyncPeriod}
-			if !hasWildcard {
+			hasPattern := slices.ContainsFunc(applicationSetNamespaces, func(ns string) bool {
+				return strings.ContainsAny(ns, "*?[") ||
+					(strings.HasPrefix(ns, "/") && strings.HasSuffix(ns, "/"))
+			})
+			if !hasPattern {
 				appSetNsConfig := make(map[string]ctrlcache.Config, len(applicationSetNamespaces))
 				for _, ns := range applicationSetNamespaces {
 					appSetNsConfig[ns] = ctrlcache.Config{}
@@ -159,8 +157,7 @@ func NewCommand() *cobra.Command {
 					},
 				}
 			} else {
-				log.Warn("applicationset-namespaces contains '*': Secret cache will be cluster-wide. " +
-					"Ensure the controller ServiceAccount has a ClusterRole with secrets list/watch permission.")
+				log.Warn("applicationset-namespaces contains a glob or regex pattern")
 			}
 
 			cfg := ctrl.GetConfigOrDie()

--- a/cmd/argocd-applicationset-controller/commands/applicationset_controller.go
+++ b/cmd/argocd-applicationset-controller/commands/applicationset_controller.go
@@ -140,7 +140,7 @@ func NewCommand() *cobra.Command {
 
 			// Restrict the cache to only the namespaces managed by this controller.
 			// If applicationSetNamespaces contains any glob/regex pattern, ByObject cannot be used
-			// In that case we fall back to the cluster-wide cache. 
+			// In that case we fall back to the cluster-wide cache.
 			cacheOpt := ctrlcache.Options{SyncPeriod: &cacheSyncPeriod}
 			hasPattern := slices.ContainsFunc(applicationSetNamespaces, func(ns string) bool {
 				return strings.ContainsAny(ns, "*?[") ||


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->
Closes: #26467 

What is the Change?
Built a map covering all namespaces the controller is allowed to manage. This restricts the Secret cache to only those namespaces. Restricting Secret caching prevents the controller from requiring cluster-wide Secret read access, which is a security concern in multi-tenant environments.


Checklist:

* -[x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* -[x] The title of the PR states what changed and the related issues number (used for the release note).
* -[x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* -[x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* -[x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* -[x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
