### PR TITLE
fix(docs): version banner redirects to stable version of current page

### DIFF
--- a/docs/assets/versions.js
+++ b/docs/assets/versions.js
@@ -139,10 +139,11 @@ window.addEventListener("DOMContentLoaded", function() {
   var headerHeight = document.getElementsByClassName("md-header")[0].offsetHeight;
   const currentVersion = getCurrentVersion();
   if (currentVersion && currentVersion !== "stable") {
+    var stableURL = window.location.href.replace(VERSION_REGEX, '/en/stable/');
     if (currentVersion === "latest") {
-      document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for an unreleased version of Argo CD, <a href='https://argo-cd.readthedocs.io/en/stable/'>view the latest stable version.</a></div>";
+      document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for an unreleased version of Argo CD, <a href='" + stableURL + "'>view the latest stable version.</a></div>";
     } else {
-      document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for a previous version of Argo CD, <a href='https://argo-cd.readthedocs.io/en/stable/'>view the latest stable version.</a></div>";
+      document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for a previous version of Argo CD, <a href='" + stableURL + "'>view the latest stable version.</a></div>";
     }
     var bannerHeight = document.getElementById('announce-msg').offsetHeight + margin;
     document.querySelector("header.md-header").style.top = bannerHeight + "px";


### PR DESCRIPTION
## Summary

- Fixes the "view the latest stable version" banner to redirect to the stable version of the **current page** instead of the docs home page
- Uses `window.location.href.replace(VERSION_REGEX, '/en/stable/')` to preserve the page path while swapping the version segment

Fixes #26857

## Details

When viewing docs for a previous or unreleased version of Argo CD (e.g., `release-2.13` or `latest`), the banner at the top links to `https://argo-cd.readthedocs.io/en/stable/` regardless of which page you are on. This is disorienting, especially when arriving via search engine.

This change constructs the stable URL by replacing the version segment in the current URL (e.g., `/en/release-2.13/` becomes `/en/stable/`), so clicking the banner takes you to the same page on the stable version.

## Test plan

- [ ] Visit a non-stable docs page (e.g., `https://argo-cd.readthedocs.io/en/latest/operator-manual/installation/`)
- [ ] Verify the banner link points to `https://argo-cd.readthedocs.io/en/stable/operator-manual/installation/` instead of just `https://argo-cd.readthedocs.io/en/stable/`
- [ ] Verify both `latest` and `release-*` version banners produce correct links

Signed-off-by: Alex Chen <alex@alexchen.dev>