### PR TITLE
fix: Use source.path as default refresh path when there is no manifest-generate-paths  (26921)

### DIFF
--- a/util/app/path/path.go
+++ b/util/app/path/path.go
@@ -101,7 +101,8 @@ func CheckOutOfBoundsSymlinks(basePath string) error {
 // The source parameter influences the returned refresh paths:
 //   - if source hydrator configured AND source is syncSource: use sync source path (ignores annotation)
 //   - if source hydrator configured AND source is drySource WITH annotation: use annotation paths with drySource base
-//   - if source hydrator not configured: use annotation paths with source base, or empty if no annotation
+//   - if source hydrator not configured AND annotation present then use annotation paths with source base
+//   - if source hydrator not configured AND no annotation AND source.Path set: use source.Path as default
 func GetSourceRefreshPaths(app *v1alpha1.Application, source v1alpha1.ApplicationSource) []string {
 	annotationPaths, hasAnnotation := app.Annotations[v1alpha1.AnnotationKeyManifestGeneratePaths]
 
@@ -135,8 +136,10 @@ func GetSourceRefreshPaths(app *v1alpha1.Application, source v1alpha1.Applicatio
 			// add the path relative to the source path
 			paths = append(paths, filepath.Clean(filepath.Join(source.Path, item)))
 		}
+	} else if !hasAnnotation && source.Path != "" && app.Spec.SourceHydrator == nil {
+		// No annotation set then use source.Path as the default refresh path.
+		paths = append(paths, source.Path)
 	}
-
 	return paths
 }
 

--- a/util/app/path/path_test.go
+++ b/util/app/path/path_test.go
@@ -144,9 +144,15 @@ func Test_GetAppRefreshPaths(t *testing.T) {
 		expectedPaths []string
 	}{
 		{
-			name:          "single source without annotation",
+			name:          "single source without annotation defaults to source path",
 			app:           getApp(nil, new("source/path")),
 			source:        v1alpha1.ApplicationSource{Path: "source/path"},
+			expectedPaths: []string{"source/path"},
+		},
+		{
+			name:          "single source without annotation and without source path",
+			app:           getApp(nil, nil),
+			source:        v1alpha1.ApplicationSource{},
 			expectedPaths: []string{},
 		},
 		{


### PR DESCRIPTION
Closes #26921

Applications without the `manifest-generate-paths` annotation always trigger a manifest refresh on every webhook push, even when the changed files have no relation to the application's source path. This is because `GetSourceRefreshPaths` returns [] for unannotated apps, and `AppFilesHaveChanged([], changedFiles)` short-circuits to true unconditionally.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
