### PR TITLE
fix: nil pointer dereference when server-side diff dry run applier fails

### DIFF
--- a/controller/state.go
+++ b/controller/state.go
@@ -842,9 +842,10 @@ func (m *appStateManager) CompareAppState(app *v1alpha1.Application, project *v1
 		if err != nil {
 			log.Errorf("CompareAppState error getting server side diff dry run applier: %s", err)
 			conditions = append(conditions, v1alpha1.ApplicationCondition{Type: v1alpha1.ApplicationConditionUnknownError, Message: err.Error(), LastTransitionTime: &now})
+		} else {
+			defer cleanup()
+			diffConfigBuilder.WithServerSideDryRunner(diff.NewK8sServerSideDryRunner(applier))
 		}
-		defer cleanup()
-		diffConfigBuilder.WithServerSideDryRunner(diff.NewK8sServerSideDryRunner(applier))
 	}
 
 	// enable structured merge diff if application syncs with server-side apply


### PR DESCRIPTION
## Summary

Fixes a nil pointer dereference panic in `CompareAppState` when `getServerSideDiffDryRunApplier` returns an error (e.g. due to API server timeout or unreachable cluster).

When `getServerSideDiffDryRunApplier` returns an error, both `applier` and `cleanup` are nil. The code unconditionally called `defer cleanup()` and passed `applier` to `NewK8sServerSideDryRunner`, causing a nil pointer dereference panic that crashes the sync operation with "runtime error: invalid memory address or nil pointer dereference".

## Changes

Moved `defer cleanup()` and the `WithServerSideDryRunner` call into the `else` (success) branch so they are only executed when the applier was successfully created.

## Impact

This is a one-line logic fix. When the dry run applier fails to initialize, the comparison now gracefully degrades (logs the error, adds an application condition) instead of panicking. The diff will fall back to client-side comparison.

## Reproduction

1. Enable `ServerSideApply=true` on an Application
2. Have the API server become temporarily slow or unreachable (e.g. TLS handshake timeout on `/openapi/v2`)
3. The controller panics with `runtime error: invalid memory address or nil pointer dereference`

This commonly affects large app-of-apps setups (100+ resources) where API server contention causes intermittent timeouts.

Fixes #24751
Fixes #25460
Relates to #14098

Signed-off-by: Sean Hackney <admin@seantech.co>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>