### PR TITLE
fix: detect inline spec changes (valuesObject) in ApplicationSet progressive sync

### DIFF
--- a/applicationset/controllers/applicationset_controller.go
+++ b/applicationset/controllers/applicationset_controller.go
@@ -16,6 +16,9 @@ package controllers
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -1144,6 +1147,15 @@ func getAppStep(appName string, appStepMap map[string]int) int {
 }
 
 // check the status of each Application's status and promote Applications to the next status if needed
+func hashSources(app argov1alpha1.Application) string {
+	data, err := json.Marshal(app.Spec.GetSources())
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
 func (r *ApplicationSetReconciler) updateApplicationSetApplicationStatus(ctx context.Context, logCtx *log.Entry, applicationSet *argov1alpha1.ApplicationSet, applications []argov1alpha1.Application, appStepMap map[string]int) ([]argov1alpha1.ApplicationSetApplicationStatus, error) {
 	now := metav1.Now()
 	appStatuses := make([]argov1alpha1.ApplicationSetApplicationStatus, 0, len(applications))
@@ -1182,12 +1194,23 @@ func (r *ApplicationSetReconciler) updateApplicationSetApplicationStatus(ctx con
 		newAppStatus := currentAppStatus.DeepCopy()
 		newAppStatus.Step = strconv.Itoa(getAppStep(newAppStatus.Application, appStepMap))
 
-		if !reflect.DeepEqual(currentAppStatus.TargetRevisions, app.Status.GetRevisions()) {
+		currentHash := hashSources(app)
+	revisionsChanged := !reflect.DeepEqual(currentAppStatus.TargetRevisions, app.Status.GetRevisions())
+	sourcesChanged := currentAppStatus.TargetSourcesHash != "" &&
+		currentAppStatus.TargetSourcesHash != currentHash
+
+	if revisionsChanged || sourcesChanged {
 			// A new version is available in the application and we need to re-sync the application
 			newAppStatus.TargetRevisions = app.Status.GetRevisions()
+			newAppStatus.TargetSourcesHash = currentHash
 			newAppStatus.Message = "Application has pending changes, setting status to Waiting"
 			newAppStatus.Status = argov1alpha1.ProgressiveSyncWaiting
 			newAppStatus.LastTransitionTime = &now
+		}
+
+		// Migration: populate hash on first reconcile without triggering a reset
+		if currentAppStatus.TargetSourcesHash == "" {
+			newAppStatus.TargetSourcesHash = currentHash
 		}
 
 		if newAppStatus.Status == argov1alpha1.ProgressiveSyncWaiting {

--- a/applicationset/controllers/applicationset_controller.go
+++ b/applicationset/controllers/applicationset_controller.go
@@ -1195,11 +1195,11 @@ func (r *ApplicationSetReconciler) updateApplicationSetApplicationStatus(ctx con
 		newAppStatus.Step = strconv.Itoa(getAppStep(newAppStatus.Application, appStepMap))
 
 		currentHash := hashSources(app)
-	revisionsChanged := !reflect.DeepEqual(currentAppStatus.TargetRevisions, app.Status.GetRevisions())
-	sourcesChanged := currentAppStatus.TargetSourcesHash != "" &&
-		currentAppStatus.TargetSourcesHash != currentHash
+		revisionsChanged := !reflect.DeepEqual(currentAppStatus.TargetRevisions, app.Status.GetRevisions())
+		sourcesChanged := currentAppStatus.TargetSourcesHash != "" &&
+			currentAppStatus.TargetSourcesHash != currentHash
 
-	if revisionsChanged || sourcesChanged {
+		if revisionsChanged || sourcesChanged {
 			// A new version is available in the application and we need to re-sync the application
 			newAppStatus.TargetRevisions = app.Status.GetRevisions()
 			newAppStatus.TargetSourcesHash = currentHash

--- a/applicationset/controllers/applicationset_controller_test.go
+++ b/applicationset/controllers/applicationset_controller_test.go
@@ -5439,9 +5439,11 @@ func TestUpdateApplicationSetApplicationStatus(t *testing.T) {
 			// opt out of testing the LastTransitionTime is accurate
 			for i := range appStatuses {
 				appStatuses[i].LastTransitionTime = nil
+				appStatuses[i].TargetSourcesHash = ""
 			}
 			for i := range cc.expectedAppStatus {
 				cc.expectedAppStatus[i].LastTransitionTime = nil
+				cc.expectedAppStatus[i].TargetSourcesHash = ""
 			}
 
 			require.NoError(t, err, "expected no errors, but errors occurred")
@@ -6192,6 +6194,7 @@ func TestUpdateApplicationSetApplicationStatusProgress(t *testing.T) {
 			// opt out of testing the LastTransitionTime is accurate
 			for i := range appStatuses {
 				appStatuses[i].LastTransitionTime = nil
+				appStatuses[i].TargetSourcesHash = ""
 			}
 
 			require.NoError(t, err, "expected no errors, but errors occurred")

--- a/applicationset/controllers/applicationset_controller_test.go
+++ b/applicationset/controllers/applicationset_controller_test.go
@@ -5415,6 +5415,77 @@ func TestUpdateApplicationSetApplicationStatus(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "resets app to Waiting when valuesObject changes but git SHA stays the same",
+			appSet: newDefaultAppSet(2, []v1alpha1.ApplicationSetApplicationStatus{
+				{
+					Application:        "app1",
+					Message:            "",
+					Status:             v1alpha1.ProgressiveSyncHealthy,
+					Step:               "1",
+					TargetRevisions:    []string{"abc123"},
+					TargetSourcesHash:  "oldhash",
+					LastTransitionTime: &nowMinus5,
+				},
+			}),
+			apps: []v1alpha1.Application{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "app1"},
+					Status: v1alpha1.ApplicationStatus{
+						ReconciledAt: &metav1.Time{Time: time.Now()},
+						Health:       v1alpha1.AppHealthStatus{Status: health.HealthStatusHealthy},
+						Sync: v1alpha1.SyncStatus{
+							Status:   v1alpha1.SyncStatusCodeOutOfSync,
+							Revision: "abc123",
+						},
+					},
+					Spec: v1alpha1.ApplicationSpec{
+						Source: &v1alpha1.ApplicationSource{
+							Helm: &v1alpha1.ApplicationSourceHelm{
+								Values: "image: newimage",
+							},
+						},
+					},
+				},
+			},
+			appStepMap: map[string]int{"app1": 0},
+			expectedAppStatus: []v1alpha1.ApplicationSetApplicationStatus{
+				{
+					Application:     "app1",
+					Message:         "Application has pending changes, setting status to Waiting",
+					Status:          v1alpha1.ProgressiveSyncWaiting,
+					Step:            "1",
+					TargetRevisions: []string{"abc123"},
+				},
+			},
+		},
+		{
+			name: "does not reset app to Waiting when TargetSourcesHash is empty (migration guard)",
+			appSet: newDefaultAppSet(2, []v1alpha1.ApplicationSetApplicationStatus{
+				{
+					Application:        "app1",
+					Message:            "",
+					Status:             v1alpha1.ProgressiveSyncHealthy,
+					Step:               "1",
+					TargetRevisions:    []string{"abc123"},
+					TargetSourcesHash:  "",
+					LastTransitionTime: &nowMinus5,
+				},
+			}),
+			apps: []v1alpha1.Application{
+				newApp("app1", health.HealthStatusHealthy, v1alpha1.SyncStatusCodeSynced, "abc123", newOperationState(common.OperationSucceeded)),
+			},
+			appStepMap: map[string]int{"app1": 0},
+			expectedAppStatus: []v1alpha1.ApplicationSetApplicationStatus{
+				{
+					Application:     "app1",
+					Message:         "",
+					Status:          v1alpha1.ProgressiveSyncHealthy,
+					Step:            "1",
+					TargetRevisions: []string{"abc123"},
+				},
+			},
+		},
 	} {
 		t.Run(cc.name, func(t *testing.T) {
 			kubeclientset := kubefake.NewClientset([]runtime.Object{}...)

--- a/assets/swagger.json
+++ b/assets/swagger.json
@@ -7193,6 +7193,10 @@
           "items": {
             "type": "string"
           }
+        },
+        "targetsourceshash": {
+          "description": "TargetSourcesHash tracks a hash of app.Spec.GetSources() to detect inline spec\nchanges (e.g. valuesObject) that do not affect the git revision.",
+          "type": "string"
         }
       }
     },

--- a/manifests/core-install-with-hydrator.yaml
+++ b/manifests/core-install-with-hydrator.yaml
@@ -30091,6 +30091,8 @@ spec:
                       items:
                         type: string
                       type: array
+                    targetSourcesHash:
+                      type: string
                   required:
                   - application
                   - message

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -30091,6 +30091,8 @@ spec:
                       items:
                         type: string
                       type: array
+                    targetSourcesHash:
+                      type: string
                   required:
                   - application
                   - message

--- a/manifests/crds/applicationset-crd.yaml
+++ b/manifests/crds/applicationset-crd.yaml
@@ -23086,6 +23086,8 @@ spec:
                       items:
                         type: string
                       type: array
+                    targetSourcesHash:
+                      type: string
                   required:
                   - application
                   - message

--- a/manifests/ha/install-with-hydrator.yaml
+++ b/manifests/ha/install-with-hydrator.yaml
@@ -30091,6 +30091,8 @@ spec:
                       items:
                         type: string
                       type: array
+                    targetSourcesHash:
+                      type: string
                   required:
                   - application
                   - message

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -30091,6 +30091,8 @@ spec:
                       items:
                         type: string
                       type: array
+                    targetSourcesHash:
+                      type: string
                   required:
                   - application
                   - message

--- a/manifests/install-with-hydrator.yaml
+++ b/manifests/install-with-hydrator.yaml
@@ -30091,6 +30091,8 @@ spec:
                       items:
                         type: string
                       type: array
+                    targetSourcesHash:
+                      type: string
                   required:
                   - application
                   - message

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -30091,6 +30091,8 @@ spec:
                       items:
                         type: string
                       type: array
+                    targetSourcesHash:
+                      type: string
                   required:
                   - application
                   - message

--- a/pkg/apis/application/v1alpha1/applicationset_types.go
+++ b/pkg/apis/application/v1alpha1/applicationset_types.go
@@ -906,6 +906,9 @@ type ApplicationSetApplicationStatus struct {
 	Step string `json:"step" protobuf:"bytes,5,opt,name=step"`
 	// TargetRevision tracks the desired revisions the Application should be synced to.
 	TargetRevisions []string `json:"targetRevisions" protobuf:"bytes,6,opt,name=targetrevisions"`
+	// TargetSourcesHash tracks a hash of app.Spec.GetSources() to detect inline spec
+	// changes (e.g. valuesObject) that do not affect the git revision.
+	TargetSourcesHash string `json:"targetSourcesHash,omitempty" protobuf:"bytes,7,opt,name=targetsourceshash"`
 }
 
 // ApplicationSetList contains a list of ApplicationSet

--- a/pkg/apis/application/v1alpha1/generated.pb.go
+++ b/pkg/apis/application/v1alpha1/generated.pb.go
@@ -6574,6 +6574,11 @@ func (m *ApplicationSetApplicationStatus) MarshalToSizedBuffer(dAtA []byte) (int
 	_ = i
 	var l int
 	_ = l
+	i -= len(m.TargetSourcesHash)
+	copy(dAtA[i:], m.TargetSourcesHash)
+	i = encodeVarintGenerated(dAtA, i, uint64(len(m.TargetSourcesHash)))
+	i--
+	dAtA[i] = 0x3a
 	if len(m.TargetRevisions) > 0 {
 		for iNdEx := len(m.TargetRevisions) - 1; iNdEx >= 0; iNdEx-- {
 			i -= len(m.TargetRevisions[iNdEx])
@@ -16625,6 +16630,8 @@ func (m *ApplicationSetApplicationStatus) Size() (n int) {
 			n += 1 + l + sovGenerated(uint64(l))
 		}
 	}
+	l = len(m.TargetSourcesHash)
+	n += 1 + l + sovGenerated(uint64(l))
 	return n
 }
 
@@ -20460,6 +20467,7 @@ func (this *ApplicationSetApplicationStatus) String() string {
 		`Status:` + fmt.Sprintf("%v", this.Status) + `,`,
 		`Step:` + fmt.Sprintf("%v", this.Step) + `,`,
 		`TargetRevisions:` + fmt.Sprintf("%v", this.TargetRevisions) + `,`,
+		`TargetSourcesHash:` + fmt.Sprintf("%v", this.TargetSourcesHash) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -25718,6 +25726,38 @@ func (m *ApplicationSetApplicationStatus) Unmarshal(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.TargetRevisions = append(m.TargetRevisions, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field TargetSourcesHash", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.TargetSourcesHash = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/pkg/apis/application/v1alpha1/generated.proto
+++ b/pkg/apis/application/v1alpha1/generated.proto
@@ -236,6 +236,10 @@ message ApplicationSetApplicationStatus {
 
   // TargetRevision tracks the desired revisions the Application should be synced to.
   repeated string targetrevisions = 6;
+
+  // TargetSourcesHash tracks a hash of app.Spec.GetSources() to detect inline spec
+  // changes (e.g. valuesObject) that do not affect the git revision.
+  optional string targetsourceshash = 7;
 }
 
 // ApplicationSetCondition contains details about an applicationset condition, which is usually an error or warning


### PR DESCRIPTION
## Summary

Fixes #26685

When using `strategy.type: RollingSync` on an ApplicationSet, changing inline spec fields like `valuesObject`, `values`, or `helm.parameters` on the template source would cause affected Applications to go OutOfSync, but the progressive sync wave machinery would **not** reset them to `Waiting`. All apps would sync simultaneously, bypassing the rollout strategy entirely.

## Root Cause

The change-detection guard in `updateApplicationSetApplicationStatus` only compared `TargetRevisions` against `app.Status.GetRevisions()` (resolved git SHAs). Inline spec fields have no git representation, so their changes were invisible to the controller.

## Fix

- Added a new `TargetSourcesHash` field to `ApplicationSetApplicationStatus` that stores a SHA-256 hash of `app.Spec.GetSources()`
- On each reconcile, if the hash has changed, apps are reset to `Waiting`, identical to the behavior triggered by a new git commit
- **Migration safe:** on first reconcile, the hash is populated without triggering a spurious reset (guarded by empty string check)

## Changes

- `pkg/apis/application/v1alpha1/applicationset_types.go`  ---> added `TargetSourcesHash` field
- `applicationset/controllers/applicationset_controller.go` --> added `hashSources()` helper and extended change-detection logic

## Testing

- [ ] Existing unit tests pass
- [ ] Manually verified with an ApplicationSet using `valuesObject` and `strategy.type: RollingSync`