### PR TITLE
fix: wrong installation id returned from cache

### DIFF
--- a/util/git/creds.go
+++ b/util/git/creds.go
@@ -685,11 +685,11 @@ func DiscoverGitHubAppInstallationID(ctx context.Context, appId int64, privateKe
 		opts.Page = resp.NextPage
 	}
 
-	// Cache all installation IDs, keyed by each installation's own org
+	// Cache each installation under its account's key so multiple orgs do not overwrite each other.
 	for _, installation := range allInstallations {
 		if installation.Account != nil && installation.Account.Login != nil && installation.ID != nil {
-			installCacheKey := fmt.Sprintf("%s:%s:%d", strings.ToLower(*installation.Account.Login), domain, appId)
-			githubInstallationIdCache.Set(installCacheKey, *installation.ID, gocache.DefaultExpiration)
+			instKey := fmt.Sprintf("%s:%s:%d", strings.ToLower(*installation.Account.Login), domain, appId)
+			githubInstallationIdCache.Set(instKey, *installation.ID, gocache.DefaultExpiration)
 		}
 	}
 

--- a/util/git/creds.go
+++ b/util/git/creds.go
@@ -685,10 +685,11 @@ func DiscoverGitHubAppInstallationID(ctx context.Context, appId int64, privateKe
 		opts.Page = resp.NextPage
 	}
 
-	// Cache all installation IDs
+	// Cache all installation IDs, keyed by each installation's own org
 	for _, installation := range allInstallations {
 		if installation.Account != nil && installation.Account.Login != nil && installation.ID != nil {
-			githubInstallationIdCache.Set(cacheKey, *installation.ID, gocache.DefaultExpiration)
+			installCacheKey := fmt.Sprintf("%s:%s:%d", strings.ToLower(*installation.Account.Login), domain, appId)
+			githubInstallationIdCache.Set(installCacheKey, *installation.ID, gocache.DefaultExpiration)
 		}
 	}
 

--- a/util/git/creds_test.go
+++ b/util/git/creds_test.go
@@ -600,6 +600,35 @@ func TestDiscoverGitHubAppInstallationID(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, int64(98765), actualId)
 	})
+
+	t.Run("returns correct installation ID when app is installed on multiple orgs", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.HasSuffix(r.URL.Path, "/app/installations") {
+				w.WriteHeader(http.StatusOK)
+				//nolint:errcheck
+				json.NewEncoder(w).Encode([]map[string]any{
+					{"id": 11111, "account": map[string]any{"login": "org-alpha"}},
+					{"id": 22222, "account": map[string]any{"login": "target-org"}},
+					{"id": 33333, "account": map[string]any{"login": "org-gamma"}},
+				})
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer server.Close()
+
+		t.Cleanup(func() {
+			domain, _ := domainFromBaseURL(server.URL)
+			for _, org := range []string{"org-alpha", "target-org", "org-gamma"} {
+				githubInstallationIdCache.Delete(fmt.Sprintf("%s:%s:%d", org, domain, 12345))
+			}
+		})
+
+		ctx := context.Background()
+		actualId, err := DiscoverGitHubAppInstallationID(ctx, 12345, fakeGitHubAppPrivateKey, server.URL, "target-org")
+		require.NoError(t, err)
+		assert.Equal(t, int64(22222), actualId, "should return the installation ID for the requested org, not the last one in the list")
+	})
 }
 
 func TestExtractOrgFromRepoURL(t *testing.T) {


### PR DESCRIPTION
The bug is in DiscoverGitHubAppInstallationID in util/git/creds.go. When the GitHub App is installed on multiple organizations, the cache loop writes every installation's ID to the same cache key (the requested org's key). The last installation in the API response overwrites all previous entries, so the wrong installation ID is returned