### PR TITLE
fix: force attempt http2 with custom tls config (#26975)

### DIFF
--- a/util/helm/client.go
+++ b/util/helm/client.go
@@ -373,6 +373,7 @@ func (c *nativeHelmChart) loadRepoIndex(ctx context.Context, maxIndexSize int64)
 		Proxy:             proxy.GetCallback(c.proxy, c.noProxy),
 		TLSClientConfig:   tlsConf,
 		DisableKeepAlives: true,
+		ForceAttemptHTTP2: true,
 	}
 	client := http.Client{Transport: tr}
 	resp, err := client.Do(req)
@@ -492,6 +493,7 @@ func (c *nativeHelmChart) GetTags(chart string, noCache bool) ([]string, error) 
 			Proxy:             proxy.GetCallback(c.proxy, c.noProxy),
 			TLSClientConfig:   tlsConf,
 			DisableKeepAlives: true,
+			ForceAttemptHTTP2: true,
 		}
 
 		// Wrap transport to add User-Agent header to all requests

--- a/util/helm/client_test.go
+++ b/util/helm/client_test.go
@@ -2,6 +2,7 @@ package helm
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -10,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -571,6 +573,68 @@ func TestGetTagsCaching(t *testing.T) {
 			"2.0.0+beta",
 		})
 		assert.Equal(t, 2, requestCount)
+	})
+}
+
+func TestGetTagsUsesHTTP2(t *testing.T) {
+	t.Run("should negotiate HTTP/2 when TLS is configured", func(t *testing.T) {
+		var requestProtos []string
+		server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestProtos = append(requestProtos, r.Proto)
+			t.Logf("called %s with proto %s", r.URL.Path, r.Proto)
+
+			responseTags := fakeTagsList{
+				Tags: []string{"1.0.0"},
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			require.NoError(t, json.NewEncoder(w).Encode(responseTags))
+		}))
+		// httptest.NewTLSServer only advertises http/1.1 in ALPN, so we must
+		// configure the server to also offer h2 for HTTP/2 negotiation to work.
+		server.TLS = &tls.Config{NextProtos: []string{"h2", "http/1.1"}}
+		server.StartTLS()
+		t.Cleanup(server.Close)
+
+		client := NewClient(server.URL, HelmCreds{InsecureSkipVerify: true}, true, "", "")
+
+		tags, err := client.GetTags("mychart", true)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"1.0.0"}, tags)
+
+		// Verify that at least one request used HTTP/2. When ForceAttemptHTTP2 is
+		// not set on the Transport, Go's TLS stack won't negotiate h2 even though
+		// the server supports it, because a custom TLSClientConfig disables the
+		// automatic HTTP/2 setup.
+		require.NotEmpty(t, requestProtos, "expected at least one request to the server")
+		hasHTTP2 := slices.Contains(requestProtos, "HTTP/2.0")
+		assert.True(t, hasHTTP2, "expected at least one HTTP/2 request, but got protocols: %v", requestProtos)
+	})
+}
+
+func TestLoadRepoIndexUsesHTTP2(t *testing.T) {
+	t.Run("should negotiate HTTP/2 when fetching index", func(t *testing.T) {
+		var requestProto string
+		server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestProto = r.Proto
+			t.Logf("called %s with proto %s", r.URL.Path, r.Proto)
+
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`apiVersion: v1
+entries: {}
+`))
+		}))
+		server.TLS = &tls.Config{NextProtos: []string{"h2", "http/1.1"}}
+		server.StartTLS()
+		t.Cleanup(server.Close)
+
+		client := NewClient(server.URL, HelmCreds{InsecureSkipVerify: true}, false, "", "")
+
+		_, err := client.GetIndex(false, 10000)
+		require.NoError(t, err)
+
+		assert.Equal(t, "HTTP/2.0", requestProto, "expected HTTP/2 request for index fetch, but got %s", requestProto)
 	})
 }
 

--- a/util/oci/client.go
+++ b/util/oci/client.go
@@ -143,6 +143,7 @@ func NewClientWithLock(repoURL string, creds Creds, repoLock sync.KeyLock, proxy
 			Proxy:             proxy.GetCallback(proxyURL, noProxy),
 			TLSClientConfig:   tlsConf,
 			DisableKeepAlives: true,
+			ForceAttemptHTTP2: true,
 		},
 		/*
 			CheckRedirect: func(req *http.Request, via []*http.Request) error {

--- a/util/oci/client_test.go
+++ b/util/oci/client_test.go
@@ -5,16 +5,22 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/specs-go"
 	imagev1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content"
@@ -761,6 +767,38 @@ func Test_nativeOCIClient_ResolveRevision(t *testing.T) {
 	}
 }
 
+func TestNewClientUsesHTTP2(t *testing.T) {
+	t.Run("should negotiate HTTP/2 when TLS is configured", func(t *testing.T) {
+		var requestProtos []string
+		server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestProtos = append(requestProtos, r.Proto)
+			t.Logf("called %s with proto %s", r.URL.Path, r.Proto)
+			w.WriteHeader(http.StatusOK)
+		}))
+		// httptest.NewTLSServer only advertises http/1.1 in ALPN, so we must
+		// configure the server to also offer h2 for HTTP/2 negotiation to work.
+		server.TLS = &tls.Config{NextProtos: []string{"h2", "http/1.1"}}
+		server.StartTLS()
+		t.Cleanup(server.Close)
+
+		serverURL, err := url.Parse(server.URL)
+		require.NoError(t, err)
+
+		// NewClient expects oci://host/path format.
+		repoURL := "oci://" + serverURL.Host + "/myorg/myrepo"
+		client, err := NewClient(repoURL, Creds{InsecureSkipVerify: true}, "", "", nil,
+			WithEventHandlers(fakeEventHandlers(t, serverURL.Host+"/myorg/myrepo")))
+		require.NoError(t, err)
+
+		// TestRepo pings the registry's /v2/ endpoint, exercising the transport.
+		_, _ = client.TestRepo(t.Context())
+
+		require.NotEmpty(t, requestProtos, "expected at least one request to the server")
+		hasHTTP2 := slices.Contains(requestProtos, "HTTP/2.0")
+		assert.True(t, hasHTTP2, "expected at least one HTTP/2 request, but got protocols: %v", requestProtos)
+	})
+}
+
 func fakeEventHandlers(t *testing.T, repoURL string) EventHandlers {
 	t.Helper()
 	return EventHandlers{
@@ -770,6 +808,9 @@ func fakeEventHandlers(t *testing.T, repoURL string) EventHandlers {
 		OnTestRepo:        func(repo string) func() { return func() { require.Equal(t, repoURL, repo) } },
 		OnGetTags:         func(repo string) func() { return func() { require.Equal(t, repoURL, repo) } },
 		OnGetTagsFail: func(repo string) func() {
+			return func() { require.Equal(t, repoURL, repo) }
+		},
+		OnTestRepoFail: func(repo string) func() {
 			return func() { require.Equal(t, repoURL, repo) }
 		},
 		OnExtractFail: func(repo string) func(revision string) {


### PR DESCRIPTION
Checklist:

  * [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug
  fix, or (c) this does not need to be in the release notes.
  * [x] The title of the PR states what changed and the related issues number (used for the release note).
  * [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
  * [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
  * [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
  * [ ] Does this PR require documentation updates?
  * [ ] I've updated documentation as required by this PR.
  * [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
  * [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
  * [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
  * [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
  * [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
  * [ ] Optional. My organization is added to USERS.md.
  * [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

  Fixes #26975

  ## Summary

  OCI Helm chart tag listing fails with `403 Forbidden` against Docker Hub (`registry-1.docker.io`). Setting a custom `TLSClientConfig` on `http.Transport` [silently
  disables HTTP/2 in Go](https://pkg.go.dev/net/http#Transport), and Docker Hub's Cloudflare-fronted token endpoint (`auth.docker.io`) rejects HTTP/1.1 Basic Auth with
  403.

  This PR adds `ForceAttemptHTTP2: true` to all three `http.Transport` instantiations that set `TLSClientConfig`:

  - `util/helm/client.go:372` — `getIndex()`
  - `util/helm/client.go:492` — `GetTags()`
  - `util/oci/client.go:142` — `NewClientWithLock()`

  ### Reproducer

  ```go
  package main

  import (
        "context"
        "crypto/tls"
        "fmt"
        "net/http"
        "os"

        "oras.land/oras-go/v2/registry/remote"
        "oras.land/oras-go/v2/registry/remote/auth"
  )

  func main() {
        username := os.Getenv("DOCKERHUB_USERNAME")
        password := os.Getenv("DOCKERHUB_TOKEN")
        repo := os.Getenv("DOCKERHUB_REPO")

        if username == "" || password == "" || repo == "" {
                fmt.Fprintln(os.Stderr, "Usage: DOCKERHUB_USERNAME=... DOCKERHUB_TOKEN=... DOCKERHUB_REPO=myorg/myapp go run main.go")
                os.Exit(1)
        }

        ref := "registry-1.docker.io/" + repo
        credential := auth.StaticCredential("registry-1.docker.io", auth.Credential{
                Username: username, Password: password,
        })

        runTest := func(name string, transport http.RoundTripper) {
                fmt.Printf("=== %s ===\n", name)
                repository, _ := remote.NewRepository(ref)
                repository.Client = &auth.Client{
                        Client: &http.Client{Transport: transport}, Credential: credential,
                }
                var tags []string
                err := repository.Tags(context.Background(), "", func(t []string) error {
                        tags = append(tags, t...)
                        return nil
                })
                if err != nil {
                        fmt.Printf("FAILED: %v\n\n", err)
                } else {
                        fmt.Printf("SUCCESS: Found %d tags\n\n", len(tags))
                }
        }

        // What ArgoCD does: custom TLS config disables HTTP/2
        runTest("Custom TLS (HTTP/1.1 only)", &http.Transport{
                TLSClientConfig: &tls.Config{}, DisableKeepAlives: true,
        })
        // The fix
        runTest("Custom TLS + ForceAttemptHTTP2", &http.Transport{
                TLSClientConfig: &tls.Config{}, DisableKeepAlives: true, ForceAttemptHTTP2: true,
        })
        runTest("DefaultTransport (HTTP/2 via ALPN)", http.DefaultTransport)
  }

  === Custom TLS (HTTP/1.1 only) ===
  FAILED: GET ".../tags/list": GET "https://auth.docker.io/token?...": response status code 403: Forbidden

  === Custom TLS + ForceAttemptHTTP2 ===
  SUCCESS: Found 55 tags

  === DefaultTransport (HTTP/2 via ALPN) ===
  SUCCESS: Found 55 tags

  Tests

  - TestGetTagsUsesHTTP2 — verifies GetTags negotiates HTTP/2 with a custom TLS config
  - TestLoadRepoIndexUsesHTTP2 — verifies getIndex negotiates HTTP/2 with a custom TLS config
  - TestNewClientUsesHTTP2 — verifies the OCI client negotiates HTTP/2 with a custom TLS config
```

All three tests spin up an h2-capable TLS test server and assert that requests arrive over HTTP/2.0. They fail without ForceAttemptHTTP2 (requests fall back to HTTP/1.1).

## Cherry-picking

I'm unsure to what versions of ArgoCD this should be backported to as this is not necessarily a regression on the side of ArgoCD. None of the versions I've tried so far are functioning without this patch. I'd like to leave this up to the maintainers.
