### PR TITLE
feat: add a button to clear logs in the pod logs viewer

### DIFF
--- a/ui/src/app/applications/components/pod-logs-viewer/clear-logs-button.tsx
+++ b/ui/src/app/applications/components/pod-logs-viewer/clear-logs-button.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import {Button} from '../../../shared/components/button';
+
+interface ClearLogsButtonProps {
+    disabled?: boolean;
+    onClear: () => void;
+}
+
+export const ClearLogsButton = ({disabled, onClear}: ClearLogsButtonProps) => <Button title='Clear displayed logs' icon='eraser' onClick={onClear} disabled={disabled} />;

--- a/ui/src/app/applications/components/pod-logs-viewer/clear-logs-button.tsx
+++ b/ui/src/app/applications/components/pod-logs-viewer/clear-logs-button.tsx
@@ -6,4 +6,6 @@ interface ClearLogsButtonProps {
     onClear: () => void;
 }
 
-export const ClearLogsButton = ({disabled, onClear}: ClearLogsButtonProps) => <Button title='Clear displayed logs' icon='eraser' onClick={onClear} disabled={disabled} />;
+export const ClearLogsButton = ({disabled, onClear}: ClearLogsButtonProps) => (
+    <Button title='Clear displayed logs' icon='eraser' onClick={() => !disabled && onClear()} disabled={disabled} />
+);

--- a/ui/src/app/applications/components/pod-logs-viewer/pod-logs-viewer.test.tsx
+++ b/ui/src/app/applications/components/pod-logs-viewer/pod-logs-viewer.test.tsx
@@ -1,0 +1,155 @@
+import * as React from 'react';
+import {act} from 'react';
+import {createRoot, Root} from 'react-dom/client';
+import {EMPTY, of} from 'rxjs';
+import {LogEntry} from '../../../shared/models';
+import {PodsLogsViewer} from './pod-logs-viewer';
+
+const mockGetContainerLogs = jest.fn();
+
+jest.mock('argo-ui', () => ({
+    DataLoader: ({children}: {children: (data: any) => React.ReactNode}) => children({appDetails: {darkMode: false, wrapLines: false}}),
+    Tooltip: ({children}: {children: React.ReactNode}) => {
+        const React = require('react');
+        return React.createElement(React.Fragment, null, children);
+    }
+}));
+
+jest.mock('react-virtualized/dist/commonjs/AutoSizer', () => ({
+    __esModule: true,
+    default: ({children}: {children: ({width, height}: {width: number; height: number}) => React.ReactNode}) => children({width: 800, height: 400})
+}));
+
+jest.mock('ansi-to-react', () => ({
+    __esModule: true,
+    default: ({children}: {children: React.ReactNode}) => {
+        const React = require('react');
+        return React.createElement(React.Fragment, null, children);
+    }
+}));
+
+jest.mock('../../../shared/services', () => ({
+    services: {
+        applications: {
+            getContainerLogs: (...args: any[]) => mockGetContainerLogs(...args)
+        },
+        viewPreferences: {
+            getPreferences: jest.fn()
+        }
+    }
+}));
+
+jest.mock('./copy-logs-button', () => ({CopyLogsButton: () => null}));
+jest.mock('./download-logs-button', () => ({DownloadLogsButton: () => null}));
+jest.mock('./container-selector', () => ({ContainerSelector: () => null}));
+jest.mock('./follow-toggle-button', () => ({FollowToggleButton: () => null}));
+jest.mock('./show-previous-logs-toggle-button', () => ({ShowPreviousLogsToggleButton: () => null}));
+jest.mock('./pod-logs-highlight-button', () => ({PodHighlightButton: () => null}));
+jest.mock('./timestamps-toggle-button', () => ({TimestampsToggleButton: () => null}));
+jest.mock('./dark-mode-toggle-button', () => ({DarkModeToggleButton: () => null}));
+jest.mock('./fullscreen-button', () => ({FullscreenButton: () => null}));
+jest.mock('./log-message-filter', () => ({LogMessageFilter: () => null}));
+jest.mock('./since-seconds-selector', () => ({SinceSecondsSelector: () => null}));
+jest.mock('./tail-selector', () => ({TailSelector: () => null}));
+jest.mock('./pod-names-toggle-button', () => ({PodNamesToggleButton: () => null}));
+jest.mock('./auto-scroll-button', () => ({AutoScrollButton: () => null}));
+jest.mock('./wrap-lines-button', () => ({WrapLinesButton: () => null}));
+jest.mock('./match-case-toggle-button', () => ({MatchCaseToggleButton: () => null}));
+
+const logsFixture: LogEntry[] = [
+    {
+        content: 'INFO  Starting application',
+        last: false,
+        podName: 'demo-app-68b8fcf645-pkc5s',
+        timeStamp: new Date().toISOString(),
+        timeStampStr: '2026-04-03T19:00:00.000Z'
+    },
+    {
+        content: 'INFO  Listening on :8080',
+        last: false,
+        podName: 'demo-app-68b8fcf645-pkc5s',
+        timeStamp: new Date().toISOString(),
+        timeStampStr: '2026-04-03T19:00:01.000Z'
+    }
+];
+
+const makeComponent = () => (
+    <PodsLogsViewer
+        applicationName='demo-app'
+        applicationNamespace='argocd'
+        namespace='default'
+        containerName='glady-app'
+        podName='demo-app-68b8fcf645-pkc5s'
+    />
+);
+
+describe('PodsLogsViewer clear logs button', () => {
+    let container: HTMLDivElement;
+    let root: Root;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        container = document.createElement('div');
+        document.body.appendChild(container);
+        root = createRoot(container);
+    });
+
+    afterEach(() => {
+        act(() => {
+            root.unmount();
+        });
+        container.remove();
+    });
+
+    const renderComponent = () => {
+        act(() => {
+            root.render(makeComponent());
+        });
+    };
+
+    const getClearButton = () => {
+        const clearButtonIcon = container.querySelector('.fa-eraser');
+        expect(clearButtonIcon).toBeTruthy();
+        return clearButtonIcon.closest('button') as HTMLButtonElement;
+    };
+
+    it('keeps the clear button disabled when no log has been loaded and ignores clicks', () => {
+        mockGetContainerLogs.mockReturnValue(EMPTY);
+
+        renderComponent();
+
+        const clearButton = getClearButton();
+        expect(clearButton.disabled).toBe(true);
+
+        const beforeClick = container.textContent;
+        act(() => {
+            clearButton.click();
+        });
+
+        expect(container.textContent).toBe(beforeClick);
+    });
+
+    it('clears displayed logs when the clear button is clicked', () => {
+        mockGetContainerLogs.mockReturnValue(of(...logsFixture));
+
+        renderComponent();
+
+        const beforeClear = container.textContent;
+        expect(beforeClear).toContain('INFO  Starting application');
+        expect(beforeClear).toContain('INFO  Listening on :8080');
+
+        const clearButton = getClearButton();
+        expect(clearButton.disabled).toBe(false);
+
+        act(() => {
+            clearButton.click();
+        });
+
+        const afterClear = container.textContent;
+        expect(afterClear).not.toContain('INFO  Starting application');
+        expect(afterClear).not.toContain('INFO  Listening on :8080');
+
+        const disabledClearButton = getClearButton();
+        expect(disabledClearButton.disabled).toBe(true);
+    });
+});

--- a/ui/src/app/applications/components/pod-logs-viewer/pod-logs-viewer.test.tsx
+++ b/ui/src/app/applications/components/pod-logs-viewer/pod-logs-viewer.test.tsx
@@ -6,12 +6,13 @@ import {LogEntry} from '../../../shared/models';
 import {PodsLogsViewer} from './pod-logs-viewer';
 
 const mockGetContainerLogs = jest.fn();
+const mockCopyLogsButton = jest.fn();
 
 jest.mock('argo-ui', () => ({
     DataLoader: ({children}: {children: (data: any) => React.ReactNode}) => children({appDetails: {darkMode: false, wrapLines: false}}),
-    Tooltip: ({children}: {children: React.ReactNode}) => {
+    Tooltip: ({children, content}: {children: React.ReactNode; content: string}) => {
         const React = require('react');
-        return React.createElement(React.Fragment, null, children);
+        return React.createElement('span', {'data-tooltip-content': content}, children);
     }
 }));
 
@@ -39,7 +40,12 @@ jest.mock('../../../shared/services', () => ({
     }
 }));
 
-jest.mock('./copy-logs-button', () => ({CopyLogsButton: () => null}));
+jest.mock('./copy-logs-button', () => ({
+    CopyLogsButton: ({logs}: {logs: LogEntry[]}) => {
+        mockCopyLogsButton(logs);
+        return null;
+    }
+}));
 jest.mock('./download-logs-button', () => ({DownloadLogsButton: () => null}));
 jest.mock('./container-selector', () => ({ContainerSelector: () => null}));
 jest.mock('./follow-toggle-button', () => ({FollowToggleButton: () => null}));
@@ -119,7 +125,9 @@ describe('PodsLogsViewer clear logs button', () => {
         renderComponent();
 
         const clearButton = getClearButton();
-        expect(clearButton.disabled).toBe(true);
+        expect(clearButton).toHaveClass('disabled');
+        expect(clearButton).not.toBeDisabled();
+        expect(clearButton.closest('[data-tooltip-content]')).toHaveAttribute('data-tooltip-content', 'Clear displayed logs');
 
         const beforeClick = container.textContent;
         act(() => {
@@ -129,7 +137,7 @@ describe('PodsLogsViewer clear logs button', () => {
         expect(container.textContent).toBe(beforeClick);
     });
 
-    it('clears displayed logs when the clear button is clicked', () => {
+    it('clears displayed logs but keeps received logs available for copying', () => {
         mockGetContainerLogs.mockReturnValue(of(...logsFixture));
 
         renderComponent();
@@ -139,7 +147,7 @@ describe('PodsLogsViewer clear logs button', () => {
         expect(beforeClear).toContain('INFO  Listening on :8080');
 
         const clearButton = getClearButton();
-        expect(clearButton.disabled).toBe(false);
+        expect(clearButton).not.toHaveClass('disabled');
 
         act(() => {
             clearButton.click();
@@ -150,6 +158,7 @@ describe('PodsLogsViewer clear logs button', () => {
         expect(afterClear).not.toContain('INFO  Listening on :8080');
 
         const disabledClearButton = getClearButton();
-        expect(disabledClearButton.disabled).toBe(true);
+        expect(disabledClearButton).toHaveClass('disabled');
+        expect(mockCopyLogsButton).toHaveBeenLastCalledWith(logsFixture);
     });
 });

--- a/ui/src/app/applications/components/pod-logs-viewer/pod-logs-viewer.tsx
+++ b/ui/src/app/applications/components/pod-logs-viewer/pod-logs-viewer.tsx
@@ -10,6 +10,7 @@ import {services, ViewPreferences} from '../../../shared/services';
 import AutoSizer from 'react-virtualized/dist/commonjs/AutoSizer';
 
 import './pod-logs-viewer.scss';
+import {ClearLogsButton} from './clear-logs-button';
 import {CopyLogsButton} from './copy-logs-button';
 import {DownloadLogsButton} from './download-logs-button';
 import {ContainerSelector} from './container-selector';
@@ -324,6 +325,7 @@ export const PodsLogsViewer = (props: PodLogsProps) => {
                             </span>
                             <Spacer />
                             <span>
+                                <ClearLogsButton disabled={logs.length === 0} onClear={() => setLogs([])} />
                                 <CopyLogsButton logs={logs} />
                                 <DownloadLogsButton {...props} previous={previous} />
                                 <FullscreenButton

--- a/ui/src/app/applications/components/pod-logs-viewer/pod-logs-viewer.tsx
+++ b/ui/src/app/applications/components/pod-logs-viewer/pod-logs-viewer.tsx
@@ -111,6 +111,7 @@ export const PodsLogsViewer = (props: PodLogsProps) => {
     const highlight = useMemo(() => buildHighlightRegExp(filter, matchCase), [filter, matchCase]);
     const [scrollToBottom, setScrollToBottom] = useState(true);
     const [logs, setLogs] = useState<LogEntry[]>([]);
+    const [receivedLogs, setReceivedLogs] = useState<LogEntry[]>([]);
     const logsContainerRef = useRef(null);
     const uniquePods = Array.from(new Set(logs.map(log => log.podName)));
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -168,6 +169,7 @@ export const PodsLogsViewer = (props: PodLogsProps) => {
     if (prevQueryKey !== queryKey) {
         setPrevQueryKey(queryKey);
         setLogs([]);
+        setReceivedLogs([]);
     }
 
     useEffect(() => {
@@ -211,6 +213,7 @@ export const PodsLogsViewer = (props: PodLogsProps) => {
             .subscribe(log => {
                 if (log.length) {
                     setLogs(previousLogs => previousLogs.concat(log));
+                    setReceivedLogs(previousLogs => previousLogs.concat(log));
                 }
             });
 
@@ -326,7 +329,7 @@ export const PodsLogsViewer = (props: PodLogsProps) => {
                             <Spacer />
                             <span>
                                 <ClearLogsButton disabled={logs.length === 0} onClear={() => setLogs([])} />
-                                <CopyLogsButton logs={logs} />
+                                <CopyLogsButton logs={receivedLogs} />
                                 <DownloadLogsButton {...props} previous={previous} />
                                 <FullscreenButton
                                     {...props}

--- a/ui/src/app/shared/components/button.tsx
+++ b/ui/src/app/shared/components/button.tsx
@@ -30,7 +30,8 @@ export const Button = ({
         <button
             className={'argo-button ' + (!outline ? 'argo-button--base' : 'argo-button--base-o') + ' ' + (disabled ? 'disabled' : '') + ' ' + (className || '')}
             style={style}
-            onClick={onClick}>
+            onClick={onClick}
+            disabled={disabled}>
             {icon && <i className={'fa fa-' + icon + ' ' + (beat ? 'fa-beat' : '') + (rotate ? 'fa-rotate-180' : '')} />} {children}
         </button>
     </Tooltip>

--- a/ui/src/app/shared/components/button.tsx
+++ b/ui/src/app/shared/components/button.tsx
@@ -30,8 +30,7 @@ export const Button = ({
         <button
             className={'argo-button ' + (!outline ? 'argo-button--base' : 'argo-button--base-o') + ' ' + (disabled ? 'disabled' : '') + ' ' + (className || '')}
             style={style}
-            onClick={onClick}
-            disabled={disabled}>
+            onClick={onClick}>
             {icon && <i className={'fa fa-' + icon + ' ' + (beat ? 'fa-beat' : '') + (rotate ? 'fa-rotate-180' : '')} />} {children}
         </button>
     </Tooltip>


### PR DESCRIPTION
## Description

This PR introduces a small UX improvement to the pod logs viewer by adding a **"Clear logs" button**.

Currently, users need to refresh or navigate away to reset the displayed logs. This change provides a quick and intuitive way to clear the log output directly from the UI, which improves usability when working with noisy or continuously updating logs.

### Scope

- UI-only change (no backend or API impact)
- Does not modify existing log fetching or filtering logic
- Adds unit test coverage for the new behavior

### Motivation

When debugging applications, logs can quickly become cluttered. Providing a clear action helps users focus on new incoming logs without extra navigation steps.

---

## Checklist

* [x] This does not need to be in the release notes (small UX improvement)
* [x] The title of the PR is clear and follows the guidelines
* [ ] Closes [ISSUE #] (not applicable)
* [x] UI updated (CLI not impacted)
* [ ] Documentation update required? (not required)
* [ ] Documentation updated (not required)
* [x] DCO sign-off added to commits
* [x] Unit and/or e2e tests added
* [ ] Build is green
* [x] This PR includes a clear explanation of the change