### PR TITLE
docs: fix submit-your-pr rebase target to upstream/master

### DIFF
--- a/docs/developer-guide/submit-your-pr.md
+++ b/docs/developer-guide/submit-your-pr.md
@@ -1,7 +1,8 @@
 # Submitting PRs
 
 ## Prerequisites
-1. [Development Environment](development-environment.md)   
+
+1. [Development Environment](development-environment.md)
 2. [Toolchain Guide](toolchain-guide.md)
 3. [Development Cycle](development-cycle.md)
 
@@ -21,10 +22,10 @@ If you need guidance with submitting a PR, or have any other questions regarding
 
 ## Before Submitting a PR
 
-1. Rebase your branch against upstream main:
+1. Rebase your branch against upstream master:
 ```shell
 git fetch upstream
-git rebase upstream/main
+git rebase upstream/master
 ```
 
 2. Run pre-commit checks:


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

## Summary

This PR updates the PR submission guide to rebase against `upstream/master` instead of `upstream/main`.

The repository currently tracks `upstream/master`, so the previous instruction was inaccurate and could confuse contributors when preparing a PR. This is a docs-only change and does not affect runtime behavior.

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
