### PR TITLE
fix: Add X-Frame-Options header to Swagger UI endpoints

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1244,7 +1244,7 @@ func (server *ArgoCDServer) newHTTPServer(ctx context.Context, port int, grpcWeb
 	mustRegisterGWHandler(ctx, gpgkeypkg.RegisterGPGKeyServiceHandler, gwmux, conn)
 
 	// Swagger UI
-	swagger.ServeSwaggerUI(mux, assets.SwaggerJSON, "/swagger-ui", server.RootPath)
+	swagger.ServeSwaggerUI(mux, assets.SwaggerJSON, "/swagger-ui", server.RootPath, server.XFrameOptions)
 	healthz.ServeHealthCheck(mux, server.healthCheck)
 
 	// Dex reverse proxy and OAuth2 login/callback

--- a/util/swagger/swagger.go
+++ b/util/swagger/swagger.go
@@ -12,19 +12,30 @@ import (
 const redocScriptName = "redoc.standalone.js"
 
 // ServeSwaggerUI serves the Swagger UI and JSON spec.
-func ServeSwaggerUI(mux *http.ServeMux, swaggerJSON string, uiPath string, rootPath string) {
+func ServeSwaggerUI(mux *http.ServeMux, swaggerJSON string, uiPath string, rootPath string, xFrameOptions string) {
 	prefix := path.Dir(uiPath)
 	swaggerPath := path.Join(prefix, "swagger.json")
 	mux.HandleFunc(swaggerPath, func(w http.ResponseWriter, _ *http.Request) {
+		if xFrameOptions != "" {
+			w.Header().Set("X-Frame-Options", xFrameOptions)
+		}
 		_, _ = fmt.Fprint(w, swaggerJSON)
 	})
 
 	specURL := path.Join(prefix, rootPath, "swagger.json")
 	scriptURL := path.Join(prefix, rootPath, "assets", "scripts", redocScriptName)
-	mux.Handle(uiPath, middleware.Redoc(middleware.RedocOpts{
+
+	redocHandler := middleware.Redoc(middleware.RedocOpts{
 		BasePath: prefix,
 		SpecURL:  specURL,
 		Path:     path.Base(uiPath),
 		RedocURL: scriptURL,
-	}, http.NotFoundHandler()))
+	}, http.NotFoundHandler())
+
+	mux.HandleFunc(uiPath, func(w http.ResponseWriter, r *http.Request) {
+		if xFrameOptions != "" {
+			w.Header().Set("X-Frame-Options", xFrameOptions)
+		}
+		redocHandler.ServeHTTP(w, r)
+	})
 }

--- a/util/swagger/swagger_test.go
+++ b/util/swagger/swagger_test.go
@@ -25,7 +25,7 @@ func TestSwaggerUI(t *testing.T) {
 		c <- listener.Addr().String()
 
 		mux := http.NewServeMux()
-		ServeSwaggerUI(mux, assets.SwaggerJSON, "/swagger-ui", "")
+		ServeSwaggerUI(mux, assets.SwaggerJSON, "/swagger-ui", "", "sameorigin")
 		panic(http.Serve(listener, mux))
 	}
 


### PR DESCRIPTION
## Summary

This PR adds the `X-Frame-Options` security header to Swagger UI endpoints (`/swagger.json` and `/swagger-ui`) to prevent clickjacking attacks.

## Changes

- Modified `util/swagger/swagger.go` to accept `xFrameOptions` parameter and set the header on both endpoints
- Updated `server/server.go` to pass `server.XFrameOptions` to `ServeSwaggerUI()`
- Updated `util/swagger/swagger_test.go` to include the new parameter in tests

## Security Impact

Previously, the Swagger UI endpoints were missing the `X-Frame-Options` header that is already applied to the main UI. This made them vulnerable to clickjacking attacks. Now both endpoints respect the server's X-Frame-Options configuration (default: "sameorigin").

## Test Plan

- [x] Verified all modified code compiles successfully
- [x] Ran unit tests: `go test ./util/swagger/...` - PASS
- [x] Verified the fix matches existing code style in `server/server.go`
- [x] Checked that header is set on both `/swagger.json` and `/swagger-ui` endpoints

Fixes #22877