### PR TITLE
feat: Add security headers to Swagger UI to prevent clickjacking

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1244,7 +1244,7 @@ func (server *ArgoCDServer) newHTTPServer(ctx context.Context, port int, grpcWeb
 	mustRegisterGWHandler(ctx, gpgkeypkg.RegisterGPGKeyServiceHandler, gwmux, conn)
 
 	// Swagger UI
-	swagger.ServeSwaggerUI(mux, assets.SwaggerJSON, "/swagger-ui", server.RootPath)
+	swagger.ServeSwaggerUI(mux, assets.SwaggerJSON, "/swagger-ui", server.RootPath, server.XFrameOptions, server.ContentSecurityPolicy)
 	healthz.ServeHealthCheck(mux, server.healthCheck)
 
 	// Dex reverse proxy and OAuth2 login/callback

--- a/util/swagger/swagger.go
+++ b/util/swagger/swagger.go
@@ -11,20 +11,46 @@ import (
 // filename of ReDoc script in UI's assets/scripts path
 const redocScriptName = "redoc.standalone.js"
 
-// ServeSwaggerUI serves the Swagger UI and JSON spec.
-func ServeSwaggerUI(mux *http.ServeMux, swaggerJSON string, uiPath string, rootPath string) {
+// setSecurityHeaders is a middleware that sets security headers on responses.
+func setSecurityHeaders(xFrameOptions, contentSecurityPolicy string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if xFrameOptions != "" {
+				w.Header().Set("X-Frame-Options", xFrameOptions)
+			}
+			if contentSecurityPolicy != "" {
+				w.Header().Set("Content-Security-Policy", contentSecurityPolicy)
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// ServeSwaggerUI serves the Swagger UI and JSON spec with security headers.
+func ServeSwaggerUI(mux *http.ServeMux, swaggerJSON string, uiPath string, rootPath string, xFrameOptions string, contentSecurityPolicy string) {
 	prefix := path.Dir(uiPath)
 	swaggerPath := path.Join(prefix, "swagger.json")
-	mux.HandleFunc(swaggerPath, func(w http.ResponseWriter, _ *http.Request) {
+
+	swaggerHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if xFrameOptions != "" {
+			w.Header().Set("X-Frame-Options", xFrameOptions)
+		}
+		if contentSecurityPolicy != "" {
+			w.Header().Set("Content-Security-Policy", contentSecurityPolicy)
+		}
 		_, _ = fmt.Fprint(w, swaggerJSON)
 	})
+	mux.Handle(swaggerPath, swaggerHandler)
 
 	specURL := path.Join(prefix, rootPath, "swagger.json")
 	scriptURL := path.Join(prefix, rootPath, "assets", "scripts", redocScriptName)
-	mux.Handle(uiPath, middleware.Redoc(middleware.RedocOpts{
+	redocHandler := middleware.Redoc(middleware.RedocOpts{
 		BasePath: prefix,
 		SpecURL:  specURL,
 		Path:     path.Base(uiPath),
 		RedocURL: scriptURL,
-	}, http.NotFoundHandler()))
+	}, http.NotFoundHandler())
+
+	wrappedRedocHandler := setSecurityHeaders(xFrameOptions, contentSecurityPolicy)(redocHandler)
+	mux.Handle(uiPath, wrappedRedocHandler)
 }

--- a/util/swagger/swagger_test.go
+++ b/util/swagger/swagger_test.go
@@ -25,7 +25,7 @@ func TestSwaggerUI(t *testing.T) {
 		c <- listener.Addr().String()
 
 		mux := http.NewServeMux()
-		ServeSwaggerUI(mux, assets.SwaggerJSON, "/swagger-ui", "")
+		ServeSwaggerUI(mux, assets.SwaggerJSON, "/swagger-ui", "", "DENY", "frame-ancestors 'none';")
 		panic(http.Serve(listener, mux))
 	}
 
@@ -51,5 +51,7 @@ func TestSwaggerUI(t *testing.T) {
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
 	require.Equalf(t, http.StatusOK, resp.StatusCode, "Was expecting status code 200 from swagger-ui, but got %d instead", resp.StatusCode)
+	require.Equal(t, "DENY", resp.Header.Get("X-Frame-Options"), "X-Frame-Options header not set correctly")
+	require.Equal(t, "frame-ancestors 'none';", resp.Header.Get("Content-Security-Policy"), "Content-Security-Policy header not set correctly")
 	require.NoError(t, resp.Body.Close())
 }


### PR DESCRIPTION
Fixes #22877

The Swagger UI endpoints were missing X-Frame-Options and 
Content-Security-Policy headers, which could allow clickjacking attacks.

This change adds those security headers to both the swagger.json endpoint 
and the Redoc UI. Headers are pulled from server configuration to stay 
consistent with other UI endpoints.

Also added test assertions to verify the headers are set correctly.