### PR TITLE
refactor: remove helper pointer functions in pull_request tests

### DIFF
--- a/applicationset/services/pull_request/azure_devops_test.go
+++ b/applicationset/services/pull_request/azure_devops_test.go
@@ -15,26 +15,6 @@ import (
 	"github.com/argoproj/argo-cd/v3/applicationset/services/scm_provider/mocks"
 )
 
-func createBoolPtr(x bool) *bool {
-	return &x
-}
-
-func createStringPtr(x string) *string {
-	return &x
-}
-
-func createIntPtr(x int) *int {
-	return &x
-}
-
-func createLabelsPtr(x []core.WebApiTagDefinition) *[]core.WebApiTagDefinition {
-	return &x
-}
-
-func createUniqueNamePtr(x string) *string {
-	return &x
-}
-
 func TestListPullRequest(t *testing.T) {
 	teamProject := "myorg_project"
 	repoName := "myorg_project_repo"
@@ -46,19 +26,19 @@ func TestListPullRequest(t *testing.T) {
 
 	pullRequestMock := []git.GitPullRequest{
 		{
-			PullRequestId: createIntPtr(prID),
-			Title:         createStringPtr(prTitle),
-			SourceRefName: createStringPtr("refs/heads/feature-branch"),
-			TargetRefName: createStringPtr("refs/heads/main"),
+			PullRequestId: new(prID),
+			Title:         new(prTitle),
+			SourceRefName: new("refs/heads/feature-branch"),
+			TargetRefName: new("refs/heads/main"),
 			LastMergeSourceCommit: &git.GitCommitRef{
-				CommitId: createStringPtr(prHeadSha),
+				CommitId: new(prHeadSha),
 			},
 			Labels: &[]core.WebApiTagDefinition{},
 			Repository: &git.GitRepository{
-				Name: createStringPtr(repoName),
+				Name: new(repoName),
 			},
 			CreatedBy: &webapi.IdentityRef{
-				UniqueName: createUniqueNamePtr(uniqueName + "@example.com"),
+				UniqueName: new(uniqueName + "@example.com"),
 			},
 		},
 	}
@@ -99,27 +79,27 @@ func TestConvertLabes(t *testing.T) {
 	}{
 		{
 			name:           "empty labels",
-			gotLabels:      createLabelsPtr([]core.WebApiTagDefinition{}),
+			gotLabels:      &[]core.WebApiTagDefinition{},
 			expectedLabels: []string{},
 		},
 		{
 			name:           "nil labels",
-			gotLabels:      createLabelsPtr(nil),
+			gotLabels:      nil,
 			expectedLabels: []string{},
 		},
 		{
 			name: "one label",
-			gotLabels: createLabelsPtr([]core.WebApiTagDefinition{
-				{Name: createStringPtr("label1"), Active: createBoolPtr(true)},
-			}),
+			gotLabels: &[]core.WebApiTagDefinition{
+				{Name: new("label1"), Active: new(true)},
+			},
 			expectedLabels: []string{"label1"},
 		},
 		{
 			name: "two label",
-			gotLabels: createLabelsPtr([]core.WebApiTagDefinition{
-				{Name: createStringPtr("label1"), Active: createBoolPtr(true)},
-				{Name: createStringPtr("label2"), Active: createBoolPtr(true)},
-			}),
+			gotLabels: &[]core.WebApiTagDefinition{
+				{Name: new("label1"), Active: new(true)},
+				{Name: new("label2"), Active: new(true)},
+			},
 			expectedLabels: []string{"label1", "label2"},
 		},
 	}
@@ -216,7 +196,7 @@ func TestBuildURL(t *testing.T) {
 
 func TestAzureDevOpsListReturnsRepositoryNotFoundError(t *testing.T) {
 	args := git.GetPullRequestsByProjectArgs{
-		Project:        createStringPtr("nonexistent"),
+		Project:        new("nonexistent"),
 		SearchCriteria: &git.GitPullRequestSearchCriteria{},
 	}
 

--- a/applicationset/services/pull_request/github_test.go
+++ b/applicationset/services/pull_request/github_test.go
@@ -10,10 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func toPtr(s string) *string {
-	return &s
-}
-
 func TestContainLabels(t *testing.T) {
 	cases := []struct {
 		Name       string
@@ -25,9 +21,9 @@ func TestContainLabels(t *testing.T) {
 			Name:   "Match labels",
 			Labels: []string{"label1", "label2"},
 			PullLabels: []*github.Label{
-				{Name: toPtr("label1")},
-				{Name: toPtr("label2")},
-				{Name: toPtr("label3")},
+				{Name: new("label1")},
+				{Name: new("label2")},
+				{Name: new("label3")},
 			},
 			Expect: true,
 		},
@@ -35,9 +31,9 @@ func TestContainLabels(t *testing.T) {
 			Name:   "Not match labels",
 			Labels: []string{"label1", "label4"},
 			PullLabels: []*github.Label{
-				{Name: toPtr("label1")},
-				{Name: toPtr("label2")},
-				{Name: toPtr("label3")},
+				{Name: new("label1")},
+				{Name: new("label2")},
+				{Name: new("label3")},
 			},
 			Expect: false,
 		},
@@ -45,9 +41,9 @@ func TestContainLabels(t *testing.T) {
 			Name:   "No specify",
 			Labels: []string{},
 			PullLabels: []*github.Label{
-				{Name: toPtr("label1")},
-				{Name: toPtr("label2")},
-				{Name: toPtr("label3")},
+				{Name: new("label1")},
+				{Name: new("label2")},
+				{Name: new("label3")},
 			},
 			Expect: true,
 		},
@@ -70,9 +66,9 @@ func TestGetGitHubPRLabelNames(t *testing.T) {
 		{
 			Name: "PR has labels",
 			PullLabels: []*github.Label{
-				{Name: toPtr("label1")},
-				{Name: toPtr("label2")},
-				{Name: toPtr("label3")},
+				{Name: new("label1")},
+				{Name: new("label2")},
+				{Name: new("label3")},
 			},
 			ExpectedResult: []string{"label1", "label2", "label3"},
 		},

--- a/applicationset/services/pull_request/utils_test.go
+++ b/applicationset/services/pull_request/utils_test.go
@@ -9,10 +9,6 @@ import (
 	argoprojiov1alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 )
 
-func strp(s string) *string {
-	return &s
-}
-
 func TestFilterBranchMatchBadRegexp(t *testing.T) {
 	provider, _ := NewFakeService(
 		t.Context(),
@@ -30,7 +26,7 @@ func TestFilterBranchMatchBadRegexp(t *testing.T) {
 	)
 	filters := []argoprojiov1alpha1.PullRequestGeneratorFilter{
 		{
-			BranchMatch: strp("("),
+			BranchMatch: new("("),
 		},
 	}
 	_, err := ListPullRequests(t.Context(), provider, filters)
@@ -78,7 +74,7 @@ func TestFilterBranchMatch(t *testing.T) {
 	)
 	filters := []argoprojiov1alpha1.PullRequestGeneratorFilter{
 		{
-			BranchMatch: strp("w"),
+			BranchMatch: new("w"),
 		},
 	}
 	pullRequests, err := ListPullRequests(t.Context(), provider, filters)
@@ -128,7 +124,7 @@ func TestFilterTargetBranchMatch(t *testing.T) {
 	)
 	filters := []argoprojiov1alpha1.PullRequestGeneratorFilter{
 		{
-			TargetBranchMatch: strp("1"),
+			TargetBranchMatch: new("1"),
 		},
 	}
 	pullRequests, err := ListPullRequests(t.Context(), provider, filters)
@@ -178,7 +174,7 @@ func TestFilterTitleMatch(t *testing.T) {
 	)
 	filters := []argoprojiov1alpha1.PullRequestGeneratorFilter{
 		{
-			TitleMatch: strp("\\[filter]"),
+			TitleMatch: new("\\[filter]"),
 		},
 	}
 	pullRequests, err := ListPullRequests(t.Context(), provider, filters)
@@ -228,10 +224,10 @@ func TestMultiFilterOrWithTitle(t *testing.T) {
 	)
 	filters := []argoprojiov1alpha1.PullRequestGeneratorFilter{
 		{
-			TitleMatch: strp("\\[filter]"),
+			TitleMatch: new("\\[filter]"),
 		},
 		{
-			TitleMatch: strp("- filter"),
+			TitleMatch: new("- filter"),
 		},
 	}
 	pullRequests, err := ListPullRequests(t.Context(), provider, filters)
@@ -282,10 +278,10 @@ func TestMultiFilterOr(t *testing.T) {
 	)
 	filters := []argoprojiov1alpha1.PullRequestGeneratorFilter{
 		{
-			BranchMatch: strp("w"),
+			BranchMatch: new("w"),
 		},
 		{
-			BranchMatch: strp("r"),
+			BranchMatch: new("r"),
 		},
 	}
 	pullRequests, err := ListPullRequests(t.Context(), provider, filters)
@@ -345,19 +341,19 @@ func TestMultiFilterOrWithTargetBranchFilterOrWithTitleFilter(t *testing.T) {
 	)
 	filters := []argoprojiov1alpha1.PullRequestGeneratorFilter{
 		{
-			BranchMatch:       strp("w"),
-			TargetBranchMatch: strp("1"),
+			BranchMatch:       new("w"),
+			TargetBranchMatch: new("1"),
 		},
 		{
-			BranchMatch:       strp("r"),
-			TargetBranchMatch: strp("3"),
+			BranchMatch:       new("r"),
+			TargetBranchMatch: new("3"),
 		},
 		{
-			TitleMatch: strp("two"),
+			TitleMatch: new("two"),
 		},
 		{
-			BranchMatch: strp("five"),
-			TitleMatch:  strp("PR title is different than branch name"),
+			BranchMatch: new("five"),
+			TitleMatch:  new("PR title is different than branch name"),
 		},
 	}
 	pullRequests, err := ListPullRequests(t.Context(), provider, filters)

--- a/applicationset/services/scm_provider/azure_devops_test.go
+++ b/applicationset/services/scm_provider/azure_devops_test.go
@@ -17,10 +17,6 @@ import (
 	"github.com/argoproj/argo-cd/v3/applicationset/services/scm_provider/mocks"
 )
 
-func s(input string) *string {
-	return new(input)
-}
-
 func TestAzureDevopsRepoHasPath(t *testing.T) {
 	organization := "myorg"
 	teamProject := "myorg_project"
@@ -50,12 +46,12 @@ func TestAzureDevopsRepoHasPath(t *testing.T) {
 		{
 			name:             "RepoHasPath when no path found returns false",
 			pathFound:        false,
-			azureDevopsError: azuredevops.WrappedError{TypeKey: s(AzureDevOpsErrorsTypeKeyValues.GitItemNotFound)},
+			azureDevopsError: azuredevops.WrappedError{TypeKey: new(AzureDevOpsErrorsTypeKeyValues.GitItemNotFound)},
 		},
 		{
 			name:             "RepoHasPath when unknown Azure DevOps WrappedError occurs returns error",
 			pathFound:        false,
-			azureDevopsError: azuredevops.WrappedError{TypeKey: s("OtherAzureDevopsException")},
+			azureDevopsError: azuredevops.WrappedError{TypeKey: new("OtherAzureDevopsException")},
 			returnError:      true,
 			errorMessage:     "failed to check for path existence",
 		},
@@ -123,12 +119,12 @@ func TestGetDefaultBranchOnDisabledRepo(t *testing.T) {
 	}{
 		{
 			name:              "azure devops error when disabled repo causes empty return value",
-			azureDevOpsError:  azuredevops.WrappedError{TypeKey: s(AzureDevOpsErrorsTypeKeyValues.GitRepositoryNotFound)},
+			azureDevOpsError:  azuredevops.WrappedError{TypeKey: new(AzureDevOpsErrorsTypeKeyValues.GitRepositoryNotFound)},
 			shouldReturnError: false,
 		},
 		{
 			name:              "azure devops error with unknown error type returns error",
-			azureDevOpsError:  azuredevops.WrappedError{TypeKey: s("OtherError")},
+			azureDevOpsError:  azuredevops.WrappedError{TypeKey: new("OtherError")},
 			shouldReturnError: true,
 		},
 		{
@@ -180,12 +176,12 @@ func TestGetAllBranchesOnDisabledRepo(t *testing.T) {
 	}{
 		{
 			name:              "azure devops error when disabled repo causes empty return value",
-			azureDevOpsError:  azuredevops.WrappedError{TypeKey: s(AzureDevOpsErrorsTypeKeyValues.GitRepositoryNotFound)},
+			azureDevOpsError:  azuredevops.WrappedError{TypeKey: new(AzureDevOpsErrorsTypeKeyValues.GitRepositoryNotFound)},
 			shouldReturnError: false,
 		},
 		{
 			name:              "azure devops error with unknown error type returns error",
-			azureDevOpsError:  azuredevops.WrappedError{TypeKey: s("OtherError")},
+			azureDevOpsError:  azuredevops.WrappedError{TypeKey: new("OtherError")},
 			shouldReturnError: true,
 		},
 		{
@@ -233,7 +229,7 @@ func TestAzureDevOpsGetDefaultBranchStripsRefsName(t *testing.T) {
 		strippedBranchName := "somebranch"
 		defaultBranch := fmt.Sprintf("refs/heads/%v", strippedBranchName)
 
-		branchReturn := &azureGit.GitBranchStats{Name: &strippedBranchName, Commit: &azureGit.GitCommitRef{CommitId: s("abc123233223")}}
+		branchReturn := &azureGit.GitBranchStats{Name: &strippedBranchName, Commit: &azureGit.GitCommitRef{CommitId: new("abc123233223")}}
 		repo := &Repository{Organization: organization, Repository: repoName, RepositoryId: uuid, Branch: defaultBranch}
 
 		gitClientMock := &azureMock.Client{}
@@ -272,7 +268,7 @@ func TestAzureDevOpsGetBranchesDefultBranchOnly(t *testing.T) {
 	}{
 		{
 			name:           "GetBranches AllBranches false when single branch returned returns branch",
-			expectedBranch: &azureGit.GitBranchStats{Name: &defaultBranch, Commit: &azureGit.GitCommitRef{CommitId: s("abc123233223")}},
+			expectedBranch: &azureGit.GitBranchStats{Name: &defaultBranch, Commit: &azureGit.GitCommitRef{CommitId: new("abc123233223")}},
 		},
 		{
 			name:                "GetBranches AllBranches false when request fails returns error and empty result",
@@ -284,7 +280,7 @@ func TestAzureDevOpsGetBranchesDefultBranchOnly(t *testing.T) {
 		},
 		{
 			name:           "GetBranches AllBranches false when branch returned with long commit SHA",
-			expectedBranch: &azureGit.GitBranchStats{Name: &defaultBranch, Commit: &azureGit.GitCommitRef{CommitId: s("53863052ADF24229AB72154B4D83DAB7")}},
+			expectedBranch: &azureGit.GitBranchStats{Name: &defaultBranch, Commit: &azureGit.GitCommitRef{CommitId: new("53863052ADF24229AB72154B4D83DAB7")}},
 		},
 	}
 
@@ -343,7 +339,7 @@ func TestAzureDevopsGetBranches(t *testing.T) {
 	}{
 		{
 			name:             "GetBranches when single branch returned returns this branch info",
-			expectedBranches: &[]azureGit.GitBranchStats{{Name: s("feature-feat1"), Commit: &azureGit.GitCommitRef{CommitId: s("abc123233223")}}},
+			expectedBranches: &[]azureGit.GitBranchStats{{Name: new("feature-feat1"), Commit: &azureGit.GitCommitRef{CommitId: new("abc123233223")}}},
 			allBranches:      true,
 		},
 		{
@@ -364,9 +360,9 @@ func TestAzureDevopsGetBranches(t *testing.T) {
 		{
 			name: "GetBranches when multiple branches returned returns branch info for all branches",
 			expectedBranches: &[]azureGit.GitBranchStats{
-				{Name: s("feature-feat1"), Commit: &azureGit.GitCommitRef{CommitId: s("abc123233223")}},
-				{Name: s("feature/feat2"), Commit: &azureGit.GitCommitRef{CommitId: s("4334")}},
-				{Name: s("feature/feat2"), Commit: &azureGit.GitCommitRef{CommitId: s("53863052ADF24229AB72154B4D83DAB7")}},
+				{Name: new("feature-feat1"), Commit: &azureGit.GitCommitRef{CommitId: new("abc123233223")}},
+				{Name: new("feature/feat2"), Commit: &azureGit.GitCommitRef{CommitId: new("4334")}},
+				{Name: new("feature/feat2"), Commit: &azureGit.GitCommitRef{CommitId: new("53863052ADF24229AB72154B4D83DAB7")}},
 			},
 			allBranches: true,
 		},
@@ -433,12 +429,12 @@ func TestGetAzureDevopsRepositories(t *testing.T) {
 	}{
 		{
 			name:                  "ListRepos when single repo found returns repo info",
-			repositories:          []azureGit.GitRepository{{Name: s("repo1"), DefaultBranch: s("main"), RemoteUrl: s("https://remoteurl.u"), Id: repoId}},
+			repositories:          []azureGit.GitRepository{{Name: new("repo1"), DefaultBranch: new("main"), RemoteUrl: new("https://remoteurl.u"), Id: repoId}},
 			expectedNumberOfRepos: 1,
 		},
 		{
 			name:         "ListRepos when repo has no default branch returns empty list",
-			repositories: []azureGit.GitRepository{{Name: s("repo2"), RemoteUrl: s("https://remoteurl.u"), Id: repoId}},
+			repositories: []azureGit.GitRepository{{Name: new("repo2"), RemoteUrl: new("https://remoteurl.u"), Id: repoId}},
 		},
 		{
 			name:                 "ListRepos when Azure DevOps request fails returns error",
@@ -446,24 +442,24 @@ func TestGetAzureDevopsRepositories(t *testing.T) {
 		},
 		{
 			name:         "ListRepos when repo has no name returns empty list",
-			repositories: []azureGit.GitRepository{{DefaultBranch: s("main"), RemoteUrl: s("https://remoteurl.u"), Id: repoId}},
+			repositories: []azureGit.GitRepository{{DefaultBranch: new("main"), RemoteUrl: new("https://remoteurl.u"), Id: repoId}},
 		},
 		{
 			name:         "ListRepos when repo has no remote URL returns empty list",
-			repositories: []azureGit.GitRepository{{DefaultBranch: s("main"), Name: s("repo_name"), Id: repoId}},
+			repositories: []azureGit.GitRepository{{DefaultBranch: new("main"), Name: new("repo_name"), Id: repoId}},
 		},
 		{
 			name:         "ListRepos when repo has no ID returns empty list",
-			repositories: []azureGit.GitRepository{{DefaultBranch: s("main"), Name: s("repo_name"), RemoteUrl: s("https://remoteurl.u")}},
+			repositories: []azureGit.GitRepository{{DefaultBranch: new("main"), Name: new("repo_name"), RemoteUrl: new("https://remoteurl.u")}},
 		},
 		{
 			name: "ListRepos when multiple repos returned returns list of eligible repos only",
 			repositories: []azureGit.GitRepository{
-				{Name: s("returned1"), DefaultBranch: s("main"), RemoteUrl: s("https://remoteurl.u"), Id: repoId},
-				{Name: s("missing_default_branch"), RemoteUrl: s("https://remoteurl.u"), Id: repoId},
-				{DefaultBranch: s("missing_name"), RemoteUrl: s("https://remoteurl.u"), Id: repoId},
-				{Name: s("missing_remote_url"), DefaultBranch: s("main"), Id: repoId},
-				{Name: s("missing_id"), DefaultBranch: s("main"), RemoteUrl: s("https://remoteurl.u")},
+				{Name: new("returned1"), DefaultBranch: new("main"), RemoteUrl: new("https://remoteurl.u"), Id: repoId},
+				{Name: new("missing_default_branch"), RemoteUrl: new("https://remoteurl.u"), Id: repoId},
+				{DefaultBranch: new("missing_name"), RemoteUrl: new("https://remoteurl.u"), Id: repoId},
+				{Name: new("missing_remote_url"), DefaultBranch: new("main"), Id: repoId},
+				{Name: new("missing_id"), DefaultBranch: new("main"), RemoteUrl: new("https://remoteurl.u")},
 			},
 			expectedNumberOfRepos: 1,
 		},
@@ -472,7 +468,7 @@ func TestGetAzureDevopsRepositories(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			gitClientMock := azureMock.NewClient(t)
-			gitClientMock.EXPECT().GetRepositories(mock.Anything, azureGit.GetRepositoriesArgs{Project: s(teamProject)}).Return(&testCase.repositories, testCase.getRepositoriesError)
+			gitClientMock.EXPECT().GetRepositories(mock.Anything, azureGit.GetRepositoriesArgs{Project: new(teamProject)}).Return(&testCase.repositories, testCase.getRepositoriesError)
 
 			clientFactoryMock := &mocks.AzureDevOpsClientFactory{}
 			clientFactoryMock.EXPECT().GetClient(mock.Anything).Return(gitClientMock, nil)

--- a/applicationset/services/scm_provider/gitlab_test.go
+++ b/applicationset/services/scm_provider/gitlab_test.go
@@ -1100,7 +1100,7 @@ func TestGitlabListRepos(t *testing.T) {
 			url:   "git@gitlab.com:test-argocd-proton/argocd.git",
 			filters: []v1alpha1.SCMProviderGeneratorFilter{
 				{
-					LabelMatch: strp("test-topic"),
+					LabelMatch: new("test-topic"),
 				},
 			},
 		},

--- a/applicationset/services/scm_provider/utils_test.go
+++ b/applicationset/services/scm_provider/utils_test.go
@@ -10,10 +10,6 @@ import (
 	argoprojiov1alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 )
 
-func strp(s string) *string {
-	return &s
-}
-
 func TestFilterRepoMatch(t *testing.T) {
 	provider := &MockProvider{
 		Repos: []*Repository{
@@ -33,7 +29,7 @@ func TestFilterRepoMatch(t *testing.T) {
 	}
 	filters := []argoprojiov1alpha1.SCMProviderGeneratorFilter{
 		{
-			RepositoryMatch: strp("n|hr"),
+			RepositoryMatch: new("n|hr"),
 		},
 	}
 	repos, err := ListRepos(t.Context(), provider, filters, "")
@@ -62,7 +58,7 @@ func TestFilterLabelMatch(t *testing.T) {
 	}
 	filters := []argoprojiov1alpha1.SCMProviderGeneratorFilter{
 		{
-			LabelMatch: strp("^prod-.*$"),
+			LabelMatch: new("^prod-.*$"),
 		},
 	}
 	repos, err := ListRepos(t.Context(), provider, filters, "")
@@ -131,7 +127,7 @@ func TestFilterRepoMatchBadRegexp(t *testing.T) {
 	}
 	filters := []argoprojiov1alpha1.SCMProviderGeneratorFilter{
 		{
-			RepositoryMatch: strp("("),
+			RepositoryMatch: new("("),
 		},
 	}
 	_, err := ListRepos(t.Context(), provider, filters, "")
@@ -148,7 +144,7 @@ func TestFilterLabelMatchBadRegexp(t *testing.T) {
 	}
 	filters := []argoprojiov1alpha1.SCMProviderGeneratorFilter{
 		{
-			LabelMatch: strp("("),
+			LabelMatch: new("("),
 		},
 	}
 	_, err := ListRepos(t.Context(), provider, filters, "")
@@ -182,7 +178,7 @@ func TestFilterBranchMatch(t *testing.T) {
 	}
 	filters := []argoprojiov1alpha1.SCMProviderGeneratorFilter{
 		{
-			BranchMatch: strp("w"),
+			BranchMatch: new("w"),
 		},
 	}
 	repos, err := ListRepos(t.Context(), provider, filters, "")
@@ -213,8 +209,8 @@ func TestMultiFilterAnd(t *testing.T) {
 	}
 	filters := []argoprojiov1alpha1.SCMProviderGeneratorFilter{
 		{
-			RepositoryMatch: strp("w"),
-			LabelMatch:      strp("^prod-.*$"),
+			RepositoryMatch: new("w"),
+			LabelMatch:      new("^prod-.*$"),
 		},
 	}
 	repos, err := ListRepos(t.Context(), provider, filters, "")
@@ -242,10 +238,10 @@ func TestMultiFilterOr(t *testing.T) {
 	}
 	filters := []argoprojiov1alpha1.SCMProviderGeneratorFilter{
 		{
-			RepositoryMatch: strp("e"),
+			RepositoryMatch: new("e"),
 		},
 		{
-			LabelMatch: strp("^prod-.*$"),
+			LabelMatch: new("^prod-.*$"),
 		},
 	}
 	repos, err := ListRepos(t.Context(), provider, filters, "")

--- a/controller/sharding/cache_test.go
+++ b/controller/sharding/cache_test.go
@@ -350,10 +350,6 @@ func TestClusterSharding_ClusterShardOfResourceShouldNotBeChanged(t *testing.T) 
 	replicas := 2
 	sharding := setupTestSharding(shard, replicas)
 
-	Int64Ptr := func(i int64) *int64 {
-		return &i
-	}
-
 	clusterWithNil := &v1alpha1.Cluster{
 		ID:     "2",
 		Server: "https://127.0.0.1:6443",
@@ -363,13 +359,13 @@ func TestClusterSharding_ClusterShardOfResourceShouldNotBeChanged(t *testing.T) 
 	clusterWithValue := &v1alpha1.Cluster{
 		ID:     "1",
 		Server: "https://kubernetes.default.svc",
-		Shard:  Int64Ptr(1),
+		Shard:  new(int64(1)),
 	}
 
 	clusterWithToBigValue := &v1alpha1.Cluster{
 		ID:     "3",
 		Server: "https://1.1.1.1",
-		Shard:  Int64Ptr(999), // shard value is explicitly bigger than the number of replicas
+		Shard:  new(int64(999)), // shard value is explicitly bigger than the number of replicas
 	}
 
 	sharding.Init(
@@ -402,10 +398,6 @@ func TestClusterSharding_ClusterShardOfResourceShouldNotBeChanged(t *testing.T) 
 }
 
 func TestHasShardingUpdates(t *testing.T) {
-	Int64Ptr := func(i int64) *int64 {
-		return &i
-	}
-
 	testCases := []struct {
 		name     string
 		old      *v1alpha1.Cluster
@@ -416,11 +408,11 @@ func TestHasShardingUpdates(t *testing.T) {
 			name: "No updates",
 			old: &v1alpha1.Cluster{
 				Server: "https://kubernetes.default.svc",
-				Shard:  Int64Ptr(1),
+				Shard:  new(int64(1)),
 			},
 			new: &v1alpha1.Cluster{
 				Server: "https://kubernetes.default.svc",
-				Shard:  Int64Ptr(1),
+				Shard:  new(int64(1)),
 			},
 			expected: false,
 		},
@@ -428,11 +420,11 @@ func TestHasShardingUpdates(t *testing.T) {
 			name: "Updates",
 			old: &v1alpha1.Cluster{
 				Server: "https://kubernetes.default.svc",
-				Shard:  Int64Ptr(1),
+				Shard:  new(int64(1)),
 			},
 			new: &v1alpha1.Cluster{
 				Server: "https://kubernetes.default.svc",
-				Shard:  Int64Ptr(2),
+				Shard:  new(int64(2)),
 			},
 			expected: true,
 		},
@@ -441,7 +433,7 @@ func TestHasShardingUpdates(t *testing.T) {
 			old:  nil,
 			new: &v1alpha1.Cluster{
 				Server: "https://kubernetes.default.svc",
-				Shard:  Int64Ptr(2),
+				Shard:  new(int64(2)),
 			},
 			expected: false,
 		},
@@ -449,7 +441,7 @@ func TestHasShardingUpdates(t *testing.T) {
 			name: "New is nil",
 			old: &v1alpha1.Cluster{
 				Server: "https://kubernetes.default.svc",
-				Shard:  Int64Ptr(2),
+				Shard:  new(int64(2)),
 			},
 			new:      nil,
 			expected: false,
@@ -480,7 +472,7 @@ func TestHasShardingUpdates(t *testing.T) {
 			},
 			new: &v1alpha1.Cluster{
 				Server: "https://kubernetes.default.svc",
-				Shard:  Int64Ptr(2),
+				Shard:  new(int64(2)),
 			},
 			expected: true,
 		},
@@ -488,7 +480,7 @@ func TestHasShardingUpdates(t *testing.T) {
 			name: "New shard is nil",
 			old: &v1alpha1.Cluster{
 				Server: "https://kubernetes.default.svc",
-				Shard:  Int64Ptr(2),
+				Shard:  new(int64(2)),
 			},
 			new: &v1alpha1.Cluster{
 				Server: "https://kubernetes.default.svc",
@@ -501,12 +493,12 @@ func TestHasShardingUpdates(t *testing.T) {
 			old: &v1alpha1.Cluster{
 				ID:     "1",
 				Server: "https://kubernetes.default.svc",
-				Shard:  Int64Ptr(2),
+				Shard:  new(int64(2)),
 			},
 			new: &v1alpha1.Cluster{
 				ID:     "2",
 				Server: "https://kubernetes.default.svc",
-				Shard:  Int64Ptr(2),
+				Shard:  new(int64(2)),
 			},
 			expected: true,
 		},
@@ -515,12 +507,12 @@ func TestHasShardingUpdates(t *testing.T) {
 			old: &v1alpha1.Cluster{
 				ID:     "1",
 				Server: "https://server1",
-				Shard:  Int64Ptr(2),
+				Shard:  new(int64(2)),
 			},
 			new: &v1alpha1.Cluster{
 				ID:     "1",
 				Server: "https://server2",
-				Shard:  Int64Ptr(2),
+				Shard:  new(int64(2)),
 			},
 			expected: true,
 		},

--- a/controller/sharding/sharding_test.go
+++ b/controller/sharding/sharding_test.go
@@ -789,17 +789,13 @@ func Test_getOrUpdateShardNumberForController(t *testing.T) {
 }
 
 func TestGetClusterSharding(t *testing.T) {
-	IntPtr := func(i int32) *int32 {
-		return &i
-	}
-
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      common.DefaultApplicationControllerName,
 			Namespace: "argocd",
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: IntPtr(1),
+			Replicas: new(int32(1)),
 		},
 	}
 
@@ -809,7 +805,7 @@ func TestGetClusterSharding(t *testing.T) {
 			Namespace: "argocd",
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: IntPtr(3),
+			Replicas: new(int32(3)),
 		},
 	}
 

--- a/server/application/application_test.go
+++ b/server/application/application_test.go
@@ -1426,10 +1426,6 @@ func BenchmarkListFewApps(b *testing.B) {
 	}
 }
 
-func strToPtr(v string) *string {
-	return &v
-}
-
 func BenchmarkListMuchAppsWithName(b *testing.B) {
 	// 10000 apps
 	appsMuch := generateTestApp(10000)
@@ -1440,7 +1436,7 @@ func BenchmarkListMuchAppsWithName(b *testing.B) {
 	appServer := newTestAppServerWithBenchmark(b, obj...)
 
 	for b.Loop() {
-		app := &application.ApplicationQuery{Name: strToPtr("test-app000099")}
+		app := &application.ApplicationQuery{Name: new("test-app000099")}
 		_, err := appServer.List(b.Context(), app)
 		if err != nil {
 			break
@@ -1479,7 +1475,7 @@ func BenchmarkListMuchAppsWithRepo(b *testing.B) {
 	appServer := newTestAppServerWithBenchmark(b, obj...)
 
 	for b.Loop() {
-		app := &application.ApplicationQuery{Repo: strToPtr("https://some-fake-source")}
+		app := &application.ApplicationQuery{Repo: new("https://some-fake-source")}
 		_, err := appServer.List(b.Context(), app)
 		if err != nil {
 			break
@@ -1877,10 +1873,10 @@ func TestDeleteResourcesRBAC(t *testing.T) {
 	req := application.ApplicationResourceDeleteRequest{
 		Name:         &testApp.Name,
 		AppNamespace: &testApp.Namespace,
-		Group:        strToPtr("fake.io"),
-		Kind:         strToPtr("PodTest"),
-		Namespace:    strToPtr("fake-ns"),
-		ResourceName: strToPtr("my-pod-test"),
+		Group:        new("fake.io"),
+		Kind:         new("PodTest"),
+		Namespace:    new("fake-ns"),
+		ResourceName: new("my-pod-test"),
 	}
 
 	expectedErrorWhenDeleteAllowed := "rpc error: code = InvalidArgument desc = PodTest fake.io my-pod-test not found as part of application test-app"
@@ -1970,10 +1966,10 @@ func TestPatchResourcesRBAC(t *testing.T) {
 	req := application.ApplicationResourcePatchRequest{
 		Name:         &testApp.Name,
 		AppNamespace: &testApp.Namespace,
-		Group:        strToPtr("fake.io"),
-		Kind:         strToPtr("PodTest"),
-		Namespace:    strToPtr("fake-ns"),
-		ResourceName: strToPtr("my-pod-test"),
+		Group:        new("fake.io"),
+		Kind:         new("PodTest"),
+		Namespace:    new("fake-ns"),
+		ResourceName: new("my-pod-test"),
 	}
 
 	expectedErrorWhenUpdateAllowed := "rpc error: code = InvalidArgument desc = PodTest fake.io my-pod-test not found as part of application test-app"
@@ -3987,7 +3983,7 @@ func TestGetAmbiguousRevision_MultiSource(t *testing.T) {
 		Sources: nil,
 	}
 	syncReq = &application.ApplicationSyncRequest{
-		Revision: strToPtr("revision3"),
+		Revision: new("revision3"),
 	}
 	expected = "revision3"
 	result = getAmbiguousRevision(app, syncReq, sourceIndex)
@@ -4003,7 +3999,7 @@ func TestGetAmbiguousRevision_SingleSource(t *testing.T) {
 		},
 	}
 	syncReq := &application.ApplicationSyncRequest{
-		Revision: strToPtr("rev1"),
+		Revision: new("rev1"),
 	}
 
 	// Test when app.Spec.HasMultipleSources() is true
@@ -4054,7 +4050,7 @@ func TestServer_ResolveSourceRevisions_SingleSource(t *testing.T) {
 	}
 
 	syncReq := &application.ApplicationSyncRequest{
-		Revision: strToPtr("HEAD"),
+		Revision: new("HEAD"),
 	}
 
 	revision, displayRevision, sourceRevisions, displayRevisions, err := s.resolveSourceRevisions(ctx, a, syncReq)

--- a/util/session/sessionmanager_test.go
+++ b/util/session/sessionmanager_test.go
@@ -236,10 +236,6 @@ func (tm *tokenVerifierMock) VerifyToken(_ context.Context, _ string) (jwt.Claim
 	return tm.claims, "", tm.err
 }
 
-func strPointer(str string) *string {
-	return &str
-}
-
 func TestSessionManager_WithAuthMiddleware(t *testing.T) {
 	handlerFunc := func() func(http.ResponseWriter, *http.Request) {
 		return func(w http.ResponseWriter, r *http.Request) {
@@ -289,7 +285,7 @@ func TestSessionManager_WithAuthMiddleware(t *testing.T) {
 			verifyTokenErr:       nil,
 			userInfoCacheClaims:  nil,
 			expectedStatusCode:   http.StatusOK,
-			expectedResponseBody: strPointer("{}"),
+			expectedResponseBody: new("{}"),
 		},
 		{
 			name:                 "will be noop if auth is disabled",
@@ -300,7 +296,7 @@ func TestSessionManager_WithAuthMiddleware(t *testing.T) {
 			verifyTokenErr:       nil,
 			userInfoCacheClaims:  nil,
 			expectedStatusCode:   http.StatusOK,
-			expectedResponseBody: strPointer("Ok"),
+			expectedResponseBody: new("Ok"),
 		},
 		{
 			name:                 "will return 400 if no cookie header",
@@ -333,7 +329,7 @@ func TestSessionManager_WithAuthMiddleware(t *testing.T) {
 			verifyTokenErr:       nil,
 			userInfoCacheClaims:  nil,
 			expectedStatusCode:   http.StatusOK,
-			expectedResponseBody: strPointer("null"),
+			expectedResponseBody: new("null"),
 		},
 		{
 			name:                 "will return 401 if sso is enabled but userinfo response not working",
@@ -344,7 +340,7 @@ func TestSessionManager_WithAuthMiddleware(t *testing.T) {
 			verifyTokenErr:       nil,
 			userInfoCacheClaims:  nil, // indicates that the userinfo response will not work since cache is empty and userinfo endpoint not rechable
 			expectedStatusCode:   http.StatusUnauthorized,
-			expectedResponseBody: strPointer("Invalid session"),
+			expectedResponseBody: new("Invalid session"),
 		},
 		{
 			name:                 "will return 200 if sso is enabled and userinfo response from cache is valid",
@@ -355,7 +351,7 @@ func TestSessionManager_WithAuthMiddleware(t *testing.T) {
 			verifyTokenErr:       nil,
 			userInfoCacheClaims:  &jwt.MapClaims{"sub": "randomUser", "groups": []string{"superusers"}, "exp": float64(time.Now().Add(5 * time.Minute).Unix())},
 			expectedStatusCode:   http.StatusOK,
-			expectedResponseBody: strPointer("\"groups\":[\"superusers\"]"),
+			expectedResponseBody: new("\"groups\":[\"superusers\"]"),
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary
- Remove helper pointer functions from test files
- Replace usages with Go 1.26's `new(expr)` syntax
