### PR TITLE
fix: exclude PostDelete hooks from sync comparison during normal operations

### DIFF
--- a/controller/state.go
+++ b/controller/state.go
@@ -718,7 +718,14 @@ func (m *appStateManager) CompareAppState(app *v1alpha1.Application, project *v1
 	}
 	ts.AddCheckpoint("dedup_ms")
 
-	liveObjByKey, err := m.liveStateCache.GetManagedLiveObjs(destCluster, app, targetObjs)
+	// Filter out PreDelete and PostDelete hooks from targetObjs before fetching managed live
+	// objects. These hooks should not be synced as regular resources and are only executed
+	// during deletion. Filtering them out here prevents untracked resources with the same
+	// name as a hook from being picked up as managed live objects, which would otherwise
+	// cause the application to be perpetually OutOfSync. (See #21579)
+	targetObjsForSync, hasPreDeleteHooks, hasPostDeleteHooks := partitionTargetObjsForSync(targetObjs)
+
+	liveObjByKey, err := m.liveStateCache.GetManagedLiveObjs(destCluster, app, targetObjsForSync)
 	if err != nil {
 		liveObjByKey = make(map[kubeutil.ResourceKey]*unstructured.Unstructured)
 		msg := "Failed to load live state: " + err.Error()
@@ -771,7 +778,7 @@ func (m *appStateManager) CompareAppState(app *v1alpha1.Application, project *v1
 			// gitops-engine, the difference here being that we create a managed namespace which is only used for comparison.
 			//
 			// targetNsExists == true implies that it already exists as a target, so no need to add the namespace to the
-			// targetObjs array.
+			// targetObjsForSync array.
 			if isManagedNamespace(liveObj, app) && !targetNsExists {
 				nsSpec := &corev1.Namespace{TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: kubeutil.NamespaceKind}, ObjectMeta: metav1.ObjectMeta{Name: liveObj.GetName()}}
 				managedNs, err := kubeutil.ToUnstructured(nsSpec)
@@ -787,12 +794,11 @@ func (m *appStateManager) CompareAppState(app *v1alpha1.Application, project *v1
 					conditions = append(conditions, v1alpha1.ApplicationCondition{Type: v1alpha1.ApplicationConditionComparisonError, Message: err.Error(), LastTransitionTime: &now})
 					failedToLoadObjs = true
 				} else {
-					targetObjs = append(targetObjs, managedNs)
+					targetObjsForSync = append(targetObjsForSync, managedNs)
 				}
 			}
 		}
 	}
-	targetObjsForSync, hasPreDeleteHooks, hasPostDeleteHooks := partitionTargetObjsForSync(targetObjs)
 
 	reconciliation := sync.Reconcile(targetObjsForSync, liveObjByKey, app.Spec.Destination.Namespace, infoProvider)
 	ts.AddCheckpoint("live_ms")

--- a/controller/state_test.go
+++ b/controller/state_test.go
@@ -616,6 +616,178 @@ func TestCompareAppStateExtraHook(t *testing.T) {
 	assert.Empty(t, app.Status.Conditions)
 }
 
+// TestCompareAppStatePostDeleteHookNotTracked verifies that a PostDelete hook defined in the
+// application manifests does not cause the app to be OutOfSync. The hook should be excluded
+// from the target objects passed to GetManagedLiveObjs so that untracked resources sharing
+// the same name are not picked up as managed resources. (See #21579)
+func TestCompareAppStatePostDeleteHookNotTracked(t *testing.T) {
+	t.Parallel()
+
+	// Create a pod manifest annotated as a PostDelete hook
+	hook := NewPod()
+	hook.SetName("post-delete-secret")
+	hook.SetNamespace(test.FakeDestNamespace)
+	hook.SetAnnotations(map[string]string{"argocd.argoproj.io/hook": "PostDelete"})
+	hookBytes, err := json.Marshal(hook)
+	require.NoError(t, err)
+
+	app := newFakeApp()
+	// managedLiveObjs is empty: since the fix excludes PostDelete hooks from the target
+	// objects passed to GetManagedLiveObjs, the untracked live resource with the same name
+	// would no longer be returned by the live state cache.
+	data := fakeData{
+		manifestResponse: &apiclient.ManifestResponse{
+			Manifests: []string{string(hookBytes)},
+			Namespace: test.FakeDestNamespace,
+			Server:    test.FakeClusterURL,
+			Revision:  "abc123",
+		},
+		managedLiveObjs: make(map[kube.ResourceKey]*unstructured.Unstructured),
+	}
+	ctrl := newFakeController(t.Context(), &data, nil)
+	sources := make([]v1alpha1.ApplicationSource, 0)
+	sources = append(sources, app.Spec.GetSource())
+	revisions := make([]string, 0)
+	revisions = append(revisions, "")
+	compRes, err := ctrl.appStateManager.CompareAppState(app, &defaultProj, revisions, sources, false, false, nil, false)
+	require.NoError(t, err)
+	assert.NotNil(t, compRes)
+	// The app should be Synced because PostDelete hooks are excluded from sync comparison
+	assert.Equal(t, v1alpha1.SyncStatusCodeSynced, compRes.syncStatus.Status)
+	assert.True(t, compRes.hasPostDeleteHooks)
+	// PostDelete hooks should not appear as managed resources or reconciled targets
+	assert.Empty(t, compRes.managedResources)
+	assert.Empty(t, compRes.resources)
+	assert.Empty(t, app.Status.Conditions)
+}
+
+// TestCompareAppStatePreDeleteHookNotTracked verifies that a PreDelete hook defined in the
+// application manifests does not cause the app to be OutOfSync.
+func TestCompareAppStatePreDeleteHookNotTracked(t *testing.T) {
+	t.Parallel()
+
+	hook := NewPod()
+	hook.SetName("pre-delete-job")
+	hook.SetNamespace(test.FakeDestNamespace)
+	hook.SetAnnotations(map[string]string{"argocd.argoproj.io/hook": "PreDelete"})
+	hookBytes, err := json.Marshal(hook)
+	require.NoError(t, err)
+
+	app := newFakeApp()
+	data := fakeData{
+		manifestResponse: &apiclient.ManifestResponse{
+			Manifests: []string{string(hookBytes)},
+			Namespace: test.FakeDestNamespace,
+			Server:    test.FakeClusterURL,
+			Revision:  "abc123",
+		},
+		managedLiveObjs: make(map[kube.ResourceKey]*unstructured.Unstructured),
+	}
+	ctrl := newFakeController(t.Context(), &data, nil)
+	sources := make([]v1alpha1.ApplicationSource, 0)
+	sources = append(sources, app.Spec.GetSource())
+	revisions := make([]string, 0)
+	revisions = append(revisions, "")
+	compRes, err := ctrl.appStateManager.CompareAppState(app, &defaultProj, revisions, sources, false, false, nil, false)
+	require.NoError(t, err)
+	assert.NotNil(t, compRes)
+	assert.Equal(t, v1alpha1.SyncStatusCodeSynced, compRes.syncStatus.Status)
+	assert.True(t, compRes.hasPreDeleteHooks)
+	assert.Empty(t, compRes.managedResources)
+	assert.Empty(t, compRes.resources)
+	assert.Empty(t, app.Status.Conditions)
+}
+
+// TestCompareAppStateHelmPostDeleteHookNotTracked verifies that a Helm post-delete hook
+// defined in the application manifests does not cause the app to be OutOfSync.
+func TestCompareAppStateHelmPostDeleteHookNotTracked(t *testing.T) {
+	t.Parallel()
+
+	hook := NewPod()
+	hook.SetName("post-delete-secret")
+	hook.SetNamespace(test.FakeDestNamespace)
+	hook.SetAnnotations(map[string]string{"helm.sh/hook": "post-delete"})
+	hookBytes, err := json.Marshal(hook)
+	require.NoError(t, err)
+
+	app := newFakeApp()
+	data := fakeData{
+		manifestResponse: &apiclient.ManifestResponse{
+			Manifests: []string{string(hookBytes)},
+			Namespace: test.FakeDestNamespace,
+			Server:    test.FakeClusterURL,
+			Revision:  "abc123",
+		},
+		managedLiveObjs: make(map[kube.ResourceKey]*unstructured.Unstructured),
+	}
+	ctrl := newFakeController(t.Context(), &data, nil)
+	sources := make([]v1alpha1.ApplicationSource, 0)
+	sources = append(sources, app.Spec.GetSource())
+	revisions := make([]string, 0)
+	revisions = append(revisions, "")
+	compRes, err := ctrl.appStateManager.CompareAppState(app, &defaultProj, revisions, sources, false, false, nil, false)
+	require.NoError(t, err)
+	assert.NotNil(t, compRes)
+	assert.Equal(t, v1alpha1.SyncStatusCodeSynced, compRes.syncStatus.Status)
+	assert.True(t, compRes.hasPostDeleteHooks)
+	assert.Empty(t, compRes.managedResources)
+	assert.Empty(t, compRes.resources)
+	assert.Empty(t, app.Status.Conditions)
+}
+
+// TestCompareAppStatePostDeleteHookWithRegularResource verifies that when an app has both
+// a PostDelete hook and a regular resource, the regular resource is properly tracked while
+// the PostDelete hook is excluded from sync comparison.
+func TestCompareAppStatePostDeleteHookWithRegularResource(t *testing.T) {
+	t.Parallel()
+
+	// Regular resource that should be tracked
+	regularPod := NewPod()
+	regularPod.SetNamespace(test.FakeDestNamespace)
+	regularBytes, err := json.Marshal(regularPod)
+	require.NoError(t, err)
+
+	// PostDelete hook that should NOT be tracked for sync
+	hook := NewPod()
+	hook.SetName("post-delete-cleanup")
+	hook.SetNamespace(test.FakeDestNamespace)
+	hook.SetAnnotations(map[string]string{"argocd.argoproj.io/hook": "PostDelete"})
+	hookBytes, err := json.Marshal(hook)
+	require.NoError(t, err)
+
+	// Live state has the regular pod
+	livePod := regularPod.DeepCopy()
+	key := kube.ResourceKey{Group: "", Kind: "Pod", Namespace: test.FakeDestNamespace, Name: regularPod.GetName()}
+
+	app := newFakeApp()
+	data := fakeData{
+		manifestResponse: &apiclient.ManifestResponse{
+			Manifests: []string{string(regularBytes), string(hookBytes)},
+			Namespace: test.FakeDestNamespace,
+			Server:    test.FakeClusterURL,
+			Revision:  "abc123",
+		},
+		managedLiveObjs: map[kube.ResourceKey]*unstructured.Unstructured{
+			key: livePod,
+		},
+	}
+	ctrl := newFakeController(t.Context(), &data, nil)
+	sources := make([]v1alpha1.ApplicationSource, 0)
+	sources = append(sources, app.Spec.GetSource())
+	revisions := make([]string, 0)
+	revisions = append(revisions, "")
+	compRes, err := ctrl.appStateManager.CompareAppState(app, &defaultProj, revisions, sources, false, false, nil, false)
+	require.NoError(t, err)
+	assert.NotNil(t, compRes)
+	// App should be Synced: regular resource is in sync, PostDelete hook is excluded
+	assert.Equal(t, v1alpha1.SyncStatusCodeSynced, compRes.syncStatus.Status)
+	assert.True(t, compRes.hasPostDeleteHooks)
+	// Only the regular resource should be tracked, not the PostDelete hook
+	assert.Len(t, compRes.managedResources, 1)
+	assert.Len(t, compRes.resources, 1)
+	assert.Empty(t, app.Status.Conditions)
+}
+
 // TestAppRevisions tests that revisions are properly propagated for a single source app
 func TestAppRevisionsSingleSource(t *testing.T) {
 	obj1 := NewPod()


### PR DESCRIPTION
Fixes #21579

PostDelete/PreDelete hooks were getting included in `targetObjs` before `GetManagedLiveObjs()`, which meant if some untracked resource happened to share the same name (e.g. a cert-manager Secret matching a PostDelete Job), it'd get picked up as a managed live object. Then when hooks got filtered out for sync, that orphaned live object had no corresponding target → perpetual OutOfSync.

Fix moves the hook filtering to happen before `GetManagedLiveObjs()` so hooks never cause live resource lookups in the first place.

Tests cover ArgoCD-style and Helm-style post-delete hooks, plus the case where a regular resource coexists with a hook of the same name.