### PR TITLE
fix(hydrator): requeue source hydration on periodic refresh timeout

### DIFF
--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -100,6 +100,14 @@ func newFakeController(ctx context.Context, data *fakeData, repoErr error) *Appl
 }
 
 func newFakeControllerWithResync(ctx context.Context, data *fakeData, appResyncPeriod time.Duration, repoErr, revisionPathsErr error) *ApplicationController {
+	return newFakeControllerWithResyncAndHydrator(ctx, data, appResyncPeriod, repoErr, revisionPathsErr, false)
+}
+
+func newFakeHydratorControllerWithResync(ctx context.Context, data *fakeData, appResyncPeriod time.Duration, repoErr, revisionPathsErr error) *ApplicationController {
+	return newFakeControllerWithResyncAndHydrator(ctx, data, appResyncPeriod, repoErr, revisionPathsErr, true)
+}
+
+func newFakeControllerWithResyncAndHydrator(ctx context.Context, data *fakeData, appResyncPeriod time.Duration, repoErr, revisionPathsErr error, hydratorEnabled bool) *ApplicationController {
 	var clust corev1.Secret
 	err := yaml.Unmarshal([]byte(fakeCluster), &clust)
 	if err != nil {
@@ -205,7 +213,7 @@ func newFakeControllerWithResync(ctx context.Context, data *fakeData, appResyncP
 		false,
 		normalizers.IgnoreNormalizerOpts{},
 		testEnableEventList,
-		false,
+		hydratorEnabled,
 	)
 	db := &dbmocks.ArgoDB{}
 	db.EXPECT().GetApplicationControllerReplicas().Return(1).Maybe()

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -68,6 +68,7 @@ type fakeData struct {
 	apps                            []runtime.Object
 	manifestResponse                *apiclient.ManifestResponse
 	manifestResponses               []*apiclient.ManifestResponse
+	resolveRevisionResponse         *apiclient.ResolveRevisionResponse
 	managedLiveObjs                 map[kube.ResourceKey]*unstructured.Unstructured
 	namespacedResources             map[kube.ResourceKey]namespacedResource
 	configMapData                   map[string]string
@@ -130,6 +131,14 @@ func newFakeControllerWithResyncAndHydrator(ctx context.Context, data *fakeData,
 			mockRepoClient.EXPECT().GenerateManifest(mock.Anything, mock.Anything).Return(data.manifestResponse, repoErr).Once()
 		} else {
 			mockRepoClient.EXPECT().GenerateManifest(mock.Anything, mock.Anything).Return(data.manifestResponse, nil).Once()
+		}
+	}
+
+	if data.resolveRevisionResponse != nil {
+		if repoErr != nil {
+			mockRepoClient.EXPECT().ResolveRevision(mock.Anything, mock.Anything).Return(nil, repoErr).Once()
+		} else {
+			mockRepoClient.EXPECT().ResolveRevision(mock.Anything, mock.Anything).Return(data.resolveRevisionResponse, nil).Once()
 		}
 	}
 

--- a/controller/hydrator/hydrator.go
+++ b/controller/hydrator/hydrator.go
@@ -3,6 +3,7 @@ package hydrator
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"path/filepath"
@@ -173,10 +174,10 @@ func (h *Hydrator) shouldCheckDrySourceRevision(app *appv1.Application, now time
 
 func (h *Hydrator) getLatestDrySourceRevision(app *appv1.Application) (string, error) {
 	if h.repoGetter == nil {
-		return "", fmt.Errorf("repo getter is not configured")
+		return "", errors.New("repo getter is not configured")
 	}
 	if h.repoClientset == nil {
-		return "", fmt.Errorf("repo clientset is not configured")
+		return "", errors.New("repo clientset is not configured")
 	}
 
 	repo, err := h.repoGetter.GetRepository(context.Background(), app.Spec.SourceHydrator.DrySource.RepoURL, app.Spec.Project)

--- a/controller/hydrator/hydrator.go
+++ b/controller/hydrator/hydrator.go
@@ -115,15 +115,9 @@ func (h *Hydrator) ProcessAppHydrateQueueItem(origApp *appv1.Application) {
 	logCtx := log.WithFields(applog.GetAppLogFields(app))
 	logCtx.Debug("Processing app hydrate queue item")
 
-	needsHydration, reason := appNeedsHydration(app)
-	if !needsHydration && h.shouldCheckDrySourceRevision(app) {
-		latestDrySHA, err := h.getLatestDrySourceRevision(app)
-		if err != nil {
-			logCtx.WithError(err).Warn("Failed to resolve latest dry source revision")
-		} else if latestDrySHA != app.Status.SourceHydrator.CurrentOperation.DrySHA {
-			needsHydration = true
-			reason = "dry source revision changed"
-		}
+	needsHydration, reason, err := h.appNeedsHydration(app)
+	if err != nil {
+		logCtx.WithError(err).Warn("Failed to determine if app needs hydration")
 	}
 	if needsHydration {
 		app.Status.SourceHydrator.CurrentOperation = &appv1.HydrateOperation{
@@ -144,6 +138,23 @@ func (h *Hydrator) ProcessAppHydrateQueueItem(origApp *appv1.Application) {
 	}
 
 	logCtx.Debug("Successfully processed app hydrate queue item")
+}
+
+func (h *Hydrator) appNeedsHydration(app *appv1.Application) (bool, string, error) {
+	needsHydration, reason := appNeedsHydration(app)
+	if needsHydration || !h.shouldCheckDrySourceRevision(app) {
+		return needsHydration, reason, nil
+	}
+
+	latestDrySHA, err := h.getLatestDrySourceRevision(app)
+	if err != nil {
+		return false, reason, err
+	}
+	if latestDrySHA != app.Status.SourceHydrator.CurrentOperation.DrySHA {
+		return true, "dry source revision changed", nil
+	}
+
+	return false, reason, nil
 }
 
 func (h *Hydrator) shouldCheckDrySourceRevision(app *appv1.Application) bool {

--- a/controller/hydrator/hydrator.go
+++ b/controller/hydrator/hydrator.go
@@ -116,6 +116,15 @@ func (h *Hydrator) ProcessAppHydrateQueueItem(origApp *appv1.Application) {
 	logCtx.Debug("Processing app hydrate queue item")
 
 	needsHydration, reason := appNeedsHydration(app)
+	if !needsHydration && h.shouldCheckDrySourceRevision(app) {
+		latestDrySHA, err := h.getLatestDrySourceRevision(app)
+		if err != nil {
+			logCtx.WithError(err).Warn("Failed to resolve latest dry source revision")
+		} else if latestDrySHA != app.Status.SourceHydrator.CurrentOperation.DrySHA {
+			needsHydration = true
+			reason = "dry source revision changed"
+		}
+	}
 	if needsHydration {
 		app.Status.SourceHydrator.CurrentOperation = &appv1.HydrateOperation{
 			StartedAt:      metav1.Now(),
@@ -135,6 +144,31 @@ func (h *Hydrator) ProcessAppHydrateQueueItem(origApp *appv1.Application) {
 	}
 
 	logCtx.Debug("Successfully processed app hydrate queue item")
+}
+
+func (h *Hydrator) shouldCheckDrySourceRevision(app *appv1.Application) bool {
+	if app.Status.SourceHydrator.CurrentOperation == nil || app.Status.SourceHydrator.CurrentOperation.Phase == appv1.HydrateOperationPhaseHydrating {
+		return false
+	}
+	if h.statusRefreshTimeout <= 0 {
+		return false
+	}
+	if app.Status.ReconciledAt == nil {
+		return true
+	}
+	return app.Status.ReconciledAt.Add(h.statusRefreshTimeout).Before(time.Now().UTC())
+}
+
+func (h *Hydrator) getLatestDrySourceRevision(app *appv1.Application) (string, error) {
+	project, err := h.dependencies.GetProcessableAppProj(app)
+	if err != nil {
+		return "", fmt.Errorf("failed to get app project %q: %w", app.Spec.Project, err)
+	}
+	revision, _, err := h.getManifests(context.Background(), app, "", project)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve latest dry source revision: %w", err)
+	}
+	return revision, nil
 }
 
 func getHydrationQueueKey(app *appv1.Application) types.HydrationQueueKey {

--- a/controller/hydrator/hydrator.go
+++ b/controller/hydrator/hydrator.go
@@ -142,7 +142,7 @@ func (h *Hydrator) ProcessAppHydrateQueueItem(origApp *appv1.Application) {
 
 func (h *Hydrator) appNeedsHydration(app *appv1.Application) (bool, string, error) {
 	needsHydration, reason := appNeedsHydration(app)
-	if needsHydration || !h.shouldCheckDrySourceRevision(app) {
+	if needsHydration || !h.shouldCheckDrySourceRevision(app, time.Now().UTC()) {
 		return needsHydration, reason, nil
 	}
 
@@ -157,17 +157,18 @@ func (h *Hydrator) appNeedsHydration(app *appv1.Application) (bool, string, erro
 	return false, reason, nil
 }
 
-func (h *Hydrator) shouldCheckDrySourceRevision(app *appv1.Application) bool {
-	if app.Status.SourceHydrator.CurrentOperation == nil || app.Status.SourceHydrator.CurrentOperation.Phase == appv1.HydrateOperationPhaseHydrating {
+func (h *Hydrator) shouldCheckDrySourceRevision(app *appv1.Application, now time.Time) bool {
+	if app.Status.SourceHydrator.CurrentOperation == nil {
+		return false
+	}
+	op := app.Status.SourceHydrator.CurrentOperation
+	if op.Phase != appv1.HydrateOperationPhaseHydrated || op.FinishedAt == nil {
 		return false
 	}
 	if h.statusRefreshTimeout <= 0 {
 		return false
 	}
-	if app.Status.ReconciledAt == nil {
-		return true
-	}
-	return app.Status.ReconciledAt.Add(h.statusRefreshTimeout).Before(time.Now().UTC())
+	return op.FinishedAt.Add(h.statusRefreshTimeout).Before(now)
 }
 
 func (h *Hydrator) getLatestDrySourceRevision(app *appv1.Application) (string, error) {

--- a/controller/hydrator/hydrator.go
+++ b/controller/hydrator/hydrator.go
@@ -172,15 +172,34 @@ func (h *Hydrator) shouldCheckDrySourceRevision(app *appv1.Application, now time
 }
 
 func (h *Hydrator) getLatestDrySourceRevision(app *appv1.Application) (string, error) {
-	project, err := h.dependencies.GetProcessableAppProj(app)
-	if err != nil {
-		return "", fmt.Errorf("failed to get app project %q: %w", app.Spec.Project, err)
+	if h.repoGetter == nil {
+		return "", fmt.Errorf("repo getter is not configured")
 	}
-	revision, _, err := h.getManifests(context.Background(), app, "", project)
+	if h.repoClientset == nil {
+		return "", fmt.Errorf("repo clientset is not configured")
+	}
+
+	repo, err := h.repoGetter.GetRepository(context.Background(), app.Spec.SourceHydrator.DrySource.RepoURL, app.Spec.Project)
+	if err != nil {
+		return "", fmt.Errorf("failed to get repo %q: %w", app.Spec.SourceHydrator.DrySource.RepoURL, err)
+	}
+
+	conn, repoClient, err := h.repoClientset.NewRepoServerClient()
+	if err != nil {
+		return "", fmt.Errorf("failed to connect to repo server: %w", err)
+	}
+	defer utilio.Close(conn)
+
+	drySource := app.Spec.SourceHydrator.GetDrySource()
+	resp, err := repoClient.ResolveRevision(context.Background(), &apiclient.ResolveRevisionRequest{
+		Repo:              repo,
+		App:               &appv1.Application{Spec: appv1.ApplicationSpec{Source: &drySource}},
+		AmbiguousRevision: drySource.TargetRevision,
+	})
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve latest dry source revision: %w", err)
 	}
-	return revision, nil
+	return resp.Revision, nil
 }
 
 func getHydrationQueueKey(app *appv1.Application) types.HydrationQueueKey {

--- a/controller/hydrator/hydrator_test.go
+++ b/controller/hydrator/hydrator_test.go
@@ -445,6 +445,56 @@ func TestProcessAppHydrateQueueItem_HydrationPassedTimeout(t *testing.T) {
 	d.AssertNotCalled(t, "PersistAppHydratorStatus", mock.Anything, mock.Anything)
 }
 
+func TestProcessAppHydrateQueueItem_ReconciledTimeout_DrySourceRevisionChanged(t *testing.T) {
+	t.Parallel()
+	d := mocks.NewDependencies(t)
+	app := setTestAppPhase(newTestApp("test-app"), v1alpha1.HydrateOperationPhaseHydrated)
+	reconciledAt := metav1.NewTime(time.Now().Add(-2 * time.Minute))
+	app.Status.ReconciledAt = &reconciledAt
+	app.Status.SourceHydrator.CurrentOperation.DrySHA = "old-sha"
+
+	d.EXPECT().GetProcessableAppProj(app).Return(newTestProject(), nil).Once()
+	d.EXPECT().GetRepoObjs(mock.Anything, app, app.Spec.SourceHydrator.GetDrySource(), "main", mock.Anything).Return(nil, &repoclient.ManifestResponse{
+		Revision: "new-sha",
+	}, nil).Once()
+	d.EXPECT().PersistAppHydratorStatus(mock.Anything, mock.Anything).Return().Once()
+	d.EXPECT().AddHydrationQueueItem(mock.Anything).Return().Once()
+
+	h := &Hydrator{
+		dependencies:         d,
+		statusRefreshTimeout: time.Minute,
+	}
+
+	h.ProcessAppHydrateQueueItem(app)
+
+	d.AssertCalled(t, "PersistAppHydratorStatus", mock.Anything, mock.Anything)
+	d.AssertCalled(t, "AddHydrationQueueItem", mock.Anything)
+}
+
+func TestProcessAppHydrateQueueItem_ReconciledTimeout_DrySourceRevisionUnchanged(t *testing.T) {
+	t.Parallel()
+	d := mocks.NewDependencies(t)
+	app := setTestAppPhase(newTestApp("test-app"), v1alpha1.HydrateOperationPhaseHydrated)
+	reconciledAt := metav1.NewTime(time.Now().Add(-2 * time.Minute))
+	app.Status.ReconciledAt = &reconciledAt
+	app.Status.SourceHydrator.CurrentOperation.DrySHA = "same-sha"
+
+	d.EXPECT().GetProcessableAppProj(app).Return(newTestProject(), nil).Once()
+	d.EXPECT().GetRepoObjs(mock.Anything, app, app.Spec.SourceHydrator.GetDrySource(), "main", mock.Anything).Return(nil, &repoclient.ManifestResponse{
+		Revision: "same-sha",
+	}, nil).Once()
+
+	h := &Hydrator{
+		dependencies:         d,
+		statusRefreshTimeout: time.Minute,
+	}
+
+	h.ProcessAppHydrateQueueItem(app)
+
+	d.AssertNotCalled(t, "PersistAppHydratorStatus", mock.Anything, mock.Anything)
+	d.AssertNotCalled(t, "AddHydrationQueueItem", mock.Anything)
+}
+
 func TestProcessAppHydrateQueueItem_NoSourceHydrator(t *testing.T) {
 	t.Parallel()
 	d := mocks.NewDependencies(t)

--- a/controller/hydrator/hydrator_test.go
+++ b/controller/hydrator/hydrator_test.go
@@ -448,13 +448,15 @@ func TestProcessAppHydrateQueueItem_HydrationPassedTimeout(t *testing.T) {
 func TestProcessAppHydrateQueueItem_ReconciledTimeout_DrySourceRevisionChanged(t *testing.T) {
 	t.Parallel()
 	d := mocks.NewDependencies(t)
+	r := mocks.NewRepoGetter(t)
+	rc := reposervermocks.NewRepoServerServiceClient(t)
 	app := setTestAppPhase(newTestApp("test-app"), v1alpha1.HydrateOperationPhaseHydrated)
 	finishedAt := metav1.NewTime(time.Now().Add(-2 * time.Minute))
 	app.Status.SourceHydrator.CurrentOperation.FinishedAt = &finishedAt
 	app.Status.SourceHydrator.CurrentOperation.DrySHA = "old-sha"
 
-	d.EXPECT().GetProcessableAppProj(app).Return(newTestProject(), nil).Once()
-	d.EXPECT().GetRepoObjs(mock.Anything, app, app.Spec.SourceHydrator.GetDrySource(), "main", mock.Anything).Return(nil, &repoclient.ManifestResponse{
+	r.EXPECT().GetRepository(mock.Anything, app.Spec.SourceHydrator.DrySource.RepoURL, app.Spec.Project).Return(nil, nil).Once()
+	rc.EXPECT().ResolveRevision(mock.Anything, mock.Anything).Return(&repoclient.ResolveRevisionResponse{
 		Revision: "new-sha",
 	}, nil).Once()
 	d.EXPECT().PersistAppHydratorStatus(mock.Anything, mock.Anything).Return().Once()
@@ -463,6 +465,8 @@ func TestProcessAppHydrateQueueItem_ReconciledTimeout_DrySourceRevisionChanged(t
 	h := &Hydrator{
 		dependencies:         d,
 		statusRefreshTimeout: time.Minute,
+		repoGetter:           r,
+		repoClientset:        &reposervermocks.Clientset{RepoServerServiceClient: rc},
 	}
 
 	h.ProcessAppHydrateQueueItem(app)
@@ -474,19 +478,23 @@ func TestProcessAppHydrateQueueItem_ReconciledTimeout_DrySourceRevisionChanged(t
 func TestProcessAppHydrateQueueItem_ReconciledTimeout_DrySourceRevisionUnchanged(t *testing.T) {
 	t.Parallel()
 	d := mocks.NewDependencies(t)
+	r := mocks.NewRepoGetter(t)
+	rc := reposervermocks.NewRepoServerServiceClient(t)
 	app := setTestAppPhase(newTestApp("test-app"), v1alpha1.HydrateOperationPhaseHydrated)
 	finishedAt := metav1.NewTime(time.Now().Add(-2 * time.Minute))
 	app.Status.SourceHydrator.CurrentOperation.FinishedAt = &finishedAt
 	app.Status.SourceHydrator.CurrentOperation.DrySHA = "same-sha"
 
-	d.EXPECT().GetProcessableAppProj(app).Return(newTestProject(), nil).Once()
-	d.EXPECT().GetRepoObjs(mock.Anything, app, app.Spec.SourceHydrator.GetDrySource(), "main", mock.Anything).Return(nil, &repoclient.ManifestResponse{
+	r.EXPECT().GetRepository(mock.Anything, app.Spec.SourceHydrator.DrySource.RepoURL, app.Spec.Project).Return(nil, nil).Once()
+	rc.EXPECT().ResolveRevision(mock.Anything, mock.Anything).Return(&repoclient.ResolveRevisionResponse{
 		Revision: "same-sha",
 	}, nil).Once()
 
 	h := &Hydrator{
 		dependencies:         d,
 		statusRefreshTimeout: time.Minute,
+		repoGetter:           r,
+		repoClientset:        &reposervermocks.Clientset{RepoServerServiceClient: rc},
 	}
 
 	h.ProcessAppHydrateQueueItem(app)
@@ -555,6 +563,27 @@ func TestHydrator_shouldCheckDrySourceRevision(t *testing.T) {
 			assert.Equal(t, tc.expected, h.shouldCheckDrySourceRevision(tc.app, now))
 		})
 	}
+}
+
+func TestHydrator_getLatestDrySourceRevision(t *testing.T) {
+	t.Parallel()
+
+	r := mocks.NewRepoGetter(t)
+	rc := reposervermocks.NewRepoServerServiceClient(t)
+	app := newTestApp("test-app")
+	h := &Hydrator{
+		repoGetter:    r,
+		repoClientset: &reposervermocks.Clientset{RepoServerServiceClient: rc},
+	}
+
+	r.EXPECT().GetRepository(mock.Anything, app.Spec.SourceHydrator.DrySource.RepoURL, app.Spec.Project).Return(nil, nil).Once()
+	rc.EXPECT().ResolveRevision(mock.Anything, mock.Anything).Return(&repoclient.ResolveRevisionResponse{
+		Revision: "sha123",
+	}, nil).Once()
+
+	revision, err := h.getLatestDrySourceRevision(app)
+	require.NoError(t, err)
+	assert.Equal(t, "sha123", revision)
 }
 
 func TestProcessAppHydrateQueueItem_NoSourceHydrator(t *testing.T) {

--- a/controller/hydrator/hydrator_test.go
+++ b/controller/hydrator/hydrator_test.go
@@ -449,8 +449,8 @@ func TestProcessAppHydrateQueueItem_ReconciledTimeout_DrySourceRevisionChanged(t
 	t.Parallel()
 	d := mocks.NewDependencies(t)
 	app := setTestAppPhase(newTestApp("test-app"), v1alpha1.HydrateOperationPhaseHydrated)
-	reconciledAt := metav1.NewTime(time.Now().Add(-2 * time.Minute))
-	app.Status.ReconciledAt = &reconciledAt
+	finishedAt := metav1.NewTime(time.Now().Add(-2 * time.Minute))
+	app.Status.SourceHydrator.CurrentOperation.FinishedAt = &finishedAt
 	app.Status.SourceHydrator.CurrentOperation.DrySHA = "old-sha"
 
 	d.EXPECT().GetProcessableAppProj(app).Return(newTestProject(), nil).Once()
@@ -475,8 +475,8 @@ func TestProcessAppHydrateQueueItem_ReconciledTimeout_DrySourceRevisionUnchanged
 	t.Parallel()
 	d := mocks.NewDependencies(t)
 	app := setTestAppPhase(newTestApp("test-app"), v1alpha1.HydrateOperationPhaseHydrated)
-	reconciledAt := metav1.NewTime(time.Now().Add(-2 * time.Minute))
-	app.Status.ReconciledAt = &reconciledAt
+	finishedAt := metav1.NewTime(time.Now().Add(-2 * time.Minute))
+	app.Status.SourceHydrator.CurrentOperation.FinishedAt = &finishedAt
 	app.Status.SourceHydrator.CurrentOperation.DrySHA = "same-sha"
 
 	d.EXPECT().GetProcessableAppProj(app).Return(newTestProject(), nil).Once()
@@ -493,6 +493,68 @@ func TestProcessAppHydrateQueueItem_ReconciledTimeout_DrySourceRevisionUnchanged
 
 	d.AssertNotCalled(t, "PersistAppHydratorStatus", mock.Anything, mock.Anything)
 	d.AssertNotCalled(t, "AddHydrationQueueItem", mock.Anything)
+}
+
+func TestHydrator_shouldCheckDrySourceRevision(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	finishedAt := metav1.NewTime(now.Add(-2 * time.Minute))
+
+	testCases := []struct {
+		name     string
+		app      *v1alpha1.Application
+		timeout  time.Duration
+		expected bool
+	}{
+		{
+			name:     "missing operation",
+			app:      newTestApp("test-app"),
+			timeout:  time.Minute,
+			expected: false,
+		},
+		{
+			name:     "still hydrating",
+			app:      setTestAppPhase(newTestApp("test-app"), v1alpha1.HydrateOperationPhaseHydrating),
+			timeout:  time.Minute,
+			expected: false,
+		},
+		{
+			name:     "no finished time",
+			app:      setTestAppPhase(newTestApp("test-app"), v1alpha1.HydrateOperationPhaseHydrated),
+			timeout:  time.Minute,
+			expected: false,
+		},
+		{
+			name: "timeout disabled",
+			app: func() *v1alpha1.Application {
+				app := setTestAppPhase(newTestApp("test-app"), v1alpha1.HydrateOperationPhaseHydrated)
+				app.Status.SourceHydrator.CurrentOperation.FinishedAt = &finishedAt
+				return app
+			}(),
+			timeout:  0,
+			expected: false,
+		},
+		{
+			name: "timeout expired",
+			app: func() *v1alpha1.Application {
+				app := setTestAppPhase(newTestApp("test-app"), v1alpha1.HydrateOperationPhaseHydrated)
+				app.Status.SourceHydrator.CurrentOperation.FinishedAt = &finishedAt
+				return app
+			}(),
+			timeout:  time.Minute,
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := &Hydrator{statusRefreshTimeout: tc.timeout}
+			assert.Equal(t, tc.expected, h.shouldCheckDrySourceRevision(tc.app, now))
+		})
+	}
 }
 
 func TestProcessAppHydrateQueueItem_NoSourceHydrator(t *testing.T) {

--- a/controller/hydrator/hydrator_test.go
+++ b/controller/hydrator/hydrator_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	repoclient "github.com/argoproj/argo-cd/v3/reposerver/apiclient"
 	reposervermocks "github.com/argoproj/argo-cd/v3/reposerver/apiclient/mocks"
+	utilio "github.com/argoproj/argo-cd/v3/util/io"
 	"github.com/argoproj/argo-cd/v3/util/settings"
 )
 
@@ -33,6 +34,14 @@ Argocd-reference-commit-repourl: https://github.com/test/argocd-example-apps
 Argocd-reference-commit-author: Argocd-reference-commit-author
 Argocd-reference-commit-subject: testhydratormd
 Signed-off-by: testUser <test@gmail.com>`
+
+type failingRepoClientset struct {
+	err error
+}
+
+func (f failingRepoClientset) NewRepoServerClient() (utilio.Closer, repoclient.RepoServerServiceClient, error) {
+	return nil, nil, f.err
+}
 
 func Test_appNeedsHydration(t *testing.T) {
 	t.Parallel()
@@ -584,6 +593,109 @@ func TestHydrator_getLatestDrySourceRevision(t *testing.T) {
 	revision, err := h.getLatestDrySourceRevision(app)
 	require.NoError(t, err)
 	assert.Equal(t, "sha123", revision)
+}
+
+func TestHydrator_getLatestDrySourceRevision_Errors(t *testing.T) {
+	t.Parallel()
+
+	app := newTestApp("test-app")
+
+	t.Run("missing repo getter", func(t *testing.T) {
+		t.Parallel()
+
+		h := &Hydrator{}
+		_, err := h.getLatestDrySourceRevision(app)
+		require.EqualError(t, err, "repo getter is not configured")
+	})
+
+	t.Run("missing repo clientset", func(t *testing.T) {
+		t.Parallel()
+
+		h := &Hydrator{repoGetter: mocks.NewRepoGetter(t)}
+		_, err := h.getLatestDrySourceRevision(app)
+		require.EqualError(t, err, "repo clientset is not configured")
+	})
+
+	t.Run("get repository fails", func(t *testing.T) {
+		t.Parallel()
+
+		r := mocks.NewRepoGetter(t)
+		r.EXPECT().GetRepository(mock.Anything, app.Spec.SourceHydrator.DrySource.RepoURL, app.Spec.Project).Return(nil, errors.New("repo lookup failed")).Once()
+
+		h := &Hydrator{repoGetter: r, repoClientset: &reposervermocks.Clientset{}}
+		_, err := h.getLatestDrySourceRevision(app)
+		require.ErrorContains(t, err, "failed to get repo")
+		require.ErrorContains(t, err, "repo lookup failed")
+	})
+
+	t.Run("repo server client fails", func(t *testing.T) {
+		t.Parallel()
+
+		r := mocks.NewRepoGetter(t)
+		r.EXPECT().GetRepository(mock.Anything, app.Spec.SourceHydrator.DrySource.RepoURL, app.Spec.Project).Return(nil, nil).Once()
+
+		h := &Hydrator{repoGetter: r, repoClientset: failingRepoClientset{err: errors.New("connect failed")}}
+		_, err := h.getLatestDrySourceRevision(app)
+		require.ErrorContains(t, err, "failed to connect to repo server")
+		require.ErrorContains(t, err, "connect failed")
+	})
+
+	t.Run("resolve revision fails", func(t *testing.T) {
+		t.Parallel()
+
+		r := mocks.NewRepoGetter(t)
+		rc := reposervermocks.NewRepoServerServiceClient(t)
+
+		r.EXPECT().GetRepository(mock.Anything, app.Spec.SourceHydrator.DrySource.RepoURL, app.Spec.Project).Return(nil, nil).Once()
+		rc.EXPECT().ResolveRevision(mock.Anything, mock.Anything).Return(nil, errors.New("resolve failed")).Once()
+
+		h := &Hydrator{
+			repoGetter:    r,
+			repoClientset: &reposervermocks.Clientset{RepoServerServiceClient: rc},
+		}
+		_, err := h.getLatestDrySourceRevision(app)
+		require.ErrorContains(t, err, "failed to resolve latest dry source revision")
+		require.ErrorContains(t, err, "resolve failed")
+	})
+}
+
+func TestHydrator_appNeedsHydration_DrySourceRevisionErrors(t *testing.T) {
+	t.Parallel()
+
+	app := setTestAppPhase(newTestApp("test-app"), v1alpha1.HydrateOperationPhaseHydrated)
+	finishedAt := metav1.NewTime(time.Now().Add(-2 * time.Minute))
+	app.Status.SourceHydrator.CurrentOperation.FinishedAt = &finishedAt
+	app.Status.SourceHydrator.CurrentOperation.DrySHA = "old-sha"
+
+	t.Run("returns resolver error", func(t *testing.T) {
+		t.Parallel()
+
+		h := &Hydrator{statusRefreshTimeout: time.Minute}
+		needsHydration, reason, err := h.appNeedsHydration(app)
+		require.False(t, needsHydration)
+		require.Equal(t, "hydration not needed", reason)
+		require.EqualError(t, err, "repo getter is not configured")
+	})
+
+	t.Run("returns none when resolved sha is unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		r := mocks.NewRepoGetter(t)
+		rc := reposervermocks.NewRepoServerServiceClient(t)
+
+		r.EXPECT().GetRepository(mock.Anything, app.Spec.SourceHydrator.DrySource.RepoURL, app.Spec.Project).Return(nil, nil).Once()
+		rc.EXPECT().ResolveRevision(mock.Anything, mock.Anything).Return(&repoclient.ResolveRevisionResponse{Revision: "old-sha"}, nil).Once()
+
+		h := &Hydrator{
+			statusRefreshTimeout: time.Minute,
+			repoGetter:           r,
+			repoClientset:        &reposervermocks.Clientset{RepoServerServiceClient: rc},
+		}
+		needsHydration, reason, err := h.appNeedsHydration(app)
+		require.NoError(t, err)
+		require.False(t, needsHydration)
+		require.Equal(t, "hydration not needed", reason)
+	})
 }
 
 func TestProcessAppHydrateQueueItem_NoSourceHydrator(t *testing.T) {

--- a/controller/hydrator_dependencies_test.go
+++ b/controller/hydrator_dependencies_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/argoproj/argo-cd/v3/common"
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
@@ -120,4 +121,50 @@ func TestGetHydratorCommitMessageTemplate(t *testing.T) {
 	tmpl, err := ctrl.GetHydratorCommitMessageTemplate()
 	require.NoError(t, err)
 	assert.NotEmpty(t, tmpl)
+}
+
+func TestProcessAppHydrateQueueItem_ReconcileTimeout_EnqueuesHydrationOnDryRevisionChange(t *testing.T) {
+	app := newFakeApp()
+	app.Spec.SourceHydrator = &v1alpha1.SourceHydrator{
+		DrySource: v1alpha1.DrySource{
+			RepoURL:        app.Spec.Source.RepoURL,
+			TargetRevision: app.Spec.Source.TargetRevision,
+			Path:           app.Spec.Source.Path,
+		},
+		SyncSource: v1alpha1.SyncSource{
+			TargetBranch: "hydrated",
+			Path:         "hydrated/path",
+		},
+	}
+	app.Status.SourceHydrator.CurrentOperation = &v1alpha1.HydrateOperation{
+		Phase:          v1alpha1.HydrateOperationPhaseHydrated,
+		DrySHA:         "old-sha",
+		SourceHydrator: *app.Spec.SourceHydrator,
+	}
+	reconciledAt := metav1.NewTime(time.Now().Add(-2 * time.Minute))
+	app.Status.ReconciledAt = &reconciledAt
+
+	data := fakeData{
+		apps: []runtime.Object{app, &defaultProj},
+		manifestResponse: &apiclient.ManifestResponse{
+			Manifests: []string{},
+			Namespace: test.FakeDestNamespace,
+			Server:    test.FakeClusterURL,
+			Revision:  "new-sha",
+		},
+	}
+
+	ctrl := newFakeHydratorControllerWithResync(t.Context(), &data, time.Minute, nil, nil)
+	ctrl.appHydrateQueue.Add(app.QualifiedName())
+	processed := ctrl.processAppHydrateQueueItem()
+	require.True(t, processed)
+
+	require.Eventually(t, func() bool {
+		updatedApp, err := ctrl.appLister.Applications(app.Namespace).Get(app.Name)
+		if err != nil {
+			return false
+		}
+		op := updatedApp.Status.SourceHydrator.CurrentOperation
+		return op != nil && op.Phase == v1alpha1.HydrateOperationPhaseHydrating
+	}, 2*time.Second, 25*time.Millisecond)
 }

--- a/controller/hydrator_dependencies_test.go
+++ b/controller/hydrator_dependencies_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
 
 	"github.com/argoproj/argo-cd/v3/common"
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
@@ -139,10 +140,10 @@ func TestProcessAppHydrateQueueItem_ReconcileTimeout_EnqueuesHydrationOnDryRevis
 	app.Status.SourceHydrator.CurrentOperation = &v1alpha1.HydrateOperation{
 		Phase:          v1alpha1.HydrateOperationPhaseHydrated,
 		DrySHA:         "old-sha",
+		FinishedAt:     &metav1.Time{Time: time.Now().Add(-2 * time.Minute)},
 		SourceHydrator: *app.Spec.SourceHydrator,
 	}
-	reconciledAt := metav1.NewTime(time.Now().Add(-2 * time.Minute))
-	app.Status.ReconciledAt = &reconciledAt
+	app.Status.ReconciledAt = &metav1.Time{Time: time.Now().Add(-2 * time.Minute)}
 
 	data := fakeData{
 		apps: []runtime.Object{app, &defaultProj},
@@ -150,13 +151,25 @@ func TestProcessAppHydrateQueueItem_ReconcileTimeout_EnqueuesHydrationOnDryRevis
 			Manifests: []string{},
 			Namespace: test.FakeDestNamespace,
 			Server:    test.FakeClusterURL,
-			Revision:  "new-sha",
+			Revision:  "old-sha",
+		},
+		resolveRevisionResponse: &apiclient.ResolveRevisionResponse{
+			Revision: "new-sha",
 		},
 	}
 
 	ctrl := newFakeHydratorControllerWithResync(t.Context(), &data, time.Minute, nil, nil)
-	ctrl.appHydrateQueue.Add(app.QualifiedName())
-	processed := ctrl.processAppHydrateQueueItem()
+	key, err := cache.MetaNamespaceKeyFunc(app)
+	require.NoError(t, err)
+	ctrl.appRefreshQueue.AddRateLimited(key)
+	processed := ctrl.processAppRefreshQueueItem()
+	require.True(t, processed)
+
+	refreshedApp, err := ctrl.appLister.Applications(app.Namespace).Get(app.Name)
+	require.NoError(t, err)
+	ctrl.appHydrateQueue.Add(refreshedApp.QualifiedName())
+
+	processed = ctrl.processAppHydrateQueueItem()
 	require.True(t, processed)
 
 	require.Eventually(t, func() bool {

--- a/test/e2e/fixture/fixture.go
+++ b/test/e2e/fixture/fixture.go
@@ -20,6 +20,7 @@ import (
 	jsonpatch "github.com/evanphx/json-patch"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -1296,6 +1297,35 @@ func RestartAPIServer(t *testing.T) {
 		}
 		errors.NewHandler(t).FailOnErr(Run("", "kubectl", "rollout", "-n", TestNamespace(), "restart", "deployment", workload))
 		errors.NewHandler(t).FailOnErr(Run("", "kubectl", "rollout", "-n", TestNamespace(), "status", "deployment", workload))
+	}
+}
+
+// RestartApplicationController performs a restart of the application controller
+// workload and waits until the rollout has completed.
+func RestartApplicationController(t *testing.T) {
+	t.Helper()
+	if IsRemote() {
+		log.Infof("Waiting for application controller to restart")
+		prefix := os.Getenv("ARGOCD_E2E_NAME_PREFIX")
+		workload := "argocd-application-controller"
+		if prefix != "" {
+			workload = prefix + "-application-controller"
+		}
+
+		restartRollout := func(kind string) {
+			errors.NewHandler(t).FailOnErr(Run("", "kubectl", "rollout", "-n", TestNamespace(), "restart", kind, workload))
+			errors.NewHandler(t).FailOnErr(Run("", "kubectl", "rollout", "-n", TestNamespace(), "status", kind, workload))
+		}
+
+		if _, err := KubeClientset.AppsV1().StatefulSets(TestNamespace()).Get(t.Context(), workload, metav1.GetOptions{}); err == nil {
+			restartRollout("statefulset")
+		} else if apierrors.IsNotFound(err) {
+			restartRollout("deployment")
+		} else {
+			require.NoError(t, err)
+		}
+
+		time.Sleep(5 * time.Second)
 	}
 }
 

--- a/test/e2e/hydrator_test.go
+++ b/test/e2e/hydrator_test.go
@@ -2,8 +2,10 @@ package e2e
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v3/test/e2e/fixture"
@@ -11,6 +13,47 @@ import (
 
 	. "github.com/argoproj/argo-cd/gitops-engine/pkg/sync/common"
 )
+
+func setHydratorReconciliationTimeout(t *testing.T, timeout, jitter string) {
+	t.Helper()
+
+	cm, err := fixture.KubeClientset.CoreV1().ConfigMaps(fixture.TestNamespace()).Get(t.Context(), "argocd-cm", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	original := map[string]*string{}
+	for _, key := range []string{"timeout.reconciliation", "timeout.reconciliation.jitter"} {
+		if value, ok := cm.Data[key]; ok {
+			v := value
+			original[key] = &v
+		} else {
+			original[key] = nil
+		}
+	}
+
+	require.NoError(t, fixture.SetParamInSettingConfigMap("timeout.reconciliation", timeout))
+	require.NoError(t, fixture.SetParamInSettingConfigMap("timeout.reconciliation.jitter", jitter))
+	fixture.RestartApplicationController(t)
+
+	t.Cleanup(func() {
+		cm, err := fixture.KubeClientset.CoreV1().ConfigMaps(fixture.TestNamespace()).Get(t.Context(), "argocd-cm", metav1.GetOptions{})
+		require.NoError(t, err)
+		if cm.Data == nil {
+			cm.Data = make(map[string]string)
+		}
+
+		for key, value := range original {
+			if value == nil {
+				delete(cm.Data, key)
+			} else {
+				cm.Data[key] = *value
+			}
+		}
+
+		_, err = fixture.KubeClientset.CoreV1().ConfigMaps(fixture.TestNamespace()).Update(t.Context(), cm, metav1.UpdateOptions{})
+		require.NoError(t, err)
+		fixture.RestartApplicationController(t)
+	})
+}
 
 func TestSimpleHydrator(t *testing.T) {
 	Given(t).
@@ -347,6 +390,63 @@ func TestHydratorNoOp(t *testing.T) {
 
 			require.Equal(t, firstHydratedSHA, app.Status.SourceHydrator.CurrentOperation.HydratedSHA,
 				"Hydrated SHA should remain the same for no-op hydration")
+		})
+}
+
+func TestHydratorPeriodicReconcilePicksUpDrySourceChanges(t *testing.T) {
+	if !fixture.IsRemote() {
+		t.Skip("requires remote e2e environment to restart the application controller after changing timeout.reconciliation")
+	}
+
+	setHydratorReconciliationTimeout(t, "5s", "0s")
+
+	var firstDrySHA string
+	var firstHydratedSHA string
+
+	ctx := Given(t).
+		Timeout(120).
+		DrySourcePath("guestbook").
+		DrySourceRevision("HEAD").
+		SyncSourcePath("guestbook").
+		SyncSourceBranch("env/test")
+
+	ctx.
+		When().
+		CreateApp().
+		Refresh(RefreshTypeNormal).
+		Wait("--hydrated").
+		Then().
+		Expect(HydrationPhaseIs(HydrateOperationPhaseHydrated)).
+		And(func(app *Application) {
+			require.NotNil(t, app.Status.SourceHydrator.CurrentOperation)
+			firstDrySHA = app.Status.SourceHydrator.CurrentOperation.DrySHA
+			firstHydratedSHA = app.Status.SourceHydrator.CurrentOperation.HydratedSHA
+			require.NotEmpty(t, firstDrySHA)
+			require.NotEmpty(t, firstHydratedSHA)
+		})
+
+	ctx.
+		When().
+		AddFile("guestbook/README.md", "# Guestbook\n\nPeriodic reconcile hydration test.").
+		Then().
+		AndAction(func() {
+			require.Eventually(t, func() bool {
+				app, err := fixture.AppClientset.ArgoprojV1alpha1().Applications(ctx.AppNamespace()).Get(t.Context(), ctx.AppName(), metav1.GetOptions{})
+				if err != nil {
+					return false
+				}
+				op := app.Status.SourceHydrator.CurrentOperation
+				if op == nil || op.Phase != HydrateOperationPhaseHydrated {
+					return false
+				}
+				return op.DrySHA != firstDrySHA
+			}, 90*time.Second, 2*time.Second)
+		}).
+		And(func(app *Application) {
+			op := app.Status.SourceHydrator.CurrentOperation
+			require.NotNil(t, op)
+			require.NotEqual(t, firstDrySHA, op.DrySHA, "dry SHA should change after the dry source commit")
+			require.Equal(t, firstHydratedSHA, op.HydratedSHA, "hydrated SHA should remain the same for a no-op hydration")
 		})
 }
 


### PR DESCRIPTION
## Summary

This updates the source-hydrator periodic refresh fix to address review feedback.

Fixes #26281

## What changed

- move the dry-source revision check into the hydration decision path
- avoid `ReconciledAt` races by keying the periodic check off the last completed hydration
- resolve the dry-source revision via repo-server `ResolveRevision` instead of manifest generation
- add an e2e that covers periodic hydration on reconcile timeout

## Validation

- focused hydrator/controller tests pass locally
- `go test -c ./test/e2e` passes locally
- the new e2e requires a remote e2e environment because it updates `timeout.reconciliation` and restarts the application controller
