### PR TITLE
fix: don't clobber non-ignored fields on "replace"

### DIFF
--- a/controller/sync.go
+++ b/controller/sync.go
@@ -463,7 +463,11 @@ func normalizeTargetResources(cr *comparisonResult) ([]*unstructured.Unstructure
 		// Strategic merge patch treats "replace" fields as atomic, so patching in
 		// one ignored sub-field pulls the entire parent from live, clobbering
 		// non-ignored sibling fields. We detect and undo this here.
-		restoreNonIgnoredFields(patchedTarget.Object, originalTarget.Object, normalizedTarget.Object)
+		var normalizedLiveObj map[string]any
+		if normalized.Lives[idx] != nil {
+			normalizedLiveObj = normalized.Lives[idx].Object
+		}
+		restoreNonIgnoredFields(patchedTarget.Object, originalTarget.Object, normalizedTarget.Object, normalizedLiveObj)
 
 		patchedTargets = append(patchedTargets, patchedTarget)
 	}
@@ -513,25 +517,34 @@ func applyMergePatch(obj *unstructured.Unstructured, patch []byte, versionedObje
 	return patchedObj, nil
 }
 
-// restoreNonIgnoredFields walks patched, original, and normalized in parallel.
-// If a field in patched differs from original, or was dropped from patched
-// entirely, but normalized and original agree (meaning the field was NOT
-// ignored by the normalizer), the original value is restored into patched.
-// This corrects collateral overwrites caused by patchStrategy:"replace"
-// treating a parent field as atomic.
-func restoreNonIgnoredFields(patched, original, normalized map[string]any) {
+// restoreNonIgnoredFields walks patched, original, normalized (target), and
+// normalizedLive in parallel. It corrects three classes of collateral damage
+// caused by patchStrategy:"replace" treating a parent field as atomic:
+//
+//  1. Overwrite — a non-ignored value was replaced with the live value.
+//  2. Drop — a non-ignored key was removed because live lacks it.
+//  3. Add — a non-ignored live-only key leaked into the patched target.
+//
+// A field is considered "not ignored" when normalizedTarget == originalTarget
+// for that field (the normalizer left it alone). For live-only keys (pass 2),
+// a key is non-ignored if it exists in normalizedLive (the normalizer did not
+// strip it from live).
+func restoreNonIgnoredFields(patched, original, normalizedTarget, normalizedLive map[string]any) {
 	// Pass 1: restore non-ignored fields that were overwritten or dropped.
 	for key, originalVal := range original {
 		patchedVal, inPatched := patched[key]
-		normalizedVal, inNormalized := normalized[key]
+		normalizedVal, inNormalized := normalizedTarget[key]
 
 		patchedMap, patchedIsMap := patchedVal.(map[string]any)
 		originalMap, originalIsMap := originalVal.(map[string]any)
 		normalizedMap, normalizedIsMap := normalizedVal.(map[string]any)
 
 		if inPatched && patchedIsMap && originalIsMap && normalizedIsMap {
-			// Recurse into nested objects.
-			restoreNonIgnoredFields(patchedMap, originalMap, normalizedMap)
+			var normalizedLiveMap map[string]any
+			if v, ok := normalizedLive[key].(map[string]any); ok {
+				normalizedLiveMap = v
+			}
+			restoreNonIgnoredFields(patchedMap, originalMap, normalizedMap, normalizedLiveMap)
 			continue
 		}
 
@@ -543,11 +556,16 @@ func restoreNonIgnoredFields(patched, original, normalized map[string]any) {
 		}
 	}
 
-	// Pass 2: remove keys that were introduced into patched from the live
-	// object via replace-strategy collateral but do not exist in the original
-	// target. These are live-only fields that should not leak into the target.
+	// Pass 2: remove non-ignored keys that were introduced into patched from
+	// the live object via replace-strategy collateral but do not exist in the
+	// original target. A key is non-ignored if it exists in normalizedLive
+	// (the normalizer did not strip it). Ignored live-only keys are kept —
+	// they were intentionally copied by the livePatch.
 	for key := range patched {
-		if _, inOriginal := original[key]; !inOriginal {
+		if _, inOriginal := original[key]; inOriginal {
+			continue
+		}
+		if _, inNormalizedLive := normalizedLive[key]; inNormalizedLive {
 			delete(patched, key)
 		}
 	}

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -514,32 +514,30 @@ func applyMergePatch(obj *unstructured.Unstructured, patch []byte, versionedObje
 }
 
 // restoreNonIgnoredFields walks patched, original, and normalized in parallel.
-// If a leaf value in patched differs from original, but normalized and original
-// agree (meaning the field was NOT ignored by the normalizer), the original
-// value is restored into patched. This corrects collateral overwrites caused by
-// patchStrategy:"replace" treating a parent field as atomic.
+// If a field in patched differs from original, or was dropped from patched
+// entirely, but normalized and original agree (meaning the field was NOT
+// ignored by the normalizer), the original value is restored into patched.
+// This corrects collateral overwrites caused by patchStrategy:"replace"
+// treating a parent field as atomic.
 func restoreNonIgnoredFields(patched, original, normalized map[string]any) {
-	for key, patchedVal := range patched {
-		originalVal, inOriginal := original[key]
-		if !inOriginal {
-			continue
-		}
+	for key, originalVal := range original {
+		patchedVal, inPatched := patched[key]
 		normalizedVal, inNormalized := normalized[key]
 
 		patchedMap, patchedIsMap := patchedVal.(map[string]any)
 		originalMap, originalIsMap := originalVal.(map[string]any)
 		normalizedMap, normalizedIsMap := normalizedVal.(map[string]any)
 
-		if patchedIsMap && originalIsMap && normalizedIsMap {
+		if inPatched && patchedIsMap && originalIsMap && normalizedIsMap {
 			// Recurse into nested objects.
 			restoreNonIgnoredFields(patchedMap, originalMap, normalizedMap)
 			continue
 		}
 
-		// Leaf (or type-changed) field.
+		// Leaf, type-changed, or missing field.
 		// If normalized == original, the normalizer did not touch this field,
 		// so it is not ignored and should keep the original (target) value.
-		if inNormalized && reflect.DeepEqual(normalizedVal, originalVal) && !reflect.DeepEqual(patchedVal, originalVal) {
+		if inNormalized && reflect.DeepEqual(normalizedVal, originalVal) && (!inPatched || !reflect.DeepEqual(patchedVal, originalVal)) {
 			patched[key] = originalVal
 		}
 	}

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -520,6 +520,7 @@ func applyMergePatch(obj *unstructured.Unstructured, patch []byte, versionedObje
 // This corrects collateral overwrites caused by patchStrategy:"replace"
 // treating a parent field as atomic.
 func restoreNonIgnoredFields(patched, original, normalized map[string]any) {
+	// Pass 1: restore non-ignored fields that were overwritten or dropped.
 	for key, originalVal := range original {
 		patchedVal, inPatched := patched[key]
 		normalizedVal, inNormalized := normalized[key]
@@ -539,6 +540,15 @@ func restoreNonIgnoredFields(patched, original, normalized map[string]any) {
 		// so it is not ignored and should keep the original (target) value.
 		if inNormalized && reflect.DeepEqual(normalizedVal, originalVal) && (!inPatched || !reflect.DeepEqual(patchedVal, originalVal)) {
 			patched[key] = originalVal
+		}
+	}
+
+	// Pass 2: remove keys that were introduced into patched from the live
+	// object via replace-strategy collateral but do not exist in the original
+	// target. These are live-only fields that should not leak into the target.
+	for key := range patched {
+		if _, inOriginal := original[key]; !inOriginal {
+			delete(patched, key)
 		}
 	}
 }

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -5,6 +5,7 @@ import (
 	stderrors "errors"
 	"fmt"
 	"os"
+	"reflect"
 	"strconv"
 	"time"
 
@@ -452,12 +453,19 @@ func normalizeTargetResources(cr *comparisonResult) ([]*unstructured.Unstructure
 			return nil, err
 		}
 
-		normalizedTarget, err = applyMergePatch(normalizedTarget, livePatch, versionedObject)
+		patchedTarget, err := applyMergePatch(normalizedTarget, livePatch, versionedObject)
 		if err != nil {
 			return nil, err
 		}
 
-		patchedTargets = append(patchedTargets, normalizedTarget)
+		// Restore non-ignored fields that may have been overwritten due to
+		// patchStrategy:"replace" on a parent field (e.g. policy/v1 PDB selector).
+		// Strategic merge patch treats "replace" fields as atomic, so patching in
+		// one ignored sub-field pulls the entire parent from live, clobbering
+		// non-ignored sibling fields. We detect and undo this here.
+		restoreNonIgnoredFields(patchedTarget.Object, originalTarget.Object, normalizedTarget.Object)
+
+		patchedTargets = append(patchedTargets, patchedTarget)
 	}
 	return patchedTargets, nil
 }
@@ -503,6 +511,38 @@ func applyMergePatch(obj *unstructured.Unstructured, patch []byte, versionedObje
 		return nil, err
 	}
 	return patchedObj, nil
+}
+
+// restoreNonIgnoredFields walks patched, original, and normalized in parallel.
+// If a leaf value in patched differs from original, but normalized and original
+// agree (meaning the field was NOT ignored by the normalizer), the original
+// value is restored into patched. This corrects collateral overwrites caused by
+// patchStrategy:"replace" treating a parent field as atomic.
+func restoreNonIgnoredFields(patched, original, normalized map[string]any) {
+	for key, patchedVal := range patched {
+		originalVal, inOriginal := original[key]
+		if !inOriginal {
+			continue
+		}
+		normalizedVal, inNormalized := normalized[key]
+
+		patchedMap, patchedIsMap := patchedVal.(map[string]any)
+		originalMap, originalIsMap := originalVal.(map[string]any)
+		normalizedMap, normalizedIsMap := normalizedVal.(map[string]any)
+
+		if patchedIsMap && originalIsMap && normalizedIsMap {
+			// Recurse into nested objects.
+			restoreNonIgnoredFields(patchedMap, originalMap, normalizedMap)
+			continue
+		}
+
+		// Leaf (or type-changed) field.
+		// If normalized == original, the normalizer did not touch this field,
+		// so it is not ignored and should keep the original (target) value.
+		if inNormalized && reflect.DeepEqual(normalizedVal, originalVal) && !reflect.DeepEqual(patchedVal, originalVal) {
+			patched[key] = originalVal
+		}
+	}
 }
 
 // hasSharedResourceCondition will check if the Application has any resource that has already

--- a/controller/sync_test.go
+++ b/controller/sync_test.go
@@ -724,6 +724,48 @@ func TestNormalizeTargetResourcesPDBSelector(t *testing.T) {
 			"non-ignored field 'app' was clobbered by live value; patchStrategy:replace on selector may cause normalizeTargetResources to overwrite the entire selector")
 	})
 
+	t.Run("ignoring one matchLabels key should not drop non-ignored sibling fields", func(t *testing.T) {
+		// Target has matchExpressions that live does not.
+		// Ignoring a matchLabels key should not cause matchExpressions to be
+		// dropped due to replace semantics pulling the entire live selector
+		// (which lacks matchExpressions) into the target.
+		cr := setupPDB(t, []v1alpha1.ResourceIgnoreDifferences{
+			{
+				Group:        "policy",
+				Kind:         "PodDisruptionBudget",
+				JSONPointers: []string{"/spec/selector/matchLabels/version"},
+			},
+		})
+
+		// Add matchExpressions to the target only (not in live).
+		target := cr.reconciliationResult.Target[0]
+		matchExpr := []any{
+			map[string]any{
+				"key":      "tier",
+				"operator": "In",
+				"values":   []any{"frontend"},
+			},
+		}
+		require.NoError(t, unstructured.SetNestedSlice(target.Object, matchExpr, "spec", "selector", "matchExpressions"))
+
+		targets, err := normalizeTargetResources(cr)
+		require.NoError(t, err)
+		require.Len(t, targets, 1)
+
+		// matchExpressions should be preserved — it was not ignored.
+		expr, ok, err := unstructured.NestedSlice(targets[0].Object, "spec", "selector", "matchExpressions")
+		require.NoError(t, err)
+		assert.True(t, ok, "matchExpressions was dropped from target by replace-strategy collateral")
+		assert.Len(t, expr, 1)
+
+		// app label should still reflect the target change.
+		matchLabels, ok, err := unstructured.NestedStringMap(targets[0].Object, "spec", "selector", "matchLabels")
+		require.NoError(t, err)
+		require.True(t, ok)
+		assert.Equal(t, "myapp-v2", matchLabels["app"])
+		assert.Equal(t, "v1", matchLabels["version"])
+	})
+
 	t.Run("ignoring entire selector should replace target selector with live", func(t *testing.T) {
 		cr := setupPDB(t, []v1alpha1.ResourceIgnoreDifferences{
 			{

--- a/controller/sync_test.go
+++ b/controller/sync_test.go
@@ -766,6 +766,38 @@ func TestNormalizeTargetResourcesPDBSelector(t *testing.T) {
 		assert.Equal(t, "v1", matchLabels["version"])
 	})
 
+	t.Run("ignoring one matchLabels key should not add live-only non-ignored selector keys", func(t *testing.T) {
+		// Live has an additional non-ignored label ("track") that target does not.
+		// Replace semantics should not copy it into the patched target.
+		cr := setupPDB(t, []v1alpha1.ResourceIgnoreDifferences{
+			{
+				Group:        "policy",
+				Kind:         "PodDisruptionBudget",
+				JSONPointers: []string{"/spec/selector/matchLabels/version"},
+			},
+		})
+
+		live := cr.reconciliationResult.Live[0]
+		matchLabels, ok, err := unstructured.NestedStringMap(live.Object, "spec", "selector", "matchLabels")
+		require.NoError(t, err)
+		require.True(t, ok)
+		matchLabels["track"] = "stable"
+		require.NoError(t, unstructured.SetNestedStringMap(live.Object, matchLabels, "spec", "selector", "matchLabels"))
+
+		targets, err := normalizeTargetResources(cr)
+		require.NoError(t, err)
+		require.Len(t, targets, 1)
+
+		patchedMatchLabels, ok, err := unstructured.NestedStringMap(targets[0].Object, "spec", "selector", "matchLabels")
+		require.NoError(t, err)
+		require.True(t, ok)
+
+		assert.Equal(t, "myapp-v2", patchedMatchLabels["app"])
+		assert.Equal(t, "v1", patchedMatchLabels["version"])
+		_, found := patchedMatchLabels["track"]
+		assert.False(t, found, "live-only non-ignored selector key was added to target by replace-strategy collateral")
+	})
+
 	t.Run("ignoring entire selector should replace target selector with live", func(t *testing.T) {
 		cr := setupPDB(t, []v1alpha1.ResourceIgnoreDifferences{
 			{

--- a/controller/sync_test.go
+++ b/controller/sync_test.go
@@ -672,6 +672,81 @@ func TestNormalizeTargetResourcesWithList(t *testing.T) {
 	})
 }
 
+// TestNormalizeTargetResourcesPDBSelector reproduces https://github.com/argoproj/argo-cd/issues/18232
+// When a PDB (policy/v1) has an ignoreDifferences rule for a matchLabels sub-field and
+// RespectIgnoreDifferences=true is set, normalizeTargetResources should only patch the
+// ignored field — not clobber the entire selector due to patchStrategy:"replace".
+func TestNormalizeTargetResourcesPDBSelector(t *testing.T) {
+	setupPDB := func(t *testing.T, ignores []v1alpha1.ResourceIgnoreDifferences) *comparisonResult {
+		t.Helper()
+		dc, err := diff.NewDiffConfigBuilder().
+			WithDiffSettings(ignores, nil, true, normalizers.IgnoreNormalizerOpts{}).
+			WithNoCache().
+			Build()
+		require.NoError(t, err)
+		live := test.YamlToUnstructured(testdata.LivePDBYaml)
+		target := test.YamlToUnstructured(testdata.TargetPDBYaml)
+		return &comparisonResult{
+			reconciliationResult: sync.ReconciliationResult{
+				Live:   []*unstructured.Unstructured{live},
+				Target: []*unstructured.Unstructured{target},
+			},
+			diffConfig: dc,
+		}
+	}
+
+	t.Run("ignoring one matchLabels key should not clobber other selector changes", func(t *testing.T) {
+		// User ignores /spec/selector/matchLabels/version but intentionally changes
+		// /spec/selector/matchLabels/app from "myapp" to "myapp-v2".
+		// With patchStrategy:"replace" on the selector field (policy/v1),
+		// normalizeTargetResources should preserve the app label change.
+		cr := setupPDB(t, []v1alpha1.ResourceIgnoreDifferences{
+			{
+				Group:        "policy",
+				Kind:         "PodDisruptionBudget",
+				JSONPointers: []string{"/spec/selector/matchLabels/version"},
+			},
+		})
+
+		targets, err := normalizeTargetResources(cr)
+		require.NoError(t, err)
+		require.Len(t, targets, 1)
+
+		matchLabels, ok, err := unstructured.NestedStringMap(targets[0].Object, "spec", "selector", "matchLabels")
+		require.NoError(t, err)
+		require.True(t, ok)
+
+		// The "version" label should take the live value (ignored field — respected).
+		assert.Equal(t, "v1", matchLabels["version"], "ignored field 'version' should use live value")
+
+		// The "app" label should keep the target value — it is NOT ignored.
+		assert.Equal(t, "myapp-v2", matchLabels["app"],
+			"non-ignored field 'app' was clobbered by live value; patchStrategy:replace on selector may cause normalizeTargetResources to overwrite the entire selector")
+	})
+
+	t.Run("ignoring entire selector should replace target selector with live", func(t *testing.T) {
+		cr := setupPDB(t, []v1alpha1.ResourceIgnoreDifferences{
+			{
+				Group:        "policy",
+				Kind:         "PodDisruptionBudget",
+				JSONPointers: []string{"/spec/selector"},
+			},
+		})
+
+		targets, err := normalizeTargetResources(cr)
+		require.NoError(t, err)
+		require.Len(t, targets, 1)
+
+		matchLabels, ok, err := unstructured.NestedStringMap(targets[0].Object, "spec", "selector", "matchLabels")
+		require.NoError(t, err)
+		require.True(t, ok)
+
+		// When the entire selector is ignored, both labels should come from live.
+		assert.Equal(t, "myapp", matchLabels["app"])
+		assert.Equal(t, "v1", matchLabels["version"])
+	})
+}
+
 func TestDeriveServiceAccountMatchingNamespaces(t *testing.T) {
 	t.Parallel()
 

--- a/controller/testdata/data.go
+++ b/controller/testdata/data.go
@@ -32,4 +32,10 @@ var (
 
 	//go:embed additional-image-replicas-deployment.yaml
 	AdditionalImageReplicaDeploymentYaml string
+
+	//go:embed live-pdb.yaml
+	LivePDBYaml string
+
+	//go:embed target-pdb.yaml
+	TargetPDBYaml string
 )

--- a/controller/testdata/live-pdb.yaml
+++ b/controller/testdata/live-pdb.yaml
@@ -1,0 +1,31 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  annotations:
+    argocd.argoproj.io/tracking-id: 'myapp:policy/PodDisruptionBudget:default/myapp-pdb'
+    kubectl.kubernetes.io/last-applied-configuration: >
+      {"apiVersion":"policy/v1","kind":"PodDisruptionBudget","metadata":{"annotations":{"argocd.argoproj.io/tracking-id":"myapp:policy/PodDisruptionBudget:default/myapp-pdb"},"name":"myapp-pdb","namespace":"default"},"spec":{"minAvailable":1,"selector":{"matchLabels":{"app":"myapp","version":"v1"}}}}
+  creationTimestamp: '2024-01-10T10:00:00Z'
+  generation: 1
+  name: myapp-pdb
+  namespace: default
+  resourceVersion: '12345'
+  uid: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: myapp
+      version: v1
+status:
+  conditions:
+    - lastTransitionTime: '2024-01-10T10:00:00Z'
+      message: ''
+      reason: SufficientPods
+      status: 'True'
+      type: DisruptionAllowed
+  currentHealthy: 3
+  desiredHealthy: 1
+  disruptionsAllowed: 2
+  expectedPods: 3
+  observedGeneration: 1

--- a/controller/testdata/target-pdb.yaml
+++ b/controller/testdata/target-pdb.yaml
@@ -1,0 +1,13 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  annotations:
+    argocd.argoproj.io/tracking-id: 'myapp:policy/PodDisruptionBudget:default/myapp-pdb'
+  name: myapp-pdb
+  namespace: default
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: myapp-v2
+      version: v2


### PR DESCRIPTION
When normalizeTargetResources computes the live-to-target patch for RespectIgnoreDifferences, it uses strategic merge patch. For resources whose fields carry `patchStrategy:"replace"` (e.g. `policy/v1` PDB `spec.selector`), strategic merge treats the entire field as atomic — so patching in one ignored sub-field (say, a single `matchLabels` key) pulls the entire parent from the live object, overwriting non-ignored sibling fields that the user intentionally changed.

Add a post-correction step that walks the patched target against the original target and normalized target. If a field was not touched by the normalizer (`normalized == original`) but was overwritten by the patch (`patched != original`), restore the original target value. This surgically undoes collateral damage from replace semantics without affecting array merge behavior.

Currently only `policy/v1` PDB `spec.selector` uses `patchStrategy:"replace"` among built-in types, but the fix is generic and will also cover CRDs with `x-kubernetes-patch-strategy: replace` when OpenAPI-based patching is re-introduced. Fixes #18232.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
