### PR TITLE
fix: Hook resources not created at PostSync when configured with PreDelete PostDelete hooks

### DIFF
--- a/controller/hook.go
+++ b/controller/hook.go
@@ -76,6 +76,21 @@ func isPostDeleteHook(obj *unstructured.Unstructured) bool {
 	return isHookOfType(obj, PostDeleteHookType)
 }
 
+// hasGitOpsEngineSyncPhaseHook is true when gitops-engine would run the resource during a sync
+// phase (PreSync, Sync, PostSync, SyncFail). PreDelete/PostDelete are not sync phases;
+// without this check, state reconciliation drops such resources
+// entirely because isPreDeleteHook/isPostDeleteHook match any comma-separated value.
+// HookTypeSkip is omitted as it is not a sync phase.
+func hasGitOpsEngineSyncPhaseHook(obj *unstructured.Unstructured) bool {
+	for _, t := range hook.Types(obj) {
+		switch t {
+		case common.HookTypePreSync, common.HookTypeSync, common.HookTypePostSync, common.HookTypeSyncFail:
+			return true
+		}
+	}
+	return false
+}
+
 // executeHooks is a generic function to execute hooks of a specified type
 func (ctrl *ApplicationController) executeHooks(hookType HookType, app *appv1.Application, proj *appv1.AppProject, liveObjs map[kube.ResourceKey]*unstructured.Unstructured, config *rest.Config, logCtx *log.Entry) (bool, error) {
 	appLabelKey, err := ctrl.settingsMgr.GetAppInstanceLabelKey()

--- a/controller/hook_test.go
+++ b/controller/hook_test.go
@@ -192,6 +192,92 @@ func TestIsPostDeleteHook(t *testing.T) {
 	}
 }
 
+// TestPartitionTargetObjsForSync covers partitionTargetObjsForSync in state.go.
+func TestPartitionTargetObjsForSync(t *testing.T) {
+	newObj := func(name string, annot map[string]string) *unstructured.Unstructured {
+		u := &unstructured.Unstructured{}
+		u.SetName(name)
+		u.SetAnnotations(annot)
+		return u
+	}
+
+	tests := []struct {
+		name           string
+		in             []*unstructured.Unstructured
+		wantNames      []string
+		wantPreDelete  bool
+		wantPostDelete bool
+	}{
+		{
+			name: "PostSync with PreDelete and PostDelete in same annotation stays in sync set",
+			in: []*unstructured.Unstructured{
+				newObj("combined", map[string]string{"argocd.argoproj.io/hook": "PostSync,PreDelete,PostDelete"}),
+			},
+			wantNames:      []string{"combined"},
+			wantPreDelete:  true,
+			wantPostDelete: true,
+		},
+		{
+			name: "PreDelete-only manifest excluded from sync",
+			in: []*unstructured.Unstructured{
+				newObj("pre-del", map[string]string{"argocd.argoproj.io/hook": "PreDelete"}),
+			},
+			wantNames:      nil,
+			wantPreDelete:  true,
+			wantPostDelete: false,
+		},
+		{
+			name: "PostDelete-only manifest excluded from sync",
+			in: []*unstructured.Unstructured{
+				newObj("post-del", map[string]string{"argocd.argoproj.io/hook": "PostDelete"}),
+			},
+			wantNames:      nil,
+			wantPreDelete:  false,
+			wantPostDelete: true,
+		},
+		{
+			name: "Helm pre-delete only excluded from sync",
+			in: []*unstructured.Unstructured{
+				newObj("helm-pre-del", map[string]string{"helm.sh/hook": "pre-delete"}),
+			},
+			wantNames:      nil,
+			wantPreDelete:  true,
+			wantPostDelete: false,
+		},
+		{
+			name: "Helm pre-install with pre-delete stays in sync (sync-phase hook wins)",
+			in: []*unstructured.Unstructured{
+				newObj("helm-mixed", map[string]string{"helm.sh/hook": "pre-install,pre-delete"}),
+			},
+			wantNames:      []string{"helm-mixed"},
+			wantPreDelete:  true,
+			wantPostDelete: false,
+		},
+		{
+			name: "Non-hook resource unchanged",
+			in: []*unstructured.Unstructured{
+				newObj("pod", map[string]string{"app": "x"}),
+			},
+			wantNames:      []string{"pod"},
+			wantPreDelete:  false,
+			wantPostDelete: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, hasPre, hasPost := partitionTargetObjsForSync(tt.in)
+			var names []string
+			for _, o := range got {
+				names = append(names, o.GetName())
+			}
+			assert.Equal(t, tt.wantNames, names)
+			assert.Equal(t, tt.wantPreDelete, hasPre, "hasPreDeleteHooks")
+			assert.Equal(t, tt.wantPostDelete, hasPost, "hasPostDeleteHooks")
+		})
+	}
+}
+
 func TestMultiHookOfType(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/controller/state.go
+++ b/controller/state.go
@@ -543,6 +543,28 @@ func isManagedNamespace(ns *unstructured.Unstructured, app *v1alpha1.Application
 	return ns != nil && ns.GetKind() == kubeutil.NamespaceKind && ns.GetName() == app.Spec.Destination.Namespace && app.Spec.SyncPolicy != nil && app.Spec.SyncPolicy.ManagedNamespaceMetadata != nil
 }
 
+// partitionTargetObjsForSync returns the manifest subset passed to gitops-engine sync, and whether
+// the full manifest set declared PreDelete and/or PostDelete hooks (for finalizer handling).
+// Uses isPreDeleteHook / isPostDeleteHook / hasGitOpsEngineSyncPhaseHook from hook.go.
+func partitionTargetObjsForSync(targetObjs []*unstructured.Unstructured) (syncObjs []*unstructured.Unstructured, hasPreDeleteHooks, hasPostDeleteHooks bool) {
+	for _, obj := range targetObjs {
+		if isPreDeleteHook(obj) {
+			hasPreDeleteHooks = true
+			if !hasGitOpsEngineSyncPhaseHook(obj) {
+				continue
+			}
+		}
+		if isPostDeleteHook(obj) {
+			hasPostDeleteHooks = true
+			if !hasGitOpsEngineSyncPhaseHook(obj) {
+				continue
+			}
+		}
+		syncObjs = append(syncObjs, obj)
+	}
+	return syncObjs, hasPreDeleteHooks, hasPostDeleteHooks
+}
+
 // CompareAppState compares application git state to the live app state, using the specified
 // revision and supplied source. If revision or overrides are empty, then compares against
 // revision and overrides in the app spec.
@@ -770,24 +792,7 @@ func (m *appStateManager) CompareAppState(app *v1alpha1.Application, project *v1
 			}
 		}
 	}
-	hasPreDeleteHooks := false
-	hasPostDeleteHooks := false
-	// Filter out PreDelete and PostDelete hooks from targetObjs since they should not be synced
-	// as regular resources. They are only executed during deletion.
-	var targetObjsForSync []*unstructured.Unstructured
-	for _, obj := range targetObjs {
-		if isPreDeleteHook(obj) {
-			hasPreDeleteHooks = true
-			// Skip PreDelete hooks - they are not synced, only executed during deletion
-			continue
-		}
-		if isPostDeleteHook(obj) {
-			hasPostDeleteHooks = true
-			// Skip PostDelete hooks - they are not synced, only executed after deletion
-			continue
-		}
-		targetObjsForSync = append(targetObjsForSync, obj)
-	}
+	targetObjsForSync, hasPreDeleteHooks, hasPostDeleteHooks := partitionTargetObjsForSync(targetObjs)
 
 	reconciliation := sync.Reconcile(targetObjsForSync, liveObjByKey, app.Spec.Destination.Namespace, infoProvider)
 	ts.AddCheckpoint("live_ms")


### PR DESCRIPTION
Closes #26956 
Fixed and extracted the logic with the fix to a separate function for better testing.
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
