### PR TITLE
chore(deps): bump notifications-engine to include checkRun fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/TomOnTime/utfutil v1.0.0
 	github.com/alicebob/miniredis/v2 v2.37.0
 	github.com/argoproj/argo-cd/gitops-engine v0.7.1-0.20250908182407-97ad5b59a627
-	github.com/argoproj/notifications-engine v0.5.1-0.20260213231747-1dbe3de712f8
+	github.com/argoproj/notifications-engine v0.5.1-0.20260214120534-27cb8a5dcaab
 	github.com/argoproj/pkg v0.13.6
 	github.com/argoproj/pkg/v2 v2.0.1
 	github.com/bmatcuk/doublestar/v4 v4.10.0

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,8 @@ github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFI
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/appscode/go v0.0.0-20191119085241-0887d8ec2ecc/go.mod h1:OawnOmAL4ZX3YaPdN+8HTNwBveT1jMsqP74moa9XUbE=
-github.com/argoproj/notifications-engine v0.5.1-0.20260213231747-1dbe3de712f8 h1:OGoe2RFv1wuhxHrFcdAC/VW+5HUkRI+1/zf3RGR5LnY=
-github.com/argoproj/notifications-engine v0.5.1-0.20260213231747-1dbe3de712f8/go.mod h1:zz+4OVgqmyD0T5whLAPO6k5BGLSop4j32BKHSAe80tM=
+github.com/argoproj/notifications-engine v0.5.1-0.20260214120534-27cb8a5dcaab h1:kCI4TCQ5nDdwd7r3KpDEOIKnazyL5yq6OCAhwf+ARLw=
+github.com/argoproj/notifications-engine v0.5.1-0.20260214120534-27cb8a5dcaab/go.mod h1:zz+4OVgqmyD0T5whLAPO6k5BGLSop4j32BKHSAe80tM=
 github.com/argoproj/pkg v0.13.6 h1:36WPD9MNYECHcO1/R1pj6teYspiK7uMQLCgLGft2abM=
 github.com/argoproj/pkg v0.13.6/go.mod h1:I698DoJBKuvNFaixh4vFl2C88cNIT1WS7KCbz5ewyF8=
 github.com/argoproj/pkg/v2 v2.0.1 h1:O/gCETzB/3+/hyFL/7d/VM/6pSOIRWIiBOTb2xqAHvc=


### PR DESCRIPTION
Bumps `github.com/argoproj/notifications-engine` past Feb 14, 2026 to include argoproj/notifications-engine#389 which fixes:

- Invalid time layout for `started_at`/`completed_at` (used `"YYYY-MM-DDTHH:MM:SSZ"` instead of `time.RFC3339`) in GitHub CheckRun provider
- Missing required `status`/`conclusion` fields in CheckRun API payload

These bugs cause all GitHub CheckRun notifications to fail with 422 errors from the GitHub Checks API.

Signed-off-by: Darmen <darmen@kertos.io>