### PR TITLE
fix: Fix 'Previous version' banner redirect to preserve page path

### DIFF
--- a/docs/assets/versions.js
+++ b/docs/assets/versions.js
@@ -140,9 +140,9 @@ window.addEventListener("DOMContentLoaded", function() {
   const currentVersion = getCurrentVersion();
   if (currentVersion && currentVersion !== "stable") {
     if (currentVersion === "latest") {
-      document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for an unreleased version of Argo CD, <a href='https://argo-cd.readthedocs.io/en/stable/'>view the latest stable version.</a></div>";
+      document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for an unreleased version of Argo CD, <a href='/en/stable/'>view the latest stable version.</a></div>";
     } else {
-      document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for a previous version of Argo CD, <a href='https://argo-cd.readthedocs.io/en/stable/'>view the latest stable version.</a></div>";
+      document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for a previous version of Argo CD, <a href='/en/stable/'>view the latest stable version.</a></div>";
     }
     var bannerHeight = document.getElementById('announce-msg').offsetHeight + margin;
     document.querySelector("header.md-header").style.top = bannerHeight + "px";


### PR DESCRIPTION
Fixes #26857

The banner that says "go to the latest stable version" was always redirecting to the docs homepage instead of the same page in the stable version.

This fix changes it so if you're on /en/latest/user-guide/getting-started/, clicking the banner takes you to /en/stable/user-guide/getting-started/ instead of just /en/stable/.

The fix replaces the version segment in the current URL and keeps everything else the same.