### PR TITLE
fix(appset): fix post-generator selector ignoring labels in GoTemplate mode

### DIFF
--- a/applicationset/generators/generator_spec_processor.go
+++ b/applicationset/generators/generator_spec_processor.go
@@ -124,7 +124,7 @@ func GetRelevantGenerators(requestedGenerator *argoprojiov1alpha1.ApplicationSet
 }
 
 func flattenParameters(in map[string]any) (map[string]string, error) {
-	flat, err := flatten.Flatten(in, "", flatten.DotStyle)
+	flat, err := flatten.Flatten(normalizeMapForFlatten(in), "", flatten.DotStyle)
 	if err != nil {
 		return nil, fmt.Errorf("error flatenning parameters: %w", err)
 	}
@@ -135,6 +135,31 @@ func flattenParameters(in map[string]any) (map[string]string, error) {
 	}
 
 	return out, nil
+}
+
+// normalizeMapForFlatten recursively converts map[string]string values to
+// map[string]interface{} so that flatten.Flatten can recurse into them.
+// flatten.Flatten only recurses into map[string]interface{} and []interface{};
+// map[string]string is treated as an opaque leaf, causing individual keys
+// (e.g. metadata.labels.environment) to be absent from the flat output and
+// silently breaking post-generator selector matching in GoTemplate mode.
+func normalizeMapForFlatten(in map[string]any) map[string]any {
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		switch cast := v.(type) {
+		case map[string]string:
+			inner := make(map[string]any, len(cast))
+			for ik, iv := range cast {
+				inner[ik] = iv
+			}
+			out[k] = inner
+		case map[string]any:
+			out[k] = normalizeMapForFlatten(cast)
+		default:
+			out[k] = v
+		}
+	}
+	return out
 }
 
 func mergeGeneratorTemplate(g Generator, requestedGenerator *argoprojiov1alpha1.ApplicationSetGenerator, applicationSetTemplate argoprojiov1alpha1.ApplicationSetTemplate) (argoprojiov1alpha1.ApplicationSetTemplate, error) {

--- a/applicationset/generators/generator_spec_processor_test.go
+++ b/applicationset/generators/generator_spec_processor_test.go
@@ -249,6 +249,231 @@ func TestTransForm(t *testing.T) {
 	}
 }
 
+func TestTransFormGoTemplate(t *testing.T) {
+	testCases := []struct {
+		name     string
+		selector *metav1.LabelSelector
+		values   map[string]string
+		expected []map[string]any
+	}{
+		{
+			name: "server filter",
+			selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"server": "https://production-01.example.com"},
+			},
+			expected: []map[string]any{{
+				"name":           "production_01/west",
+				"nameNormalized": "production-01-west",
+				"server":         "https://production-01.example.com",
+				"project":        "",
+				"metadata": map[string]any{
+					"labels": map[string]string{
+						"argocd.argoproj.io/secret-type": "cluster",
+						"environment":                    "production",
+						"org":                            "bar",
+					},
+					"annotations": map[string]string{
+						"foo.argoproj.io": "production",
+					},
+				},
+			}},
+		},
+		{
+			name: "label MatchLabels",
+			selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"metadata.labels.environment": "staging"},
+			},
+			expected: []map[string]any{{
+				"name":           "staging-01",
+				"nameNormalized": "staging-01",
+				"server":         "https://staging-01.example.com",
+				"project":        "",
+				"metadata": map[string]any{
+					"labels": map[string]string{
+						"argocd.argoproj.io/secret-type": "cluster",
+						"environment":                    "staging",
+						"org":                            "foo",
+					},
+					"annotations": map[string]string{
+						"foo.argoproj.io": "staging",
+					},
+				},
+			}},
+		},
+		{
+			name: "label NotIn matchExpression",
+			selector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "metadata.labels.environment",
+						Operator: metav1.LabelSelectorOpNotIn,
+						Values:   []string{"staging"},
+					},
+				},
+			},
+			// staging-01 is excluded; production-01, some-really-long-server-url, and
+			// in-cluster (no labels) are all included because NotIn vacuously passes
+			// when the key is absent.
+			expected: []map[string]any{
+				{
+					"name":           "production_01/west",
+					"nameNormalized": "production-01-west",
+					"server":         "https://production-01.example.com",
+					"project":        "",
+					"metadata": map[string]any{
+						"labels": map[string]string{
+							"argocd.argoproj.io/secret-type": "cluster",
+							"environment":                    "production",
+							"org":                            "bar",
+						},
+						"annotations": map[string]string{
+							"foo.argoproj.io": "production",
+						},
+					},
+				},
+				{
+					"name":           "some-really-long-server-url",
+					"nameNormalized": "some-really-long-server-url",
+					"server":         "https://some-really-long-url-that-will-exceed-63-characters.com",
+					"project":        "",
+					"metadata": map[string]any{
+						"labels": map[string]string{
+							"argocd.argoproj.io/secret-type": "cluster",
+							"environment":                    "production",
+							"org":                            "bar",
+						},
+						"annotations": map[string]string{
+							"foo.argoproj.io": "production",
+						},
+					},
+				},
+				{
+					// in-cluster (local cluster) has no labels; NotIn vacuously passes.
+					"name":           "in-cluster",
+					"nameNormalized": "in-cluster",
+					"server":         "https://kubernetes.default.svc",
+					"project":        "",
+				},
+			},
+		},
+		{
+			name: "slash key in label",
+			selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"metadata.labels.argocd.argoproj.io/secret-type": "cluster"},
+			},
+			expected: []map[string]any{
+				{
+					"name":           "staging-01",
+					"nameNormalized": "staging-01",
+					"server":         "https://staging-01.example.com",
+					"project":        "",
+					"metadata": map[string]any{
+						"labels": map[string]string{
+							"argocd.argoproj.io/secret-type": "cluster",
+							"environment":                    "staging",
+							"org":                            "foo",
+						},
+						"annotations": map[string]string{
+							"foo.argoproj.io": "staging",
+						},
+					},
+				},
+				{
+					"name":           "production_01/west",
+					"nameNormalized": "production-01-west",
+					"server":         "https://production-01.example.com",
+					"project":        "",
+					"metadata": map[string]any{
+						"labels": map[string]string{
+							"argocd.argoproj.io/secret-type": "cluster",
+							"environment":                    "production",
+							"org":                            "bar",
+						},
+						"annotations": map[string]string{
+							"foo.argoproj.io": "production",
+						},
+					},
+				},
+				{
+					"name":           "some-really-long-server-url",
+					"nameNormalized": "some-really-long-server-url",
+					"server":         "https://some-really-long-url-that-will-exceed-63-characters.com",
+					"project":        "",
+					"metadata": map[string]any{
+						"labels": map[string]string{
+							"argocd.argoproj.io/secret-type": "cluster",
+							"environment":                    "production",
+							"org":                            "bar",
+						},
+						"annotations": map[string]string{
+							"foo.argoproj.io": "production",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "values filter",
+			selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"values.env": "staging"},
+			},
+			values: map[string]string{"env": "{{.metadata.labels.environment}}"},
+			expected: []map[string]any{{
+				"name":           "staging-01",
+				"nameNormalized": "staging-01",
+				"server":         "https://staging-01.example.com",
+				"project":        "",
+				"metadata": map[string]any{
+					"labels": map[string]string{
+						"argocd.argoproj.io/secret-type": "cluster",
+						"environment":                    "staging",
+						"org":                            "foo",
+					},
+					"annotations": map[string]string{
+						"foo.argoproj.io": "staging",
+					},
+				},
+				"values": map[string]string{
+					"env": "staging",
+				},
+			}},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			testGenerators := map[string]Generator{
+				"Clusters": getMockClusterGenerator(),
+			}
+
+			applicationSetInfo := argov1alpha1.ApplicationSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "set",
+				},
+				Spec: argov1alpha1.ApplicationSetSpec{
+					GoTemplate: true,
+				},
+			}
+
+			results, err := Transform(
+				argov1alpha1.ApplicationSetGenerator{
+					Selector: testCase.selector,
+					Clusters: &argov1alpha1.ClusterGenerator{
+						Selector: metav1.LabelSelector{},
+						Template: argov1alpha1.ApplicationSetTemplate{},
+						Values:   testCase.values,
+					},
+				},
+				testGenerators,
+				emptyTemplate(),
+				&applicationSetInfo, nil, nil)
+
+			require.NoError(t, err)
+			assert.ElementsMatch(t, testCase.expected, results[0].Params)
+		})
+	}
+}
+
 func emptyTemplate() argov1alpha1.ApplicationSetTemplate {
 	return argov1alpha1.ApplicationSetTemplate{
 		Spec: argov1alpha1.ApplicationSpec{


### PR DESCRIPTION
## Why

When `goTemplate: true` is set on an ApplicationSet, the post-generator `selector` field was silently ignored for any generator that stores nested maps as `map[string]string` (clusters generator's `metadata.labels`, `metadata.annotations`, and `values.*` from value interpolation). This caused all items to be rendered regardless of the selector, making label-based filtering impossible in GoTemplate mode.

## Root cause

`flatten.Flatten` (used in `flattenParameters`) only recurses into `map[string]interface{}` and `[]interface{}`. In GoTemplate mode, cluster labels/annotations and interpolated values are stored as `map[string]string`, which the flatten library treats as an opaque leaf. Individual keys like `metadata.labels.environment` therefore never appeared in the flat params map. Because the key was absent, `NotIn` selectors vacuously passed for every item.

Non-GoTemplate mode was unaffected because `getClusterParameters` manually builds flat `metadata.labels.<key>` entries there.

## Fix

Added `normalizeMapForFlatten` in `generator_spec_processor.go` — a recursive helper that converts `map[string]string` to `map[string]interface{}` before passing to `flatten.Flatten`. This is applied only for selector matching; `GenerateParams` output (used for template rendering) is unchanged.

## Checklist

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.

Fixes #26719