### PR TITLE
fix: support sidecar containers in web terminal

### DIFF
--- a/server/application/terminal.go
+++ b/server/application/terminal.go
@@ -223,6 +223,15 @@ func (s *terminalHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if !findContainer {
+		// Also check init containers (sidecar containers with restartPolicy: Always)
+		for _, c := range pod.Spec.InitContainers {
+			if container == c.Name {
+				findContainer = true
+				break
+			}
+		}
+	}
+	if !findContainer {
 		fieldLog.Warn("terminal container not found")
 		http.Error(w, "Cannot find container", http.StatusBadRequest)
 		return


### PR DESCRIPTION
## Summary
Fixes #26830.
**Root cause:** Web terminal container lookup only checked `pod.Spec.Containers`, missing sidecar containers defined as init containers with `restartPolicy: Always` in `pod.Spec.InitContainers`.
**Fix:** Extended the container lookup to also search `pod.Spec.InitContainers`.
## Changes
- `server/application/terminal.go`: Extended container search to include init containers
## Testing
- Verified fix addresses reported scenario (sidecar containers now found by web terminal)
- Change is minimal and follows existing code patterns

Made with [Cursor](https://cursor.com)