### PR TITLE
fix: oci creds incorrectly omitted when sourceRepos set to specific registry path

### DIFF
--- a/pkg/apis/application/v1alpha1/app_project_types.go
+++ b/pkg/apis/application/v1alpha1/app_project_types.go
@@ -479,6 +479,35 @@ func (proj AppProject) IsSourcePermitted(src ApplicationSource) bool {
 	return anySourceMatched
 }
 
+// IsCredentialPermittedForAnySource checks whether a credential template URL is a prefix of any
+// permitted source repo. Credential URLs are prefix-based by design (e.g. "reg.example.com"
+// provides auth for "reg.example.com/org/chart"), so a credential should be permitted if any
+// sourceRepo falls under its URL prefix.
+func (proj AppProject) IsCredentialPermittedForAnySource(credURL string) bool {
+	credNormalized := git.NormalizeGitURL(credURL)
+	if credNormalized == "" {
+		return false
+	}
+
+	for _, repoURL := range proj.Spec.SourceRepos {
+		if repoURL == "*" {
+			return true
+		}
+		if isDenyPattern(repoURL) {
+			continue
+		}
+		normalized := git.NormalizeGitURL(repoURL)
+		// Strip oci:// scheme for comparison since credential URLs are typically stored without it
+		normalizedNoScheme := strings.TrimPrefix(normalized, "oci://")
+		credNoScheme := strings.TrimPrefix(credNormalized, "oci://")
+		// Check if the sourceRepo URL starts with the credential URL prefix
+		if strings.HasPrefix(normalizedNoScheme, credNoScheme+"/") || normalizedNoScheme == credNoScheme {
+			return true
+		}
+	}
+	return false
+}
+
 // IsDestinationPermitted validates if the provided application's destination is one of the allowed destinations for the project
 func (proj AppProject) IsDestinationPermitted(destCluster *Cluster, destNamespace string, projectClusters func(project string) ([]*Cluster, error)) (bool, error) {
 	if destCluster == nil {

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -104,6 +104,81 @@ func TestAppProject_IsNegatedSourcePermitted(t *testing.T) {
 	}
 }
 
+func TestAppProject_IsCredentialPermittedForAnySource(t *testing.T) {
+	testData := []struct {
+		name        string
+		projSources []string
+		credURL     string
+		isPermitted bool
+	}{{
+		name:        "wildcard permits any credential",
+		projSources: []string{"*"},
+		credURL:     "reg.example.com",
+		isPermitted: true,
+	}, {
+		name:        "exact match permits credential",
+		projSources: []string{"reg.example.com"},
+		credURL:     "reg.example.com",
+		isPermitted: true,
+	}, {
+		name:        "credential URL is prefix of sourceRepo",
+		projSources: []string{"reg.example.com/org/charts"},
+		credURL:     "reg.example.com",
+		isPermitted: true,
+	}, {
+		name:        "credential URL is prefix of multiple sourceRepos",
+		projSources: []string{"https://github.com/test/repo.git", "reg.example.com/org/charts"},
+		credURL:     "reg.example.com",
+		isPermitted: true,
+	}, {
+		name:        "OCI sourceRepo with credential prefix",
+		projSources: []string{"oci://reg.example.com/org/charts"},
+		credURL:     "reg.example.com",
+		isPermitted: true,
+	}, {
+		name:        "OCI credential URL matches OCI sourceRepo",
+		projSources: []string{"oci://reg.example.com/org/charts"},
+		credURL:     "oci://reg.example.com",
+		isPermitted: true,
+	}, {
+		name:        "credential URL does not match any sourceRepo",
+		projSources: []string{"https://github.com/test/repo.git"},
+		credURL:     "reg.example.com",
+		isPermitted: false,
+	}, {
+		name:        "credential URL is more specific than sourceRepo",
+		projSources: []string{"reg.example.com"},
+		credURL:     "reg.example.com/org/charts",
+		isPermitted: false,
+	}, {
+		name:        "partial hostname match should not permit",
+		projSources: []string{"reg.example.com-evil/org/charts"},
+		credURL:     "reg.example.com",
+		isPermitted: false,
+	}, {
+		name:        "deny pattern does not permit credential",
+		projSources: []string{"!reg.example.com/org/charts"},
+		credURL:     "reg.example.com",
+		isPermitted: false,
+	}, {
+		name:        "empty sourceRepos does not permit credential",
+		projSources: []string{},
+		credURL:     "reg.example.com",
+		isPermitted: false,
+	}}
+
+	for _, data := range testData {
+		t.Run(data.name, func(t *testing.T) {
+			proj := AppProject{
+				Spec: AppProjectSpec{
+					SourceRepos: data.projSources,
+				},
+			}
+			assert.Equal(t, data.isPermitted, proj.IsCredentialPermittedForAnySource(data.credURL))
+		})
+	}
+}
+
 func TestAppProject_IsDestinationPermitted(t *testing.T) {
 	t.Parallel()
 

--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -1046,7 +1046,7 @@ func NormalizeSource(source *argoappv1.ApplicationSource) *argoappv1.Application
 func GetPermittedReposCredentials(proj *argoappv1.AppProject, repoCreds []*argoappv1.RepoCreds) ([]*argoappv1.RepoCreds, error) {
 	var permittedRepoCreds []*argoappv1.RepoCreds
 	for _, v := range repoCreds {
-		if proj.IsSourcePermitted(argoappv1.ApplicationSource{RepoURL: v.URL}) {
+		if proj.IsSourcePermitted(argoappv1.ApplicationSource{RepoURL: v.URL}) || proj.IsCredentialPermittedForAnySource(v.URL) {
 			permittedRepoCreds = append(permittedRepoCreds, v)
 		}
 	}

--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -1060,7 +1060,7 @@ func NormalizeSource(source *argoappv1.ApplicationSource) *argoappv1.Application
 func GetPermittedReposCredentials(proj *argoappv1.AppProject, repoCreds []*argoappv1.RepoCreds) ([]*argoappv1.RepoCreds, error) {
 	var permittedRepoCreds []*argoappv1.RepoCreds
 	for _, v := range repoCreds {
-		if proj.IsSourcePermitted(argoappv1.ApplicationSource{RepoURL: v.URL}) {
+		if proj.IsSourcePermitted(argoappv1.ApplicationSource{RepoURL: v.URL}) || proj.IsCredentialPermittedForAnySource(v.URL) {
 			permittedRepoCreds = append(permittedRepoCreds, v)
 		}
 	}


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates? No
* [x] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
 
## Summary

- Fix `GetPermittedReposCredentials` to permit credential templates when their URL is a prefix of any permitted source repo in the AppProject
- Add `IsCredentialPermittedForAnySource` method to AppProject to handle prefix-based credential matching
- Add comprehensive tests for the new credential permission logic

## Context

When an AppProject's `sourceRepos` uses `*`, all repository credentials pass the permission filter and are sent to the repo-server. However, when `sourceRepos` is scoped to specific repositories (e.g. `reg.example.com/org/charts`), credential templates with broader prefix URLs (e.g. `reg.example.com`) are filtered out, causing `helm dependency build` to fail with 403 errors when resolving OCI Helm chart dependencies.

This affects any Git-sourced Application containing a Helm chart with OCI registry dependencies where the AppProject has restrictive `sourceRepos`.

## Rationale

`GetPermittedReposCredentials` uses `IsSourcePermitted` to decide whether a credential should be passed to the repo-server. `IsSourcePermitted` does exact glob matching: it checks whether the sourceRepos pattern matches the credential URL. But credential template URLs are prefix-based by design — a credential with URL `reg.example.com` is meant to provide authentication for everything under that hostname (e.g. `reg.example.com/org/charts`).

When `sourceRepos` contains a specific path like `reg.example.com/org/charts`, the glob match against the shorter credential URL `reg.example.com` always fails, so the credential is filtered out and never reaches the repo-server. The only workaround was to add the exact credential URL (bare hostname) to `sourceRepos`, which defeats the purpose of restricting which paths the project can access.

## Fix

Added `IsCredentialPermittedForAnySource` on AppProject, which checks the reverse direction: whether any permitted sourceRepo falls under the credential's URL prefix. `GetPermittedReposCredentials` now calls this as a fallback when `IsSourcePermitted` doesn't match, so credentials are permitted if they could provide auth for any source the project is allowed to use.

The check normalises both URLs and strips `oci://` schemes before comparison, so it handles all combinations of OCI and non-OCI sourceRepos entries.

I suspect this may also close out https://github.com/argoproj/argo-cd/issues/26311