### PR TITLE
fix: address nil pointer when SSD returns error

### DIFF
--- a/controller/state.go
+++ b/controller/state.go
@@ -848,7 +848,9 @@ func (m *appStateManager) CompareAppState(app *v1alpha1.Application, project *v1
 			log.Errorf("CompareAppState error getting server side diff dry run applier: %s", err)
 			conditions = append(conditions, v1alpha1.ApplicationCondition{Type: v1alpha1.ApplicationConditionUnknownError, Message: err.Error(), LastTransitionTime: &now})
 		}
-		defer cleanup()
+		if cleanup != nil {
+			defer cleanup()
+		}
 		diffConfigBuilder.WithServerSideDryRunner(diff.NewK8sServerSideDryRunner(applier))
 	}
 


### PR DESCRIPTION
We are seeing the following error while enabling SSD in our clusters. This PR addresses the issue.

```
Recovered from panic: runtime error: invalid memory address or nil pointer dereference
goroutine 445 [running]:
runtime/debug.Stack()
	/usr/local/go/src/runtime/debug/stack.go:26 +0x5e
github.com/argoproj/argo-cd/v3/controller.(*ApplicationController).processAppRefreshQueueItem.func1()
	/go/src/github.com/argoproj/argo-cd/controller/appcontroller.go:1699 +0x96
panic({0x47bd060?, 0x972dc50?})
	/usr/local/go/src/runtime/panic.go:783 +0x132
github.com/argoproj/argo-cd/v3/controller.(*appStateManager).CompareAppState(0xc00029b3b0, 0xc006a56008, 0xc0140046c8, {0xc01a2cb900, 0x1, 0x1}, {0xc02e22fe80, 0x1, 0x1}, 0x0, ...)
	/go/src/github.com/argoproj/argo-cd/controller/state.go:1025 +0x5f19
github.com/argoproj/argo-cd/v3/controller.(*ApplicationController).processAppRefreshQueueItem(0xc000de1600)
	/go/src/github.com/argoproj/argo-cd/controller/appcontroller.go:1836 +0x1acf
github.com/argoproj/argo-cd/v3/controller.(*ApplicationController).Run.func3()
	/go/src/github.com/argoproj/argo-cd/controller/appcontroller.go:932 +0x25
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1({0x218e5d9?, 0x50d0220?})
	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:233 +0x13
k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext.func1({0x679ebe8?, 0xc000dac0e0?}, 0x41d054?)
	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:255 +0x51
k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext({0x679ebe8, 0xc000dac0e0}, 0xc015c63f50, {0x67521c0, 0xc007101980}, 0x1)
	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:256 +0xe5
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x0?, {0x67521c0?, 0xc007101980?}, 0xa0?, 0x218f125?)
	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:233 +0x46
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc006c7ec50, 0x3b9aca00, 0x0, 0x1, 0xc000dac0e0)
	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:210 +0x7f
k8s.io/apimachinery/pkg/util/wait.Until(...)
	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:163
created by github.com/argoproj/argo-cd/v3/controller.(*ApplicationController).Run in goroutine 84
	/go/src/github.com/argoproj/argo-cd/controller/appcontroller.go:931 +0x8fb
```

This is happening in Argo CD 3.3.3 but it should probably be cherry-picked into all current supported versions.

cc @crenshaw-dev 

Signed-off-by: Leonardo Luz Almeida <leonardo_almeida@intuit.com>
