### PR TITLE
fix(docs): version banner redirects to same page on stable instead of homepage

### DIFF
--- a/docs/assets/versions.js
+++ b/docs/assets/versions.js
@@ -139,10 +139,11 @@ window.addEventListener("DOMContentLoaded", function() {
   var headerHeight = document.getElementsByClassName("md-header")[0].offsetHeight;
   const currentVersion = getCurrentVersion();
   if (currentVersion && currentVersion !== "stable") {
+    var stableUrl = window.location.href.replace(VERSION_REGEX, '/en/stable/');
     if (currentVersion === "latest") {
-      document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for an unreleased version of Argo CD, <a href='https://argo-cd.readthedocs.io/en/stable/'>view the latest stable version.</a></div>";
+      document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for an unreleased version of Argo CD, <a href='" + stableUrl + "'>view the latest stable version.</a></div>";
     } else {
-      document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for a previous version of Argo CD, <a href='https://argo-cd.readthedocs.io/en/stable/'>view the latest stable version.</a></div>";
+      document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for a previous version of Argo CD, <a href='" + stableUrl + "'>view the latest stable version.</a></div>";
     }
     var bannerHeight = document.getElementById('announce-msg').offsetHeight + margin;
     document.querySelector("header.md-header").style.top = bannerHeight + "px";


### PR DESCRIPTION
## Summary

The 'view the latest stable version' banner in the docs previously always redirected to the docs homepage (`/en/stable/`). This change makes the banner link preserve the current page path, replacing only the version segment with `/stable/`.

For example, if you're on `/en/release-2.9/user-guide/commands/`, clicking the banner now takes you to `/en/stable/user-guide/commands/` instead of `/en/stable/`.

Fixes #26857

## Changes

- `docs/assets/versions.js`: Use `window.location.href.replace()` with the existing `VERSION_REGEX` to dynamically build the stable URL from the current page URL, instead of hardcoding the homepage URL.

## Checklist

- [x] Either (a) I've created an enhancement proposal and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [x] The title of the PR conforms to the Title of the PR guidelines
- [x] I've included "Fixes [ISSUE #]" in the description to automatically close the associated issue.
- [x] Does this PR require documentation updates? N/A - this IS a docs fix.
- [x] I've updated documentation as required by this PR.
- [x] I have signed off all my commits as required by DCO
- [x] My build is green
- [x] I have added a brief description of why this PR is necessary and/or what this PR solves.