### PR TITLE
fix: log client IP address on authentication failures

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1518,7 +1518,6 @@ func replaceBaseHRef(data string, replaceWith string) string {
 	return baseHRefRegex.ReplaceAllString(data, replaceWith)
 }
 
-// Authenticate checks for the presence of a valid token when accessing server-side resources.
 // clientAddress returns the client IP address from the gRPC peer info, or "unknown" if unavailable.
 func clientAddress(ctx context.Context) string {
 	if p, ok := peer.FromContext(ctx); ok && p.Addr != nil {
@@ -1527,6 +1526,7 @@ func clientAddress(ctx context.Context) string {
 	return "unknown"
 }
 
+// Authenticate checks for the presence of a valid token when accessing server-side resources.
 func (server *ArgoCDServer) Authenticate(ctx context.Context) (context.Context, error) {
 	var span trace.Span
 	ctx, span = tracer.Start(ctx, "server.ArgoCDServer.Authenticate")
@@ -1554,8 +1554,9 @@ func (server *ArgoCDServer) Authenticate(ctx context.Context) (context.Context, 
 	}
 
 	if claimsErr != nil {
-		clientAddr := clientAddress(ctx)
-		log.Warnf("authentication failed: %v (client: %s)", claimsErr, clientAddr)
+		log.WithFields(log.Fields{
+			"client": clientAddress(ctx),
+		}).Warnf("authentication failed: %v", claimsErr)
 
 		argoCDSettings, err := server.settingsMgr.GetSettings()
 		if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -57,6 +57,7 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/status"
 	"gopkg.in/yaml.v2"
@@ -1518,6 +1519,14 @@ func replaceBaseHRef(data string, replaceWith string) string {
 }
 
 // Authenticate checks for the presence of a valid token when accessing server-side resources.
+// clientAddress returns the client IP address from the gRPC peer info, or "unknown" if unavailable.
+func clientAddress(ctx context.Context) string {
+	if p, ok := peer.FromContext(ctx); ok && p.Addr != nil {
+		return p.Addr.String()
+	}
+	return "unknown"
+}
+
 func (server *ArgoCDServer) Authenticate(ctx context.Context) (context.Context, error) {
 	var span trace.Span
 	ctx, span = tracer.Start(ctx, "server.ArgoCDServer.Authenticate")
@@ -1545,6 +1554,9 @@ func (server *ArgoCDServer) Authenticate(ctx context.Context) (context.Context, 
 	}
 
 	if claimsErr != nil {
+		clientAddr := clientAddress(ctx)
+		log.Warnf("authentication failed: %v (client: %s)", claimsErr, clientAddr)
+
 		argoCDSettings, err := server.settingsMgr.GetSettings()
 		if err != nil {
 			return ctx, status.Errorf(codes.Internal, "unable to load settings: %v", err)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1759,4 +1759,16 @@ func TestClientAddress(t *testing.T) {
 	t.Run("returns unknown when no peer", func(t *testing.T) {
 		assert.Equal(t, "unknown", clientAddress(context.Background()))
 	})
+
+	t.Run("returns unknown when peer has nil Addr", func(t *testing.T) {
+		ctx := peer.NewContext(context.Background(), &peer.Peer{Addr: nil})
+		assert.Equal(t, "unknown", clientAddress(ctx))
+	})
+
+	t.Run("returns IPv6 address", func(t *testing.T) {
+		ctx := peer.NewContext(context.Background(), &peer.Peer{
+			Addr: &net.TCPAddr{IP: net.ParseIP("::1"), Port: 443},
+		})
+		assert.Equal(t, "[::1]:443", clientAddress(ctx))
+	})
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -21,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
@@ -1744,4 +1746,17 @@ func Test_StaticAssetsDir_no_symlink_traversal(t *testing.T) {
 	argocd.newStaticAssetsHandler()(w, req)
 	resp = w.Result()
 	assert.Equal(t, http.StatusOK, resp.StatusCode, "should have been able to access the normal file")
+}
+
+func TestClientAddress(t *testing.T) {
+	t.Run("returns peer address when available", func(t *testing.T) {
+		ctx := peer.NewContext(context.Background(), &peer.Peer{
+			Addr: &net.TCPAddr{IP: net.ParseIP("192.168.1.1"), Port: 12345},
+		})
+		assert.Equal(t, "192.168.1.1:12345", clientAddress(ctx))
+	})
+
+	t.Run("returns unknown when no peer", func(t *testing.T) {
+		assert.Equal(t, "unknown", clientAddress(context.Background()))
+	})
 }


### PR DESCRIPTION
## Summary

When authentication fails, the ArgoCD server logs the error but does not include any client information. This makes it difficult for admins to identify the source of failed authentication attempts from server logs.

This change adds the client IP address to the warning log emitted on authentication failures:

```
WARN authentication failed: invalid session: token is expired (client: 192.168.1.50:43210)
```

## Changes

- Added `clientAddress()` helper in `server/server.go` that extracts the client address from gRPC peer info
- Added a `log.Warnf` call in `Authenticate()` that logs the error with the client IP when authentication fails
- Added unit tests for `clientAddress()` covering both peer-present and peer-absent cases

## Discussion

As discussed in #20388, this starts with logging the client IP address. Additional token metadata (issuer, subject, etc.) can be added in follow-up work if needed.

Fixes #20388

Signed-off-by: Umut Polat <52835619+umut-polat@users.noreply.github.com>