### PR TITLE
fix(appset): include repository URL in generator error messages

### DIFF
--- a/applicationset/generators/git.go
+++ b/applicationset/generators/git.go
@@ -105,7 +105,7 @@ func (g *GitGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.Applic
 		return nil, ErrEmptyAppSetGenerator
 	}
 	if err != nil {
-		return nil, fmt.Errorf("error generating params from git: %w", err)
+		return nil, fmt.Errorf("error generating params from git repo '%s': %w", appSetGenerator.Git.RepoURL, err)
 	}
 
 	return res, nil
@@ -207,7 +207,7 @@ func (g *GitGenerator) generateParamsForGitFiles(appSetGenerator *argoprojiov1al
 		// A JSON / YAML file path can contain multiple sets of parameters (ie it is an array)
 		paramsFromFileArray, err := g.generateParamsFromGitFile(filePath, fileContentMap[filePath], appSetGenerator.Git.Values, useGoTemplate, goTemplateOptions, appSetGenerator.Git.PathParamPrefix)
 		if err != nil {
-			return nil, fmt.Errorf("unable to process file '%s': %w", filePath, err)
+			return nil, fmt.Errorf("unable to process file '%s' in repo '%s': %w", filePath, appSetGenerator.Git.RepoURL, err)
 		}
 		allParams = append(allParams, paramsFromFileArray...)
 	}

--- a/applicationset/generators/git.go
+++ b/applicationset/generators/git.go
@@ -207,7 +207,7 @@ func (g *GitGenerator) generateParamsForGitFiles(appSetGenerator *argoprojiov1al
 		// A JSON / YAML file path can contain multiple sets of parameters (ie it is an array)
 		paramsFromFileArray, err := g.generateParamsFromGitFile(filePath, fileContentMap[filePath], appSetGenerator.Git.Values, useGoTemplate, goTemplateOptions, appSetGenerator.Git.PathParamPrefix)
 		if err != nil {
-			return nil, fmt.Errorf("unable to process file '%s' in repo '%s': %w", filePath, appSetGenerator.Git.RepoURL, err)
+			return nil, fmt.Errorf("unable to process file '%s': %w", filePath, err)
 		}
 		allParams = append(allParams, paramsFromFileArray...)
 	}

--- a/applicationset/generators/git.go
+++ b/applicationset/generators/git.go
@@ -208,7 +208,7 @@ func (g *GitGenerator) generateParamsForGitFiles(appSetGenerator *argoprojiov1al
 		// A JSON / YAML file path can contain multiple sets of parameters (ie it is an array)
 		paramsFromFileArray, err := g.generateParamsFromGitFile(filePath, fileContentMap[filePath], appSetGenerator.Git.Values, useGoTemplate, goTemplateOptions, appSetGenerator.Git.PathParamPrefix)
 		if err != nil {
-			return nil, fmt.Errorf("unable to process file '%s' in repo '%s': %w", filePath, appSetGenerator.Git.RepoURL, err)
+			return nil, fmt.Errorf("unable to process file '%s': %w", filePath, err)
 		}
 		allParams = append(allParams, paramsFromFileArray...)
 	}

--- a/applicationset/generators/git.go
+++ b/applicationset/generators/git.go
@@ -106,7 +106,7 @@ func (g *GitGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.Applic
 		return nil, ErrEmptyAppSetGenerator
 	}
 	if err != nil {
-		return nil, fmt.Errorf("error generating params from git: %w", err)
+		return nil, fmt.Errorf("error generating params from git repo '%s': %w", appSetGenerator.Git.RepoURL, err)
 	}
 
 	return res, nil
@@ -208,7 +208,7 @@ func (g *GitGenerator) generateParamsForGitFiles(appSetGenerator *argoprojiov1al
 		// A JSON / YAML file path can contain multiple sets of parameters (ie it is an array)
 		paramsFromFileArray, err := g.generateParamsFromGitFile(filePath, fileContentMap[filePath], appSetGenerator.Git.Values, useGoTemplate, goTemplateOptions, appSetGenerator.Git.PathParamPrefix)
 		if err != nil {
-			return nil, fmt.Errorf("unable to process file '%s' from repository '%s': %w", filePath, appSetGenerator.Git.RepoURL, err)
+			return nil, fmt.Errorf("unable to process file '%s' in repo '%s': %w", filePath, appSetGenerator.Git.RepoURL, err)
 		}
 		allParams = append(allParams, paramsFromFileArray...)
 	}

--- a/applicationset/generators/git_test.go
+++ b/applicationset/generators/git_test.go
@@ -349,7 +349,7 @@ func TestGitGenerateParamsFromDirectories(t *testing.T) {
 			repoApps:      []string{},
 			repoError:     errors.New("error"),
 			expected:      []map[string]any{},
-			expectedError: errors.New("error generating params from git: error getting directories from repo: error"),
+			expectedError: errors.New("error generating params from git repo 'RepoURL': error getting directories from repo: error"),
 		},
 	}
 
@@ -650,7 +650,7 @@ func TestGitGenerateParamsFromDirectoriesGoTemplate(t *testing.T) {
 			repoApps:      []string{},
 			repoError:     errors.New("error"),
 			expected:      []map[string]any{},
-			expectedError: errors.New("error generating params from git: error getting directories from repo: error"),
+			expectedError: errors.New("error generating params from git repo 'RepoURL': error getting directories from repo: error"),
 		},
 	}
 
@@ -850,7 +850,7 @@ func TestGitGenerateParamsFromFiles(t *testing.T) {
 			repoFileContents: map[string][]byte{},
 			repoPathsError:   errors.New("paths error"),
 			expected:         []map[string]any{},
-			expectedError:    errors.New("error generating params from git: paths error"),
+			expectedError:    errors.New("error generating params from git repo 'RepoURL': paths error"),
 		},
 		{
 			name:  "test invalid JSON file returns error",
@@ -860,7 +860,7 @@ func TestGitGenerateParamsFromFiles(t *testing.T) {
 			},
 			repoPathsError: nil,
 			expected:       []map[string]any{},
-			expectedError:  errors.New("error generating params from git: unable to process file 'cluster-config/production/config.json': unable to parse file: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type []map[string]interface {}"),
+			expectedError:  errors.New("error generating params from git repo 'RepoURL': unable to process file 'cluster-config/production/config.json' in repo 'RepoURL': unable to parse file: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type []map[string]interface {}"),
 		},
 		{
 			name:  "test JSON array",
@@ -2081,7 +2081,7 @@ func TestGitGenerateParamsFromFilesGoTemplate(t *testing.T) {
 			repoFileContents: map[string][]byte{},
 			repoPathsError:   errors.New("paths error"),
 			expected:         []map[string]any{},
-			expectedError:    errors.New("error generating params from git: paths error"),
+			expectedError:    errors.New("error generating params from git repo 'RepoURL': paths error"),
 		},
 		{
 			name:  "test invalid JSON file returns error",
@@ -2091,7 +2091,7 @@ func TestGitGenerateParamsFromFilesGoTemplate(t *testing.T) {
 			},
 			repoPathsError: nil,
 			expected:       []map[string]any{},
-			expectedError:  errors.New("error generating params from git: unable to process file 'cluster-config/production/config.json': unable to parse file: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type []map[string]interface {}"),
+			expectedError:  errors.New("error generating params from git repo 'RepoURL': unable to process file 'cluster-config/production/config.json' in repo 'RepoURL': unable to parse file: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type []map[string]interface {}"),
 		},
 		{
 			name:  "test JSON array",

--- a/applicationset/generators/git_test.go
+++ b/applicationset/generators/git_test.go
@@ -860,7 +860,7 @@ func TestGitGenerateParamsFromFiles(t *testing.T) {
 			},
 			repoPathsError: nil,
 			expected:       []map[string]any{},
-			expectedError:  errors.New("error generating params from git repo 'RepoURL': unable to process file 'cluster-config/production/config.json' in repo 'RepoURL': unable to parse file: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type []map[string]interface {}"),
+			expectedError:  errors.New("error generating params from git repo 'RepoURL': unable to process file 'cluster-config/production/config.json': unable to parse file: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type []map[string]interface {}"),
 		},
 		{
 			name:  "test JSON array",
@@ -2091,7 +2091,7 @@ func TestGitGenerateParamsFromFilesGoTemplate(t *testing.T) {
 			},
 			repoPathsError: nil,
 			expected:       []map[string]any{},
-			expectedError:  errors.New("error generating params from git repo 'RepoURL': unable to process file 'cluster-config/production/config.json' in repo 'RepoURL': unable to parse file: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type []map[string]interface {}"),
+			expectedError:  errors.New("error generating params from git repo 'RepoURL': unable to process file 'cluster-config/production/config.json': unable to parse file: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type []map[string]interface {}"),
 		},
 		{
 			name:  "test JSON array",

--- a/applicationset/generators/git_test.go
+++ b/applicationset/generators/git_test.go
@@ -2,6 +2,7 @@ package generators
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -2530,4 +2531,52 @@ func TestGitGenerator_GenerateParams(t *testing.T) {
 			assert.Equal(t, testCase.expected, got)
 		}
 	}
+}
+
+// TestGitGenerateParamsRepoURLAppearsOnceInChainedError guards the dedup fix:
+// the outer wrapper at GenerateParams already prefixes the repo URL, so the
+// inner per-file wrapper must not include it again. Without this, the URL
+// shows up twice in the chained error string, which is what the original
+// reviewer flagged.
+func TestGitGenerateParamsRepoURLAppearsOnceInChainedError(t *testing.T) {
+	t.Parallel()
+
+	const repoURL = "https://example.com/some/repo.git"
+
+	argoCDServiceMock := mocks.NewRepos(t)
+	argoCDServiceMock.EXPECT().
+		GetFiles(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(map[string][]byte{
+			"cluster-config/production/config.json": []byte(`invalid json file`),
+		}, nil)
+
+	gitGenerator := NewGitGenerator(argoCDServiceMock, "")
+	applicationSetInfo := v1alpha1.ApplicationSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "set"},
+		Spec: v1alpha1.ApplicationSetSpec{
+			Generators: []v1alpha1.ApplicationSetGenerator{{
+				Git: &v1alpha1.GitGenerator{
+					RepoURL:  repoURL,
+					Revision: "Revision",
+					Files:    []v1alpha1.GitFileGeneratorItem{{Path: "**/config.json"}},
+				},
+			}},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+	appProject := v1alpha1.AppProject{}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&appProject).Build()
+
+	_, err := gitGenerator.GenerateParams(&applicationSetInfo.Spec.Generators[0], &applicationSetInfo, client)
+	require.Error(t, err)
+
+	// The chained error walks through generateParamsFromGitFile ->
+	// generateParamsForGitFiles -> GenerateParams. Only the outermost wrap
+	// should mention the repo URL.
+	got := err.Error()
+	assert.Equalf(t, 1, strings.Count(got, repoURL),
+		"repo URL should appear exactly once in the chained error, got: %q", got)
+	assert.Contains(t, got, repoURL, "outer error must still surface the repo URL")
 }

--- a/applicationset/generators/git_test.go
+++ b/applicationset/generators/git_test.go
@@ -349,7 +349,7 @@ func TestGitGenerateParamsFromDirectories(t *testing.T) {
 			repoApps:      []string{},
 			repoError:     errors.New("error"),
 			expected:      []map[string]any{},
-			expectedError: errors.New("error generating params from git: error getting directories from repo: error"),
+			expectedError: errors.New("error generating params from git repo 'RepoURL': error getting directories from repo: error"),
 		},
 	}
 
@@ -650,7 +650,7 @@ func TestGitGenerateParamsFromDirectoriesGoTemplate(t *testing.T) {
 			repoApps:      []string{},
 			repoError:     errors.New("error"),
 			expected:      []map[string]any{},
-			expectedError: errors.New("error generating params from git: error getting directories from repo: error"),
+			expectedError: errors.New("error generating params from git repo 'RepoURL': error getting directories from repo: error"),
 		},
 	}
 
@@ -850,7 +850,7 @@ func TestGitGenerateParamsFromFiles(t *testing.T) {
 			repoFileContents: map[string][]byte{},
 			repoPathsError:   errors.New("paths error"),
 			expected:         []map[string]any{},
-			expectedError:    errors.New("error generating params from git: paths error"),
+			expectedError:    errors.New("error generating params from git repo 'RepoURL': paths error"),
 		},
 		{
 			name:  "test invalid JSON file returns error",
@@ -860,7 +860,7 @@ func TestGitGenerateParamsFromFiles(t *testing.T) {
 			},
 			repoPathsError: nil,
 			expected:       []map[string]any{},
-			expectedError:  errors.New("error generating params from git: unable to process file 'cluster-config/production/config.json' from repository 'RepoURL': unable to parse file: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type []map[string]interface {}"),
+			expectedError:  errors.New("error generating params from git repo 'RepoURL': unable to process file 'cluster-config/production/config.json' in repo 'RepoURL': unable to parse file: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type []map[string]interface {}"),
 		},
 		{
 			name:  "test JSON array",
@@ -2081,7 +2081,7 @@ func TestGitGenerateParamsFromFilesGoTemplate(t *testing.T) {
 			repoFileContents: map[string][]byte{},
 			repoPathsError:   errors.New("paths error"),
 			expected:         []map[string]any{},
-			expectedError:    errors.New("error generating params from git: paths error"),
+			expectedError:    errors.New("error generating params from git repo 'RepoURL': paths error"),
 		},
 		{
 			name:  "test invalid JSON file returns error",
@@ -2091,7 +2091,7 @@ func TestGitGenerateParamsFromFilesGoTemplate(t *testing.T) {
 			},
 			repoPathsError: nil,
 			expected:       []map[string]any{},
-			expectedError:  errors.New("error generating params from git: unable to process file 'cluster-config/production/config.json' from repository 'RepoURL': unable to parse file: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type []map[string]interface {}"),
+			expectedError:  errors.New("error generating params from git repo 'RepoURL': unable to process file 'cluster-config/production/config.json' in repo 'RepoURL': unable to parse file: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type []map[string]interface {}"),
 		},
 		{
 			name:  "test JSON array",

--- a/applicationset/generators/matrix.go
+++ b/applicationset/generators/matrix.go
@@ -49,7 +49,7 @@ func (m *MatrixGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.App
 
 	g0, err := m.getParams(appSetGenerator.Matrix.Generators[0], appSet, nil, client)
 	if err != nil {
-		return nil, fmt.Errorf("error failed to get params for first generator in matrix generator: %w", err)
+		return nil, fmt.Errorf("failed to get params for first generator in the matrix generator: %w", err)
 	}
 	for _, a := range g0 {
 		g1, err := m.getParams(appSetGenerator.Matrix.Generators[1], appSet, a, client)

--- a/test/e2e/applicationset_git_generator_test.go
+++ b/test/e2e/applicationset_git_generator_test.go
@@ -245,7 +245,7 @@ func TestSimpleGitDirectoryGeneratorGoTemplate(t *testing.T) {
 
 func TestSimpleGitDirectoryGeneratorGPGEnabledUnsignedCommits(t *testing.T) {
 	fixture.SkipOnEnv(t, "GPG")
-	expectedErrorMessage := `error generating params from git: error getting directories from repo: error retrieving Git Directories: rpc error: code = Unknown desc = permission denied`
+	expectedErrorMessage := `error generating params from git repo 'https://github.com/argoproj/argocd-example-apps.git': error getting directories from repo: error retrieving Git Directories: rpc error: code = Unknown desc = permission denied`
 	expectedConditionsParamsError := []v1alpha1.ApplicationSetCondition{
 		{
 			Type:    v1alpha1.ApplicationSetConditionErrorOccurred,
@@ -340,7 +340,7 @@ func TestSimpleGitDirectoryGeneratorGPGEnabledUnsignedCommits(t *testing.T) {
 
 func TestSimpleGitDirectoryGeneratorGPGEnabledWithoutKnownKeys(t *testing.T) {
 	fixture.SkipOnEnv(t, "GPG")
-	expectedErrorMessage := `error generating params from git: error getting directories from repo: error retrieving Git Directories: rpc error: code = Unknown desc = permission denied`
+	expectedErrorMessage := `error generating params from git repo 'https://github.com/argoproj/argocd-example-apps.git': error getting directories from repo: error retrieving Git Directories: rpc error: code = Unknown desc = permission denied`
 	expectedConditionsParamsError := []v1alpha1.ApplicationSetCondition{
 		{
 			Type:    v1alpha1.ApplicationSetConditionErrorOccurred,
@@ -549,7 +549,7 @@ func TestSimpleGitFilesGenerator(t *testing.T) {
 
 func TestSimpleGitFilesGeneratorGPGEnabledUnsignedCommits(t *testing.T) {
 	fixture.SkipOnEnv(t, "GPG")
-	expectedErrorMessage := `error generating params from git: error retrieving Git files: rpc error: code = Unknown desc = permission denied`
+	expectedErrorMessage := `error generating params from git repo 'https://github.com/argoproj/applicationset.git': error retrieving Git files: rpc error: code = Unknown desc = permission denied`
 	expectedConditionsParamsError := []v1alpha1.ApplicationSetCondition{
 		{
 			Type:    v1alpha1.ApplicationSetConditionErrorOccurred,
@@ -644,7 +644,7 @@ func TestSimpleGitFilesGeneratorGPGEnabledUnsignedCommits(t *testing.T) {
 
 func TestSimpleGitFilesGeneratorGPGEnabledWithoutKnownKeys(t *testing.T) {
 	fixture.SkipOnEnv(t, "GPG")
-	expectedErrorMessage := `error generating params from git: error retrieving Git files: rpc error: code = Unknown desc = permission denied`
+	expectedErrorMessage := `error generating params from git repo 'https://github.com/argoproj/applicationset.git': error retrieving Git files: rpc error: code = Unknown desc = permission denied`
 	expectedConditionsParamsError := []v1alpha1.ApplicationSetCondition{
 		{
 			Type:    v1alpha1.ApplicationSetConditionErrorOccurred,

--- a/test/e2e/applicationset_git_generator_test.go
+++ b/test/e2e/applicationset_git_generator_test.go
@@ -248,7 +248,7 @@ func TestSimpleGitDirectoryGeneratorGPGEnabledUnsignedCommits(t *testing.T) {
 	fixture.SkipOnEnv(t, "GPG")
 	fixture.EnsureCleanState(t)
 	expectedErrorMessage := regexp.MustCompile(
-		`error generating params from git: error getting directories from repo: error retrieving Git Directories: rpc error: code = Unknown desc = GIT/GPG: Failed verifying revision .* by '.*': unsigned \(key_id=\)`,
+		`error generating params from git repo '.+': error getting directories from repo: error retrieving Git Directories: rpc error: code = Unknown desc = GIT/GPG: Failed verifying revision .* by '.*': unsigned \(key_id=\)`,
 	)
 	generateExpectedApp := func(name string) v1alpha1.Application {
 		return v1alpha1.Application{
@@ -345,7 +345,7 @@ func TestSimpleGitDirectoryGeneratorGPGEnabledWithoutKnownKeys(t *testing.T) {
 	fixture.SkipOnEnv(t, "GPG")
 	fixture.EnsureCleanState(t)
 	expectedErrorMessage := regexp.MustCompile(
-		`error generating params from git: error getting directories from repo: error retrieving Git Directories: rpc error: code = Unknown desc = GIT/GPG: Failed verifying revision .* by '.*': signed with key not in keyring \(key_id=` + fixture.GpgGoodKeyID + `\)`,
+		`error generating params from git repo '.+': error getting directories from repo: error retrieving Git Directories: rpc error: code = Unknown desc = GIT/GPG: Failed verifying revision .* by '.*': signed with key not in keyring \(key_id=` + fixture.GpgGoodKeyID + `\)`,
 	)
 	generateExpectedApp := func(name string) v1alpha1.Application {
 		return v1alpha1.Application{
@@ -553,7 +553,7 @@ func TestSimpleGitFilesGenerator(t *testing.T) {
 func TestSimpleGitFilesGeneratorGPGEnabledUnsignedCommits(t *testing.T) {
 	fixture.SkipOnEnv(t, "GPG")
 	fixture.EnsureCleanState(t)
-	expectedErrorMessage := regexp.MustCompile(`error generating params from git: error retrieving Git files: rpc error: code = Unknown desc = GIT/GPG: Failed verifying revision .* by '.*': unsigned \(key_id=\)`)
+	expectedErrorMessage := regexp.MustCompile(`error generating params from git repo '.+': error retrieving Git files: rpc error: code = Unknown desc = GIT/GPG: Failed verifying revision .* by '.*': unsigned \(key_id=\)`)
 
 	project := "gpg"
 	generateExpectedApp := func(name string) v1alpha1.Application {
@@ -654,7 +654,7 @@ func TestSimpleGitFilesGeneratorGPGEnabledWithoutKnownKeys(t *testing.T) {
 	fixture.SkipOnEnv(t, "GPG")
 	fixture.EnsureCleanState(t)
 	expectedErrorMessage := regexp.MustCompile(
-		`error generating params from git: error retrieving Git files: rpc error: code = Unknown desc = GIT/GPG: Failed verifying revision .* by '.*': signed with key not in keyring \(key_id=` + fixture.GpgGoodKeyID + `\)`,
+		`error generating params from git repo '.+': error retrieving Git files: rpc error: code = Unknown desc = GIT/GPG: Failed verifying revision .* by '.*': signed with key not in keyring \(key_id=` + fixture.GpgGoodKeyID + `\)`,
 	)
 
 	project := "gpg"


### PR DESCRIPTION
## Summary
Add repository URL context to error messages in ApplicationSet generators (git, matrix) to make debugging easier when using matrix generators with scmProvider across many repositories.

## Changes
- `applicationset/generators/git.go`: Include `RepoURL` in error messages for file/directory generation failures
- `applicationset/generators/matrix.go`: Normalize error message wording for consistency
- `applicationset/generators/git_test.go`: Updated error assertions to match new messages

## How it helps
Before:
```
error generating params from git: unable to process file 'ste1/values.yaml': unable to parse file: error converting YAML to JSON: yaml: line 23: did not find expected key
```

After:
```
error generating params from git repo 'https://github.com/org/broken-repo': unable to process file 'ste1/values.yaml' in repo 'https://github.com/org/broken-repo': unable to parse file: error converting YAML to JSON: yaml: line 23: did not find expected key
```

Fixes #19982