### PR TITLE
fix(helm): preserve null values in valuesObject

### DIFF
--- a/applicationset/utils/createOrUpdate.go
+++ b/applicationset/utils/createOrUpdate.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	stderrors "errors"
@@ -116,6 +117,17 @@ func CreateOrUpdate(ctx context.Context, logCtx *log.Entry, c client.Client, dif
 		return controllerutil.OperationResultNone, nil
 	}
 
+	// JSON Merge Patch (RFC 7396) interprets null values as field deletions. When
+	// valuesObject contains null entries (used by Helm to unset chart defaults), a
+	// merge patch would silently strip them. Fall back to a full Update in that case
+	// so the null values are preserved as-is in the stored object.
+	if helmSourcesHaveNullValues(obj) {
+		if err := c.Update(ctx, obj); err != nil {
+			return controllerutil.OperationResultNone, err
+		}
+		return controllerutil.OperationResultUpdated, nil
+	}
+
 	patch := client.MergeFrom(normalizedLive)
 	if log.IsLevelEnabled(log.DebugLevel) {
 		LogPatch(logCtx, patch, obj)
@@ -203,6 +215,58 @@ func applyIgnoreDifferences(diffConfig argodiff.DiffConfig, found *argov1alpha1.
 	generatedApp.Namespace = generatedAppCopy.Namespace
 	generatedApp.Operation = generatedAppCopy.Operation
 	return nil
+}
+
+// helmSourcesHaveNullValues returns true if any helm source in the application has
+// null values in its valuesObject. This is used to determine whether a JSON Merge Patch
+// is safe to use, since RFC 7396 treats null as a deletion directive.
+func helmSourcesHaveNullValues(app *argov1alpha1.Application) bool {
+	sources := app.Spec.GetSources()
+	for _, src := range sources {
+		if src.Helm != nil && src.Helm.ValuesObject != nil && src.Helm.ValuesObject.Raw != nil {
+			// Fast path: skip JSON parsing if no null literal is present.
+			if !bytes.Contains(src.Helm.ValuesObject.Raw, []byte("null")) {
+				continue
+			}
+			if jsonContainsNull(src.Helm.ValuesObject.Raw) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// jsonContainsNull checks whether JSON data contains any null values.
+func jsonContainsNull(data []byte) bool {
+	var parsed any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return false
+	}
+	return anyContainsNull(parsed)
+}
+
+func anyContainsNull(v any) bool {
+	switch val := v.(type) {
+	case map[string]any:
+		for _, value := range val {
+			if value == nil {
+				return true
+			}
+			if anyContainsNull(value) {
+				return true
+			}
+		}
+	case []any:
+		for _, item := range val {
+			if item == nil {
+				return true
+			}
+			if anyContainsNull(item) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func appToUnstructured(app client.Object) (*unstructured.Unstructured, error) {

--- a/applicationset/utils/createOrUpdate.go
+++ b/applicationset/utils/createOrUpdate.go
@@ -106,6 +106,12 @@ func CreateOrUpdate(ctx context.Context, logCtx *log.Entry, c client.Client, dif
 	// empty SyncPolicy). obj.Spec is already normalized by the caller; only the live side needs it.
 	normalizedLive.Spec = *argo.NormalizeApplicationSpec(&normalizedLive.Spec)
 
+	// Preserve an unmodified copy of the desired object before applyIgnoreDifferences
+	// strips ignored fields in place. This copy still carries the ResourceVersion from
+	// the live read above and is used by the null-values fallback below, so that a full
+	// Update does not clear ignored fields on the live resource.
+	desiredOriginal := obj.DeepCopy()
+
 	// Apply ignoreApplicationDifferences rules to remove ignored fields from both the live and the desired state. This
 	// prevents those differences from appearing in the diff and therefore in the patch.
 	err := applyIgnoreDifferences(diffConfig, normalizedLive, obj)
@@ -121,10 +127,17 @@ func CreateOrUpdate(ctx context.Context, logCtx *log.Entry, c client.Client, dif
 	// valuesObject contains null entries (used by Helm to unset chart defaults), a
 	// merge patch would silently strip them. Fall back to a full Update in that case
 	// so the null values are preserved as-is in the stored object.
-	if helmSourcesHaveNullValues(obj) {
-		if err := c.Update(ctx, obj); err != nil {
+	//
+	// Use desiredOriginal here. obj has had ignored fields stripped by
+	// applyIgnoreDifferences, so sending it to Update would clear those fields on the
+	// live resource and violate ignoreDifferences semantics.
+	if helmSourcesHaveNullValues(desiredOriginal) {
+		if err := c.Update(ctx, desiredOriginal); err != nil {
 			return controllerutil.OperationResultNone, err
 		}
+		// Keep obj in sync with what was written so callers observing it see the
+		// post-update state, matching the patch path's behavior.
+		desiredOriginal.DeepCopyInto(obj)
 		return controllerutil.OperationResultUpdated, nil
 	}
 

--- a/applicationset/utils/createOrUpdate_test.go
+++ b/applicationset/utils/createOrUpdate_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v3/util/argo/normalizers"
@@ -233,6 +234,157 @@ spec:
 			yamlExpected, err := yaml.Marshal(tc.expectedApp)
 			require.NoError(t, err)
 			assert.YAMLEq(t, string(yamlExpected), string(yamlFound))
+		})
+	}
+}
+
+func Test_helmSourcesHaveNullValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		app      *v1alpha1.Application
+		expected bool
+	}{
+		{
+			name: "no helm source",
+			app: &v1alpha1.Application{
+				Spec: v1alpha1.ApplicationSpec{
+					Source: &v1alpha1.ApplicationSource{},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "helm source without valuesObject",
+			app: &v1alpha1.Application{
+				Spec: v1alpha1.ApplicationSpec{
+					Source: &v1alpha1.ApplicationSource{
+						Helm: &v1alpha1.ApplicationSourceHelm{},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "helm source with valuesObject without nulls",
+			app: &v1alpha1.Application{
+				Spec: v1alpha1.ApplicationSpec{
+					Source: &v1alpha1.ApplicationSource{
+						Helm: &v1alpha1.ApplicationSourceHelm{
+							ValuesObject: &runtime.RawExtension{
+								Raw: []byte(`{"memory":"64Mi"}`),
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "helm source with valuesObject with top-level null",
+			app: &v1alpha1.Application{
+				Spec: v1alpha1.ApplicationSpec{
+					Source: &v1alpha1.ApplicationSource{
+						Helm: &v1alpha1.ApplicationSourceHelm{
+							ValuesObject: &runtime.RawExtension{
+								Raw: []byte(`{"cpu":null,"memory":"64Mi"}`),
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "helm source with valuesObject with nested null",
+			app: &v1alpha1.Application{
+				Spec: v1alpha1.ApplicationSpec{
+					Source: &v1alpha1.ApplicationSource{
+						Helm: &v1alpha1.ApplicationSourceHelm{
+							ValuesObject: &runtime.RawExtension{
+								Raw: []byte(`{"recommender":{"resources":{"limits":{"cpu":null,"memory":"64Mi"}}}}`),
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "multi-source with null in one source",
+			app: &v1alpha1.Application{
+				Spec: v1alpha1.ApplicationSpec{
+					Sources: v1alpha1.ApplicationSources{
+						{
+							Helm: &v1alpha1.ApplicationSourceHelm{
+								ValuesObject: &runtime.RawExtension{
+									Raw: []byte(`{"key":"value"}`),
+								},
+							},
+						},
+						{
+							Helm: &v1alpha1.ApplicationSourceHelm{
+								ValuesObject: &runtime.RawExtension{
+									Raw: []byte(`{"key":null}`),
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "string containing null word is not a false positive",
+			app: &v1alpha1.Application{
+				Spec: v1alpha1.ApplicationSpec{
+					Source: &v1alpha1.ApplicationSource{
+						Helm: &v1alpha1.ApplicationSourceHelm{
+							ValuesObject: &runtime.RawExtension{
+								Raw: []byte(`{"message":"this is not null at all"}`),
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := helmSourcesHaveNullValues(tt.app)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func Test_jsonContainsNull(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		json     string
+		expected bool
+	}{
+		{"empty object", `{}`, false},
+		{"no nulls", `{"a":"b"}`, false},
+		{"top-level null", `{"a":null}`, true},
+		{"nested null", `{"a":{"b":null}}`, true},
+		{"null in array", `{"a":[null]}`, true},
+		{"deeply nested null", `{"a":{"b":{"c":{"d":null}}}}`, true},
+		{"string with null word", `{"a":"null"}`, false},
+		{"number value", `{"a":0}`, false},
+		{"boolean false", `{"a":false}`, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := jsonContainsNull([]byte(tt.json))
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/applicationset/utils/createOrUpdate_test.go
+++ b/applicationset/utils/createOrUpdate_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v3/util/argo/normalizers"
@@ -233,6 +234,157 @@ spec:
 			yamlExpected, err := yaml.Marshal(tc.expectedApp)
 			require.NoError(t, err)
 			assert.YAMLEq(t, string(yamlExpected), string(yamlFound))
+		})
+	}
+}
+
+func Test_helmSourcesHaveNullValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		app      *v1alpha1.Application
+		expected bool
+	}{
+		{
+			name: "no helm source",
+			app: &v1alpha1.Application{
+				Spec: v1alpha1.ApplicationSpec{
+					Source: &v1alpha1.ApplicationSource{},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "helm source without valuesObject",
+			app: &v1alpha1.Application{
+				Spec: v1alpha1.ApplicationSpec{
+					Source: &v1alpha1.ApplicationSource{
+						Helm: &v1alpha1.ApplicationSourceHelm{},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "helm source with valuesObject without nulls",
+			app: &v1alpha1.Application{
+				Spec: v1alpha1.ApplicationSpec{
+					Source: &v1alpha1.ApplicationSource{
+						Helm: &v1alpha1.ApplicationSourceHelm{
+							ValuesObject: &runtime.RawExtension{
+								Raw: []byte(`{"memory":"64Mi"}`),
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "helm source with valuesObject with top-level null",
+			app: &v1alpha1.Application{
+				Spec: v1alpha1.ApplicationSpec{
+					Source: &v1alpha1.ApplicationSource{
+						Helm: &v1alpha1.ApplicationSourceHelm{
+							ValuesObject: &runtime.RawExtension{
+								Raw: []byte(`{"cpu":null,"memory":"64Mi"}`),
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "helm source with valuesObject with nested null",
+			app: &v1alpha1.Application{
+				Spec: v1alpha1.ApplicationSpec{
+					Source: &v1alpha1.ApplicationSource{
+						Helm: &v1alpha1.ApplicationSourceHelm{
+							ValuesObject: &runtime.RawExtension{
+								Raw: []byte(`{"recommender":{"resources":{"limits":{"cpu":null,"memory":"64Mi"}}}}`),
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "multi-source with null in one source",
+			app: &v1alpha1.Application{
+				Spec: v1alpha1.ApplicationSpec{
+					Sources: v1alpha1.ApplicationSources{
+						{
+							Helm: &v1alpha1.ApplicationSourceHelm{
+								ValuesObject: &runtime.RawExtension{
+									Raw: []byte(`{"key":"value"}`),
+								},
+							},
+						},
+						{
+							Helm: &v1alpha1.ApplicationSourceHelm{
+								ValuesObject: &runtime.RawExtension{
+									Raw: []byte(`{"key":null}`),
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "string containing null word is not a false positive",
+			app: &v1alpha1.Application{
+				Spec: v1alpha1.ApplicationSpec{
+					Source: &v1alpha1.ApplicationSource{
+						Helm: &v1alpha1.ApplicationSourceHelm{
+							ValuesObject: &runtime.RawExtension{
+								Raw: []byte(`{"message":"this is not null at all"}`),
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := helmSourcesHaveNullValues(tt.app)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func Test_jsonContainsNull(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		json     string
+		expected bool
+	}{
+		{"empty object", `{}`, false},
+		{"no nulls", `{"a":"b"}`, false},
+		{"top-level null", `{"a":null}`, true},
+		{"nested null", `{"a":{"b":null}}`, true},
+		{"null in array", `{"a":[null]}`, true},
+		{"deeply nested null", `{"a":{"b":{"c":{"d":null}}}}`, true},
+		{"string with null word", `{"a":"null"}`, false},
+		{"number value", `{"a":0}`, false},
+		{"boolean false", `{"a":false}`, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := jsonContainsNull([]byte(tt.json))
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/applicationset/utils/createOrUpdate_test.go
+++ b/applicationset/utils/createOrUpdate_test.go
@@ -3,11 +3,14 @@ package utils
 import (
 	"testing"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v3/util/argo/normalizers"
@@ -387,4 +390,114 @@ func Test_jsonContainsNull(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+// TestCreateOrUpdate_IgnoreDifferencesWithNullValuesObject exercises the interaction
+// between ignoreDifferences and the null-values fallback path. applyIgnoreDifferences
+// mutates the desired object in place to strip ignored fields; if that mutated object
+// is then sent to a full Update (the fallback used when valuesObject contains nulls),
+// ignored fields are cleared on the live resource and ignoreDifferences semantics are
+// violated. CreateOrUpdate must preserve a pre-ignore copy of the desired object and
+// use that copy on the Update path.
+func TestCreateOrUpdate_IgnoreDifferencesWithNullValuesObject(t *testing.T) {
+	t.Parallel()
+
+	appMeta := metav1.TypeMeta{
+		APIVersion: v1alpha1.ApplicationSchemaGroupVersionKind.GroupVersion().String(),
+		Kind:       v1alpha1.ApplicationSchemaGroupVersionKind.Kind,
+	}
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+
+	// Both the live and the generated app carry a value for an ignored label. The
+	// generated valuesObject contains a null entry, forcing the Update fallback. Without
+	// the fix, applyIgnoreDifferences strips the label from the desired object in
+	// place; the subsequent Update would then write a label-less object and clear the
+	// label on the live resource. With the fix, the pre-ignore copy of the desired
+	// object is used for the Update so the label is written through.
+	live := &v1alpha1.Application{
+		TypeMeta: appMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-app",
+			Namespace: "argocd",
+			Labels: map[string]string{
+				"team": "platform-live",
+			},
+		},
+		Spec: v1alpha1.ApplicationSpec{
+			Source: &v1alpha1.ApplicationSource{
+				RepoURL: "https://example.com/chart",
+				Helm: &v1alpha1.ApplicationSourceHelm{
+					ValuesObject: &runtime.RawExtension{
+						Raw: []byte(`{"replicas":1}`),
+					},
+				},
+			},
+		},
+	}
+
+	desired := &v1alpha1.Application{
+		TypeMeta: appMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-app",
+			Namespace: "argocd",
+			Labels: map[string]string{
+				"team": "platform-desired",
+			},
+		},
+		Spec: v1alpha1.ApplicationSpec{
+			Source: &v1alpha1.ApplicationSource{
+				RepoURL: "https://example.com/chart",
+				Helm: &v1alpha1.ApplicationSourceHelm{
+					ValuesObject: &runtime.RawExtension{
+						Raw: []byte(`{"replicas":2,"resources":{"limits":{"cpu":null}}}`),
+					},
+				},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(live).Build()
+
+	ignoreDifferences := v1alpha1.ApplicationSetIgnoreDifferences{
+		{JSONPointers: []string{"/metadata/labels/team"}},
+	}
+	diffConfig, err := BuildIgnoreDiffConfig(ignoreDifferences, normalizers.IgnoreNormalizerOpts{})
+	require.NoError(t, err)
+
+	target := &v1alpha1.Application{
+		TypeMeta:   appMeta,
+		ObjectMeta: metav1.ObjectMeta{Name: "test-app", Namespace: "argocd"},
+	}
+	logCtx := log.NewEntry(log.New())
+	result, err := CreateOrUpdate(t.Context(), logCtx, c, diffConfig, target, func() error {
+		// c.Get clears TypeMeta on the fake client. Restore it so the diff/normalize
+		// machinery in applyIgnoreDifferences resolves the IgnoreDifferences rule for
+		// this Kind/Group; otherwise the rule silently no-ops and the test would not
+		// actually exercise the in-place mutation that this fix protects against.
+		target.TypeMeta = appMeta
+		target.Labels = map[string]string{}
+		for k, v := range desired.Labels {
+			target.Labels[k] = v
+		}
+		desired.Spec.DeepCopyInto(&target.Spec)
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "updated", string(result))
+
+	// Read the live object back. The label that ignoreDifferences ignores must NOT
+	// have been cleared by the Update fallback (it should hold the desired value), and
+	// the null entry in valuesObject must survive on the live resource.
+	got := &v1alpha1.Application{}
+	require.NoError(t, c.Get(t.Context(), types.NamespacedName{Name: "test-app", Namespace: "argocd"}, got))
+
+	assert.NotEmpty(t, got.Labels["team"],
+		"ignored label must not be cleared by the null-values Update fallback")
+	require.NotNil(t, got.Spec.Source)
+	require.NotNil(t, got.Spec.Source.Helm)
+	require.NotNil(t, got.Spec.Source.Helm.ValuesObject)
+	assert.Contains(t, string(got.Spec.Source.Helm.ValuesObject.Raw), "null",
+		"null entry in valuesObject must be preserved on the live resource")
 }

--- a/applicationset/utils/utils.go
+++ b/applicationset/utils/utils.go
@@ -208,16 +208,6 @@ func (r *Render) deeplyReplaceWithFilter(destination, original reflect.Value, re
 		}
 		for _, key := range original.MapKeys() {
 			originalValue := original.MapIndex(key)
-			if originalValue.Kind() != reflect.String && isNillable(originalValue) && originalValue.IsNil() {
-				continue
-			}
-			// New gives us a pointer, but again we want the value
-			copyValue := reflect.New(originalValue.Type()).Elem()
-
-			if err := r.deeplyReplaceWithFilter(copyValue, originalValue, replaceMap, useGoTemplate, goTemplateOptions, filter); err != nil {
-				// Not wrapping the error, since this is a recursive function. Avoids excessively long error messages.
-				return err
-			}
 
 			// Keys can be templated as well as values (e.g. to template something into an annotation).
 			if key.Kind() == reflect.String {
@@ -227,6 +217,20 @@ func (r *Render) deeplyReplaceWithFilter(destination, original reflect.Value, re
 					return err
 				}
 				key = reflect.ValueOf(templatedKey)
+			}
+
+			// Preserve nil map values (e.g. null in Helm valuesObject used to unset chart defaults).
+			// Previously these were skipped, which silently dropped null values from the rendered output.
+			if originalValue.Kind() != reflect.String && isNillable(originalValue) && originalValue.IsNil() {
+				destination.SetMapIndex(key, reflect.Zero(originalValue.Type()))
+				continue
+			}
+			// New gives us a pointer, but again we want the value
+			copyValue := reflect.New(originalValue.Type()).Elem()
+
+			if err := r.deeplyReplaceWithFilter(copyValue, originalValue, replaceMap, useGoTemplate, goTemplateOptions, filter); err != nil {
+				// Not wrapping the error, since this is a recursive function. Avoids excessively long error messages.
+				return err
 			}
 
 			destination.SetMapIndex(key, copyValue)

--- a/applicationset/utils/utils_test.go
+++ b/applicationset/utils/utils_test.go
@@ -298,6 +298,109 @@ func TestRenderHelmValuesObjectYaml(t *testing.T) {
 	assert.Equal(t, "Hello world", unmarshaled.(map[string]any)["some"].(map[string]any)["string"])
 }
 
+func TestRenderHelmValuesObjectPreservesNulls(t *testing.T) {
+	params := map[string]any{
+		"release": "my-release",
+	}
+
+	application := &argoappsv1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations:       map[string]string{},
+			Labels:            map[string]string{},
+			CreationTimestamp: metav1.NewTime(time.Now()),
+			UID:               types.UID("d546da12-06b7-4f9a-8ea2-3adb16a20e2b"),
+			Name:              "application-one",
+			Namespace:         "default",
+		},
+		Spec: argoappsv1.ApplicationSpec{
+			Source: &argoappsv1.ApplicationSource{
+				Helm: &argoappsv1.ApplicationSourceHelm{
+					ReleaseName: "{{.release}}",
+					ValuesObject: &runtime.RawExtension{
+						Raw: []byte(`{
+							"recommender": {
+								"resources": {
+									"limits": {
+										"cpu": null,
+										"memory": "64Mi"
+									}
+								}
+							}
+						}`),
+					},
+				},
+			},
+			Destination: argoappsv1.ApplicationDestination{},
+			Project:     "",
+		},
+	}
+
+	render := Render{}
+	newApplication, err := render.RenderTemplateParams(application, nil, params, true, []string{})
+
+	require.NoError(t, err)
+	require.NotNil(t, newApplication)
+
+	assert.Equal(t, "my-release", newApplication.Spec.Source.Helm.ReleaseName)
+
+	var unmarshaled map[string]any
+	err = json.Unmarshal(newApplication.Spec.Source.Helm.ValuesObject.Raw, &unmarshaled)
+	require.NoError(t, err)
+
+	limits := unmarshaled["recommender"].(map[string]any)["resources"].(map[string]any)["limits"].(map[string]any)
+	assert.Nil(t, limits["cpu"], "null values should be preserved in valuesObject")
+	assert.Contains(t, limits, "cpu", "null keys should not be stripped from valuesObject")
+	assert.Equal(t, "64Mi", limits["memory"])
+}
+
+func TestRenderHelmValuesObjectPreservesNullsYaml(t *testing.T) {
+	params := map[string]any{
+		"release": "my-release",
+	}
+
+	application := &argoappsv1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations:       map[string]string{},
+			Labels:            map[string]string{},
+			CreationTimestamp: metav1.NewTime(time.Now()),
+			UID:               types.UID("d546da12-06b7-4f9a-8ea2-3adb16a20e2b"),
+			Name:              "application-one",
+			Namespace:         "default",
+		},
+		Spec: argoappsv1.ApplicationSpec{
+			Source: &argoappsv1.ApplicationSource{
+				Helm: &argoappsv1.ApplicationSourceHelm{
+					ReleaseName: "{{.release}}",
+					ValuesObject: &runtime.RawExtension{
+						Raw: []byte(`recommender:
+  resources:
+    limits:
+      cpu: null
+      memory: 64Mi`),
+					},
+				},
+			},
+			Destination: argoappsv1.ApplicationDestination{},
+			Project:     "",
+		},
+	}
+
+	render := Render{}
+	newApplication, err := render.RenderTemplateParams(application, nil, params, true, []string{})
+
+	require.NoError(t, err)
+	require.NotNil(t, newApplication)
+
+	var unmarshaled map[string]any
+	err = json.Unmarshal(newApplication.Spec.Source.Helm.ValuesObject.Raw, &unmarshaled)
+	require.NoError(t, err)
+
+	limits := unmarshaled["recommender"].(map[string]any)["resources"].(map[string]any)["limits"].(map[string]any)
+	assert.Nil(t, limits["cpu"], "null values should be preserved in valuesObject")
+	assert.Contains(t, limits, "cpu", "null keys should not be stripped from valuesObject")
+	assert.Equal(t, "64Mi", limits["memory"])
+}
+
 func TestRenderTemplateParamsGoTemplate(t *testing.T) {
 	// Believe it or not, this is actually less complex than the equivalent solution using reflection
 	fieldMap := map[string]func(app *argoappsv1.Application) *string{}

--- a/pkg/apis/application/v1alpha1/values_test.go
+++ b/pkg/apis/application/v1alpha1/values_test.go
@@ -1,7 +1,6 @@
 package v1alpha1
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -152,7 +151,7 @@ func TestValues_NullPreservation(t *testing.T) {
 		require.NoError(t, err)
 
 		yamlOutput := string(source.ValuesYAML())
-		assert.True(t, strings.Contains(yamlOutput, "cpu: null"),
+		assert.Contains(t, yamlOutput, "cpu: null",
 			"null values should survive JSON round-trip, got: %s", yamlOutput)
 	})
 }

--- a/pkg/apis/application/v1alpha1/values_test.go
+++ b/pkg/apis/application/v1alpha1/values_test.go
@@ -1,10 +1,12 @@
 package v1alpha1
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func TestValues_SetString(t *testing.T) {
@@ -79,4 +81,78 @@ func TestValues_SetString(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValues_NullPreservation(t *testing.T) {
+	t.Run("ValuesYAML preserves null values from JSON", func(t *testing.T) {
+		source := &ApplicationSourceHelm{
+			ValuesObject: &runtime.RawExtension{
+				Raw: []byte(`{"recommender":{"resources":{"limits":{"cpu":null,"memory":"64Mi"}}}}`),
+			},
+		}
+		yamlOutput := string(source.ValuesYAML())
+		assert.Contains(t, yamlOutput, "cpu: null", "null values should be preserved in YAML output")
+		assert.Contains(t, yamlOutput, "memory: 64Mi")
+	})
+
+	t.Run("SetValuesString preserves null values in nested objects", func(t *testing.T) {
+		source := &ApplicationSourceHelm{}
+		err := source.SetValuesString(`{"limits": {"cpu": null, "memory": "64Mi"}}`)
+		require.NoError(t, err)
+
+		yamlOutput := source.ValuesString()
+		assert.Contains(t, yamlOutput, "cpu: null", "null values should be preserved after SetValuesString")
+		assert.Contains(t, yamlOutput, "memory: 64Mi")
+	})
+
+	t.Run("SetValuesString preserves null values from YAML input", func(t *testing.T) {
+		source := &ApplicationSourceHelm{}
+		yamlInput := "limits:\n  cpu: null\n  memory: 64Mi"
+		err := source.SetValuesString(yamlInput)
+		require.NoError(t, err)
+
+		yamlOutput := source.ValuesString()
+		assert.Contains(t, yamlOutput, "cpu: null", "null values should be preserved from YAML input")
+		assert.Contains(t, yamlOutput, "memory: 64Mi")
+	})
+
+	t.Run("ValuesYAML with raw JSON containing null produces valid YAML for Helm", func(t *testing.T) {
+		source := &ApplicationSourceHelm{
+			ValuesObject: &runtime.RawExtension{
+				Raw: []byte(`{"podDisruptionBudget":{"enabled":true,"maxUnavailable":1,"minAvailable":null}}`),
+			},
+		}
+		yamlOutput := string(source.ValuesYAML())
+		assert.Contains(t, yamlOutput, "minAvailable: null")
+		assert.Contains(t, yamlOutput, "maxUnavailable: 1")
+		assert.Contains(t, yamlOutput, "enabled: true")
+	})
+
+	t.Run("ValuesIsEmpty returns false when values contain only null entries", func(t *testing.T) {
+		source := &ApplicationSourceHelm{
+			ValuesObject: &runtime.RawExtension{
+				Raw: []byte(`{"cpu":null}`),
+			},
+		}
+		assert.False(t, source.ValuesIsEmpty(), "values with null entries should not be considered empty")
+	})
+
+	t.Run("round-trip JSON marshal/unmarshal preserves null values", func(t *testing.T) {
+		source := &ApplicationSourceHelm{
+			ValuesObject: &runtime.RawExtension{
+				Raw: []byte(`{"limits":{"cpu":null,"memory":"64Mi"}}`),
+			},
+		}
+
+		data, err := source.ValuesObject.MarshalJSON()
+		require.NoError(t, err)
+		assert.Contains(t, string(data), "null")
+
+		err = source.ValuesObject.UnmarshalJSON(data)
+		require.NoError(t, err)
+
+		yamlOutput := string(source.ValuesYAML())
+		assert.True(t, strings.Contains(yamlOutput, "cpu: null"),
+			"null values should survive JSON round-trip, got: %s", yamlOutput)
+	})
 }

--- a/pkg/apis/application/v1alpha1/values_test.go
+++ b/pkg/apis/application/v1alpha1/values_test.go
@@ -2,7 +2,6 @@ package v1alpha1
 
 import (
 	"encoding/json"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -292,7 +291,7 @@ func TestValues_NullPreservation(t *testing.T) {
 		require.NoError(t, err)
 
 		yamlOutput := string(source.ValuesYAML())
-		assert.True(t, strings.Contains(yamlOutput, "cpu: null"),
+		assert.Contains(t, yamlOutput, "cpu: null",
 			"null values should survive JSON round-trip, got: %s", yamlOutput)
 	})
 }

--- a/pkg/apis/application/v1alpha1/values_test.go
+++ b/pkg/apis/application/v1alpha1/values_test.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -219,5 +220,79 @@ func TestApplicationSource_String(t *testing.T) {
 		assert.NotContains(t, out, "[114", "must not contain raw byte integers, got: %s", out)
 		assert.Contains(t, out, "replicaCount: 2")
 		assert.Contains(t, out, "tag: latest")
+	})
+}
+
+func TestValues_NullPreservation(t *testing.T) {
+	t.Run("ValuesYAML preserves null values from JSON", func(t *testing.T) {
+		source := &ApplicationSourceHelm{
+			ValuesObject: &runtime.RawExtension{
+				Raw: []byte(`{"recommender":{"resources":{"limits":{"cpu":null,"memory":"64Mi"}}}}`),
+			},
+		}
+		yamlOutput := string(source.ValuesYAML())
+		assert.Contains(t, yamlOutput, "cpu: null", "null values should be preserved in YAML output")
+		assert.Contains(t, yamlOutput, "memory: 64Mi")
+	})
+
+	t.Run("SetValuesString preserves null values in nested objects", func(t *testing.T) {
+		source := &ApplicationSourceHelm{}
+		err := source.SetValuesString(`{"limits": {"cpu": null, "memory": "64Mi"}}`)
+		require.NoError(t, err)
+
+		yamlOutput := source.ValuesString()
+		assert.Contains(t, yamlOutput, "cpu: null", "null values should be preserved after SetValuesString")
+		assert.Contains(t, yamlOutput, "memory: 64Mi")
+	})
+
+	t.Run("SetValuesString preserves null values from YAML input", func(t *testing.T) {
+		source := &ApplicationSourceHelm{}
+		yamlInput := "limits:\n  cpu: null\n  memory: 64Mi"
+		err := source.SetValuesString(yamlInput)
+		require.NoError(t, err)
+
+		yamlOutput := source.ValuesString()
+		assert.Contains(t, yamlOutput, "cpu: null", "null values should be preserved from YAML input")
+		assert.Contains(t, yamlOutput, "memory: 64Mi")
+	})
+
+	t.Run("ValuesYAML with raw JSON containing null produces valid YAML for Helm", func(t *testing.T) {
+		source := &ApplicationSourceHelm{
+			ValuesObject: &runtime.RawExtension{
+				Raw: []byte(`{"podDisruptionBudget":{"enabled":true,"maxUnavailable":1,"minAvailable":null}}`),
+			},
+		}
+		yamlOutput := string(source.ValuesYAML())
+		assert.Contains(t, yamlOutput, "minAvailable: null")
+		assert.Contains(t, yamlOutput, "maxUnavailable: 1")
+		assert.Contains(t, yamlOutput, "enabled: true")
+	})
+
+	t.Run("ValuesIsEmpty returns false when values contain only null entries", func(t *testing.T) {
+		source := &ApplicationSourceHelm{
+			ValuesObject: &runtime.RawExtension{
+				Raw: []byte(`{"cpu":null}`),
+			},
+		}
+		assert.False(t, source.ValuesIsEmpty(), "values with null entries should not be considered empty")
+	})
+
+	t.Run("round-trip JSON marshal/unmarshal preserves null values", func(t *testing.T) {
+		source := &ApplicationSourceHelm{
+			ValuesObject: &runtime.RawExtension{
+				Raw: []byte(`{"limits":{"cpu":null,"memory":"64Mi"}}`),
+			},
+		}
+
+		data, err := source.ValuesObject.MarshalJSON()
+		require.NoError(t, err)
+		assert.Contains(t, string(data), "null")
+
+		err = source.ValuesObject.UnmarshalJSON(data)
+		require.NoError(t, err)
+
+		yamlOutput := string(source.ValuesYAML())
+		assert.True(t, strings.Contains(yamlOutput, "cpu: null"),
+			"null values should survive JSON round-trip, got: %s", yamlOutput)
 	})
 }


### PR DESCRIPTION
Fixes #16312

Two places were eating null values in `valuesObject`:

1. `deeplyReplaceWithFilter` in applicationset utils skipped nil map values entirely during template rendering
2. `CreateOrUpdate` used JSON merge patch (`client.MergeFrom`) where null means "delete this key" per RFC 7396 - so every update cycle silently stripped nulls

Fix preserves nils in template rendering and falls back to a full Update when valuesObject contains null values to avoid the merge patch semantics.