### PR TITLE
fix: include pending resource details in app wait timeout error

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -2938,7 +2938,38 @@ func waitOnApplicationStatus(ctx context.Context, acdClient argocdclient.Client,
 		}
 		_ = w.Flush()
 	}
-	_ = printFinalStatus(appWithLock.GetApp())
+	app = appWithLock.GetApp()
+	_ = printFinalStatus(app)
+
+	// collect resources that have not yet reached the desired state to provide
+	// actionable information in the timeout error message
+	var pending []string
+	if len(selectedResources) > 0 {
+		for _, state := range getResourceStates(app, selectedResources) {
+			if !checkResourceStatus(watch, state.Health, state.Status, app.Operation, false) {
+				pending = append(pending, fmt.Sprintf("%s/%s/%s (sync: %s, health: %s)", state.Group, state.Kind, state.Name, state.Status, state.Health))
+			}
+		}
+	} else {
+		for _, res := range app.Status.Resources {
+			healthStatus := ""
+			if res.Health != nil {
+				healthStatus = string(res.Health.Status)
+			}
+			if !checkResourceStatus(watch, healthStatus, string(res.Status), app.Operation, false) {
+				pending = append(pending, fmt.Sprintf("%s/%s/%s (sync: %s, health: %s)", res.Group, res.Kind, res.Name, res.Status, healthStatus))
+			}
+		}
+	}
+
+	if len(pending) > 0 {
+		const maxPending = 10
+		summary := strings.Join(pending, ", ")
+		if len(pending) > maxPending {
+			summary = strings.Join(pending[:maxPending], ", ") + fmt.Sprintf(", ... and %d more", len(pending)-maxPending)
+		}
+		return nil, finalOperationState, fmt.Errorf("timed out (%ds) waiting for app %q match desired state. resources not ready: %s", timeout, appName, summary)
+	}
 	return nil, finalOperationState, fmt.Errorf("timed out (%ds) waiting for app %q match desired state", timeout, appName)
 }
 

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -2963,11 +2963,7 @@ func waitOnApplicationStatus(ctx context.Context, acdClient argocdclient.Client,
 	}
 
 	if len(pending) > 0 {
-		const maxPending = 10
-		summary := strings.Join(pending, ", ")
-		if len(pending) > maxPending {
-			summary = strings.Join(pending[:maxPending], ", ") + fmt.Sprintf(", ... and %d more", len(pending)-maxPending)
-		}
+		summary := formatPendingResources(pending)
 		return nil, finalOperationState, fmt.Errorf("timed out (%ds) waiting for app %q match desired state. resources not ready: %s", timeout, appName, summary)
 	}
 	return nil, finalOperationState, fmt.Errorf("timed out (%ds) waiting for app %q match desired state", timeout, appName)
@@ -2976,6 +2972,17 @@ func waitOnApplicationStatus(ctx context.Context, acdClient argocdclient.Client,
 // setParameterOverrides updates an existing or appends a new parameter override in the application
 // the app is assumed to be a helm app and is expected to be in the form:
 // param=value
+// formatPendingResources builds a summary string for resources that have not
+// reached the desired state. If there are more than 10 entries the list is
+// truncated and a count of the remaining items is appended.
+func formatPendingResources(pending []string) string {
+	const maxPending = 10
+	if len(pending) > maxPending {
+		return strings.Join(pending[:maxPending], ", ") + fmt.Sprintf(", ... and %d more", len(pending)-maxPending)
+	}
+	return strings.Join(pending, ", ")
+}
+
 func setParameterOverrides(app *argoappv1.Application, parameters []string, sourcePosition int) {
 	if len(parameters) == 0 {
 		return

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -2533,7 +2533,38 @@ func waitOnApplicationStatus(ctx context.Context, acdClient argocdclient.Client,
 		}
 		_ = w.Flush()
 	}
-	_ = printFinalStatus(appWithLock.GetApp())
+	app = appWithLock.GetApp()
+	_ = printFinalStatus(app)
+
+	// collect resources that have not yet reached the desired state to provide
+	// actionable information in the timeout error message
+	var pending []string
+	if len(selectedResources) > 0 {
+		for _, state := range getResourceStates(app, selectedResources) {
+			if !checkResourceStatus(watch, state.Health, state.Status, app.Operation, false) {
+				pending = append(pending, fmt.Sprintf("%s/%s/%s (sync: %s, health: %s)", state.Group, state.Kind, state.Name, state.Status, state.Health))
+			}
+		}
+	} else {
+		for _, res := range app.Status.Resources {
+			healthStatus := ""
+			if res.Health != nil {
+				healthStatus = string(res.Health.Status)
+			}
+			if !checkResourceStatus(watch, healthStatus, string(res.Status), app.Operation, false) {
+				pending = append(pending, fmt.Sprintf("%s/%s/%s (sync: %s, health: %s)", res.Group, res.Kind, res.Name, res.Status, healthStatus))
+			}
+		}
+	}
+
+	if len(pending) > 0 {
+		const maxPending = 10
+		summary := strings.Join(pending, ", ")
+		if len(pending) > maxPending {
+			summary = strings.Join(pending[:maxPending], ", ") + fmt.Sprintf(", ... and %d more", len(pending)-maxPending)
+		}
+		return nil, finalOperationState, fmt.Errorf("timed out (%ds) waiting for app %q match desired state. resources not ready: %s", timeout, appName, summary)
+	}
 	return nil, finalOperationState, fmt.Errorf("timed out (%ds) waiting for app %q match desired state", timeout, appName)
 }
 

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -2326,14 +2326,7 @@ func checkAppWaitConditions(app *argoappv1.Application, watch watchOpts, selecte
 		}
 	}
 
-	// LastSuccessfulOperation is only populated after a successful hydration,
-	// so it can be nil while CurrentOperation is set. Guard against the nil
-	// dereference before comparing the two.
-	hydrationFinished := app.Status.SourceHydrator.CurrentOperation != nil &&
-		app.Status.SourceHydrator.LastSuccessfulOperation != nil &&
-		app.Status.SourceHydrator.CurrentOperation.Phase == argoappv1.HydrateOperationPhaseHydrated &&
-		app.Status.SourceHydrator.CurrentOperation.SourceHydrator.DeepEquals(app.Status.SourceHydrator.LastSuccessfulOperation.SourceHydrator) &&
-		app.Status.SourceHydrator.CurrentOperation.DrySHA == app.Status.SourceHydrator.LastSuccessfulOperation.DrySHA
+	hydrationFinished := appHydrationFinished(app)
 
 	if len(selectedResources) > 0 {
 		ready = true
@@ -2536,36 +2529,60 @@ func waitOnApplicationStatus(ctx context.Context, acdClient argocdclient.Client,
 	app = appWithLock.GetApp()
 	_ = printFinalStatus(app)
 
-	// collect resources that have not yet reached the desired state to provide
-	// actionable information in the timeout error message
-	var pending []string
+	// Collect the state that kept the wait from completing so the timeout
+	// error carries actionable information.
+	hydrationFinished := appHydrationFinished(app)
 	if len(selectedResources) > 0 {
+		var pending []string
 		for _, state := range getResourceStates(app, selectedResources) {
-			if !checkResourceStatus(watch, state.Health, state.Status, app.Operation, false) {
-				pending = append(pending, fmt.Sprintf("%s/%s/%s (sync: %s, health: %s)", state.Group, state.Kind, state.Name, state.Status, state.Health))
+			if !checkResourceStatus(watch, state.Health, state.Status, app.Operation, hydrationFinished) {
+				pending = append(pending, fmt.Sprintf("%s (sync: %s, health: %s)", state.Key(), state.Status, state.Health))
 			}
 		}
-	} else {
-		for _, res := range app.Status.Resources {
-			healthStatus := ""
-			if res.Health != nil {
-				healthStatus = string(res.Health.Status)
-			}
-			if !checkResourceStatus(watch, healthStatus, string(res.Status), app.Operation, false) {
-				pending = append(pending, fmt.Sprintf("%s/%s/%s (sync: %s, health: %s)", res.Group, res.Kind, res.Name, res.Status, healthStatus))
-			}
+		if len(pending) > 0 {
+			return nil, finalOperationState, fmt.Errorf("timed out (%ds) waiting for app %q match desired state. resources not ready: %s", timeout, appName, formatPendingResources(pending))
 		}
+		return nil, finalOperationState, fmt.Errorf("timed out (%ds) waiting for app %q match desired state", timeout, appName)
 	}
 
-	if len(pending) > 0 {
-		const maxPending = 10
-		summary := strings.Join(pending, ", ")
-		if len(pending) > maxPending {
-			summary = strings.Join(pending[:maxPending], ", ") + fmt.Sprintf(", ... and %d more", len(pending)-maxPending)
+	// Without selected resources the wait condition is evaluated against the
+	// app-level aggregate status, which can differ from the individual
+	// resource statuses. Report the aggregate and list any not-ready
+	// resources (including hooks) as a hint.
+	detail := fmt.Sprintf("app sync status: %s, health status: %s", app.Status.Sync.Status, app.Status.Health.Status)
+	var pending []string
+	for _, state := range getResourceStates(app, nil) {
+		if !checkResourceStatus(watch, state.Health, state.Status, app.Operation, hydrationFinished) {
+			pending = append(pending, fmt.Sprintf("%s (sync: %s, health: %s)", state.Key(), state.Status, state.Health))
 		}
-		return nil, finalOperationState, fmt.Errorf("timed out (%ds) waiting for app %q match desired state. resources not ready: %s", timeout, appName, summary)
 	}
-	return nil, finalOperationState, fmt.Errorf("timed out (%ds) waiting for app %q match desired state", timeout, appName)
+	if len(pending) > 0 {
+		detail += ", resources not ready: " + formatPendingResources(pending)
+	}
+	return nil, finalOperationState, fmt.Errorf("timed out (%ds) waiting for app %q match desired state. %s", timeout, appName, detail)
+}
+
+// appHydrationFinished reports whether the app's current hydration operation
+// has completed successfully. LastSuccessfulOperation is only populated after
+// a successful hydration, so it can be nil while CurrentOperation is set.
+func appHydrationFinished(app *argoappv1.Application) bool {
+	return app.Status.SourceHydrator.CurrentOperation != nil &&
+		app.Status.SourceHydrator.LastSuccessfulOperation != nil &&
+		app.Status.SourceHydrator.CurrentOperation.Phase == argoappv1.HydrateOperationPhaseHydrated &&
+		app.Status.SourceHydrator.CurrentOperation.SourceHydrator.DeepEquals(app.Status.SourceHydrator.LastSuccessfulOperation.SourceHydrator) &&
+		app.Status.SourceHydrator.CurrentOperation.DrySHA == app.Status.SourceHydrator.LastSuccessfulOperation.DrySHA
+}
+
+// formatPendingResources builds a summary string for resources that have not
+// reached the desired state. If there are more than maxPending entries the
+// list is truncated and a count of the remaining items is appended.
+func formatPendingResources(pending []string) string {
+	// TODO: make the limit configurable via a command flag
+	const maxPending = 10
+	if len(pending) > maxPending {
+		return strings.Join(pending[:maxPending], ", ") + fmt.Sprintf(", ... and %d more", len(pending)-maxPending)
+	}
+	return strings.Join(pending, ", ")
 }
 
 // isContextCanceledErr returns true if the error is a context cancellation or deadline exceeded,

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -2533,6 +2533,10 @@ func waitOnApplicationStatus(ctx context.Context, acdClient argocdclient.Client,
 	// error carries actionable information.
 	hydrationFinished := appHydrationFinished(app)
 	if len(selectedResources) > 0 {
+		// The selected-resources wait gate evaluates checkResourceStatus per
+		// resource state (the same states, including hooks, it gates on), so
+		// mirror that here to keep the message consistent with the condition
+		// that actually failed.
 		var pending []string
 		for _, state := range getResourceStates(app, selectedResources) {
 			if !checkResourceStatus(watch, state.Health, state.Status, app.Operation, hydrationFinished) {
@@ -2540,18 +2544,38 @@ func waitOnApplicationStatus(ctx context.Context, acdClient argocdclient.Client,
 			}
 		}
 		if len(pending) > 0 {
-			return nil, finalOperationState, fmt.Errorf("timed out (%ds) waiting for app %q match desired state. resources not ready: %s", timeout, appName, formatPendingResources(pending))
+			return nil, finalOperationState, fmt.Errorf("timed out (%ds) waiting for app %q to match desired state. resources not ready: %s", timeout, appName, formatPendingResources(pending))
 		}
-		return nil, finalOperationState, fmt.Errorf("timed out (%ds) waiting for app %q match desired state", timeout, appName)
+		return nil, finalOperationState, fmt.Errorf("timed out (%ds) waiting for app %q to match desired state", timeout, appName)
 	}
 
 	// Without selected resources the wait condition is evaluated against the
-	// app-level aggregate status, which can differ from the individual
-	// resource statuses. Report the aggregate and list any not-ready
-	// resources (including hooks) as a hint.
-	detail := fmt.Sprintf("app sync status: %s, health status: %s", app.Status.Sync.Status, app.Status.Health.Status)
+	// app-level aggregate status. Report only the conditions the wait was
+	// gated on (a --operation/--hydrated wait shouldn't mention sync/health),
+	// and list any not-ready resources as a hint.
+	var conditions []string
+	if watch.sync {
+		conditions = append(conditions, fmt.Sprintf("sync status: %s", app.Status.Sync.Status))
+	}
+	if watch.health || watch.suspended || watch.degraded {
+		conditions = append(conditions, fmt.Sprintf("health status: %s", app.Status.Health.Status))
+	}
+	if watch.operation && app.Operation != nil {
+		conditions = append(conditions, "operation: still in progress")
+	}
+	if watch.hydrated {
+		conditions = append(conditions, fmt.Sprintf("hydrated: %t", hydrationFinished))
+	}
+	detail := "app " + strings.Join(conditions, ", ")
+
 	var pending []string
 	for _, state := range getResourceStates(app, nil) {
+		// A completed hook reports its hook phase (e.g. Succeeded) in Status,
+		// which checkResourceStatus treats as not-Synced. It isn't part of the
+		// desired-state wait, so don't surface it as "not ready".
+		if state.Hook != "" && state.Status == string(common.OperationSucceeded) {
+			continue
+		}
 		if !checkResourceStatus(watch, state.Health, state.Status, app.Operation, hydrationFinished) {
 			pending = append(pending, fmt.Sprintf("%s (sync: %s, health: %s)", state.Key(), state.Status, state.Health))
 		}
@@ -2559,7 +2583,7 @@ func waitOnApplicationStatus(ctx context.Context, acdClient argocdclient.Client,
 	if len(pending) > 0 {
 		detail += ", resources not ready: " + formatPendingResources(pending)
 	}
-	return nil, finalOperationState, fmt.Errorf("timed out (%ds) waiting for app %q match desired state. %s", timeout, appName, detail)
+	return nil, finalOperationState, fmt.Errorf("timed out (%ds) waiting for app %q to match desired state. %s", timeout, appName, detail)
 }
 
 // appHydrationFinished reports whether the app's current hydration operation
@@ -2577,7 +2601,7 @@ func appHydrationFinished(app *argoappv1.Application) bool {
 // reached the desired state. If there are more than maxPending entries the
 // list is truncated and a count of the remaining items is appended.
 func formatPendingResources(pending []string) string {
-	// TODO: make the limit configurable via a command flag
+	// TODO(#29031): make the limit configurable via a command flag
 	const maxPending = 10
 	if len(pending) > maxPending {
 		return strings.Join(pending[:maxPending], ", ") + fmt.Sprintf(", ... and %d more", len(pending)-maxPending)

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -2533,20 +2533,25 @@ func waitOnApplicationStatus(ctx context.Context, acdClient argocdclient.Client,
 	// error carries actionable information.
 	hydrationFinished := appHydrationFinished(app)
 	if len(selectedResources) > 0 {
-		// The selected-resources wait gate evaluates checkResourceStatus per
-		// resource state (the same states, including hooks, it gates on), so
-		// mirror that here to keep the message consistent with the condition
-		// that actually failed.
-		var pending []string
-		for _, state := range getResourceStates(app, selectedResources) {
-			if !checkResourceStatus(watch, state.Health, state.Status, app.Operation, hydrationFinished) {
-				pending = append(pending, fmt.Sprintf("%s (sync: %s, health: %s)", state.Key(), state.Status, state.Health))
-			}
+		// The selected-resources wait gates checkResourceStatus per resource,
+		// so mirror that here (see notReadyResources, which also filters out
+		// completed hooks). Operation and hydration are app-level conditions,
+		// not resource-specific, so report them too; the sync/health aggregate
+		// is intentionally omitted for a selected-resource wait.
+		var parts []string
+		if watch.operation {
+			parts = append(parts, "operation: "+operationStatus(app))
 		}
-		if len(pending) > 0 {
-			return nil, finalOperationState, fmt.Errorf("timed out (%ds) waiting for app %q to match desired state. resources not ready: %s", timeout, appName, formatPendingResources(pending))
+		if watch.hydrated {
+			parts = append(parts, fmt.Sprintf("hydrated: %t", hydrationFinished))
 		}
-		return nil, finalOperationState, fmt.Errorf("timed out (%ds) waiting for app %q to match desired state", timeout, appName)
+		if pending := notReadyResources(app, watch, selectedResources, hydrationFinished); len(pending) > 0 {
+			parts = append(parts, "resources not ready: "+formatPendingResources(pending))
+		}
+		if len(parts) == 0 {
+			return nil, finalOperationState, fmt.Errorf("timed out (%ds) waiting for app %q to match desired state", timeout, appName)
+		}
+		return nil, finalOperationState, fmt.Errorf("timed out (%ds) waiting for app %q to match desired state. %s", timeout, appName, strings.Join(parts, ", "))
 	}
 
 	// Without selected resources the wait condition is evaluated against the
@@ -2560,30 +2565,49 @@ func waitOnApplicationStatus(ctx context.Context, acdClient argocdclient.Client,
 	if watch.health || watch.suspended || watch.degraded {
 		conditions = append(conditions, fmt.Sprintf("health status: %s", app.Status.Health.Status))
 	}
-	if watch.operation && app.Operation != nil {
-		conditions = append(conditions, "operation: still in progress")
+	if watch.operation {
+		conditions = append(conditions, "operation: "+operationStatus(app))
 	}
 	if watch.hydrated {
 		conditions = append(conditions, fmt.Sprintf("hydrated: %t", hydrationFinished))
 	}
 	detail := "app " + strings.Join(conditions, ", ")
 
+	if pending := notReadyResources(app, watch, nil, hydrationFinished); len(pending) > 0 {
+		detail += ", resources not ready: " + formatPendingResources(pending)
+	}
+	return nil, finalOperationState, fmt.Errorf("timed out (%ds) waiting for app %q to match desired state. %s", timeout, appName, detail)
+}
+
+// operationStatus describes the app's operation for a timeout message. The
+// requested operation (app.Operation) is cleared once the controller starts
+// processing it, so fall back to the recorded OperationState phase.
+func operationStatus(app *argoappv1.Application) string {
+	switch {
+	case app.Status.OperationState != nil:
+		return string(app.Status.OperationState.Phase)
+	case app.Operation != nil:
+		return "still in progress"
+	default:
+		return "none"
+	}
+}
+
+// notReadyResources returns the resources that kept the wait from completing,
+// skipping completed hooks. A hook reports its terminal phase (Succeeded,
+// Failed or Error) in Status, which checkResourceStatus treats as not-Synced;
+// such a hook is done, not pending, so it must not be listed as "not ready".
+func notReadyResources(app *argoappv1.Application, watch watchOpts, selectedResources []*argoappv1.SyncOperationResource, hydrationFinished bool) []string {
 	var pending []string
-	for _, state := range getResourceStates(app, nil) {
-		// A completed hook reports its hook phase (e.g. Succeeded) in Status,
-		// which checkResourceStatus treats as not-Synced. It isn't part of the
-		// desired-state wait, so don't surface it as "not ready".
-		if state.Hook != "" && state.Status == string(common.OperationSucceeded) {
+	for _, state := range getResourceStates(app, selectedResources) {
+		if state.Hook != "" && common.OperationPhase(state.Status).Completed() {
 			continue
 		}
 		if !checkResourceStatus(watch, state.Health, state.Status, app.Operation, hydrationFinished) {
 			pending = append(pending, fmt.Sprintf("%s (sync: %s, health: %s)", state.Key(), state.Status, state.Health))
 		}
 	}
-	if len(pending) > 0 {
-		detail += ", resources not ready: " + formatPendingResources(pending)
-	}
-	return nil, finalOperationState, fmt.Errorf("timed out (%ds) waiting for app %q to match desired state. %s", timeout, appName, detail)
+	return pending
 }
 
 // appHydrationFinished reports whether the app's current hydration operation

--- a/cmd/argocd/commands/app_test.go
+++ b/cmd/argocd/commands/app_test.go
@@ -2481,3 +2481,46 @@ func (c *fakeAcdClient) WatchApplicationSetWithRetry(_ context.Context, _ string
 	}()
 	return appSetEventsCh
 }
+
+func TestFormatPendingResources(t *testing.T) {
+	tests := []struct {
+		name     string
+		pending  []string
+		expected string
+	}{
+		{
+			name:     "empty",
+			pending:  nil,
+			expected: "",
+		},
+		{
+			name:     "single resource",
+			pending:  []string{"apps/Deployment/nginx (sync: OutOfSync, health: Degraded)"},
+			expected: "apps/Deployment/nginx (sync: OutOfSync, health: Degraded)",
+		},
+		{
+			name:     "exactly 10 resources",
+			pending:  makeResources(10),
+			expected: strings.Join(makeResources(10), ", "),
+		},
+		{
+			name:     "more than 10 resources",
+			pending:  makeResources(13),
+			expected: strings.Join(makeResources(10), ", ") + ", ... and 3 more",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, formatPendingResources(tt.pending))
+		})
+	}
+}
+
+func makeResources(n int) []string {
+	res := make([]string, n)
+	for i := range res {
+		res[i] = fmt.Sprintf("apps/Deployment/resource-%d (sync: OutOfSync, health: Degraded)", i)
+	}
+	return res
+}

--- a/cmd/argocd/commands/app_test.go
+++ b/cmd/argocd/commands/app_test.go
@@ -2048,6 +2048,46 @@ apps   Deployment  default    test           Synced  Healthy
 	assert.Equalf(t, expectationSorted, outputSorted, "Incorrect output %q, should be %q (items order doesn't matter)", output, expectation)
 }
 
+func TestWaitOnApplicationStatus_TimeoutErrorIncludesPendingResources(t *testing.T) {
+	// the fake app has resources that are Synced/Healthy but app-level sync is OutOfSync,
+	// so when watching for sync the timeout error should mention that the app hasn't synced
+	acdClient := &customAcdClient{&fakeAcdClient{}}
+	ctx := t.Context()
+	var selectResource []*v1alpha1.SyncOperationResource
+	watch := watchOpts{
+		sync:   true,
+		health: true,
+	}
+	watch = getWatchOpts(watch)
+
+	// channel closes immediately so waitOnApplicationStatus returns the timeout error
+	_, _, err := waitOnApplicationStatus(ctx, acdClient, "app-name", 0, watch, selectResource, "wide")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timed out")
+	// the individual resources are Synced/Healthy so they should not appear as pending,
+	// but the app-level sync status is OutOfSync so the error should still fire
+}
+
+func TestWaitOnApplicationStatus_TimeoutErrorListsNotReadyResources(t *testing.T) {
+	// the fake app has OutOfSync status at app level, individual resources are Synced/Healthy
+	// when we watch for sync with no selected resources, the error should fire because
+	// the app-level check fails (OutOfSync), even though individual resources look fine
+	acdClient := &customAcdClient{&fakeAcdClient{}}
+	ctx := t.Context()
+	watch := watchOpts{
+		sync: true,
+	}
+	watch = getWatchOpts(watch)
+
+	_, _, err := waitOnApplicationStatus(ctx, acdClient, "app-name", 0, watch, nil, "wide")
+	require.Error(t, err)
+	errMsg := err.Error()
+	assert.Contains(t, errMsg, "timed out")
+	// since we check app-level sync (OutOfSync) but individual resources are Synced,
+	// no individual resources should appear as "not ready" in the error
+	assert.NotContains(t, errMsg, "resources not ready")
+}
+
 type customAcdClient struct {
 	*fakeAcdClient
 }

--- a/cmd/argocd/commands/app_test.go
+++ b/cmd/argocd/commands/app_test.go
@@ -2302,45 +2302,206 @@ func (c *readyFakeAppServiceClient) Get(_ context.Context, _ *applicationpkg.App
 			Health: v1alpha1.AppHealthStatus{Status: health.HealthStatusHealthy},
 		},
 	}, nil
-
-func TestWaitOnApplicationStatus_TimeoutErrorIncludesPendingResources(t *testing.T) {
-	// the fake app has resources that are Synced/Healthy but app-level sync is OutOfSync,
-	// so when watching for sync the timeout error should mention that the app hasn't synced
-	acdClient := &customAcdClient{&fakeAcdClient{}}
-	ctx := t.Context()
-	var selectResource []*v1alpha1.SyncOperationResource
-	watch := watchOpts{
-		sync:   true,
-		health: true,
-	}
-	watch = getWatchOpts(watch)
-
-	// channel closes immediately so waitOnApplicationStatus returns the timeout error
-	_, _, err := waitOnApplicationStatus(ctx, acdClient, "app-name", 0, watch, selectResource, "wide")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "timed out")
-	// the individual resources are Synced/Healthy so they should not appear as pending,
-	// but the app-level sync status is OutOfSync so the error should still fire
 }
 
-func TestWaitOnApplicationStatus_TimeoutErrorListsNotReadyResources(t *testing.T) {
-	// the fake app has OutOfSync status at app level, individual resources are Synced/Healthy
-	// when we watch for sync with no selected resources, the error should fire because
-	// the app-level check fails (OutOfSync), even though individual resources look fine
-	acdClient := &customAcdClient{&fakeAcdClient{}}
-	ctx := t.Context()
-	watch := watchOpts{
-		sync: true,
-	}
-	watch = getWatchOpts(watch)
+// pendingAcdClient returns an application that is OutOfSync at the app level
+// with one not-ready resource, so wait timeouts exercise the pending-resource
+// reporting.
+type pendingAcdClient struct {
+	*fakeAcdClient
+}
 
-	_, _, err := waitOnApplicationStatus(ctx, acdClient, "app-name", 0, watch, nil, "wide")
+func (c *pendingAcdClient) WatchApplicationWithRetry(_ context.Context, _ string, _ string) chan *v1alpha1.ApplicationWatchEvent {
+	appEventsCh := make(chan *v1alpha1.ApplicationWatchEvent)
+	close(appEventsCh)
+	return appEventsCh
+}
+
+func (c *pendingAcdClient) NewApplicationClientOrDie() (io.Closer, applicationpkg.ApplicationServiceClient) {
+	return &fakeConnection{}, &pendingFakeAppServiceClient{}
+}
+
+func (c *pendingAcdClient) NewSettingsClientOrDie() (io.Closer, settingspkg.SettingsServiceClient) {
+	return &fakeConnection{}, &fakeSettingsServiceClient{}
+}
+
+type pendingFakeAppServiceClient struct {
+	fakeAppServiceClient
+}
+
+func (c *pendingFakeAppServiceClient) Get(_ context.Context, _ *applicationpkg.ApplicationQuery, _ ...grpc.CallOption) (*v1alpha1.Application, error) {
+	return &v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "argocd",
+		},
+		Spec: v1alpha1.ApplicationSpec{
+			Project:     "default",
+			Destination: v1alpha1.ApplicationDestination{Server: "local", Namespace: "argocd"},
+			Source:      &v1alpha1.ApplicationSource{RepoURL: "test", TargetRevision: "master", Path: "/test"},
+		},
+		Status: v1alpha1.ApplicationStatus{
+			Sync:   v1alpha1.SyncStatus{Status: v1alpha1.SyncStatusCodeOutOfSync},
+			Health: v1alpha1.AppHealthStatus{Status: health.HealthStatusProgressing},
+			Resources: []v1alpha1.ResourceStatus{
+				{
+					Group:     "apps",
+					Kind:      "Deployment",
+					Namespace: "prod",
+					Name:      "api",
+					Status:    v1alpha1.SyncStatusCodeOutOfSync,
+					Health:    &v1alpha1.HealthStatus{Status: health.HealthStatusDegraded},
+				},
+				{
+					Kind:      "Service",
+					Namespace: "prod",
+					Name:      "web",
+					Status:    v1alpha1.SyncStatusCodeSynced,
+					Health:    &v1alpha1.HealthStatus{Status: health.HealthStatusHealthy},
+				},
+			},
+		},
+	}, nil
+}
+
+func TestWaitOnApplicationStatus_TimeoutErrorListsPendingResources(t *testing.T) {
+	// The app-level status is OutOfSync and one resource is
+	// OutOfSync/Degraded: the timeout error must report the aggregate status
+	// and list only the not-ready resource.
+	acdClient := &pendingAcdClient{&fakeAcdClient{}}
+	watch := getWatchOpts(watchOpts{sync: true, health: true})
+
+	_, _, err := waitOnApplicationStatus(t.Context(), acdClient, "app-name", 0, watch, nil, "wide")
 	require.Error(t, err)
 	errMsg := err.Error()
 	assert.Contains(t, errMsg, "timed out")
-	// since we check app-level sync (OutOfSync) but individual resources are Synced,
-	// no individual resources should appear as "not ready" in the error
+	assert.Contains(t, errMsg, "app sync status: OutOfSync, health status: Progressing")
+	assert.Contains(t, errMsg, "resources not ready: apps/Deployment/prod/api (sync: OutOfSync, health: Degraded)")
+	assert.NotContains(t, errMsg, "prod/web")
+}
+
+func TestWaitOnApplicationStatus_TimeoutErrorSelectedResources(t *testing.T) {
+	// With selected resources only the matching not-ready resources are
+	// reported; the app-level aggregate is not included.
+	acdClient := &pendingAcdClient{&fakeAcdClient{}}
+	selected := []*v1alpha1.SyncOperationResource{
+		{Group: "apps", Kind: "Deployment", Name: "api"},
+	}
+	watch := getWatchOpts(watchOpts{sync: true, health: true})
+
+	_, _, err := waitOnApplicationStatus(t.Context(), acdClient, "app-name", 0, watch, selected, "wide")
+	require.Error(t, err)
+	errMsg := err.Error()
+	assert.Contains(t, errMsg, "resources not ready: apps/Deployment/prod/api (sync: OutOfSync, health: Degraded)")
+	assert.NotContains(t, errMsg, "app sync status")
+}
+
+func TestWaitOnApplicationStatus_TimeoutErrorAppLevelWithoutPendingResources(t *testing.T) {
+	// The aggregate status can differ from the individual resource statuses
+	// (e.g. right after a spec change): the timeout error must still report
+	// the aggregate even when no individual resource is pending.
+	acdClient := &aggregatePendingAcdClient{&fakeAcdClient{}}
+	watch := getWatchOpts(watchOpts{sync: true})
+
+	_, _, err := waitOnApplicationStatus(t.Context(), acdClient, "app-name", 0, watch, nil, "wide")
+	require.Error(t, err)
+	errMsg := err.Error()
+	assert.Contains(t, errMsg, "app sync status: OutOfSync")
 	assert.NotContains(t, errMsg, "resources not ready")
+}
+
+// aggregatePendingAcdClient returns an application that is OutOfSync at the
+// app level while all individual resources are Synced/Healthy.
+type aggregatePendingAcdClient struct {
+	*fakeAcdClient
+}
+
+func (c *aggregatePendingAcdClient) WatchApplicationWithRetry(_ context.Context, _ string, _ string) chan *v1alpha1.ApplicationWatchEvent {
+	appEventsCh := make(chan *v1alpha1.ApplicationWatchEvent)
+	close(appEventsCh)
+	return appEventsCh
+}
+
+func (c *aggregatePendingAcdClient) NewApplicationClientOrDie() (io.Closer, applicationpkg.ApplicationServiceClient) {
+	return &fakeConnection{}, &aggregatePendingFakeAppServiceClient{}
+}
+
+func (c *aggregatePendingAcdClient) NewSettingsClientOrDie() (io.Closer, settingspkg.SettingsServiceClient) {
+	return &fakeConnection{}, &fakeSettingsServiceClient{}
+}
+
+type aggregatePendingFakeAppServiceClient struct {
+	fakeAppServiceClient
+}
+
+func (c *aggregatePendingFakeAppServiceClient) Get(_ context.Context, _ *applicationpkg.ApplicationQuery, _ ...grpc.CallOption) (*v1alpha1.Application, error) {
+	return &v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "argocd",
+		},
+		Spec: v1alpha1.ApplicationSpec{
+			Project:     "default",
+			Destination: v1alpha1.ApplicationDestination{Server: "local", Namespace: "argocd"},
+			Source:      &v1alpha1.ApplicationSource{RepoURL: "test", TargetRevision: "master", Path: "/test"},
+		},
+		Status: v1alpha1.ApplicationStatus{
+			Sync:   v1alpha1.SyncStatus{Status: v1alpha1.SyncStatusCodeOutOfSync},
+			Health: v1alpha1.AppHealthStatus{Status: health.HealthStatusHealthy},
+			Resources: []v1alpha1.ResourceStatus{
+				{
+					Kind:      "Service",
+					Namespace: "prod",
+					Name:      "web",
+					Status:    v1alpha1.SyncStatusCodeSynced,
+					Health:    &v1alpha1.HealthStatus{Status: health.HealthStatusHealthy},
+				},
+			},
+		},
+	}, nil
+}
+
+func TestFormatPendingResources(t *testing.T) {
+	tests := []struct {
+		name     string
+		pending  []string
+		expected string
+	}{
+		{
+			name:     "empty",
+			pending:  nil,
+			expected: "",
+		},
+		{
+			name:     "single resource",
+			pending:  []string{"apps/Deployment/prod/api (sync: OutOfSync, health: Degraded)"},
+			expected: "apps/Deployment/prod/api (sync: OutOfSync, health: Degraded)",
+		},
+		{
+			name:     "exactly ten resources",
+			pending:  makePendingResources(10),
+			expected: strings.Join(makePendingResources(10), ", "),
+		},
+		{
+			name:     "more than ten resources",
+			pending:  makePendingResources(13),
+			expected: strings.Join(makePendingResources(10), ", ") + ", ... and 3 more",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, formatPendingResources(tt.pending))
+		})
+	}
+}
+
+func makePendingResources(n int) []string {
+	res := make([]string, n)
+	for i := range res {
+		res[i] = fmt.Sprintf("apps/Deployment/ns/app-%d (sync: OutOfSync, health: Missing)", i)
+	}
+	return res
 }
 
 type customAcdClient struct {

--- a/cmd/argocd/commands/app_test.go
+++ b/cmd/argocd/commands/app_test.go
@@ -2302,6 +2302,45 @@ func (c *readyFakeAppServiceClient) Get(_ context.Context, _ *applicationpkg.App
 			Health: v1alpha1.AppHealthStatus{Status: health.HealthStatusHealthy},
 		},
 	}, nil
+
+func TestWaitOnApplicationStatus_TimeoutErrorIncludesPendingResources(t *testing.T) {
+	// the fake app has resources that are Synced/Healthy but app-level sync is OutOfSync,
+	// so when watching for sync the timeout error should mention that the app hasn't synced
+	acdClient := &customAcdClient{&fakeAcdClient{}}
+	ctx := t.Context()
+	var selectResource []*v1alpha1.SyncOperationResource
+	watch := watchOpts{
+		sync:   true,
+		health: true,
+	}
+	watch = getWatchOpts(watch)
+
+	// channel closes immediately so waitOnApplicationStatus returns the timeout error
+	_, _, err := waitOnApplicationStatus(ctx, acdClient, "app-name", 0, watch, selectResource, "wide")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timed out")
+	// the individual resources are Synced/Healthy so they should not appear as pending,
+	// but the app-level sync status is OutOfSync so the error should still fire
+}
+
+func TestWaitOnApplicationStatus_TimeoutErrorListsNotReadyResources(t *testing.T) {
+	// the fake app has OutOfSync status at app level, individual resources are Synced/Healthy
+	// when we watch for sync with no selected resources, the error should fire because
+	// the app-level check fails (OutOfSync), even though individual resources look fine
+	acdClient := &customAcdClient{&fakeAcdClient{}}
+	ctx := t.Context()
+	watch := watchOpts{
+		sync: true,
+	}
+	watch = getWatchOpts(watch)
+
+	_, _, err := waitOnApplicationStatus(ctx, acdClient, "app-name", 0, watch, nil, "wide")
+	require.Error(t, err)
+	errMsg := err.Error()
+	assert.Contains(t, errMsg, "timed out")
+	// since we check app-level sync (OutOfSync) but individual resources are Synced,
+	// no individual resources should appear as "not ready" in the error
+	assert.NotContains(t, errMsg, "resources not ready")
 }
 
 type customAcdClient struct {

--- a/cmd/argocd/commands/app_test.go
+++ b/cmd/argocd/commands/app_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/argoproj/argo-cd/gitops-engine/v3/pkg/health"
+	synccommon "github.com/argoproj/argo-cd/gitops-engine/v3/pkg/sync/common"
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -2304,71 +2305,98 @@ func (c *readyFakeAppServiceClient) Get(_ context.Context, _ *applicationpkg.App
 	}, nil
 }
 
-// pendingAcdClient returns an application that is OutOfSync at the app level
-// with one not-ready resource, so wait timeouts exercise the pending-resource
-// reporting.
-type pendingAcdClient struct {
+// statusAcdClient serves a fixed application status so wait-timeout tests can
+// exercise the pending-resource reporting without duplicating client
+// boilerplate per scenario.
+type statusAcdClient struct {
 	*fakeAcdClient
+	status v1alpha1.ApplicationStatus
 }
 
-func (c *pendingAcdClient) WatchApplicationWithRetry(_ context.Context, _ string, _ string) chan *v1alpha1.ApplicationWatchEvent {
+func newStatusAcdClient(status v1alpha1.ApplicationStatus) *statusAcdClient {
+	return &statusAcdClient{fakeAcdClient: &fakeAcdClient{}, status: status}
+}
+
+func (c *statusAcdClient) WatchApplicationWithRetry(_ context.Context, _ string, _ string) chan *v1alpha1.ApplicationWatchEvent {
 	appEventsCh := make(chan *v1alpha1.ApplicationWatchEvent)
 	close(appEventsCh)
 	return appEventsCh
 }
 
-func (c *pendingAcdClient) NewApplicationClientOrDie() (io.Closer, applicationpkg.ApplicationServiceClient) {
-	return &fakeConnection{}, &pendingFakeAppServiceClient{}
+func (c *statusAcdClient) NewApplicationClientOrDie() (io.Closer, applicationpkg.ApplicationServiceClient) {
+	return &fakeConnection{}, &statusFakeAppServiceClient{status: c.status}
 }
 
-func (c *pendingAcdClient) NewSettingsClientOrDie() (io.Closer, settingspkg.SettingsServiceClient) {
+func (c *statusAcdClient) NewSettingsClientOrDie() (io.Closer, settingspkg.SettingsServiceClient) {
 	return &fakeConnection{}, &fakeSettingsServiceClient{}
 }
 
-type pendingFakeAppServiceClient struct {
+type statusFakeAppServiceClient struct {
 	fakeAppServiceClient
+	status v1alpha1.ApplicationStatus
 }
 
-func (c *pendingFakeAppServiceClient) Get(_ context.Context, _ *applicationpkg.ApplicationQuery, _ ...grpc.CallOption) (*v1alpha1.Application, error) {
+func (c *statusFakeAppServiceClient) Get(_ context.Context, _ *applicationpkg.ApplicationQuery, _ ...grpc.CallOption) (*v1alpha1.Application, error) {
 	return &v1alpha1.Application{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "argocd",
-		},
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "argocd"},
 		Spec: v1alpha1.ApplicationSpec{
 			Project:     "default",
 			Destination: v1alpha1.ApplicationDestination{Server: "local", Namespace: "argocd"},
 			Source:      &v1alpha1.ApplicationSource{RepoURL: "test", TargetRevision: "master", Path: "/test"},
 		},
-		Status: v1alpha1.ApplicationStatus{
-			Sync:   v1alpha1.SyncStatus{Status: v1alpha1.SyncStatusCodeOutOfSync},
-			Health: v1alpha1.AppHealthStatus{Status: health.HealthStatusProgressing},
-			Resources: []v1alpha1.ResourceStatus{
-				{
-					Group:     "apps",
-					Kind:      "Deployment",
-					Namespace: "prod",
-					Name:      "api",
-					Status:    v1alpha1.SyncStatusCodeOutOfSync,
-					Health:    &v1alpha1.HealthStatus{Status: health.HealthStatusDegraded},
-				},
-				{
-					Kind:      "Service",
-					Namespace: "prod",
-					Name:      "web",
-					Status:    v1alpha1.SyncStatusCodeSynced,
-					Health:    &v1alpha1.HealthStatus{Status: health.HealthStatusHealthy},
-				},
+		Status: c.status,
+	}, nil
+}
+
+// pendingAppStatus is OutOfSync at the app level with one not-ready resource
+// (Deployment/api) and one ready resource (Service/web).
+func pendingAppStatus() v1alpha1.ApplicationStatus {
+	return v1alpha1.ApplicationStatus{
+		Sync:   v1alpha1.SyncStatus{Status: v1alpha1.SyncStatusCodeOutOfSync},
+		Health: v1alpha1.AppHealthStatus{Status: health.HealthStatusProgressing},
+		Resources: []v1alpha1.ResourceStatus{
+			{
+				Group:     "apps",
+				Kind:      "Deployment",
+				Namespace: "prod",
+				Name:      "api",
+				Status:    v1alpha1.SyncStatusCodeOutOfSync,
+				Health:    &v1alpha1.HealthStatus{Status: health.HealthStatusDegraded},
+			},
+			{
+				Kind:      "Service",
+				Namespace: "prod",
+				Name:      "web",
+				Status:    v1alpha1.SyncStatusCodeSynced,
+				Health:    &v1alpha1.HealthStatus{Status: health.HealthStatusHealthy},
 			},
 		},
-	}, nil
+	}
+}
+
+// aggregateOnlyAppStatus is OutOfSync at the app level while every individual
+// resource is Synced/Healthy (the aggregate disagrees with the resources).
+func aggregateOnlyAppStatus() v1alpha1.ApplicationStatus {
+	return v1alpha1.ApplicationStatus{
+		Sync:   v1alpha1.SyncStatus{Status: v1alpha1.SyncStatusCodeOutOfSync},
+		Health: v1alpha1.AppHealthStatus{Status: health.HealthStatusHealthy},
+		Resources: []v1alpha1.ResourceStatus{
+			{
+				Kind:      "Service",
+				Namespace: "prod",
+				Name:      "web",
+				Status:    v1alpha1.SyncStatusCodeSynced,
+				Health:    &v1alpha1.HealthStatus{Status: health.HealthStatusHealthy},
+			},
+		},
+	}
 }
 
 func TestWaitOnApplicationStatus_TimeoutErrorListsPendingResources(t *testing.T) {
 	// The app-level status is OutOfSync and one resource is
 	// OutOfSync/Degraded: the timeout error must report the aggregate status
 	// and list only the not-ready resource.
-	acdClient := &pendingAcdClient{&fakeAcdClient{}}
+	acdClient := newStatusAcdClient(pendingAppStatus())
 	watch := getWatchOpts(watchOpts{sync: true, health: true})
 
 	_, _, err := waitOnApplicationStatus(t.Context(), acdClient, "app-name", 0, watch, nil, "wide")
@@ -2383,7 +2411,7 @@ func TestWaitOnApplicationStatus_TimeoutErrorListsPendingResources(t *testing.T)
 func TestWaitOnApplicationStatus_TimeoutErrorSelectedResources(t *testing.T) {
 	// With selected resources only the matching not-ready resources are
 	// reported; the app-level aggregate is not included.
-	acdClient := &pendingAcdClient{&fakeAcdClient{}}
+	acdClient := newStatusAcdClient(pendingAppStatus())
 	selected := []*v1alpha1.SyncOperationResource{
 		{Group: "apps", Kind: "Deployment", Name: "api"},
 	}
@@ -2400,7 +2428,7 @@ func TestWaitOnApplicationStatus_TimeoutErrorAppLevelWithoutPendingResources(t *
 	// The aggregate status can differ from the individual resource statuses
 	// (e.g. right after a spec change): the timeout error must still report
 	// the aggregate even when no individual resource is pending.
-	acdClient := &aggregatePendingAcdClient{&fakeAcdClient{}}
+	acdClient := newStatusAcdClient(aggregateOnlyAppStatus())
 	watch := getWatchOpts(watchOpts{sync: true})
 
 	_, _, err := waitOnApplicationStatus(t.Context(), acdClient, "app-name", 0, watch, nil, "wide")
@@ -2410,55 +2438,52 @@ func TestWaitOnApplicationStatus_TimeoutErrorAppLevelWithoutPendingResources(t *
 	assert.NotContains(t, errMsg, "resources not ready")
 }
 
-// aggregatePendingAcdClient returns an application that is OutOfSync at the
-// app level while all individual resources are Synced/Healthy.
-type aggregatePendingAcdClient struct {
-	*fakeAcdClient
+func TestWaitOnApplicationStatus_TimeoutErrorOnlyReportsWatchedConditions(t *testing.T) {
+	// An --operation-only wait must not mention sync/health status, since
+	// those were not the conditions being waited on.
+	status := aggregateOnlyAppStatus()
+	status.OperationState = &v1alpha1.OperationState{Phase: synccommon.OperationRunning}
+	acdClient := newStatusAcdClient(status)
+	// Give the app an in-flight operation so the operation wait is unmet.
+	watch := watchOpts{operation: true}
+
+	_, _, err := waitOnApplicationStatus(t.Context(), acdClient, "app-name", 0, watch, nil, "wide")
+	require.Error(t, err)
+	errMsg := err.Error()
+	assert.Contains(t, errMsg, "timed out")
+	assert.NotContains(t, errMsg, "sync status")
+	assert.NotContains(t, errMsg, "health status")
 }
 
-func (c *aggregatePendingAcdClient) WatchApplicationWithRetry(_ context.Context, _ string, _ string) chan *v1alpha1.ApplicationWatchEvent {
-	appEventsCh := make(chan *v1alpha1.ApplicationWatchEvent)
-	close(appEventsCh)
-	return appEventsCh
-}
-
-func (c *aggregatePendingAcdClient) NewApplicationClientOrDie() (io.Closer, applicationpkg.ApplicationServiceClient) {
-	return &fakeConnection{}, &aggregatePendingFakeAppServiceClient{}
-}
-
-func (c *aggregatePendingAcdClient) NewSettingsClientOrDie() (io.Closer, settingspkg.SettingsServiceClient) {
-	return &fakeConnection{}, &fakeSettingsServiceClient{}
-}
-
-type aggregatePendingFakeAppServiceClient struct {
-	fakeAppServiceClient
-}
-
-func (c *aggregatePendingFakeAppServiceClient) Get(_ context.Context, _ *applicationpkg.ApplicationQuery, _ ...grpc.CallOption) (*v1alpha1.Application, error) {
-	return &v1alpha1.Application{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "argocd",
-		},
-		Spec: v1alpha1.ApplicationSpec{
-			Project:     "default",
-			Destination: v1alpha1.ApplicationDestination{Server: "local", Namespace: "argocd"},
-			Source:      &v1alpha1.ApplicationSource{RepoURL: "test", TargetRevision: "master", Path: "/test"},
-		},
-		Status: v1alpha1.ApplicationStatus{
-			Sync:   v1alpha1.SyncStatus{Status: v1alpha1.SyncStatusCodeOutOfSync},
-			Health: v1alpha1.AppHealthStatus{Status: health.HealthStatusHealthy},
-			Resources: []v1alpha1.ResourceStatus{
+func TestWaitOnApplicationStatus_TimeoutErrorSkipsCompletedHooks(t *testing.T) {
+	// A Succeeded hook reports its hook phase in Status, which
+	// checkResourceStatus treats as not-Synced; it must not be listed as a
+	// not-ready resource in the timeout hint.
+	status := aggregateOnlyAppStatus()
+	status.OperationState = &v1alpha1.OperationState{
+		SyncResult: &v1alpha1.SyncOperationResult{
+			Resources: []*v1alpha1.ResourceResult{
 				{
-					Kind:      "Service",
+					Group:     "batch",
+					Kind:      "Job",
 					Namespace: "prod",
-					Name:      "web",
-					Status:    v1alpha1.SyncStatusCodeSynced,
-					Health:    &v1alpha1.HealthStatus{Status: health.HealthStatusHealthy},
+					Name:      "migrate",
+					HookType:  synccommon.HookTypePreSync,
+					HookPhase: synccommon.OperationSucceeded,
+					Status:    synccommon.ResultCodeSynced,
 				},
 			},
 		},
-	}, nil
+	}
+	acdClient := newStatusAcdClient(status)
+	watch := getWatchOpts(watchOpts{sync: true})
+
+	_, _, err := waitOnApplicationStatus(t.Context(), acdClient, "app-name", 0, watch, nil, "wide")
+	require.Error(t, err)
+	errMsg := err.Error()
+	assert.Contains(t, errMsg, "timed out")
+	assert.NotContains(t, errMsg, "migrate")
+	assert.NotContains(t, errMsg, "resources not ready")
 }
 
 func TestFormatPendingResources(t *testing.T) {

--- a/cmd/argocd/commands/app_test.go
+++ b/cmd/argocd/commands/app_test.go
@@ -2440,17 +2440,19 @@ func TestWaitOnApplicationStatus_TimeoutErrorAppLevelWithoutPendingResources(t *
 
 func TestWaitOnApplicationStatus_TimeoutErrorOnlyReportsWatchedConditions(t *testing.T) {
 	// An --operation-only wait must not mention sync/health status, since
-	// those were not the conditions being waited on.
+	// those were not the conditions being waited on. The operation phase is
+	// reported from OperationState even though app.Operation is nil (the
+	// controller clears it once it starts processing the operation).
 	status := aggregateOnlyAppStatus()
 	status.OperationState = &v1alpha1.OperationState{Phase: synccommon.OperationRunning}
 	acdClient := newStatusAcdClient(status)
-	// Give the app an in-flight operation so the operation wait is unmet.
 	watch := watchOpts{operation: true}
 
 	_, _, err := waitOnApplicationStatus(t.Context(), acdClient, "app-name", 0, watch, nil, "wide")
 	require.Error(t, err)
 	errMsg := err.Error()
 	assert.Contains(t, errMsg, "timed out")
+	assert.Contains(t, errMsg, "operation: Running")
 	assert.NotContains(t, errMsg, "sync status")
 	assert.NotContains(t, errMsg, "health status")
 }
@@ -2484,6 +2486,57 @@ func TestWaitOnApplicationStatus_TimeoutErrorSkipsCompletedHooks(t *testing.T) {
 	assert.Contains(t, errMsg, "timed out")
 	assert.NotContains(t, errMsg, "migrate")
 	assert.NotContains(t, errMsg, "resources not ready")
+}
+
+func TestWaitOnApplicationStatus_TimeoutErrorSkipsFailedHooks(t *testing.T) {
+	// A failed hook is terminal, not pending, so it must not be listed as a
+	// not-ready resource either. Its failure surfaces via the operation phase.
+	status := aggregateOnlyAppStatus()
+	status.OperationState = &v1alpha1.OperationState{
+		Phase: synccommon.OperationFailed,
+		SyncResult: &v1alpha1.SyncOperationResult{
+			Resources: []*v1alpha1.ResourceResult{
+				{
+					Group:     "batch",
+					Kind:      "Job",
+					Namespace: "prod",
+					Name:      "migrate",
+					HookType:  synccommon.HookTypePreSync,
+					HookPhase: synccommon.OperationFailed,
+					Status:    synccommon.ResultCodeSynced,
+				},
+			},
+		},
+	}
+	acdClient := newStatusAcdClient(status)
+	watch := getWatchOpts(watchOpts{sync: true})
+
+	_, _, err := waitOnApplicationStatus(t.Context(), acdClient, "app-name", 0, watch, nil, "wide")
+	require.Error(t, err)
+	errMsg := err.Error()
+	assert.Contains(t, errMsg, "timed out")
+	assert.NotContains(t, errMsg, "migrate")
+	assert.NotContains(t, errMsg, "resources not ready")
+}
+
+func TestWaitOnApplicationStatus_TimeoutErrorSelectedResourcesReportsOperation(t *testing.T) {
+	// A selected-resource wait with --operation must still report the
+	// operation phase even when app.Operation is nil and no selected resource
+	// is pending; otherwise the message says nothing about what was awaited.
+	status := aggregateOnlyAppStatus()
+	status.OperationState = &v1alpha1.OperationState{Phase: synccommon.OperationRunning}
+	acdClient := newStatusAcdClient(status)
+	selected := []*v1alpha1.SyncOperationResource{
+		{Kind: "Service", Name: "web"},
+	}
+	watch := watchOpts{operation: true}
+
+	_, _, err := waitOnApplicationStatus(t.Context(), acdClient, "app-name", 0, watch, selected, "wide")
+	require.Error(t, err)
+	errMsg := err.Error()
+	assert.Contains(t, errMsg, "timed out")
+	assert.Contains(t, errMsg, "operation: Running")
+	assert.NotContains(t, errMsg, "app sync status")
 }
 
 func TestFormatPendingResources(t *testing.T) {


### PR DESCRIPTION
## Summary

When `argocd app wait` times out, the error message currently only shows:

```
timed out (300s) waiting for app "my-app" match desired state
```

This provides no actionable information about which resources are still blocking. Users have to manually inspect the app to figure out what went wrong.

This change appends the list of resources that haven't reached their desired state to the timeout error:

```
timed out (300s) waiting for app "my-app" match desired state. resources not ready: apps/Deployment/my-deploy (sync: OutOfSync, health: Progressing), /Service/my-svc (sync: OutOfSync, health: Missing)
```

## Changes

- Modified `waitOnApplicationStatus` in `cmd/argocd/commands/app.go` to collect and report pending resources on timeout
- Handles both app-level and selected-resource wait modes
- Properly handles nil health status on resources

## Tests

- Added `TestWaitOnApplicationStatus_TimeoutErrorIncludesPendingResources` - verifies timeout error fires on app-level sync mismatch
- Added `TestWaitOnApplicationStatus_TimeoutErrorListsNotReadyResources` - verifies pending resource info is absent when individual resources are ready
- All existing `TestWaitOnApplicationStatus_*` tests pass

Fixes #14705

Signed-off-by: Umut Polat <52835619+umut-polat@users.noreply.github.com>