### PR TITLE
docs: fix incorrect wording for ApplicationSets in other namespaces

### DIFF
--- a/docs/operator-manual/applicationset/Appset-Any-Namespace.md
+++ b/docs/operator-manual/applicationset/Appset-Any-Namespace.md
@@ -230,7 +230,7 @@ p, somerole, applicationsets, get, foo/bar/*, allow
 
 ### Using the CLI
 
-You can use all existing Argo CD CLI commands for managing applications in other namespaces, exactly as you would use the CLI to manage applications in the control plane's namespace.
+You can use all existing Argo CD CLI commands for managing ApplicationSets in other namespaces, exactly as you would use the CLI to manage ApplicationSets in the control plane's namespace.
 
 For example, to retrieve the `ApplicationSet` named `foo` in the namespace `bar`, you can use the following CLI command:
 


### PR DESCRIPTION
## Description

This PR fixes incorrect wording in the documentation section "Managing ApplicationSets in other namespaces".

The documentation currently refers to "applications" instead of "ApplicationSets", which is inconsistent with the context of the section.

## Changes
- Replaced the word "applications" with "ApplicationSets" in the documentation to correctly reflect the section context.

Fixes #26888

## Checklist

- [x] The title of the PR states what changed and the related issue number.
- [x] I have included "Fixes #26888" in the description to automatically close the associated issue.
- [x] Does this PR require documentation updates? Yes.
- [x] I have updated the documentation as required by this PR.

