### PR TITLE
docs: fix README GitHub branding in community section

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ## What is Argo CD?
 
-Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.
+Argo CD is a declarative GitOps continuous delivery tool for Kubernetes.
 
 ![Argo CD UI](docs/assets/argocd-ui.gif)
 
@@ -45,7 +45,7 @@ Check live demo at https://cd.apps.argoproj.io/.
 
  You can reach the Argo CD community and developers via the following channels:
 
-* Q & A : [Github Discussions](https://github.com/argoproj/argo-cd/discussions)
+* Q & A : [GitHub Discussions](https://github.com/argoproj/argo-cd/discussions)
 * Chat : [The #argo-cd Slack channel](https://argoproj.github.io/community/join-slack)
 * Contributors Office Hours: [Every Thursday](https://calendar.google.com/calendar/u/0/embed?src=argoproj@gmail.com) | [Agenda](https://docs.google.com/document/d/1xkoFkVviB70YBzSEa4bDnu-rUZ1sIFtwKKG1Uw8XsY8)
 * User Community meeting: [First Wednesday of the month](https://calendar.google.com/calendar/u/0/embed?src=argoproj@gmail.com) | [Agenda](https://docs.google.com/document/d/1ttgw98MO45Dq7ZUHpIiOIEfbyeitKHNfMjbY5dLLMKQ)


### PR DESCRIPTION
## Summary
- Fix README branding: `Github` → `GitHub` for the Discussions link in the Community section
- Minor wording tweak in the "What is Argo CD?" intro for consistency

## Motivation
Correct product/branding and readability (docs-only).

## Testing
- [x] Docs-only (README)

Signed-off-by: Pratik Lawate <39809928+pratik268@users.noreply.github.com>
