### PR TITLE
fix: kustomize: ignore Components directories missing a kustomization file

### DIFF
--- a/docs/user-guide/kustomize.md
+++ b/docs/user-guide/kustomize.md
@@ -133,7 +133,7 @@ spec:
 
 ## Components
 Kustomize [components](https://github.com/kubernetes-sigs/kustomize/blob/master/examples/components.md) encapsulate both resources and patches together. They provide a powerful way to modularize and reuse configuration in Kubernetes applications. 
-If Kustomize is passed a non-existing component directory, it will error out. Missing component directories can be ignored (meaning, not passed to Kustomize) using `ignoreMissingComponents`. This can be particularly helpful to implement a [default/override pattern].
+If Kustomize is passed a non-existing component directory, it will error out. Missing or invalid (missing a Kustomization file) component directories can be ignored (meaning, not passed to Kustomize) using `ignoreMissingComponents`. This can be particularly helpful to implement a [default/override pattern].
 
 Outside of Argo CD, to utilize components, you must add the following to the `kustomization.yaml` that the Application references. For example:
 ```yaml

--- a/util/kustomize/kustomize.go
+++ b/util/kustomize/kustomize.go
@@ -351,17 +351,24 @@ func (k *kustomize) Build(opts *v1alpha1.ApplicationSourceKustomize, kustomizeOp
 					return nil, nil, nil, fmt.Errorf("failed to open the repo folder: %w", err)
 				}
 
+				kustomizationFileValidNames := []string{"kustomization.yaml", "kustomization.yml", "Kustomization"}
+			component:
 				for _, c := range opts.Components {
-					resolvedPath, err := filepath.Rel(k.repoRoot, filepath.Join(k.path, c))
+					componentDir, err := filepath.Rel(k.repoRoot, filepath.Join(k.path, c))
 					if err != nil {
 						return nil, nil, nil, fmt.Errorf("kustomize components path failed: %w", err)
 					}
-					_, err = root.Stat(resolvedPath)
-					if err != nil {
-						log.Debugf("%s component directory does not exist", resolvedPath)
-						continue
+					for _, kustomizationFile := range kustomizationFileValidNames {
+						kustomization, err := root.Stat(filepath.Join(componentDir, kustomizationFile))
+						if err == nil && kustomization.Mode().IsRegular() {
+							foundComponents = append(foundComponents, c)
+							log.Infof("Adding component '%s' to kustomization.yaml", c)
+							break component
+						}
 					}
-					foundComponents = append(foundComponents, c)
+					log.Infof("Ignoring component '%s': directory does not exist or unable to find one of %s",
+						componentDir,
+						strings.Join(kustomizationFileValidNames, ", "))
 				}
 			}
 

--- a/util/kustomize/kustomize_test.go
+++ b/util/kustomize/kustomize_test.go
@@ -495,13 +495,29 @@ func TestKustomizeBuildComponents(t *testing.T) {
 	}
 	_, _, _, err = kustomize.Build(&kustomizeSource, nil, nil, nil)
 	require.Error(t, err)
+	kustomizeSource = v1alpha1.ApplicationSourceKustomize{
+		Components:              []string{"./components", "./components_no_kustomization"},
+		IgnoreMissingComponents: false,
+	}
+	_, _, _, err = kustomize.Build(&kustomizeSource, nil, nil, nil)
+	require.Error(t, err)
+
+	// `kustomize edit add component` works if the directory exists even if there is no kustomization.yaml inside,
+	// but then `kustomize build` fails
+	// Reset the kustomize app so we don't let components_no_kustomization in the kustomization.yaml
+	appPath, err = testDataDir(t, kustomization6)
+	require.NoError(t, err)
+	kustomize = NewKustomizeApp(appPath, appPath, git.NopCreds{}, "", "", "", "")
 
 	kustomizeSource = v1alpha1.ApplicationSourceKustomize{
-		Components:              []string{"./components", "./missing-components"},
+		Components:              []string{"./components", "./missing-components", "./components_no_kustomization"},
 		IgnoreMissingComponents: true,
 	}
 	objs, _, _, err := kustomize.Build(&kustomizeSource, nil, nil, nil)
 	require.NoError(t, err)
+	for _, o := range objs {
+		assert.NotEqual(t, "notproduced", o.GetName())
+	}
 	obj := objs[0]
 	assert.Equal(t, "nginx-deployment", obj.GetName())
 	assert.Equal(t, map[string]string{

--- a/util/kustomize/testdata/kustomization_yaml_components/components_no_kustomization/configmap.yaml
+++ b/util/kustomize/testdata/kustomization_yaml_components/components_no_kustomization/configmap.yaml
@@ -1,0 +1,6 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: notproduced
+data:
+  somekey: somevalue


### PR DESCRIPTION
The `ignoreMissingComponents` switch for Kustomize Applications
currently consider a Component specified in the Application spec as
present if the directory exists, which is not enough for kustomize
itself, which needs a not empty kustomization.yml file (with 3 filenames
accepted)

There is however some use cases where the directory exists, but not the
components: for instance, when using ApplicationSets, another file in
the directory can control the generation of an Application, even if it
does not need modification with a Component.

Check that the kustomization file exists to make that workflow possible.

We don't check that the file is valid, though, as:
1. This amount to reimplementing kustomize validation
2. Silently skipping an invalid file is more surprising than just
   skipping an absent one.

Fixes #24308

This should be backported to 3.0, 3.1, 3.2, and 3.3 (all releases where the ignoreMissingComponents feature is present) (I'm not sure which of those branches are supported though)
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
