### PR TITLE
fix: controller incorrectly detecting diff during app normalization

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -1851,7 +1851,7 @@ func (ctrl *ApplicationController) processAppRefreshQueueItem() (processNext boo
 		logCtx = logCtx.WithField(k, v.Milliseconds())
 	}
 
-	ctrl.normalizeApplication(origApp, app)
+	ctrl.normalizeApplication(app)
 	ts.AddCheckpoint("normalize_application_ms")
 
 	tree, err := ctrl.setAppManagedResources(destCluster, app, compareResult)
@@ -2090,7 +2090,8 @@ func (ctrl *ApplicationController) refreshAppConditions(app *appv1.Application) 
 }
 
 // normalizeApplication normalizes an application.spec and additionally persists updates if it changed
-func (ctrl *ApplicationController) normalizeApplication(orig, app *appv1.Application) {
+func (ctrl *ApplicationController) normalizeApplication(app *appv1.Application) {
+	orig := app.DeepCopy()
 	app.Spec = *argo.NormalizeApplicationSpec(&app.Spec)
 	logCtx := log.WithFields(applog.GetAppLogFields(app))
 


### PR DESCRIPTION
Application controller might incorrectly attempt to normalize application: during normalization it normalizes app spec and then generate patch using unmodified copy of app created in a beginning of reconciliation. The problem is app status changes during normalization and controller incorrectly thinks that there was a change during normalization.

The bag causes unnecessary k8s api calls and noise in logs.