### PR TITLE
chore(ci): remove cherry-pick branch if already present

### DIFF
--- a/.github/workflows/cherry-pick-single.yml
+++ b/.github/workflows/cherry-pick-single.yml
@@ -66,6 +66,13 @@ jobs:
 
           # Create new branch for cherry-pick
           CHERRY_PICK_BRANCH="cherry-pick-${{ inputs.pr_number }}-to-${TARGET_BRANCH}"
+
+          # Remove existing remote branch if it exists (e.g. from a previous failed run)
+          if git show-ref --verify --quiet "refs/remotes/origin/$CHERRY_PICK_BRANCH"; then
+            echo "🗑️ Removing existing branch '$CHERRY_PICK_BRANCH'"
+            git push origin --delete "$CHERRY_PICK_BRANCH"
+          fi
+
           git checkout -b "$CHERRY_PICK_BRANCH" "origin/$TARGET_BRANCH"
 
           # Perform cherry-pick

--- a/.github/workflows/cherry-pick-single.yml
+++ b/.github/workflows/cherry-pick-single.yml
@@ -67,12 +67,6 @@ jobs:
           # Create new branch for cherry-pick
           CHERRY_PICK_BRANCH="cherry-pick-${{ inputs.pr_number }}-to-${TARGET_BRANCH}"
 
-          # Remove existing remote branch if it exists (e.g. from a previous failed run)
-          if git show-ref --verify --quiet "refs/remotes/origin/$CHERRY_PICK_BRANCH"; then
-            echo "🗑️ Removing existing branch '$CHERRY_PICK_BRANCH'"
-            git push origin --delete "$CHERRY_PICK_BRANCH"
-          fi
-
           git checkout -b "$CHERRY_PICK_BRANCH" "origin/$TARGET_BRANCH"
 
           # Perform cherry-pick
@@ -82,8 +76,9 @@ jobs:
             # Extract Signed-off-by from the cherry-pick commit
             SIGNOFF=$(git log -1 --pretty=format:"%B" | grep -E '^Signed-off-by:' || echo "")
 
-            # Push the new branch
-            git push origin "$CHERRY_PICK_BRANCH"
+            # Push the new branch. Force push to ensure that in case the original cherry-pick branch is stale, 
+            # that the current state of the $TARGET_BRANCH + cherry-pick gets in $CHERRY_PICK_BRANCH.
+            git push origin -f "$CHERRY_PICK_BRANCH"
 
             # Save data for PR creation
             echo "branch_name=$CHERRY_PICK_BRANCH" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
In case there was a failed cherry-pick for whatever reason and we'd like to retry, it'll fail since the cherry-pick branch already exists. So let's remove the branch if it already exist.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
