### PR TITLE
chore(ci): remove deprecated --client flag from helm version

### DIFF
--- a/hack/installers/install-helm.sh
+++ b/hack/installers/install-helm.sh
@@ -9,4 +9,4 @@ export TARGET_FILE=helm-v${helm3_version}-${INSTALL_OS}-${ARCHITECTURE}.tar.gz
 "$(dirname "$0")"/compare-chksum.sh
 mkdir -p /tmp/helm && tar -C /tmp/helm -xf "$DOWNLOADS/${TARGET_FILE}"
 sudo install -m 0755 "/tmp/helm/$INSTALL_OS-$ARCHITECTURE/helm" "$BIN/helm"
-helm version --client
+helm version


### PR DESCRIPTION
## Summary
- Removes the deprecated `--client` flag from `helm version` in the Helm installer script
- The `--client` flag was a Helm 2 concept (client vs Tiller server). In Helm 3, there is no Tiller, so `helm version` already only shows the client version
- The flag still works but prints a deprecation warning, adding unnecessary noise to CI output

## Test plan
- [ ] Verify `make install-tools-local` completes without errors
- [ ] Confirm `helm version` output is clean (no deprecation warning)

Signed-off-by: Malik Draz <engineering@malikdraz.io>