### PR TITLE
fix: add X-Frame-Options and CSP headers to Swagger UI endpoints

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1244,7 +1244,7 @@ func (server *ArgoCDServer) newHTTPServer(ctx context.Context, port int, grpcWeb
 	mustRegisterGWHandler(ctx, gpgkeypkg.RegisterGPGKeyServiceHandler, gwmux, conn)
 
 	// Swagger UI
-	swagger.ServeSwaggerUI(mux, assets.SwaggerJSON, "/swagger-ui", server.RootPath)
+	swagger.ServeSwaggerUI(mux, assets.SwaggerJSON, "/swagger-ui", server.RootPath, server.XFrameOptions, server.ContentSecurityPolicy)
 	healthz.ServeHealthCheck(mux, server.healthCheck)
 
 	// Dex reverse proxy and OAuth2 login/callback

--- a/util/swagger/swagger.go
+++ b/util/swagger/swagger.go
@@ -11,20 +11,33 @@ import (
 // filename of ReDoc script in UI's assets/scripts path
 const redocScriptName = "redoc.standalone.js"
 
+// withSecurityHeaders wraps an http.Handler to add clickjacking-prevention headers.
+func withSecurityHeaders(h http.Handler, xFrameOptions, contentSecurityPolicy string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if xFrameOptions != "" {
+			w.Header().Set("X-Frame-Options", xFrameOptions)
+		}
+		if contentSecurityPolicy != "" {
+			w.Header().Set("Content-Security-Policy", contentSecurityPolicy)
+		}
+		h.ServeHTTP(w, r)
+	})
+}
+
 // ServeSwaggerUI serves the Swagger UI and JSON spec.
-func ServeSwaggerUI(mux *http.ServeMux, swaggerJSON string, uiPath string, rootPath string) {
+func ServeSwaggerUI(mux *http.ServeMux, swaggerJSON string, uiPath string, rootPath string, xFrameOptions string, contentSecurityPolicy string) {
 	prefix := path.Dir(uiPath)
 	swaggerPath := path.Join(prefix, "swagger.json")
-	mux.HandleFunc(swaggerPath, func(w http.ResponseWriter, _ *http.Request) {
+	mux.Handle(swaggerPath, withSecurityHeaders(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = fmt.Fprint(w, swaggerJSON)
-	})
+	}), xFrameOptions, contentSecurityPolicy))
 
 	specURL := path.Join(prefix, rootPath, "swagger.json")
 	scriptURL := path.Join(prefix, rootPath, "assets", "scripts", redocScriptName)
-	mux.Handle(uiPath, middleware.Redoc(middleware.RedocOpts{
+	mux.Handle(uiPath, withSecurityHeaders(middleware.Redoc(middleware.RedocOpts{
 		BasePath: prefix,
 		SpecURL:  specURL,
 		Path:     path.Base(uiPath),
 		RedocURL: scriptURL,
-	}, http.NotFoundHandler()))
+	}, http.NotFoundHandler()), xFrameOptions, contentSecurityPolicy))
 }

--- a/util/swagger/swagger_test.go
+++ b/util/swagger/swagger_test.go
@@ -25,7 +25,7 @@ func TestSwaggerUI(t *testing.T) {
 		c <- listener.Addr().String()
 
 		mux := http.NewServeMux()
-		ServeSwaggerUI(mux, assets.SwaggerJSON, "/swagger-ui", "")
+		ServeSwaggerUI(mux, assets.SwaggerJSON, "/swagger-ui", "", "", "")
 		panic(http.Serve(listener, mux))
 	}
 
@@ -52,4 +52,68 @@ func TestSwaggerUI(t *testing.T) {
 	require.NoError(t, err)
 	require.Equalf(t, http.StatusOK, resp.StatusCode, "Was expecting status code 200 from swagger-ui, but got %d instead", resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
+}
+
+func TestSwaggerUISecurityHeaders(t *testing.T) {
+	lc := &net.ListenConfig{}
+	serve := func(c chan<- string) {
+		listener, err := lc.Listen(t.Context(), "tcp", ":0")
+		if err != nil {
+			panic(err)
+		}
+		c <- listener.Addr().String()
+
+		mux := http.NewServeMux()
+		ServeSwaggerUI(mux, assets.SwaggerJSON, "/swagger-ui", "", "DENY", "frame-ancestors 'none'")
+		panic(http.Serve(listener, mux))
+	}
+
+	c := make(chan string, 1)
+	go serve(c)
+	address := <-c
+
+	serverURL := "http://" + address
+
+	for _, path := range []string{"/swagger.json", "/swagger-ui"} {
+		t.Run(path, func(t *testing.T) {
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, serverURL+path, http.NoBody)
+			require.NoError(t, err)
+
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			require.NoError(t, resp.Body.Close())
+
+			require.Equal(t, "DENY", resp.Header.Get("X-Frame-Options"), "X-Frame-Options header missing on %s", path)
+			require.Equal(t, "frame-ancestors 'none'", resp.Header.Get("Content-Security-Policy"), "Content-Security-Policy header missing on %s", path)
+		})
+	}
+}
+
+func TestSwaggerUISecurityHeadersNotSetWhenEmpty(t *testing.T) {
+	lc := &net.ListenConfig{}
+	serve := func(c chan<- string) {
+		listener, err := lc.Listen(t.Context(), "tcp", ":0")
+		if err != nil {
+			panic(err)
+		}
+		c <- listener.Addr().String()
+
+		mux := http.NewServeMux()
+		ServeSwaggerUI(mux, assets.SwaggerJSON, "/swagger-ui", "", "", "")
+		panic(http.Serve(listener, mux))
+	}
+
+	c := make(chan string, 1)
+	go serve(c)
+	address := <-c
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://"+address+"/swagger.json", http.NoBody)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	require.Empty(t, resp.Header.Get("X-Frame-Options"), "X-Frame-Options should not be set when not configured")
+	require.Empty(t, resp.Header.Get("Content-Security-Policy"), "Content-Security-Policy should not be set when not configured")
 }


### PR DESCRIPTION
## Summary

Fixes #22877

The Swagger UI (`/swagger-ui`) and spec (`/swagger.json`) endpoints were missing clickjacking-prevention headers. These endpoints were served via `ServeSwaggerUI()` in `util/swagger/swagger.go`, which bypassed the security headers middleware that's applied to the main UI assets handler (`newStaticAssetsHandler`).

### Root cause

`newStaticAssetsHandler()` sets `X-Frame-Options` and `Content-Security-Policy` on every response — but only for routes registered at `/`. The Swagger UI is registered separately on the `http.ServeMux` and never went through this middleware.

### Changes

- **`util/swagger/swagger.go`**: Added `withSecurityHeaders` middleware wrapper; updated `ServeSwaggerUI` to accept `xFrameOptions` and `contentSecurityPolicy` params and apply them to both the `/swagger.json` and `/swagger-ui` handlers.
- **`server/server.go`**: Pass `server.XFrameOptions` and `server.ContentSecurityPolicy` to `ServeSwaggerUI` — keeping behaviour consistent with the rest of the application (headers are only set when configured).
- **`util/swagger/swagger_test.go`**: Added two new tests:
  - `TestSwaggerUISecurityHeaders` — verifies headers are present when configured
  - `TestSwaggerUISecurityHeadersNotSetWhenEmpty` — verifies headers are absent when not configured

## Test plan

- [x] `go build ./util/swagger/... ./server/...` — compiles cleanly
- [ ] `go test ./util/swagger/...` — new tests pass
- [ ] Curl against a running instance with `ARGOCD_SERVER_X_FRAME_OPTIONS=DENY` set and verify `/swagger-ui` and `/swagger.json` return the header

