### PR TITLE
fix: 'Previous version' banner should redirect to

### DIFF
--- a/docs/assets/versions.js
+++ b/docs/assets/versions.js
@@ -139,10 +139,11 @@ window.addEventListener("DOMContentLoaded", function() {
   var headerHeight = document.getElementsByClassName("md-header")[0].offsetHeight;
   const currentVersion = getCurrentVersion();
   if (currentVersion && currentVersion !== "stable") {
+    var stablePath = window.location.pathname.replace(VERSION_REGEX, '/en/stable/');
     if (currentVersion === "latest") {
-      document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for an unreleased version of Argo CD, <a href='https://argo-cd.readthedocs.io/en/stable/'>view the latest stable version.</a></div>";
+      document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for an unreleased version of Argo CD, <a href='" + stablePath + "'>view the latest stable version.</a></div>";
     } else {
-      document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for a previous version of Argo CD, <a href='https://argo-cd.readthedocs.io/en/stable/'>view the latest stable version.</a></div>";
+      document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for a previous version of Argo CD, <a href='" + stablePath + "'>view the latest stable version.</a></div>";
     }
     var bannerHeight = document.getElementById('announce-msg').offsetHeight + margin;
     document.querySelector("header.md-header").style.top = bannerHeight + "px";

--- a/docs/assets/versions.js
+++ b/docs/assets/versions.js
@@ -139,7 +139,7 @@ window.addEventListener("DOMContentLoaded", function() {
   var headerHeight = document.getElementsByClassName("md-header")[0].offsetHeight;
   const currentVersion = getCurrentVersion();
   if (currentVersion && currentVersion !== "stable") {
-    var stablePath = window.location.pathname.replace(VERSION_REGEX, '/en/stable/');
+    var stablePath = 'https://argo-cd.readthedocs.io' + window.location.pathname.replace(VERSION_REGEX, '/en/stable/');
     if (currentVersion === "latest") {
       document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for an unreleased version of Argo CD, <a href='" + stablePath + "'>view the latest stable version.</a></div>";
     } else {


### PR DESCRIPTION
Fixes #26857

The version warning banner in `docs/assets/versions.js` always linked to the stable docs home page (`/en/stable/`) regardless of which page the user was currently viewing. The root cause was that the `href` values were hardcoded to `https://argo-cd.readthedocs.io/en/stable/` in both the `latest` and previous-version branches of the `DOMContentLoaded` listener. Fixes this by computing `stablePath` using `window.location.pathname.replace(VERSION_REGEX, '/en/stable/')` and prepending the `argo-cd.readthedocs.io` origin, so the banner link points to the equivalent page on the stable version. Verified by reviewing that the constructed URL preserves the absolute URL format expected by the original code while dynamically replacing the version segment in the path.