### PR TITLE
fix: use app/pod/container name in log download filename

### DIFF
--- a/pkg/apiclient/application/forwarder_overwrite.go
+++ b/pkg/apiclient/application/forwarder_overwrite.go
@@ -135,7 +135,7 @@ func buildLogFilename(urlPath string, queryGet func(string) string) string {
 	if len(nameParts) == 0 {
 		return "log.log"
 	}
-	return strings.Join(nameParts, "-") + ".log"
+	return strings.Join(nameParts, "_") + ".log"
 }
 
 func init() {

--- a/pkg/apiclient/application/forwarder_overwrite.go
+++ b/pkg/apiclient/application/forwarder_overwrite.go
@@ -112,18 +112,38 @@ func processApplicationListField(v any, fields map[string]any, exclude bool) (an
 	return nil, errors.New("not an application list")
 }
 
+// buildLogFilename constructs a descriptive log filename from URL path and query parameters.
+// It extracts the application name from the URL path and combines it with podName and container
+// query parameters when available, falling back to "log" if no valid parts are found.
+func buildLogFilename(urlPath string, queryGet func(string) string) string {
+	// Extract application name from URL path: /api/v1/applications/{name}/...
+	var appName string
+	parts := strings.Split(urlPath, "/")
+	for i, part := range parts {
+		if part == "applications" && i+1 < len(parts) {
+			appName = parts[i+1]
+			break
+		}
+	}
+
+	var nameParts []string
+	for _, name := range []string{appName, queryGet("podName"), queryGet("container")} {
+		if kube.IsValidResourceName(name) {
+			nameParts = append(nameParts, name)
+		}
+	}
+	if len(nameParts) == 0 {
+		return "log.log"
+	}
+	return strings.Join(nameParts, "-") + ".log"
+}
+
 func init() {
 	logsForwarder := func(ctx context.Context, mux *runtime.ServeMux, marshaler runtime.Marshaler, w gohttp.ResponseWriter, req *gohttp.Request, recv func() (proto.Message, error), opts ...func(context.Context, gohttp.ResponseWriter, proto.Message) error) {
 		if req.URL.Query().Get("download") == "true" {
 			w.Header().Set("Content-Type", "application/octet-stream")
-			fileName := "log"
-			namespace := req.URL.Query().Get("namespace")
-			podName := req.URL.Query().Get("podName")
-			container := req.URL.Query().Get("container")
-			if kube.IsValidResourceName(namespace) && kube.IsValidResourceName(podName) && kube.IsValidResourceName(container) {
-				fileName = fmt.Sprintf("%s-%s-%s", namespace, podName, container)
-			}
-			w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment;filename="%s.log"`, fileName))
+			fileName := buildLogFilename(req.URL.Path, req.URL.Query().Get)
+			w.Header().Set("Content-Disposition", fmt.Sprintf("attachment;filename=%q", fileName))
 			for {
 				msg, err := recv()
 				if err != nil {

--- a/pkg/apiclient/application/forwarder_overwrite_test.go
+++ b/pkg/apiclient/application/forwarder_overwrite_test.go
@@ -46,21 +46,21 @@ func TestBuildLogFilename(t *testing.T) {
 			urlPath:   "/api/v1/applications/my-app/logs",
 			podName:   "my-pod",
 			container: "nginx",
-			expected:  "my-app-my-pod-nginx.log",
+			expected:  "my-app_my-pod_nginx.log",
 		},
 		{
 			name:      "missing podName",
 			urlPath:   "/api/v1/applications/my-app/logs",
 			podName:   "",
 			container: "nginx",
-			expected:  "my-app-nginx.log",
+			expected:  "my-app_nginx.log",
 		},
 		{
 			name:      "missing container",
 			urlPath:   "/api/v1/applications/my-app/logs",
 			podName:   "my-pod",
 			container: "",
-			expected:  "my-app-my-pod.log",
+			expected:  "my-app_my-pod.log",
 		},
 		{
 			name:      "only app name",
@@ -81,7 +81,7 @@ func TestBuildLogFilename(t *testing.T) {
 			urlPath:   "/api/v1/applications/my-app/pods/my-pod/logs",
 			podName:   "my-pod",
 			container: "sidecar",
-			expected:  "my-app-my-pod-sidecar.log",
+			expected:  "my-app_my-pod_sidecar.log",
 		},
 	}
 

--- a/pkg/apiclient/application/forwarder_overwrite_test.go
+++ b/pkg/apiclient/application/forwarder_overwrite_test.go
@@ -33,6 +33,76 @@ func TestProcessApplicationListField_SyncOperation(t *testing.T) {
 	require.Equal(t, "abc", val)
 }
 
+func TestBuildLogFilename(t *testing.T) {
+	tests := []struct {
+		name      string
+		urlPath   string
+		podName   string
+		container string
+		expected  string
+	}{
+		{
+			name:      "all params present",
+			urlPath:   "/api/v1/applications/my-app/logs",
+			podName:   "my-pod",
+			container: "nginx",
+			expected:  "my-app-my-pod-nginx.log",
+		},
+		{
+			name:      "missing podName",
+			urlPath:   "/api/v1/applications/my-app/logs",
+			podName:   "",
+			container: "nginx",
+			expected:  "my-app-nginx.log",
+		},
+		{
+			name:      "missing container",
+			urlPath:   "/api/v1/applications/my-app/logs",
+			podName:   "my-pod",
+			container: "",
+			expected:  "my-app-my-pod.log",
+		},
+		{
+			name:      "only app name",
+			urlPath:   "/api/v1/applications/my-app/logs",
+			podName:   "",
+			container: "",
+			expected:  "my-app.log",
+		},
+		{
+			name:      "no valid params",
+			urlPath:   "/api/v1/other/endpoint",
+			podName:   "",
+			container: "",
+			expected:  "log.log",
+		},
+		{
+			name:      "pods URL pattern",
+			urlPath:   "/api/v1/applications/my-app/pods/my-pod/logs",
+			podName:   "my-pod",
+			container: "sidecar",
+			expected:  "my-app-my-pod-sidecar.log",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			queryGet := func(key string) string {
+				switch key {
+				case "podName":
+					return tt.podName
+				case "container":
+					return tt.container
+				default:
+					return ""
+				}
+			}
+			result := buildLogFilename(tt.urlPath, queryGet)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestProcessApplicationListField_SyncOperationMissing(t *testing.T) {
 	list := v1alpha1.ApplicationList{
 		Items: []v1alpha1.Application{{Operation: nil}},


### PR DESCRIPTION
Fixes #26970

## Changes

The `logsForwarder` in `forwarder_overwrite.go` constructed download filenames using an all-or-nothing approach — requiring namespace, podName, AND container to all be valid. If any was missing (common when viewing resource-level logs), the filename fell back to `log.log`. It also used namespace instead of application name.

This PR:
1. Extracts the **application name** from the URL path (`/api/v1/applications/{name}/logs`)
2. Builds the filename from available valid parts (appName, podName, container) joined with `-`
3. Falls back to `log.log` only if no valid identifiers exist

Examples: `my-app-my-pod-nginx.log`, `my-app-nginx.log`, `my-app.log`

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] Does this PR require documentation updates? No.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.