### PR TITLE
fix(reposerver): make temp dir cleanup best-effort in `TestGenerateManifestsHelmWithRefs_CachedNoLsRemote`

### DIFF
--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -466,14 +466,17 @@ func TestGenerateManifestsHelmWithRefs_CachedNoLsRemote(t *testing.T) {
 	cacheMocks := newCacheMocks()
 	t.Cleanup(func() {
 		cacheMocks.mockCache.StopRedisCallback()
-		err := filepath.WalkDir(dir,
+		// Best-effort: make all files writable so t.TempDir() can clean up.
+		// Ignore errors (e.g. git object files with restrictive permissions in CI)
+		// to avoid failing the test in the cleanup phase rather than the logic phase.
+		_ = filepath.WalkDir(dir,
 			func(path string, _ fs.DirEntry, err error) error {
-				if err == nil {
-					return os.Chmod(path, 0o777)
+				if err != nil {
+					return nil
 				}
-				return err
+				_ = os.Chmod(path, 0o777)
+				return nil
 			})
-		require.NoError(t, err)
 	})
 	service := NewService(metrics.NewMetricsServer(), cacheMocks.cache, RepoServerInitConstants{ParallelismLimit: 1}, &git.NoopCredsStore{}, repopath)
 	var gitClient git.Client


### PR DESCRIPTION
Closes https://github.com/argoproj/argo-cd/issues/26738

During `GenerateManifest`, the git client clones the repo into a temp path under the test's `t.TempDir()`. On some CI runners, git creates object files with permissions or ownership that make `os.Chmod` return `EPERM`. The existing cleanup code treated this as a fatal test error.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
