### PR TITLE
feat(health): add health check for flink.apache.org/FlinkSessionJob

### DIFF
--- a/resource_customizations/flink.apache.org/FlinkSessionJob/health.lua
+++ b/resource_customizations/flink.apache.org/FlinkSessionJob/health.lua
@@ -1,0 +1,41 @@
+local health_status = {}
+
+if obj.status ~= nil and obj.status.jobStatus ~= nil then
+  if obj.status.jobStatus.state == "RUNNING" or obj.status.jobStatus.state == "FINISHED" then
+    health_status.status = "Healthy"
+    health_status.message = obj.status.jobStatus.state
+    return health_status
+  end
+
+  if obj.status.jobStatus.state == "RECONCILING" or obj.status.jobStatus.state == "CREATED" then
+    health_status.status = "Progressing"
+    health_status.message = obj.status.jobStatus.state
+    return health_status
+  end
+
+  if obj.status.jobStatus.state == "SUSPENDED" or obj.status.jobStatus.state == "CANCELED" then
+    health_status.status = "Suspended"
+    health_status.message = obj.status.jobStatus.state
+    return health_status
+  end
+
+  if obj.status.jobStatus.state == "FAILED" then
+    health_status.status = "Degraded"
+    if obj.status.error ~= nil then
+      health_status.message = obj.status.error
+    else
+      health_status.message = "FlinkSessionJob failed"
+    end
+    return health_status
+  end
+end
+
+if obj.status ~= nil and obj.status.error ~= nil then
+  health_status.status = "Degraded"
+  health_status.message = obj.status.error
+  return health_status
+end
+
+health_status.status = "Progressing"
+health_status.message = "Waiting for FlinkSessionJob to be reconciled"
+return health_status

--- a/resource_customizations/flink.apache.org/FlinkSessionJob/health_test.yaml
+++ b/resource_customizations/flink.apache.org/FlinkSessionJob/health_test.yaml
@@ -1,0 +1,33 @@
+tests:
+- healthStatus:
+    status: Healthy
+    message: RUNNING
+  inputPath: testdata/healthy_running.yaml
+- healthStatus:
+    status: Healthy
+    message: FINISHED
+  inputPath: testdata/healthy_finished.yaml
+- healthStatus:
+    status: Progressing
+    message: RECONCILING
+  inputPath: testdata/progressing_reconciling.yaml
+- healthStatus:
+    status: Progressing
+    message: CREATED
+  inputPath: testdata/progressing_created.yaml
+- healthStatus:
+    status: Suspended
+    message: SUSPENDED
+  inputPath: testdata/suspended.yaml
+- healthStatus:
+    status: Degraded
+    message: "Job submission failed: Could not find a registered TaskManager"
+  inputPath: testdata/degraded_failed.yaml
+- healthStatus:
+    status: Degraded
+    message: "Session cluster not found: flink-session-cluster"
+  inputPath: testdata/degraded_error.yaml
+- healthStatus:
+    status: Progressing
+    message: Waiting for FlinkSessionJob to be reconciled
+  inputPath: testdata/progressing_no_status.yaml

--- a/resource_customizations/flink.apache.org/FlinkSessionJob/testdata/degraded_error.yaml
+++ b/resource_customizations/flink.apache.org/FlinkSessionJob/testdata/degraded_error.yaml
@@ -1,0 +1,10 @@
+apiVersion: flink.apache.org/v1beta1
+kind: FlinkSessionJob
+metadata:
+  name: flink-session-job-example
+spec:
+  deploymentName: flink-session-cluster
+  job:
+    jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar
+status:
+  error: "Session cluster not found: flink-session-cluster"

--- a/resource_customizations/flink.apache.org/FlinkSessionJob/testdata/degraded_failed.yaml
+++ b/resource_customizations/flink.apache.org/FlinkSessionJob/testdata/degraded_failed.yaml
@@ -1,0 +1,12 @@
+apiVersion: flink.apache.org/v1beta1
+kind: FlinkSessionJob
+metadata:
+  name: flink-session-job-example
+spec:
+  deploymentName: flink-session-cluster
+  job:
+    jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar
+status:
+  error: "Job submission failed: Could not find a registered TaskManager"
+  jobStatus:
+    state: FAILED

--- a/resource_customizations/flink.apache.org/FlinkSessionJob/testdata/healthy_finished.yaml
+++ b/resource_customizations/flink.apache.org/FlinkSessionJob/testdata/healthy_finished.yaml
@@ -1,0 +1,11 @@
+apiVersion: flink.apache.org/v1beta1
+kind: FlinkSessionJob
+metadata:
+  name: flink-session-job-example
+spec:
+  deploymentName: flink-session-cluster
+  job:
+    jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar
+status:
+  jobStatus:
+    state: FINISHED

--- a/resource_customizations/flink.apache.org/FlinkSessionJob/testdata/healthy_running.yaml
+++ b/resource_customizations/flink.apache.org/FlinkSessionJob/testdata/healthy_running.yaml
@@ -1,0 +1,11 @@
+apiVersion: flink.apache.org/v1beta1
+kind: FlinkSessionJob
+metadata:
+  name: flink-session-job-example
+spec:
+  deploymentName: flink-session-cluster
+  job:
+    jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar
+status:
+  jobStatus:
+    state: RUNNING

--- a/resource_customizations/flink.apache.org/FlinkSessionJob/testdata/progressing_created.yaml
+++ b/resource_customizations/flink.apache.org/FlinkSessionJob/testdata/progressing_created.yaml
@@ -1,0 +1,11 @@
+apiVersion: flink.apache.org/v1beta1
+kind: FlinkSessionJob
+metadata:
+  name: flink-session-job-example
+spec:
+  deploymentName: flink-session-cluster
+  job:
+    jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar
+status:
+  jobStatus:
+    state: CREATED

--- a/resource_customizations/flink.apache.org/FlinkSessionJob/testdata/progressing_no_status.yaml
+++ b/resource_customizations/flink.apache.org/FlinkSessionJob/testdata/progressing_no_status.yaml
@@ -1,0 +1,8 @@
+apiVersion: flink.apache.org/v1beta1
+kind: FlinkSessionJob
+metadata:
+  name: flink-session-job-example
+spec:
+  deploymentName: flink-session-cluster
+  job:
+    jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar

--- a/resource_customizations/flink.apache.org/FlinkSessionJob/testdata/progressing_reconciling.yaml
+++ b/resource_customizations/flink.apache.org/FlinkSessionJob/testdata/progressing_reconciling.yaml
@@ -1,0 +1,11 @@
+apiVersion: flink.apache.org/v1beta1
+kind: FlinkSessionJob
+metadata:
+  name: flink-session-job-example
+spec:
+  deploymentName: flink-session-cluster
+  job:
+    jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar
+status:
+  jobStatus:
+    state: RECONCILING

--- a/resource_customizations/flink.apache.org/FlinkSessionJob/testdata/suspended.yaml
+++ b/resource_customizations/flink.apache.org/FlinkSessionJob/testdata/suspended.yaml
@@ -1,0 +1,11 @@
+apiVersion: flink.apache.org/v1beta1
+kind: FlinkSessionJob
+metadata:
+  name: flink-session-job-example
+spec:
+  deploymentName: flink-session-cluster
+  job:
+    jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar
+status:
+  jobStatus:
+    state: SUSPENDED


### PR DESCRIPTION
## Summary

Add built-in Lua health check for `flink.apache.org/FlinkSessionJob` CRD.

Fixes #26523

