### PR TITLE
fix: clean up stale operationState when operation field is nil

### DIFF
--- a/server/application/application.go
+++ b/server/application/application.go
@@ -2447,10 +2447,26 @@ func (s *Server) TerminateOperation(ctx context.Context, termOpReq *application.
 	}
 
 	for range 10 {
-		if a.Operation == nil || a.Status.OperationState == nil {
+		if a.Status.OperationState == nil {
 			return nil, status.Errorf(codes.InvalidArgument, "Unable to terminate operation. No operation is in progress")
 		}
-		a.Status.OperationState.Phase = common.OperationTerminating
+
+		if a.Operation == nil {
+			if !a.Status.OperationState.Phase.Completed() {
+				// The operation field was cleared (e.g. by another controller reconciliation) while
+				// operationState still shows Running/Terminating. This is an inconsistent state.
+				// Clean it up by marking the operation as Failed.
+				log.Warnf("application '%s' has nil operation but operationState phase is %s; cleaning up stale state", a.QualifiedName(), a.Status.OperationState.Phase)
+				a.Status.OperationState.Phase = common.OperationFailed
+				a.Status.OperationState.Message = "operation was interrupted"
+				now := metav1.Now()
+				a.Status.OperationState.FinishedAt = &now
+			} else {
+				return nil, status.Errorf(codes.InvalidArgument, "Unable to terminate operation. No operation is in progress")
+			}
+		} else {
+			a.Status.OperationState.Phase = common.OperationTerminating
+		}
 		updated, err := s.appclientset.ArgoprojV1alpha1().Applications(appNs).Update(ctx, a, metav1.UpdateOptions{})
 		if err == nil {
 			s.waitSync(updated)

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -2452,18 +2452,17 @@ func (s *Server) TerminateOperation(ctx context.Context, termOpReq *application.
 		}
 
 		if a.Operation == nil {
-			if !a.Status.OperationState.Phase.Completed() {
-				// The operation field was cleared (e.g. by another controller reconciliation) while
-				// operationState still shows Running/Terminating. This is an inconsistent state.
-				// Clean it up by marking the operation as Failed.
-				log.Warnf("application '%s' has nil operation but operationState phase is %s; cleaning up stale state", a.QualifiedName(), a.Status.OperationState.Phase)
-				a.Status.OperationState.Phase = common.OperationFailed
-				a.Status.OperationState.Message = "operation was interrupted"
-				now := metav1.Now()
-				a.Status.OperationState.FinishedAt = &now
-			} else {
+			if a.Status.OperationState.Phase.Completed() {
 				return nil, status.Errorf(codes.InvalidArgument, "Unable to terminate operation. No operation is in progress")
 			}
+			// The operation field was cleared (e.g. by another controller reconciliation) while
+			// operationState still shows Running/Terminating. This is an inconsistent state.
+			// Clean it up by marking the operation as Failed.
+			log.Warnf("application '%s' has nil operation but operationState phase is %s; cleaning up stale state", a.QualifiedName(), a.Status.OperationState.Phase)
+			a.Status.OperationState.Phase = common.OperationFailed
+			a.Status.OperationState.Message = "operation was interrupted"
+			now := metav1.Now()
+			a.Status.OperationState.FinishedAt = &now
 		} else {
 			a.Status.OperationState.Phase = common.OperationTerminating
 		}

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -2505,18 +2505,17 @@ func (s *Server) TerminateOperation(ctx context.Context, termOpReq *application.
 		}
 
 		if a.Operation == nil {
-			if !a.Status.OperationState.Phase.Completed() {
-				// The operation field was cleared (e.g. by another controller reconciliation) while
-				// operationState still shows Running/Terminating. This is an inconsistent state.
-				// Clean it up by marking the operation as Failed.
-				log.Warnf("application '%s' has nil operation but operationState phase is %s; cleaning up stale state", a.QualifiedName(), a.Status.OperationState.Phase)
-				a.Status.OperationState.Phase = common.OperationFailed
-				a.Status.OperationState.Message = "operation was interrupted"
-				now := metav1.Now()
-				a.Status.OperationState.FinishedAt = &now
-			} else {
+			if a.Status.OperationState.Phase.Completed() {
 				return nil, status.Errorf(codes.InvalidArgument, "Unable to terminate operation. No operation is in progress")
 			}
+			// The operation field was cleared (e.g. by another controller reconciliation) while
+			// operationState still shows Running/Terminating. This is an inconsistent state.
+			// Clean it up by marking the operation as Failed.
+			log.Warnf("application '%s' has nil operation but operationState phase is %s; cleaning up stale state", a.QualifiedName(), a.Status.OperationState.Phase)
+			a.Status.OperationState.Phase = common.OperationFailed
+			a.Status.OperationState.Message = "operation was interrupted"
+			now := metav1.Now()
+			a.Status.OperationState.FinishedAt = &now
 		} else {
 			a.Status.OperationState.Phase = common.OperationTerminating
 		}

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -2500,10 +2500,26 @@ func (s *Server) TerminateOperation(ctx context.Context, termOpReq *application.
 	}
 
 	for range 10 {
-		if a.Operation == nil || a.Status.OperationState == nil {
+		if a.Status.OperationState == nil {
 			return nil, status.Errorf(codes.InvalidArgument, "Unable to terminate operation. No operation is in progress")
 		}
-		a.Status.OperationState.Phase = common.OperationTerminating
+
+		if a.Operation == nil {
+			if !a.Status.OperationState.Phase.Completed() {
+				// The operation field was cleared (e.g. by another controller reconciliation) while
+				// operationState still shows Running/Terminating. This is an inconsistent state.
+				// Clean it up by marking the operation as Failed.
+				log.Warnf("application '%s' has nil operation but operationState phase is %s; cleaning up stale state", a.QualifiedName(), a.Status.OperationState.Phase)
+				a.Status.OperationState.Phase = common.OperationFailed
+				a.Status.OperationState.Message = "operation was interrupted"
+				now := metav1.Now()
+				a.Status.OperationState.FinishedAt = &now
+			} else {
+				return nil, status.Errorf(codes.InvalidArgument, "Unable to terminate operation. No operation is in progress")
+			}
+		} else {
+			a.Status.OperationState.Phase = common.OperationTerminating
+		}
 		updated, err := s.appclientset.ArgoprojV1alpha1().Applications(appNs).Update(ctx, a, metav1.UpdateOptions{})
 		if err == nil {
 			s.waitSync(updated)

--- a/server/application/application_test.go
+++ b/server/application/application_test.go
@@ -4644,3 +4644,103 @@ func TestTerminateOperationWithConflicts(t *testing.T) {
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, updateCallCount, 2, "Update should be called at least twice (once with conflict, once with success)")
 }
+
+func TestTerminateOperation_NilOperationWithRunningState(t *testing.T) {
+	// Reproduces issue #17155: when .operation is nil but .status.operationState
+	// still shows Running, TerminateOperation should clean up the stale state
+	// instead of returning "No operation is in progress".
+	testApp := newTestApp()
+	testApp.Operation = nil // operation field already cleared
+	testApp.Status.OperationState = &v1alpha1.OperationState{
+		Operation: v1alpha1.Operation{
+			Sync: &v1alpha1.SyncOperation{},
+		},
+		Phase:     synccommon.OperationRunning,
+		StartedAt: metav1.NewTime(time.Now()),
+	}
+
+	appServer := newTestAppServer(t, testApp)
+	ctx := context.Background()
+
+	resp, err := appServer.TerminateOperation(ctx, &application.OperationTerminateRequest{
+		Name: &testApp.Name,
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+
+	// Verify the stale operationState was cleaned up
+	app, err := appServer.appclientset.ArgoprojV1alpha1().Applications(testApp.Namespace).Get(ctx, testApp.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, synccommon.OperationFailed, app.Status.OperationState.Phase)
+	assert.Equal(t, "operation was interrupted", app.Status.OperationState.Message)
+	assert.NotNil(t, app.Status.OperationState.FinishedAt)
+}
+
+func TestTerminateOperation_NilOperationWithTerminatingState(t *testing.T) {
+	// Same issue as #17155 but operationState is in Terminating phase.
+	testApp := newTestApp()
+	testApp.Operation = nil
+	testApp.Status.OperationState = &v1alpha1.OperationState{
+		Operation: v1alpha1.Operation{
+			Sync: &v1alpha1.SyncOperation{},
+		},
+		Phase:     synccommon.OperationTerminating,
+		StartedAt: metav1.NewTime(time.Now()),
+	}
+
+	appServer := newTestAppServer(t, testApp)
+	ctx := context.Background()
+
+	resp, err := appServer.TerminateOperation(ctx, &application.OperationTerminateRequest{
+		Name: &testApp.Name,
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+
+	app, err := appServer.appclientset.ArgoprojV1alpha1().Applications(testApp.Namespace).Get(ctx, testApp.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, synccommon.OperationFailed, app.Status.OperationState.Phase)
+	assert.Equal(t, "operation was interrupted", app.Status.OperationState.Message)
+	assert.NotNil(t, app.Status.OperationState.FinishedAt)
+}
+
+func TestTerminateOperation_NilOperationWithCompletedState(t *testing.T) {
+	// When operation is nil and operationState is already completed,
+	// should still return "no operation in progress" error.
+	testApp := newTestApp()
+	testApp.Operation = nil
+	now := metav1.Now()
+	testApp.Status.OperationState = &v1alpha1.OperationState{
+		Operation: v1alpha1.Operation{
+			Sync: &v1alpha1.SyncOperation{},
+		},
+		Phase:      synccommon.OperationSucceeded,
+		StartedAt:  metav1.NewTime(time.Now()),
+		FinishedAt: &now,
+	}
+
+	appServer := newTestAppServer(t, testApp)
+	ctx := context.Background()
+
+	_, err := appServer.TerminateOperation(ctx, &application.OperationTerminateRequest{
+		Name: &testApp.Name,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "No operation is in progress")
+}
+
+func TestTerminateOperation_NilOperationStateReturnsError(t *testing.T) {
+	// When both operation and operationState are nil, should return error.
+	testApp := newTestApp()
+	testApp.Operation = nil
+	testApp.Status.OperationState = nil
+
+	appServer := newTestAppServer(t, testApp)
+	ctx := context.Background()
+
+	_, err := appServer.TerminateOperation(ctx, &application.OperationTerminateRequest{
+		Name: &testApp.Name,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "No operation is in progress")
+}

--- a/server/application/application_test.go
+++ b/server/application/application_test.go
@@ -5168,3 +5168,103 @@ func TestGetUnstructuredLiveResourceOrAppWithImpersonation(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "system:serviceaccount:"+test.FakeDestNamespace+":test-sa", config.Impersonate.UserName)
 }
+
+func TestTerminateOperation_NilOperationWithRunningState(t *testing.T) {
+	// Reproduces issue #17155: when .operation is nil but .status.operationState
+	// still shows Running, TerminateOperation should clean up the stale state
+	// instead of returning "No operation is in progress".
+	testApp := newTestApp()
+	testApp.Operation = nil // operation field already cleared
+	testApp.Status.OperationState = &v1alpha1.OperationState{
+		Operation: v1alpha1.Operation{
+			Sync: &v1alpha1.SyncOperation{},
+		},
+		Phase:     synccommon.OperationRunning,
+		StartedAt: metav1.NewTime(time.Now()),
+	}
+
+	appServer := newTestAppServer(t, testApp)
+	ctx := t.Context()
+
+	resp, err := appServer.TerminateOperation(ctx, &application.OperationTerminateRequest{
+		Name: &testApp.Name,
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+
+	// Verify the stale operationState was cleaned up
+	app, err := appServer.appclientset.ArgoprojV1alpha1().Applications(testApp.Namespace).Get(ctx, testApp.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, synccommon.OperationFailed, app.Status.OperationState.Phase)
+	assert.Equal(t, "operation was interrupted", app.Status.OperationState.Message)
+	assert.NotNil(t, app.Status.OperationState.FinishedAt)
+}
+
+func TestTerminateOperation_NilOperationWithTerminatingState(t *testing.T) {
+	// Same issue as #17155 but operationState is in Terminating phase.
+	testApp := newTestApp()
+	testApp.Operation = nil
+	testApp.Status.OperationState = &v1alpha1.OperationState{
+		Operation: v1alpha1.Operation{
+			Sync: &v1alpha1.SyncOperation{},
+		},
+		Phase:     synccommon.OperationTerminating,
+		StartedAt: metav1.NewTime(time.Now()),
+	}
+
+	appServer := newTestAppServer(t, testApp)
+	ctx := t.Context()
+
+	resp, err := appServer.TerminateOperation(ctx, &application.OperationTerminateRequest{
+		Name: &testApp.Name,
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+
+	app, err := appServer.appclientset.ArgoprojV1alpha1().Applications(testApp.Namespace).Get(ctx, testApp.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, synccommon.OperationFailed, app.Status.OperationState.Phase)
+	assert.Equal(t, "operation was interrupted", app.Status.OperationState.Message)
+	assert.NotNil(t, app.Status.OperationState.FinishedAt)
+}
+
+func TestTerminateOperation_NilOperationWithCompletedState(t *testing.T) {
+	// When operation is nil and operationState is already completed,
+	// should still return "no operation in progress" error.
+	testApp := newTestApp()
+	testApp.Operation = nil
+	now := metav1.Now()
+	testApp.Status.OperationState = &v1alpha1.OperationState{
+		Operation: v1alpha1.Operation{
+			Sync: &v1alpha1.SyncOperation{},
+		},
+		Phase:      synccommon.OperationSucceeded,
+		StartedAt:  metav1.NewTime(time.Now()),
+		FinishedAt: &now,
+	}
+
+	appServer := newTestAppServer(t, testApp)
+	ctx := t.Context()
+
+	_, err := appServer.TerminateOperation(ctx, &application.OperationTerminateRequest{
+		Name: &testApp.Name,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "No operation is in progress")
+}
+
+func TestTerminateOperation_NilOperationStateReturnsError(t *testing.T) {
+	// When both operation and operationState are nil, should return error.
+	testApp := newTestApp()
+	testApp.Operation = nil
+	testApp.Status.OperationState = nil
+
+	appServer := newTestAppServer(t, testApp)
+	ctx := t.Context()
+
+	_, err := appServer.TerminateOperation(ctx, &application.OperationTerminateRequest{
+		Name: &testApp.Name,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "No operation is in progress")
+}


### PR DESCRIPTION
Fixes #17155

When `.operation` gets cleared while `.status.operationState` still shows Running, `TerminateOperation` returns "No operation is in progress" and the user is stuck.

This detects the inconsistent state and cleans up the stale operationState by marking it Failed. Doesn't touch the normal path where `.operation` exists.

Added tests for the nil-operation-with-running-state scenario and the edge cases around it.