### PR TITLE
fix(UI): show RollingSync step clearly when labels match no step

### DIFF
--- a/ui/src/app/applications/components/application-status-panel/application-status-panel.tsx
+++ b/ui/src/app/applications/components/application-status-panel/application-status-panel.tsx
@@ -8,6 +8,7 @@ import {services} from '../../../shared/services';
 import {
     ApplicationSyncWindowStatusIcon,
     ComparisonStatusIcon,
+    formatApplicationSetProgressiveSyncStep,
     getAppDefaultSource,
     getAppDefaultSyncRevisionExtra,
     getAppOperationState,
@@ -134,7 +135,9 @@ const ProgressiveSyncStatus = ({application}: {application: models.Application})
                         <div className='application-status-panel__item-value' style={{color: getProgressiveSyncStatusColor(appResource.status)}}>
                             {getProgressiveSyncStatusIcon({status: appResource.status})}&nbsp;{appResource.status}
                         </div>
-                        {appResource?.step && <div className='application-status-panel__item-value'>Wave: {appResource.step}</div>}
+                        {appResource?.step !== undefined && (
+                            <div className='application-status-panel__item-value'>Step: {formatApplicationSetProgressiveSyncStep(appResource.step)}</div>
+                        )}
                         {lastTransitionTime && (
                             <div className='application-status-panel__item-name' style={{marginBottom: '0.5em'}}>
                                 Last Transition: <br />

--- a/ui/src/app/applications/components/application-status-panel/application-status-panel.tsx
+++ b/ui/src/app/applications/components/application-status-panel/application-status-panel.tsx
@@ -135,9 +135,7 @@ const ProgressiveSyncStatus = ({application}: {application: models.Application})
                         <div className='application-status-panel__item-value' style={{color: getProgressiveSyncStatusColor(appResource.status)}}>
                             {getProgressiveSyncStatusIcon({status: appResource.status})}&nbsp;{appResource.status}
                         </div>
-                        {appResource?.step !== undefined && (
-                            <div className='application-status-panel__item-value'>Step: {formatApplicationSetProgressiveSyncStep(appResource.step)}</div>
-                        )}
+                        {appResource?.step !== undefined && <div className='application-status-panel__item-value'>{formatApplicationSetProgressiveSyncStep(appResource.step)}</div>}
                         {lastTransitionTime && (
                             <div className='application-status-panel__item-name' style={{marginBottom: '0.5em'}}>
                                 Last Transition: <br />

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -1858,6 +1858,11 @@ export function getAppUrl(app: appModels.AbstractApplication): string {
     return `${basePath}/${app.metadata.namespace}/${app.metadata.name}`;
 }
 
+/** RollingSync step for display; backend uses -1 when no step matches the app's labels. */
+export function formatApplicationSetProgressiveSyncStep(step: string | undefined): string {
+    return step === '-1' ? 'unmatched label' : step ?? '';
+}
+
 export const getProgressiveSyncStatusIcon = ({status, isButton}: {status: string; isButton?: boolean}) => {
     const getIconProps = () => {
         switch (status) {

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -1860,7 +1860,10 @@ export function getAppUrl(app: appModels.AbstractApplication): string {
 
 /** RollingSync step for display; backend uses -1 when no step matches the app's labels. */
 export function formatApplicationSetProgressiveSyncStep(step: string | undefined): string {
-    return step === '-1' ? 'unmatched label' : step ?? '';
+    if (step === '-1') {
+        return 'Step: unmatched label';
+    }
+    return `Step: ${step ?? ''}`;
 }
 
 export const getProgressiveSyncStatusIcon = ({status, isButton}: {status: string; isButton?: boolean}) => {


### PR DESCRIPTION
When an ApplicationSet uses a RollingSync strategy and an application’s labels do not match any step’s matchExpressions, the controller reports step: "-1". The UI now shows that in a clear way instead of a confusing raw value.

Fixes: #26861 

**Before**:

<img width="1691" height="278" alt="image" src="https://github.com/user-attachments/assets/126bea81-e0f2-4c09-8d9f-da90605dedbd" />

**After**:

<img width="1696" height="554" alt="Screenshot 2026-03-17 at 3 10 26 PM" src="https://github.com/user-attachments/assets/aa05e5d2-1820-485f-b10d-11e204bc79f3" />
 
 and when all labels match change from Wave: 2 -> Step: 2

<img width="1696" height="373" alt="Screenshot 2026-03-17 at 3 09 46 PM" src="https://github.com/user-attachments/assets/dbd525f5-6843-4319-8be3-df2b8f731da9" />


<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->



Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
