### PR TITLE
feat: resolve path-relevant revision for monorepo apps using git log

### DIFF
--- a/controller/state.go
+++ b/controller/state.go
@@ -268,7 +268,7 @@ func (m *appStateManager) GetRepoObjs(ctx context.Context, app *v1alpha1.Applica
 			// just reading pre-generated manifests is comparable to updating revisions time-wise
 			app.Status.SourceType != v1alpha1.ApplicationSourceTypeDirectory
 
-		if updateRevisions && syncedRevision != "" && keyManifestGenerateAnnotationExists && keyManifestGenerateAnnotationVal != "" && (syncedRevision != revision || app.Spec.HasMultipleSources()) {
+		if updateRevisions && syncedRevision != "" && !source.IsRef() && keyManifestGenerateAnnotationExists && keyManifestGenerateAnnotationVal != "" && (syncedRevision != revision || app.Spec.HasMultipleSources()) {
 			// Validate the manifest-generate-path annotation to avoid generating manifests if it has not changed.
 			updateRevisionResult, err := repoClient.UpdateRevisionForPaths(ctx, &apiclient.UpdateRevisionForPathsRequest{
 				Repo:               repo,

--- a/controller/state.go
+++ b/controller/state.go
@@ -268,7 +268,7 @@ func (m *appStateManager) GetRepoObjs(ctx context.Context, app *v1alpha1.Applica
 			// just reading pre-generated manifests is comparable to updating revisions time-wise
 			app.Status.SourceType != v1alpha1.ApplicationSourceTypeDirectory
 
-		if updateRevisions && repo.Depth == 0 && syncedRevision != "" && !source.IsRef() && keyManifestGenerateAnnotationExists && keyManifestGenerateAnnotationVal != "" && (syncedRevision != revision || app.Spec.HasMultipleSources()) {
+		if updateRevisions && syncedRevision != "" && keyManifestGenerateAnnotationExists && keyManifestGenerateAnnotationVal != "" && (syncedRevision != revision || app.Spec.HasMultipleSources()) {
 			// Validate the manifest-generate-path annotation to avoid generating manifests if it has not changed.
 			updateRevisionResult, err := repoClient.UpdateRevisionForPaths(ctx, &apiclient.UpdateRevisionForPathsRequest{
 				Repo:               repo,

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -2908,50 +2908,6 @@ func (s *Service) checkoutRevision(gitClient git.Client, revision string, submod
 	return closer, err
 }
 
-// fetch is a convenience function to fetch revisions
-// We assumed that the caller has already initialized the git repo, i.e. gitClient.Init() has been called
-func (s *Service) fetch(gitClient git.Client, targetRevisions []string) error {
-	err := fetch(gitClient, targetRevisions)
-	if err != nil {
-		for _, revision := range targetRevisions {
-			s.metricsServer.IncGitFetchFail(gitClient.Root(), revision)
-		}
-	}
-	return err
-}
-
-func fetch(gitClient git.Client, targetRevisions []string) error {
-	revisionPresent := true
-	for _, revision := range targetRevisions {
-		revisionPresent = gitClient.IsRevisionPresent(revision)
-		if !revisionPresent {
-			break
-		}
-	}
-	// Fetching can be skipped if the revision is already present locally.
-	if revisionPresent {
-		return nil
-	}
-	// Fetching with no revision first. Fetching with an explicit version can cause repo bloat. https://github.com/argoproj/argo-cd/issues/8845
-	err := gitClient.Fetch("", 0)
-	if err != nil {
-		return err
-	}
-	for _, revision := range targetRevisions {
-		if !gitClient.IsRevisionPresent(revision) {
-			// When fetching with no revision, only refs/heads/* and refs/remotes/origin/* are fetched. If fetch fails
-			// for the given revision, try explicitly fetching it.
-			log.Infof("Failed to fetch revision %s: %v", revision, err)
-			log.Infof("Fallback to fetching specific revision %s. ref might not have been in the default refspec fetched.", revision)
-
-			if err := gitClient.Fetch(revision, 0); err != nil {
-				return status.Errorf(codes.Internal, "Failed to fetch revision %s: %v", revision, err)
-			}
-		}
-	}
-	return nil
-}
-
 func checkoutRevision(gitClient git.Client, revision string, submoduleEnabled bool, depth int64, cleanState bool) error {
 	err := gitClient.Init()
 	if err != nil {
@@ -3295,15 +3251,18 @@ func (s *Service) gitSourceHasChanges(repo *v1alpha1.Repository, revision, synce
 		defer s.metricsServer.DecPendingRepoRequest(repo.Repo)
 
 		closer, err := s.repoLock.Lock(gitClient.Root(), revision, true, func(clean bool) (goio.Closer, error) {
-			return s.checkoutRevision(gitClient, revision, false, 0, clean)
+			return s.checkoutRevision(gitClient, revision, false, repo.Depth, clean)
 		})
 		if err != nil {
 			return files, status.Errorf(codes.Internal, "unable to checkout git repo %s with revision %s: %v", repo.Repo, revision, err)
 		}
 		defer utilio.Close(closer)
 
-		if err := s.fetch(gitClient, []string{syncedRevision}); err != nil {
-			return files, status.Errorf(codes.Internal, "unable to fetch git repo %s with syncedRevisions %s: %v", repo.Repo, syncedRevision, err)
+		// Shallow-fetch syncedRevision: we only need the commit tree for diffing
+		if !gitClient.IsRevisionPresent(syncedRevision) {
+			if err := gitClient.Fetch(syncedRevision, 1); err != nil {
+				return files, status.Errorf(codes.Internal, "unable to fetch synced revision %s for repo %s: %v", syncedRevision, repo.Repo, err)
+			}
 		}
 
 		files, err = gitClient.ChangedFiles(syncedRevision, revision)
@@ -3328,6 +3287,15 @@ func (s *Service) gitSourceHasChanges(repo *v1alpha1.Repository, revision, synce
 	changed := false
 	if len(files) != 0 {
 		changed = apppathutil.AppFilesHaveChanged(refreshPaths, files)
+	}
+
+	if !changed {
+		// No files in the declared manifest-generate-paths changed between syncedRevision
+		// and revision. Return syncedRevision as the path-relevant revision: it is the last
+		// point where the app was synced and its manifests are identical to those at HEAD
+		// for the relevant paths. This avoids polluting revision history with commits that
+		// did not affect this application.
+		return syncedRevision, syncedRevision, false, nil
 	}
 
 	return revision, syncedRevision, changed, nil

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -3244,61 +3244,40 @@ func (s *Service) gitSourceHasChanges(repo *v1alpha1.Repository, revision, synce
 		return revision, syncedRevision, false, nil
 	}
 
-	getGitFilesChanges := func() ([]string, error) {
-		var files []string
-
+	getPathRelevantRevision := func() (string, error) {
 		s.metricsServer.IncPendingRepoRequest(repo.Repo)
 		defer s.metricsServer.DecPendingRepoRequest(repo.Repo)
 
 		closer, err := s.repoLock.Lock(gitClient.Root(), revision, true, func(clean bool) (goio.Closer, error) {
-			return s.checkoutRevision(gitClient, revision, false, repo.Depth, clean)
+			return s.checkoutRevision(gitClient, revision, false, 0, clean)
 		})
 		if err != nil {
-			return files, status.Errorf(codes.Internal, "unable to checkout git repo %s with revision %s: %v", repo.Repo, revision, err)
+			return "", status.Errorf(codes.Internal, "unable to checkout git repo %s with revision %s: %v", repo.Repo, revision, err)
 		}
 		defer utilio.Close(closer)
 
-		// Shallow-fetch syncedRevision: we only need the commit tree for diffing
-		if !gitClient.IsRevisionPresent(syncedRevision) {
-			if err := gitClient.Fetch(syncedRevision, 1); err != nil {
-				return files, status.Errorf(codes.Internal, "unable to fetch synced revision %s for repo %s: %v", syncedRevision, repo.Repo, err)
-			}
-		}
-
-		files, err = gitClient.ChangedFiles(syncedRevision, revision)
+		pathRevision, err := gitClient.RevisionForPaths(revision, refreshPaths)
 		if err != nil {
-			return files, status.Errorf(codes.Internal, "unable to get changed files for repo %s with revision %s: %v", repo.Repo, revision, err)
+			return "", status.Errorf(codes.Internal, "unable to find revision for paths %v in repo %s: %v", refreshPaths, repo.Repo, err)
 		}
-		return files, nil
+		return pathRevision, nil
 	}
 
-	files, err := s.cache.GetGitFilesChanges(repo.Repo, revision, syncedRevision)
+	pathRevision, err := getPathRelevantRevision()
 	if err != nil {
-		files, err = getGitFilesChanges()
-		if err != nil {
-			return revision, syncedRevision, true, err
-		}
+		return revision, syncedRevision, true, err
 	}
 
-	if err := s.cache.SetGitFilesChanges(repo.Repo, revision, syncedRevision, files); err != nil {
-		log.Warnf("Failed to store git files changes for `%s` repo in `%s...%s` with: %v", repo.Repo, revision, syncedRevision, err)
+	if pathRevision == "" || pathRevision != syncedRevision {
+		// Either no commit in the available history touched these paths (empty),
+		// or the last commit that touched them is different from the synced revision.
+		// In both cases, assume changes occurred.
+		return revision, syncedRevision, true, nil
 	}
 
-	changed := false
-	if len(files) != 0 {
-		changed = apppathutil.AppFilesHaveChanged(refreshPaths, files)
-	}
-
-	if !changed {
-		// No files in the declared manifest-generate-paths changed between syncedRevision
-		// and revision. Return syncedRevision as the path-relevant revision: it is the last
-		// point where the app was synced and its manifests are identical to those at HEAD
-		// for the relevant paths. This avoids polluting revision history with commits that
-		// did not affect this application.
-		return syncedRevision, syncedRevision, false, nil
-	}
-
-	return revision, syncedRevision, changed, nil
+	// The last commit that modified the declared manifest-generate-paths is exactly
+	// the synced revision. No path-relevant changes since sync.
+	return syncedRevision, syncedRevision, false, nil
 }
 
 // UpdateRevisionForPaths compares git revisions for single and multi-source applications

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -3217,61 +3217,6 @@ func TestCheckoutRevisionNotPresentCallFetch(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestFetch(t *testing.T) {
-	revision1 := "0123456789012345678901234567890123456789"
-	revision2 := "abcdefabcdefabcdefabcdefabcdefabcdefabcd"
-
-	gitClient := &gitmocks.Client{}
-	gitClient.EXPECT().Init().Return(nil)
-	gitClient.EXPECT().IsRevisionPresent(revision1).Once().Return(true)
-	gitClient.EXPECT().IsRevisionPresent(revision2).Once().Return(false)
-	gitClient.EXPECT().Fetch("", mock.Anything).Return(nil)
-	gitClient.EXPECT().IsRevisionPresent(revision1).Once().Return(true)
-	gitClient.EXPECT().IsRevisionPresent(revision2).Once().Return(true)
-
-	err := fetch(gitClient, []string{revision1, revision2})
-	require.NoError(t, err)
-}
-
-// TestFetchRevisionCanGetNonstandardRefs shows that we can fetch a revision that points to a non-standard ref. In
-func TestFetchRevisionCanGetNonstandardRefs(t *testing.T) {
-	rootPath := t.TempDir()
-
-	sourceRepoPath, err := os.MkdirTemp(rootPath, "")
-	require.NoError(t, err)
-
-	// Create a repo such that one commit is on a non-standard ref _and nowhere else_. This is meant to simulate, for
-	// example, a GitHub ref for a pull into one repo from a fork of that repo.
-	runGit(t, sourceRepoPath, "init")
-	runGit(t, sourceRepoPath, "checkout", "-b", "main") // make sure there's a main branch to switch back to
-	runGit(t, sourceRepoPath, "commit", "-m", "empty", "--allow-empty")
-	runGit(t, sourceRepoPath, "checkout", "-b", "branch")
-	runGit(t, sourceRepoPath, "commit", "-m", "empty", "--allow-empty")
-	sha := runGit(t, sourceRepoPath, "rev-parse", "HEAD")
-	runGit(t, sourceRepoPath, "update-ref", "refs/pull/123/head", strings.TrimSuffix(sha, "\n"))
-	runGit(t, sourceRepoPath, "checkout", "main")
-	runGit(t, sourceRepoPath, "branch", "-D", "branch")
-
-	destRepoPath, err := os.MkdirTemp(rootPath, "")
-	require.NoError(t, err)
-
-	gitClient, err := git.NewClientExt("file://"+sourceRepoPath, destRepoPath, &git.NopCreds{}, true, false, "", "")
-	require.NoError(t, err)
-
-	// We should initialize repository
-	err = gitClient.Init()
-	require.NoError(t, err)
-
-	pullSha, err := gitClient.LsRemote("refs/pull/123/head")
-	require.NoError(t, err)
-
-	err = fetch(gitClient, []string{"does-not-exist"})
-	require.Error(t, err)
-
-	err = fetch(gitClient, []string{pullSha})
-	require.NoError(t, err)
-}
-
 // runGit runs a git command in the given working directory. If the command succeeds, it returns the combined standard
 // and error output. If it fails, it stops the test with a failure message.
 func runGit(t *testing.T, workDir string, args ...string) string {
@@ -4847,13 +4792,12 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 		{name: "ChangedFilesDoNothing", fields: func() fields {
 			s, _, c := newServiceWithOpt(t, func(gitClient *gitmocks.Client, _ *helmmocks.Client, _ *ocimocks.Client, paths *iomocks.TempPaths) {
 				gitClient.EXPECT().Init().Return(nil)
-				gitClient.EXPECT().Fetch(mock.Anything, mock.Anything).Once().Return(nil)
+				gitClient.EXPECT().Fetch("", int64(0)).Once().Return(nil)
 				gitClient.EXPECT().IsRevisionPresent("632039659e542ed7de0c170a4fcc1c571b288fc0").Once().Return(false)
 				gitClient.EXPECT().Checkout("632039659e542ed7de0c170a4fcc1c571b288fc0", mock.Anything, mock.Anything).Once().Return("", nil)
-				// fetch
+				// shallow fetch syncedRevision
 				gitClient.EXPECT().IsRevisionPresent("1e67a504d03def3a6a1125d934cb511680f72555").Once().Return(false)
-				gitClient.EXPECT().Fetch(mock.Anything, mock.Anything).Once().Return(nil)
-				gitClient.EXPECT().IsRevisionPresent("1e67a504d03def3a6a1125d934cb511680f72555").Once().Return(true)
+				gitClient.EXPECT().Fetch("1e67a504d03def3a6a1125d934cb511680f72555", int64(1)).Once().Return(nil)
 				gitClient.EXPECT().LsRemote("HEAD").Once().Return("632039659e542ed7de0c170a4fcc1c571b288fc0", nil)
 				gitClient.EXPECT().LsRemote("SYNCEDHEAD").Once().Return("1e67a504d03def3a6a1125d934cb511680f72555", nil)
 				paths.EXPECT().GetPath(mock.Anything).Return(".", nil)
@@ -4884,13 +4828,12 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 		{name: "NoChangesUpdateCache", fields: func() fields {
 			s, _, c := newServiceWithOpt(t, func(gitClient *gitmocks.Client, _ *helmmocks.Client, _ *ocimocks.Client, paths *iomocks.TempPaths) {
 				gitClient.EXPECT().Init().Return(nil)
-				gitClient.EXPECT().Fetch(mock.Anything, mock.Anything).Once().Return(nil)
+				gitClient.EXPECT().Fetch("", int64(0)).Once().Return(nil)
 				gitClient.EXPECT().IsRevisionPresent("632039659e542ed7de0c170a4fcc1c571b288fc0").Once().Return(false)
 				gitClient.EXPECT().Checkout(mock.Anything, mock.Anything, mock.Anything).Return("", nil)
+				// shallow fetch syncedRevision
 				gitClient.EXPECT().IsRevisionPresent("1e67a504d03def3a6a1125d934cb511680f72555").Once().Return(false)
-				// fetch
-				gitClient.EXPECT().Fetch(mock.Anything, mock.Anything).Once().Return(nil)
-				gitClient.EXPECT().IsRevisionPresent("1e67a504d03def3a6a1125d934cb511680f72555").Once().Return(true)
+				gitClient.EXPECT().Fetch("1e67a504d03def3a6a1125d934cb511680f72555", int64(1)).Once().Return(nil)
 				gitClient.EXPECT().LsRemote("HEAD").Once().Return("632039659e542ed7de0c170a4fcc1c571b288fc0", nil)
 				gitClient.EXPECT().LsRemote("SYNCEDHEAD").Once().Return("1e67a504d03def3a6a1125d934cb511680f72555", nil)
 				paths.EXPECT().GetPath(mock.Anything).Return(".", nil)
@@ -4917,13 +4860,10 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 				KubeVersion:       "v1.16.0",
 			},
 		}, want: &apiclient.UpdateRevisionForPathsResponse{
-			Revision: "632039659e542ed7de0c170a4fcc1c571b288fc0", Changes: true, // FIXME: need to fix changes=true, because now test can't mock Rename cache
-
-		}, wantErr: assert.NoError, cacheHit: &cacheHit{
-			previousRevision: "1e67a504d03def3a6a1125d934cb511680f72555",
-			revision:         "632039659e542ed7de0c170a4fcc1c571b288fc0",
-		}, cacheCallCount: &repositorymocks.CacheCallCounts{
-			ExternalRenames: 1,
+			// No relevant files changed — revision resolves to syncedRevision
+			Revision: "1e67a504d03def3a6a1125d934cb511680f72555", Changes: false,
+		}, wantErr: assert.NoError, cacheCallCount: &repositorymocks.CacheCallCounts{
+			ExternalRenames: 0,
 			ExternalGets:    1,
 			ExternalSets:    1,
 		}},
@@ -4933,9 +4873,8 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 				gitClient.EXPECT().IsRevisionPresent("632039659e542ed7de0c170a4fcc1c571b288fc0").Once().Return(false)
 				gitClient.EXPECT().Fetch(mock.Anything, mock.Anything).Once().Return(nil)
 				gitClient.EXPECT().Checkout(mock.Anything, mock.Anything, mock.Anything).Return("", nil)
-				// fetch
+				// shallow fetch syncedRevision - already present
 				gitClient.EXPECT().IsRevisionPresent("1e67a504d03def3a6a1125d934cb511680f72555").Once().Return(true)
-				gitClient.EXPECT().Fetch(mock.Anything, mock.Anything).Once().Return(nil)
 				gitClient.EXPECT().LsRemote("HEAD").Once().Return("632039659e542ed7de0c170a4fcc1c571b288fc0", nil)
 				gitClient.EXPECT().LsRemote("SYNCEDHEAD").Once().Return("1e67a504d03def3a6a1125d934cb511680f72555", nil)
 				paths.EXPECT().GetPath(mock.Anything).Return(".", nil)
@@ -4964,12 +4903,9 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 				HasMultipleSources: true,
 			},
 		}, want: &apiclient.UpdateRevisionForPathsResponse{
-			Revision: "632039659e542ed7de0c170a4fcc1c571b288fc0", Changes: true, // FIXME: need to fix changes=true, because now test can't mock Rename cache
-		}, wantErr: assert.NoError, cacheHit: &cacheHit{
-			previousRevision: "1e67a504d03def3a6a1125d934cb511680f72555",
-			revision:         "632039659e542ed7de0c170a4fcc1c571b288fc0",
-		}, cacheCallCount: &repositorymocks.CacheCallCounts{
-			ExternalRenames: 1,
+			Revision: "1e67a504d03def3a6a1125d934cb511680f72555", Changes: false,
+		}, wantErr: assert.NoError, cacheCallCount: &repositorymocks.CacheCallCounts{
+			ExternalRenames: 0,
 			ExternalGets:    1,
 			ExternalSets:    1,
 		}},
@@ -4979,11 +4915,10 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 				gitClient.EXPECT().IsRevisionPresent("632039659e542ed7de0c170a4fcc1c571b288fc0").Once().Return(false)
 				gitClient.EXPECT().Fetch(mock.Anything, mock.Anything).Once().Return(nil)
 				gitClient.EXPECT().Checkout(mock.Anything, mock.Anything, mock.Anything).Return("", nil)
-				// fetch
+				// shallow fetch syncedRevision - already present
 				gitClient.EXPECT().IsRevisionPresent("1e67a504d03def3a6a1125d934cb511680f72555").Once().Return(true)
 				gitClient.EXPECT().IsRevisionPresent("732039659e542ed7de0c170a4fcc1c571b288fc1").Once().Return(true)
 				gitClient.EXPECT().IsRevisionPresent("2e67a504d03def3a6a1125d934cb511680f72554").Once().Return(true)
-				gitClient.EXPECT().Fetch(mock.Anything, mock.Anything).Once().Return(nil)
 				gitClient.EXPECT().LsRemote("HEAD").Once().Return("632039659e542ed7de0c170a4fcc1c571b288fc0", nil)
 				gitClient.EXPECT().LsRemote("SYNCEDHEAD").Once().Return("1e67a504d03def3a6a1125d934cb511680f72555", nil)
 				gitClient.EXPECT().LsRemote("HEAD-1").Once().Return("732039659e542ed7de0c170a4fcc1c571b288fc1", nil)
@@ -5021,12 +4956,9 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 				HasMultipleSources: true,
 			},
 		}, want: &apiclient.UpdateRevisionForPathsResponse{
-			Revision: "0.0.1", Changes: true, // FIXME: need to fix changes=true, because now test can't mock Rename cache
-		}, wantErr: assert.NoError, cacheHit: &cacheHit{
-			previousRevision: "0.0.1",
-			revision:         "0.0.1",
-		}, cacheCallCount: &repositorymocks.CacheCallCounts{
-			ExternalRenames: 1,
+			Revision: "0.0.1", Changes: false,
+		}, wantErr: assert.NoError, cacheCallCount: &repositorymocks.CacheCallCounts{
+			ExternalRenames: 0,
 			ExternalGets:    2,
 			ExternalSets:    2,
 		}},
@@ -5036,11 +4968,10 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 				gitClient.EXPECT().IsRevisionPresent("632039659e542ed7de0c170a4fcc1c571b288fc0").Once().Return(false)
 				gitClient.EXPECT().Fetch(mock.Anything, mock.Anything).Once().Return(nil)
 				gitClient.EXPECT().Checkout(mock.Anything, mock.Anything, mock.Anything).Return("", nil)
-				// fetch
+				// shallow fetch syncedRevision - already present
 				gitClient.EXPECT().IsRevisionPresent("1e67a504d03def3a6a1125d934cb511680f72555").Once().Return(true)
 				gitClient.EXPECT().IsRevisionPresent("732039659e542ed7de0c170a4fcc1c571b288fc1").Once().Return(true)
 				gitClient.EXPECT().IsRevisionPresent("2e67a504d03def3a6a1125d934cb511680f72554").Once().Return(true)
-				gitClient.EXPECT().Fetch(mock.Anything, mock.Anything).Once().Return(nil)
 				gitClient.EXPECT().LsRemote("HEAD").Once().Return("632039659e542ed7de0c170a4fcc1c571b288fc0", nil)
 				gitClient.EXPECT().LsRemote("SYNCEDHEAD").Once().Return("1e67a504d03def3a6a1125d934cb511680f72555", nil)
 				paths.EXPECT().GetPath(mock.Anything).Return(".", nil)
@@ -5076,12 +5007,9 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 				HasMultipleSources: true,
 			},
 		}, want: &apiclient.UpdateRevisionForPathsResponse{
-			Revision: "0.0.1", Changes: true, // FIXME: need to fix changes=true, because now test can't mock Rename cache
-		}, wantErr: assert.NoError, cacheHit: &cacheHit{
-			previousRevision: "0.0.1",
-			revision:         "0.0.1",
-		}, cacheCallCount: &repositorymocks.CacheCallCounts{
-			ExternalRenames: 1,
+			Revision: "0.0.1", Changes: false,
+		}, wantErr: assert.NoError, cacheCallCount: &repositorymocks.CacheCallCounts{
+			ExternalRenames: 0,
 			ExternalGets:    1,
 			ExternalSets:    1,
 		}},
@@ -5139,11 +5067,8 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 				gitClient.EXPECT().IsRevisionPresent("632039659e542ed7de0c170a4fcc1c571b288fc0").Once().Return(false)
 				gitClient.EXPECT().Fetch(mock.Anything, mock.Anything).Once().Return(nil)
 				gitClient.EXPECT().Checkout(mock.Anything, mock.Anything, mock.Anything).Return("", nil)
-				// fetch
+				// shallow fetch syncedRevision - already present
 				gitClient.EXPECT().IsRevisionPresent("1e67a504d03def3a6a1125d934cb511680f72555").Once().Return(true)
-				gitClient.EXPECT().IsRevisionPresent("732039659e542ed7de0c170a4fcc1c571b288fc1").Once().Return(true)
-				gitClient.EXPECT().IsRevisionPresent("2e67a504d03def3a6a1125d934cb511680f72554").Once().Return(true)
-				gitClient.EXPECT().Fetch(mock.Anything, mock.Anything).Once().Return(nil)
 				gitClient.EXPECT().LsRemote("HEAD").Once().Return("632039659e542ed7de0c170a4fcc1c571b288fc0", nil)
 				gitClient.EXPECT().LsRemote("SYNCEDHEAD").Once().Return("1e67a504d03def3a6a1125d934cb511680f72555", nil)
 				paths.EXPECT().GetPath(mock.Anything).Return(".", nil)
@@ -5182,12 +5107,52 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 				HasMultipleSources: true,
 			},
 		}, want: &apiclient.UpdateRevisionForPathsResponse{
-			Revision: "632039659e542ed7de0c170a4fcc1c571b288fc0", Changes: true, // FIXME: need to fix changes=true, because now test can't mock Rename cache
-		}, wantErr: assert.NoError, cacheHit: &cacheHit{
-			previousRevision: "632039659e542ed7de0c170a4fcc1c571b288fc0",
-			revision:         "1e67a504d03def3a6a1125d934cb511680f72555",
-		}, cacheCallCount: &repositorymocks.CacheCallCounts{
-			ExternalRenames: 1,
+			Revision: "1e67a504d03def3a6a1125d934cb511680f72555", Changes: false,
+		}, wantErr: assert.NoError, cacheCallCount: &repositorymocks.CacheCallCounts{
+			ExternalRenames: 0,
+			ExternalGets:    1,
+			ExternalSets:    1,
+		}},
+		{name: "NoChangesInAppPathsReturnsSyncedRevision", fields: func() fields {
+			s, _, c := newServiceWithOpt(t, func(gitClient *gitmocks.Client, _ *helmmocks.Client, _ *ocimocks.Client, paths *iomocks.TempPaths) {
+				gitClient.EXPECT().Init().Return(nil)
+				gitClient.EXPECT().Fetch("", int64(0)).Once().Return(nil)
+				gitClient.EXPECT().IsRevisionPresent("aaaa39659e542ed7de0c170a4fcc1c571b288fc0").Once().Return(false)
+				gitClient.EXPECT().Checkout(mock.Anything, mock.Anything, mock.Anything).Return("", nil)
+				// shallow fetch syncedRevision
+				gitClient.EXPECT().IsRevisionPresent("cccc504d03def3a6a1125d934cb511680f72555").Once().Return(false)
+				gitClient.EXPECT().Fetch("cccc504d03def3a6a1125d934cb511680f72555", int64(1)).Once().Return(nil)
+				gitClient.EXPECT().LsRemote("HEAD").Once().Return("aaaa39659e542ed7de0c170a4fcc1c571b288fc0", nil)
+				gitClient.EXPECT().LsRemote("SYNCEDHEAD").Once().Return("cccc504d03def3a6a1125d934cb511680f72555", nil)
+				paths.EXPECT().GetPath(mock.Anything).Return(".", nil)
+				paths.EXPECT().GetPathIfExists(mock.Anything).Return(".")
+				gitClient.EXPECT().Root().Return("")
+				// Files changed in other-dir but not in app-dir
+				gitClient.EXPECT().ChangedFiles(mock.Anything, mock.Anything).Return([]string{"other-dir/file.yaml"}, nil)
+			}, ".")
+			return fields{
+				service: s,
+				cache:   c,
+			}
+		}(), args: args{
+			ctx: t.Context(),
+			request: &apiclient.UpdateRevisionForPathsRequest{
+				Repo:              &v1alpha1.Repository{Repo: "a-url.com", Type: "git"},
+				Revision:          "HEAD",
+				SyncedRevision:    "SYNCEDHEAD",
+				Paths:             []string{"app-dir"},
+				AppLabelKey:       "app.kubernetes.io/name",
+				AppName:           "path-relevant-revision",
+				Namespace:         "default",
+				TrackingMethod:    "annotation+label",
+				ApplicationSource: &v1alpha1.ApplicationSource{Path: "app-dir"},
+				KubeVersion:       "v1.16.0",
+			},
+		}, want: &apiclient.UpdateRevisionForPathsResponse{
+			// No files in app-dir changed — revision resolves to syncedRevision
+			Revision: "cccc504d03def3a6a1125d934cb511680f72555", Changes: false,
+		}, wantErr: assert.NoError, cacheCallCount: &repositorymocks.CacheCallCounts{
+			ExternalRenames: 0,
 			ExternalGets:    1,
 			ExternalSets:    1,
 		}},

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -4792,18 +4792,16 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 		{name: "ChangedFilesDoNothing", fields: func() fields {
 			s, _, c := newServiceWithOpt(t, func(gitClient *gitmocks.Client, _ *helmmocks.Client, _ *ocimocks.Client, paths *iomocks.TempPaths) {
 				gitClient.EXPECT().Init().Return(nil)
-				gitClient.EXPECT().Fetch("", int64(0)).Once().Return(nil)
+				gitClient.EXPECT().Fetch(mock.Anything, mock.Anything).Once().Return(nil)
 				gitClient.EXPECT().IsRevisionPresent("632039659e542ed7de0c170a4fcc1c571b288fc0").Once().Return(false)
 				gitClient.EXPECT().Checkout("632039659e542ed7de0c170a4fcc1c571b288fc0", mock.Anything, mock.Anything).Once().Return("", nil)
-				// shallow fetch syncedRevision
-				gitClient.EXPECT().IsRevisionPresent("1e67a504d03def3a6a1125d934cb511680f72555").Once().Return(false)
-				gitClient.EXPECT().Fetch("1e67a504d03def3a6a1125d934cb511680f72555", int64(1)).Once().Return(nil)
 				gitClient.EXPECT().LsRemote("HEAD").Once().Return("632039659e542ed7de0c170a4fcc1c571b288fc0", nil)
 				gitClient.EXPECT().LsRemote("SYNCEDHEAD").Once().Return("1e67a504d03def3a6a1125d934cb511680f72555", nil)
 				paths.EXPECT().GetPath(mock.Anything).Return(".", nil)
 				paths.EXPECT().GetPathIfExists(mock.Anything).Return(".")
 				gitClient.EXPECT().Root().Return("")
-				gitClient.EXPECT().ChangedFiles(mock.Anything, mock.Anything).Return([]string{"app.yaml"}, nil)
+				// RevisionForPaths returns a different revision than syncedRevision — changes detected
+				gitClient.EXPECT().RevisionForPaths("632039659e542ed7de0c170a4fcc1c571b288fc0", mock.Anything).Return("632039659e542ed7de0c170a4fcc1c571b288fc0", nil)
 			}, ".")
 			return fields{
 				service: s,
@@ -4822,24 +4820,22 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 			Changes:  true,
 		}, wantErr: assert.NoError, cacheCallCount: &repositorymocks.CacheCallCounts{
 			ExternalRenames: 0,
-			ExternalGets:    1,
-			ExternalSets:    1,
+			ExternalGets:    0,
+			ExternalSets:    0,
 		}},
 		{name: "NoChangesUpdateCache", fields: func() fields {
 			s, _, c := newServiceWithOpt(t, func(gitClient *gitmocks.Client, _ *helmmocks.Client, _ *ocimocks.Client, paths *iomocks.TempPaths) {
 				gitClient.EXPECT().Init().Return(nil)
-				gitClient.EXPECT().Fetch("", int64(0)).Once().Return(nil)
+				gitClient.EXPECT().Fetch(mock.Anything, mock.Anything).Once().Return(nil)
 				gitClient.EXPECT().IsRevisionPresent("632039659e542ed7de0c170a4fcc1c571b288fc0").Once().Return(false)
 				gitClient.EXPECT().Checkout(mock.Anything, mock.Anything, mock.Anything).Return("", nil)
-				// shallow fetch syncedRevision
-				gitClient.EXPECT().IsRevisionPresent("1e67a504d03def3a6a1125d934cb511680f72555").Once().Return(false)
-				gitClient.EXPECT().Fetch("1e67a504d03def3a6a1125d934cb511680f72555", int64(1)).Once().Return(nil)
 				gitClient.EXPECT().LsRemote("HEAD").Once().Return("632039659e542ed7de0c170a4fcc1c571b288fc0", nil)
 				gitClient.EXPECT().LsRemote("SYNCEDHEAD").Once().Return("1e67a504d03def3a6a1125d934cb511680f72555", nil)
 				paths.EXPECT().GetPath(mock.Anything).Return(".", nil)
 				paths.EXPECT().GetPathIfExists(mock.Anything).Return(".")
 				gitClient.EXPECT().Root().Return("")
-				gitClient.EXPECT().ChangedFiles(mock.Anything, mock.Anything).Return([]string{}, nil)
+				// RevisionForPaths returns syncedRevision — no changes in paths
+				gitClient.EXPECT().RevisionForPaths("632039659e542ed7de0c170a4fcc1c571b288fc0", mock.Anything).Return("1e67a504d03def3a6a1125d934cb511680f72555", nil)
 			}, ".")
 			return fields{
 				service: s,
@@ -4864,8 +4860,8 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 			Revision: "1e67a504d03def3a6a1125d934cb511680f72555", Changes: false,
 		}, wantErr: assert.NoError, cacheCallCount: &repositorymocks.CacheCallCounts{
 			ExternalRenames: 0,
-			ExternalGets:    1,
-			ExternalSets:    1,
+			ExternalGets:    0,
+			ExternalSets:    0,
 		}},
 		{name: "NoChangesHelmMultiSourceUpdateCache", fields: func() fields {
 			s, _, c := newServiceWithOpt(t, func(gitClient *gitmocks.Client, _ *helmmocks.Client, _ *ocimocks.Client, paths *iomocks.TempPaths) {
@@ -4873,14 +4869,12 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 				gitClient.EXPECT().IsRevisionPresent("632039659e542ed7de0c170a4fcc1c571b288fc0").Once().Return(false)
 				gitClient.EXPECT().Fetch(mock.Anything, mock.Anything).Once().Return(nil)
 				gitClient.EXPECT().Checkout(mock.Anything, mock.Anything, mock.Anything).Return("", nil)
-				// shallow fetch syncedRevision - already present
-				gitClient.EXPECT().IsRevisionPresent("1e67a504d03def3a6a1125d934cb511680f72555").Once().Return(true)
 				gitClient.EXPECT().LsRemote("HEAD").Once().Return("632039659e542ed7de0c170a4fcc1c571b288fc0", nil)
 				gitClient.EXPECT().LsRemote("SYNCEDHEAD").Once().Return("1e67a504d03def3a6a1125d934cb511680f72555", nil)
 				paths.EXPECT().GetPath(mock.Anything).Return(".", nil)
 				paths.EXPECT().GetPathIfExists(mock.Anything).Return(".")
 				gitClient.EXPECT().Root().Return("")
-				gitClient.EXPECT().ChangedFiles(mock.Anything, mock.Anything).Return([]string{}, nil)
+				gitClient.EXPECT().RevisionForPaths("632039659e542ed7de0c170a4fcc1c571b288fc0", mock.Anything).Return("1e67a504d03def3a6a1125d934cb511680f72555", nil)
 			}, ".")
 			return fields{
 				service: s,
@@ -4906,19 +4900,15 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 			Revision: "1e67a504d03def3a6a1125d934cb511680f72555", Changes: false,
 		}, wantErr: assert.NoError, cacheCallCount: &repositorymocks.CacheCallCounts{
 			ExternalRenames: 0,
-			ExternalGets:    1,
-			ExternalSets:    1,
+			ExternalGets:    0,
+			ExternalSets:    0,
 		}},
 		{name: "NoChangesHelmWithRefMultiSourceUpdateCache", fields: func() fields {
 			s, _, c := newServiceWithOpt(t, func(gitClient *gitmocks.Client, _ *helmmocks.Client, _ *ocimocks.Client, paths *iomocks.TempPaths) {
 				gitClient.EXPECT().Init().Return(nil)
-				gitClient.EXPECT().IsRevisionPresent("632039659e542ed7de0c170a4fcc1c571b288fc0").Once().Return(false)
-				gitClient.EXPECT().Fetch(mock.Anything, mock.Anything).Once().Return(nil)
+				gitClient.EXPECT().IsRevisionPresent(mock.Anything).Return(false)
+				gitClient.EXPECT().Fetch(mock.Anything, mock.Anything).Return(nil)
 				gitClient.EXPECT().Checkout(mock.Anything, mock.Anything, mock.Anything).Return("", nil)
-				// shallow fetch syncedRevision - already present
-				gitClient.EXPECT().IsRevisionPresent("1e67a504d03def3a6a1125d934cb511680f72555").Once().Return(true)
-				gitClient.EXPECT().IsRevisionPresent("732039659e542ed7de0c170a4fcc1c571b288fc1").Once().Return(true)
-				gitClient.EXPECT().IsRevisionPresent("2e67a504d03def3a6a1125d934cb511680f72554").Once().Return(true)
 				gitClient.EXPECT().LsRemote("HEAD").Once().Return("632039659e542ed7de0c170a4fcc1c571b288fc0", nil)
 				gitClient.EXPECT().LsRemote("SYNCEDHEAD").Once().Return("1e67a504d03def3a6a1125d934cb511680f72555", nil)
 				gitClient.EXPECT().LsRemote("HEAD-1").Once().Return("732039659e542ed7de0c170a4fcc1c571b288fc1", nil)
@@ -4926,7 +4916,8 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 				paths.EXPECT().GetPath(mock.Anything).Return(".", nil)
 				paths.EXPECT().GetPathIfExists(mock.Anything).Return(".")
 				gitClient.EXPECT().Root().Return("")
-				gitClient.EXPECT().ChangedFiles(mock.Anything, mock.Anything).Return([]string{}, nil)
+				gitClient.EXPECT().RevisionForPaths("632039659e542ed7de0c170a4fcc1c571b288fc0", mock.Anything).Return("1e67a504d03def3a6a1125d934cb511680f72555", nil)
+				gitClient.EXPECT().RevisionForPaths("732039659e542ed7de0c170a4fcc1c571b288fc1", mock.Anything).Return("2e67a504d03def3a6a1125d934cb511680f72554", nil)
 			}, ".")
 			return fields{
 				service: s,
@@ -4959,8 +4950,8 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 			Revision: "0.0.1", Changes: false,
 		}, wantErr: assert.NoError, cacheCallCount: &repositorymocks.CacheCallCounts{
 			ExternalRenames: 0,
-			ExternalGets:    2,
-			ExternalSets:    2,
+			ExternalGets:    0,
+			ExternalSets:    0,
 		}},
 		{name: "NoChangesHelmWithRefMultiSource_IgnoreUnusedRef", fields: func() fields {
 			s, _, c := newServiceWithOpt(t, func(gitClient *gitmocks.Client, _ *helmmocks.Client, _ *ocimocks.Client, paths *iomocks.TempPaths) {
@@ -4968,16 +4959,12 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 				gitClient.EXPECT().IsRevisionPresent("632039659e542ed7de0c170a4fcc1c571b288fc0").Once().Return(false)
 				gitClient.EXPECT().Fetch(mock.Anything, mock.Anything).Once().Return(nil)
 				gitClient.EXPECT().Checkout(mock.Anything, mock.Anything, mock.Anything).Return("", nil)
-				// shallow fetch syncedRevision - already present
-				gitClient.EXPECT().IsRevisionPresent("1e67a504d03def3a6a1125d934cb511680f72555").Once().Return(true)
-				gitClient.EXPECT().IsRevisionPresent("732039659e542ed7de0c170a4fcc1c571b288fc1").Once().Return(true)
-				gitClient.EXPECT().IsRevisionPresent("2e67a504d03def3a6a1125d934cb511680f72554").Once().Return(true)
 				gitClient.EXPECT().LsRemote("HEAD").Once().Return("632039659e542ed7de0c170a4fcc1c571b288fc0", nil)
 				gitClient.EXPECT().LsRemote("SYNCEDHEAD").Once().Return("1e67a504d03def3a6a1125d934cb511680f72555", nil)
 				paths.EXPECT().GetPath(mock.Anything).Return(".", nil)
 				paths.EXPECT().GetPathIfExists(mock.Anything).Return(".")
 				gitClient.EXPECT().Root().Return("")
-				gitClient.EXPECT().ChangedFiles(mock.Anything, mock.Anything).Return([]string{}, nil)
+				gitClient.EXPECT().RevisionForPaths("632039659e542ed7de0c170a4fcc1c571b288fc0", mock.Anything).Return("1e67a504d03def3a6a1125d934cb511680f72555", nil)
 			}, ".")
 			return fields{
 				service: s,
@@ -5010,8 +4997,8 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 			Revision: "0.0.1", Changes: false,
 		}, wantErr: assert.NoError, cacheCallCount: &repositorymocks.CacheCallCounts{
 			ExternalRenames: 0,
-			ExternalGets:    1,
-			ExternalSets:    1,
+			ExternalGets:    0,
+			ExternalSets:    0,
 		}},
 		{name: "NoChangesHelmWithRefMultiSource_UndefinedRef", fields: func() fields {
 			s, _, c := newServiceWithOpt(t, func(gitClient *gitmocks.Client, _ *helmmocks.Client, _ *ocimocks.Client, paths *iomocks.TempPaths) {
@@ -5019,17 +5006,12 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 				gitClient.EXPECT().IsRevisionPresent("632039659e542ed7de0c170a4fcc1c571b288fc0").Once().Return(false)
 				gitClient.EXPECT().Fetch(mock.Anything, mock.Anything).Once().Return(nil)
 				gitClient.EXPECT().Checkout(mock.Anything, mock.Anything, mock.Anything).Return("", nil)
-				// fetch
-				gitClient.EXPECT().IsRevisionPresent("1e67a504d03def3a6a1125d934cb511680f72555").Once().Return(true)
-				gitClient.EXPECT().IsRevisionPresent("732039659e542ed7de0c170a4fcc1c571b288fc1").Once().Return(true)
-				gitClient.EXPECT().IsRevisionPresent("2e67a504d03def3a6a1125d934cb511680f72554").Once().Return(true)
-				gitClient.EXPECT().Fetch(mock.Anything, mock.Anything).Once().Return(nil)
 				gitClient.EXPECT().LsRemote("HEAD").Once().Return("632039659e542ed7de0c170a4fcc1c571b288fc0", nil)
 				gitClient.EXPECT().LsRemote("SYNCEDHEAD").Once().Return("1e67a504d03def3a6a1125d934cb511680f72555", nil)
 				paths.EXPECT().GetPath(mock.Anything).Return(".", nil)
 				paths.EXPECT().GetPathIfExists(mock.Anything).Return(".")
 				gitClient.EXPECT().Root().Return("")
-				gitClient.EXPECT().ChangedFiles(mock.Anything, mock.Anything).Return([]string{}, nil)
+				gitClient.EXPECT().RevisionForPaths("632039659e542ed7de0c170a4fcc1c571b288fc0", mock.Anything).Return("1e67a504d03def3a6a1125d934cb511680f72555", nil)
 			}, ".")
 			return fields{
 				service: s,
@@ -5067,14 +5049,12 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 				gitClient.EXPECT().IsRevisionPresent("632039659e542ed7de0c170a4fcc1c571b288fc0").Once().Return(false)
 				gitClient.EXPECT().Fetch(mock.Anything, mock.Anything).Once().Return(nil)
 				gitClient.EXPECT().Checkout(mock.Anything, mock.Anything, mock.Anything).Return("", nil)
-				// shallow fetch syncedRevision - already present
-				gitClient.EXPECT().IsRevisionPresent("1e67a504d03def3a6a1125d934cb511680f72555").Once().Return(true)
 				gitClient.EXPECT().LsRemote("HEAD").Once().Return("632039659e542ed7de0c170a4fcc1c571b288fc0", nil)
 				gitClient.EXPECT().LsRemote("SYNCEDHEAD").Once().Return("1e67a504d03def3a6a1125d934cb511680f72555", nil)
 				paths.EXPECT().GetPath(mock.Anything).Return(".", nil)
 				paths.EXPECT().GetPathIfExists(mock.Anything).Return(".")
 				gitClient.EXPECT().Root().Return("")
-				gitClient.EXPECT().ChangedFiles(mock.Anything, mock.Anything).Return([]string{}, nil)
+				gitClient.EXPECT().RevisionForPaths("632039659e542ed7de0c170a4fcc1c571b288fc0", mock.Anything).Return("1e67a504d03def3a6a1125d934cb511680f72555", nil)
 			}, ".")
 			return fields{
 				service: s,
@@ -5110,25 +5090,22 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 			Revision: "1e67a504d03def3a6a1125d934cb511680f72555", Changes: false,
 		}, wantErr: assert.NoError, cacheCallCount: &repositorymocks.CacheCallCounts{
 			ExternalRenames: 0,
-			ExternalGets:    1,
-			ExternalSets:    1,
+			ExternalGets:    0,
+			ExternalSets:    0,
 		}},
 		{name: "NoChangesInAppPathsReturnsSyncedRevision", fields: func() fields {
 			s, _, c := newServiceWithOpt(t, func(gitClient *gitmocks.Client, _ *helmmocks.Client, _ *ocimocks.Client, paths *iomocks.TempPaths) {
 				gitClient.EXPECT().Init().Return(nil)
-				gitClient.EXPECT().Fetch("", int64(0)).Once().Return(nil)
+				gitClient.EXPECT().Fetch(mock.Anything, mock.Anything).Once().Return(nil)
 				gitClient.EXPECT().IsRevisionPresent("aaaa39659e542ed7de0c170a4fcc1c571b288fc0").Once().Return(false)
 				gitClient.EXPECT().Checkout(mock.Anything, mock.Anything, mock.Anything).Return("", nil)
-				// shallow fetch syncedRevision
-				gitClient.EXPECT().IsRevisionPresent("cccc504d03def3a6a1125d934cb511680f72555").Once().Return(false)
-				gitClient.EXPECT().Fetch("cccc504d03def3a6a1125d934cb511680f72555", int64(1)).Once().Return(nil)
 				gitClient.EXPECT().LsRemote("HEAD").Once().Return("aaaa39659e542ed7de0c170a4fcc1c571b288fc0", nil)
 				gitClient.EXPECT().LsRemote("SYNCEDHEAD").Once().Return("cccc504d03def3a6a1125d934cb511680f72555", nil)
 				paths.EXPECT().GetPath(mock.Anything).Return(".", nil)
 				paths.EXPECT().GetPathIfExists(mock.Anything).Return(".")
 				gitClient.EXPECT().Root().Return("")
-				// Files changed in other-dir but not in app-dir
-				gitClient.EXPECT().ChangedFiles(mock.Anything, mock.Anything).Return([]string{"other-dir/file.yaml"}, nil)
+				// RevisionForPaths returns syncedRevision — app-dir not modified since sync
+				gitClient.EXPECT().RevisionForPaths("aaaa39659e542ed7de0c170a4fcc1c571b288fc0", mock.Anything).Return("cccc504d03def3a6a1125d934cb511680f72555", nil)
 			}, ".")
 			return fields{
 				service: s,
@@ -5153,8 +5130,8 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 			Revision: "cccc504d03def3a6a1125d934cb511680f72555", Changes: false,
 		}, wantErr: assert.NoError, cacheCallCount: &repositorymocks.CacheCallCounts{
 			ExternalRenames: 0,
-			ExternalGets:    1,
-			ExternalSets:    1,
+			ExternalGets:    0,
+			ExternalSets:    0,
 		}},
 	}
 	for _, tt := range tests {

--- a/util/git/client.go
+++ b/util/git/client.go
@@ -137,6 +137,9 @@ type Client interface {
 	VerifyCommitSignature(string) (string, error)
 	IsAnnotatedTag(string) bool
 	ChangedFiles(revision string, targetRevision string) ([]string, error)
+	// RevisionForPaths returns the SHA of the most recent commit reachable from revision
+	// that modified any of the given paths. Returns empty string if no such commit exists.
+	RevisionForPaths(revision string, paths []string) (string, error)
 	IsRevisionPresent(revision string) bool
 	// SetAuthor sets the author name and email in the git configuration.
 	SetAuthor(name, email string) (string, error)
@@ -1000,6 +1003,21 @@ func (m *nativeGitClient) ChangedFiles(revision string, targetRevision string) (
 
 	files := strings.Split(out, "\n")
 	return files, nil
+}
+
+func (m *nativeGitClient) RevisionForPaths(revision string, paths []string) (string, error) {
+	if !IsCommitSHA(revision) {
+		return "", errors.New("invalid revision provided, must be SHA")
+	}
+	if len(paths) == 0 {
+		return "", nil
+	}
+	args := append([]string{"log", "-1", "--format=%H", revision, "--"}, paths...)
+	out, err := m.runCmd(context.Background(), args...)
+	if err != nil {
+		return "", fmt.Errorf("failed to find revision for paths %v: %w", paths, err)
+	}
+	return strings.TrimSpace(out), nil
 }
 
 // config runs a git config command.

--- a/util/git/mocks/Client.go
+++ b/util/git/mocks/Client.go
@@ -1185,6 +1185,72 @@ func (_c *Client_RevisionMetadata_Call) RunAndReturn(run func(revision string) (
 	return _c
 }
 
+// RevisionForPaths provides a mock function for the type Client
+func (_mock *Client) RevisionForPaths(revision string, paths []string) (string, error) {
+	ret := _mock.Called(revision, paths)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RevisionForPaths")
+	}
+
+	var r0 string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string, []string) (string, error)); ok {
+		return returnFunc(revision, paths)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string, []string) string); ok {
+		r0 = returnFunc(revision, paths)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	if returnFunc, ok := ret.Get(1).(func(string, []string) error); ok {
+		r1 = returnFunc(revision, paths)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Client_RevisionForPaths_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RevisionForPaths'
+type Client_RevisionForPaths_Call struct {
+	*mock.Call
+}
+
+// RevisionForPaths is a helper method to define mock.On call
+//   - revision string
+//   - paths []string
+func (_e *Client_Expecter) RevisionForPaths(revision interface{}, paths interface{}) *Client_RevisionForPaths_Call {
+	return &Client_RevisionForPaths_Call{Call: _e.mock.On("RevisionForPaths", revision, paths)}
+}
+
+func (_c *Client_RevisionForPaths_Call) Run(run func(revision string, paths []string)) *Client_RevisionForPaths_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *Client_RevisionForPaths_Call) Return(s string, err error) *Client_RevisionForPaths_Call {
+	_c.Call.Return(s, err)
+	return _c
+}
+
+func (_c *Client_RevisionForPaths_Call) RunAndReturn(run func(revision string, paths []string) (string, error)) *Client_RevisionForPaths_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Root provides a mock function for the type Client
 func (_mock *Client) Root() string {
 	ret := _mock.Called()


### PR DESCRIPTION
## Summary

Resolves #27102 — **Path-Relevant Revision History for Monorepo Applications**.

When `manifest-generate-paths` is configured and no relevant files changed between the synced revision and HEAD, the Application's revision is resolved to the **synced revision** rather than the literal HEAD SHA. This avoids polluting revision history with commits that did not affect the application.

### Changes

- Add `RevisionForPaths` to the git `Client` interface (`git log -1 --format=%H <rev> -- <paths>`) to find the most recent commit that modified any of the given paths
- Replace `ChangedFiles` + `AppFilesHaveChanged` with `RevisionForPaths` in `gitSourceHasChanges` — a single git command instead of diffing file lists
- Remove the `repo.Depth == 0` guard in the controller so path-relevant revision resolution works for **all** clone depths, including shallow clones (the reposerver always does a full fetch in its temporary working directory via `checkoutRevision(..., 0, ...)`)
- Keep the `!source.IsRef()` guard (ref sources don't have their own paths)
- Remove the `fetch` helper and `GetGitFilesChanges`/`SetGitFilesChanges` cache calls from `gitSourceHasChanges` since they are no longer needed

### How it works

1. `gitSourceHasChanges` checks out the target revision (full fetch, depth 0)
2. Calls `RevisionForPaths(revision, refreshPaths)` which runs `git log -1 --format=%H <revision> -- <paths...>`
3. If the returned SHA equals `syncedRevision` → the paths were last modified at the sync point → no changes since sync
4. Otherwise → changes detected, manifest regeneration proceeds as before

## Test plan

- [x] `go test ./reposerver/repository/... -run TestUpdateRevisionForPaths` — validates all path-relevant revision flows
- [x] `go build ./...` — clean build
- [ ] Manual: deploy to a monorepo environment and verify revision history entries reference path-relevant commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)