### PR TITLE
fix: skip target normalization when no ignoreDifferences rules exist

### DIFF
--- a/controller/sync.go
+++ b/controller/sync.go
@@ -424,19 +424,22 @@ func (m *appStateManager) SyncAppState(app *v1alpha1.Application, project *v1alp
 //   - copies ignored fields from the matching live resources: apply normalizer to the live resource,
 //     calculates the patch performed by normalizer and applies the patch to the target resource
 func normalizeTargetResources(cr *comparisonResult) ([]*unstructured.Unstructured, error) {
-	// If there are no ignore differences rules configured, normalization is a no-op.
-	// Running normalization without ignore rules can corrupt target resources for CRDs
-	// that lack a registered Kubernetes scheme (e.g., Argo Rollouts), because the merge
-	// patch computation falls back to JSON merge patch which incorrectly handles arrays.
-	if len(cr.diffConfig.Ignores()) == 0 {
-		return cr.reconciliationResult.Target, nil
-	}
-
-	// normalize live and target resources
+	// Always run diff.Normalize() for standard Kubernetes normalization (resource
+	// tracking, managed fields, known types, etc.).
 	normalized, err := diff.Normalize(cr.reconciliationResult.Live, cr.reconciliationResult.Target, cr.diffConfig)
 	if err != nil {
 		return nil, err
 	}
+
+	// If there are no ignore differences rules configured, return the normalized targets
+	// directly without applying the live-to-normalized merge patch. The merge patch
+	// computation falls back to JSON merge patch for CRDs that lack a registered
+	// Kubernetes scheme (e.g., Argo Rollouts), which incorrectly handles arrays and
+	// can corrupt target resources.
+	if len(cr.diffConfig.Ignores()) == 0 {
+		return normalized.Targets, nil
+	}
+
 	patchedTargets := []*unstructured.Unstructured{}
 	for idx, live := range cr.reconciliationResult.Live {
 		normalizedTarget := normalized.Targets[idx]

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -424,6 +424,14 @@ func (m *appStateManager) SyncAppState(app *v1alpha1.Application, project *v1alp
 //   - copies ignored fields from the matching live resources: apply normalizer to the live resource,
 //     calculates the patch performed by normalizer and applies the patch to the target resource
 func normalizeTargetResources(cr *comparisonResult) ([]*unstructured.Unstructured, error) {
+	// If there are no ignore differences rules configured, normalization is a no-op.
+	// Running normalization without ignore rules can corrupt target resources for CRDs
+	// that lack a registered Kubernetes scheme (e.g., Argo Rollouts), because the merge
+	// patch computation falls back to JSON merge patch which incorrectly handles arrays.
+	if len(cr.diffConfig.Ignores()) == 0 {
+		return cr.reconciliationResult.Target, nil
+	}
+
 	// normalize live and target resources
 	normalized, err := diff.Normalize(cr.reconciliationResult.Live, cr.reconciliationResult.Target, cr.diffConfig)
 	if err != nil {

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
@@ -31,6 +32,7 @@ import (
 	applog "github.com/argoproj/argo-cd/v3/util/app/log"
 	"github.com/argoproj/argo-cd/v3/util/argo"
 	"github.com/argoproj/argo-cd/v3/util/argo/diff"
+	"github.com/argoproj/argo-cd/v3/util/glob"
 	kubeutil "github.com/argoproj/argo-cd/v3/util/kube"
 	logutils "github.com/argoproj/argo-cd/v3/util/log"
 	"github.com/argoproj/argo-cd/v3/util/lua"
@@ -404,14 +406,13 @@ func normalizeTargetResources(cr *comparisonResult) ([]*unstructured.Unstructure
 		return nil, err
 	}
 
-	// If there are no ignore differences rules configured, return the normalized targets
-	// directly without applying the live-to-normalized merge patch. The merge patch
-	// computation falls back to JSON merge patch for CRDs that lack a registered
-	// Kubernetes scheme (e.g., Argo Rollouts), which incorrectly handles arrays and
-	// can corrupt target resources.
-	if len(cr.diffConfig.Ignores()) == 0 {
-		return normalized.Targets, nil
-	}
+	// Pre-compute the set of effective ignore rules once. A rule is "effective"
+	// when it sets at least one of JSONPointers / JQPathExpressions /
+	// ManagedFieldsManagers. Entries with all three empty have nothing to remove
+	// from the live state and so contribute no fields to preserve. We also pull
+	// in system-level ResourceOverrides since the diff normalizer treats them as
+	// additional ignore rules keyed by group/kind.
+	effectiveIgnores := collectEffectiveIgnoreRules(cr.diffConfig.Ignores(), cr.diffConfig.Overrides())
 
 	patchedTargets := []*unstructured.Unstructured{}
 	for idx, live := range cr.reconciliationResult.Live {
@@ -423,6 +424,17 @@ func normalizeTargetResources(cr *comparisonResult) ([]*unstructured.Unstructure
 		originalTarget := cr.reconciliationResult.Target[idx]
 		if live == nil {
 			patchedTargets = append(patchedTargets, originalTarget)
+			continue
+		}
+
+		// Skip the live-to-normalized merge patch when no effective ignore rule
+		// matches this resource. The merge patch falls back to JSON merge patch
+		// for CRDs that lack a registered Kubernetes scheme (e.g. Argo Rollouts),
+		// which mishandles array fields and can corrupt the target. If nothing
+		// is being ignored for this resource there is also nothing to copy from
+		// live, so the normalized target is already what we want to apply.
+		if !resourceMatchesAnyEffectiveIgnore(normalizedTarget, effectiveIgnores) {
+			patchedTargets = append(patchedTargets, normalizedTarget)
 			continue
 		}
 
@@ -466,6 +478,83 @@ func normalizeTargetResources(cr *comparisonResult) ([]*unstructured.Unstructure
 		patchedTargets = append(patchedTargets, normalizedTarget)
 	}
 	return patchedTargets, nil
+}
+
+// collectEffectiveIgnoreRules returns the union of application-level
+// ignoreDifferences entries and system-level ResourceOverride.ignoreDifferences
+// entries that actually carry at least one field to ignore (JSONPointers,
+// JQPathExpressions, or ManagedFieldsManagers). Entries with all three empty
+// are filtered out because they do not preserve any live fields and so should
+// not force the merge-patch path to run for a resource.
+func collectEffectiveIgnoreRules(ignores []v1alpha1.ResourceIgnoreDifferences, overrides map[string]v1alpha1.ResourceOverride) []v1alpha1.ResourceIgnoreDifferences {
+	effective := make([]v1alpha1.ResourceIgnoreDifferences, 0, len(ignores))
+	for _, rule := range ignores {
+		if len(rule.JSONPointers)+len(rule.JQPathExpressions)+len(rule.ManagedFieldsManagers) > 0 {
+			effective = append(effective, rule)
+		}
+	}
+	for key, override := range overrides {
+		ignoreDiff := override.IgnoreDifferences
+		if len(ignoreDiff.JSONPointers)+len(ignoreDiff.JQPathExpressions)+len(ignoreDiff.ManagedFieldsManagers) == 0 {
+			continue
+		}
+		group, kind := splitOverrideKey(key)
+		effective = append(effective, v1alpha1.ResourceIgnoreDifferences{
+			Group:                 group,
+			Kind:                  kind,
+			JSONPointers:          ignoreDiff.JSONPointers,
+			JQPathExpressions:     ignoreDiff.JQPathExpressions,
+			ManagedFieldsManagers: ignoreDiff.ManagedFieldsManagers,
+		})
+	}
+	return effective
+}
+
+// splitOverrideKey parses a ResourceOverride map key. The key follows the
+// "<group>/<kind>" format used elsewhere in argo-cd (see
+// util/argo/normalizers/util.go), with bare "<kind>" treated as the core API
+// group. Malformed keys collapse to empty strings; the glob match below will
+// then fail to match any real resource, which is the safe default.
+func splitOverrideKey(key string) (group, kind string) {
+	parts := strings.Split(key, "/")
+	switch len(parts) {
+	case 2:
+		return parts[0], parts[1]
+	case 1:
+		return "", parts[0]
+	default:
+		return "", ""
+	}
+}
+
+// resourceMatchesAnyEffectiveIgnore reports whether any of the supplied
+// effective ignore rules selects the given resource. Matching mirrors the
+// ignoreNormalizer logic in util/argo/normalizers/diff_normalizer.go: group
+// and kind use glob.Match (so "*" wildcards work) and name/namespace match
+// exactly when set or are ignored when empty.
+func resourceMatchesAnyEffectiveIgnore(un *unstructured.Unstructured, rules []v1alpha1.ResourceIgnoreDifferences) bool {
+	if un == nil || len(rules) == 0 {
+		return false
+	}
+	gk := un.GroupVersionKind().GroupKind()
+	name := un.GetName()
+	namespace := un.GetNamespace()
+	for _, rule := range rules {
+		if !glob.Match(rule.Group, gk.Group) {
+			continue
+		}
+		if !glob.Match(rule.Kind, gk.Kind) {
+			continue
+		}
+		if rule.Name != "" && rule.Name != name {
+			continue
+		}
+		if rule.Namespace != "" && rule.Namespace != namespace {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 // getMergePatch calculates and returns the patch between the original and the

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -397,6 +397,14 @@ func (m *appStateManager) SyncAppState(ctx context.Context, app *v1alpha1.Applic
 //   - copies ignored fields from the matching live resources: apply normalizer to the live resource,
 //     calculates the patch performed by normalizer and applies the patch to the target resource
 func normalizeTargetResources(cr *comparisonResult) ([]*unstructured.Unstructured, error) {
+	// If there are no ignore differences rules configured, normalization is a no-op.
+	// Running normalization without ignore rules can corrupt target resources for CRDs
+	// that lack a registered Kubernetes scheme (e.g., Argo Rollouts), because the merge
+	// patch computation falls back to JSON merge patch which incorrectly handles arrays.
+	if len(cr.diffConfig.Ignores()) == 0 {
+		return cr.reconciliationResult.Target, nil
+	}
+
 	// normalize live and target resources
 	normalized, err := diff.Normalize(cr.reconciliationResult.Live, cr.reconciliationResult.Target, cr.diffConfig)
 	if err != nil {

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -397,19 +397,22 @@ func (m *appStateManager) SyncAppState(ctx context.Context, app *v1alpha1.Applic
 //   - copies ignored fields from the matching live resources: apply normalizer to the live resource,
 //     calculates the patch performed by normalizer and applies the patch to the target resource
 func normalizeTargetResources(cr *comparisonResult) ([]*unstructured.Unstructured, error) {
-	// If there are no ignore differences rules configured, normalization is a no-op.
-	// Running normalization without ignore rules can corrupt target resources for CRDs
-	// that lack a registered Kubernetes scheme (e.g., Argo Rollouts), because the merge
-	// patch computation falls back to JSON merge patch which incorrectly handles arrays.
-	if len(cr.diffConfig.Ignores()) == 0 {
-		return cr.reconciliationResult.Target, nil
-	}
-
-	// normalize live and target resources
+	// Always run diff.Normalize() for standard Kubernetes normalization (resource
+	// tracking, managed fields, known types, etc.).
 	normalized, err := diff.Normalize(cr.reconciliationResult.Live, cr.reconciliationResult.Target, cr.diffConfig)
 	if err != nil {
 		return nil, err
 	}
+
+	// If there are no ignore differences rules configured, return the normalized targets
+	// directly without applying the live-to-normalized merge patch. The merge patch
+	// computation falls back to JSON merge patch for CRDs that lack a registered
+	// Kubernetes scheme (e.g., Argo Rollouts), which incorrectly handles arrays and
+	// can corrupt target resources.
+	if len(cr.diffConfig.Ignores()) == 0 {
+		return normalized.Targets, nil
+	}
+
 	patchedTargets := []*unstructured.Unstructured{}
 	for idx, live := range cr.reconciliationResult.Live {
 		normalizedTarget := normalized.Targets[idx]

--- a/controller/sync_test.go
+++ b/controller/sync_test.go
@@ -458,6 +458,100 @@ func TestNormalizeTargetResources(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, int64(4), replicas)
 	})
+	t.Run("will return original targets when no ignore rules configured", func(t *testing.T) {
+		// given - no ignore differences rules
+		f := setup(t, []v1alpha1.ResourceIgnoreDifferences{})
+
+		// Capture the original target pointer
+		originalTarget := f.comparisonResult.reconciliationResult.Target[0]
+
+		// when
+		targets, err := normalizeTargetResources(f.comparisonResult)
+
+		// then - targets should be returned as-is (same slice)
+		require.NoError(t, err)
+		require.Len(t, targets, 1)
+		// The returned target should be the exact same object (pointer equality),
+		// confirming that no normalization was performed.
+		assert.Same(t, originalTarget, targets[0])
+	})
+	t.Run("will not corrupt CRD target when no ignore rules configured", func(t *testing.T) {
+		// given - a CRD resource (like Argo Rollout) with no ignore rules
+		// This is the exact scenario from issue #26588: RespectIgnoreDifferences=true
+		// with no actual ignoreDifferences rules should not modify the target.
+		dc, err := diff.NewDiffConfigBuilder().
+			WithDiffSettings([]v1alpha1.ResourceIgnoreDifferences{}, nil, false, normalizers.IgnoreNormalizerOpts{}).
+			WithNoCache().
+			Build()
+		require.NoError(t, err)
+		live := test.YamlToUnstructured(testdata.LiveRolloutYaml)
+		target := test.YamlToUnstructured(testdata.TargetRolloutYaml)
+		cr := &comparisonResult{
+			reconciliationResult: sync.ReconciliationResult{
+				Live:   []*unstructured.Unstructured{live},
+				Target: []*unstructured.Unstructured{target},
+			},
+			diffConfig: dc,
+		}
+
+		// when
+		targets, err := normalizeTargetResources(cr)
+
+		// then - target should be unchanged
+		require.NoError(t, err)
+		require.Len(t, targets, 1)
+
+		// The env array in the target should be preserved exactly
+		containers, ok, err := unstructured.NestedSlice(targets[0].Object, "spec", "template", "spec", "containers")
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Len(t, containers, 1)
+
+		env := containers[0].(map[string]any)["env"].([]any)
+		require.Len(t, env, 2)
+		// Verify the updated value is preserved
+		assert.Equal(t, "ENV_VAR_1", env[0].(map[string]any)["name"])
+		assert.Equal(t, "value-1-updated", env[0].(map[string]any)["value"])
+		assert.Equal(t, "ENV_VAR_2", env[1].(map[string]any)["name"])
+		assert.Equal(t, "value-2", env[1].(map[string]any)["value"])
+	})
+	t.Run("will still normalize CRD target when ignore rules are configured", func(t *testing.T) {
+		// given - a CRD resource with ignore rules configured
+		ignores := []v1alpha1.ResourceIgnoreDifferences{
+			{
+				Group:        "argoproj.io",
+				Kind:         "Rollout",
+				JSONPointers: []string{"/spec/replicas"},
+			},
+		}
+		dc, err := diff.NewDiffConfigBuilder().
+			WithDiffSettings(ignores, nil, false, normalizers.IgnoreNormalizerOpts{}).
+			WithNoCache().
+			Build()
+		require.NoError(t, err)
+		live := test.YamlToUnstructured(testdata.LiveRolloutYaml)
+		target := test.YamlToUnstructured(testdata.TargetRolloutYaml)
+		cr := &comparisonResult{
+			reconciliationResult: sync.ReconciliationResult{
+				Live:   []*unstructured.Unstructured{live},
+				Target: []*unstructured.Unstructured{target},
+			},
+			diffConfig: dc,
+		}
+
+		// when
+		targets, err := normalizeTargetResources(cr)
+
+		// then - normalization should have been applied
+		require.NoError(t, err)
+		require.Len(t, targets, 1)
+
+		// The replicas field should be normalized to match the live value
+		replicas, ok, err := unstructured.NestedInt64(targets[0].Object, "spec", "replicas")
+		require.NoError(t, err)
+		require.True(t, ok)
+		assert.Equal(t, int64(1), replicas)
+	})
 	t.Run("will keep new array entries not found in live state if not ignored", func(t *testing.T) {
 		t.Skip("limitation in the current implementation")
 		// given

--- a/controller/sync_test.go
+++ b/controller/sync_test.go
@@ -458,22 +458,22 @@ func TestNormalizeTargetResources(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, int64(4), replicas)
 	})
-	t.Run("will return original targets when no ignore rules configured", func(t *testing.T) {
+	t.Run("will return normalized targets without merge patch when no ignore rules configured", func(t *testing.T) {
 		// given - no ignore differences rules
 		f := setup(t, []v1alpha1.ResourceIgnoreDifferences{})
 
-		// Capture the original target pointer
 		originalTarget := f.comparisonResult.reconciliationResult.Target[0]
 
 		// when
 		targets, err := normalizeTargetResources(f.comparisonResult)
 
-		// then - targets should be returned as-is (same slice)
+		// then - diff.Normalize() still runs (for standard Kubernetes normalization),
+		// so the returned target is a deep copy, not the same pointer. But the content
+		// should match the original target since no merge patch is applied.
 		require.NoError(t, err)
 		require.Len(t, targets, 1)
-		// The returned target should be the exact same object (pointer equality),
-		// confirming that no normalization was performed.
-		assert.Same(t, originalTarget, targets[0])
+		assert.NotSame(t, originalTarget, targets[0])
+		assert.Equal(t, originalTarget.GetAnnotations()["iksm-version"], targets[0].GetAnnotations()["iksm-version"])
 	})
 	t.Run("will not corrupt CRD target when no ignore rules configured", func(t *testing.T) {
 		// given - a CRD resource (like Argo Rollout) with no ignore rules

--- a/controller/sync_test.go
+++ b/controller/sync_test.go
@@ -487,6 +487,100 @@ func TestNormalizeTargetResources(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, int64(4), replicas)
 	})
+	t.Run("will return original targets when no ignore rules configured", func(t *testing.T) {
+		// given - no ignore differences rules
+		f := setup(t, []v1alpha1.ResourceIgnoreDifferences{})
+
+		// Capture the original target pointer
+		originalTarget := f.comparisonResult.reconciliationResult.Target[0]
+
+		// when
+		targets, err := normalizeTargetResources(f.comparisonResult)
+
+		// then - targets should be returned as-is (same slice)
+		require.NoError(t, err)
+		require.Len(t, targets, 1)
+		// The returned target should be the exact same object (pointer equality),
+		// confirming that no normalization was performed.
+		assert.Same(t, originalTarget, targets[0])
+	})
+	t.Run("will not corrupt CRD target when no ignore rules configured", func(t *testing.T) {
+		// given - a CRD resource (like Argo Rollout) with no ignore rules
+		// This is the exact scenario from issue #26588: RespectIgnoreDifferences=true
+		// with no actual ignoreDifferences rules should not modify the target.
+		dc, err := diff.NewDiffConfigBuilder().
+			WithDiffSettings([]v1alpha1.ResourceIgnoreDifferences{}, nil, false, normalizers.IgnoreNormalizerOpts{}).
+			WithNoCache().
+			Build()
+		require.NoError(t, err)
+		live := test.YamlToUnstructured(testdata.LiveRolloutYaml)
+		target := test.YamlToUnstructured(testdata.TargetRolloutYaml)
+		cr := &comparisonResult{
+			reconciliationResult: sync.ReconciliationResult{
+				Live:   []*unstructured.Unstructured{live},
+				Target: []*unstructured.Unstructured{target},
+			},
+			diffConfig: dc,
+		}
+
+		// when
+		targets, err := normalizeTargetResources(cr)
+
+		// then - target should be unchanged
+		require.NoError(t, err)
+		require.Len(t, targets, 1)
+
+		// The env array in the target should be preserved exactly
+		containers, ok, err := unstructured.NestedSlice(targets[0].Object, "spec", "template", "spec", "containers")
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Len(t, containers, 1)
+
+		env := containers[0].(map[string]any)["env"].([]any)
+		require.Len(t, env, 2)
+		// Verify the updated value is preserved
+		assert.Equal(t, "ENV_VAR_1", env[0].(map[string]any)["name"])
+		assert.Equal(t, "value-1-updated", env[0].(map[string]any)["value"])
+		assert.Equal(t, "ENV_VAR_2", env[1].(map[string]any)["name"])
+		assert.Equal(t, "value-2", env[1].(map[string]any)["value"])
+	})
+	t.Run("will still normalize CRD target when ignore rules are configured", func(t *testing.T) {
+		// given - a CRD resource with ignore rules configured
+		ignores := []v1alpha1.ResourceIgnoreDifferences{
+			{
+				Group:        "argoproj.io",
+				Kind:         "Rollout",
+				JSONPointers: []string{"/spec/replicas"},
+			},
+		}
+		dc, err := diff.NewDiffConfigBuilder().
+			WithDiffSettings(ignores, nil, false, normalizers.IgnoreNormalizerOpts{}).
+			WithNoCache().
+			Build()
+		require.NoError(t, err)
+		live := test.YamlToUnstructured(testdata.LiveRolloutYaml)
+		target := test.YamlToUnstructured(testdata.TargetRolloutYaml)
+		cr := &comparisonResult{
+			reconciliationResult: sync.ReconciliationResult{
+				Live:   []*unstructured.Unstructured{live},
+				Target: []*unstructured.Unstructured{target},
+			},
+			diffConfig: dc,
+		}
+
+		// when
+		targets, err := normalizeTargetResources(cr)
+
+		// then - normalization should have been applied
+		require.NoError(t, err)
+		require.Len(t, targets, 1)
+
+		// The replicas field should be normalized to match the live value
+		replicas, ok, err := unstructured.NestedInt64(targets[0].Object, "spec", "replicas")
+		require.NoError(t, err)
+		require.True(t, ok)
+		assert.Equal(t, int64(1), replicas)
+	})
 	t.Run("will keep new array entries not found in live state if not ignored", func(t *testing.T) {
 		t.Skip("limitation in the current implementation")
 		// given

--- a/controller/sync_test.go
+++ b/controller/sync_test.go
@@ -581,6 +581,100 @@ func TestNormalizeTargetResources(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, int64(1), replicas)
 	})
+	t.Run("will not corrupt CRD target when ignoreDifferences rule does not match resource", func(t *testing.T) {
+		// given - a CRD resource (Argo Rollout) and an ignoreDifferences rule
+		// targeting an unrelated kind (apps/Deployment). This is the second
+		// repro case from issue #26588 reported by @ogierussell: the bug
+		// reproduces even when ignoreDifferences is configured, as long as no
+		// rule matches the resource being synced.
+		ignores := []v1alpha1.ResourceIgnoreDifferences{
+			{
+				Group:        "apps",
+				Kind:         "Deployment",
+				JSONPointers: []string{"/spec/replicas"},
+			},
+		}
+		dc, err := diff.NewDiffConfigBuilder().
+			WithDiffSettings(ignores, nil, false, normalizers.IgnoreNormalizerOpts{}).
+			WithNoCache().
+			Build()
+		require.NoError(t, err)
+		live := test.YamlToUnstructured(testdata.LiveRolloutYaml)
+		target := test.YamlToUnstructured(testdata.TargetRolloutYaml)
+		cr := &comparisonResult{
+			reconciliationResult: sync.ReconciliationResult{
+				Live:   []*unstructured.Unstructured{live},
+				Target: []*unstructured.Unstructured{target},
+			},
+			diffConfig: dc,
+		}
+
+		// when
+		targets, err := normalizeTargetResources(cr)
+
+		// then - the Rollout target should be untouched. Specifically, the
+		// updated env value must survive (no JSON-merge-patch array corruption).
+		require.NoError(t, err)
+		require.Len(t, targets, 1)
+
+		containers, ok, err := unstructured.NestedSlice(targets[0].Object, "spec", "template", "spec", "containers")
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Len(t, containers, 1)
+
+		env := containers[0].(map[string]any)["env"].([]any)
+		require.Len(t, env, 2)
+		assert.Equal(t, "ENV_VAR_1", env[0].(map[string]any)["name"])
+		assert.Equal(t, "value-1-updated", env[0].(map[string]any)["value"])
+		assert.Equal(t, "ENV_VAR_2", env[1].(map[string]any)["name"])
+		assert.Equal(t, "value-2", env[1].(map[string]any)["value"])
+	})
+	t.Run("will treat ignoreDifferences entries with no effective fields as no-op", func(t *testing.T) {
+		// given - an ignoreDifferences entry that matches the resource but has
+		// no JSONPointers / JQPathExpressions / ManagedFieldsManagers. Such an
+		// entry has nothing to remove from the live state, so it should not
+		// drag the resource through the merge-patch path. This guards Qodo's
+		// finding that `len(Ignores()) == 0` did not distinguish empty entries
+		// from real rules.
+		ignores := []v1alpha1.ResourceIgnoreDifferences{
+			{
+				Group: "argoproj.io",
+				Kind:  "Rollout",
+			},
+		}
+		dc, err := diff.NewDiffConfigBuilder().
+			WithDiffSettings(ignores, nil, false, normalizers.IgnoreNormalizerOpts{}).
+			WithNoCache().
+			Build()
+		require.NoError(t, err)
+		live := test.YamlToUnstructured(testdata.LiveRolloutYaml)
+		target := test.YamlToUnstructured(testdata.TargetRolloutYaml)
+		cr := &comparisonResult{
+			reconciliationResult: sync.ReconciliationResult{
+				Live:   []*unstructured.Unstructured{live},
+				Target: []*unstructured.Unstructured{target},
+			},
+			diffConfig: dc,
+		}
+
+		// when
+		targets, err := normalizeTargetResources(cr)
+
+		// then - same expectation as the "no rules configured" case: the env
+		// array stays intact.
+		require.NoError(t, err)
+		require.Len(t, targets, 1)
+
+		containers, ok, err := unstructured.NestedSlice(targets[0].Object, "spec", "template", "spec", "containers")
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Len(t, containers, 1)
+
+		env := containers[0].(map[string]any)["env"].([]any)
+		require.Len(t, env, 2)
+		assert.Equal(t, "value-1-updated", env[0].(map[string]any)["value"])
+		assert.Equal(t, "value-2", env[1].(map[string]any)["value"])
+	})
 	t.Run("will keep new array entries not found in live state if not ignored", func(t *testing.T) {
 		t.Skip("limitation in the current implementation")
 		// given

--- a/controller/sync_test.go
+++ b/controller/sync_test.go
@@ -487,22 +487,22 @@ func TestNormalizeTargetResources(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, int64(4), replicas)
 	})
-	t.Run("will return original targets when no ignore rules configured", func(t *testing.T) {
+	t.Run("will return normalized targets without merge patch when no ignore rules configured", func(t *testing.T) {
 		// given - no ignore differences rules
 		f := setup(t, []v1alpha1.ResourceIgnoreDifferences{})
 
-		// Capture the original target pointer
 		originalTarget := f.comparisonResult.reconciliationResult.Target[0]
 
 		// when
 		targets, err := normalizeTargetResources(f.comparisonResult)
 
-		// then - targets should be returned as-is (same slice)
+		// then - diff.Normalize() still runs (for standard Kubernetes normalization),
+		// so the returned target is a deep copy, not the same pointer. But the content
+		// should match the original target since no merge patch is applied.
 		require.NoError(t, err)
 		require.Len(t, targets, 1)
-		// The returned target should be the exact same object (pointer equality),
-		// confirming that no normalization was performed.
-		assert.Same(t, originalTarget, targets[0])
+		assert.NotSame(t, originalTarget, targets[0])
+		assert.Equal(t, originalTarget.GetAnnotations()["iksm-version"], targets[0].GetAnnotations()["iksm-version"])
 	})
 	t.Run("will not corrupt CRD target when no ignore rules configured", func(t *testing.T) {
 		// given - a CRD resource (like Argo Rollout) with no ignore rules

--- a/controller/testdata/data.go
+++ b/controller/testdata/data.go
@@ -32,4 +32,10 @@ var (
 
 	//go:embed additional-image-replicas-deployment.yaml
 	AdditionalImageReplicaDeploymentYaml string
+
+	//go:embed live-rollout.yaml
+	LiveRolloutYaml string
+
+	//go:embed target-rollout.yaml
+	TargetRolloutYaml string
 )

--- a/controller/testdata/live-rollout.yaml
+++ b/controller/testdata/live-rollout.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: demo-rollout
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: demo
+  template:
+    metadata:
+      labels:
+        app: demo
+    spec:
+      containers:
+        - name: demo
+          image: nginx:1.19
+          env:
+            - name: ENV_VAR_1
+              value: value-1
+            - name: ENV_VAR_2
+              value: value-2
+          ports:
+            - containerPort: 80

--- a/controller/testdata/target-rollout.yaml
+++ b/controller/testdata/target-rollout.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: demo-rollout
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: demo
+  template:
+    metadata:
+      labels:
+        app: demo
+    spec:
+      containers:
+        - name: demo
+          image: nginx:1.19
+          env:
+            - name: ENV_VAR_1
+              value: value-1-updated
+            - name: ENV_VAR_2
+              value: value-2
+          ports:
+            - containerPort: 80


### PR DESCRIPTION
Fixes #26588

`normalizeTargetResources()` runs `diff.Normalize()` then computes a merge patch between normalized and raw live resources and applies it to the target. For CRDs without a registered K8s scheme, this falls back to JSON merge patch which replaces arrays wholesale instead of merging by key — corrupting things like env arrays in Rollouts.

Fix: still run `diff.Normalize()` (needed for standard K8s normalization), but skip the merge patch application when no ignoreDifferences rules are configured.