### PR TITLE
feat(ui): add warnings for common Hydrator misconfigurations

### DIFF
--- a/ui/src/app/applications/components/application-details/application-details.tsx
+++ b/ui/src/app/applications/components/application-details/application-details.tsx
@@ -8,7 +8,7 @@ import {BehaviorSubject, combineLatest, from, merge, Observable} from 'rxjs';
 import {delay, filter, map, mergeMap, repeat, retryWhen} from 'rxjs/operators';
 
 import {DataLoader, EmptyState, ErrorNotification, ObservableQuery, Page, Paginate, Revision, Timestamp} from '../../../shared/components';
-import {AppContext, Context, ContextApis} from '../../../shared/context';
+import {AppContext, AuthSettingsCtx, Context, ContextApis} from '../../../shared/context';
 import * as appModels from '../../../shared/models';
 import {AppDetailsPreferences, AppsDetailsViewKey, AppsDetailsViewType, services} from '../../../shared/services';
 
@@ -82,6 +82,7 @@ export const SelectNode = (fullName: string, containerIndex = 0, tab: string = n
 
 export const ApplicationDetails: FC<RouteComponentProps<{appnamespace: string; name: string}> & {objectListKind: string}> = props => {
     const appContext = useContext(Context);
+    const authSettings = useContext(AuthSettingsCtx);
     const appChanged = useRef(new BehaviorSubject<appModels.AbstractApplication>(null));
     const objectListKind = props.objectListKind;
 
@@ -678,6 +679,11 @@ Are you sure you want to disable auto-sync and rollback application '${props.mat
                             const selectedNode = !isAppSelected && (selectedItem as appModels.ResourceNode);
                             const operationState = isApplication ? (application as appModels.Application).status.operationState : undefined;
                             const hydrateOperationState = isApplication ? (application as appModels.Application).status.sourceHydrator?.currentOperation : undefined;
+                            const hydratePanelWaitingForController =
+                                isApplication && AppUtils.isWaitingForSourceHydratorController(application as appModels.Application, authSettings?.hydratorEnabled);
+                            const serverHydratorDisabledAtAPI =
+                                isApplication && !!(application as appModels.Application).spec.sourceHydrator && !!authSettings && !authSettings.hydratorEnabled;
+                            const hydratePanelServerDisabledOnly = serverHydratorDisabledAtAPI && !hydrateOperationState && !hydratePanelWaitingForController;
                             const conditions = application.status?.conditions || [];
                             const syncResourceKey = new URLSearchParams(props.history.location.search).get('deploy');
                             const source = isApplication ? getAppDefaultSource(application as appModels.Application) : undefined;
@@ -1193,8 +1199,21 @@ Are you sure you want to disable auto-sync and rollback application '${props.mat
                                             </SlidingPanel>
                                         )}
                                         {isApplication && (
-                                            <SlidingPanel isShown={showHydrateOperationState && !!hydrateOperationState} onClose={() => setHydrateOperationStatusVisible(false)}>
-                                                {hydrateOperationState && <ApplicationHydrateOperationState hydrateOperationState={hydrateOperationState} />}
+                                            <SlidingPanel
+                                                isShown={
+                                                    showHydrateOperationState && (!!hydrateOperationState || hydratePanelWaitingForController || hydratePanelServerDisabledOnly)
+                                                }
+                                                onClose={() => setHydrateOperationStatusVisible(false)}>
+                                                {hydrateOperationState ? (
+                                                    <ApplicationHydrateOperationState
+                                                        hydrateOperationState={hydrateOperationState}
+                                                        serverHydratorDisabledAtAPI={serverHydratorDisabledAtAPI}
+                                                    />
+                                                ) : hydratePanelWaitingForController ? (
+                                                    <ApplicationHydrateOperationState waitingForController={true} />
+                                                ) : (
+                                                    hydratePanelServerDisabledOnly && <ApplicationHydrateOperationState serverHydratorDisabledAtAPI={true} />
+                                                )}
                                             </SlidingPanel>
                                         )}
                                         <SlidingPanel isShown={showConditions && !!conditions} onClose={() => setConditionsStatusVisible(false)}>

--- a/ui/src/app/applications/components/application-hydrate-operation-state/application-hydrate-operation-state.scss
+++ b/ui/src/app/applications/components/application-hydrate-operation-state/application-hydrate-operation-state.scss
@@ -1,3 +1,45 @@
+@import 'node_modules/argo-ui/src/styles/config';
+@import 'node_modules/argo-ui/src/styles/theme';
+
+.application-hydrate-operation-state__server-disabled-notice {
+    padding: 0.75rem 1rem 0.25rem;
+    white-space: normal;
+
+    p {
+        margin-bottom: 0.85rem;
+        line-height: 1.45;
+    }
+
+    code {
+        font-size: 0.92em;
+    }
+}
+
+.application-hydrate-operation-state__server-disabled-notice-title {
+    font-weight: 600;
+    margin-bottom: 0.65rem;
+
+    .fa {
+        margin-right: 6px;
+        color: $argo-status-warning-color;
+    }
+}
+
+.application-hydrate-operation-state__waiting-body {
+    margin-top: 1rem;
+    padding: 0 0.75rem 0.5rem;
+
+    p {
+        margin-bottom: 0.85rem;
+        line-height: 1.45;
+        white-space: normal;
+    }
+
+    code {
+        font-size: 0.92em;
+    }
+}
+
 .application-operation-state {
   &__icons_container {
     position: absolute;

--- a/ui/src/app/applications/components/application-hydrate-operation-state/application-hydrate-operation-state.tsx
+++ b/ui/src/app/applications/components/application-hydrate-operation-state/application-hydrate-operation-state.tsx
@@ -9,10 +9,83 @@ import * as models from '../../../shared/models';
 import './application-hydrate-operation-state.scss';
 
 interface Props {
-    hydrateOperationState: models.HydrateOperation;
+    hydrateOperationState?: models.HydrateOperation;
+    /** When true, show troubleshooting copy for spec.sourceHydrator set but no status.sourceHydrator.currentOperation yet. */
+    waitingForController?: boolean;
+    /** API server reports hydrator disabled while the Application still uses spec.sourceHydrator (status may be residual or reflect a controller with hydrator still enabled). */
+    serverHydratorDisabledAtAPI?: boolean;
 }
 
-export const ApplicationHydrateOperationState: React.FunctionComponent<Props> = ({hydrateOperationState}) => {
+const ServerHydratorDisabledAtAPIExplanation = ({hasHydrateOperationDetails}: {hasHydrateOperationDetails: boolean}) => (
+    <div className='application-hydrate-operation-state__server-disabled-notice'>
+        <p className='application-hydrate-operation-state__server-disabled-notice-title'>
+            <i className='fa fa-exclamation-triangle' /> Source hydrator disabled on the Argo CD API server
+        </p>
+        <p>
+            The Argo CD API server reports Source Hydrator as disabled. The application controller independently loads the hydrator flag and may be enabled even when the API server
+            has it disabled.
+        </p>
+        {hasHydrateOperationDetails && (
+            <p>
+                The hydrate operation details below <strong>may be a residual status</strong> from an earlier reconciliation (for example from when hydrator was enabled or from
+                another environment), or they may reflect live work if the application controller still has hydrator enabled. Sync status and manifests may be stale relative to the
+                dry source when server and controller configuration do not match.
+            </p>
+        )}
+        <p>
+            To fix this, either enable source hydrator on the API server and application controller consistently (for example <code>hydrator.enabled</code> in the{' '}
+            <code>argocd-cmd-params-cm</code> ConfigMap, then restart the relevant workloads), or remove <code>spec.sourceHydrator</code> from the Application spec if you do not
+            intend to use the feature.
+        </p>
+    </div>
+);
+
+export const ApplicationHydrateOperationState: React.FunctionComponent<Props> = ({hydrateOperationState, waitingForController, serverHydratorDisabledAtAPI}) => {
+    if (waitingForController) {
+        return (
+            <div>
+                <div className='white-box'>
+                    <div className='white-box__details'>
+                        <div className='row white-box__details-row'>
+                            <div className='columns small-3'>STATUS</div>
+                            <div className='columns small-9'>Waiting for application controller</div>
+                        </div>
+                        <div className='application-hydrate-operation-state__waiting-body columns small-12'>
+                            <p>
+                                This Application has <code>spec.sourceHydrator</code> set, but the API response does not yet include{' '}
+                                <code>status.sourceHydrator.currentOperation</code>. The application controller normally writes that field when it reconciles hydration.
+                            </p>
+                            <p>
+                                The Argo CD API server can report source hydrator as enabled in UI settings even when the application controller is still running with hydrator
+                                disabled—each component has its own <code>ARGOCD_HYDRATOR_ENABLED</code> flag (for example via <code>hydrator.enabled</code> in the{' '}
+                                <code>argocd-cmd-params-cm</code> ConfigMap).
+                            </p>
+                            <p>
+                                If you set <code>hydrator.enabled</code> to <code>true</code> in <code>argocd-cmd-params-cm</code>, restart the{' '}
+                                <strong>argocd-application-controller</strong> workload so it picks up the change, and ensure the server and controller are configured consistently.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+
+    if (!hydrateOperationState) {
+        if (serverHydratorDisabledAtAPI) {
+            return (
+                <div>
+                    <div className='white-box'>
+                        <div className='white-box__details'>
+                            <ServerHydratorDisabledAtAPIExplanation hasHydrateOperationDetails={false} />
+                        </div>
+                    </div>
+                </div>
+            );
+        }
+        return null;
+    }
+
     const operationAttributes = [
         {title: 'PHASE', value: hydrateOperationState.phase},
         ...(hydrateOperationState.message ? [{title: 'MESSAGE', value: hydrateOperationState.message}] : []),
@@ -59,6 +132,13 @@ export const ApplicationHydrateOperationState: React.FunctionComponent<Props> = 
     }
     return (
         <div>
+            {serverHydratorDisabledAtAPI && (
+                <div className='white-box' style={{marginBottom: '12px'}}>
+                    <div className='white-box__details'>
+                        <ServerHydratorDisabledAtAPIExplanation hasHydrateOperationDetails={true} />
+                    </div>
+                </div>
+            )}
             <div className='white-box'>
                 <div className='white-box__details'>
                     {operationAttributes.map(attr => (

--- a/ui/src/app/applications/components/application-status-panel/application-status-panel.scss
+++ b/ui/src/app/applications/components/application-status-panel/application-status-panel.scss
@@ -118,6 +118,14 @@
                 color: $argo-success-color;
             }
         }
+        & {
+            a.progressing,
+            a.neutral {
+                @include themify($themes) {
+                    color: themed('text-1');
+                }
+            }
+        }
 
         label {
             display: block;
@@ -179,10 +187,7 @@
         }
 
         &__status-button {
-            display: inline-block;
-            position: relative;
-            z-index: 1;
-            vertical-align: middle;
+            display: inline;
             border-radius: 5px;
             padding: 2px;
             border: 1px solid $argo-color-gray-5;
@@ -191,10 +196,10 @@
             }
         }
 
-        &__hydrator-link {
-            @include themify($themes) {
-                color: themed('text-1');
-            }
+        // Rows with __revision: baseline + overflow:hidden clips the top of __status-button borders.
+        &--with-revision {
+            align-items: flex-start;
+            padding-top: 5px;
         }
     }
 

--- a/ui/src/app/applications/components/application-status-panel/application-status-panel.scss
+++ b/ui/src/app/applications/components/application-status-panel/application-status-panel.scss
@@ -179,7 +179,10 @@
         }
 
         &__status-button {
-            display: inline;
+            display: inline-block;
+            position: relative;
+            z-index: 1;
+            vertical-align: middle;
             border-radius: 5px;
             padding: 2px;
             border: 1px solid $argo-color-gray-5;
@@ -188,10 +191,11 @@
             }
         }
 
-    }
-
-    &__hydrator-link {
-        width: 134px;
+        &__hydrator-link {
+            @include themify($themes) {
+                color: themed('text-1');
+            }
+        }
     }
 
     &__item-name {

--- a/ui/src/app/applications/components/application-status-panel/application-status-panel.scss
+++ b/ui/src/app/applications/components/application-status-panel/application-status-panel.scss
@@ -142,10 +142,10 @@
 
     &__item-value {
         display: flex;
-        align-items: baseline;
+        align-items: flex-start;
         margin-bottom: 0.5em;
         font-weight: 500;
-        padding: 2px 0px;
+        padding: 5px 0 2px;
         .fa {
             font-size: 1em;
         }
@@ -194,12 +194,6 @@
             &:hover {
                 background-color: $argo-color-gray-4;
             }
-        }
-
-        // Rows with __revision: baseline + overflow:hidden clips the top of __status-button borders.
-        &--with-revision {
-            align-items: flex-start;
-            padding-top: 5px;
         }
     }
 

--- a/ui/src/app/applications/components/application-status-panel/application-status-panel.tsx
+++ b/ui/src/app/applications/components/application-status-panel/application-status-panel.tsx
@@ -46,7 +46,27 @@ interface SectionInfo {
 const SOURCE_HYDRATOR_HELP = 'The source hydrator reads manifests from git, hydrates (renders) them, and pushes them to a different location in git.';
 
 const SOURCE_HYDRATOR_SERVER_DISABLED_TOOLTIP =
-    'Hydrator is disabled on the API server, but it may be enabled on the application controller. This data may be stale. Open the hydration details for more information.';
+    'Source Hydrator is disabled on the API server. If it is also disabled on the application controller, then this data may be stale. Open the hydration details for more information.';
+
+const hydratorPanelLinkClass = (phase: string): 'neutral' | 'warning' | 'error' | 'progressing' => {
+    if (phase === models.HydrateOperationPhases.Hydrated) {
+        return 'neutral';
+    }
+    if (phase === models.HydrateOperationPhases.Failed) {
+        return 'error';
+    }
+    if (phase === models.HydrateOperationPhases.Hydrating) {
+        return 'progressing';
+    }
+    return 'progressing';
+};
+
+const sourceHydratorSectionHeader = (warningTooltip?: string) =>
+    sectionHeader({
+        title: 'SOURCE HYDRATOR',
+        helpContent: SOURCE_HYDRATOR_HELP,
+        ...(warningTooltip ? {warningTooltip} : {})
+    });
 
 const sectionLabel = (info: SectionInfo) => (
     <label style={{display: 'flex', alignItems: 'flex-start', fontSize: '12px', fontWeight: 600, color: ARGO_GRAY6_COLOR, minHeight: '18px'}}>
@@ -208,12 +228,6 @@ export const ApplicationStatusPanel = ({application, showDiff, showOperation, sh
     const source = getAppDefaultSource(application);
     const hasMultipleSources = application.spec.sources?.length > 0;
     const revisionType = source?.repoURL?.startsWith('oci://') ? 'oci' : source?.chart ? 'helm' : 'git';
-    const hydratorLabelWithOptionalWarning = (warningTooltip?: string) =>
-        sectionLabel({
-            title: 'SOURCE HYDRATOR',
-            helpContent: SOURCE_HYDRATOR_HELP,
-            ...(warningTooltip ? {warningTooltip} : {})
-        });
     return (
         <div className='application-status-panel row'>
             <div className='application-status-panel__item'>
@@ -227,10 +241,10 @@ export const ApplicationStatusPanel = ({application, showDiff, showOperation, sh
             </div>
             {waitingForSourceHydratorController && (
                 <div className='application-status-panel__item'>
-                    <div style={{lineHeight: '19.5px', marginBottom: '0.3em'}}>{hydratorLabelWithOptionalWarning()}</div>
+                    {sourceHydratorSectionHeader()}
                     <div className='application-status-panel__item-value'>
-                        <a className='application-status-panel__item-value__hydrator-link' onClick={() => showHydrateOperation && showHydrateOperation()}>
-                            <i className='fa fa-clock-o application-status-panel__item-value__status-button' style={{color: COLORS.sync.out_of_sync}} />
+                        <a className='warning' onClick={() => showHydrateOperation && showHydrateOperation()}>
+                            <i className='fa fa-clock-o application-status-panel__item-value__status-button' />
                             &nbsp; Waiting for controller
                         </a>
                     </div>
@@ -241,11 +255,11 @@ export const ApplicationStatusPanel = ({application, showDiff, showOperation, sh
             )}
             {sourceHydratorDisabledAtServer && !application.status?.sourceHydrator?.currentOperation && !waitingForSourceHydratorController && (
                 <div className='application-status-panel__item'>
-                    <div style={{lineHeight: '19.5px', marginBottom: '0.3em'}}>{hydratorLabelWithOptionalWarning()}</div>
+                    {sourceHydratorSectionHeader()}
                     <div className='application-status-panel__item-value'>
-                        <a className='application-status-panel__item-value__hydrator-link' onClick={() => showHydrateOperation && showHydrateOperation()}>
-                            <i className='fa fa-exclamation-triangle application-status-panel__item-value__status-button' style={{color: ARGO_WARNING_COLOR}} />
-                            &nbsp; Hydrator disabled
+                        <a className='warning' onClick={() => showHydrateOperation && showHydrateOperation()}>
+                            <i className='fa fa-exclamation-triangle application-status-panel__item-value__status-button' />
+                            &nbsp; Disabled
                         </a>
                     </div>
                     <div className='application-status-panel__item-name' style={{marginBottom: '0.5em'}}>
@@ -255,14 +269,12 @@ export const ApplicationStatusPanel = ({application, showDiff, showOperation, sh
             )}
             {application.spec.sourceHydrator && application.status?.sourceHydrator?.currentOperation && (
                 <div className='application-status-panel__item'>
-                    <div style={{lineHeight: '19.5px', marginBottom: '0.3em'}}>
-                        {hydratorLabelWithOptionalWarning(sourceHydratorDisabledAtServer ? SOURCE_HYDRATOR_SERVER_DISABLED_TOOLTIP : undefined)}
-                    </div>
-                    <div className='application-status-panel__item-value'>
-                        <a className='application-status-panel__item-value__hydrator-link' onClick={() => showHydrateOperation && showHydrateOperation()}>
-                            <span className='application-status-panel__item-value__status-button'>
-                                <HydrateOperationPhaseIcon operationState={application.status.sourceHydrator.currentOperation} isButton={false} />
-                            </span>
+                    {sourceHydratorSectionHeader(sourceHydratorDisabledAtServer ? SOURCE_HYDRATOR_SERVER_DISABLED_TOOLTIP : undefined)}
+                    <div className='application-status-panel__item-value application-status-panel__item-value--with-revision'>
+                        <a
+                            className={hydratorPanelLinkClass(application.status.sourceHydrator.currentOperation.phase)}
+                            onClick={() => showHydrateOperation && showHydrateOperation()}>
+                            <HydrateOperationPhaseIcon operationState={application.status.sourceHydrator.currentOperation} isButton={true} />
                             &nbsp;
                             {application.status.sourceHydrator.currentOperation.phase}
                         </a>
@@ -296,7 +308,10 @@ export const ApplicationStatusPanel = ({application, showDiff, showOperation, sh
                     },
                     () => showMetadataInfo(application.status.sync ? 'SYNC_STATUS_REVISION' : null)
                 )}
-                <div className={`application-status-panel__item-value${appOperationState?.phase ? ` application-status-panel__item-value--${appOperationState.phase}` : ''}`}>
+                <div
+                    className={`application-status-panel__item-value application-status-panel__item-value--with-revision${
+                        appOperationState?.phase ? ` application-status-panel__item-value--${appOperationState.phase}` : ''
+                    }`}>
                     <div>
                         {application.status.sync.status === models.SyncStatuses.OutOfSync ? (
                             <a onClick={() => showDiff && showDiff()}>
@@ -344,7 +359,12 @@ export const ApplicationStatusPanel = ({application, showDiff, showOperation, sh
                                     : null
                             )
                     )}
-                    <div className={`application-status-panel__item-value application-status-panel__item-value--${appOperationState.phase}`}>
+                    <div
+                        className={`application-status-panel__item-value application-status-panel__item-value--${appOperationState.phase}${
+                            appOperationState.syncResult && (appOperationState.syncResult.revision || appOperationState.syncResult.revisions)
+                                ? ' application-status-panel__item-value--with-revision'
+                                : ''
+                        }`}>
                         <a onClick={() => showOperation && showOperation()}>
                             <OperationState app={application} isButton={true} />{' '}
                         </a>

--- a/ui/src/app/applications/components/application-status-panel/application-status-panel.tsx
+++ b/ui/src/app/applications/components/application-status-panel/application-status-panel.tsx
@@ -48,25 +48,38 @@ const SOURCE_HYDRATOR_HELP = 'The source hydrator reads manifests from git, hydr
 const SOURCE_HYDRATOR_SERVER_DISABLED_TOOLTIP =
     'Source Hydrator is disabled on the API server. If it is also disabled on the application controller, then this data may be stale. Open the hydration details for more information.';
 
-const hydratorPanelLinkClass = (phase: string): 'neutral' | 'warning' | 'error' | 'progressing' => {
-    if (phase === models.HydrateOperationPhases.Hydrated) {
-        return 'neutral';
+function getHydratorStatusLinkLabel(
+    currentOperation: models.HydrateOperation | undefined,
+    waitingForController: boolean,
+    hydratorDisabledOnApiServer: boolean
+): string | null {
+    if (currentOperation) {
+        return currentOperation.phase;
     }
-    if (phase === models.HydrateOperationPhases.Failed) {
-        return 'error';
+    if (waitingForController) {
+        return 'Waiting';
     }
-    if (phase === models.HydrateOperationPhases.Hydrating) {
-        return 'progressing';
+    if (hydratorDisabledOnApiServer) {
+        return 'Disabled';
     }
-    return 'progressing';
-};
+    return null;
+}
 
-const sourceHydratorSectionHeader = (warningTooltip?: string) =>
-    sectionHeader({
-        title: 'SOURCE HYDRATOR',
-        helpContent: SOURCE_HYDRATOR_HELP,
-        ...(warningTooltip ? {warningTooltip} : {})
-    });
+const hydratorPanelLinkClass = (operation: models.HydrateOperation | undefined | null, hydratorDisabledOnApiServer: boolean): 'neutral' | 'warning' | 'error' | 'progressing' => {
+    if (!operation) {
+        return hydratorDisabledOnApiServer ? 'neutral' : 'warning';
+    }
+    switch (operation.phase) {
+        case models.HydrateOperationPhases.Hydrated:
+            return 'neutral';
+        case models.HydrateOperationPhases.Failed:
+            return 'error';
+        case models.HydrateOperationPhases.Hydrating:
+            return 'progressing';
+        default:
+            return 'progressing';
+    }
+};
 
 const sectionLabel = (info: SectionInfo) => (
     <label style={{display: 'flex', alignItems: 'flex-start', fontSize: '12px', fontWeight: 600, color: ARGO_GRAY6_COLOR, minHeight: '18px'}}>
@@ -191,8 +204,15 @@ const ProgressiveSyncStatus = ({application}: {application: models.Application})
 
 export const ApplicationStatusPanel = ({application, showDiff, showOperation, showHydrateOperation, showConditions, showExtension, showMetadataInfo}: Props) => {
     const authSettings = React.useContext(AuthSettingsCtx);
-    const sourceHydratorDisabledAtServer = !!(authSettings && !authSettings.hydratorEnabled && application.spec.sourceHydrator);
     const waitingForSourceHydratorController = isWaitingForSourceHydratorController(application, authSettings?.hydratorEnabled);
+    const currentHydrateOperation = application.status?.sourceHydrator?.currentOperation;
+
+    // Auth setting only; spec.sourceHydrator is guaranteed by the panel block below.
+    const hydratorDisabledOnApiServer = !!(authSettings && !authSettings.hydratorEnabled);
+
+    // Show the warning tooltip on the header, but only if there's an ongoing hydrate operation. If there's no ongoing operation, the whole
+    // toolbar gets used as a warning that Source Hydrator is disabled, so the extra tooltip is not needed and would be redundant.
+    const showHydratorServerDisabledHeaderTooltip = hydratorDisabledOnApiServer && !!currentHydrateOperation;
     const [showProgressiveSync, setShowProgressiveSync] = React.useState(false);
 
     React.useEffect(() => {
@@ -239,61 +259,42 @@ export const ApplicationStatusPanel = ({application, showDiff, showOperation, sh
                 </div>
                 {application.status.health.message && <div className='application-status-panel__item-name'>{application.status.health.message}</div>}
             </div>
-            {waitingForSourceHydratorController && (
+            {application.spec.sourceHydrator && (
                 <div className='application-status-panel__item'>
-                    {sourceHydratorSectionHeader()}
+                    {sectionHeader({
+                        title: 'SOURCE HYDRATOR',
+                        helpContent: SOURCE_HYDRATOR_HELP,
+                        ...(showHydratorServerDisabledHeaderTooltip ? {warningTooltip: SOURCE_HYDRATOR_SERVER_DISABLED_TOOLTIP} : {})
+                    })}
                     <div className='application-status-panel__item-value'>
-                        <a className='warning' onClick={() => showHydrateOperation && showHydrateOperation()}>
-                            <i className='fa fa-clock-o application-status-panel__item-value__status-button' />
-                            &nbsp; Waiting for controller
-                        </a>
-                    </div>
-                    <div className='application-status-panel__item-name' style={{marginBottom: '0.5em'}}>
-                        No hydrate operation in <code>status.sourceHydrator</code> yet. Click for details.
-                    </div>
-                </div>
-            )}
-            {sourceHydratorDisabledAtServer && !application.status?.sourceHydrator?.currentOperation && !waitingForSourceHydratorController && (
-                <div className='application-status-panel__item'>
-                    {sourceHydratorSectionHeader()}
-                    <div className='application-status-panel__item-value'>
-                        <a className='warning' onClick={() => showHydrateOperation && showHydrateOperation()}>
-                            <i className='fa fa-exclamation-triangle application-status-panel__item-value__status-button' />
-                            &nbsp; Disabled
-                        </a>
-                    </div>
-                    <div className='application-status-panel__item-name' style={{marginBottom: '0.5em'}}>
-                        Source Hydrator is configured on the application, but Source Hydrator is disabled. Click for details.
-                    </div>
-                </div>
-            )}
-            {application.spec.sourceHydrator && application.status?.sourceHydrator?.currentOperation && (
-                <div className='application-status-panel__item'>
-                    {sourceHydratorSectionHeader(sourceHydratorDisabledAtServer ? SOURCE_HYDRATOR_SERVER_DISABLED_TOOLTIP : undefined)}
-                    <div className='application-status-panel__item-value application-status-panel__item-value--with-revision'>
-                        <a
-                            className={hydratorPanelLinkClass(application.status.sourceHydrator.currentOperation.phase)}
-                            onClick={() => showHydrateOperation && showHydrateOperation()}>
-                            <HydrateOperationPhaseIcon operationState={application.status.sourceHydrator.currentOperation} isButton={true} />
+                        <a className={hydratorPanelLinkClass(currentHydrateOperation, hydratorDisabledOnApiServer)} onClick={() => showHydrateOperation && showHydrateOperation()}>
+                            <HydrateOperationPhaseIcon operation={currentHydrateOperation} isButton={true} apiHydratorDisabled={hydratorDisabledOnApiServer} />
                             &nbsp;
-                            {application.status.sourceHydrator.currentOperation.phase}
+                            {getHydratorStatusLinkLabel(currentHydrateOperation, waitingForSourceHydratorController, hydratorDisabledOnApiServer)}
                         </a>
-                        <div className='application-status-panel__item-value__revision show-for-large'>{hydrationStatusMessage(application)}</div>
+                        {currentHydrateOperation && <div className='application-status-panel__item-value__revision show-for-large'>{hydrationStatusMessage(application)}</div>}
                     </div>
                     <div className='application-status-panel__item-name' style={{marginBottom: '0.5em'}}>
-                        {application.status.sourceHydrator.currentOperation.phase}{' '}
-                        <Timestamp date={application.status.sourceHydrator.currentOperation.finishedAt || application.status.sourceHydrator.currentOperation.startedAt} />
+                        {waitingForSourceHydratorController && (
+                            <>
+                                No hydrate operation has started yet.
+                            </>
+                        )}
+                        {hydratorDisabledOnApiServer && !currentHydrateOperation && <>Source Hydrator is configured on the application, but Source Hydrator is disabled.</>}
+                        {currentHydrateOperation && (
+                            <>
+                                {currentHydrateOperation.phase} <Timestamp date={currentHydrateOperation.finishedAt || currentHydrateOperation.startedAt} />
+                            </>
+                        )}
                     </div>
-                    {application.status.sourceHydrator.currentOperation.message && (
-                        <div className='application-status-panel__item-name'>{application.status.sourceHydrator.currentOperation.message}</div>
-                    )}
+                    <div className='application-status-panel__item-name'>{currentHydrateOperation?.message}</div>
                     <div className='application-status-panel__item-name'>
-                        {application.status.sourceHydrator.currentOperation.drySHA && (
+                        {currentHydrateOperation?.drySHA && (
                             <RevisionMetadataPanel
                                 appName={application.metadata.name}
                                 appNamespace={application.metadata.namespace}
                                 type={''}
-                                revision={application.status.sourceHydrator.currentOperation.drySHA}
+                                revision={currentHydrateOperation.drySHA}
                                 versionId={utils.getAppCurrentVersion(application)}
                             />
                         )}
@@ -308,10 +309,7 @@ export const ApplicationStatusPanel = ({application, showDiff, showOperation, sh
                     },
                     () => showMetadataInfo(application.status.sync ? 'SYNC_STATUS_REVISION' : null)
                 )}
-                <div
-                    className={`application-status-panel__item-value application-status-panel__item-value--with-revision${
-                        appOperationState?.phase ? ` application-status-panel__item-value--${appOperationState.phase}` : ''
-                    }`}>
+                <div className={`application-status-panel__item-value${appOperationState?.phase ? ` application-status-panel__item-value--${appOperationState.phase}` : ''}`}>
                     <div>
                         {application.status.sync.status === models.SyncStatuses.OutOfSync ? (
                             <a onClick={() => showDiff && showDiff()}>
@@ -359,12 +357,7 @@ export const ApplicationStatusPanel = ({application, showDiff, showOperation, sh
                                     : null
                             )
                     )}
-                    <div
-                        className={`application-status-panel__item-value application-status-panel__item-value--${appOperationState.phase}${
-                            appOperationState.syncResult && (appOperationState.syncResult.revision || appOperationState.syncResult.revisions)
-                                ? ' application-status-panel__item-value--with-revision'
-                                : ''
-                        }`}>
+                    <div className={`application-status-panel__item-value application-status-panel__item-value--${appOperationState.phase}`}>
                         <a onClick={() => showOperation && showOperation()}>
                             <OperationState app={application} isButton={true} />{' '}
                         </a>

--- a/ui/src/app/applications/components/application-status-panel/application-status-panel.tsx
+++ b/ui/src/app/applications/components/application-status-panel/application-status-panel.tsx
@@ -1,6 +1,7 @@
-import {HelpIcon} from 'argo-ui';
+import {HelpIcon, Tooltip} from 'argo-ui';
 import * as React from 'react';
-import {ARGO_GRAY6_COLOR, DataLoader} from '../../../shared/components';
+import {ARGO_GRAY6_COLOR, ARGO_WARNING_COLOR, DataLoader} from '../../../shared/components';
+import {AuthSettingsCtx} from '../../../shared/context';
 import {Revision} from '../../../shared/components/revision';
 import {Timestamp} from '../../../shared/components/timestamp';
 import * as models from '../../../shared/models';
@@ -15,7 +16,8 @@ import {
     HydrateOperationPhaseIcon,
     hydrationStatusMessage,
     getProgressiveSyncStatusColor,
-    getProgressiveSyncStatusIcon
+    getProgressiveSyncStatusIcon,
+    isWaitingForSourceHydratorController
 } from '../utils';
 import {getConditionCategory, HealthStatusIcon, OperationState, syncStatusMessage, getAppDefaultSyncRevision, getAppDefaultOperationSyncRevision} from '../utils';
 import {RevisionMetadataPanel} from './revision-metadata-panel';
@@ -37,7 +39,14 @@ interface Props {
 interface SectionInfo {
     title: string;
     helpContent?: string;
+    /** Shown as a warning icon with tooltip after the help icon (e.g. source hydrator disabled at API server). */
+    warningTooltip?: string;
 }
+
+const SOURCE_HYDRATOR_HELP = 'The source hydrator reads manifests from git, hydrates (renders) them, and pushes them to a different location in git.';
+
+const SOURCE_HYDRATOR_SERVER_DISABLED_TOOLTIP =
+    'Hydrator is disabled on the API server, but it may be enabled on the application controller. This data may be stale. Open the hydration details for more information.';
 
 const sectionLabel = (info: SectionInfo) => (
     <label style={{display: 'flex', alignItems: 'flex-start', fontSize: '12px', fontWeight: 600, color: ARGO_GRAY6_COLOR, minHeight: '18px'}}>
@@ -45,6 +54,16 @@ const sectionLabel = (info: SectionInfo) => (
         {info.helpContent && (
             <span style={{marginLeft: '5px'}}>
                 <HelpIcon title={info.helpContent} />
+            </span>
+        )}
+        {info.warningTooltip && (
+            <span style={{marginLeft: '5px'}}>
+                <Tooltip content={info.warningTooltip} interactive={false}>
+                    <span style={{fontSize: 'smaller'}}>
+                        {' '}
+                        <i className='fa fa-exclamation-triangle' style={{color: ARGO_WARNING_COLOR, cursor: 'help'}} aria-label='Source hydrator warning' />
+                    </span>
+                </Tooltip>
             </span>
         )}
     </label>
@@ -151,6 +170,9 @@ const ProgressiveSyncStatus = ({application}: {application: models.Application})
 };
 
 export const ApplicationStatusPanel = ({application, showDiff, showOperation, showHydrateOperation, showConditions, showExtension, showMetadataInfo}: Props) => {
+    const authSettings = React.useContext(AuthSettingsCtx);
+    const sourceHydratorDisabledAtServer = !!(authSettings && !authSettings.hydratorEnabled && application.spec.sourceHydrator);
+    const waitingForSourceHydratorController = isWaitingForSourceHydratorController(application, authSettings?.hydratorEnabled);
     const [showProgressiveSync, setShowProgressiveSync] = React.useState(false);
 
     React.useEffect(() => {
@@ -186,6 +208,12 @@ export const ApplicationStatusPanel = ({application, showDiff, showOperation, sh
     const source = getAppDefaultSource(application);
     const hasMultipleSources = application.spec.sources?.length > 0;
     const revisionType = source?.repoURL?.startsWith('oci://') ? 'oci' : source?.chart ? 'helm' : 'git';
+    const hydratorLabelWithOptionalWarning = (warningTooltip?: string) =>
+        sectionLabel({
+            title: 'SOURCE HYDRATOR',
+            helpContent: SOURCE_HYDRATOR_HELP,
+            ...(warningTooltip ? {warningTooltip} : {})
+        });
     return (
         <div className='application-status-panel row'>
             <div className='application-status-panel__item'>
@@ -197,17 +225,44 @@ export const ApplicationStatusPanel = ({application, showDiff, showOperation, sh
                 </div>
                 {application.status.health.message && <div className='application-status-panel__item-name'>{application.status.health.message}</div>}
             </div>
+            {waitingForSourceHydratorController && (
+                <div className='application-status-panel__item'>
+                    <div style={{lineHeight: '19.5px', marginBottom: '0.3em'}}>{hydratorLabelWithOptionalWarning()}</div>
+                    <div className='application-status-panel__item-value'>
+                        <a className='application-status-panel__item-value__hydrator-link' onClick={() => showHydrateOperation && showHydrateOperation()}>
+                            <i className='fa fa-clock-o application-status-panel__item-value__status-button' style={{color: COLORS.sync.out_of_sync}} />
+                            &nbsp; Waiting for controller
+                        </a>
+                    </div>
+                    <div className='application-status-panel__item-name' style={{marginBottom: '0.5em'}}>
+                        No hydrate operation in <code>status.sourceHydrator</code> yet. Click for details.
+                    </div>
+                </div>
+            )}
+            {sourceHydratorDisabledAtServer && !application.status?.sourceHydrator?.currentOperation && !waitingForSourceHydratorController && (
+                <div className='application-status-panel__item'>
+                    <div style={{lineHeight: '19.5px', marginBottom: '0.3em'}}>{hydratorLabelWithOptionalWarning()}</div>
+                    <div className='application-status-panel__item-value'>
+                        <a className='application-status-panel__item-value__hydrator-link' onClick={() => showHydrateOperation && showHydrateOperation()}>
+                            <i className='fa fa-exclamation-triangle application-status-panel__item-value__status-button' style={{color: ARGO_WARNING_COLOR}} />
+                            &nbsp; Hydrator disabled
+                        </a>
+                    </div>
+                    <div className='application-status-panel__item-name' style={{marginBottom: '0.5em'}}>
+                        Source Hydrator is configured on the application, but Source Hydrator is disabled. Click for details.
+                    </div>
+                </div>
+            )}
             {application.spec.sourceHydrator && application.status?.sourceHydrator?.currentOperation && (
                 <div className='application-status-panel__item'>
                     <div style={{lineHeight: '19.5px', marginBottom: '0.3em'}}>
-                        {sectionLabel({
-                            title: 'SOURCE HYDRATOR',
-                            helpContent: 'The source hydrator reads manifests from git, hydrates (renders) them, and pushes them to a different location in git.'
-                        })}
+                        {hydratorLabelWithOptionalWarning(sourceHydratorDisabledAtServer ? SOURCE_HYDRATOR_SERVER_DISABLED_TOOLTIP : undefined)}
                     </div>
                     <div className='application-status-panel__item-value'>
                         <a className='application-status-panel__item-value__hydrator-link' onClick={() => showHydrateOperation && showHydrateOperation()}>
-                            <HydrateOperationPhaseIcon operationState={application.status.sourceHydrator.currentOperation} isButton={true} />
+                            <span className='application-status-panel__item-value__status-button'>
+                                <HydrateOperationPhaseIcon operationState={application.status.sourceHydrator.currentOperation} isButton={false} />
+                            </span>
                             &nbsp;
                             {application.status.sourceHydrator.currentOperation.phase}
                         </a>

--- a/ui/src/app/applications/components/applications-list/application-table-row.tsx
+++ b/ui/src/app/applications/components/applications-list/application-table-row.tsx
@@ -127,7 +127,7 @@ export const ApplicationTableRow = ({app, selected, pref, ctx, syncApplication, 
                     <AppUtils.HealthStatusIcon state={app.status.health} /> <span>{app.status.health.status}</span> <br />
                     {app.status.sourceHydrator?.currentOperation && (
                         <>
-                            <AppUtils.HydrateOperationPhaseIcon operationState={app.status.sourceHydrator.currentOperation} />{' '}
+                            <AppUtils.HydrateOperationPhaseIcon operation={app.status.sourceHydrator.currentOperation} />{' '}
                             <span>{app.status.sourceHydrator.currentOperation.phase}</span> <br />
                         </>
                     )}

--- a/ui/src/app/applications/components/applications-list/application-tile.tsx
+++ b/ui/src/app/applications/components/applications-list/application-tile.tsx
@@ -133,8 +133,7 @@ export const ApplicationTile = ({app, selected, pref, ctx, tileRef, syncApplicat
                             &nbsp;
                             {app.status.sourceHydrator?.currentOperation && (
                                 <>
-                                    <AppUtils.HydrateOperationPhaseIcon operationState={app.status.sourceHydrator.currentOperation} />{' '}
-                                    {app.status.sourceHydrator.currentOperation.phase}
+                                    <AppUtils.HydrateOperationPhaseIcon operation={app.status.sourceHydrator.currentOperation} /> {app.status.sourceHydrator.currentOperation.phase}
                                     &nbsp;
                                 </>
                             )}

--- a/ui/src/app/applications/components/applications-list/applications-summary.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-summary.tsx
@@ -119,7 +119,7 @@ export const ApplicationsSummary = ({applications}: {applications: models.Applic
                                                             {chart.title === 'Sync' && <ComparisonStatusIcon status={key as SyncStatusCode} noSpin={true} />}
                                                             {chart.title === 'Hydrator' && key !== 'None' && (
                                                                 <HydrateOperationPhaseIcon
-                                                                    operationState={{
+                                                                    operation={{
                                                                         phase: key as any,
                                                                         startedAt: '',
                                                                         message: '',

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -1479,6 +1479,17 @@ export function getAppDrySource(app?: appModels.Application): appModels.Applicat
     return {repoURL, targetRevision, path};
 }
 
+/** True when spec requests source hydration, the API server reports hydrator enabled, but the controller has not written currentOperation yet. */
+export function isWaitingForSourceHydratorController(app: appModels.Application, apiServerHydratorEnabled: boolean | null | undefined): boolean {
+    if (!app.spec.sourceHydrator) {
+        return false;
+    }
+    if (apiServerHydratorEnabled !== true) {
+        return false;
+    }
+    return !app.status?.sourceHydrator?.currentOperation;
+}
+
 // getAppDefaultSyncRevision gets the first app revisions from `status.sync.revisions` or, if that list is missing or empty, the `revision`
 // field.
 export function getAppDefaultSyncRevision(app?: appModels.Application) {

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -288,11 +288,11 @@ export const HydrateOperationPhaseIcon = ({operationState, isButton}: {operation
     let color = '';
     switch (operationState.phase) {
         case appModels.HydrateOperationPhases.Hydrated:
-            className = `fa fa-check-circle${isButton ? ' status-button' : ''}`;
+            className = 'fa fa-check-circle';
             color = COLORS.operation.success;
             break;
         case appModels.HydrateOperationPhases.Failed:
-            className = `fa fa-times-circle${isButton ? ' status-button' : ''}`;
+            className = 'fa fa-times-circle';
             color = COLORS.operation.failed;
             break;
         default:
@@ -300,10 +300,12 @@ export const HydrateOperationPhaseIcon = ({operationState, isButton}: {operation
             color = COLORS.operation.running;
             break;
     }
+    const panelButtonClass = isButton ? ' application-status-panel__item-value__status-button' : '';
+    const iconColorStyle = !className.includes('fa-spin') && (!isButton || operationState.phase === appModels.HydrateOperationPhases.Hydrated) ? {style: {color}} : {};
     return className.includes('fa-spin') ? (
         <SpinningIcon color={color} qeId='utils-operations-status-title' />
     ) : (
-        <i title={operationState.phase} qe-id='utils-operations-status-title' className={className} style={{color}} />
+        <i title={operationState.phase} qe-id='utils-operations-status-title' className={className + panelButtonClass} {...iconColorStyle} />
     );
 };
 

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -280,13 +280,37 @@ export const OperationPhaseIcon = ({app, isButton}: {app: appModels.Application;
     );
 };
 
-export const HydrateOperationPhaseIcon = ({operationState, isButton}: {operationState?: appModels.HydrateOperation; isButton?: boolean}) => {
-    if (operationState === undefined) {
-        return null;
+export const HydrateOperationPhaseIcon = ({
+    operation,
+    isButton,
+    /** When there is no operation and `isButton`, whether the API has hydrator disabled (triangle vs clock). Ignored when `operation` is set. */
+    apiHydratorDisabled
+}: {
+    operation?: appModels.HydrateOperation | null;
+    isButton?: boolean;
+    apiHydratorDisabled?: boolean;
+}) => {
+    const panelButtonClass = isButton ? ' application-status-panel__item-value__status-button' : '';
+
+    if (!operation) {
+        if (!isButton) {
+            return null;
+        }
+        return apiHydratorDisabled ? (
+            <i
+                title='Source hydrator disabled'
+                qe-id='utils-hydrate-status-panel'
+                className={'fa fa-exclamation-triangle' + panelButtonClass}
+                style={{color: COLORS.sync.out_of_sync}}
+            />
+        ) : (
+            <i title='Waiting for controller' qe-id='utils-hydrate-status-panel' className={'fa fa-clock-o' + panelButtonClass} />
+        );
     }
+
     let className = '';
     let color = '';
-    switch (operationState.phase) {
+    switch (operation.phase) {
         case appModels.HydrateOperationPhases.Hydrated:
             className = 'fa fa-check-circle';
             color = COLORS.operation.success;
@@ -300,12 +324,11 @@ export const HydrateOperationPhaseIcon = ({operationState, isButton}: {operation
             color = COLORS.operation.running;
             break;
     }
-    const panelButtonClass = isButton ? ' application-status-panel__item-value__status-button' : '';
-    const iconColorStyle = !className.includes('fa-spin') && (!isButton || operationState.phase === appModels.HydrateOperationPhases.Hydrated) ? {style: {color}} : {};
+    const iconColorStyle = !className.includes('fa-spin') && (!isButton || operation.phase === appModels.HydrateOperationPhases.Hydrated) ? {style: {color}} : {};
     return className.includes('fa-spin') ? (
         <SpinningIcon color={color} qeId='utils-operations-status-title' />
     ) : (
-        <i title={operationState.phase} qe-id='utils-operations-status-title' className={className + panelButtonClass} {...iconColorStyle} />
+        <i title={operation.phase} qe-id='utils-operations-status-title' className={className + panelButtonClass} {...iconColorStyle} />
     );
 };
 


### PR DESCRIPTION
Adding warnings for two common scenarios: 

1) You've configured Source Hydrator in an app but have forgotten to enable Source Hydrator
2) You have stale hydrator information on an app, because you've disabled Source Hydrator



https://github.com/user-attachments/assets/eb5c368d-9f44-4746-8b26-de1f3b66f2e8


https://github.com/user-attachments/assets/45313314-6406-417f-a16b-ed5ac7986d5a

