### PR TITLE
fix: use force flag in copyutil symlink to prevent repo-server crashes

### DIFF
--- a/manifests/base/repo-server/argocd-repo-server-deployment.yaml
+++ b/manifests/base/repo-server/argocd-repo-server-deployment.yaml
@@ -320,10 +320,11 @@ spec:
           name: plugins
       initContainers:
       - args:
-          - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln -sf /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+          - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln -s /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
         command:
           - sh
           - '-c'
+        restartPolicy: Never
         image: quay.io/argoproj/argocd:latest
         name: copyutil
         securityContext:

--- a/manifests/base/repo-server/argocd-repo-server-deployment.yaml
+++ b/manifests/base/repo-server/argocd-repo-server-deployment.yaml
@@ -320,11 +320,10 @@ spec:
           name: plugins
       initContainers:
       - args:
-          - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln -s /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+          - /bin/cp /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln -sf /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
         command:
           - sh
           - '-c'
-        restartPolicy: Never
         image: quay.io/argoproj/argocd:latest
         name: copyutil
         securityContext:

--- a/manifests/base/repo-server/argocd-repo-server-deployment.yaml
+++ b/manifests/base/repo-server/argocd-repo-server-deployment.yaml
@@ -320,7 +320,7 @@ spec:
           name: plugins
       initContainers:
       - args:
-          - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln -s /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+          - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln -sf /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
         command:
           - sh
           - '-c'

--- a/manifests/core-install-with-hydrator.yaml
+++ b/manifests/core-install-with-hydrator.yaml
@@ -31959,12 +31959,13 @@ spec:
       initContainers:
       - args:
         - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln
-          -sf /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+          -s /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
         command:
         - sh
         - -c
         image: quay.io/argoproj/argocd:latest
         name: copyutil
+        restartPolicy: Never
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/core-install-with-hydrator.yaml
+++ b/manifests/core-install-with-hydrator.yaml
@@ -31959,7 +31959,7 @@ spec:
       initContainers:
       - args:
         - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln
-          -s /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+          -sf /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
         command:
         - sh
         - -c

--- a/manifests/core-install-with-hydrator.yaml
+++ b/manifests/core-install-with-hydrator.yaml
@@ -31958,14 +31958,13 @@ spec:
           name: plugins
       initContainers:
       - args:
-        - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln
-          -s /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+        - /bin/cp /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln -sf /var/run/argocd/argocd
+          /var/run/argocd/argocd-cmp-server
         command:
         - sh
         - -c
         image: quay.io/argoproj/argocd:latest
         name: copyutil
-        restartPolicy: Never
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -31786,14 +31786,13 @@ spec:
           name: plugins
       initContainers:
       - args:
-        - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln
-          -s /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+        - /bin/cp /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln -sf /var/run/argocd/argocd
+          /var/run/argocd/argocd-cmp-server
         command:
         - sh
         - -c
         image: quay.io/argoproj/argocd:latest
         name: copyutil
-        restartPolicy: Never
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -31787,7 +31787,7 @@ spec:
       initContainers:
       - args:
         - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln
-          -s /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+          -sf /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
         command:
         - sh
         - -c

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -31787,12 +31787,13 @@ spec:
       initContainers:
       - args:
         - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln
-          -sf /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+          -s /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
         command:
         - sh
         - -c
         image: quay.io/argoproj/argocd:latest
         name: copyutil
+        restartPolicy: Never
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/ha/install-with-hydrator.yaml
+++ b/manifests/ha/install-with-hydrator.yaml
@@ -33654,7 +33654,7 @@ spec:
       initContainers:
       - args:
         - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln
-          -s /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+          -sf /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
         command:
         - sh
         - -c

--- a/manifests/ha/install-with-hydrator.yaml
+++ b/manifests/ha/install-with-hydrator.yaml
@@ -33654,12 +33654,13 @@ spec:
       initContainers:
       - args:
         - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln
-          -sf /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+          -s /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
         command:
         - sh
         - -c
         image: quay.io/argoproj/argocd:latest
         name: copyutil
+        restartPolicy: Never
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/ha/install-with-hydrator.yaml
+++ b/manifests/ha/install-with-hydrator.yaml
@@ -33653,14 +33653,13 @@ spec:
           name: plugins
       initContainers:
       - args:
-        - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln
-          -s /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+        - /bin/cp /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln -sf /var/run/argocd/argocd
+          /var/run/argocd/argocd-cmp-server
         command:
         - sh
         - -c
         image: quay.io/argoproj/argocd:latest
         name: copyutil
-        restartPolicy: Never
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -33484,7 +33484,7 @@ spec:
       initContainers:
       - args:
         - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln
-          -s /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+          -sf /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
         command:
         - sh
         - -c

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -33484,12 +33484,13 @@ spec:
       initContainers:
       - args:
         - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln
-          -sf /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+          -s /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
         command:
         - sh
         - -c
         image: quay.io/argoproj/argocd:latest
         name: copyutil
+        restartPolicy: Never
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -33483,14 +33483,13 @@ spec:
           name: plugins
       initContainers:
       - args:
-        - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln
-          -s /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+        - /bin/cp /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln -sf /var/run/argocd/argocd
+          /var/run/argocd/argocd-cmp-server
         command:
         - sh
         - -c
         image: quay.io/argoproj/argocd:latest
         name: copyutil
-        restartPolicy: Never
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/ha/namespace-install-with-hydrator.yaml
+++ b/manifests/ha/namespace-install-with-hydrator.yaml
@@ -2900,14 +2900,13 @@ spec:
           name: plugins
       initContainers:
       - args:
-        - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln
-          -s /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+        - /bin/cp /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln -sf /var/run/argocd/argocd
+          /var/run/argocd/argocd-cmp-server
         command:
         - sh
         - -c
         image: quay.io/argoproj/argocd:latest
         name: copyutil
-        restartPolicy: Never
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/ha/namespace-install-with-hydrator.yaml
+++ b/manifests/ha/namespace-install-with-hydrator.yaml
@@ -2901,7 +2901,7 @@ spec:
       initContainers:
       - args:
         - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln
-          -s /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+          -sf /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
         command:
         - sh
         - -c

--- a/manifests/ha/namespace-install-with-hydrator.yaml
+++ b/manifests/ha/namespace-install-with-hydrator.yaml
@@ -2901,12 +2901,13 @@ spec:
       initContainers:
       - args:
         - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln
-          -sf /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+          -s /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
         command:
         - sh
         - -c
         image: quay.io/argoproj/argocd:latest
         name: copyutil
+        restartPolicy: Never
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -2730,14 +2730,13 @@ spec:
           name: plugins
       initContainers:
       - args:
-        - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln
-          -s /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+        - /bin/cp /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln -sf /var/run/argocd/argocd
+          /var/run/argocd/argocd-cmp-server
         command:
         - sh
         - -c
         image: quay.io/argoproj/argocd:latest
         name: copyutil
-        restartPolicy: Never
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -2731,12 +2731,13 @@ spec:
       initContainers:
       - args:
         - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln
-          -sf /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+          -s /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
         command:
         - sh
         - -c
         image: quay.io/argoproj/argocd:latest
         name: copyutil
+        restartPolicy: Never
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -2731,7 +2731,7 @@ spec:
       initContainers:
       - args:
         - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln
-          -s /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+          -sf /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
         command:
         - sh
         - -c

--- a/manifests/install-with-hydrator.yaml
+++ b/manifests/install-with-hydrator.yaml
@@ -32624,7 +32624,7 @@ spec:
       initContainers:
       - args:
         - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln
-          -s /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+          -sf /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
         command:
         - sh
         - -c

--- a/manifests/install-with-hydrator.yaml
+++ b/manifests/install-with-hydrator.yaml
@@ -32624,12 +32624,13 @@ spec:
       initContainers:
       - args:
         - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln
-          -sf /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+          -s /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
         command:
         - sh
         - -c
         image: quay.io/argoproj/argocd:latest
         name: copyutil
+        restartPolicy: Never
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/install-with-hydrator.yaml
+++ b/manifests/install-with-hydrator.yaml
@@ -32623,14 +32623,13 @@ spec:
           name: plugins
       initContainers:
       - args:
-        - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln
-          -s /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+        - /bin/cp /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln -sf /var/run/argocd/argocd
+          /var/run/argocd/argocd-cmp-server
         command:
         - sh
         - -c
         image: quay.io/argoproj/argocd:latest
         name: copyutil
-        restartPolicy: Never
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -32452,7 +32452,7 @@ spec:
       initContainers:
       - args:
         - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln
-          -s /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+          -sf /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
         command:
         - sh
         - -c

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -32451,14 +32451,13 @@ spec:
           name: plugins
       initContainers:
       - args:
-        - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln
-          -s /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+        - /bin/cp /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln -sf /var/run/argocd/argocd
+          /var/run/argocd/argocd-cmp-server
         command:
         - sh
         - -c
         image: quay.io/argoproj/argocd:latest
         name: copyutil
-        restartPolicy: Never
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -32452,12 +32452,13 @@ spec:
       initContainers:
       - args:
         - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln
-          -sf /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+          -s /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
         command:
         - sh
         - -c
         image: quay.io/argoproj/argocd:latest
         name: copyutil
+        restartPolicy: Never
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/namespace-install-with-hydrator.yaml
+++ b/manifests/namespace-install-with-hydrator.yaml
@@ -1870,14 +1870,13 @@ spec:
           name: plugins
       initContainers:
       - args:
-        - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln
-          -s /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+        - /bin/cp /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln -sf /var/run/argocd/argocd
+          /var/run/argocd/argocd-cmp-server
         command:
         - sh
         - -c
         image: quay.io/argoproj/argocd:latest
         name: copyutil
-        restartPolicy: Never
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/namespace-install-with-hydrator.yaml
+++ b/manifests/namespace-install-with-hydrator.yaml
@@ -1871,12 +1871,13 @@ spec:
       initContainers:
       - args:
         - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln
-          -sf /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+          -s /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
         command:
         - sh
         - -c
         image: quay.io/argoproj/argocd:latest
         name: copyutil
+        restartPolicy: Never
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/namespace-install-with-hydrator.yaml
+++ b/manifests/namespace-install-with-hydrator.yaml
@@ -1871,7 +1871,7 @@ spec:
       initContainers:
       - args:
         - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln
-          -s /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+          -sf /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
         command:
         - sh
         - -c

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -1699,7 +1699,7 @@ spec:
       initContainers:
       - args:
         - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln
-          -s /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+          -sf /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
         command:
         - sh
         - -c

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -1699,12 +1699,13 @@ spec:
       initContainers:
       - args:
         - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln
-          -sf /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+          -s /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
         command:
         - sh
         - -c
         image: quay.io/argoproj/argocd:latest
         name: copyutil
+        restartPolicy: Never
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -1698,14 +1698,13 @@ spec:
           name: plugins
       initContainers:
       - args:
-        - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln
-          -s /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+        - /bin/cp /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln -sf /var/run/argocd/argocd
+          /var/run/argocd/argocd-cmp-server
         command:
         - sh
         - -c
         image: quay.io/argoproj/argocd:latest
         name: copyutil
-        restartPolicy: Never
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
# What this PR does

Fixes the repo-server pod crashing/completing due to a failed symlink 
in the copyutil init container.

## Why

When ArgoCD upgrades itself (self-managed), the repo-server pod restarts 
and the copyutil init container tries to create a symlink that already 
exists. `/bin/ln -s` fails with "Already exists" causing the pod to 
crash loop.

## Fix

Changed `/bin/ln -s` to `/bin/ln -sf` (force flag) so the symlink is 
overwritten if it already exists instead of failing.

Fixes #26595