### PR TITLE
fix: make config key optional

### DIFF
--- a/manifests/base/dex/argocd-dex-server-deployment.yaml
+++ b/manifests/base/dex/argocd-dex-server-deployment.yaml
@@ -70,7 +70,7 @@ spec:
               configMapKeyRef:
                 name: argocd-cmd-params-cm
                 key: dexserver.connector.failure.continue
-                optional: false
+                optional: true
         securityContext:
           capabilities:
             drop:

--- a/manifests/ha/install-with-hydrator.yaml
+++ b/manifests/ha/install-with-hydrator.yaml
@@ -33026,7 +33026,7 @@ spec:
             configMapKeyRef:
               key: dexserver.connector.failure.continue
               name: argocd-cmd-params-cm
-              optional: false
+              optional: true
         image: ghcr.io/dexidp/dex:v2.45.0
         imagePullPolicy: Always
         name: dex

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -32856,7 +32856,7 @@ spec:
             configMapKeyRef:
               key: dexserver.connector.failure.continue
               name: argocd-cmd-params-cm
-              optional: false
+              optional: true
         image: ghcr.io/dexidp/dex:v2.45.0
         imagePullPolicy: Always
         name: dex

--- a/manifests/ha/namespace-install-with-hydrator.yaml
+++ b/manifests/ha/namespace-install-with-hydrator.yaml
@@ -2273,7 +2273,7 @@ spec:
             configMapKeyRef:
               key: dexserver.connector.failure.continue
               name: argocd-cmd-params-cm
-              optional: false
+              optional: true
         image: ghcr.io/dexidp/dex:v2.45.0
         imagePullPolicy: Always
         name: dex

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -2103,7 +2103,7 @@ spec:
             configMapKeyRef:
               key: dexserver.connector.failure.continue
               name: argocd-cmd-params-cm
-              optional: false
+              optional: true
         image: ghcr.io/dexidp/dex:v2.45.0
         imagePullPolicy: Always
         name: dex

--- a/manifests/install-with-hydrator.yaml
+++ b/manifests/install-with-hydrator.yaml
@@ -32044,7 +32044,7 @@ spec:
             configMapKeyRef:
               key: dexserver.connector.failure.continue
               name: argocd-cmd-params-cm
-              optional: false
+              optional: true
         image: ghcr.io/dexidp/dex:v2.45.0
         imagePullPolicy: Always
         name: dex

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -31872,7 +31872,7 @@ spec:
             configMapKeyRef:
               key: dexserver.connector.failure.continue
               name: argocd-cmd-params-cm
-              optional: false
+              optional: true
         image: ghcr.io/dexidp/dex:v2.45.0
         imagePullPolicy: Always
         name: dex

--- a/manifests/namespace-install-with-hydrator.yaml
+++ b/manifests/namespace-install-with-hydrator.yaml
@@ -1291,7 +1291,7 @@ spec:
             configMapKeyRef:
               key: dexserver.connector.failure.continue
               name: argocd-cmd-params-cm
-              optional: false
+              optional: true
         image: ghcr.io/dexidp/dex:v2.45.0
         imagePullPolicy: Always
         name: dex

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -1119,7 +1119,7 @@ spec:
             configMapKeyRef:
               key: dexserver.connector.failure.continue
               name: argocd-cmd-params-cm
-              optional: false
+              optional: true
         image: ghcr.io/dexidp/dex:v2.45.0
         imagePullPolicy: Always
         name: dex


### PR DESCRIPTION
https://github.com/argoproj/argo-cd/pull/26609 introduced a new argocd-cmd-params-cm config key and a reference from the Dex deployment. But it made the config key required, even though the config key is not present in the default install manifest.

This makes the key optional, since we don't set it in the default manifest.