### PR TITLE
fix(docs): version banner keeps page path (#26857)

### DIFF
--- a/docs/assets/versions.js
+++ b/docs/assets/versions.js
@@ -138,11 +138,21 @@ window.addEventListener("DOMContentLoaded", function() {
   var margin = 30;
   var headerHeight = document.getElementsByClassName("md-header")[0].offsetHeight;
   const currentVersion = getCurrentVersion();
+  // Build equivalent stable URL for the current page (preserve path, query, hash)
+  const stableUrl = (() => {
+    try {
+      const path = window.location.pathname.replace(/^\/en\/[^/]+/, '');
+      return 'https://argo-cd.readthedocs.io/en/stable' + path + window.location.search + window.location.hash;
+    } catch (e) {
+      return 'https://argo-cd.readthedocs.io/en/stable/';
+    }
+  })();
+
   if (currentVersion && currentVersion !== "stable") {
     if (currentVersion === "latest") {
-      document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for an unreleased version of Argo CD, <a href='https://argo-cd.readthedocs.io/en/stable/'>view the latest stable version.</a></div>";
+      document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for an unreleased version of Argo CD, <a href='" + stableUrl + "'>view the latest stable version.</a></div>";
     } else {
-      document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for a previous version of Argo CD, <a href='https://argo-cd.readthedocs.io/en/stable/'>view the latest stable version.</a></div>";
+      document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for a previous version of Argo CD, <a href='" + stableUrl + "'>view the latest stable version.</a></div>";
     }
     var bannerHeight = document.getElementById('announce-msg').offsetHeight + margin;
     document.querySelector("header.md-header").style.top = bannerHeight + "px";


### PR DESCRIPTION
## Summary
- Preserve the current page path/query/hash when the banner points to stable docs.
- Strip the `/en/<version>` prefix and redirect to the same path under `/en/stable/`.
- Fallback to the stable homepage if path parsing fails.

## Testing
- mkdocs build
- python -m http.server 8000 (in `site/`)
- Visited `/en/latest/operator-manual/` and `/en/release-3.0/…`; banner now lands on the same path under `/en/stable/`.

Fixes #26857
