### PR TITLE
fix(test): make fail message better for TestAuthReconcileWithMissingNamespace

### DIFF
--- a/gitops-engine/pkg/utils/kube/resource_ops_test.go
+++ b/gitops-engine/pkg/utils/kube/resource_ops_test.go
@@ -57,14 +57,14 @@ func TestAuthReconcileWithMissingNamespace(t *testing.T) {
 
 	_, err := k.authReconcile(context.Background(), role, "/dev/null", cmdutil.DryRunNone)
 	assert.Error(t, err)
-	assert.True(t, errors.IsNotFound(err), "returned error wasn't not found")
+	assert.True(t, errors.IsNotFound(err), "returned error should be resource not found")
 
 	roleBinding := testingutils.NewRoleBinding()
 	roleBinding.SetNamespace(namespace)
 
 	_, err = k.authReconcile(context.Background(), roleBinding, "/dev/null", cmdutil.DryRunNone)
 	assert.Error(t, err)
-	assert.True(t, errors.IsNotFound(err), "returned error wasn't not found")
+	assert.True(t, errors.IsNotFound(err), "returned error should be resource not found")
 
 	clusterRole := testingutils.NewClusterRole()
 	clusterRole.SetNamespace(namespace)


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

This PR improves the fail messages for TestAuthReconcileWithMissingNamespace as discussed on the CNCF Slack.

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [N/A] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [N/A Does this PR require documentation updates?
* [N/A] I've updated documentation as required by this PR.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [X] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [X] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
