### PR TITLE
fix(reposerver): propagate OCI auth for kustomize --enable-helm (#16894)

### DIFF
--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -10,6 +10,7 @@ import (
 	"io/fs"
 	"net/url"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -57,6 +58,7 @@ import (
 	apppathutil "github.com/argoproj/argo-cd/v3/util/app/path"
 	"github.com/argoproj/argo-cd/v3/util/argo"
 	"github.com/argoproj/argo-cd/v3/util/cmp"
+	executil "github.com/argoproj/argo-cd/v3/util/exec"
 	"github.com/argoproj/argo-cd/v3/util/git"
 	"github.com/argoproj/argo-cd/v3/util/glob"
 	"github.com/argoproj/argo-cd/v3/util/gpg"
@@ -67,6 +69,7 @@ import (
 	pathutil "github.com/argoproj/argo-cd/v3/util/io/path"
 	"github.com/argoproj/argo-cd/v3/util/kustomize"
 	"github.com/argoproj/argo-cd/v3/util/manifeststream"
+	proxyutil "github.com/argoproj/argo-cd/v3/util/proxy"
 	"github.com/argoproj/argo-cd/v3/util/settings"
 	"github.com/argoproj/argo-cd/v3/util/versions"
 )
@@ -1177,6 +1180,318 @@ func sanitizeRepoName(repoName string) string {
 	return strings.ReplaceAll(repoName, "/", "-")
 }
 
+func isKustomizeHelmEnabled(kustomizeOptions *v1alpha1.KustomizeOptions) bool {
+	return kustomizeOptions != nil && strings.Contains(kustomizeOptions.BuildOptions, "--enable-helm")
+}
+
+func prepareKustomizeHelmOCIRegistryCredentials(ctx context.Context, appPath string, repositories []*v1alpha1.Repository, helmRepoCreds []*v1alpha1.RepoCreds, proxy string, noProxy string) (utilio.Closer, error) {
+	kustomizationPath, kMap, originalKustomization, fileMode, err := getKustomizeHelmConfig(appPath)
+	if err != nil {
+		return utilio.NopCloser, err
+	}
+	if kustomizationPath == "" {
+		return utilio.NopCloser, nil
+	}
+	if getKustomizeHelmGlobalsConfigHome(kMap) != "" {
+		// Respect explicit user configuration.
+		return utilio.NopCloser, nil
+	}
+
+	ociDependencies := getOCIHelmChartReposFromKustomization(kMap)
+	if len(ociDependencies) == 0 {
+		return utilio.NopCloser, nil
+	}
+	resolvedRepos := getResolvedKustomizeHelmOCIRepos(ociDependencies, repositories, helmRepoCreds)
+	if len(resolvedRepos) == 0 {
+		return utilio.NopCloser, nil
+	}
+
+	tmpDir, err := os.MkdirTemp("", "kustomize-helm-auth-")
+	if err != nil {
+		return utilio.NopCloser, fmt.Errorf("failed to create temp directory for kustomize helm auth: %w", err)
+	}
+	cleanup := utilio.NewCloser(func() error {
+		if err := os.WriteFile(kustomizationPath, originalKustomization, fileMode); err != nil {
+			_ = os.RemoveAll(tmpDir)
+			return err
+		}
+		return os.RemoveAll(tmpDir)
+	})
+
+	configHome := filepath.Join(tmpDir, "helm")
+	if err := os.MkdirAll(configHome, 0o700); err != nil {
+		utilio.Close(cleanup)
+		return utilio.NopCloser, fmt.Errorf("failed to create configHome for kustomize helm auth: %w", err)
+	}
+
+	loginCount := 0
+	alreadyLoggedIn := make(map[string]bool)
+	for _, repo := range resolvedRepos {
+		if !repo.EnableOci {
+			continue
+		}
+		registryHost, err := getHelmRegistryHost(repo.Repo)
+		if err != nil {
+			utilio.Close(cleanup)
+			return utilio.NopCloser, fmt.Errorf("failed to parse OCI registry URL %q: %w", repo.Repo, err)
+		}
+		if alreadyLoggedIn[registryHost] {
+			continue
+		}
+		alreadyLoggedIn[registryHost] = true
+		helmPassword, err := repo.GetPassword()
+		if err != nil {
+			utilio.Close(cleanup)
+			return utilio.NopCloser, fmt.Errorf("failed to get password for OCI registry %q: %w", repo.Repo, err)
+		}
+		// Match existing Helm behavior: login only when username and password are both present.
+		if repo.GetUsername() == "" || helmPassword == "" {
+			continue
+		}
+		if err := helmRegistryLogin(ctx, appPath, configHome, proxy, noProxy, repo.Repo, repo.Creds, helmPassword); err != nil {
+			utilio.Close(cleanup)
+			return utilio.NopCloser, err
+		}
+		loginCount++
+	}
+
+	if loginCount == 0 {
+		utilio.Close(cleanup)
+		return utilio.NopCloser, nil
+	}
+
+	setKustomizeHelmGlobalsConfigHome(kMap, configHome)
+	updatedKustomization, err := yaml.Marshal(kMap)
+	if err != nil {
+		utilio.Close(cleanup)
+		return utilio.NopCloser, fmt.Errorf("failed to marshal kustomization.yaml after setting helmGlobals.configHome: %w", err)
+	}
+	if err := os.WriteFile(kustomizationPath, updatedKustomization, fileMode); err != nil {
+		utilio.Close(cleanup)
+		return utilio.NopCloser, fmt.Errorf("failed to write kustomization.yaml after setting helmGlobals.configHome: %w", err)
+	}
+
+	return cleanup, nil
+}
+
+func getKustomizeHelmConfig(appPath string) (string, map[string]any, []byte, os.FileMode, error) {
+	kustomizationPath, err := findKustomizationFilePath(appPath)
+	if err != nil {
+		return "", nil, nil, 0, err
+	}
+	if kustomizationPath == "" {
+		return "", nil, nil, 0, nil
+	}
+	kustomizationFileInfo, err := os.Stat(kustomizationPath)
+	if err != nil {
+		return "", nil, nil, 0, fmt.Errorf("failed to stat kustomization.yaml: %w", err)
+	}
+	kustomizationContents, err := os.ReadFile(kustomizationPath)
+	if err != nil {
+		return "", nil, nil, 0, fmt.Errorf("failed to load kustomization.yaml: %w", err)
+	}
+	kMap := make(map[string]any)
+	if err := yaml.Unmarshal(kustomizationContents, &kMap); err != nil {
+		return "", nil, nil, 0, fmt.Errorf("failed to unmarshal kustomization.yaml: %w", err)
+	}
+	return kustomizationPath, kMap, kustomizationContents, kustomizationFileInfo.Mode(), nil
+}
+
+func findKustomizationFilePath(appPath string) (string, error) {
+	for _, file := range kustomize.KustomizationNames {
+		kustomizationPath := filepath.Join(appPath, file)
+		if info, err := os.Stat(kustomizationPath); err == nil && !info.IsDir() {
+			return kustomizationPath, nil
+		} else if err != nil && !os.IsNotExist(err) {
+			return "", fmt.Errorf("failed to stat %s: %w", kustomizationPath, err)
+		}
+	}
+	return "", nil
+}
+
+func getKustomizeHelmGlobalsConfigHome(kMap map[string]any) string {
+	helmGlobals, ok := kMap["helmGlobals"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	configHome, _ := helmGlobals["configHome"].(string)
+	return strings.TrimSpace(configHome)
+}
+
+func setKustomizeHelmGlobalsConfigHome(kMap map[string]any, configHome string) {
+	helmGlobals, ok := kMap["helmGlobals"].(map[string]any)
+	if !ok {
+		helmGlobals = make(map[string]any)
+		kMap["helmGlobals"] = helmGlobals
+	}
+	helmGlobals["configHome"] = configHome
+}
+
+func getOCIHelmChartReposFromKustomization(kMap map[string]any) []*v1alpha1.Repository {
+	helmCharts, ok := kMap["helmCharts"].([]any)
+	if !ok {
+		return nil
+	}
+	dependencies := make([]*v1alpha1.Repository, 0)
+	seen := make(map[string]bool)
+	for _, chart := range helmCharts {
+		chartMap, ok := chart.(map[string]any)
+		if !ok {
+			continue
+		}
+		repoURL, _ := chartMap["repo"].(string)
+		if !strings.HasPrefix(repoURL, ociPrefix) {
+			continue
+		}
+		if _, err := url.Parse(repoURL); err != nil {
+			continue
+		}
+		repo := strings.TrimPrefix(repoURL, ociPrefix)
+		if seen[repo] {
+			continue
+		}
+		seen[repo] = true
+		dependencies = append(dependencies, &v1alpha1.Repository{
+			Repo:      repo,
+			Name:      sanitizeRepoName(repoURL),
+			EnableOCI: true,
+		})
+	}
+	return dependencies
+}
+
+func getResolvedKustomizeHelmOCIRepos(dependencies []*v1alpha1.Repository, repositories []*v1alpha1.Repository, helmRepoCreds []*v1alpha1.RepoCreds) []helm.HelmRepository {
+	reposByName := make(map[string]*v1alpha1.Repository)
+	reposByURL := make(map[string]*v1alpha1.Repository)
+	for _, repo := range repositories {
+		reposByURL[strings.TrimPrefix(repo.Repo, ociPrefix)] = repo
+		if repo.Name != "" {
+			reposByName[repo.Name] = repo
+		}
+	}
+	repos := make([]helm.HelmRepository, 0, len(dependencies))
+	for _, dep := range dependencies {
+		// find matching repo credentials by URL or name
+		repo, ok := reposByURL[dep.Repo]
+		if !ok && dep.Name != "" {
+			repo, ok = reposByName[dep.Name]
+		}
+		if !ok {
+			// if no matching repo credentials found, use the repo creds from the credential list
+			repo = &v1alpha1.Repository{Repo: dep.Repo, Name: dep.Name, EnableOCI: dep.EnableOCI}
+			if repositoryCredential := getRepoCredential(helmRepoCreds, dep.Repo); repositoryCredential != nil {
+				repo.EnableOCI = repositoryCredential.EnableOCI
+				repo.Password = repositoryCredential.Password
+				repo.Username = repositoryCredential.Username
+				repo.SSHPrivateKey = repositoryCredential.SSHPrivateKey
+				repo.TLSClientCertData = repositoryCredential.TLSClientCertData
+				repo.TLSClientCertKey = repositoryCredential.TLSClientCertKey
+				repo.UseAzureWorkloadIdentity = repositoryCredential.UseAzureWorkloadIdentity
+			} else if repo.EnableOCI {
+				// finally if repo is OCI and no credentials found, use the first OCI credential matching by hostname
+				// see https://github.com/argoproj/argo-cd/issues/14636
+				depRepoWithScheme := ociPrefix + dep.Repo
+				for _, cred := range repositories {
+					credRepo := strings.TrimPrefix(cred.Repo, ociPrefix)
+					// if the repo is OCI, don't match the repository URL exactly, but only as a dependent repository prefix just like in the getRepoCredential function
+					// see https://github.com/argoproj/argo-cd/issues/12436
+					if (cred.EnableOCI && (strings.HasPrefix(dep.Repo, credRepo) || strings.HasPrefix(credRepo, dep.Repo))) || (cred.Type == "oci" && (strings.HasPrefix(depRepoWithScheme, cred.Repo) || strings.HasPrefix(cred.Repo, depRepoWithScheme))) {
+						repo.Username = cred.Username
+						repo.Password = cred.Password
+						repo.UseAzureWorkloadIdentity = cred.UseAzureWorkloadIdentity
+						repo.EnableOCI = true
+						break
+					}
+				}
+			}
+		}
+		repos = append(repos, helm.HelmRepository{Name: repo.Name, Repo: repo.Repo, Creds: repo.GetHelmCreds(), EnableOci: repo.EnableOCI})
+	}
+	return repos
+}
+
+func helmRegistryLogin(ctx context.Context, workDir string, configHome string, proxy string, noProxy string, repo string, creds helm.Creds, helmPassword string) error {
+	args := []string{"registry", "login"}
+	registry, err := getHelmRegistryHost(repo)
+	if err != nil {
+		return fmt.Errorf("failed to parse registry URL %q: %w", repo, err)
+	}
+	args = append(args, registry)
+
+	if creds.GetUsername() != "" {
+		args = append(args, "--username", creds.GetUsername())
+	}
+	if helmPassword != "" {
+		args = append(args, "--password", helmPassword)
+	}
+	if creds.GetCAPath() != "" {
+		args = append(args, "--ca-file", creds.GetCAPath())
+	}
+
+	if len(creds.GetCertData()) > 0 {
+		certFile, err := writeTempCredentialFile("helm-cert", creds.GetCertData())
+		if err != nil {
+			return fmt.Errorf("failed to write certificate data to temporary file: %w", err)
+		}
+		defer func() { _ = os.Remove(certFile) }()
+		args = append(args, "--cert-file", certFile)
+	}
+	if len(creds.GetKeyData()) > 0 {
+		keyFile, err := writeTempCredentialFile("helm-key", creds.GetKeyData())
+		if err != nil {
+			return fmt.Errorf("failed to write key data to temporary file: %w", err)
+		}
+		defer func() { _ = os.Remove(keyFile) }()
+		args = append(args, "--key-file", keyFile)
+	}
+	if creds.GetInsecureSkipVerify() {
+		args = append(args, "--insecure")
+	}
+
+	cmd := exec.CommandContext(ctx, "helm", args...)
+	cmd.Dir = workDir
+	cmd.Env = append(
+		os.Environ(),
+		fmt.Sprintf("HELM_CONFIG_HOME=%s", configHome),
+		fmt.Sprintf("HELM_CACHE_HOME=%s/.cache", configHome),
+		fmt.Sprintf("HELM_DATA_HOME=%s/.data", configHome),
+	)
+	cmd.Env = proxyutil.UpsertEnv(cmd, proxy, noProxy)
+	_, err = executil.RunWithRedactor(cmd, executil.Redact([]string{helmPassword}))
+	if err != nil {
+		return fmt.Errorf("failed to login to OCI registry %q: %w", repo, err)
+	}
+	return nil
+}
+
+func writeTempCredentialFile(prefix string, data []byte) (string, error) {
+	file, err := os.CreateTemp("", prefix)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	if _, err := file.Write(data); err != nil {
+		_ = os.Remove(file.Name())
+		return "", err
+	}
+	return file.Name(), nil
+}
+
+func getHelmRegistryHost(repo string) (string, error) {
+	repoURL := repo
+	if !strings.Contains(repoURL, "://") {
+		repoURL = "https://" + repoURL
+	}
+	parsedURL, err := url.Parse(repoURL)
+	if err != nil {
+		return "", err
+	}
+	if parsedURL.Host == "" {
+		return "", fmt.Errorf("empty host in URL %q", repoURL)
+	}
+	return parsedURL.Host, nil
+}
+
 // runHelmBuild executes `helm dependency build` in a given path and ensures that it is executed only once
 // if multiple threads are trying to run it.
 // Multiple goroutines might process same helm app in one repo concurrently when repo server process multiple
@@ -1712,6 +2027,20 @@ func GenerateManifests(ctx context.Context, appPath, repoRoot, revision string, 
 		if err != nil {
 			return nil, fmt.Errorf("could not parse kubernetes version %s: %w", q.ApplicationSource.GetKubeVersionOrDefault(q.KubeVersion), err)
 		}
+		kustomizeHelmAuthCloser := utilio.NopCloser
+		if isKustomizeHelmEnabled(q.KustomizeOptions) {
+			repoProxy := ""
+			repoNoProxy := ""
+			if q.Repo != nil {
+				repoProxy = q.Repo.Proxy
+				repoNoProxy = q.Repo.NoProxy
+			}
+			kustomizeHelmAuthCloser, err = prepareKustomizeHelmOCIRegistryCredentials(ctx, appPath, q.Repos, q.HelmRepoCreds, repoProxy, repoNoProxy)
+			if err != nil {
+				return nil, fmt.Errorf("error preparing kustomize helm OCI registry credentials: %w", err)
+			}
+		}
+		defer utilio.Close(kustomizeHelmAuthCloser)
 		k := kustomize.NewKustomizeApp(repoRoot, appPath, q.Repo.GetGitCreds(gitCredsStore), repoURL, kustomizeBinary, q.Repo.Proxy, q.Repo.NoProxy)
 		targetObjs, _, commands, err = k.Build(q.ApplicationSource.Kustomize, q.KustomizeOptions, env, &kustomize.BuildOpts{
 			KubeVersion: kubeVersion,

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -1452,9 +1452,9 @@ func helmRegistryLogin(ctx context.Context, workDir string, configHome string, p
 	cmd.Dir = workDir
 	cmd.Env = append(
 		os.Environ(),
-		fmt.Sprintf("HELM_CONFIG_HOME=%s", configHome),
-		fmt.Sprintf("HELM_CACHE_HOME=%s/.cache", configHome),
-		fmt.Sprintf("HELM_DATA_HOME=%s/.data", configHome),
+		"HELM_CONFIG_HOME="+configHome,
+		"HELM_CACHE_HOME="+configHome+"/.cache",
+		"HELM_DATA_HOME="+configHome+"/.data",
 	)
 	cmd.Env = proxyutil.UpsertEnv(cmd, proxy, noProxy)
 	_, err = executil.RunWithRedactor(cmd, executil.Redact([]string{helmPassword}))

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -81,6 +81,10 @@ const (
 	appSourceFile                  = ".argocd-source-%s.yaml"
 	ociPrefix                      = "oci://"
 	skipFileRenderingMarker        = "+argocd:skip-file-rendering"
+	kustomizeHelmChartsKey         = "helmCharts"
+	kustomizeHelmGlobalsKey        = "helmGlobals"
+	kustomizeHelmConfigHomeKey     = "configHome"
+	kustomizeHelmRepoKey           = "repo"
 )
 
 var ErrExceededMaxCombinedManifestFileSize = errors.New("exceeded max combined manifest file size")
@@ -1181,47 +1185,97 @@ func sanitizeRepoName(repoName string) string {
 }
 
 func isKustomizeHelmEnabled(kustomizeOptions *v1alpha1.KustomizeOptions) bool {
-	return kustomizeOptions != nil && strings.Contains(kustomizeOptions.BuildOptions, "--enable-helm")
+	return kustomizeOptions != nil && kustomize.HasEnableHelmFlag(kustomizeOptions.BuildOptions)
 }
 
-func prepareKustomizeHelmOCIRegistryCredentials(ctx context.Context, appPath string, repositories []*v1alpha1.Repository, helmRepoCreds []*v1alpha1.RepoCreds, proxy string, noProxy string) (utilio.Closer, error) {
-	kustomizationPath, kMap, originalKustomization, fileMode, err := getKustomizeHelmConfig(appPath)
+func runKustomizeBuild(ctx context.Context, appPath string, kustomizeOptions *v1alpha1.KustomizeOptions, kustomizeBinary string, repositories []*v1alpha1.Repository, helmRepoCreds []*v1alpha1.RepoCreds, proxy string, noProxy string, build func(string) error) error {
+	if !isKustomizeHelmEnabled(kustomizeOptions) {
+		return build("")
+	}
+
+	manifestGenerateLock.Lock(appPath)
+	defer manifestGenerateLock.Unlock(appPath)
+
+	kustomizeHelmAuthCloser, configHome, err := prepareKustomizeHelmOCIRegistryCredentials(ctx, appPath, repositories, helmRepoCreds, proxy, noProxy)
 	if err != nil {
-		return utilio.NopCloser, err
+		return fmt.Errorf("error preparing kustomize helm OCI registry credentials: %w", err)
+	}
+	closers := []utilio.Closer{kustomizeHelmAuthCloser}
+	helmCommand := ""
+	if configHome != "" {
+		if !kustomize.SupportsHelmCommandFlag(ctx, kustomizeBinary) {
+			closeErr := kustomizeHelmAuthCloser.Close()
+			if closeErr != nil {
+				return errors.Join(
+					fmt.Errorf("kustomize binary %q does not support --helm-command required for OCI helm auth", kustomizeBinary),
+					fmt.Errorf("error cleaning up kustomize helm OCI registry credentials: %w", closeErr),
+				)
+			}
+			return fmt.Errorf("kustomize binary %q does not support --helm-command required for OCI helm auth", kustomizeBinary)
+		}
+		var wrapperCloser utilio.Closer
+		helmCommand, wrapperCloser, err = createKustomizeHelmCommandWrapper(configHome)
+		if err != nil {
+			closeErr := kustomizeHelmAuthCloser.Close()
+			if closeErr != nil {
+				return errors.Join(
+					fmt.Errorf("error creating kustomize helm command wrapper: %w", err),
+					fmt.Errorf("error cleaning up kustomize helm OCI registry credentials: %w", closeErr),
+				)
+			}
+			return fmt.Errorf("error creating kustomize helm command wrapper: %w", err)
+		}
+		closers = append(closers, wrapperCloser)
+	}
+
+	buildErr := build(helmCommand)
+
+	var closeErr error
+	for i := len(closers) - 1; i >= 0; i-- {
+		if err := closers[i].Close(); err != nil {
+			closeErr = errors.Join(closeErr, err)
+		}
+	}
+	if closeErr != nil {
+		closeErr = fmt.Errorf("error cleaning up kustomize helm OCI registry credentials: %w", closeErr)
+	}
+	return errors.Join(buildErr, closeErr)
+}
+
+func prepareKustomizeHelmOCIRegistryCredentials(ctx context.Context, appPath string, repositories []*v1alpha1.Repository, helmRepoCreds []*v1alpha1.RepoCreds, proxy string, noProxy string) (utilio.Closer, string, error) {
+	kustomizationPath, kMap, err := getKustomizeHelmConfig(appPath)
+	if err != nil {
+		return utilio.NopCloser, "", err
 	}
 	if kustomizationPath == "" {
-		return utilio.NopCloser, nil
+		return utilio.NopCloser, "", nil
 	}
 	if getKustomizeHelmGlobalsConfigHome(kMap) != "" {
 		// Respect explicit user configuration.
-		return utilio.NopCloser, nil
+		return utilio.NopCloser, "", nil
 	}
 
 	ociDependencies := getOCIHelmChartReposFromKustomization(kMap)
 	if len(ociDependencies) == 0 {
-		return utilio.NopCloser, nil
+		return utilio.NopCloser, "", nil
 	}
 	resolvedRepos := getResolvedKustomizeHelmOCIRepos(ociDependencies, repositories, helmRepoCreds)
 	if len(resolvedRepos) == 0 {
-		return utilio.NopCloser, nil
+		return utilio.NopCloser, "", nil
 	}
 
 	tmpDir, err := os.MkdirTemp("", "kustomize-helm-auth-")
 	if err != nil {
-		return utilio.NopCloser, fmt.Errorf("failed to create temp directory for kustomize helm auth: %w", err)
+		return utilio.NopCloser, "", fmt.Errorf("failed to create temp directory for kustomize helm auth: %w", err)
 	}
 	cleanup := utilio.NewCloser(func() error {
-		if err := os.WriteFile(kustomizationPath, originalKustomization, fileMode); err != nil {
-			_ = os.RemoveAll(tmpDir)
-			return err
-		}
 		return os.RemoveAll(tmpDir)
 	})
 
 	configHome := filepath.Join(tmpDir, "helm")
 	if err := os.MkdirAll(configHome, 0o700); err != nil {
 		utilio.Close(cleanup)
-		return utilio.NopCloser, fmt.Errorf("failed to create configHome for kustomize helm auth: %w", err)
+		return utilio.NopCloser, "", fmt.Errorf("failed to create configHome for kustomize helm auth: %w", err)
 	}
 
 	loginCount := 0
@@ -1233,7 +1287,7 @@ func prepareKustomizeHelmOCIRegistryCredentials(ctx context.Context, appPath str
 		registryHost, err := getHelmRegistryHost(repo.Repo)
 		if err != nil {
 			utilio.Close(cleanup)
-			return utilio.NopCloser, fmt.Errorf("failed to parse OCI registry URL %q: %w", repo.Repo, err)
+			return utilio.NopCloser, "", fmt.Errorf("failed to parse OCI registry URL %q: %w", repo.Repo, err)
 		}
 		if alreadyLoggedIn[registryHost] {
 			continue
@@ -1242,7 +1296,7 @@ func prepareKustomizeHelmOCIRegistryCredentials(ctx context.Context, appPath str
 		helmPassword, err := repo.GetPassword()
 		if err != nil {
 			utilio.Close(cleanup)
-			return utilio.NopCloser, fmt.Errorf("failed to get password for OCI registry %q: %w", repo.Repo, err)
+			return utilio.NopCloser, "", fmt.Errorf("failed to get password for OCI registry %q: %w", repo.Repo, err)
 		}
 		// Match existing Helm behavior: login only when username and password are both present.
 		if repo.GetUsername() == "" || helmPassword == "" {
@@ -1250,51 +1304,36 @@ func prepareKustomizeHelmOCIRegistryCredentials(ctx context.Context, appPath str
 		}
 		if err := helmRegistryLogin(ctx, appPath, configHome, proxy, noProxy, repo.Repo, repo.Creds, helmPassword); err != nil {
 			utilio.Close(cleanup)
-			return utilio.NopCloser, err
+			return utilio.NopCloser, "", err
 		}
 		loginCount++
 	}
 
 	if loginCount == 0 {
 		utilio.Close(cleanup)
-		return utilio.NopCloser, nil
+		return utilio.NopCloser, "", nil
 	}
 
-	setKustomizeHelmGlobalsConfigHome(kMap, configHome)
-	updatedKustomization, err := yaml.Marshal(kMap)
-	if err != nil {
-		utilio.Close(cleanup)
-		return utilio.NopCloser, fmt.Errorf("failed to marshal kustomization.yaml after setting helmGlobals.configHome: %w", err)
-	}
-	if err := os.WriteFile(kustomizationPath, updatedKustomization, fileMode); err != nil {
-		utilio.Close(cleanup)
-		return utilio.NopCloser, fmt.Errorf("failed to write kustomization.yaml after setting helmGlobals.configHome: %w", err)
-	}
-
-	return cleanup, nil
+	return cleanup, configHome, nil
 }
 
-func getKustomizeHelmConfig(appPath string) (string, map[string]any, []byte, os.FileMode, error) {
+func getKustomizeHelmConfig(appPath string) (string, map[string]any, error) {
 	kustomizationPath, err := findKustomizationFilePath(appPath)
 	if err != nil {
-		return "", nil, nil, 0, err
+		return "", nil, err
 	}
 	if kustomizationPath == "" {
-		return "", nil, nil, 0, nil
-	}
-	kustomizationFileInfo, err := os.Stat(kustomizationPath)
-	if err != nil {
-		return "", nil, nil, 0, fmt.Errorf("failed to stat kustomization.yaml: %w", err)
+		return "", nil, nil
 	}
 	kustomizationContents, err := os.ReadFile(kustomizationPath)
 	if err != nil {
-		return "", nil, nil, 0, fmt.Errorf("failed to load kustomization.yaml: %w", err)
+		return "", nil, fmt.Errorf("failed to load kustomization.yaml: %w", err)
 	}
 	kMap := make(map[string]any)
 	if err := yaml.Unmarshal(kustomizationContents, &kMap); err != nil {
-		return "", nil, nil, 0, fmt.Errorf("failed to unmarshal kustomization.yaml: %w", err)
+		return "", nil, fmt.Errorf("failed to unmarshal kustomization.yaml: %w", err)
 	}
-	return kustomizationPath, kMap, kustomizationContents, kustomizationFileInfo.Mode(), nil
+	return kustomizationPath, kMap, nil
 }
 
 func findKustomizationFilePath(appPath string) (string, error) {
@@ -1310,25 +1349,16 @@ func findKustomizationFilePath(appPath string) (string, error) {
 }
 
 func getKustomizeHelmGlobalsConfigHome(kMap map[string]any) string {
-	helmGlobals, ok := kMap["helmGlobals"].(map[string]any)
+	helmGlobals, ok := kMap[kustomizeHelmGlobalsKey].(map[string]any)
 	if !ok {
 		return ""
 	}
-	configHome, _ := helmGlobals["configHome"].(string)
+	configHome, _ := helmGlobals[kustomizeHelmConfigHomeKey].(string)
 	return strings.TrimSpace(configHome)
 }
 
-func setKustomizeHelmGlobalsConfigHome(kMap map[string]any, configHome string) {
-	helmGlobals, ok := kMap["helmGlobals"].(map[string]any)
-	if !ok {
-		helmGlobals = make(map[string]any)
-		kMap["helmGlobals"] = helmGlobals
-	}
-	helmGlobals["configHome"] = configHome
-}
-
 func getOCIHelmChartReposFromKustomization(kMap map[string]any) []*v1alpha1.Repository {
-	helmCharts, ok := kMap["helmCharts"].([]any)
+	helmCharts, ok := kMap[kustomizeHelmChartsKey].([]any)
 	if !ok {
 		return nil
 	}
@@ -1339,7 +1369,7 @@ func getOCIHelmChartReposFromKustomization(kMap map[string]any) []*v1alpha1.Repo
 		if !ok {
 			continue
 		}
-		repoURL, _ := chartMap["repo"].(string)
+		repoURL, _ := chartMap[kustomizeHelmRepoKey].(string)
 		if !strings.HasPrefix(repoURL, ociPrefix) {
 			continue
 		}
@@ -1361,53 +1391,93 @@ func getOCIHelmChartReposFromKustomization(kMap map[string]any) []*v1alpha1.Repo
 }
 
 func getResolvedKustomizeHelmOCIRepos(dependencies []*v1alpha1.Repository, repositories []*v1alpha1.Repository, helmRepoCreds []*v1alpha1.RepoCreds) []helm.HelmRepository {
-	reposByName := make(map[string]*v1alpha1.Repository)
-	reposByURL := make(map[string]*v1alpha1.Repository)
-	for _, repo := range repositories {
-		reposByURL[strings.TrimPrefix(repo.Repo, ociPrefix)] = repo
-		if repo.Name != "" {
-			reposByName[repo.Name] = repo
-		}
-	}
+	resolver := newKustomizeHelmOCIRepoResolver(repositories, helmRepoCreds)
 	repos := make([]helm.HelmRepository, 0, len(dependencies))
 	for _, dep := range dependencies {
-		// find matching repo credentials by URL or name
-		repo, ok := reposByURL[dep.Repo]
-		if !ok && dep.Name != "" {
-			repo, ok = reposByName[dep.Name]
-		}
-		if !ok {
-			// if no matching repo credentials found, use the repo creds from the credential list
-			repo = &v1alpha1.Repository{Repo: dep.Repo, Name: dep.Name, EnableOCI: dep.EnableOCI}
-			if repositoryCredential := getRepoCredential(helmRepoCreds, dep.Repo); repositoryCredential != nil {
-				repo.EnableOCI = repositoryCredential.EnableOCI
-				repo.Password = repositoryCredential.Password
-				repo.Username = repositoryCredential.Username
-				repo.SSHPrivateKey = repositoryCredential.SSHPrivateKey
-				repo.TLSClientCertData = repositoryCredential.TLSClientCertData
-				repo.TLSClientCertKey = repositoryCredential.TLSClientCertKey
-				repo.UseAzureWorkloadIdentity = repositoryCredential.UseAzureWorkloadIdentity
-			} else if repo.EnableOCI {
-				// finally if repo is OCI and no credentials found, use the first OCI credential matching by hostname
-				// see https://github.com/argoproj/argo-cd/issues/14636
-				depRepoWithScheme := ociPrefix + dep.Repo
-				for _, cred := range repositories {
-					credRepo := strings.TrimPrefix(cred.Repo, ociPrefix)
-					// if the repo is OCI, don't match the repository URL exactly, but only as a dependent repository prefix just like in the getRepoCredential function
-					// see https://github.com/argoproj/argo-cd/issues/12436
-					if (cred.EnableOCI && (strings.HasPrefix(dep.Repo, credRepo) || strings.HasPrefix(credRepo, dep.Repo))) || (cred.Type == "oci" && (strings.HasPrefix(depRepoWithScheme, cred.Repo) || strings.HasPrefix(cred.Repo, depRepoWithScheme))) {
-						repo.Username = cred.Username
-						repo.Password = cred.Password
-						repo.UseAzureWorkloadIdentity = cred.UseAzureWorkloadIdentity
-						repo.EnableOCI = true
-						break
-					}
-				}
-			}
-		}
+		repo := resolver.resolve(dep)
 		repos = append(repos, helm.HelmRepository{Name: repo.Name, Repo: repo.Repo, Creds: repo.GetHelmCreds(), EnableOci: repo.EnableOCI})
 	}
 	return repos
+}
+
+type kustomizeHelmOCIRepoResolver struct {
+	repositories  []*v1alpha1.Repository
+	helmRepoCreds []*v1alpha1.RepoCreds
+	reposByName   map[string]*v1alpha1.Repository
+	reposByURL    map[string]*v1alpha1.Repository
+}
+
+func newKustomizeHelmOCIRepoResolver(repositories []*v1alpha1.Repository, helmRepoCreds []*v1alpha1.RepoCreds) kustomizeHelmOCIRepoResolver {
+	resolver := kustomizeHelmOCIRepoResolver{
+		repositories:  repositories,
+		helmRepoCreds: helmRepoCreds,
+		reposByName:   make(map[string]*v1alpha1.Repository),
+		reposByURL:    make(map[string]*v1alpha1.Repository),
+	}
+	for _, repo := range repositories {
+		resolver.reposByURL[strings.TrimPrefix(repo.Repo, ociPrefix)] = repo
+		if repo.Name != "" {
+			resolver.reposByName[repo.Name] = repo
+		}
+	}
+	return resolver
+}
+
+func (r kustomizeHelmOCIRepoResolver) resolve(dep *v1alpha1.Repository) *v1alpha1.Repository {
+	if repo, ok := r.findMatchingRepository(dep); ok {
+		return repo
+	}
+
+	repo := &v1alpha1.Repository{Repo: dep.Repo, Name: dep.Name, EnableOCI: dep.EnableOCI}
+	if repositoryCredential := getRepoCredential(r.helmRepoCreds, dep.Repo); repositoryCredential != nil {
+		applyRepoCredsToRepository(repo, repositoryCredential)
+		return repo
+	}
+
+	if repo.EnableOCI {
+		r.applyMatchingOCIRepositoryCredentials(repo)
+	}
+
+	return repo
+}
+
+func (r kustomizeHelmOCIRepoResolver) findMatchingRepository(dep *v1alpha1.Repository) (*v1alpha1.Repository, bool) {
+	repo, ok := r.reposByURL[dep.Repo]
+	if ok {
+		return repo, true
+	}
+	if dep.Name == "" {
+		return nil, false
+	}
+	repo, ok = r.reposByName[dep.Name]
+	return repo, ok
+}
+
+func applyRepoCredsToRepository(repo *v1alpha1.Repository, repositoryCredential *v1alpha1.RepoCreds) {
+	repo.EnableOCI = repositoryCredential.EnableOCI
+	repo.Password = repositoryCredential.Password
+	repo.Username = repositoryCredential.Username
+	repo.SSHPrivateKey = repositoryCredential.SSHPrivateKey
+	repo.TLSClientCertData = repositoryCredential.TLSClientCertData
+	repo.TLSClientCertKey = repositoryCredential.TLSClientCertKey
+	repo.UseAzureWorkloadIdentity = repositoryCredential.UseAzureWorkloadIdentity
+}
+
+func (r kustomizeHelmOCIRepoResolver) applyMatchingOCIRepositoryCredentials(repo *v1alpha1.Repository) {
+	// Use the first OCI credential matching by prefix when there is no exact repository or repo-creds match.
+	// See https://github.com/argoproj/argo-cd/issues/14636 and https://github.com/argoproj/argo-cd/issues/12436.
+	depRepoWithScheme := ociPrefix + repo.Repo
+	for _, candidate := range r.repositories {
+		candidateRepo := strings.TrimPrefix(candidate.Repo, ociPrefix)
+		if (candidate.EnableOCI && (strings.HasPrefix(repo.Repo, candidateRepo) || strings.HasPrefix(candidateRepo, repo.Repo))) ||
+			(candidate.Type == "oci" && (strings.HasPrefix(depRepoWithScheme, candidate.Repo) || strings.HasPrefix(candidate.Repo, depRepoWithScheme))) {
+			repo.Username = candidate.Username
+			repo.Password = candidate.Password
+			repo.UseAzureWorkloadIdentity = candidate.UseAzureWorkloadIdentity
+			repo.EnableOCI = true
+			return
+		}
+	}
 }
 
 func helmRegistryLogin(ctx context.Context, workDir string, configHome string, proxy string, noProxy string, repo string, creds helm.Creds, helmPassword string) error {
@@ -1422,7 +1492,7 @@ func helmRegistryLogin(ctx context.Context, workDir string, configHome string, p
 		args = append(args, "--username", creds.GetUsername())
 	}
 	if helmPassword != "" {
-		args = append(args, "--password", helmPassword)
+		args = append(args, "--password-stdin")
 	}
 	if creds.GetCAPath() != "" {
 		args = append(args, "--ca-file", creds.GetCAPath())
@@ -1450,18 +1520,68 @@ func helmRegistryLogin(ctx context.Context, workDir string, configHome string, p
 
 	cmd := exec.CommandContext(ctx, "helm", args...)
 	cmd.Dir = workDir
-	cmd.Env = append(
-		os.Environ(),
-		"HELM_CONFIG_HOME="+configHome,
-		"HELM_CACHE_HOME="+configHome+"/.cache",
-		"HELM_DATA_HOME="+configHome+"/.data",
-	)
+	if helmPassword != "" {
+		cmd.Stdin = bytes.NewBufferString(helmPassword)
+	}
+	cmd.Env = helmRegistryLoginEnv(configHome)
 	cmd.Env = proxyutil.UpsertEnv(cmd, proxy, noProxy)
 	_, err = executil.RunWithRedactor(cmd, executil.Redact([]string{helmPassword}))
 	if err != nil {
 		return fmt.Errorf("failed to login to OCI registry %q: %w", repo, err)
 	}
 	return nil
+}
+
+func helmRegistryLoginEnv(configHome string) []string {
+	env := make([]string, 0, 9)
+	for _, key := range []string{"HOME", "PATH", "SSL_CERT_DIR", "SSL_CERT_FILE", "TMPDIR", "TMP", "TEMP"} {
+		if value, ok := os.LookupEnv(key); ok {
+			env = append(env, key+"="+value)
+		}
+	}
+	return append(env,
+		"HELM_CONFIG_HOME="+configHome,
+		"HELM_CACHE_HOME="+configHome+"/.cache",
+		"HELM_DATA_HOME="+configHome+"/.data",
+	)
+}
+
+func createKustomizeHelmCommandWrapper(configHome string) (string, utilio.Closer, error) {
+	helmPath, err := exec.LookPath("helm")
+	if err != nil {
+		return "", utilio.NopCloser, fmt.Errorf("failed to resolve helm binary path: %w", err)
+	}
+	helmCacheHome := filepath.Join(configHome, ".cache")
+	helmDataHome := filepath.Join(configHome, ".data")
+	wrapperScript := fmt.Sprintf(`#!/bin/sh
+set -eu
+export HELM_CONFIG_HOME=%q
+export HELM_CACHE_HOME=%q
+export HELM_DATA_HOME=%q
+exec %q "$@"
+`, configHome, helmCacheHome, helmDataHome, helmPath)
+	file, err := os.CreateTemp("", "argocd-kustomize-helm-wrapper-*")
+	if err != nil {
+		return "", utilio.NopCloser, fmt.Errorf("failed to create kustomize helm wrapper: %w", err)
+	}
+	filePath := file.Name()
+	cleanup := utilio.NewCloser(func() error {
+		return os.Remove(filePath)
+	})
+	if _, err := file.WriteString(wrapperScript); err != nil {
+		utilio.Close(cleanup)
+		_ = file.Close()
+		return "", utilio.NopCloser, fmt.Errorf("failed to write kustomize helm wrapper: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		utilio.Close(cleanup)
+		return "", utilio.NopCloser, fmt.Errorf("failed to close kustomize helm wrapper: %w", err)
+	}
+	if err := os.Chmod(filePath, 0o700); err != nil {
+		utilio.Close(cleanup)
+		return "", utilio.NopCloser, fmt.Errorf("failed to set executable permissions on kustomize helm wrapper: %w", err)
+	}
+	return filePath, cleanup, nil
 }
 
 func writeTempCredentialFile(prefix string, data []byte) (string, error) {
@@ -2027,24 +2147,14 @@ func GenerateManifests(ctx context.Context, appPath, repoRoot, revision string, 
 		if err != nil {
 			return nil, fmt.Errorf("could not parse kubernetes version %s: %w", q.ApplicationSource.GetKubeVersionOrDefault(q.KubeVersion), err)
 		}
-		kustomizeHelmAuthCloser := utilio.NopCloser
-		if isKustomizeHelmEnabled(q.KustomizeOptions) {
-			repoProxy := ""
-			repoNoProxy := ""
-			if q.Repo != nil {
-				repoProxy = q.Repo.Proxy
-				repoNoProxy = q.Repo.NoProxy
-			}
-			kustomizeHelmAuthCloser, err = prepareKustomizeHelmOCIRegistryCredentials(ctx, appPath, q.Repos, q.HelmRepoCreds, repoProxy, repoNoProxy)
-			if err != nil {
-				return nil, fmt.Errorf("error preparing kustomize helm OCI registry credentials: %w", err)
-			}
-		}
-		defer utilio.Close(kustomizeHelmAuthCloser)
 		k := kustomize.NewKustomizeApp(repoRoot, appPath, q.Repo.GetGitCreds(gitCredsStore), repoURL, kustomizeBinary, q.Repo.Proxy, q.Repo.NoProxy)
-		targetObjs, _, commands, err = k.Build(q.ApplicationSource.Kustomize, q.KustomizeOptions, env, &kustomize.BuildOpts{
-			KubeVersion: kubeVersion,
-			APIVersions: q.ApplicationSource.GetAPIVersionsOrDefault(q.ApiVersions),
+		err = runKustomizeBuild(ctx, appPath, q.KustomizeOptions, kustomizeBinary, q.Repos, q.HelmRepoCreds, q.Repo.Proxy, q.Repo.NoProxy, func(helmCommand string) error {
+			targetObjs, _, commands, err = k.Build(q.ApplicationSource.Kustomize, q.KustomizeOptions, env, &kustomize.BuildOpts{
+				KubeVersion: kubeVersion,
+				APIVersions: q.ApplicationSource.GetAPIVersionsOrDefault(q.ApiVersions),
+				HelmCommand: helmCommand,
+			})
+			return err
 		})
 		if err != nil {
 			return nil, err
@@ -2711,7 +2821,7 @@ func (s *Service) GetAppDetails(ctx context.Context, q *apiclient.RepoServerAppD
 				return err
 			}
 		case v1alpha1.ApplicationSourceTypeKustomize:
-			if err := populateKustomizeAppDetails(res, q, repoRoot, opContext.appPath, commitSHA, s.gitCredsStore); err != nil {
+			if err := populateKustomizeAppDetails(ctx, res, q, repoRoot, opContext.appPath, commitSHA, s.gitCredsStore); err != nil {
 				return err
 			}
 		case v1alpha1.ApplicationSourceTypePlugin:
@@ -2897,12 +3007,13 @@ func walkHelmValueFilesInPath(root string, valueFiles *[]string) filepath.WalkFu
 	}
 }
 
-func populateKustomizeAppDetails(res *apiclient.RepoAppDetailsResponse, q *apiclient.RepoServerAppDetailsQuery, repoRoot string, appPath string, reversion string, credsStore git.CredsStore) error {
+func populateKustomizeAppDetails(ctx context.Context, res *apiclient.RepoAppDetailsResponse, q *apiclient.RepoServerAppDetailsQuery, repoRoot string, appPath string, reversion string, credsStore git.CredsStore) error {
 	res.Kustomize = &apiclient.KustomizeAppSpec{}
 	kustomizeBinary, err := settings.GetKustomizeBinaryPath(q.KustomizeOptions, *q.Source)
 	if err != nil {
 		return fmt.Errorf("failed to get kustomize binary path: %w", err)
 	}
+	var images []string
 	k := kustomize.NewKustomizeApp(repoRoot, appPath, q.Repo.GetGitCreds(credsStore), q.Repo.Repo, kustomizeBinary, q.Repo.Proxy, q.Repo.NoProxy)
 	fakeManifestRequest := apiclient.ManifestRequest{
 		AppName:           q.AppName,
@@ -2911,7 +3022,10 @@ func populateKustomizeAppDetails(res *apiclient.RepoAppDetailsResponse, q *apicl
 		ApplicationSource: q.Source,
 	}
 	env := newEnv(&fakeManifestRequest, reversion)
-	_, images, _, err := k.Build(q.Source.Kustomize, q.KustomizeOptions, env, nil)
+	err = runKustomizeBuild(ctx, appPath, q.KustomizeOptions, kustomizeBinary, q.Repos, nil, q.Repo.Proxy, q.Repo.NoProxy, func(helmCommand string) error {
+		_, images, _, err = k.Build(q.Source.Kustomize, q.KustomizeOptions, env, &kustomize.BuildOpts{HelmCommand: helmCommand})
+		return err
+	})
 	if err != nil {
 		return err
 	}

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -3736,6 +3736,142 @@ func TestGetHelmRepo_NamedReposAlias(t *testing.T) {
 	assert.Equal(t, "https://example.com", helmRepos[0].Repo)
 }
 
+func Test_getOCIHelmChartReposFromKustomization(t *testing.T) {
+	kMap := map[string]any{
+		"helmCharts": []any{
+			map[string]any{
+				"name": "private-chart",
+				"repo": "oci://example.azurecr.io/charts",
+			},
+			map[string]any{
+				"name": "public-chart",
+				"repo": "https://charts.example.com",
+			},
+			map[string]any{
+				"name": "duplicate",
+				"repo": "oci://example.azurecr.io/charts",
+			},
+		},
+	}
+
+	repos := getOCIHelmChartReposFromKustomization(kMap)
+	require.Len(t, repos, 1)
+	assert.Equal(t, "example.azurecr.io/charts", repos[0].Repo)
+	assert.True(t, repos[0].EnableOCI)
+}
+
+func Test_prepareKustomizeHelmOCIRegistryCredentials_injectsConfigHomeAndLogsIn(t *testing.T) {
+	appPath := t.TempDir()
+	kustomizationPath := filepath.Join(appPath, "kustomization.yaml")
+	err := os.WriteFile(kustomizationPath, []byte(`
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+helmCharts:
+  - name: my-chart
+    repo: oci://example.azurecr.io/charts
+    version: 1.2.3
+`), 0o644)
+	require.NoError(t, err)
+
+	binDir := filepath.Join(t.TempDir(), "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	helmArgsFile := filepath.Join(t.TempDir(), "helm-args.log")
+	helmConfigHomeFile := filepath.Join(t.TempDir(), "helm-config-home.log")
+	fakeHelm := filepath.Join(binDir, "helm")
+	fakeHelmScript := `#!/bin/sh
+echo "$HELM_CONFIG_HOME" > "$HELM_TEST_CONFIG_HOME_FILE"
+echo "$@" >> "$HELM_TEST_ARGS_FILE"
+exit 0
+`
+	require.NoError(t, os.WriteFile(fakeHelm, []byte(fakeHelmScript), 0o755))
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("HELM_TEST_ARGS_FILE", helmArgsFile)
+	t.Setenv("HELM_TEST_CONFIG_HOME_FILE", helmConfigHomeFile)
+
+	repositories := []*v1alpha1.Repository{{
+		Repo:      "oci://example.azurecr.io/charts",
+		Username:  "test-user",
+		Password:  "test-password",
+		EnableOCI: true,
+	}}
+
+	closer, err := prepareKustomizeHelmOCIRegistryCredentials(t.Context(), appPath, repositories, nil, "", "")
+	require.NoError(t, err)
+
+	updatedKustomization, err := os.ReadFile(kustomizationPath)
+	require.NoError(t, err)
+	kMap := map[string]any{}
+	require.NoError(t, yaml.Unmarshal(updatedKustomization, &kMap))
+
+	configHome := getKustomizeHelmGlobalsConfigHome(kMap)
+	require.NotEmpty(t, configHome)
+
+	loggedConfigHome, err := os.ReadFile(helmConfigHomeFile)
+	require.NoError(t, err)
+	assert.Equal(t, configHome, strings.TrimSpace(string(loggedConfigHome)))
+
+	argsLog, err := os.ReadFile(helmArgsFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(argsLog), "registry login example.azurecr.io")
+
+	utilio.Close(closer)
+
+	restoredKustomization, err := os.ReadFile(kustomizationPath)
+	require.NoError(t, err)
+	restoredMap := map[string]any{}
+	require.NoError(t, yaml.Unmarshal(restoredKustomization, &restoredMap))
+	assert.Empty(t, getKustomizeHelmGlobalsConfigHome(restoredMap))
+}
+
+func Test_prepareKustomizeHelmOCIRegistryCredentials_respectsExistingConfigHome(t *testing.T) {
+	appPath := t.TempDir()
+	kustomizationPath := filepath.Join(appPath, "kustomization.yaml")
+	const existingConfigHome = "/tmp/existing-config-home"
+	err := os.WriteFile(kustomizationPath, []byte(`
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+helmGlobals:
+  configHome: /tmp/existing-config-home
+helmCharts:
+  - name: my-chart
+    repo: oci://example.azurecr.io/charts
+    version: 1.2.3
+`), 0o644)
+	require.NoError(t, err)
+
+	binDir := filepath.Join(t.TempDir(), "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	helmArgsFile := filepath.Join(t.TempDir(), "helm-args.log")
+	fakeHelm := filepath.Join(binDir, "helm")
+	fakeHelmScript := `#!/bin/sh
+echo "$@" >> "$HELM_TEST_ARGS_FILE"
+exit 0
+`
+	require.NoError(t, os.WriteFile(fakeHelm, []byte(fakeHelmScript), 0o755))
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("HELM_TEST_ARGS_FILE", helmArgsFile)
+
+	repositories := []*v1alpha1.Repository{{
+		Repo:      "oci://example.azurecr.io/charts",
+		Username:  "test-user",
+		Password:  "test-password",
+		EnableOCI: true,
+	}}
+
+	closer, err := prepareKustomizeHelmOCIRegistryCredentials(t.Context(), appPath, repositories, nil, "", "")
+	require.NoError(t, err)
+	utilio.Close(closer)
+
+	updatedKustomization, err := os.ReadFile(kustomizationPath)
+	require.NoError(t, err)
+	kMap := map[string]any{}
+	require.NoError(t, yaml.Unmarshal(updatedKustomization, &kMap))
+	assert.Equal(t, existingConfigHome, getKustomizeHelmGlobalsConfigHome(kMap))
+
+	_, err = os.Stat(helmArgsFile)
+	assert.True(t, os.IsNotExist(err))
+}
+
 func Test_getResolvedValueFiles(t *testing.T) {
 	t.Parallel()
 

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -3760,7 +3760,82 @@ func Test_getOCIHelmChartReposFromKustomization(t *testing.T) {
 	assert.True(t, repos[0].EnableOCI)
 }
 
-func Test_prepareKustomizeHelmOCIRegistryCredentials_injectsConfigHomeAndLogsIn(t *testing.T) {
+func Test_isKustomizeHelmEnabled(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name         string
+		buildOptions string
+		expected     bool
+	}{
+		{name: "missing", buildOptions: "--load-restrictor LoadRestrictionsNone", expected: false},
+		{name: "exact flag", buildOptions: "--enable-helm", expected: true},
+		{name: "true assignment", buildOptions: "--enable-helm=true", expected: true},
+		{name: "false assignment", buildOptions: "--enable-helm=false", expected: false},
+		{name: "substring only", buildOptions: "--enable-helm-plugins", expected: false},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, testCase.expected, isKustomizeHelmEnabled(&v1alpha1.KustomizeOptions{BuildOptions: testCase.buildOptions}))
+		})
+	}
+}
+
+func Test_getResolvedKustomizeHelmOCIRepos(t *testing.T) {
+	t.Parallel()
+
+	t.Run("uses repo creds template when no repository match exists", func(t *testing.T) {
+		t.Parallel()
+
+		dependencies := []*v1alpha1.Repository{{
+			Repo:      "example.azurecr.io/charts",
+			Name:      "example-azurecr-io-charts",
+			EnableOCI: true,
+		}}
+		helmRepoCreds := []*v1alpha1.RepoCreds{{
+			URL:       "example.azurecr.io/charts",
+			Username:  "template-user",
+			Password:  "template-password",
+			EnableOCI: true,
+		}}
+
+		repos := getResolvedKustomizeHelmOCIRepos(dependencies, nil, helmRepoCreds)
+		require.Len(t, repos, 1)
+		assert.Equal(t, "template-user", repos[0].GetUsername())
+		password, err := repos[0].GetPassword()
+		require.NoError(t, err)
+		assert.Equal(t, "template-password", password)
+		assert.True(t, repos[0].EnableOci)
+	})
+
+	t.Run("falls back to OCI repository prefix match", func(t *testing.T) {
+		t.Parallel()
+
+		dependencies := []*v1alpha1.Repository{{
+			Repo:      "example.azurecr.io/charts/team-a",
+			Name:      "example-azurecr-io-charts-team-a",
+			EnableOCI: true,
+		}}
+		repositories := []*v1alpha1.Repository{{
+			Repo:      "oci://example.azurecr.io/charts",
+			Username:  "prefix-user",
+			Password:  "prefix-password",
+			EnableOCI: true,
+		}}
+
+		repos := getResolvedKustomizeHelmOCIRepos(dependencies, repositories, nil)
+		require.Len(t, repos, 1)
+		assert.Equal(t, "prefix-user", repos[0].GetUsername())
+		password, err := repos[0].GetPassword()
+		require.NoError(t, err)
+		assert.Equal(t, "prefix-password", password)
+		assert.True(t, repos[0].EnableOci)
+	})
+}
+
+func Test_prepareKustomizeHelmOCIRegistryCredentials_returnsConfigHomeAndLogsIn(t *testing.T) {
 	appPath := t.TempDir()
 	kustomizationPath := filepath.Join(appPath, "kustomization.yaml")
 	err := os.WriteFile(kustomizationPath, []byte(`
@@ -3772,21 +3847,26 @@ helmCharts:
     version: 1.2.3
 `), 0o644)
 	require.NoError(t, err)
+	originalKustomization, err := os.ReadFile(kustomizationPath)
+	require.NoError(t, err)
 
 	binDir := filepath.Join(t.TempDir(), "bin")
 	require.NoError(t, os.MkdirAll(binDir, 0o755))
 	helmArgsFile := filepath.Join(t.TempDir(), "helm-args.log")
 	helmConfigHomeFile := filepath.Join(t.TempDir(), "helm-config-home.log")
+	helmEnvFile := filepath.Join(t.TempDir(), "helm-env.log")
+	helmPasswordFile := filepath.Join(t.TempDir(), "helm-password.log")
 	fakeHelm := filepath.Join(binDir, "helm")
-	fakeHelmScript := `#!/bin/sh
-echo "$HELM_CONFIG_HOME" > "$HELM_TEST_CONFIG_HOME_FILE"
-echo "$@" >> "$HELM_TEST_ARGS_FILE"
+	fakeHelmScript := fmt.Sprintf(`#!/bin/sh
+cat > %q
+env | sort > %q
+echo "$HELM_CONFIG_HOME" > %q
+echo "$@" >> %q
 exit 0
-`
+`, helmPasswordFile, helmEnvFile, helmConfigHomeFile, helmArgsFile)
 	require.NoError(t, os.WriteFile(fakeHelm, []byte(fakeHelmScript), 0o755))
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
-	t.Setenv("HELM_TEST_ARGS_FILE", helmArgsFile)
-	t.Setenv("HELM_TEST_CONFIG_HOME_FILE", helmConfigHomeFile)
+	t.Setenv("KUSTOMIZE_HELM_UNRELATED_ENV", "should-not-be-passed")
 
 	repositories := []*v1alpha1.Repository{{
 		Repo:      "oci://example.azurecr.io/charts",
@@ -3795,16 +3875,13 @@ exit 0
 		EnableOCI: true,
 	}}
 
-	closer, err := prepareKustomizeHelmOCIRegistryCredentials(t.Context(), appPath, repositories, nil, "", "")
+	closer, configHome, err := prepareKustomizeHelmOCIRegistryCredentials(t.Context(), appPath, repositories, nil, "", "")
 	require.NoError(t, err)
+	require.NotEmpty(t, configHome)
 
 	updatedKustomization, err := os.ReadFile(kustomizationPath)
 	require.NoError(t, err)
-	kMap := map[string]any{}
-	require.NoError(t, yaml.Unmarshal(updatedKustomization, &kMap))
-
-	configHome := getKustomizeHelmGlobalsConfigHome(kMap)
-	require.NotEmpty(t, configHome)
+	assert.Equal(t, string(originalKustomization), string(updatedKustomization))
 
 	loggedConfigHome, err := os.ReadFile(helmConfigHomeFile)
 	require.NoError(t, err)
@@ -3813,14 +3890,28 @@ exit 0
 	argsLog, err := os.ReadFile(helmArgsFile)
 	require.NoError(t, err)
 	assert.Contains(t, string(argsLog), "registry login example.azurecr.io")
+	assert.Contains(t, string(argsLog), "--password-stdin")
+	assert.NotContains(t, string(argsLog), "--password test-password")
 
-	utilio.Close(closer)
+	loggedPassword, err := os.ReadFile(helmPasswordFile)
+	require.NoError(t, err)
+	assert.Equal(t, "test-password", strings.TrimSpace(string(loggedPassword)))
+
+	envLog, err := os.ReadFile(helmEnvFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(envLog), "HELM_CONFIG_HOME="+strings.TrimSpace(string(configHome)))
+	assert.Contains(t, string(envLog), "HELM_CACHE_HOME="+strings.TrimSpace(string(configHome))+"/.cache")
+	assert.Contains(t, string(envLog), "HELM_DATA_HOME="+strings.TrimSpace(string(configHome))+"/.data")
+	assert.NotContains(t, string(envLog), "KUSTOMIZE_HELM_UNRELATED_ENV=should-not-be-passed")
+
+	require.NoError(t, closer.Close())
+
+	_, err = os.Stat(configHome)
+	assert.True(t, os.IsNotExist(err))
 
 	restoredKustomization, err := os.ReadFile(kustomizationPath)
 	require.NoError(t, err)
-	restoredMap := map[string]any{}
-	require.NoError(t, yaml.Unmarshal(restoredKustomization, &restoredMap))
-	assert.Empty(t, getKustomizeHelmGlobalsConfigHome(restoredMap))
+	assert.Equal(t, string(originalKustomization), string(restoredKustomization))
 }
 
 func Test_prepareKustomizeHelmOCIRegistryCredentials_respectsExistingConfigHome(t *testing.T) {
@@ -3858,8 +3949,9 @@ exit 0
 		EnableOCI: true,
 	}}
 
-	closer, err := prepareKustomizeHelmOCIRegistryCredentials(t.Context(), appPath, repositories, nil, "", "")
+	closer, configHome, err := prepareKustomizeHelmOCIRegistryCredentials(t.Context(), appPath, repositories, nil, "", "")
 	require.NoError(t, err)
+	assert.Empty(t, configHome)
 	utilio.Close(closer)
 
 	updatedKustomization, err := os.ReadFile(kustomizationPath)
@@ -3870,6 +3962,221 @@ exit 0
 
 	_, err = os.Stat(helmArgsFile)
 	assert.True(t, os.IsNotExist(err))
+}
+
+func Test_prepareKustomizeHelmOCIRegistryCredentials_cleanupRemovesTempDir(t *testing.T) {
+	appPath := t.TempDir()
+	kustomizationPath := filepath.Join(appPath, "kustomization.yaml")
+	err := os.WriteFile(kustomizationPath, []byte(`
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+helmCharts:
+  - name: my-chart
+    repo: oci://example.azurecr.io/charts
+    version: 1.2.3
+`), 0o644)
+	require.NoError(t, err)
+
+	binDir := filepath.Join(t.TempDir(), "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	fakeHelm := filepath.Join(binDir, "helm")
+	require.NoError(t, os.WriteFile(fakeHelm, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	repositories := []*v1alpha1.Repository{{
+		Repo:      "oci://example.azurecr.io/charts",
+		Username:  "test-user",
+		Password:  "test-password",
+		EnableOCI: true,
+	}}
+
+	closer, configHome, err := prepareKustomizeHelmOCIRegistryCredentials(t.Context(), appPath, repositories, nil, "", "")
+	require.NoError(t, err)
+	require.NotEmpty(t, configHome)
+	if info, err := os.Stat(configHome); assert.NoError(t, err) {
+		assert.True(t, info.IsDir())
+	}
+
+	require.NoError(t, closer.Close())
+	_, err = os.Stat(configHome)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func Test_runKustomizeBuild_serializesEnableHelmBuilds(t *testing.T) {
+	t.Parallel()
+
+	appPath := t.TempDir()
+	buildOptions := &v1alpha1.KustomizeOptions{BuildOptions: "--enable-helm"}
+
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	secondStarted := make(chan struct{})
+	errCh := make(chan error, 2)
+
+	go func() {
+		errCh <- runKustomizeBuild(t.Context(), appPath, buildOptions, "kustomize", nil, nil, "", "", func(_ string) error {
+			close(firstStarted)
+			<-releaseFirst
+			return nil
+		})
+	}()
+
+	<-firstStarted
+
+	go func() {
+		errCh <- runKustomizeBuild(t.Context(), appPath, buildOptions, "kustomize", nil, nil, "", "", func(_ string) error {
+			close(secondStarted)
+			return nil
+		})
+	}()
+
+	select {
+	case <-secondStarted:
+		t.Fatal("second kustomize build started before first build released the lock")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(releaseFirst)
+
+	select {
+	case <-secondStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("second kustomize build did not start after first build released the lock")
+	}
+
+	require.NoError(t, <-errCh)
+	require.NoError(t, <-errCh)
+}
+
+func Test_runKustomizeBuild_injectsHelmCommandWhenSupported(t *testing.T) {
+	appPath := t.TempDir()
+	kustomizationPath := filepath.Join(appPath, "kustomization.yaml")
+	err := os.WriteFile(kustomizationPath, []byte(`
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+helmCharts:
+  - name: my-chart
+    repo: oci://example.azurecr.io/charts
+    version: 1.2.3
+`), 0o644)
+	require.NoError(t, err)
+
+	binDir := filepath.Join(t.TempDir(), "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+
+	fakeHelm := filepath.Join(binDir, "helm")
+	require.NoError(t, os.WriteFile(fakeHelm, []byte(`#!/bin/sh
+exit 0
+`), 0o755))
+
+	fakeKustomize := filepath.Join(binDir, "kustomize-test")
+	require.NoError(t, os.WriteFile(fakeKustomize, []byte(`#!/bin/sh
+if [ "$1" = "build" ] && [ "$2" = "--help" ]; then
+	echo "      --helm-command string"
+	exit 0
+fi
+exit 1
+`), 0o755))
+
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	repositories := []*v1alpha1.Repository{{
+		Repo:      "oci://example.azurecr.io/charts",
+		Username:  "test-user",
+		Password:  "test-password",
+		EnableOCI: true,
+	}}
+
+	var helmCommandPath string
+	err = runKustomizeBuild(t.Context(), appPath, &v1alpha1.KustomizeOptions{BuildOptions: "--enable-helm"}, fakeKustomize, repositories, nil, "", "", func(helmCommand string) error {
+		helmCommandPath = helmCommand
+		require.NotEmpty(t, helmCommand)
+		contents, err := os.ReadFile(helmCommand)
+		require.NoError(t, err)
+		assert.Contains(t, string(contents), "HELM_CONFIG_HOME=")
+		assert.Contains(t, string(contents), "exec ")
+		return nil
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, helmCommandPath)
+
+	_, err = os.Stat(helmCommandPath)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func Test_runKustomizeBuild_returnsErrorWhenHelmCommandUnsupported(t *testing.T) {
+	appPath := t.TempDir()
+	kustomizationPath := filepath.Join(appPath, "kustomization.yaml")
+	err := os.WriteFile(kustomizationPath, []byte(`
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+helmCharts:
+  - name: my-chart
+    repo: oci://example.azurecr.io/charts
+    version: 1.2.3
+`), 0o644)
+	require.NoError(t, err)
+
+	binDir := filepath.Join(t.TempDir(), "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	fakeHelm := filepath.Join(binDir, "helm")
+	require.NoError(t, os.WriteFile(fakeHelm, []byte(`#!/bin/sh
+exit 0
+`), 0o755))
+
+	fakeKustomize := filepath.Join(binDir, "kustomize-test")
+	require.NoError(t, os.WriteFile(fakeKustomize, []byte(`#!/bin/sh
+if [ "$1" = "build" ] && [ "$2" = "--help" ]; then
+	echo "kustomize build help"
+	exit 0
+fi
+exit 1
+`), 0o755))
+
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	repositories := []*v1alpha1.Repository{{
+		Repo:      "oci://example.azurecr.io/charts",
+		Username:  "test-user",
+		Password:  "test-password",
+		EnableOCI: true,
+	}}
+
+	buildCalled := false
+	err = runKustomizeBuild(t.Context(), appPath, &v1alpha1.KustomizeOptions{BuildOptions: "--enable-helm"}, fakeKustomize, repositories, nil, "", "", func(_ string) error {
+		buildCalled = true
+		return nil
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not support --helm-command")
+	assert.False(t, buildCalled)
+}
+
+func Test_findKustomizationFilePath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("finds alternate kustomization file names", func(t *testing.T) {
+		t.Parallel()
+
+		appPath := t.TempDir()
+		kustomizationPath := filepath.Join(appPath, "kustomization.yml")
+		require.NoError(t, os.WriteFile(kustomizationPath, []byte("kind: Kustomization\n"), 0o644))
+
+		resolvedPath, err := findKustomizationFilePath(appPath)
+		require.NoError(t, err)
+		assert.Equal(t, kustomizationPath, resolvedPath)
+	})
+
+	t.Run("returns stat error for invalid app path", func(t *testing.T) {
+		t.Parallel()
+
+		appPath := filepath.Join(t.TempDir(), "not-a-directory")
+		require.NoError(t, os.WriteFile(appPath, []byte("not a directory"), 0o644))
+
+		_, err := findKustomizationFilePath(appPath)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to stat")
+	})
 }
 
 func Test_getResolvedValueFiles(t *testing.T) {

--- a/test/e2e/fixture/app/context.go
+++ b/test/e2e/fixture/app/context.go
@@ -209,6 +209,11 @@ func (c *Context) HelmOCIRepoAdded(name string) *Context {
 	return c
 }
 
+func (c *Context) AuthenticatedHelmOCIRepoAdded(name string) *Context {
+	repos.AddAuthenticatedHelmOCIRepo(c.T(), name)
+	return c
+}
+
 func (c *Context) PushImageToOCIRegistry(pathName, tag string) *Context {
 	repos.PushImageToOCIRegistry(c.T(), pathName, tag)
 	return c

--- a/test/e2e/fixture/repos/repos.go
+++ b/test/e2e/fixture/repos/repos.go
@@ -160,6 +160,21 @@ func AddHelmOCIRepo(t *testing.T, name string) {
 	errors.NewHandler(t).FailOnErr(fixture.RunCli(args...))
 }
 
+func AddAuthenticatedHelmOCIRepo(t *testing.T, name string) {
+	t.Helper()
+	args := []string{
+		"repo",
+		"add",
+		fixture.HelmAuthenticatedOCIRegistryURL,
+		"--username", fixture.GitUsername,
+		"--password", fixture.GitPassword,
+		"--type", "helm",
+		"--name", name,
+		"--enable-oci",
+	}
+	errors.NewHandler(t).FailOnErr(fixture.RunCli(args...))
+}
+
 // AddHTTPSRepoCredentialsUserPass adds E2E username/password credentials for HTTPS repos to context
 func AddHTTPSCredentialsUserPass(t *testing.T) {
 	t.Helper()

--- a/test/e2e/kustomize_test.go
+++ b/test/e2e/kustomize_test.go
@@ -353,6 +353,36 @@ func TestKustomizeApiVersions(t *testing.T) {
 		})
 }
 
+func TestKustomizeWithAuthenticatedOCIHelmChart(t *testing.T) {
+	ctx := Given(t)
+	ctx.PushChartToAuthenticatedOCIRegistry("testdata/helm-values", "helm-values", "1.0.0").
+		AuthenticatedHelmOCIRepoAdded("myrepo-auth").
+		Path("kustomize-oci-helm-authenticated").
+		And(func() {
+			errors.NewHandler(t).FailOnErr(fixture.Run("", "kubectl", "patch", "cm", "argocd-cm",
+				"-n", fixture.TestNamespace(),
+				"-p", `{ "data": { "kustomize.buildOptions": "--enable-helm" } }`))
+		}).
+		When().
+		CreateApp().
+		Sync().
+		Then().
+		Expect(OperationPhaseIs(OperationSucceeded)).
+		Expect(SyncStatusIs(SyncStatusCodeSynced)).
+		Expect(HealthIs(health.HealthStatusHealthy)).
+		And(func(_ *Application) {
+			foo := errors.NewHandler(t).FailOnErr(fixture.Run(".", "kubectl", "-n", ctx.DeploymentNamespace(), "get", "cm", "my-map",
+				"-o", "jsonpath={.data.foo}")).(string)
+			assert.Equal(t, "bar", foo)
+		}).
+		When().
+		Sync().
+		Then().
+		Expect(OperationPhaseIs(OperationSucceeded)).
+		Expect(SyncStatusIs(SyncStatusCodeSynced)).
+		Expect(HealthIs(health.HealthStatusHealthy))
+}
+
 func TestKustomizeNamespaceOverride(t *testing.T) {
 	Given(t).
 		Path("kustomize-kube-version").

--- a/test/e2e/testdata/kustomize-oci-helm-authenticated/kustomization.yaml
+++ b/test/e2e/testdata/kustomize-oci-helm-authenticated/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+helmCharts:
+  - name: helm-values
+    releaseName: authed-oci
+    repo: oci://localhost:5001/myrepo
+    version: 1.0.0

--- a/util/kustomize/kustomize.go
+++ b/util/kustomize/kustomize.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -36,6 +37,7 @@ type Image = string
 type BuildOpts struct {
 	KubeVersion string
 	APIVersions []string
+	HelmCommand string
 }
 
 // Kustomize provides wrapper functionality around the `kustomize` command.
@@ -412,7 +414,11 @@ func (k *kustomize) Build(opts *v1alpha1.ApplicationSourceKustomize, kustomizeOp
 func parseKustomizeBuildOptions(ctx context.Context, k *kustomize, buildOptions string, buildOpts *BuildOpts) []string {
 	buildOptsParams := append([]string{"build", k.path}, strings.Fields(buildOptions)...)
 
-	if buildOpts != nil && !getSemverSafe(ctx, k).LessThan(semver.MustParse("v5.3.0")) && isHelmEnabled(buildOptions) {
+	if buildOpts != nil && buildOpts.HelmCommand != "" && HasEnableHelmFlag(buildOptions) {
+		buildOptsParams = append(buildOptsParams, "--helm-command", buildOpts.HelmCommand)
+	}
+
+	if buildOpts != nil && !getSemverSafe(ctx, k).LessThan(semver.MustParse("v5.3.0")) && HasEnableHelmFlag(buildOptions) {
 		if buildOpts.KubeVersion != "" {
 			buildOptsParams = append(buildOptsParams, "--helm-kube-version", buildOpts.KubeVersion)
 		}
@@ -424,8 +430,55 @@ func parseKustomizeBuildOptions(ctx context.Context, k *kustomize, buildOptions 
 	return buildOptsParams
 }
 
-func isHelmEnabled(buildOptions string) bool {
-	return strings.Contains(buildOptions, "--enable-helm")
+// HasEnableHelmFlag reports whether build options contain an enabled --enable-helm flag.
+// It follows the same tokenization used when we later pass the options to kustomize.
+func HasEnableHelmFlag(buildOptions string) bool {
+	var (
+		enabled bool
+		seen    bool
+	)
+
+	for option := range strings.FieldsSeq(buildOptions) {
+		switch option {
+		case "--enable-helm":
+			enabled = true
+			seen = true
+		default:
+			value, found := strings.CutPrefix(option, "--enable-helm=")
+			if !found {
+				continue
+			}
+			parsed, err := strconv.ParseBool(value)
+			if err != nil {
+				continue
+			}
+			enabled = parsed
+			seen = true
+		}
+	}
+
+	return seen && enabled
+}
+
+func SupportsHelmCommandFlag(ctx context.Context, binaryPath string) bool {
+	if binaryPath == "" {
+		binaryPath = "kustomize"
+	}
+
+	if cached, ok := helmCommandSupportCache.Load(binaryPath); ok {
+		return cached.(bool)
+	}
+
+	cmd := exec.CommandContext(ctx, binaryPath, "build", "--help")
+	out, err := executil.Run(cmd)
+	if err != nil {
+		log.Warnf("Failed to detect --helm-command support for %s: %v", binaryPath, err)
+		return false
+	}
+
+	supported := strings.Contains(out, "--helm-command")
+	helmCommandSupportCache.Store(binaryPath, supported)
+	return supported
 }
 
 // semver/v3 doesn't export the regexp anymore, so shamelessly copied it over to
@@ -440,6 +493,8 @@ var (
 	semverRegex    = regexp.MustCompile(semVerRegex)
 	semVer         *semver.Version
 	semVerLock     sync.Mutex
+
+	helmCommandSupportCache sync.Map
 )
 
 // getSemver returns parsed kustomize version

--- a/util/kustomize/kustomize_test.go
+++ b/util/kustomize/kustomize_test.go
@@ -169,6 +169,114 @@ func TestParseKustomizeBuildHelmOptions(t *testing.T) {
 	}, built)
 }
 
+func TestParseKustomizeBuildHelmOptionsWithHelmCommand(t *testing.T) {
+	built := parseKustomizeBuildOptions(t.Context(), &kustomize{path: "guestbook"}, "-v 6 --logtostderr --enable-helm", &BuildOpts{
+		KubeVersion: "1.27",
+		APIVersions: []string{"foo", "bar"},
+		HelmCommand: "/tmp/kustomize-helm-wrapper",
+	})
+	assert.Equal(t, []string{
+		"build", "guestbook",
+		"-v", "6", "--logtostderr", "--enable-helm",
+		"--helm-command", "/tmp/kustomize-helm-wrapper",
+		"--helm-kube-version", "1.27",
+		"--helm-api-versions", "foo", "--helm-api-versions", "bar",
+	}, built)
+}
+
+func TestHasEnableHelmFlag(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name         string
+		buildOptions string
+		expected     bool
+	}{
+		{name: "missing", buildOptions: "--load-restrictor LoadRestrictionsNone", expected: false},
+		{name: "exact flag", buildOptions: "--enable-helm --load-restrictor LoadRestrictionsNone", expected: true},
+		{name: "true assignment", buildOptions: "--enable-helm=true", expected: true},
+		{name: "false assignment", buildOptions: "--enable-helm=false", expected: false},
+		{name: "substring only", buildOptions: "--enable-helm-plugins", expected: false},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, testCase.expected, HasEnableHelmFlag(testCase.buildOptions))
+		})
+	}
+}
+
+func TestSupportsHelmCommandFlag(t *testing.T) {
+	t.Parallel()
+
+	makeScript := func(content string) string {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "kustomize")
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o755))
+		return path
+	}
+
+	t.Run("supported", func(t *testing.T) {
+		t.Parallel()
+		kustomizePath := makeScript(`#!/bin/sh
+if [ "$1" = "build" ] && [ "$2" = "--help" ]; then
+	echo "      --helm-command string"
+	exit 0
+fi
+exit 1
+`)
+		assert.True(t, SupportsHelmCommandFlag(t.Context(), kustomizePath))
+	})
+
+	t.Run("unsupported", func(t *testing.T) {
+		t.Parallel()
+		kustomizePath := makeScript(`#!/bin/sh
+if [ "$1" = "build" ] && [ "$2" = "--help" ]; then
+	echo "kustomize build help"
+	exit 0
+fi
+exit 1
+`)
+		assert.False(t, SupportsHelmCommandFlag(t.Context(), kustomizePath))
+	})
+}
+
+func TestSupportsHelmCommandFlag_DoesNotCacheProbeFailure(t *testing.T) {
+	clearHelmCommandSupportCache()
+	t.Cleanup(clearHelmCommandSupportCache)
+
+	probeCounter := filepath.Join(t.TempDir(), "probe-counter")
+	kustomizePath := filepath.Join(t.TempDir(), "kustomize")
+	script := fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "build" ] && [ "$2" = "--help" ]; then
+	count=0
+	if [ -f %q ]; then
+		count=$(cat %q)
+	fi
+	count=$((count + 1))
+	echo "$count" > %q
+	if [ "$count" -eq 1 ]; then
+		exit 1
+	fi
+	echo "      --helm-command string"
+	exit 0
+fi
+exit 1
+`, probeCounter, probeCounter, probeCounter)
+	require.NoError(t, os.WriteFile(kustomizePath, []byte(script), 0o755))
+
+	assert.False(t, SupportsHelmCommandFlag(t.Context(), kustomizePath))
+	assert.True(t, SupportsHelmCommandFlag(t.Context(), kustomizePath))
+}
+
+func clearHelmCommandSupportCache() {
+	helmCommandSupportCache.Range(func(key, _ any) bool {
+		helmCommandSupportCache.Delete(key)
+		return true
+	})
+}
+
 func TestVersion(t *testing.T) {
 	ver, err := Version()
 	require.NoError(t, err)


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an enhancement proposal and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

## What this PR solves
Kustomize with `--enable-helm` failed to pull private OCI charts because Kustomize Helm pulls did not get OCI auth context from Argo CD repo credentials.

## What changed
- Detect Kustomize Helm path in repo-server.
- Parse `helmCharts` OCI dependencies from kustomization.
- Resolve credentials from both repository secrets and repo-creds templates.
- Perform `helm registry login` into a temp Helm config home for the render.
- Inject `helmGlobals.configHome` for that render cycle.
- Restore original kustomization file and clean up temp files after render.
- Respect existing user-defined `helmGlobals.configHome` (no override).

## Tests
Added unit tests in `reposerver/repository/repository_test.go`:
- `Test_getOCIHelmChartReposFromKustomization`
- `Test_prepareKustomizeHelmOCIRegistryCredentials_injectsConfigHomeAndLogsIn`
- `Test_prepareKustomizeHelmOCIRegistryCredentials_respectsExistingConfigHome`

Validated with:
- `go test ./reposerver/repository -count=1`

Fixes #16894