### PR TITLE
docs: fix GitHub Discussions capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ## What is Argo CD?
 
-Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.
+Argo CD is a declarative GitOps continuous delivery tool for Kubernetes.
 
 ![Argo CD UI](docs/assets/argocd-ui.gif)
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Check live demo at https://cd.apps.argoproj.io/.
 
  You can reach the Argo CD community and developers via the following channels:
 
-* Q & A : [Github Discussions](https://github.com/argoproj/argo-cd/discussions)
+* Q & A : [GitHub Discussions](https://github.com/argoproj/argo-cd/discussions)
 * Chat : [The #argo-cd Slack channel](https://argoproj.github.io/community/join-slack)
 * Contributors Office Hours: [Every Thursday](https://calendar.google.com/calendar/u/0/embed?src=argoproj@gmail.com) | [Agenda](https://docs.google.com/document/d/1xkoFkVviB70YBzSEa4bDnu-rUZ1sIFtwKKG1Uw8XsY8)
 * User Community meeting: [First Wednesday of the month](https://calendar.google.com/calendar/u/0/embed?src=argoproj@gmail.com) | [Agenda](https://docs.google.com/document/d/1ttgw98MO45Dq7ZUHpIiOIEfbyeitKHNfMjbY5dLLMKQ)


### PR DESCRIPTION
## Summary
- fix branding/capitalization from `Github` to `GitHub` in README community section
- docs-only change, no behavior impact

## Testing
- [x] docs-only change