### PR TITLE
fix: handle parse errors in ReadLocalConfig properly

### DIFF
--- a/util/localconfig/localconfig.go
+++ b/util/localconfig/localconfig.go
@@ -94,7 +94,7 @@ func ReadLocalConfig(path string) (*LocalConfig, error) {
 		return nil, nil
 	}
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to parse config file: %w", err)
 	}
 	err = ValidateLocalConfig(localconfig)
 	if err != nil {

--- a/util/localconfig/localconfig.go
+++ b/util/localconfig/localconfig.go
@@ -93,6 +93,9 @@ func ReadLocalConfig(path string) (*LocalConfig, error) {
 	if os.IsNotExist(err) {
 		return nil, nil
 	}
+	if err != nil {
+		return nil, err
+	}
 	err = ValidateLocalConfig(localconfig)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Fixes #26113

This PR fixes a panic in `argocd context` command when the config file exists but contains invalid YAML.

