### PR TITLE
fix: application controller avoid missing requested app operations

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -133,6 +133,8 @@ type ApplicationController struct {
 	settingsMgr                   *settings_util.SettingsManager
 	refreshRequestedApps          map[string]CompareWith
 	refreshRequestedAppsMutex     *sync.Mutex
+	requestedAppOperations        map[string]struct{}
+	requestedAppOperationsMutex   *sync.Mutex
 	metricsServer                 *metrics.MetricsServer
 	metricsClusterLabels          []string
 	kubectlSemaphore              *semaphore.Weighted
@@ -205,6 +207,8 @@ func NewApplicationController(
 		statusRefreshJitter:               appResyncJitter,
 		refreshRequestedApps:              make(map[string]CompareWith),
 		refreshRequestedAppsMutex:         &sync.Mutex{},
+		requestedAppOperations:            make(map[string]struct{}),
+		requestedAppOperationsMutex:       &sync.Mutex{},
 		auditLogger:                       argo.NewAuditLogger(kubeClientset, namespace, common.CommandApplicationController, enableK8sEvent),
 		settingsMgr:                       settingsMgr,
 		selfHealTimeout:                   selfHealTimeout,
@@ -997,6 +1001,29 @@ func (ctrl *ApplicationController) isRefreshRequested(appName string) (bool, Com
 	return ok, level
 }
 
+// requestAppOperation marks the application as having a newly requested operation
+// and schedules prompt operation processing.
+func (ctrl *ApplicationController) requestAppOperation(appName string) {
+	key := ctrl.toAppKey(appName)
+	ctrl.requestedAppOperationsMutex.Lock()
+	ctrl.requestedAppOperations[key] = struct{}{}
+	ctrl.requestedAppOperationsMutex.Unlock()
+	ctrl.appOperationQueue.Add(key)
+}
+
+func (ctrl *ApplicationController) isAppOperationRequested(appKey string) bool {
+	ctrl.requestedAppOperationsMutex.Lock()
+	defer ctrl.requestedAppOperationsMutex.Unlock()
+	_, ok := ctrl.requestedAppOperations[appKey]
+	return ok
+}
+
+func (ctrl *ApplicationController) clearAppOperationRequest(appKey string) {
+	ctrl.requestedAppOperationsMutex.Lock()
+	defer ctrl.requestedAppOperationsMutex.Unlock()
+	delete(ctrl.requestedAppOperations, appKey)
+}
+
 func (ctrl *ApplicationController) processAppOperationQueueItem() (processNext bool) {
 	appKey, shutdown := ctrl.appOperationQueue.Get()
 	if shutdown {
@@ -1036,16 +1063,34 @@ func (ctrl *ApplicationController) processAppOperationQueueItem() (processNext b
 		logCtx.Debug("Finished processing app operation queue item")
 	}()
 
-	if app.Operation != nil {
+	requestedOperation := ctrl.isAppOperationRequested(appKey)
+	if app.Operation != nil || requestedOperation {
 		// If we get here, we are about to process an operation, but we cannot rely on informer since it might have stale data.
 		// So always retrieve the latest version to ensure it is not stale to avoid unnecessary syncing.
 		// We cannot rely on informer since applications might be updated by both application controller and api server.
 		freshApp, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(app.ObjectMeta.Namespace).Get(context.Background(), app.Name, metav1.GetOptions{})
 		if err != nil {
+			if requestedOperation {
+				if isRetryableAppOperationGetError(err) {
+					logCtx.WithError(err).Warn("Failed to retrieve latest application state, requeueing operation")
+					ctrl.appOperationQueue.AddRateLimited(appKey)
+				} else {
+					ctrl.clearAppOperationRequest(appKey)
+					logCtx.WithError(err).Error("Failed to retrieve latest application state")
+				}
+				return processNext
+			}
+
+			if isRetryableAppOperationGetError(err) {
+				logCtx.WithError(err).Warn("Failed to retrieve latest application state, requeueing operation")
+				ctrl.appOperationQueue.AddRateLimited(appKey)
+				return processNext
+			}
 			logCtx.WithError(err).Error("Failed to retrieve latest application state")
 			return processNext
 		}
 		app = freshApp
+		ctrl.clearAppOperationRequest(appKey)
 	}
 	ts.AddCheckpoint("get_fresh_app_ms")
 
@@ -2550,6 +2595,9 @@ func (ctrl *ApplicationController) newApplicationInformerAndLister() (cache.Shar
 						log.WithFields(applog.GetAppLogFields(newApp)).Info("Enabled automated sync")
 						compareWith = CompareWithLatest.Pointer()
 					}
+					if oldApp.Operation == nil && newApp.Operation != nil {
+						ctrl.requestAppOperation(newApp.QualifiedName())
+					}
 					if ctrl.statusRefreshJitter != 0 && oldApp.ResourceVersion == newApp.ResourceVersion {
 						// Handler is refreshing the apps, add a random jitter to spread the load and avoid spikes
 						jitter := time.Duration(float64(ctrl.statusRefreshJitter) * rand.Float64())
@@ -2610,6 +2658,14 @@ func (ctrl *ApplicationController) RegisterClusterSecretUpdater(ctx context.Cont
 
 func isOperationInProgress(app *appv1.Application) bool {
 	return app.Status.OperationState != nil && !app.Status.OperationState.Phase.Completed()
+}
+
+func isRetryableAppOperationGetError(err error) bool {
+	return apierrors.IsInternalError(err) ||
+		apierrors.IsTimeout(err) ||
+		apierrors.IsServerTimeout(err) ||
+		apierrors.IsTooManyRequests(err) ||
+		apierrors.IsServiceUnavailable(err)
 }
 
 // automatedSyncEnabled tests if an app went from auto-sync disabled to enabled.

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -1634,6 +1634,155 @@ func TestHandleAppUpdated(t *testing.T) {
 	assert.Equal(t, CompareWithRecent, level)
 }
 
+func TestRequestAppOperation_EnqueuesOperationQueueWhenOperationAdded(t *testing.T) {
+	defaultProj := v1alpha1.AppProject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: test.FakeArgoCDNamespace,
+		},
+		Spec: v1alpha1.AppProjectSpec{
+			SourceRepos: []string{"*"},
+			Destinations: []v1alpha1.ApplicationDestination{{
+				Server:    "*",
+				Namespace: "*",
+			}},
+		},
+	}
+	app := newFakeApp()
+	app.Status.OperationState = nil
+
+	ctrl := newFakeController(t.Context(), &fakeData{
+		apps: []runtime.Object{app, &defaultProj},
+		manifestResponse: &apiclient.ManifestResponse{
+			Manifests: []string{},
+			Namespace: test.FakeDestNamespace,
+			Server:    test.FakeClusterURL,
+			Revision:  "abc123",
+		},
+	}, nil)
+
+	require.Zero(t, ctrl.appOperationQueue.Len())
+	ctrl.requestAppOperation(app.QualifiedName())
+
+	assert.Eventually(t, func() bool {
+		return ctrl.appOperationQueue.Len() > 0
+	}, time.Second, 10*time.Millisecond)
+	assert.True(t, ctrl.isAppOperationRequested(ctrl.toAppKey(app.QualifiedName())))
+}
+
+func TestProcessAppOperationQueueItem_UsesFreshAppForExplicitOperationRequest(t *testing.T) {
+	defaultProj := v1alpha1.AppProject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: test.FakeArgoCDNamespace,
+		},
+		Spec: v1alpha1.AppProjectSpec{
+			SourceRepos: []string{"*"},
+			Destinations: []v1alpha1.ApplicationDestination{{
+				Server:    "*",
+				Namespace: "*",
+			}},
+		},
+	}
+	app := newFakeApp()
+	app.Status.OperationState = nil
+
+	ctrl := newFakeController(t.Context(), &fakeData{
+		apps: []runtime.Object{app, &defaultProj},
+		manifestResponse: &apiclient.ManifestResponse{
+			Manifests: []string{},
+			Namespace: test.FakeDestNamespace,
+			Server:    test.FakeClusterURL,
+			Revision:  "abc123",
+		},
+	}, nil)
+
+	liveApp, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(app.Namespace).Get(t.Context(), app.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	liveApp.Operation = &v1alpha1.Operation{
+		Sync: &v1alpha1.SyncOperation{Revision: "HEAD"},
+	}
+	_, err = ctrl.applicationClientset.ArgoprojV1alpha1().Applications(app.Namespace).Update(t.Context(), liveApp, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	staleApp := app.DeepCopy()
+	staleApp.ResourceVersion = liveApp.ResourceVersion
+	require.NoError(t, ctrl.appInformer.GetStore().Update(staleApp))
+
+	ctrl.requestAppOperation(app.QualifiedName())
+	ctrl.processAppOperationQueueItem()
+
+	updatedApp, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(app.Namespace).Get(t.Context(), app.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, updatedApp.Status.OperationState)
+	assert.NotEmpty(t, string(updatedApp.Status.OperationState.Phase))
+}
+
+func TestProcessAppOperationQueueItem_RequeuesOnTransientGetFailure(t *testing.T) {
+	defaultProj := v1alpha1.AppProject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: test.FakeArgoCDNamespace,
+		},
+		Spec: v1alpha1.AppProjectSpec{
+			SourceRepos: []string{"*"},
+			Destinations: []v1alpha1.ApplicationDestination{{
+				Server:    "*",
+				Namespace: "*",
+			}},
+		},
+	}
+	app := newFakeApp()
+	app.Status.OperationState = nil
+
+	ctrl := newFakeController(t.Context(), &fakeData{
+		apps: []runtime.Object{app, &defaultProj},
+		manifestResponse: &apiclient.ManifestResponse{
+			Manifests: []string{},
+			Namespace: test.FakeDestNamespace,
+			Server:    test.FakeClusterURL,
+			Revision:  "abc123",
+		},
+	}, nil)
+
+	liveApp, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(app.Namespace).Get(t.Context(), app.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	liveApp.Operation = &v1alpha1.Operation{
+		Sync: &v1alpha1.SyncOperation{Revision: "HEAD"},
+	}
+	_, err = ctrl.applicationClientset.ArgoprojV1alpha1().Applications(app.Namespace).Update(t.Context(), liveApp, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	staleApp := app.DeepCopy()
+	staleApp.ResourceVersion = liveApp.ResourceVersion
+	require.NoError(t, ctrl.appInformer.GetStore().Update(staleApp))
+
+	fakeAppCs := ctrl.applicationClientset.(*appclientset.Clientset)
+	gets := 0
+	fakeAppCs.PrependReactor("get", "applications", func(_ kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+		if gets == 0 {
+			gets++
+			return true, nil, apierrors.NewTooManyRequests("transient get failure", 1)
+		}
+		return false, nil, nil
+	})
+
+	ctrl.requestAppOperation(app.QualifiedName())
+	ctrl.processAppOperationQueueItem()
+
+	assert.Eventually(t, func() bool {
+		return ctrl.appOperationQueue.Len() > 0
+	}, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, ctrl.appInformer.GetStore().Update(staleApp))
+	ctrl.processAppOperationQueueItem()
+
+	updatedApp, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(app.Namespace).Get(t.Context(), app.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, updatedApp.Status.OperationState)
+	assert.NotEmpty(t, string(updatedApp.Status.OperationState.Phase))
+}
+
 func TestHandleOrphanedResourceUpdated(t *testing.T) {
 	app1 := newFakeApp()
 	app1.Name = "app1"


### PR DESCRIPTION
Under API server pressure, an Application update that adds `.operation`
can reach the controller at an awkward time: refresh processing may
enqueue the operation queue before the informer cache reflects the new
operation, and `processAppOperationQueueItem()` previously only performed
a live GET when informer state already showed `app.Operation != nil`. In
that case the worker could observe a stale Application, treat it as
having no requested operation, and silently return. The operation would
only start later if some other refresh or comparison-expiry path
re-enqueued the app after informer state caught up.

Address that gap by tracking explicit operation requests when an
Application update transitions from `operation=nil` to `operation!=nil`,
enqueueing the operation queue immediately, and allowing operation
workers to do a live GET whenever that explicit request marker is
present even if informer state is stale. Retry transient GET failures
such as timeout, 429, or 503 instead of dropping the request.

Add regression coverage for immediate operation enqueueing, recovery
from stale informer state, and requeue behavior on transient live-GET
failures.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
