### PR TITLE
fix(ui): show resource kind and name in restart action confirmation (#26531)

### DIFF
--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -638,14 +638,17 @@ export async function getResourceActionsMenuItems(resource: ResourceTreeNode, me
                 iconClassName: action.iconClass,
                 action: async () => {
                     const confirmed = false;
-                    const title = action.params ? `Enter input parameters for action: ${action.name}` : `Perform ${action.name} action?`;
+                    const title = action.params ? `Enter input parameters for action: ${action.name}` : `Perform ${action.name} action on ${resource.kind} ${resource.name}?`;
                     await apis.popup.prompt(
                         title,
                         api => (
                             <div>
                                 {!action.params && (
                                     <div className='argo-form-row'>
-                                        <div> Are you sure you want to perform {action.name} action?</div>
+                                        <div>
+                                            {' '}
+                                            Are you sure you want to perform <strong>{action.name}</strong> on <strong>{resource.kind}</strong> <kbd>{resource.name}</kbd>?
+                                        </div>
                                     </div>
                                 )}
                                 {action.params &&

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -638,7 +638,8 @@ export async function getResourceActionsMenuItems(resource: ResourceTreeNode, me
                 iconClassName: action.iconClass,
                 action: async () => {
                     const confirmed = false;
-                    const title = action.params ? `Enter input parameters for action: ${action.name}` : `Perform ${action.name} action on ${resource.kind} ${resource.name}?`;
+                    const resourceLabel = `${resource.kind}/${resource.name}${resource.namespace ? ` (${resource.namespace})` : ' (cluster-scoped)'}`;
+                    const title = action.params ? `Enter input parameters for action: ${action.name}` : `Perform ${action.name} action on ${resourceLabel}?`;
                     await apis.popup.prompt(
                         title,
                         api => (
@@ -647,7 +648,8 @@ export async function getResourceActionsMenuItems(resource: ResourceTreeNode, me
                                     <div className='argo-form-row'>
                                         <div>
                                             {' '}
-                                            Are you sure you want to perform <strong>{action.name}</strong> on <strong>{resource.kind}</strong> <kbd>{resource.name}</kbd>?
+                                            Are you sure you want to perform <strong>{action.name}</strong> on <strong>{resource.kind}</strong>/<kbd>{resource.name}</kbd>
+                                            {resource.namespace ? ` (${resource.namespace})` : ' (cluster-scoped)'}?
                                         </div>
                                     </div>
                                 )}


### PR DESCRIPTION
Fixes #26531

## Description

When performing a resource action (e.g. restart), the confirmation dialog only showed the action name:
> "Are you sure you want to perform restart action?"

<details><summary>Before</summary>

<img width="991" height="237" alt="image" src="https://github.com/user-attachments/assets/944097af-a6ac-4180-8492-5ec6fe5c6274" />

</details>

<details><summary>After</summary>

<img width="994" height="239" alt="image" src="https://github.com/user-attachments/assets/01f28dce-e170-4c93-ae65-de6e002ac3ec" />

</details>

### Existing pattern followed

The same file already uses `<strong>{kind}</strong> <kbd>{name}</kbd>` for delete confirmations:
- App delete (line 116): `Are you sure you want to delete the <strong>{appType}</strong> <kbd>{appName}</kbd>?`
- Pod delete (line 408): `Are you sure you want to delete <strong>Pod</strong> <kbd>{pod.name}</kbd>?`
- Resource delete (line 538): `Are you sure you want to delete <strong>{resource.kind}</strong> <kbd>{resource.name}</kbd>?`

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->