### PR TITLE
fix: relogin command ignores --argocd-context flag

### DIFF
--- a/cmd/argocd/commands/relogin.go
+++ b/cmd/argocd/commands/relogin.go
@@ -42,7 +42,7 @@ func NewReloginCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 			if localCfg == nil {
 				log.Fatalf("No context found. Login using `argocd login`")
 			}
-			configCtx, err := localCfg.ResolveContext(localCfg.CurrentContext)
+			configCtx, err := localCfg.ResolveContext(clientOpts.Context)
 			errors.CheckError(err)
 
 			var tokenString string
@@ -79,13 +79,13 @@ func NewReloginCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 			}
 
 			localCfg.UpsertUser(localconfig.User{
-				Name:         localCfg.CurrentContext,
+				Name:         configCtx.Name,
 				AuthToken:    tokenString,
 				RefreshToken: refreshToken,
 			})
 			err = localconfig.WriteLocalConfig(*localCfg, clientOpts.ConfigPath)
 			errors.CheckError(err)
-			fmt.Printf("Context '%s' updated\n", localCfg.CurrentContext)
+			fmt.Printf("Context '%s' updated\n", configCtx.Name)
 		},
 		Example: `
 # Reinitiates the login with previous contexts


### PR DESCRIPTION
## Summary

- `argocd relogin --argocd-context <name>` uses the current context's server instead of the server from the specified `--argocd-context`, causing credentials to be sent to the wrong ArgoCD server
- The root cause is that `relogin.go` hardcodes `localCfg.CurrentContext` instead of using `clientOpts.Context` (the `--argocd-context` flag value), unlike every other command which correctly passes `clientOpts.Context` to `ResolveContext()`
- Fix: use `clientOpts.Context` for context resolution (which already falls back to `CurrentContext` when empty), and use `configCtx.Name` for the upsert and status message

## Test plan

- [x] Set current context to cluster A (`argocd context cluster-a`)
- [x] Run `argocd relogin --argocd-context cluster-b --password <cluster-b-password>`
- [x] Verified it succeeds and prints `Context 'cluster-b' updated` (previously failed with "Invalid username or password" and would have printed `Context 'cluster-a' updated`)
- [x] Verify `argocd relogin` without `--argocd-context` still works (falls back to current context via `ResolveContext("")`)