### PR TITLE
fix(ui): avoid reloading PodView quickstarts on rerender

### DIFF
--- a/ui/src/app/applications/components/utils.quickstart.test.tsx
+++ b/ui/src/app/applications/components/utils.quickstart.test.tsx
@@ -1,0 +1,127 @@
+import * as React from 'react';
+import * as renderer from 'react-test-renderer';
+import {BehaviorSubject, Subscription} from 'rxjs';
+
+import {ContextApis} from '../../shared/context';
+import {AbstractApplication, Application, ApplicationTree, ResourceNode} from '../../shared/models';
+import {services} from '../../shared/services';
+import {renderResourceButtons} from './utils';
+
+describe('renderResourceButtons', () => {
+    const resource = {
+        uid: 'apps/Deployment/default/guestbook',
+        group: 'apps',
+        kind: 'Deployment',
+        namespace: 'default',
+        name: 'guestbook'
+    } as ResourceNode;
+
+    const otherResource = {
+        ...resource,
+        uid: 'apps/Deployment/default/guestbook-canary',
+        name: 'guestbook-canary'
+    } as ResourceNode;
+
+    const application = {
+        kind: 'Application',
+        metadata: {name: 'guestbook', namespace: 'argocd'},
+        spec: {project: 'default'},
+        status: {
+            resources: [
+                {
+                    group: resource.group,
+                    kind: resource.kind,
+                    namespace: resource.namespace,
+                    name: resource.name
+                }
+            ]
+        }
+    } as Application;
+
+    const tree = {
+        nodes: [resource]
+    } as ApplicationTree;
+
+    const apis = {
+        popup: {prompt: jest.fn()},
+        notifications: {show: jest.fn()},
+        navigation: {goto: jest.fn()},
+        baseHref: ''
+    } as unknown as ContextApis;
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    function QuickStartWrapper(props: {resourceNode: ResourceNode; version: number; appChanged: BehaviorSubject<AbstractApplication>}) {
+        return <div data-version={props.version}>{renderResourceButtons(props.resourceNode, application, tree, apis, props.appChanged)}</div>;
+    }
+
+    it('does not reload quickstart actions on unrelated parent rerenders', () => {
+        const canISpy = jest.spyOn(services.accounts, 'canI').mockResolvedValue(false);
+        const appChanged = new BehaviorSubject<AbstractApplication>(application);
+        const subscription: Subscription = appChanged.subscribe(() => undefined);
+        let rendered: renderer.ReactTestRenderer | undefined;
+
+        try {
+            renderer.act(() => {
+                rendered = renderer.create(<QuickStartWrapper resourceNode={resource} version={0} appChanged={appChanged} />);
+            });
+
+            expect(canISpy).toHaveBeenCalledTimes(1);
+
+            renderer.act(() => {
+                rendered!.update(<QuickStartWrapper resourceNode={resource} version={1} appChanged={appChanged} />);
+            });
+
+            expect(canISpy).toHaveBeenCalledTimes(1);
+        } finally {
+            subscription.unsubscribe();
+        }
+    });
+
+    it('reloads quickstart actions when the resource changes', () => {
+        const canISpy = jest.spyOn(services.accounts, 'canI').mockResolvedValue(false);
+        const appChanged = new BehaviorSubject<AbstractApplication>(application);
+        const subscription: Subscription = appChanged.subscribe(() => undefined);
+        let rendered: renderer.ReactTestRenderer | undefined;
+
+        try {
+            renderer.act(() => {
+                rendered = renderer.create(<QuickStartWrapper resourceNode={resource} version={0} appChanged={appChanged} />);
+            });
+
+            renderer.act(() => {
+                rendered!.update(<QuickStartWrapper resourceNode={otherResource} version={0} appChanged={appChanged} />);
+            });
+
+            expect(canISpy).toHaveBeenCalledTimes(2);
+        } finally {
+            subscription.unsubscribe();
+        }
+    });
+
+    it('reloads quickstart actions when the appChanged subject identity changes', () => {
+        const canISpy = jest.spyOn(services.accounts, 'canI').mockResolvedValue(false);
+        const firstAppChanged = new BehaviorSubject<AbstractApplication>(application);
+        const secondAppChanged = new BehaviorSubject<AbstractApplication>(application);
+        const firstSubscription: Subscription = firstAppChanged.subscribe(() => undefined);
+        const secondSubscription: Subscription = secondAppChanged.subscribe(() => undefined);
+        let rendered: renderer.ReactTestRenderer | undefined;
+
+        try {
+            renderer.act(() => {
+                rendered = renderer.create(<QuickStartWrapper resourceNode={resource} version={0} appChanged={firstAppChanged} />);
+            });
+
+            renderer.act(() => {
+                rendered!.update(<QuickStartWrapper resourceNode={resource} version={0} appChanged={secondAppChanged} />);
+            });
+
+            expect(canISpy).toHaveBeenCalledTimes(2);
+        } finally {
+            firstSubscription.unsubscribe();
+            secondSubscription.unsubscribe();
+        }
+    });
+});

--- a/ui/src/app/applications/components/utils.quickstart.test.tsx
+++ b/ui/src/app/applications/components/utils.quickstart.test.tsx
@@ -3,7 +3,7 @@ import * as renderer from 'react-test-renderer';
 import {BehaviorSubject, Subscription} from 'rxjs';
 
 import {ContextApis} from '../../shared/context';
-import {AbstractApplication, Application, ApplicationTree, ResourceNode} from '../../shared/models';
+import {AbstractApplication, Application, ApplicationTree, HealthStatuses, ResourceNode} from '../../shared/models';
 import {services} from '../../shared/services';
 import {renderResourceButtons} from './utils';
 
@@ -53,8 +53,14 @@ describe('renderResourceButtons', () => {
         jest.restoreAllMocks();
     });
 
-    function QuickStartWrapper(props: {resourceNode: ResourceNode; version: number; appChanged: BehaviorSubject<AbstractApplication>}) {
-        return <div data-version={props.version}>{renderResourceButtons(props.resourceNode, application, tree, apis, props.appChanged)}</div>;
+    function QuickStartWrapper(props: {
+        resourceNode: ResourceNode;
+        version: number;
+        appChanged: BehaviorSubject<AbstractApplication>;
+        app: Application;
+        appTree: ApplicationTree;
+    }) {
+        return <div data-version={props.version}>{renderResourceButtons(props.resourceNode, props.app, props.appTree, apis, props.appChanged)}</div>;
     }
 
     it('does not reload quickstart actions on unrelated parent rerenders', () => {
@@ -65,13 +71,13 @@ describe('renderResourceButtons', () => {
 
         try {
             renderer.act(() => {
-                rendered = renderer.create(<QuickStartWrapper resourceNode={resource} version={0} appChanged={appChanged} />);
+                rendered = renderer.create(<QuickStartWrapper resourceNode={resource} version={0} appChanged={appChanged} app={application} appTree={tree} />);
             });
 
             expect(canISpy).toHaveBeenCalledTimes(1);
 
             renderer.act(() => {
-                rendered!.update(<QuickStartWrapper resourceNode={resource} version={1} appChanged={appChanged} />);
+                rendered!.update(<QuickStartWrapper resourceNode={resource} version={1} appChanged={appChanged} app={application} appTree={tree} />);
             });
 
             expect(canISpy).toHaveBeenCalledTimes(1);
@@ -88,11 +94,11 @@ describe('renderResourceButtons', () => {
 
         try {
             renderer.act(() => {
-                rendered = renderer.create(<QuickStartWrapper resourceNode={resource} version={0} appChanged={appChanged} />);
+                rendered = renderer.create(<QuickStartWrapper resourceNode={resource} version={0} appChanged={appChanged} app={application} appTree={tree} />);
             });
 
             renderer.act(() => {
-                rendered!.update(<QuickStartWrapper resourceNode={otherResource} version={0} appChanged={appChanged} />);
+                rendered!.update(<QuickStartWrapper resourceNode={otherResource} version={0} appChanged={appChanged} app={application} appTree={tree} />);
             });
 
             expect(canISpy).toHaveBeenCalledTimes(2);
@@ -111,17 +117,51 @@ describe('renderResourceButtons', () => {
 
         try {
             renderer.act(() => {
-                rendered = renderer.create(<QuickStartWrapper resourceNode={resource} version={0} appChanged={firstAppChanged} />);
+                rendered = renderer.create(<QuickStartWrapper resourceNode={resource} version={0} appChanged={firstAppChanged} app={application} appTree={tree} />);
             });
 
             renderer.act(() => {
-                rendered!.update(<QuickStartWrapper resourceNode={resource} version={0} appChanged={secondAppChanged} />);
+                rendered!.update(<QuickStartWrapper resourceNode={resource} version={0} appChanged={secondAppChanged} app={application} appTree={tree} />);
             });
 
             expect(canISpy).toHaveBeenCalledTimes(2);
         } finally {
             firstSubscription.unsubscribe();
             secondSubscription.unsubscribe();
+        }
+    });
+
+    it('does not reload quickstart actions when application and tree objects change without affecting quickstart behavior', () => {
+        const canISpy = jest.spyOn(services.accounts, 'canI').mockResolvedValue(false);
+        const appChanged = new BehaviorSubject<AbstractApplication>(application);
+        const subscription: Subscription = appChanged.subscribe(() => undefined);
+        const refreshedApplication = {
+            ...application,
+            status: {
+                ...application.status,
+                health: {status: HealthStatuses.Healthy}
+            }
+        } as Application;
+        const refreshedTree = {
+            ...tree,
+            nodes: [...tree.nodes]
+        } as ApplicationTree;
+        let rendered: renderer.ReactTestRenderer | undefined;
+
+        try {
+            renderer.act(() => {
+                rendered = renderer.create(<QuickStartWrapper resourceNode={resource} version={0} appChanged={appChanged} app={application} appTree={tree} />);
+            });
+
+            renderer.act(() => {
+                rendered!.update(
+                    <QuickStartWrapper resourceNode={resource} version={0} appChanged={appChanged} app={refreshedApplication} appTree={refreshedTree} />
+                );
+            });
+
+            expect(canISpy).toHaveBeenCalledTimes(1);
+        } finally {
+            subscription.unsubscribe();
         }
     });
 });

--- a/ui/src/app/applications/components/utils.quickstart.test.tsx
+++ b/ui/src/app/applications/components/utils.quickstart.test.tsx
@@ -164,4 +164,31 @@ describe('renderResourceButtons', () => {
             subscription.unsubscribe();
         }
     });
+
+    it('does not reload quickstart actions when the apis wrapper object changes without changing the underlying managers', () => {
+        const canISpy = jest.spyOn(services.accounts, 'canI').mockResolvedValue(false);
+        const appChanged = new BehaviorSubject<AbstractApplication>(application);
+        const subscription: Subscription = appChanged.subscribe(() => undefined);
+        const refreshedApis = {
+            popup: apis.popup,
+            notifications: apis.notifications,
+            navigation: apis.navigation,
+            baseHref: apis.baseHref
+        } as unknown as ContextApis;
+        let rendered: renderer.ReactTestRenderer | undefined;
+
+        try {
+            renderer.act(() => {
+                rendered = renderer.create(<div>{renderResourceButtons(resource, application, tree, apis, appChanged)}</div>);
+            });
+
+            renderer.act(() => {
+                rendered!.update(<div>{renderResourceButtons(resource, application, tree, refreshedApis, appChanged)}</div>);
+            });
+
+            expect(canISpy).toHaveBeenCalledTimes(1);
+        } finally {
+            subscription.unsubscribe();
+        }
+    });
 });

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -693,6 +693,15 @@ export async function getResourceActionsMenuItems(resource: ResourceTreeNode, me
         .catch(() => [] as ActionMenuItem[]);
 }
 
+function isTopLevelResource(resource: ResourceTreeNode, application: appModels.AbstractApplication): boolean {
+    const resourceID = `/${resource.namespace}/${resource.group}/${resource.kind}/${resource.name}`;
+    return (
+        application.status?.resources?.some(
+            (resourceStatus: appModels.ResourceStatus) => `/${resourceStatus.namespace}/${resourceStatus.group}/${resourceStatus.kind}/${resourceStatus.name}` === resourceID
+        ) || false
+    );
+}
+
 function getActionItems(
     resource: ResourceTreeNode,
     application: appModels.AbstractApplication,
@@ -701,14 +710,6 @@ function getActionItems(
     appChanged: BehaviorSubject<appModels.AbstractApplication>,
     isQuickStart: boolean
 ): Observable<ActionMenuItem[]> {
-    function isTopLevelResource(res: ResourceTreeNode, app: appModels.AbstractApplication): boolean {
-        const uniqRes = `/${res.namespace}/${res.group}/${res.kind}/${res.name}`;
-        return (
-            app.status?.resources?.some((resStatus: appModels.ResourceStatus) => `/${resStatus.namespace}/${resStatus.group}/${resStatus.kind}/${resStatus.name}` === uniqRes) ||
-            false
-        );
-    }
-
     const isPod = resource.kind === 'Pod';
     const isManaged = isTopLevelResource(resource, application);
     const childResources = isApp(application) ? findChildResources(resource, tree as appModels.ApplicationTree) : [];
@@ -899,14 +900,6 @@ interface ResourceButtonsProps {
     appChanged: BehaviorSubject<appModels.AbstractApplication>;
 }
 
-interface ResourceButtonsInput {
-    resource: ResourceTreeNode;
-    application: appModels.AbstractApplication;
-    tree: appModels.AbstractApplicationTree;
-    apisId: number;
-    appChangedId: number;
-}
-
 const objectIds = new WeakMap<object, number>();
 let nextObjectId = 1;
 
@@ -921,19 +914,38 @@ function getObjectId(value: object) {
 
 // Keep quickstart action loading stable across unrelated PodView rerenders.
 const ResourceButtons = React.memo(({resource, application, tree, apis, appChanged}: ResourceButtonsProps) => {
+    const isManaged = React.useMemo(() => isTopLevelResource(resource, application), [resource, application]);
+    const childResourceKeys = React.useMemo(
+        () =>
+            isApp(application)
+                ? findChildResources(resource, tree as appModels.ApplicationTree)
+                      .map(node => nodeKey(node))
+                      .sort()
+                : [],
+        [resource, application, tree]
+    );
+    const hasLogsTarget = React.useMemo(
+        () => resource.kind === 'Pod' || (isApp(application) && !!findChildPod(resource, tree as appModels.ApplicationTree)),
+        [resource, application, tree]
+    );
     const input = React.useMemo(
         () => ({
-            resource,
-            application,
-            tree,
+            resourceKey: nodeKey(resource),
+            applicationKind: application.kind,
+            applicationName: application.metadata.name,
+            applicationNamespace: application.metadata.namespace,
+            applicationProject: isApp(application) ? application.spec.project : '',
+            isManaged,
+            childResourceKeys,
+            hasLogsTarget,
             apisId: getObjectId(apis),
             appChangedId: getObjectId(appChanged)
         }),
-        [resource, application, tree, apis, appChanged]
+        [resource, application, isManaged, childResourceKeys, hasLogsTarget, apis, appChanged]
     );
 
     return (
-        <DataLoader input={input} load={(value: ResourceButtonsInput) => getActionItems(value.resource, value.application, value.tree, apis, appChanged, true)}>
+        <DataLoader input={input} load={() => getActionItems(resource, application, tree, apis, appChanged, true)}>
             {items => (
                 <div className='pod-view__node__quick-start-actions'>
                     {items.map((item, i) => (

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -938,10 +938,13 @@ const ResourceButtons = React.memo(({resource, application, tree, apis, appChang
             isManaged,
             childResourceKeys,
             hasLogsTarget,
-            apisId: getObjectId(apis),
+            popupId: getObjectId(apis.popup),
+            notificationsId: getObjectId(apis.notifications),
+            navigationId: getObjectId(apis.navigation),
+            baseHref: apis.baseHref,
             appChangedId: getObjectId(appChanged)
         }),
-        [resource, application, isManaged, childResourceKeys, hasLogsTarget, apis, appChanged]
+        [resource, application, isManaged, childResourceKeys, hasLogsTarget, apis.popup, apis.notifications, apis.navigation, apis.baseHref, appChanged]
     );
 
     return (

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -891,16 +891,49 @@ export function renderResourceActionMenu(menuItems: ActionMenuItem[]): React.Rea
     );
 }
 
-export function renderResourceButtons(
-    resource: ResourceTreeNode,
-    application: appModels.AbstractApplication,
-    tree: appModels.AbstractApplicationTree,
-    apis: ContextApis,
-    appChanged: BehaviorSubject<appModels.AbstractApplication>
-): React.ReactNode {
-    const menuItems: Observable<ActionMenuItem[]> = getActionItems(resource, application, tree, apis, appChanged, true);
+interface ResourceButtonsProps {
+    resource: ResourceTreeNode;
+    application: appModels.AbstractApplication;
+    tree: appModels.AbstractApplicationTree;
+    apis: ContextApis;
+    appChanged: BehaviorSubject<appModels.AbstractApplication>;
+}
+
+interface ResourceButtonsInput {
+    resource: ResourceTreeNode;
+    application: appModels.AbstractApplication;
+    tree: appModels.AbstractApplicationTree;
+    apisId: number;
+    appChangedId: number;
+}
+
+const objectIds = new WeakMap<object, number>();
+let nextObjectId = 1;
+
+function getObjectId(value: object) {
+    let id = objectIds.get(value);
+    if (id === undefined) {
+        id = nextObjectId++;
+        objectIds.set(value, id);
+    }
+    return id;
+}
+
+// Keep quickstart action loading stable across unrelated PodView rerenders.
+const ResourceButtons = React.memo(({resource, application, tree, apis, appChanged}: ResourceButtonsProps) => {
+    const input = React.useMemo(
+        () => ({
+            resource,
+            application,
+            tree,
+            apisId: getObjectId(apis),
+            appChangedId: getObjectId(appChanged)
+        }),
+        [resource, application, tree, apis, appChanged]
+    );
+
     return (
-        <DataLoader load={() => menuItems}>
+        <DataLoader input={input} load={(value: ResourceButtonsInput) => getActionItems(value.resource, value.application, value.tree, apis, appChanged, true)}>
             {items => (
                 <div className='pod-view__node__quick-start-actions'>
                     {items.map((item, i) => (
@@ -922,6 +955,17 @@ export function renderResourceButtons(
             )}
         </DataLoader>
     );
+});
+ResourceButtons.displayName = 'ResourceButtons';
+
+export function renderResourceButtons(
+    resource: ResourceTreeNode,
+    application: appModels.AbstractApplication,
+    tree: appModels.AbstractApplicationTree,
+    apis: ContextApis,
+    appChanged: BehaviorSubject<appModels.AbstractApplication>
+): React.ReactNode {
+    return <ResourceButtons resource={resource} application={application} tree={tree} apis={apis} appChanged={appChanged} />;
 }
 
 export function syncStatusMessage(app: appModels.Application) {


### PR DESCRIPTION
Fixes #24831

## Summary
PodView currently recreates quickstart button loading inline during render, which causes quickstart action loading to run again on unrelated rerenders. In practice that means interactions like group expansion or panel updates can retrigger quickstart permission requests.

This change moves quickstart action loading behind a memoized component and uses a stable serializable DataLoader input so quickstart actions only reload when the relevant resource/application/tree inputs change.

## Verification
- Added regression coverage for:
  - unrelated parent rerenders do not reload quickstart actions
  - resource changes still reload quickstart actions
  - appChanged subject identity changes still reload quickstart actions
- Ran:
  - `corepack yarn test --runTestsByPath src/app/applications/components/utils.quickstart.test.tsx src/app/applications/components/utils.test.tsx --runInBand`
  - `./node_modules/.bin/tsc --noEmit --project ./src/app`
  - `./node_modules/.bin/eslint src/app/applications/components/utils.tsx src/app/applications/components/utils.quickstart.test.tsx --no-warn-ignored`