### PR TITLE
docs: document notification template variable fields

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -83,6 +83,26 @@ or a randomly generated password stored in a secret (Argo CD 1.9 and later).
 Add `admin.enabled: "false"` to the `argocd-cm` ConfigMap
 (see [user management](./operator-manual/user-management/index.md)).
 
+## How to view orphaned resources?
+
+Orphaned Kubernetes resources are top-level namespaced resources that do not belong to any Argo CD Application. For more information, see [Orphaned Resources Monitoring](./user-guide/orphaned-resources.md).
+
+!!! warning
+    Enabling orphaned resource monitoring has performance implications. If an AppProject monitors a namespace containing many resources not managed by Argo CD (e.g. `kube-system`), it can significantly impact your Argo CD instance. Enable this feature only on projects with well-scoped namespaces.
+
+To view orphaned resources in the Argo CD UI:
+
+1. Click on **Settings** in the sidebar.
+2. Click on **Projects**.
+3. Select the desired project.
+4. Scroll down to the **RESOURCE MONITORING** section.
+5. Click **Edit** and enable the monitoring feature.
+6. Check **Enable application warning conditions?** to enable warnings.
+7. Click **Save**.
+8. Navigate back to **Applications** and select an application under the configured project.
+9. In the **Sync Panel**, under **APP CONDITIONS**, you will see the orphaned resources warning.
+10. Click **Show Orphaned** below the **HEALTH STATUS** filters to display orphaned resources.
+
 ## Argo CD cannot deploy Helm Chart based applications without internet access, how can I solve it?
 
 Argo CD might fail to generate Helm chart manifests if the chart has dependencies located in external repositories. To

--- a/docs/operator-manual/notifications/templates.md
+++ b/docs/operator-manual/notifications/templates.md
@@ -18,13 +18,59 @@ data:
 
 Each template has access to the following fields:
 
-- `app` holds the application object.
-- `appProject` holds the AppProject object associated with the application. This provides access to project-level details like RBAC roles, policies, source repository restrictions, and destination cluster restrictions.
+- `app` holds the full [Application](../../declarative-setup.md#applications) resource object. See [commonly used `app` fields](#commonly-used-app-fields) below for details.
+- `appProject` holds the [AppProject](../../declarative-setup.md#projects) object associated with the application. This provides access to project-level details like RBAC roles, policies, source repository restrictions, and destination cluster restrictions.
 - `context` is a user-defined string map and might include any string keys and values.
 - `secrets` provides access to sensitive data stored in `argocd-notifications-secret`
 - `serviceType` holds the notification service type name (such as "slack" or "email). The field can be used to conditionally
 render service-specific fields.
 - `recipient` holds the recipient name.
+- `time` provides time parsing functions. See [Change the timezone](#change-the-timezone) for usage.
+- `strings` provides string manipulation functions.
+- `repo` provides access to the Git repository. For example, `(call .repo.GetCommitMetadata .app.status.sync.revision)` returns commit metadata.
+
+## Commonly used `app` fields
+
+The `app` variable contains the full Application resource as an unstructured object. You can access any field using dot notation. The most commonly used fields in notification templates are:
+
+**Metadata:**
+
+| Expression | Description |
+|------------|-------------|
+| `.app.metadata.name` | Application name |
+| `.app.metadata.namespace` | Application namespace |
+| `.app.metadata.annotations` | Application annotations (map) |
+| `.app.metadata.labels` | Application labels (map) |
+
+**Spec (desired state):**
+
+| Expression | Description |
+|------------|-------------|
+| `.app.spec.project` | Project name |
+| `.app.spec.source.repoURL` | Git repository URL |
+| `.app.spec.source.path` | Path within the repository |
+| `.app.spec.source.targetRevision` | Target branch, tag, or commit |
+| `.app.spec.source.chart` | Helm chart name (for Helm apps) |
+| `.app.spec.destination.server` | Destination cluster URL |
+| `.app.spec.destination.namespace` | Destination namespace |
+
+**Status (actual state):**
+
+| Expression | Description |
+|------------|-------------|
+| `.app.status.sync.status` | Sync status (`Synced`, `OutOfSync`, `Unknown`) |
+| `.app.status.sync.revision` | Currently synced Git revision |
+| `.app.status.health.status` | Health status (`Healthy`, `Degraded`, `Progressing`, `Missing`, `Suspended`, `Unknown`) |
+| `.app.status.health.message` | Health status message |
+| `.app.status.operationState.phase` | Operation phase (`Succeeded`, `Failed`, `Error`, `Running`) |
+| `.app.status.operationState.message` | Operation result message |
+| `.app.status.operationState.startedAt` | Operation start time |
+| `.app.status.operationState.finishedAt` | Operation finish time |
+| `.app.status.operationState.syncResult.revision` | Revision of the last sync operation |
+| `.app.status.summary.images` | List of container images used by the application |
+| `.app.status.conditions` | List of application conditions |
+
+For the complete Application spec, refer to the [Application CRD reference](https://argo-cd.readthedocs.io/en/stable/operator-manual/application.yaml).
 
 ## Defining user-defined `context`
 


### PR DESCRIPTION
## Summary

Document the fields available in notification templates and triggers:

- Add a "Commonly used `app` fields" section with tables listing metadata, spec, and status fields with their dot-notation expressions
- Document the `time`, `strings`, and `repo` helper variables that were missing from the variable list
- Link to the Application CRD reference for the complete spec

Users previously had to read the source code or guess by trial and error to discover which fields were available (e.g. `app.status.sync.status`, `app.status.health.status`, `app.status.operationState.phase`).

Fixes #17628