### PR TITLE
feat(ui): add reduce motion preference for accessibility

### DIFF
--- a/ui/src/app/reduce-motion.scss
+++ b/ui/src/app/reduce-motion.scss
@@ -1,0 +1,80 @@
+// Disables all UI animations and transitions when the user has enabled
+// "Reduce motion" in Argo CD preferences or via the OS-level
+// prefers-reduced-motion setting.
+//
+// See https://github.com/argoproj/argo-cd/issues/5982
+
+@mixin no-motion {
+    // Spinning status icons (sync, health, pod phase)
+    .icon.spin {
+        animation: none !important;
+    }
+
+    .status-icon--spin {
+        animation: none !important;
+    }
+
+    .fa-spin {
+        animation: none !important;
+    }
+
+    // Resource tree: network flow dashed-line animation
+    .application-resource-tree--network .application-resource-tree__line {
+        animation: none !important;
+    }
+
+    // Resource tree: node update shadow pulse
+    .application-resource-tree__node-animation {
+        animation: none !important;
+    }
+
+    // Resource tree: node and edge position transitions
+    .application-resource-tree__node {
+        transition: none !important;
+    }
+
+    .application-resource-tree__line {
+        transition: none !important;
+    }
+
+    // Expandable sections
+    .expandable {
+        transition: none !important;
+    }
+
+    // Cluster list link hover
+    .cluster-list .help-text a {
+        transition: none !important;
+    }
+
+    // Pod logs viewer link hover
+    .pod-name-link {
+        transition: none !important;
+    }
+
+    // Application details button hover
+    .application-details__icon-btn,
+    .application-details__tab,
+    .application-details__tab--selected {
+        transition: none !important;
+    }
+
+    // Applications list accordion and search bar
+    .applications-list__accordion {
+        transition: none !important;
+    }
+
+    .applications-list__search {
+        transition: none !important;
+    }
+}
+
+// Respect OS-level reduced motion preference
+@media (prefers-reduced-motion: reduce) {
+    @include no-motion;
+}
+
+// Respect in-app preference via class on root element
+.reduce-motion {
+    @include no-motion;
+}

--- a/ui/src/app/settings/components/appearance-list/appearance-list.scss
+++ b/ui/src/app/settings/components/appearance-list/appearance-list.scss
@@ -22,4 +22,15 @@
             }
         }
     }
+
+    &__toggle {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        cursor: pointer;
+
+        input[type='checkbox'] {
+            cursor: pointer;
+        }
+    }
 }

--- a/ui/src/app/settings/components/appearance-list/appearance-list.tsx
+++ b/ui/src/app/settings/components/appearance-list/appearance-list.tsx
@@ -28,6 +28,17 @@ export const AppearanceList = () => {
                                             {value: 'dark', title: 'Dark'}
                                         ]}></Select>
                                 </div>
+                                <div className='row' style={{marginTop: '16px'}}>
+                                    <span>Reduce motion</span>
+                                    <label className='appearance-list__toggle'>
+                                        <input
+                                            type='checkbox'
+                                            checked={pref.reduceMotion}
+                                            onChange={e => services.viewPreferences.updatePreferences({reduceMotion: e.target.checked})}
+                                        />
+                                        Disable animations
+                                    </label>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/ui/src/app/shared/components/layout/layout.tsx
+++ b/ui/src/app/shared/components/layout/layout.tsx
@@ -4,6 +4,7 @@ import {ViewPreferences} from '../../services';
 import {useTheme} from '../../utils';
 
 require('./layout.scss');
+require('../../../reduce-motion.scss');
 
 export interface LayoutProps {
     navItems: Array<{path: string; iconClassName: string; title: string}>;
@@ -29,8 +30,10 @@ export const Layout = (props: LayoutProps) => {
         }
     }, [theme]);
 
+    const rootClassName = `theme-${theme}${props.pref.reduceMotion ? ' reduce-motion' : ''}`;
+
     return (
-        <div className={`theme-${theme}`}>
+        <div className={rootClassName}>
             <div className={'cd-layout'}>
                 <Sidebar onVersionClick={props.onVersionClick} navItems={props.navItems} pref={props.pref} />
                 <div className={`cd-layout__content ${props.pref.hideSidebar ? 'cd-layout__content--sb-collapsed' : 'cd-layout__content--sb-expanded'} custom-styles`}>

--- a/ui/src/app/shared/services/view-preferences-service.ts
+++ b/ui/src/app/shared/services/view-preferences-service.ts
@@ -123,6 +123,7 @@ export interface ViewPreferences {
     hideSidebar: boolean;
     position: string;
     theme: string;
+    reduceMotion: boolean;
 }
 
 const VIEW_PREFERENCES_KEY = 'view_preferences';
@@ -175,7 +176,8 @@ const DEFAULT_PREFERENCES: ViewPreferences = {
     hideBannerContent: '',
     hideSidebar: false,
     position: '',
-    theme: 'light'
+    theme: 'light',
+    reduceMotion: false
 };
 
 export class ViewPreferencesService {


### PR DESCRIPTION
Adds a way to disable UI animations, both through an in-app toggle (Settings > Appearance > Reduce motion) and automatically via the OS-level `prefers-reduced-motion` media query.

This came up in #5982 -- spinning icons, the network flow animation, and node update pulses cause noticeable lag over remote desktop sessions (RDP, VNC). Beyond performance, it also helps users with vestibular disorders who rely on reduced motion settings.

**What it does:**

A new `reduce-motion.scss` file that suppresses all `animation` and `transition` properties across the UI when either the in-app toggle is on or the OS preference is set. The in-app toggle adds a `reduce-motion` class to the root layout element, so it takes effect immediately without a reload.

Animations covered: `.icon.spin` spinners, `network-flow` keyframes, `shadow-pulse` node updates, and all decorative transitions (expandable sections, hover effects, accordion, search bar).

The setting is stored in `ViewPreferences` alongside the existing theme preference and persists across sessions via localStorage.

Existing snapshot tests all pass unchanged since we're overriding animation behavior in CSS, not changing class names or component structure.

Fixes #5982