### PR TITLE
fix(ui): return full source for non-hydrator apps in Parameters tab

### DIFF
--- a/ui/src/app/applications/components/utils.test.tsx
+++ b/ui/src/app/applications/components/utils.test.tsx
@@ -14,6 +14,7 @@ import * as jsYaml from 'js-yaml';
 import {
     appRBACName,
     ComparisonStatusIcon,
+    getAppDrySource,
     getAppOperationState,
     getOperationType,
     getPodStateReason,
@@ -942,5 +943,63 @@ describe('appRBACName', () => {
         const result = appRBACName(app);
 
         expect(result).toBe('test-project/test-app');
+    });
+});
+
+describe('getAppDrySource', () => {
+    it('returns null for undefined app', () => {
+        expect(getAppDrySource(undefined)).toBeNull();
+    });
+
+    it('returns full source for non-hydrator app', () => {
+        const app = {
+            spec: {
+                source: {
+                    repoURL: 'https://github.com/example/repo.git',
+                    path: 'helm-chart',
+                    targetRevision: 'HEAD',
+                    helm: {
+                        parameters: [{name: 'replicaCount', value: '2'}],
+                    },
+                },
+            },
+        } as Application;
+
+        const result = getAppDrySource(app);
+
+        expect(result).toEqual(app.spec.source);
+        expect(result.helm).toBeDefined();
+        expect(result.helm.parameters).toHaveLength(1);
+    });
+
+    it('returns stripped drySource for hydrator app', () => {
+        const app = {
+            spec: {
+                source: {
+                    repoURL: 'https://github.com/example/repo.git',
+                    path: 'helm-chart',
+                    targetRevision: 'HEAD',
+                    helm: {
+                        parameters: [{name: 'replicaCount', value: '2'}],
+                    },
+                },
+                sourceHydrator: {
+                    drySource: {
+                        repoURL: 'https://github.com/example/dry-repo.git',
+                        path: 'dry-path',
+                        targetRevision: 'main',
+                    },
+                },
+            },
+        } as Application;
+
+        const result = getAppDrySource(app);
+
+        expect(result).toEqual({
+            repoURL: 'https://github.com/example/dry-repo.git',
+            path: 'dry-path',
+            targetRevision: 'main',
+        });
+        expect(result).not.toHaveProperty('helm');
     });
 });

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -1494,9 +1494,11 @@ export function getAppDrySource(app?: appModels.Application): appModels.Applicat
     if (!app) {
         return null;
     }
-    const {path, targetRevision, repoURL} = app.spec.sourceHydrator?.drySource || app.spec.source;
-
-    return {repoURL, targetRevision, path};
+    if (app.spec.sourceHydrator?.drySource) {
+        const {path, targetRevision, repoURL} = app.spec.sourceHydrator.drySource;
+        return {repoURL, targetRevision, path};
+    }
+    return getAppDefaultSource(app);
 }
 
 // getAppAllSources gets all app sources as an array. For single source apps, returns [source].


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. N/A - bug fix, UI-only change.
* [x] Does this PR require documentation updates? No.
* [x] I've updated documentation as required by this PR. N/A.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into.

## Summary

Fixes #26938

PR #26179 introduced `getAppDrySource()` to support the SourceHydrator feature in the Parameters tab. However, for **non-hydrator apps**, this function strips the source to only `{repoURL, targetRevision, path}`, dropping fields like `helm.parameters` and `kustomize` config.

The server-side `isSourceInHistory()` check uses `source.Equals()` (which does `reflect.DeepEqual`) to verify the request source matches the app's actual source. The stripped source fails this check, returning `PermissionDenied`.

**Fix:** `getAppDrySource()` now only strips fields for hydrator apps (where only the dry source identity matters). For non-hydrator apps, it delegates to `getAppDefaultSource()`, restoring v3.3.4 behavior.

**Cherry-pick:** This should be cherry-picked into the `release-3.4` branch since it's a regression introduced in v3.4.0-rc1.

## Test plan

- [x] Added unit tests for `getAppDrySource` covering: undefined app, non-hydrator app (returns full source), hydrator app (returns stripped source)
- [x] Verified existing `GetAppDetails` backend tests still pass
- [x] Reproduced bug locally on k3d cluster with a Helm app — Parameters tab showed "permission denied"
- [x] Verified fix locally — Parameters tab correctly shows Helm parameters after the change

### After (fix)
<img width="1460" height="841" alt="Screenshot 2026-03-21 at 12 49 07 PM" src="https://github.com/user-attachments/assets/c796435b-7dc9-4d17-98a7-68c1ce9e86a9" />
