### PR TITLE
fix(docs): version banner redirects to stable version of current page

### DIFF
--- a/docs/assets/versions.js
+++ b/docs/assets/versions.js
@@ -139,10 +139,11 @@ window.addEventListener("DOMContentLoaded", function() {
   var headerHeight = document.getElementsByClassName("md-header")[0].offsetHeight;
   const currentVersion = getCurrentVersion();
   if (currentVersion && currentVersion !== "stable") {
+    var stableUrl = window.location.href.replace(VERSION_REGEX, '/en/stable/');
     if (currentVersion === "latest") {
-      document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for an unreleased version of Argo CD, <a href='https://argo-cd.readthedocs.io/en/stable/'>view the latest stable version.</a></div>";
+      document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for an unreleased version of Argo CD, <a href='" + stableUrl + "'>view the latest stable version.</a></div>";
     } else {
-      document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for a previous version of Argo CD, <a href='https://argo-cd.readthedocs.io/en/stable/'>view the latest stable version.</a></div>";
+      document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for a previous version of Argo CD, <a href='" + stableUrl + "'>view the latest stable version.</a></div>";
     }
     var bannerHeight = document.getElementById('announce-msg').offsetHeight + margin;
     document.querySelector("header.md-header").style.top = bannerHeight + "px";


### PR DESCRIPTION
## Summary

Previously, the 'view the latest stable version' banner link on old/unreleased doc versions always redirected to the docs homepage (`https://argo-cd.readthedocs.io/en/stable/`).

This change makes the banner link preserve the current page path, so users viewing e.g. `/en/release-2.9/operator-manual/installation/` are redirected to `/en/stable/operator-manual/installation/` instead of the homepage.

## Changes

- Modified `docs/assets/versions.js` to use `window.location.href.replace()` with the existing `VERSION_REGEX` to construct the stable URL for the current page instead of hardcoding the homepage URL.

## Before
Clicking 'view the latest stable version' on any page → redirects to `/en/stable/` (homepage)

## After
Clicking 'view the latest stable version' on any page → redirects to `/en/stable/<current-page>`

Fixes #26857