### PR TITLE
fix(server): add security headers to Swagger UI endpoints

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1244,7 +1244,7 @@ func (server *ArgoCDServer) newHTTPServer(ctx context.Context, port int, grpcWeb
 	mustRegisterGWHandler(ctx, gpgkeypkg.RegisterGPGKeyServiceHandler, gwmux, conn)
 
 	// Swagger UI
-	swagger.ServeSwaggerUI(mux, assets.SwaggerJSON, "/swagger-ui", server.RootPath)
+	swagger.ServeSwaggerUI(mux, assets.SwaggerJSON, "/swagger-ui", server.RootPath, server.XFrameOptions, server.ContentSecurityPolicy)
 	healthz.ServeHealthCheck(mux, server.healthCheck)
 
 	// Dex reverse proxy and OAuth2 login/callback

--- a/util/swagger/swagger.go
+++ b/util/swagger/swagger.go
@@ -12,19 +12,45 @@ import (
 const redocScriptName = "redoc.standalone.js"
 
 // ServeSwaggerUI serves the Swagger UI and JSON spec.
-func ServeSwaggerUI(mux *http.ServeMux, swaggerJSON string, uiPath string, rootPath string) {
+func ServeSwaggerUI(mux *http.ServeMux, swaggerJSON string, uiPath string, rootPath string, xFrameOptions string, contentSecurityPolicy string) {
 	prefix := path.Dir(uiPath)
 	swaggerPath := path.Join(prefix, "swagger.json")
-	mux.HandleFunc(swaggerPath, func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc(swaggerPath, withSecurityHeaders(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = fmt.Fprint(w, swaggerJSON)
-	})
+	}, xFrameOptions, contentSecurityPolicy))
 
 	specURL := path.Join(prefix, rootPath, "swagger.json")
 	scriptURL := path.Join(prefix, rootPath, "assets", "scripts", redocScriptName)
-	mux.Handle(uiPath, middleware.Redoc(middleware.RedocOpts{
+	mux.Handle(uiPath, withSecurityHeadersHandler(middleware.Redoc(middleware.RedocOpts{
 		BasePath: prefix,
 		SpecURL:  specURL,
 		Path:     path.Base(uiPath),
 		RedocURL: scriptURL,
-	}, http.NotFoundHandler()))
+	}, http.NotFoundHandler()), xFrameOptions, contentSecurityPolicy))
+}
+
+// withSecurityHeaders wraps an http.HandlerFunc with X-Frame-Options and Content-Security-Policy headers.
+func withSecurityHeaders(next http.HandlerFunc, xFrameOptions string, contentSecurityPolicy string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if xFrameOptions != "" {
+			w.Header().Set("X-Frame-Options", xFrameOptions)
+		}
+		if contentSecurityPolicy != "" {
+			w.Header().Set("Content-Security-Policy", contentSecurityPolicy)
+		}
+		next(w, r)
+	}
+}
+
+// withSecurityHeadersHandler wraps an http.Handler with X-Frame-Options and Content-Security-Policy headers.
+func withSecurityHeadersHandler(next http.Handler, xFrameOptions string, contentSecurityPolicy string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if xFrameOptions != "" {
+			w.Header().Set("X-Frame-Options", xFrameOptions)
+		}
+		if contentSecurityPolicy != "" {
+			w.Header().Set("Content-Security-Policy", contentSecurityPolicy)
+		}
+		next.ServeHTTP(w, r)
+	})
 }

--- a/util/swagger/swagger_test.go
+++ b/util/swagger/swagger_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/go-openapi/loads"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/argoproj/argo-cd/v3/util/assets"
@@ -25,7 +26,7 @@ func TestSwaggerUI(t *testing.T) {
 		c <- listener.Addr().String()
 
 		mux := http.NewServeMux()
-		ServeSwaggerUI(mux, assets.SwaggerJSON, "/swagger-ui", "")
+		ServeSwaggerUI(mux, assets.SwaggerJSON, "/swagger-ui", "", "sameorigin", "frame-ancestors 'self';")
 		panic(http.Serve(listener, mux))
 	}
 
@@ -52,4 +53,72 @@ func TestSwaggerUI(t *testing.T) {
 	require.NoError(t, err)
 	require.Equalf(t, http.StatusOK, resp.StatusCode, "Was expecting status code 200 from swagger-ui, but got %d instead", resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
+}
+
+func TestSwaggerUISecurityHeaders(t *testing.T) {
+	lc := &net.ListenConfig{}
+
+	startServer := func(t *testing.T, xFrameOptions string, contentSecurityPolicy string) string {
+		t.Helper()
+		listener, err := lc.Listen(t.Context(), "tcp", ":0")
+		require.NoError(t, err)
+
+		mux := http.NewServeMux()
+		ServeSwaggerUI(mux, assets.SwaggerJSON, "/swagger-ui", "", xFrameOptions, contentSecurityPolicy)
+		go func() { _ = http.Serve(listener, mux) }()
+
+		return "http://" + listener.Addr().String()
+	}
+
+	t.Run("default headers on swagger.json", func(t *testing.T) {
+		server := startServer(t, "sameorigin", "frame-ancestors 'self';")
+
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server+"/swagger.json", http.NoBody)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, "sameorigin", resp.Header.Get("X-Frame-Options"))
+		assert.Equal(t, "frame-ancestors 'self';", resp.Header.Get("Content-Security-Policy"))
+	})
+
+	t.Run("default headers on swagger-ui", func(t *testing.T) {
+		server := startServer(t, "sameorigin", "frame-ancestors 'self';")
+
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server+"/swagger-ui", http.NoBody)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, "sameorigin", resp.Header.Get("X-Frame-Options"))
+		assert.Equal(t, "frame-ancestors 'self';", resp.Header.Get("Content-Security-Policy"))
+	})
+
+	t.Run("custom headers", func(t *testing.T) {
+		server := startServer(t, "deny", "frame-ancestors 'none';")
+
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server+"/swagger.json", http.NoBody)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, "deny", resp.Header.Get("X-Frame-Options"))
+		assert.Equal(t, "frame-ancestors 'none';", resp.Header.Get("Content-Security-Policy"))
+	})
+
+	t.Run("empty headers omitted", func(t *testing.T) {
+		server := startServer(t, "", "")
+
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server+"/swagger.json", http.NoBody)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Empty(t, resp.Header.Get("X-Frame-Options"))
+		assert.Empty(t, resp.Header.Get("Content-Security-Policy"))
+	})
 }


### PR DESCRIPTION
Fixes #22877

## Summary

The Swagger UI (`/swagger-ui`) and spec (`/swagger.json`) endpoints were missing `X-Frame-Options` and `Content-Security-Policy` headers. These headers are already applied to static assets via `newStaticAssetsHandler()`, but the Swagger endpoints are registered as separate handlers and didn't inherit them. This gap could allow the Swagger interface to be embedded in an external iframe, enabling clickjacking.

## Changes

- Added `xFrameOptions` and `contentSecurityPolicy` parameters to `ServeSwaggerUI()` in `util/swagger/swagger.go`
- Wrapped both the `/swagger.json` handler and the Redoc UI handler with security header middleware
- Updated the call site in `server/server.go` to pass the existing configurable header values
- Added unit tests covering default headers, custom values, and empty/disabled headers on both endpoints

The fix reuses the same `--x-frame-options` (default: `sameorigin`) and `--content-security-policy` (default: `frame-ancestors 'self';`) server flags that already control headers on static assets, so no new configuration is needed.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.