### PR TITLE
refactor: use new(expr) for pointer literals in Go 1.26

### DIFF
--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -662,8 +662,7 @@ func TestAutoSync(t *testing.T) {
 
 func TestAutoSyncEnabledSetToTrue(t *testing.T) {
 	app := newFakeApp()
-	enable := true
-	app.Spec.SyncPolicy.Automated = &v1alpha1.SyncPolicyAutomated{Enabled: &enable}
+	app.Spec.SyncPolicy.Automated = &v1alpha1.SyncPolicyAutomated{Enabled: new(true)}
 	ctrl := newFakeController(t.Context(), &fakeData{apps: []runtime.Object{app}}, nil)
 	syncStatus := v1alpha1.SyncStatus{
 		Status:   v1alpha1.SyncStatusCodeOutOfSync,
@@ -789,8 +788,7 @@ func TestSkipAutoSync(t *testing.T) {
 	// Verify we skip when auto-sync is disabled
 	t.Run("AutoSyncEnableFieldIsSetFalse", func(t *testing.T) {
 		app := newFakeApp()
-		enable := false
-		app.Spec.SyncPolicy.Automated = &v1alpha1.SyncPolicyAutomated{Enabled: &enable}
+		app.Spec.SyncPolicy.Automated = &v1alpha1.SyncPolicyAutomated{Enabled: new(false)}
 		ctrl := newFakeController(t.Context(), &fakeData{apps: []runtime.Object{app}}, nil)
 		syncStatus := v1alpha1.SyncStatus{
 			Status:   v1alpha1.SyncStatusCodeOutOfSync,

--- a/test/e2e/app_autosync_ns_test.go
+++ b/test/e2e/app_autosync_ns_test.go
@@ -24,8 +24,7 @@ func TestNSAutoSyncSelfHealDisabled(t *testing.T) {
 		When().
 		// app should be auto-synced once created
 		CreateFromFile(func(app *Application) {
-			selfHeal := false
-			app.Spec.SyncPolicy = &SyncPolicy{Automated: &SyncPolicyAutomated{SelfHeal: &selfHeal}}
+			app.Spec.SyncPolicy = &SyncPolicy{Automated: &SyncPolicyAutomated{SelfHeal: new(false)}}
 		}).
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
@@ -53,9 +52,8 @@ func TestNSAutoSyncSelfHealEnabled(t *testing.T) {
 		When().
 		// app should be auto-synced once created
 		CreateFromFile(func(app *Application) {
-			selfHeal := true
 			app.Spec.SyncPolicy = &SyncPolicy{
-				Automated: &SyncPolicyAutomated{SelfHeal: &selfHeal},
+				Automated: &SyncPolicyAutomated{SelfHeal: new(true)},
 				Retry:     &RetryStrategy{Limit: 0},
 			}
 		}).

--- a/test/e2e/app_autosync_test.go
+++ b/test/e2e/app_autosync_test.go
@@ -23,8 +23,7 @@ func TestAutoSyncSelfHealDisabled(t *testing.T) {
 		When().
 		// app should be auto-synced once created
 		CreateFromFile(func(app *Application) {
-			selfHeal := false
-			app.Spec.SyncPolicy = &SyncPolicy{Automated: &SyncPolicyAutomated{SelfHeal: &selfHeal}}
+			app.Spec.SyncPolicy = &SyncPolicy{Automated: &SyncPolicyAutomated{SelfHeal: new(false)}}
 		}).
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
@@ -51,9 +50,8 @@ func TestAutoSyncSelfHealEnabled(t *testing.T) {
 		When().
 		// app should be auto-synced once created
 		CreateFromFile(func(app *Application) {
-			selfHeal := true
 			app.Spec.SyncPolicy = &SyncPolicy{
-				Automated: &SyncPolicyAutomated{SelfHeal: &selfHeal},
+				Automated: &SyncPolicyAutomated{SelfHeal: new(true)},
 				Retry:     &RetryStrategy{Limit: 0},
 			}
 		}).
@@ -194,9 +192,8 @@ func TestAutoSyncAllowEmptyCanBeDisabled(t *testing.T) {
 		Path(guestbookPath).
 		When().
 		CreateFromFile(func(app *Application) {
-			allowEmpty := true
 			app.Spec.SyncPolicy = &SyncPolicy{
-				Automated: &SyncPolicyAutomated{AllowEmpty: &allowEmpty},
+				Automated: &SyncPolicyAutomated{AllowEmpty: new(true)},
 			}
 		}).
 		Then().

--- a/test/e2e/applicationset_test.go
+++ b/test/e2e/applicationset_test.go
@@ -615,26 +615,6 @@ func TestTemplatePatch(t *testing.T) {
 		},
 	}
 
-	templatePatch := `{
-		"metadata": {
-			"annotations": {
-				{{- range $k, $v := .annotations }}
-				"{{ $k }}": "{{ $v }}"
-				{{- end }}
-			}
-		},
-		{{- if .createNamespace }}
-		"spec": {
-			"syncPolicy": {
-				"syncOptions": [
-					"CreateNamespace=true"
-				]
-			}
-		}
-		{{- end }}
-	}
-	`
-
 	var expectedAppNewNamespace *v1alpha1.Application
 	var expectedAppNewMetadata *v1alpha1.Application
 
@@ -658,7 +638,25 @@ func TestTemplatePatch(t *testing.T) {
 					},
 				},
 			},
-			TemplatePatch: &templatePatch,
+			TemplatePatch: new(`{
+		"metadata": {
+			"annotations": {
+				{{- range $k, $v := .annotations }}
+				"{{ $k }}": "{{ $v }}"
+				{{- end }}
+			}
+		},
+		{{- if .createNamespace }}
+		"spec": {
+			"syncPolicy": {
+				"syncOptions": [
+					"CreateNamespace=true"
+				]
+			}
+		}
+		{{- end }}
+	}
+	`),
 			Generators: []v1alpha1.ApplicationSetGenerator{
 				{
 					List: &v1alpha1.ListGenerator{
@@ -878,9 +876,8 @@ func TestSyncPolicyCreateUpdate(t *testing.T) {
 			appset.Spec.Template.Labels = map[string]string{
 				"label-key": "label-value",
 			}
-			applicationsSyncPolicy := v1alpha1.ApplicationsSyncPolicyCreateUpdate
 			appset.Spec.SyncPolicy = &v1alpha1.ApplicationSetSyncPolicy{
-				ApplicationsSync: &applicationsSyncPolicy,
+				ApplicationsSync: new(v1alpha1.ApplicationsSyncPolicyCreateUpdate),
 			}
 		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{*expectedAppNewMetadata})).
 
@@ -976,9 +973,8 @@ func TestSyncPolicyCreateDelete(t *testing.T) {
 		Update(func(appset *v1alpha1.ApplicationSet) {
 			appset.Spec.Template.Annotations = map[string]string{"annotation-key": "annotation-value"}
 			appset.Spec.Template.Labels = map[string]string{"label-key": "label-value"}
-			applicationsSyncPolicy := v1alpha1.ApplicationsSyncPolicyCreateDelete
 			appset.Spec.SyncPolicy = &v1alpha1.ApplicationSetSyncPolicy{
-				ApplicationsSync: &applicationsSyncPolicy,
+				ApplicationsSync: new(v1alpha1.ApplicationsSyncPolicyCreateDelete),
 			}
 		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{*expectedAppNewNamespace})).
 
@@ -1075,9 +1071,8 @@ func TestSyncPolicyCreateOnly(t *testing.T) {
 		Update(func(appset *v1alpha1.ApplicationSet) {
 			appset.Spec.Template.Annotations = map[string]string{"annotation-key": "annotation-value"}
 			appset.Spec.Template.Labels = map[string]string{"label-key": "label-value"}
-			applicationsSyncPolicy := v1alpha1.ApplicationsSyncPolicyCreateOnly
 			appset.Spec.SyncPolicy = &v1alpha1.ApplicationSetSyncPolicy{
-				ApplicationsSync: &applicationsSyncPolicy,
+				ApplicationsSync: new(v1alpha1.ApplicationsSyncPolicyCreateOnly),
 			}
 		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{*expectedAppNewNamespace})).
 
@@ -1334,9 +1329,6 @@ func TestSimpleSCMProviderGenerator(t *testing.T) {
 		},
 	}
 
-	// Because you can't &"".
-	repoMatch := "argo-cd"
-
 	Given(t).
 		// Create an SCMProviderGenerator-based ApplicationSet
 		When().Create(v1alpha1.ApplicationSet{
@@ -1365,7 +1357,7 @@ func TestSimpleSCMProviderGenerator(t *testing.T) {
 						},
 						Filters: []v1alpha1.SCMProviderGeneratorFilter{
 							{
-								RepositoryMatch: &repoMatch,
+								RepositoryMatch: new("argo-cd"),
 							},
 						},
 					},
@@ -1406,9 +1398,6 @@ func TestSimpleSCMProviderGeneratorGoTemplate(t *testing.T) {
 		},
 	}
 
-	// Because you can't &"".
-	repoMatch := "argo-cd"
-
 	Given(t).
 		// Create an SCMProviderGenerator-based ApplicationSet
 		When().Create(v1alpha1.ApplicationSet{
@@ -1438,7 +1427,7 @@ func TestSimpleSCMProviderGeneratorGoTemplate(t *testing.T) {
 						},
 						Filters: []v1alpha1.SCMProviderGeneratorFilter{
 							{
-								RepositoryMatch: &repoMatch,
+								RepositoryMatch: new("argo-cd"),
 							},
 						},
 					},
@@ -1473,9 +1462,6 @@ func TestSCMProviderGeneratorSCMProviderNotAllowed(t *testing.T) {
 		},
 	}
 
-	// Because you can't &"".
-	repoMatch := "argo-cd"
-
 	ctx := Given(t)
 	// Create an SCMProviderGenerator-based ApplicationSet
 	ctx.When().Create(v1alpha1.ApplicationSet{
@@ -1505,7 +1491,7 @@ func TestSCMProviderGeneratorSCMProviderNotAllowed(t *testing.T) {
 						},
 						Filters: []v1alpha1.SCMProviderGeneratorFilter{
 							{
-								RepositoryMatch: &repoMatch,
+								RepositoryMatch: new("argo-cd"),
 							},
 						},
 					},
@@ -1721,9 +1707,6 @@ func TestSimpleSCMProviderGeneratorTokenRefStrictOk(t *testing.T) {
 		},
 	}
 
-	// Because you can't &"".
-	repoMatch := "argo-cd"
-
 	Given(t).
 		And(func() {
 			_, err := utils.GetE2EFixtureK8sClient(t).KubeClientset.CoreV1().Secrets(fixture.TestNamespace()).Create(t.Context(), &corev1.Secret{
@@ -1772,7 +1755,7 @@ func TestSimpleSCMProviderGeneratorTokenRefStrictOk(t *testing.T) {
 						},
 						Filters: []v1alpha1.SCMProviderGeneratorFilter{
 							{
-								RepositoryMatch: &repoMatch,
+								RepositoryMatch: new("argo-cd"),
 							},
 						},
 					},
@@ -1823,9 +1806,6 @@ func TestSimpleSCMProviderGeneratorTokenRefStrictKo(t *testing.T) {
 		},
 	}
 
-	// Because you can't &"".
-	repoMatch := "argo-cd"
-
 	ctx := Given(t)
 	ctx.And(func() {
 		_, err := utils.GetE2EFixtureK8sClient(t).KubeClientset.CoreV1().Secrets(fixture.TestNamespace()).Create(t.Context(), &corev1.Secret{
@@ -1875,7 +1855,7 @@ func TestSimpleSCMProviderGeneratorTokenRefStrictKo(t *testing.T) {
 						},
 						Filters: []v1alpha1.SCMProviderGeneratorFilter{
 							{
-								RepositoryMatch: &repoMatch,
+								RepositoryMatch: new("argo-cd"),
 							},
 						},
 					},

--- a/test/e2e/clusterdecisiongenerator_e2e_test.go
+++ b/test/e2e/clusterdecisiongenerator_e2e_test.go
@@ -14,8 +14,6 @@ import (
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application"
 )
 
-var tenSec = int64(10)
-
 func TestSimpleClusterDecisionResourceGeneratorExternalNamespace(t *testing.T) {
 	externalNamespace := string(utils.ArgoCDExternalNamespace)
 
@@ -296,7 +294,7 @@ func TestSimpleClusterDecisionResourceGeneratorAddingCluster(t *testing.T) {
 						ClusterDecisionResource: &v1alpha1.DuckTypeGenerator{
 							ConfigMapRef:        "my-configmap",
 							Name:                "my-placementdecision",
-							RequeueAfterSeconds: &tenSec,
+							RequeueAfterSeconds: new(int64(10)),
 						},
 					},
 				},
@@ -389,7 +387,7 @@ func TestSimpleClusterDecisionResourceGeneratorDeletingClusterSecret(t *testing.
 						ClusterDecisionResource: &v1alpha1.DuckTypeGenerator{
 							ConfigMapRef:        "my-configmap",
 							Name:                "my-placementdecision",
-							RequeueAfterSeconds: &tenSec,
+							RequeueAfterSeconds: new(int64(10)),
 						},
 					},
 				},
@@ -490,7 +488,7 @@ func TestSimpleClusterDecisionResourceGeneratorDeletingClusterFromResource(t *te
 						ClusterDecisionResource: &v1alpha1.DuckTypeGenerator{
 							ConfigMapRef:        "my-configmap",
 							Name:                "my-placementdecision",
-							RequeueAfterSeconds: &tenSec,
+							RequeueAfterSeconds: new(int64(10)),
 						},
 					},
 				},

--- a/test/e2e/fixture/app/actions.go
+++ b/test/e2e/fixture/app/actions.go
@@ -199,7 +199,7 @@ func (a *Actions) CreateMultiSourceAppFromFile(flags ...string) *Actions {
 			},
 			SyncPolicy: &v1alpha1.SyncPolicy{
 				Automated: &v1alpha1.SyncPolicyAutomated{
-					SelfHeal: func() *bool { b := true; return &b }(),
+					SelfHeal: new(true),
 				},
 			},
 		},

--- a/test/e2e/git_test.go
+++ b/test/e2e/git_test.go
@@ -129,8 +129,7 @@ func TestAnnotatedTagInStatusSyncRevision(t *testing.T) {
 		// Create Application targeting annotated-tag, with automatedSync: true
 		CreateFromFile(func(app *Application) {
 			app.Spec.Source.TargetRevision = "annotated-tag"
-			prune, selfHeal := true, false
-			app.Spec.SyncPolicy = &SyncPolicy{Automated: &SyncPolicyAutomated{Prune: &prune, SelfHeal: &selfHeal}}
+			app.Spec.SyncPolicy = &SyncPolicy{Automated: &SyncPolicyAutomated{Prune: new(true), SelfHeal: new(false)}}
 		}).
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
@@ -165,8 +164,7 @@ func TestAutomatedSelfHealingAgainstAnnotatedTag(t *testing.T) {
 		// App should be auto-synced once created
 		CreateFromFile(func(app *Application) {
 			app.Spec.Source.TargetRevision = "annotated-tag"
-			prune, selfHeal := true, false
-			app.Spec.SyncPolicy = &SyncPolicy{Automated: &SyncPolicyAutomated{Prune: &prune, SelfHeal: &selfHeal}}
+			app.Spec.SyncPolicy = &SyncPolicy{Automated: &SyncPolicyAutomated{Prune: new(true), SelfHeal: new(false)}}
 		}).
 		Then().
 		ExpectConsistently(SyncStatusIs(SyncStatusCodeSynced), WaitDuration, time.Second*10).
@@ -218,8 +216,7 @@ func TestAutomatedSelfHealingAgainstLightweightTag(t *testing.T) {
 		// App should be auto-synced once created
 		CreateFromFile(func(app *Application) {
 			app.Spec.Source.TargetRevision = "annotated-tag"
-			prune, selfHeal := true, false
-			app.Spec.SyncPolicy = &SyncPolicy{Automated: &SyncPolicyAutomated{Prune: &prune, SelfHeal: &selfHeal}}
+			app.Spec.SyncPolicy = &SyncPolicy{Automated: &SyncPolicyAutomated{Prune: new(true), SelfHeal: new(false)}}
 		}).
 		Then().
 		ExpectConsistently(SyncStatusIs(SyncStatusCodeSynced), WaitDuration, time.Second*10).

--- a/test/e2e/sync_options_test.go
+++ b/test/e2e/sync_options_test.go
@@ -131,8 +131,7 @@ func TestSyncWithStatusIgnored(t *testing.T) {
 			}))
 		}).
 		CreateFromFile(func(app *Application) {
-			selfHeal := true
-			app.Spec.SyncPolicy = &SyncPolicy{Automated: &SyncPolicyAutomated{SelfHeal: &selfHeal}}
+			app.Spec.SyncPolicy = &SyncPolicy{Automated: &SyncPolicyAutomated{SelfHeal: new(true)}}
 		}).
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
@@ -181,8 +180,7 @@ func TestSyncWithSkipHook(t *testing.T) {
 		Path(guestbookPath).
 		When().
 		CreateFromFile(func(app *Application) {
-			selfHeal := true
-			app.Spec.SyncPolicy = &SyncPolicy{Automated: &SyncPolicyAutomated{SelfHeal: &selfHeal}}
+			app.Spec.SyncPolicy = &SyncPolicy{Automated: &SyncPolicyAutomated{SelfHeal: new(true)}}
 		}).
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).

--- a/util/lua/lua_test.go
+++ b/util/lua/lua_test.go
@@ -1009,8 +1009,8 @@ func TestExecuteResourceActionWithParams(t *testing.T) {
 
 	params := []*applicationpkg.ResourceActionParameters{
 		{
-			Name:  func() *string { s := "replicas"; return &s }(),
-			Value: func() *string { s := "3"; return &s }(),
+			Name:  new("replicas"),
+			Value: new("3"),
 		},
 	}
 


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

  Checklist:

  * [x] Either (a) I've created an enhancement proposal and discussed it with the community, (b) this is a bug fix, or (c) this does not need
  to be in the release notes.
  * [ ] The title of the PR states what changed and the related issues number (used for the release note).
  * [x] The title of the PR conforms to the Title of the PR guidance.
  * [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
  * [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
  * [ ] Does this PR require documentation updates?
  * [ ] I've updated documentation as required by this PR.
  * [x] I have signed off all my commits as required by DCO.
  * [x] I have written unit and/or e2e tests for my change.
  * [ ] My build is green.
  * [ ] My new feature complies with the feature status guidelines.
  * [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
  * [ ] Optional. My organization is added to USERS.md.
  * [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into.

  ## Summary

  This PR replaces ad-hoc pointer literal helper closures in tests with Go 1.26's `new(expr)` form.

  ## Why

  The repository already targets Go 1.26, so these call sites can use the built-in `new(expr)` syntax directly.
  This makes the tests shorter and removes inline helper closures that existed only to take the address of literals.

  ## Impact

  There is no intended behavior change.
  This is a small refactor limited to test code and test fixtures.

  ## Validation

  Targeted checks run locally:

  * `go test ./util/lua`
  * `go test ./test/e2e/fixture/app`

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
