### PR TITLE
fix: stream list requests straight to http writer

### DIFF
--- a/pkg/apiclient/application/forwarder_overwrite.go
+++ b/pkg/apiclient/application/forwarder_overwrite.go
@@ -198,15 +198,16 @@ func writeInlineTypeMeta(w io.Writer, tm *metav1.TypeMeta) error {
 // parseFieldSelection parses the "fields" query parameter into a field map and exclude flag.
 func parseFieldSelection(req *gohttp.Request) (fields map[string]any, exclude bool) {
 	fieldsQuery := req.URL.Query().Get("fields")
+	if fieldsQuery == "" {
+		return nil, false
+	}
+	if strings.HasPrefix(fieldsQuery, "-") {
+		fieldsQuery = fieldsQuery[1:]
+		exclude = true
+	}
 	fields = make(map[string]any)
-	if fieldsQuery != "" {
-		if strings.HasPrefix(fieldsQuery, "-") {
-			fieldsQuery = fieldsQuery[1:]
-			exclude = true
-		}
-		for field := range strings.SplitSeq(fieldsQuery, ",") {
-			fields[field] = true
-		}
+	for field := range strings.SplitSeq(fieldsQuery, ",") {
+		fields[field] = true
 	}
 	return fields, exclude
 }

--- a/pkg/apiclient/application/forwarder_overwrite.go
+++ b/pkg/apiclient/application/forwarder_overwrite.go
@@ -132,6 +132,7 @@ func processApplicationListField(v any, fields map[string]any, exclude bool) (an
 // streaming one application at a time to avoid buffering the entire response.
 func streamApplicationListJSON(w io.Writer, appList *v1alpha1.ApplicationList, fields map[string]any, exclude bool) error {
 	useFieldFilter := len(fields) > 0
+	enc := json.NewEncoder(w)
 
 	if _, err := w.Write([]byte("{")); err != nil {
 		return err
@@ -147,11 +148,7 @@ func streamApplicationListJSON(w io.Writer, appList *v1alpha1.ApplicationList, f
 	if _, err := w.Write([]byte(`"metadata":`)); err != nil {
 		return err
 	}
-	metaData, err := json.Marshal(appList.ListMeta)
-	if err != nil {
-		return err
-	}
-	if _, err := w.Write(metaData); err != nil {
+	if err := enc.Encode(appList.ListMeta); err != nil {
 		return err
 	}
 	if _, err := w.Write([]byte(`,"items":[`)); err != nil {
@@ -164,29 +161,24 @@ func streamApplicationListJSON(w io.Writer, appList *v1alpha1.ApplicationList, f
 				return err
 			}
 		}
-		var data []byte
 		if useFieldFilter {
 			converted, err := processAppFields(&appList.Items[i], fields, exclude)
 			if err != nil {
 				return err
 			}
-			data, err = json.Marshal(converted)
-			if err != nil {
+			if err := enc.Encode(converted); err != nil {
 				return err
 			}
 		} else {
-			data, err = json.Marshal(appList.Items[i])
-			if err != nil {
+			if err := enc.Encode(&appList.Items[i]); err != nil {
 				return err
 			}
 		}
-		if _, err := w.Write(data); err != nil {
-			return err
-		}
 	}
-
-	_, err = w.Write([]byte("]}"))
-	return err
+	if _, err := w.Write([]byte("]}")); err != nil {
+		return err
+	}
+	return nil
 }
 
 // writeInlineTypeMeta writes the TypeMeta fields as inline JSON key-value pairs

--- a/pkg/apiclient/application/forwarder_overwrite.go
+++ b/pkg/apiclient/application/forwarder_overwrite.go
@@ -110,24 +110,6 @@ func processAppFields(app *v1alpha1.Application, fields map[string]any, exclude 
 	return converted, nil
 }
 
-func processApplicationListField(v any, fields map[string]any, exclude bool) (any, error) {
-	if appList, ok := v.(*v1alpha1.ApplicationList); ok {
-		var items []map[string]any
-		for i := range appList.Items {
-			converted, err := processAppFields(&appList.Items[i], fields, exclude)
-			if err != nil {
-				return nil, err
-			}
-			items = append(items, converted)
-		}
-		return map[string]any{
-			"items":    items,
-			"metadata": appList.ListMeta,
-		}, nil
-	}
-	return nil, errors.New("not an application list")
-}
-
 // streamApplicationListJSON writes the ApplicationList as JSON directly to w,
 // streaming one application at a time to avoid buffering the entire response.
 func streamApplicationListJSON(w io.Writer, appList *v1alpha1.ApplicationList, fields map[string]any, exclude bool) error {
@@ -151,6 +133,13 @@ func streamApplicationListJSON(w io.Writer, appList *v1alpha1.ApplicationList, f
 	if err := enc.Encode(appList.ListMeta); err != nil {
 		return err
 	}
+	if appList.Items == nil {
+		if _, err := w.Write([]byte(`,"items":null}`)); err != nil {
+			return err
+		}
+		return nil
+	}
+
 	if _, err := w.Write([]byte(`,"items":[`)); err != nil {
 		return err
 	}
@@ -297,6 +286,7 @@ func init() {
 
 		if err := streamApplicationListJSON(w, appList, fields, exclude); err != nil {
 			log.Errorf("Failed to stream application list response: %v", err)
+			panic(gohttp.ErrAbortHandler)
 		}
 
 		if ok {

--- a/pkg/apiclient/application/forwarder_overwrite.go
+++ b/pkg/apiclient/application/forwarder_overwrite.go
@@ -175,20 +175,12 @@ func streamApplicationListJSON(w io.Writer, appList *v1alpha1.ApplicationList, f
 // Respects omitempty: fields are only written when non-empty.
 func writeInlineTypeMeta(w io.Writer, tm *metav1.TypeMeta) error {
 	if tm.Kind != "" {
-		data, err := json.Marshal(tm.Kind)
-		if err != nil {
-			return err
-		}
-		if _, err := fmt.Fprintf(w, `"kind":%s,`, data); err != nil {
+		if _, err := fmt.Fprintf(w, `"kind":"%s",`, tm.Kind); err != nil {
 			return err
 		}
 	}
 	if tm.APIVersion != "" {
-		data, err := json.Marshal(tm.APIVersion)
-		if err != nil {
-			return err
-		}
-		if _, err := fmt.Fprintf(w, `"apiVersion":%s,`, data); err != nil {
+		if _, err := fmt.Fprintf(w, `"apiVersion":"%s",`, tm.APIVersion); err != nil {
 			return err
 		}
 	}
@@ -210,6 +202,24 @@ func parseFieldSelection(req *gohttp.Request) (fields map[string]any, exclude bo
 		fields[field] = true
 	}
 	return fields, exclude
+}
+
+func processApplicationListField(v any, fields map[string]any, exclude bool) (any, error) {
+	if appList, ok := v.(*v1alpha1.ApplicationList); ok {
+		var items []map[string]any
+		for i := range appList.Items {
+			converted, err := processAppFields(&appList.Items[i], fields, exclude)
+			if err != nil {
+				return nil, err
+			}
+			items = append(items, converted)
+		}
+		return map[string]any{
+			"items":    items,
+			"metadata": appList.ListMeta,
+		}, nil
+	}
+	return nil, errors.New("not an application list")
 }
 
 func init() {
@@ -257,6 +267,12 @@ func init() {
 		appList, ok := resp.(*v1alpha1.ApplicationList)
 		if !ok {
 			runtime.ForwardResponseMessage(ctx, mux, marshaler, w, req, resp, opts...)
+			return
+		}
+
+		if req.Header.Get("Accept") == "text/event-stream" {
+			// Use old non-streaming processor
+			http.UnaryForwarderWithFieldProcessor(processApplicationListField)(ctx, mux, marshaler, w, req, resp, opts...)
 			return
 		}
 

--- a/pkg/apiclient/application/forwarder_overwrite.go
+++ b/pkg/apiclient/application/forwarder_overwrite.go
@@ -2,10 +2,15 @@ package application
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	gohttp "net/http"
+	"net/textproto"
 	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-cd/v3/util/kube"
 
@@ -14,6 +19,8 @@ import (
 
 	//nolint:staticcheck
 	"github.com/golang/protobuf/proto"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 )
@@ -71,38 +78,47 @@ var appFields = map[string]func(app *v1alpha1.Application) any{
 	},
 }
 
+// processAppFields extracts the requested fields from a single application into a map.
+func processAppFields(app *v1alpha1.Application, fields map[string]any, exclude bool) (map[string]any, error) {
+	converted := make(map[string]any)
+	for field, fn := range appFields {
+		if _, ok := fields["items."+field]; ok == exclude {
+			continue
+		}
+		value := fn(app)
+		if value == nil {
+			continue
+		}
+		parts := strings.Split(field, ".")
+		item := converted
+		for i := range parts {
+			subField := parts[i]
+			if i == len(parts)-1 {
+				item[subField] = value
+			} else {
+				if _, ok := item[subField]; !ok {
+					item[subField] = make(map[string]any)
+				}
+				nestedMap, ok := item[subField].(map[string]any)
+				if !ok {
+					return nil, fmt.Errorf("field %s is not a map", field)
+				}
+				item = nestedMap
+			}
+		}
+	}
+	return converted, nil
+}
+
 func processApplicationListField(v any, fields map[string]any, exclude bool) (any, error) {
 	if appList, ok := v.(*v1alpha1.ApplicationList); ok {
 		var items []map[string]any
-		for _, app := range appList.Items {
-			converted := make(map[string]any)
-			items = append(items, converted)
-			for field, fn := range appFields {
-				if _, ok := fields["items."+field]; ok == exclude {
-					continue
-				}
-				value := fn(&app)
-				if value == nil {
-					continue
-				}
-				parts := strings.Split(field, ".")
-				item := converted
-				for i := range parts {
-					subField := parts[i]
-					if i == len(parts)-1 {
-						item[subField] = value
-					} else {
-						if _, ok := item[subField]; !ok {
-							item[subField] = make(map[string]any)
-						}
-						nestedMap, ok := item[subField].(map[string]any)
-						if !ok {
-							return nil, fmt.Errorf("field %s is not a map", field)
-						}
-						item = nestedMap
-					}
-				}
+		for i := range appList.Items {
+			converted, err := processAppFields(&appList.Items[i], fields, exclude)
+			if err != nil {
+				return nil, err
 			}
+			items = append(items, converted)
 		}
 		return map[string]any{
 			"items":    items,
@@ -110,6 +126,108 @@ func processApplicationListField(v any, fields map[string]any, exclude bool) (an
 		}, nil
 	}
 	return nil, errors.New("not an application list")
+}
+
+// streamApplicationListJSON writes the ApplicationList as JSON directly to w,
+// streaming one application at a time to avoid buffering the entire response.
+func streamApplicationListJSON(w io.Writer, appList *v1alpha1.ApplicationList, fields map[string]any, exclude bool) error {
+	useFieldFilter := len(fields) > 0
+
+	if _, err := w.Write([]byte("{")); err != nil {
+		return err
+	}
+
+	// When not field-filtering, include TypeMeta fields to match json.Marshal(ApplicationList) output.
+	if !useFieldFilter {
+		if err := writeInlineTypeMeta(w, &appList.TypeMeta); err != nil {
+			return err
+		}
+	}
+
+	if _, err := w.Write([]byte(`"metadata":`)); err != nil {
+		return err
+	}
+	metaData, err := json.Marshal(appList.ListMeta)
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(metaData); err != nil {
+		return err
+	}
+	if _, err := w.Write([]byte(`,"items":[`)); err != nil {
+		return err
+	}
+
+	for i := range appList.Items {
+		if i > 0 {
+			if _, err := w.Write([]byte(",")); err != nil {
+				return err
+			}
+		}
+		var data []byte
+		if useFieldFilter {
+			converted, err := processAppFields(&appList.Items[i], fields, exclude)
+			if err != nil {
+				return err
+			}
+			data, err = json.Marshal(converted)
+			if err != nil {
+				return err
+			}
+		} else {
+			data, err = json.Marshal(appList.Items[i])
+			if err != nil {
+				return err
+			}
+		}
+		if _, err := w.Write(data); err != nil {
+			return err
+		}
+	}
+
+	_, err = w.Write([]byte("]}"))
+	return err
+}
+
+// writeInlineTypeMeta writes the TypeMeta fields as inline JSON key-value pairs
+// (with trailing comma), matching the behavior of json:",inline" on the struct tag.
+// Respects omitempty: fields are only written when non-empty.
+func writeInlineTypeMeta(w io.Writer, tm *metav1.TypeMeta) error {
+	if tm.Kind != "" {
+		data, err := json.Marshal(tm.Kind)
+		if err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(w, `"kind":%s,`, data); err != nil {
+			return err
+		}
+	}
+	if tm.APIVersion != "" {
+		data, err := json.Marshal(tm.APIVersion)
+		if err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(w, `"apiVersion":%s,`, data); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// parseFieldSelection parses the "fields" query parameter into a field map and exclude flag.
+func parseFieldSelection(req *gohttp.Request) (fields map[string]any, exclude bool) {
+	fieldsQuery := req.URL.Query().Get("fields")
+	fields = make(map[string]any)
+	if fieldsQuery != "" {
+		if strings.HasPrefix(fieldsQuery, "-") {
+			fieldsQuery = fieldsQuery[1:]
+			exclude = true
+		}
+		for field := range strings.SplitSeq(fieldsQuery, ",") {
+			fields[field] = true
+		}
+	}
+	return fields, exclude
 }
 
 func init() {
@@ -153,6 +271,50 @@ func init() {
 		}
 		return event.Application.Name, nil
 	})
-	forward_ApplicationService_List_0 = http.UnaryForwarderWithFieldProcessor(processApplicationListField)
+	forward_ApplicationService_List_0 = func(ctx context.Context, mux *runtime.ServeMux, marshaler runtime.Marshaler, w gohttp.ResponseWriter, req *gohttp.Request, resp proto.Message, opts ...func(context.Context, gohttp.ResponseWriter, proto.Message) error) {
+		appList, ok := resp.(*v1alpha1.ApplicationList)
+		if !ok {
+			runtime.ForwardResponseMessage(ctx, mux, marshaler, w, req, resp, opts...)
+			return
+		}
+
+		// Replicate grpc-gateway ForwardResponseMessage header handling.
+		md, ok := runtime.ServerMetadataFromContext(ctx)
+		if ok {
+			for k, vs := range md.HeaderMD {
+				for _, v := range vs {
+					w.Header().Add(fmt.Sprintf("%s%s", runtime.MetadataHeaderPrefix, k), v)
+				}
+			}
+			for k := range md.TrailerMD {
+				tKey := textproto.CanonicalMIMEHeaderKey(fmt.Sprintf("%s%s", runtime.MetadataTrailerPrefix, k))
+				w.Header().Add("Trailer", tKey)
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+
+		for _, opt := range opts {
+			if err := opt(ctx, w, resp); err != nil {
+				runtime.HTTPError(ctx, mux, marshaler, w, req, err)
+				return
+			}
+		}
+
+		fields, exclude := parseFieldSelection(req)
+
+		if err := streamApplicationListJSON(w, appList, fields, exclude); err != nil {
+			log.Errorf("Failed to stream application list response: %v", err)
+		}
+
+		if ok {
+			for k, vs := range md.TrailerMD {
+				tKey := fmt.Sprintf("%s%s", runtime.MetadataTrailerPrefix, k)
+				for _, v := range vs {
+					w.Header().Add(tKey, v)
+				}
+			}
+		}
+	}
 	forward_ApplicationService_ManagedResources_0 = http.UnaryForwarder
 }

--- a/pkg/apiclient/application/forwarder_overwrite.go
+++ b/pkg/apiclient/application/forwarder_overwrite.go
@@ -182,20 +182,12 @@ func streamApplicationListJSON(w io.Writer, appList *v1alpha1.ApplicationList, f
 // Respects omitempty: fields are only written when non-empty.
 func writeInlineTypeMeta(w io.Writer, tm *metav1.TypeMeta) error {
 	if tm.Kind != "" {
-		data, err := json.Marshal(tm.Kind)
-		if err != nil {
-			return err
-		}
-		if _, err := fmt.Fprintf(w, `"kind":%s,`, data); err != nil {
+		if _, err := fmt.Fprintf(w, `"kind":"%s",`, tm.Kind); err != nil {
 			return err
 		}
 	}
 	if tm.APIVersion != "" {
-		data, err := json.Marshal(tm.APIVersion)
-		if err != nil {
-			return err
-		}
-		if _, err := fmt.Fprintf(w, `"apiVersion":%s,`, data); err != nil {
+		if _, err := fmt.Fprintf(w, `"apiVersion":"%s",`, tm.APIVersion); err != nil {
 			return err
 		}
 	}
@@ -217,6 +209,24 @@ func parseFieldSelection(req *gohttp.Request) (fields map[string]any, exclude bo
 		fields[field] = true
 	}
 	return fields, exclude
+}
+
+func processApplicationListField(v any, fields map[string]any, exclude bool) (any, error) {
+	if appList, ok := v.(*v1alpha1.ApplicationList); ok {
+		var items []map[string]any
+		for i := range appList.Items {
+			converted, err := processAppFields(&appList.Items[i], fields, exclude)
+			if err != nil {
+				return nil, err
+			}
+			items = append(items, converted)
+		}
+		return map[string]any{
+			"items":    items,
+			"metadata": appList.ListMeta,
+		}, nil
+	}
+	return nil, errors.New("not an application list")
 }
 
 func init() {
@@ -264,6 +274,12 @@ func init() {
 		appList, ok := resp.(*v1alpha1.ApplicationList)
 		if !ok {
 			runtime.ForwardResponseMessage(ctx, mux, marshaler, w, req, resp, opts...)
+			return
+		}
+
+		if req.Header.Get("Accept") == "text/event-stream" {
+			// Use old non-streaming processor
+			http.UnaryForwarderWithFieldProcessor(processApplicationListField)(ctx, mux, marshaler, w, req, resp, opts...)
 			return
 		}
 

--- a/pkg/apiclient/application/forwarder_overwrite.go
+++ b/pkg/apiclient/application/forwarder_overwrite.go
@@ -85,22 +85,39 @@ var appFields = map[string]func(app *v1alpha1.Application) any{
 	},
 }
 
-// processAppFields extracts the requested fields from a single application into a map.
-func processAppFields(app *v1alpha1.Application, fields map[string]any, exclude bool) (map[string]any, error) {
-	converted := make(map[string]any)
+// appFieldSpec is a precomputed appFields entry: the dotted field name, its
+// pre-split path, and the value extractor.
+type appFieldSpec struct {
+	field string
+	parts []string
+	fn    func(app *v1alpha1.Application) any
+}
+
+// selectAppFields resolves the fields/exclude selection against appFields once
+// per request, so the per-application loop doesn't repeat the map lookups and
+// path splitting for every item.
+func selectAppFields(fields map[string]any, exclude bool) []appFieldSpec {
+	specs := make([]appFieldSpec, 0, len(appFields))
 	for field, fn := range appFields {
 		if _, ok := fields["items."+field]; ok == exclude {
 			continue
 		}
-		value := fn(app)
+		specs = append(specs, appFieldSpec{field: field, parts: strings.Split(field, "."), fn: fn})
+	}
+	return specs
+}
+
+// processAppFields extracts the selected fields from a single application into a map.
+func processAppFields(app *v1alpha1.Application, specs []appFieldSpec) (map[string]any, error) {
+	converted := make(map[string]any)
+	for _, spec := range specs {
+		value := spec.fn(app)
 		if value == nil {
 			continue
 		}
-		parts := strings.Split(field, ".")
 		item := converted
-		for i := range parts {
-			subField := parts[i]
-			if i == len(parts)-1 {
+		for i, subField := range spec.parts {
+			if i == len(spec.parts)-1 {
 				item[subField] = value
 			} else {
 				if _, ok := item[subField]; !ok {
@@ -108,7 +125,7 @@ func processAppFields(app *v1alpha1.Application, fields map[string]any, exclude 
 				}
 				nestedMap, ok := item[subField].(map[string]any)
 				if !ok {
-					return nil, fmt.Errorf("field %s is not a map", field)
+					return nil, fmt.Errorf("field %s is not a map", spec.field)
 				}
 				item = nestedMap
 			}
@@ -121,6 +138,10 @@ func processAppFields(app *v1alpha1.Application, fields map[string]any, exclude 
 // streaming one application at a time to avoid buffering the entire response.
 func streamApplicationListJSON(w io.Writer, appList *v1alpha1.ApplicationList, fields map[string]any, exclude bool) error {
 	useFieldFilter := len(fields) > 0
+	var specs []appFieldSpec
+	if useFieldFilter {
+		specs = selectAppFields(fields, exclude)
+	}
 	enc := json.NewEncoder(w)
 
 	if _, err := w.Write([]byte("{")); err != nil {
@@ -158,7 +179,7 @@ func streamApplicationListJSON(w io.Writer, appList *v1alpha1.ApplicationList, f
 			}
 		}
 		if useFieldFilter {
-			converted, err := processAppFields(&appList.Items[i], fields, exclude)
+			converted, err := processAppFields(&appList.Items[i], specs)
 			if err != nil {
 				return err
 			}
@@ -195,6 +216,9 @@ func writeInlineTypeMeta(w io.Writer, tm *metav1.TypeMeta) error {
 }
 
 // parseFieldSelection parses the "fields" query parameter into a field map and exclude flag.
+// Keep the semantics in sync with newMarshaler in github.com/argoproj/pkg/v2/grpc/http
+// (used via UnaryForwarderWithFieldProcessor on the Accept: text/event-stream branch),
+// so both branches of the List endpoint filter identically.
 func parseFieldSelection(req *gohttp.Request) (fields map[string]any, exclude bool) {
 	fieldsQuery := req.URL.Query().Get("fields")
 	if fieldsQuery == "" {
@@ -213,9 +237,10 @@ func parseFieldSelection(req *gohttp.Request) (fields map[string]any, exclude bo
 
 func processApplicationListField(v any, fields map[string]any, exclude bool) (any, error) {
 	if appList, ok := v.(*v1alpha1.ApplicationList); ok {
+		specs := selectAppFields(fields, exclude)
 		var items []map[string]any
 		for i := range appList.Items {
-			converted, err := processAppFields(&appList.Items[i], fields, exclude)
+			converted, err := processAppFields(&appList.Items[i], specs)
 			if err != nil {
 				return nil, err
 			}
@@ -284,8 +309,8 @@ func init() {
 		}
 
 		// Replicate grpc-gateway ForwardResponseMessage header handling.
-		md, ok := runtime.ServerMetadataFromContext(ctx)
-		if ok {
+		md, hasMD := runtime.ServerMetadataFromContext(ctx)
+		if hasMD {
 			for k, vs := range md.HeaderMD {
 				for _, v := range vs {
 					w.Header().Add(fmt.Sprintf("%s%s", runtime.MetadataHeaderPrefix, k), v)
@@ -309,11 +334,17 @@ func init() {
 		fields, exclude := parseFieldSelection(req)
 
 		if err := streamApplicationListJSON(w, appList, fields, exclude); err != nil {
-			log.Errorf("Failed to stream application list response: %v", err)
+			if req.Context().Err() != nil {
+				// The client went away mid-stream (tab closed, CLI interrupted);
+				// this is routine, not a server error.
+				log.Debugf("Client disconnected while streaming application list response: %v", err)
+			} else {
+				log.Errorf("Failed to stream application list response: %v", err)
+			}
 			panic(gohttp.ErrAbortHandler)
 		}
 
-		if ok {
+		if hasMD {
 			for k, vs := range md.TrailerMD {
 				tKey := fmt.Sprintf("%s%s", runtime.MetadataTrailerPrefix, k)
 				for _, v := range vs {

--- a/pkg/apiclient/application/forwarder_overwrite.go
+++ b/pkg/apiclient/application/forwarder_overwrite.go
@@ -205,15 +205,16 @@ func writeInlineTypeMeta(w io.Writer, tm *metav1.TypeMeta) error {
 // parseFieldSelection parses the "fields" query parameter into a field map and exclude flag.
 func parseFieldSelection(req *gohttp.Request) (fields map[string]any, exclude bool) {
 	fieldsQuery := req.URL.Query().Get("fields")
+	if fieldsQuery == "" {
+		return nil, false
+	}
+	if strings.HasPrefix(fieldsQuery, "-") {
+		fieldsQuery = fieldsQuery[1:]
+		exclude = true
+	}
 	fields = make(map[string]any)
-	if fieldsQuery != "" {
-		if strings.HasPrefix(fieldsQuery, "-") {
-			fieldsQuery = fieldsQuery[1:]
-			exclude = true
-		}
-		for field := range strings.SplitSeq(fieldsQuery, ",") {
-			fields[field] = true
-		}
+	for field := range strings.SplitSeq(fieldsQuery, ",") {
+		fields[field] = true
 	}
 	return fields, exclude
 }

--- a/pkg/apiclient/application/forwarder_overwrite.go
+++ b/pkg/apiclient/application/forwarder_overwrite.go
@@ -139,6 +139,7 @@ func processApplicationListField(v any, fields map[string]any, exclude bool) (an
 // streaming one application at a time to avoid buffering the entire response.
 func streamApplicationListJSON(w io.Writer, appList *v1alpha1.ApplicationList, fields map[string]any, exclude bool) error {
 	useFieldFilter := len(fields) > 0
+	enc := json.NewEncoder(w)
 
 	if _, err := w.Write([]byte("{")); err != nil {
 		return err
@@ -154,11 +155,7 @@ func streamApplicationListJSON(w io.Writer, appList *v1alpha1.ApplicationList, f
 	if _, err := w.Write([]byte(`"metadata":`)); err != nil {
 		return err
 	}
-	metaData, err := json.Marshal(appList.ListMeta)
-	if err != nil {
-		return err
-	}
-	if _, err := w.Write(metaData); err != nil {
+	if err := enc.Encode(appList.ListMeta); err != nil {
 		return err
 	}
 	if _, err := w.Write([]byte(`,"items":[`)); err != nil {
@@ -171,29 +168,24 @@ func streamApplicationListJSON(w io.Writer, appList *v1alpha1.ApplicationList, f
 				return err
 			}
 		}
-		var data []byte
 		if useFieldFilter {
 			converted, err := processAppFields(&appList.Items[i], fields, exclude)
 			if err != nil {
 				return err
 			}
-			data, err = json.Marshal(converted)
-			if err != nil {
+			if err := enc.Encode(converted); err != nil {
 				return err
 			}
 		} else {
-			data, err = json.Marshal(appList.Items[i])
-			if err != nil {
+			if err := enc.Encode(&appList.Items[i]); err != nil {
 				return err
 			}
 		}
-		if _, err := w.Write(data); err != nil {
-			return err
-		}
 	}
-
-	_, err = w.Write([]byte("]}"))
-	return err
+	if _, err := w.Write([]byte("]}")); err != nil {
+		return err
+	}
+	return nil
 }
 
 // writeInlineTypeMeta writes the TypeMeta fields as inline JSON key-value pairs

--- a/pkg/apiclient/application/forwarder_overwrite.go
+++ b/pkg/apiclient/application/forwarder_overwrite.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	gohttp "net/http"
 	"net/textproto"
+	"sort"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -96,14 +97,36 @@ type appFieldSpec struct {
 // selectAppFields resolves the fields/exclude selection against appFields once
 // per request, so the per-application loop doesn't repeat the map lookups and
 // path splitting for every item.
+//
+// appFields may contain both a field and its descendants (e.g. "spec" and
+// "spec.destination"). When an ancestor is selected its value already covers
+// every descendant, so descendant specs are dropped; otherwise the write order
+// of the shared "spec" key would depend on map iteration order and could fail
+// with "field ... is not a map". The result is sorted to keep output
+// deterministic across requests.
 func selectAppFields(fields map[string]any, exclude bool) []appFieldSpec {
-	specs := make([]appFieldSpec, 0, len(appFields))
-	for field, fn := range appFields {
-		if _, ok := fields["items."+field]; ok == exclude {
+	selected := make(map[string]bool, len(appFields))
+	for field := range appFields {
+		if _, ok := fields["items."+field]; ok != exclude {
+			selected[field] = true
+		}
+	}
+	specs := make([]appFieldSpec, 0, len(selected))
+	for field := range selected {
+		parts := strings.Split(field, ".")
+		coveredByAncestor := false
+		for i := 1; i < len(parts); i++ {
+			if selected[strings.Join(parts[:i], ".")] {
+				coveredByAncestor = true
+				break
+			}
+		}
+		if coveredByAncestor {
 			continue
 		}
-		specs = append(specs, appFieldSpec{field: field, parts: strings.Split(field, "."), fn: fn})
+		specs = append(specs, appFieldSpec{field: field, parts: parts, fn: appFields[field]})
 	}
+	sort.Slice(specs, func(i, j int) bool { return specs[i].field < specs[j].field })
 	return specs
 }
 

--- a/pkg/apiclient/application/forwarder_overwrite.go
+++ b/pkg/apiclient/application/forwarder_overwrite.go
@@ -2,10 +2,15 @@ package application
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	gohttp "net/http"
+	"net/textproto"
 	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-cd/v3/util/kube"
 
@@ -14,6 +19,8 @@ import (
 
 	//nolint:staticcheck
 	"github.com/golang/protobuf/proto"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 )
@@ -78,38 +85,47 @@ var appFields = map[string]func(app *v1alpha1.Application) any{
 	},
 }
 
+// processAppFields extracts the requested fields from a single application into a map.
+func processAppFields(app *v1alpha1.Application, fields map[string]any, exclude bool) (map[string]any, error) {
+	converted := make(map[string]any)
+	for field, fn := range appFields {
+		if _, ok := fields["items."+field]; ok == exclude {
+			continue
+		}
+		value := fn(app)
+		if value == nil {
+			continue
+		}
+		parts := strings.Split(field, ".")
+		item := converted
+		for i := range parts {
+			subField := parts[i]
+			if i == len(parts)-1 {
+				item[subField] = value
+			} else {
+				if _, ok := item[subField]; !ok {
+					item[subField] = make(map[string]any)
+				}
+				nestedMap, ok := item[subField].(map[string]any)
+				if !ok {
+					return nil, fmt.Errorf("field %s is not a map", field)
+				}
+				item = nestedMap
+			}
+		}
+	}
+	return converted, nil
+}
+
 func processApplicationListField(v any, fields map[string]any, exclude bool) (any, error) {
 	if appList, ok := v.(*v1alpha1.ApplicationList); ok {
 		var items []map[string]any
-		for _, app := range appList.Items {
-			converted := make(map[string]any)
-			items = append(items, converted)
-			for field, fn := range appFields {
-				if _, ok := fields["items."+field]; ok == exclude {
-					continue
-				}
-				value := fn(&app)
-				if value == nil {
-					continue
-				}
-				parts := strings.Split(field, ".")
-				item := converted
-				for i := range parts {
-					subField := parts[i]
-					if i == len(parts)-1 {
-						item[subField] = value
-					} else {
-						if _, ok := item[subField]; !ok {
-							item[subField] = make(map[string]any)
-						}
-						nestedMap, ok := item[subField].(map[string]any)
-						if !ok {
-							return nil, fmt.Errorf("field %s is not a map", field)
-						}
-						item = nestedMap
-					}
-				}
+		for i := range appList.Items {
+			converted, err := processAppFields(&appList.Items[i], fields, exclude)
+			if err != nil {
+				return nil, err
 			}
+			items = append(items, converted)
 		}
 		return map[string]any{
 			"items":    items,
@@ -117,6 +133,108 @@ func processApplicationListField(v any, fields map[string]any, exclude bool) (an
 		}, nil
 	}
 	return nil, errors.New("not an application list")
+}
+
+// streamApplicationListJSON writes the ApplicationList as JSON directly to w,
+// streaming one application at a time to avoid buffering the entire response.
+func streamApplicationListJSON(w io.Writer, appList *v1alpha1.ApplicationList, fields map[string]any, exclude bool) error {
+	useFieldFilter := len(fields) > 0
+
+	if _, err := w.Write([]byte("{")); err != nil {
+		return err
+	}
+
+	// When not field-filtering, include TypeMeta fields to match json.Marshal(ApplicationList) output.
+	if !useFieldFilter {
+		if err := writeInlineTypeMeta(w, &appList.TypeMeta); err != nil {
+			return err
+		}
+	}
+
+	if _, err := w.Write([]byte(`"metadata":`)); err != nil {
+		return err
+	}
+	metaData, err := json.Marshal(appList.ListMeta)
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(metaData); err != nil {
+		return err
+	}
+	if _, err := w.Write([]byte(`,"items":[`)); err != nil {
+		return err
+	}
+
+	for i := range appList.Items {
+		if i > 0 {
+			if _, err := w.Write([]byte(",")); err != nil {
+				return err
+			}
+		}
+		var data []byte
+		if useFieldFilter {
+			converted, err := processAppFields(&appList.Items[i], fields, exclude)
+			if err != nil {
+				return err
+			}
+			data, err = json.Marshal(converted)
+			if err != nil {
+				return err
+			}
+		} else {
+			data, err = json.Marshal(appList.Items[i])
+			if err != nil {
+				return err
+			}
+		}
+		if _, err := w.Write(data); err != nil {
+			return err
+		}
+	}
+
+	_, err = w.Write([]byte("]}"))
+	return err
+}
+
+// writeInlineTypeMeta writes the TypeMeta fields as inline JSON key-value pairs
+// (with trailing comma), matching the behavior of json:",inline" on the struct tag.
+// Respects omitempty: fields are only written when non-empty.
+func writeInlineTypeMeta(w io.Writer, tm *metav1.TypeMeta) error {
+	if tm.Kind != "" {
+		data, err := json.Marshal(tm.Kind)
+		if err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(w, `"kind":%s,`, data); err != nil {
+			return err
+		}
+	}
+	if tm.APIVersion != "" {
+		data, err := json.Marshal(tm.APIVersion)
+		if err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(w, `"apiVersion":%s,`, data); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// parseFieldSelection parses the "fields" query parameter into a field map and exclude flag.
+func parseFieldSelection(req *gohttp.Request) (fields map[string]any, exclude bool) {
+	fieldsQuery := req.URL.Query().Get("fields")
+	fields = make(map[string]any)
+	if fieldsQuery != "" {
+		if strings.HasPrefix(fieldsQuery, "-") {
+			fieldsQuery = fieldsQuery[1:]
+			exclude = true
+		}
+		for field := range strings.SplitSeq(fieldsQuery, ",") {
+			fields[field] = true
+		}
+	}
+	return fields, exclude
 }
 
 func init() {
@@ -160,6 +278,50 @@ func init() {
 		}
 		return event.Application.Name, nil
 	})
-	forward_ApplicationService_List_0 = http.UnaryForwarderWithFieldProcessor(processApplicationListField)
+	forward_ApplicationService_List_0 = func(ctx context.Context, mux *runtime.ServeMux, marshaler runtime.Marshaler, w gohttp.ResponseWriter, req *gohttp.Request, resp proto.Message, opts ...func(context.Context, gohttp.ResponseWriter, proto.Message) error) {
+		appList, ok := resp.(*v1alpha1.ApplicationList)
+		if !ok {
+			runtime.ForwardResponseMessage(ctx, mux, marshaler, w, req, resp, opts...)
+			return
+		}
+
+		// Replicate grpc-gateway ForwardResponseMessage header handling.
+		md, ok := runtime.ServerMetadataFromContext(ctx)
+		if ok {
+			for k, vs := range md.HeaderMD {
+				for _, v := range vs {
+					w.Header().Add(fmt.Sprintf("%s%s", runtime.MetadataHeaderPrefix, k), v)
+				}
+			}
+			for k := range md.TrailerMD {
+				tKey := textproto.CanonicalMIMEHeaderKey(fmt.Sprintf("%s%s", runtime.MetadataTrailerPrefix, k))
+				w.Header().Add("Trailer", tKey)
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+
+		for _, opt := range opts {
+			if err := opt(ctx, w, resp); err != nil {
+				runtime.HTTPError(ctx, mux, marshaler, w, req, err)
+				return
+			}
+		}
+
+		fields, exclude := parseFieldSelection(req)
+
+		if err := streamApplicationListJSON(w, appList, fields, exclude); err != nil {
+			log.Errorf("Failed to stream application list response: %v", err)
+		}
+
+		if ok {
+			for k, vs := range md.TrailerMD {
+				tKey := fmt.Sprintf("%s%s", runtime.MetadataTrailerPrefix, k)
+				for _, v := range vs {
+					w.Header().Add(tKey, v)
+				}
+			}
+		}
+	}
 	forward_ApplicationService_ManagedResources_0 = http.UnaryForwarder
 }

--- a/pkg/apiclient/application/forwarder_overwrite.go
+++ b/pkg/apiclient/application/forwarder_overwrite.go
@@ -117,24 +117,6 @@ func processAppFields(app *v1alpha1.Application, fields map[string]any, exclude 
 	return converted, nil
 }
 
-func processApplicationListField(v any, fields map[string]any, exclude bool) (any, error) {
-	if appList, ok := v.(*v1alpha1.ApplicationList); ok {
-		var items []map[string]any
-		for i := range appList.Items {
-			converted, err := processAppFields(&appList.Items[i], fields, exclude)
-			if err != nil {
-				return nil, err
-			}
-			items = append(items, converted)
-		}
-		return map[string]any{
-			"items":    items,
-			"metadata": appList.ListMeta,
-		}, nil
-	}
-	return nil, errors.New("not an application list")
-}
-
 // streamApplicationListJSON writes the ApplicationList as JSON directly to w,
 // streaming one application at a time to avoid buffering the entire response.
 func streamApplicationListJSON(w io.Writer, appList *v1alpha1.ApplicationList, fields map[string]any, exclude bool) error {
@@ -158,6 +140,13 @@ func streamApplicationListJSON(w io.Writer, appList *v1alpha1.ApplicationList, f
 	if err := enc.Encode(appList.ListMeta); err != nil {
 		return err
 	}
+	if appList.Items == nil {
+		if _, err := w.Write([]byte(`,"items":null}`)); err != nil {
+			return err
+		}
+		return nil
+	}
+
 	if _, err := w.Write([]byte(`,"items":[`)); err != nil {
 		return err
 	}
@@ -304,6 +293,7 @@ func init() {
 
 		if err := streamApplicationListJSON(w, appList, fields, exclude); err != nil {
 			log.Errorf("Failed to stream application list response: %v", err)
+			panic(gohttp.ErrAbortHandler)
 		}
 
 		if ok {

--- a/pkg/apiclient/application/forwarder_overwrite_test.go
+++ b/pkg/apiclient/application/forwarder_overwrite_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -23,6 +25,25 @@ import (
 	"github.com/argoproj/argo-cd/v3/test"
 )
 
+func processApplicationListField(t *testing.T, v any, fields map[string]any, exclude bool) (any, error) {
+	t.Helper()
+	if appList, ok := v.(*v1alpha1.ApplicationList); ok {
+		var items []map[string]any
+		for i := range appList.Items {
+			converted, err := processAppFields(&appList.Items[i], fields, exclude)
+			if err != nil {
+				return nil, err
+			}
+			items = append(items, converted)
+		}
+		return map[string]any{
+			"items":    items,
+			"metadata": appList.ListMeta,
+		}, nil
+	}
+	return nil, errors.New("not an application list")
+}
+
 func TestProcessApplicationListField_SyncOperation(t *testing.T) {
 	list := v1alpha1.ApplicationList{
 		Items: []v1alpha1.Application{{Operation: &v1alpha1.Operation{Sync: &v1alpha1.SyncOperation{
@@ -30,7 +51,7 @@ func TestProcessApplicationListField_SyncOperation(t *testing.T) {
 		}}}},
 	}
 
-	res, err := processApplicationListField(&list, map[string]any{"items.operation.sync": true}, false)
+	res, err := processApplicationListField(t, &list, map[string]any{"items.operation.sync": true}, false)
 	require.NoError(t, err)
 	resMap, ok := res.(map[string]any)
 	require.True(t, ok)
@@ -51,7 +72,7 @@ func TestProcessApplicationListField_SyncOperationMissing(t *testing.T) {
 		Items: []v1alpha1.Application{{Operation: nil}},
 	}
 
-	res, err := processApplicationListField(&list, map[string]any{"items.operation.sync": true}, false)
+	res, err := processApplicationListField(t, &list, map[string]any{"items.operation.sync": true}, false)
 	require.NoError(t, err)
 	resMap, ok := res.(map[string]any)
 	require.True(t, ok)
@@ -150,6 +171,56 @@ func TestStreamApplicationListJSON_EmptyList(t *testing.T) {
 	assert.Empty(t, items)
 }
 
+func TestStreamApplicationListJSON_NilItems(t *testing.T) {
+	list := &v1alpha1.ApplicationList{
+		ListMeta: metav1.ListMeta{ResourceVersion: "1"},
+		Items:    nil,
+	}
+
+	var buf bytes.Buffer
+	err := streamApplicationListJSON(&buf, list, nil, false)
+	require.NoError(t, err)
+
+	var result map[string]any
+	err = json.Unmarshal(buf.Bytes(), &result)
+	require.NoError(t, err)
+
+	// nil items should produce "items":null, not "items":[]
+	assert.Nil(t, result["items"])
+}
+
+// TestStreamApplicationListJSON_NilVsEmptyMatchesJSONMarshal verifies that
+// the streaming output for nil and empty items matches json.Marshal behavior.
+func TestStreamApplicationListJSON_NilVsEmptyMatchesJSONMarshal(t *testing.T) {
+	tests := []struct {
+		name  string
+		items []v1alpha1.Application
+	}{
+		{"nil items", nil},
+		{"empty items", []v1alpha1.Application{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			list := &v1alpha1.ApplicationList{
+				ListMeta: metav1.ListMeta{ResourceVersion: "1"},
+				Items:    tt.items,
+			}
+
+			oldJSON, err := json.Marshal(list)
+			require.NoError(t, err)
+
+			var buf bytes.Buffer
+			err = streamApplicationListJSON(&buf, list, nil, false)
+			require.NoError(t, err)
+
+			var oldParsed, newParsed map[string]any
+			require.NoError(t, json.Unmarshal(oldJSON, &oldParsed))
+			require.NoError(t, json.Unmarshal(buf.Bytes(), &newParsed))
+			assert.Equal(t, oldParsed, newParsed)
+		})
+	}
+}
+
 func TestStreamApplicationListJSON_MatchesProcessApplicationListField(t *testing.T) {
 	list := &v1alpha1.ApplicationList{
 		ListMeta: metav1.ListMeta{ResourceVersion: "99"},
@@ -172,7 +243,7 @@ func TestStreamApplicationListJSON_MatchesProcessApplicationListField(t *testing
 	}
 
 	// Get result from the batch processApplicationListField
-	batchResult, err := processApplicationListField(list, fields, false)
+	batchResult, err := processApplicationListField(t, list, fields, false)
 	require.NoError(t, err)
 	batchJSON, err := json.Marshal(batchResult)
 	require.NoError(t, err)
@@ -304,7 +375,7 @@ func TestStreamApplicationListJSON_MatchesFieldFilter_AllFields(t *testing.T) {
 	}
 
 	// Batch (old path)
-	batchResult, err := processApplicationListField(list, fields, false)
+	batchResult, err := processApplicationListField(t, list, fields, false)
 	require.NoError(t, err)
 	batchJSON, err := json.Marshal(batchResult)
 	require.NoError(t, err)
@@ -339,7 +410,7 @@ func TestStreamApplicationListJSON_MatchesFieldFilter_Exclude(t *testing.T) {
 	// Exclude spec
 	fields := map[string]any{"items.spec": true}
 
-	batchResult, err := processApplicationListField(list, fields, true)
+	batchResult, err := processApplicationListField(t, list, fields, true)
 	require.NoError(t, err)
 	batchJSON, err := json.Marshal(batchResult)
 	require.NoError(t, err)
@@ -387,7 +458,9 @@ func TestForwarder_HeadersMatchForwardResponseMessage(t *testing.T) {
 	}
 
 	// --- Old path: UnaryForwarderWithFieldProcessor via ForwardResponseMessage ---
-	oldForwarder := argohttp.UnaryForwarderWithFieldProcessor(processApplicationListField)
+	oldForwarder := argohttp.UnaryForwarderWithFieldProcessor(func(val any, fields map[string]any, exclude bool) (any, error) {
+		return processApplicationListField(t, val, fields, exclude)
+	})
 	oldRec := httptest.NewRecorder()
 	oldReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/v1/applications?fields=items.metadata.name", http.NoBody)
 	oldForwarder(ctx, mux, nil, oldRec, oldReq, list, testOpt)
@@ -428,4 +501,61 @@ func TestForwarder_HeadersMatchForwardResponseMessage(t *testing.T) {
 	require.NoError(t, json.Unmarshal(oldRec.Body.Bytes(), &oldParsed))
 	require.NoError(t, json.Unmarshal(newRec.Body.Bytes(), &newParsed))
 	assert.Equal(t, oldParsed, newParsed)
+}
+
+// failAfterNWriter wraps a writer and returns an error after n bytes have been written.
+type failAfterNWriter struct {
+	w       io.Writer
+	limit   int
+	written int
+}
+
+func (f *failAfterNWriter) Write(p []byte) (int, error) {
+	if f.written+len(p) > f.limit {
+		return 0, errors.New("simulated write failure")
+	}
+	n, err := f.w.Write(p)
+	f.written += n
+	return n, err
+}
+
+func TestForwarder_StreamErrorPanicsWithErrAbortHandler(t *testing.T) {
+	list := &v1alpha1.ApplicationList{
+		ListMeta: metav1.ListMeta{ResourceVersion: "1"},
+		Items: []v1alpha1.Application{
+			{ObjectMeta: metav1.ObjectMeta{Name: "app1"}},
+		},
+	}
+
+	ctx := runtime.NewServerMetadataContext(context.Background(), runtime.ServerMetadata{})
+	mux := runtime.NewServeMux()
+
+	// Use an httptest.Server so the panic(http.ErrAbortHandler) is handled
+	// the same way a real net/http server handles it: the connection is aborted.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Wrap the ResponseWriter so writes fail mid-stream after headers are sent.
+		failing := &failAfterNWriter{w: w, limit: 1}
+		fw := &failingResponseWriter{ResponseWriter: w, Writer: failing}
+		forward_ApplicationService_List_0(ctx, mux, nil, fw, r, list)
+	}))
+	defer ts.Close()
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, ts.URL+"/api/v1/applications", http.NoBody)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	if err == nil {
+		resp.Body.Close()
+	}
+	require.ErrorIs(t, err, io.EOF)
+}
+
+// failingResponseWriter delegates Header/WriteHeader to the real ResponseWriter
+// but routes Write through a separate writer that can simulate failures.the
+type failingResponseWriter struct {
+	http.ResponseWriter
+	Writer io.Writer
+}
+
+func (f *failingResponseWriter) Write(p []byte) (int, error) {
+	return f.Writer.Write(p)
 }

--- a/pkg/apiclient/application/forwarder_overwrite_test.go
+++ b/pkg/apiclient/application/forwarder_overwrite_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	gohttp "net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -381,7 +380,7 @@ func TestForwarder_HeadersMatchForwardResponseMessage(t *testing.T) {
 
 	// Track whether forward-response opts are called
 	optCalled := false
-	testOpt := func(_ context.Context, w gohttp.ResponseWriter, _ proto.Message) error {
+	testOpt := func(_ context.Context, w http.ResponseWriter, _ proto.Message) error {
 		w.Header().Set("X-Test-Opt", "applied")
 		optCalled = true
 		return nil
@@ -390,14 +389,14 @@ func TestForwarder_HeadersMatchForwardResponseMessage(t *testing.T) {
 	// --- Old path: UnaryForwarderWithFieldProcessor via ForwardResponseMessage ---
 	oldForwarder := argohttp.UnaryForwarderWithFieldProcessor(processApplicationListField)
 	oldRec := httptest.NewRecorder()
-	oldReq := httptest.NewRequest(http.MethodGet, "/api/v1/applications?fields=items.metadata.name", nil)
+	oldReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/v1/applications?fields=items.metadata.name", http.NoBody)
 	oldForwarder(ctx, mux, nil, oldRec, oldReq, list, testOpt)
 	require.True(t, optCalled, "old path should call forward-response option")
 
 	// --- New path: streaming forwarder ---
 	optCalled = false
 	newRec := httptest.NewRecorder()
-	newReq := httptest.NewRequest(http.MethodGet, "/api/v1/applications?fields=items.metadata.name", nil)
+	newReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/v1/applications?fields=items.metadata.name", http.NoBody)
 	forward_ApplicationService_List_0(ctx, mux, nil, newRec, newReq, list, testOpt)
 	require.True(t, optCalled, "new path should call forward-response option")
 

--- a/pkg/apiclient/application/forwarder_overwrite_test.go
+++ b/pkg/apiclient/application/forwarder_overwrite_test.go
@@ -550,7 +550,7 @@ func TestForwarder_StreamErrorPanicsWithErrAbortHandler(t *testing.T) {
 }
 
 // failingResponseWriter delegates Header/WriteHeader to the real ResponseWriter
-// but routes Write through a separate writer that can simulate failures.the
+// but routes Write through a separate writer that can simulate failures. The
 type failingResponseWriter struct {
 	http.ResponseWriter
 	Writer io.Writer

--- a/pkg/apiclient/application/forwarder_overwrite_test.go
+++ b/pkg/apiclient/application/forwarder_overwrite_test.go
@@ -25,25 +25,6 @@ import (
 	"github.com/argoproj/argo-cd/v3/test"
 )
 
-func processApplicationListField(t *testing.T, v any, fields map[string]any, exclude bool) (any, error) {
-	t.Helper()
-	if appList, ok := v.(*v1alpha1.ApplicationList); ok {
-		var items []map[string]any
-		for i := range appList.Items {
-			converted, err := processAppFields(&appList.Items[i], fields, exclude)
-			if err != nil {
-				return nil, err
-			}
-			items = append(items, converted)
-		}
-		return map[string]any{
-			"items":    items,
-			"metadata": appList.ListMeta,
-		}, nil
-	}
-	return nil, errors.New("not an application list")
-}
-
 func TestProcessApplicationListField_SyncOperation(t *testing.T) {
 	list := v1alpha1.ApplicationList{
 		Items: []v1alpha1.Application{{Operation: &v1alpha1.Operation{Sync: &v1alpha1.SyncOperation{
@@ -51,7 +32,7 @@ func TestProcessApplicationListField_SyncOperation(t *testing.T) {
 		}}}},
 	}
 
-	res, err := processApplicationListField(t, &list, map[string]any{"items.operation.sync": true}, false)
+	res, err := processApplicationListField(&list, map[string]any{"items.operation.sync": true}, false)
 	require.NoError(t, err)
 	resMap, ok := res.(map[string]any)
 	require.True(t, ok)
@@ -72,7 +53,7 @@ func TestProcessApplicationListField_SyncOperationMissing(t *testing.T) {
 		Items: []v1alpha1.Application{{Operation: nil}},
 	}
 
-	res, err := processApplicationListField(t, &list, map[string]any{"items.operation.sync": true}, false)
+	res, err := processApplicationListField(&list, map[string]any{"items.operation.sync": true}, false)
 	require.NoError(t, err)
 	resMap, ok := res.(map[string]any)
 	require.True(t, ok)
@@ -243,7 +224,7 @@ func TestStreamApplicationListJSON_MatchesProcessApplicationListField(t *testing
 	}
 
 	// Get result from the batch processApplicationListField
-	batchResult, err := processApplicationListField(t, list, fields, false)
+	batchResult, err := processApplicationListField(list, fields, false)
 	require.NoError(t, err)
 	batchJSON, err := json.Marshal(batchResult)
 	require.NoError(t, err)
@@ -375,7 +356,7 @@ func TestStreamApplicationListJSON_MatchesFieldFilter_AllFields(t *testing.T) {
 	}
 
 	// Batch (old path)
-	batchResult, err := processApplicationListField(t, list, fields, false)
+	batchResult, err := processApplicationListField(list, fields, false)
 	require.NoError(t, err)
 	batchJSON, err := json.Marshal(batchResult)
 	require.NoError(t, err)
@@ -410,7 +391,7 @@ func TestStreamApplicationListJSON_MatchesFieldFilter_Exclude(t *testing.T) {
 	// Exclude spec
 	fields := map[string]any{"items.spec": true}
 
-	batchResult, err := processApplicationListField(t, list, fields, true)
+	batchResult, err := processApplicationListField(list, fields, true)
 	require.NoError(t, err)
 	batchJSON, err := json.Marshal(batchResult)
 	require.NoError(t, err)
@@ -458,9 +439,7 @@ func TestForwarder_HeadersMatchForwardResponseMessage(t *testing.T) {
 	}
 
 	// --- Old path: UnaryForwarderWithFieldProcessor via ForwardResponseMessage ---
-	oldForwarder := argohttp.UnaryForwarderWithFieldProcessor(func(val any, fields map[string]any, exclude bool) (any, error) {
-		return processApplicationListField(t, val, fields, exclude)
-	})
+	oldForwarder := argohttp.UnaryForwarderWithFieldProcessor(processApplicationListField)
 	oldRec := httptest.NewRecorder()
 	oldReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/v1/applications?fields=items.metadata.name", http.NoBody)
 	oldForwarder(ctx, mux, nil, oldRec, oldReq, list, testOpt)

--- a/pkg/apiclient/application/forwarder_overwrite_test.go
+++ b/pkg/apiclient/application/forwarder_overwrite_test.go
@@ -1,10 +1,24 @@
 package application
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	gohttp "net/http"
+	"net/http/httptest"
 	"testing"
 
+	//nolint:staticcheck
+	"github.com/golang/protobuf/proto"
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	argohttp "github.com/argoproj/pkg/v2/grpc/http"
 
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v3/test"
@@ -50,4 +64,369 @@ func TestProcessApplicationListField_SyncOperationMissing(t *testing.T) {
 	_, ok, err = unstructured.NestedString(item, "operation")
 	require.NoError(t, err)
 	require.False(t, ok)
+}
+
+func TestStreamApplicationListJSON_WithFieldFilter(t *testing.T) {
+	list := &v1alpha1.ApplicationList{
+		ListMeta: metav1.ListMeta{ResourceVersion: "100"},
+		Items: []v1alpha1.Application{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "app1", Namespace: "default"},
+				Status:     v1alpha1.ApplicationStatus{Health: v1alpha1.AppHealthStatus{Status: "Healthy"}},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "app2", Namespace: "default"},
+				Status:     v1alpha1.ApplicationStatus{Health: v1alpha1.AppHealthStatus{Status: "Degraded"}},
+			},
+		},
+	}
+
+	fields := map[string]any{"items.metadata.name": true, "items.status.health": true}
+	var buf bytes.Buffer
+	err := streamApplicationListJSON(&buf, list, fields, false)
+	require.NoError(t, err)
+
+	var result map[string]any
+	err = json.Unmarshal(buf.Bytes(), &result)
+	require.NoError(t, err)
+
+	items, ok := result["items"].([]any)
+	require.True(t, ok)
+	assert.Len(t, items, 2)
+
+	item0 := items[0].(map[string]any)
+	metadata0 := item0["metadata"].(map[string]any)
+	assert.Equal(t, "app1", metadata0["name"])
+
+	item1 := items[1].(map[string]any)
+	metadata1 := item1["metadata"].(map[string]any)
+	assert.Equal(t, "app2", metadata1["name"])
+
+	meta := result["metadata"].(map[string]any)
+	assert.Equal(t, "100", meta["resourceVersion"])
+}
+
+func TestStreamApplicationListJSON_NoFieldFilter(t *testing.T) {
+	list := &v1alpha1.ApplicationList{
+		ListMeta: metav1.ListMeta{ResourceVersion: "42"},
+		Items: []v1alpha1.Application{
+			{ObjectMeta: metav1.ObjectMeta{Name: "myapp", Namespace: "ns"}},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := streamApplicationListJSON(&buf, list, nil, false)
+	require.NoError(t, err)
+
+	var result map[string]any
+	err = json.Unmarshal(buf.Bytes(), &result)
+	require.NoError(t, err)
+
+	items, ok := result["items"].([]any)
+	require.True(t, ok)
+	assert.Len(t, items, 1)
+
+	item0 := items[0].(map[string]any)
+	metadata0 := item0["metadata"].(map[string]any)
+	assert.Equal(t, "myapp", metadata0["name"])
+	assert.Equal(t, "ns", metadata0["namespace"])
+}
+
+func TestStreamApplicationListJSON_EmptyList(t *testing.T) {
+	list := &v1alpha1.ApplicationList{
+		ListMeta: metav1.ListMeta{ResourceVersion: "1"},
+		Items:    []v1alpha1.Application{},
+	}
+
+	var buf bytes.Buffer
+	err := streamApplicationListJSON(&buf, list, nil, false)
+	require.NoError(t, err)
+
+	var result map[string]any
+	err = json.Unmarshal(buf.Bytes(), &result)
+	require.NoError(t, err)
+
+	items, ok := result["items"].([]any)
+	require.True(t, ok)
+	assert.Empty(t, items)
+}
+
+func TestStreamApplicationListJSON_MatchesProcessApplicationListField(t *testing.T) {
+	list := &v1alpha1.ApplicationList{
+		ListMeta: metav1.ListMeta{ResourceVersion: "99"},
+		Items: []v1alpha1.Application{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "app1"},
+				Operation:  &v1alpha1.Operation{Sync: &v1alpha1.SyncOperation{Revision: "abc"}},
+				Status: v1alpha1.ApplicationStatus{
+					Health: v1alpha1.AppHealthStatus{Status: "Healthy"},
+					Sync:   v1alpha1.SyncStatus{Status: "Synced"},
+				},
+			},
+		},
+	}
+	fields := map[string]any{
+		"items.metadata.name":      true,
+		"items.operation.sync":     true,
+		"items.status.health":      true,
+		"items.status.sync.status": true,
+	}
+
+	// Get result from the batch processApplicationListField
+	batchResult, err := processApplicationListField(list, fields, false)
+	require.NoError(t, err)
+	batchJSON, err := json.Marshal(batchResult)
+	require.NoError(t, err)
+
+	// Get result from streaming
+	var buf bytes.Buffer
+	err = streamApplicationListJSON(&buf, list, fields, false)
+	require.NoError(t, err)
+
+	// Both should parse to equivalent structures
+	var batchParsed, streamParsed map[string]any
+	require.NoError(t, json.Unmarshal(batchJSON, &batchParsed))
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &streamParsed))
+	assert.Equal(t, batchParsed, streamParsed)
+}
+
+// TestStreamApplicationListJSON_MatchesJSONMarshal verifies that the unfiltered streaming
+// path produces the same parsed JSON as json.Marshal on the full ApplicationList struct.
+func TestStreamApplicationListJSON_MatchesJSONMarshal(t *testing.T) {
+	list := &v1alpha1.ApplicationList{
+		ListMeta: metav1.ListMeta{ResourceVersion: "200"},
+		Items: []v1alpha1.Application{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "app1",
+					Namespace: "ns1",
+					Labels:    map[string]string{"env": "prod"},
+				},
+				Spec: v1alpha1.ApplicationSpec{
+					Project: "default",
+					Sources: v1alpha1.ApplicationSources{{RepoURL: "https://github.com/example/repo"}},
+				},
+				Status: v1alpha1.ApplicationStatus{
+					Health: v1alpha1.AppHealthStatus{Status: "Healthy"},
+					Sync:   v1alpha1.SyncStatus{Status: "Synced"},
+					Resources: []v1alpha1.ResourceStatus{
+						{Group: "apps", Kind: "Deployment", Name: "nginx"},
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "app2", Namespace: "ns2"},
+				Operation:  &v1alpha1.Operation{Sync: &v1alpha1.SyncOperation{Revision: "def456"}},
+			},
+		},
+	}
+
+	// Old path: json.Marshal the full struct
+	oldJSON, err := json.Marshal(list)
+	require.NoError(t, err)
+
+	// New path: streaming
+	var buf bytes.Buffer
+	err = streamApplicationListJSON(&buf, list, nil, false)
+	require.NoError(t, err)
+
+	var oldParsed, newParsed map[string]any
+	require.NoError(t, json.Unmarshal(oldJSON, &oldParsed))
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &newParsed))
+	assert.Equal(t, oldParsed, newParsed)
+}
+
+// TestStreamApplicationListJSON_MatchesJSONMarshal_WithTypeMeta verifies TypeMeta fields
+// are preserved in the unfiltered streaming path.
+func TestStreamApplicationListJSON_MatchesJSONMarshal_WithTypeMeta(t *testing.T) {
+	list := &v1alpha1.ApplicationList{
+		TypeMeta: metav1.TypeMeta{Kind: "ApplicationList", APIVersion: "argoproj.io/v1alpha1"},
+		ListMeta: metav1.ListMeta{ResourceVersion: "300"},
+		Items: []v1alpha1.Application{
+			{ObjectMeta: metav1.ObjectMeta{Name: "app1"}},
+		},
+	}
+
+	oldJSON, err := json.Marshal(list)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	err = streamApplicationListJSON(&buf, list, nil, false)
+	require.NoError(t, err)
+
+	var oldParsed, newParsed map[string]any
+	require.NoError(t, json.Unmarshal(oldJSON, &oldParsed))
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &newParsed))
+	assert.Equal(t, oldParsed, newParsed)
+}
+
+// TestStreamApplicationListJSON_MatchesFieldFilter_AllFields exercises every entry
+// in the appFields map to ensure streaming and batch produce the same result.
+func TestStreamApplicationListJSON_MatchesFieldFilter_AllFields(t *testing.T) {
+	startedAt := metav1.Now()
+	finishedAt := metav1.Now()
+	list := &v1alpha1.ApplicationList{
+		ListMeta: metav1.ListMeta{ResourceVersion: "500"},
+		Items: []v1alpha1.Application{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "full-app",
+					Namespace:         "argocd",
+					Annotations:       map[string]string{"note": "test"},
+					Labels:            map[string]string{"team": "platform"},
+					CreationTimestamp: metav1.Now(),
+				},
+				Spec: v1alpha1.ApplicationSpec{Project: "default"},
+				Operation: &v1alpha1.Operation{
+					Sync: &v1alpha1.SyncOperation{Revision: "HEAD"},
+				},
+				Status: v1alpha1.ApplicationStatus{
+					Health:  v1alpha1.AppHealthStatus{Status: "Healthy"},
+					Sync:    v1alpha1.SyncStatus{Status: "Synced"},
+					Summary: v1alpha1.ApplicationSummary{Images: []string{"nginx:latest"}},
+					Resources: []v1alpha1.ResourceStatus{
+						{Group: "apps", Kind: "Deployment", Name: "web"},
+					},
+					OperationState: &v1alpha1.OperationState{
+						Phase:      "Succeeded",
+						StartedAt:  startedAt,
+						FinishedAt: &finishedAt,
+						SyncResult: &v1alpha1.SyncOperationResult{Revision: "abc123"},
+					},
+				},
+			},
+		},
+	}
+
+	// Build fields map with every known appField
+	fields := make(map[string]any)
+	for field := range appFields {
+		fields["items."+field] = true
+	}
+
+	// Batch (old path)
+	batchResult, err := processApplicationListField(list, fields, false)
+	require.NoError(t, err)
+	batchJSON, err := json.Marshal(batchResult)
+	require.NoError(t, err)
+
+	// Streaming (new path)
+	var buf bytes.Buffer
+	err = streamApplicationListJSON(&buf, list, fields, false)
+	require.NoError(t, err)
+
+	var batchParsed, streamParsed map[string]any
+	require.NoError(t, json.Unmarshal(batchJSON, &batchParsed))
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &streamParsed))
+	assert.Equal(t, batchParsed, streamParsed)
+}
+
+// TestStreamApplicationListJSON_MatchesFieldFilter_Exclude tests the exclude (negative) field selector.
+func TestStreamApplicationListJSON_MatchesFieldFilter_Exclude(t *testing.T) {
+	list := &v1alpha1.ApplicationList{
+		ListMeta: metav1.ListMeta{ResourceVersion: "600"},
+		Items: []v1alpha1.Application{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "app1", Namespace: "default"},
+				Spec:       v1alpha1.ApplicationSpec{Project: "myproject"},
+				Status: v1alpha1.ApplicationStatus{
+					Health: v1alpha1.AppHealthStatus{Status: "Healthy"},
+					Sync:   v1alpha1.SyncStatus{Status: "Synced"},
+				},
+			},
+		},
+	}
+
+	// Exclude spec
+	fields := map[string]any{"items.spec": true}
+
+	batchResult, err := processApplicationListField(list, fields, true)
+	require.NoError(t, err)
+	batchJSON, err := json.Marshal(batchResult)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	err = streamApplicationListJSON(&buf, list, fields, true)
+	require.NoError(t, err)
+
+	var batchParsed, streamParsed map[string]any
+	require.NoError(t, json.Unmarshal(batchJSON, &batchParsed))
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &streamParsed))
+	assert.Equal(t, batchParsed, streamParsed)
+}
+
+// TestForwarder_HeadersMatchForwardResponseMessage compares the HTTP headers produced by
+// our streaming forwarder against runtime.ForwardResponseMessage (via UnaryForwarderWithFieldProcessor)
+// to verify that gRPC metadata, trailers, Content-Type, and forward-response options are handled identically.
+func TestForwarder_HeadersMatchForwardResponseMessage(t *testing.T) {
+	list := &v1alpha1.ApplicationList{
+		ListMeta: metav1.ListMeta{ResourceVersion: "700"},
+		Items: []v1alpha1.Application{
+			{ObjectMeta: metav1.ObjectMeta{Name: "app1"}},
+		},
+	}
+
+	// Build context with gRPC server metadata
+	grpcMD := runtime.ServerMetadata{
+		HeaderMD: metadata.MD{
+			"x-request-id": []string{"req-123"},
+			"x-ratelimit":  []string{"100", "200"},
+		},
+		TrailerMD: metadata.MD{
+			"x-stream-id": []string{"stream-abc"},
+		},
+	}
+	ctx := runtime.NewServerMetadataContext(context.Background(), grpcMD)
+	mux := runtime.NewServeMux()
+
+	// Track whether forward-response opts are called
+	optCalled := false
+	testOpt := func(_ context.Context, w gohttp.ResponseWriter, _ proto.Message) error {
+		w.Header().Set("X-Test-Opt", "applied")
+		optCalled = true
+		return nil
+	}
+
+	// --- Old path: UnaryForwarderWithFieldProcessor via ForwardResponseMessage ---
+	oldForwarder := argohttp.UnaryForwarderWithFieldProcessor(processApplicationListField)
+	oldRec := httptest.NewRecorder()
+	oldReq := httptest.NewRequest(http.MethodGet, "/api/v1/applications?fields=items.metadata.name", nil)
+	oldForwarder(ctx, mux, nil, oldRec, oldReq, list, testOpt)
+	require.True(t, optCalled, "old path should call forward-response option")
+
+	// --- New path: streaming forwarder ---
+	optCalled = false
+	newRec := httptest.NewRecorder()
+	newReq := httptest.NewRequest(http.MethodGet, "/api/v1/applications?fields=items.metadata.name", nil)
+	forward_ApplicationService_List_0(ctx, mux, nil, newRec, newReq, list, testOpt)
+	require.True(t, optCalled, "new path should call forward-response option")
+
+	// Compare headers
+	assert.Equal(t, oldRec.Header().Get("Content-Type"), newRec.Header().Get("Content-Type"),
+		"Content-Type should match")
+	assert.Equal(t, "application/json", newRec.Header().Get("Content-Type"))
+
+	// gRPC metadata headers (Grpc-Metadata-* prefix)
+	assert.Equal(t, oldRec.Header().Values("Grpc-Metadata-X-Request-Id"), newRec.Header().Values("Grpc-Metadata-X-Request-Id"),
+		"gRPC metadata header x-request-id should match")
+	assert.Equal(t, oldRec.Header().Values("Grpc-Metadata-X-Ratelimit"), newRec.Header().Values("Grpc-Metadata-X-Ratelimit"),
+		"gRPC metadata header x-ratelimit should match")
+
+	// Trailer announcement headers
+	assert.Equal(t, oldRec.Header().Values("Trailer"), newRec.Header().Values("Trailer"),
+		"Trailer announcement headers should match")
+
+	// Trailer values
+	assert.Equal(t, oldRec.Header().Values("Grpc-Trailer-X-Stream-Id"), newRec.Header().Values("Grpc-Trailer-X-Stream-Id"),
+		"trailer values should match")
+
+	// Forward-response option header
+	assert.Equal(t, "applied", oldRec.Header().Get("X-Test-Opt"))
+	assert.Equal(t, "applied", newRec.Header().Get("X-Test-Opt"))
+
+	// Body should be equivalent JSON
+	var oldParsed, newParsed map[string]any
+	require.NoError(t, json.Unmarshal(oldRec.Body.Bytes(), &oldParsed))
+	require.NoError(t, json.Unmarshal(newRec.Body.Bytes(), &newParsed))
+	assert.Equal(t, oldParsed, newParsed)
 }

--- a/pkg/apiclient/application/forwarder_overwrite_test.go
+++ b/pkg/apiclient/application/forwarder_overwrite_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -23,6 +25,25 @@ import (
 	"github.com/argoproj/argo-cd/v3/test"
 )
 
+func processApplicationListField(t *testing.T, v any, fields map[string]any, exclude bool) (any, error) {
+	t.Helper()
+	if appList, ok := v.(*v1alpha1.ApplicationList); ok {
+		var items []map[string]any
+		for i := range appList.Items {
+			converted, err := processAppFields(&appList.Items[i], fields, exclude)
+			if err != nil {
+				return nil, err
+			}
+			items = append(items, converted)
+		}
+		return map[string]any{
+			"items":    items,
+			"metadata": appList.ListMeta,
+		}, nil
+	}
+	return nil, errors.New("not an application list")
+}
+
 func TestProcessApplicationListField_SyncOperation(t *testing.T) {
 	t.Parallel()
 	list := v1alpha1.ApplicationList{
@@ -31,7 +52,7 @@ func TestProcessApplicationListField_SyncOperation(t *testing.T) {
 		}}}},
 	}
 
-	res, err := processApplicationListField(&list, map[string]any{"items.operation.sync": true}, false)
+	res, err := processApplicationListField(t, &list, map[string]any{"items.operation.sync": true}, false)
 	require.NoError(t, err)
 	resMap, ok := res.(map[string]any)
 	require.True(t, ok)
@@ -53,7 +74,7 @@ func TestProcessApplicationListField_SyncOperationMissing(t *testing.T) {
 		Items: []v1alpha1.Application{{Operation: nil}},
 	}
 
-	res, err := processApplicationListField(&list, map[string]any{"items.operation.sync": true}, false)
+	res, err := processApplicationListField(t, &list, map[string]any{"items.operation.sync": true}, false)
 	require.NoError(t, err)
 	resMap, ok := res.(map[string]any)
 	require.True(t, ok)
@@ -152,6 +173,56 @@ func TestStreamApplicationListJSON_EmptyList(t *testing.T) {
 	assert.Empty(t, items)
 }
 
+func TestStreamApplicationListJSON_NilItems(t *testing.T) {
+	list := &v1alpha1.ApplicationList{
+		ListMeta: metav1.ListMeta{ResourceVersion: "1"},
+		Items:    nil,
+	}
+
+	var buf bytes.Buffer
+	err := streamApplicationListJSON(&buf, list, nil, false)
+	require.NoError(t, err)
+
+	var result map[string]any
+	err = json.Unmarshal(buf.Bytes(), &result)
+	require.NoError(t, err)
+
+	// nil items should produce "items":null, not "items":[]
+	assert.Nil(t, result["items"])
+}
+
+// TestStreamApplicationListJSON_NilVsEmptyMatchesJSONMarshal verifies that
+// the streaming output for nil and empty items matches json.Marshal behavior.
+func TestStreamApplicationListJSON_NilVsEmptyMatchesJSONMarshal(t *testing.T) {
+	tests := []struct {
+		name  string
+		items []v1alpha1.Application
+	}{
+		{"nil items", nil},
+		{"empty items", []v1alpha1.Application{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			list := &v1alpha1.ApplicationList{
+				ListMeta: metav1.ListMeta{ResourceVersion: "1"},
+				Items:    tt.items,
+			}
+
+			oldJSON, err := json.Marshal(list)
+			require.NoError(t, err)
+
+			var buf bytes.Buffer
+			err = streamApplicationListJSON(&buf, list, nil, false)
+			require.NoError(t, err)
+
+			var oldParsed, newParsed map[string]any
+			require.NoError(t, json.Unmarshal(oldJSON, &oldParsed))
+			require.NoError(t, json.Unmarshal(buf.Bytes(), &newParsed))
+			assert.Equal(t, oldParsed, newParsed)
+		})
+	}
+}
+
 func TestStreamApplicationListJSON_MatchesProcessApplicationListField(t *testing.T) {
 	list := &v1alpha1.ApplicationList{
 		ListMeta: metav1.ListMeta{ResourceVersion: "99"},
@@ -174,7 +245,7 @@ func TestStreamApplicationListJSON_MatchesProcessApplicationListField(t *testing
 	}
 
 	// Get result from the batch processApplicationListField
-	batchResult, err := processApplicationListField(list, fields, false)
+	batchResult, err := processApplicationListField(t, list, fields, false)
 	require.NoError(t, err)
 	batchJSON, err := json.Marshal(batchResult)
 	require.NoError(t, err)
@@ -306,7 +377,7 @@ func TestStreamApplicationListJSON_MatchesFieldFilter_AllFields(t *testing.T) {
 	}
 
 	// Batch (old path)
-	batchResult, err := processApplicationListField(list, fields, false)
+	batchResult, err := processApplicationListField(t, list, fields, false)
 	require.NoError(t, err)
 	batchJSON, err := json.Marshal(batchResult)
 	require.NoError(t, err)
@@ -341,7 +412,7 @@ func TestStreamApplicationListJSON_MatchesFieldFilter_Exclude(t *testing.T) {
 	// Exclude spec
 	fields := map[string]any{"items.spec": true}
 
-	batchResult, err := processApplicationListField(list, fields, true)
+	batchResult, err := processApplicationListField(t, list, fields, true)
 	require.NoError(t, err)
 	batchJSON, err := json.Marshal(batchResult)
 	require.NoError(t, err)
@@ -389,7 +460,9 @@ func TestForwarder_HeadersMatchForwardResponseMessage(t *testing.T) {
 	}
 
 	// --- Old path: UnaryForwarderWithFieldProcessor via ForwardResponseMessage ---
-	oldForwarder := argohttp.UnaryForwarderWithFieldProcessor(processApplicationListField)
+	oldForwarder := argohttp.UnaryForwarderWithFieldProcessor(func(val any, fields map[string]any, exclude bool) (any, error) {
+		return processApplicationListField(t, val, fields, exclude)
+	})
 	oldRec := httptest.NewRecorder()
 	oldReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/v1/applications?fields=items.metadata.name", http.NoBody)
 	oldForwarder(ctx, mux, nil, oldRec, oldReq, list, testOpt)
@@ -430,4 +503,61 @@ func TestForwarder_HeadersMatchForwardResponseMessage(t *testing.T) {
 	require.NoError(t, json.Unmarshal(oldRec.Body.Bytes(), &oldParsed))
 	require.NoError(t, json.Unmarshal(newRec.Body.Bytes(), &newParsed))
 	assert.Equal(t, oldParsed, newParsed)
+}
+
+// failAfterNWriter wraps a writer and returns an error after n bytes have been written.
+type failAfterNWriter struct {
+	w       io.Writer
+	limit   int
+	written int
+}
+
+func (f *failAfterNWriter) Write(p []byte) (int, error) {
+	if f.written+len(p) > f.limit {
+		return 0, errors.New("simulated write failure")
+	}
+	n, err := f.w.Write(p)
+	f.written += n
+	return n, err
+}
+
+func TestForwarder_StreamErrorPanicsWithErrAbortHandler(t *testing.T) {
+	list := &v1alpha1.ApplicationList{
+		ListMeta: metav1.ListMeta{ResourceVersion: "1"},
+		Items: []v1alpha1.Application{
+			{ObjectMeta: metav1.ObjectMeta{Name: "app1"}},
+		},
+	}
+
+	ctx := runtime.NewServerMetadataContext(context.Background(), runtime.ServerMetadata{})
+	mux := runtime.NewServeMux()
+
+	// Use an httptest.Server so the panic(http.ErrAbortHandler) is handled
+	// the same way a real net/http server handles it: the connection is aborted.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Wrap the ResponseWriter so writes fail mid-stream after headers are sent.
+		failing := &failAfterNWriter{w: w, limit: 1}
+		fw := &failingResponseWriter{ResponseWriter: w, Writer: failing}
+		forward_ApplicationService_List_0(ctx, mux, nil, fw, r, list)
+	}))
+	defer ts.Close()
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, ts.URL+"/api/v1/applications", http.NoBody)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	if err == nil {
+		resp.Body.Close()
+	}
+	require.ErrorIs(t, err, io.EOF)
+}
+
+// failingResponseWriter delegates Header/WriteHeader to the real ResponseWriter
+// but routes Write through a separate writer that can simulate failures.the
+type failingResponseWriter struct {
+	http.ResponseWriter
+	Writer io.Writer
+}
+
+func (f *failingResponseWriter) Write(p []byte) (int, error) {
+	return f.Writer.Write(p)
 }

--- a/pkg/apiclient/application/forwarder_overwrite_test.go
+++ b/pkg/apiclient/application/forwarder_overwrite_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	gohttp "net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -383,7 +382,7 @@ func TestForwarder_HeadersMatchForwardResponseMessage(t *testing.T) {
 
 	// Track whether forward-response opts are called
 	optCalled := false
-	testOpt := func(_ context.Context, w gohttp.ResponseWriter, _ proto.Message) error {
+	testOpt := func(_ context.Context, w http.ResponseWriter, _ proto.Message) error {
 		w.Header().Set("X-Test-Opt", "applied")
 		optCalled = true
 		return nil
@@ -392,14 +391,14 @@ func TestForwarder_HeadersMatchForwardResponseMessage(t *testing.T) {
 	// --- Old path: UnaryForwarderWithFieldProcessor via ForwardResponseMessage ---
 	oldForwarder := argohttp.UnaryForwarderWithFieldProcessor(processApplicationListField)
 	oldRec := httptest.NewRecorder()
-	oldReq := httptest.NewRequest(http.MethodGet, "/api/v1/applications?fields=items.metadata.name", nil)
+	oldReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/v1/applications?fields=items.metadata.name", http.NoBody)
 	oldForwarder(ctx, mux, nil, oldRec, oldReq, list, testOpt)
 	require.True(t, optCalled, "old path should call forward-response option")
 
 	// --- New path: streaming forwarder ---
 	optCalled = false
 	newRec := httptest.NewRecorder()
-	newReq := httptest.NewRequest(http.MethodGet, "/api/v1/applications?fields=items.metadata.name", nil)
+	newReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/v1/applications?fields=items.metadata.name", http.NoBody)
 	forward_ApplicationService_List_0(ctx, mux, nil, newRec, newReq, list, testOpt)
 	require.True(t, optCalled, "new path should call forward-response option")
 

--- a/pkg/apiclient/application/forwarder_overwrite_test.go
+++ b/pkg/apiclient/application/forwarder_overwrite_test.go
@@ -552,7 +552,7 @@ func TestForwarder_StreamErrorPanicsWithErrAbortHandler(t *testing.T) {
 }
 
 // failingResponseWriter delegates Header/WriteHeader to the real ResponseWriter
-// but routes Write through a separate writer that can simulate failures.the
+// but routes Write through a separate writer that can simulate failures. The
 type failingResponseWriter struct {
 	http.ResponseWriter
 	Writer io.Writer

--- a/pkg/apiclient/application/forwarder_overwrite_test.go
+++ b/pkg/apiclient/application/forwarder_overwrite_test.go
@@ -374,6 +374,69 @@ func TestStreamApplicationListJSON_MatchesFieldFilter_AllFields(t *testing.T) {
 	assert.Equal(t, batchParsed, streamParsed)
 }
 
+// TestSelectAppFields_OverlappingFields ensures that selecting both a field and
+// its descendants (e.g. "spec" and "spec.destination", as appFields contains on
+// master) keeps only the ancestor, so processAppFields neither fails with
+// "field ... is not a map" nor depends on map iteration order.
+func TestSelectAppFields_OverlappingFields(t *testing.T) {
+	// Inject descendant entries unless already present (master defines them).
+	overlapping := map[string]func(app *v1alpha1.Application) any{
+		"spec.destination": func(app *v1alpha1.Application) any { return app.Spec.Destination },
+		"spec.project":     func(app *v1alpha1.Application) any { return app.Spec.Project },
+	}
+	var injected []string
+	for field, fn := range overlapping {
+		if _, exists := appFields[field]; !exists {
+			appFields[field] = fn
+			injected = append(injected, field)
+		}
+	}
+	t.Cleanup(func() {
+		for _, field := range injected {
+			delete(appFields, field)
+		}
+	})
+
+	fields := make(map[string]any)
+	for field := range appFields {
+		fields["items."+field] = true
+	}
+
+	app := &v1alpha1.Application{
+		Spec: v1alpha1.ApplicationSpec{
+			Project:     "default",
+			Destination: v1alpha1.ApplicationDestination{Namespace: "prod"},
+		},
+	}
+
+	// Map iteration order is randomized per range loop, so repeat to cover
+	// both "spec"-first and descendant-first orderings.
+	var firstJSON []byte
+	for range 50 {
+		specs := selectAppFields(fields, false)
+		for _, spec := range specs {
+			assert.NotEqual(t, "spec.destination", spec.field)
+			assert.NotEqual(t, "spec.project", spec.field)
+		}
+		converted, err := processAppFields(app, specs)
+		require.NoError(t, err)
+		convertedJSON, err := json.Marshal(converted)
+		require.NoError(t, err)
+		if firstJSON == nil {
+			firstJSON = convertedJSON
+		} else {
+			assert.JSONEq(t, string(firstJSON), string(convertedJSON))
+		}
+	}
+
+	// The full spec must be present, covering the dropped descendants.
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(firstJSON, &parsed))
+	spec, ok := parsed["spec"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "default", spec["project"])
+}
+
 // TestStreamApplicationListJSON_MatchesFieldFilter_Exclude tests the exclude (negative) field selector.
 func TestStreamApplicationListJSON_MatchesFieldFilter_Exclude(t *testing.T) {
 	list := &v1alpha1.ApplicationList{

--- a/pkg/apiclient/application/forwarder_overwrite_test.go
+++ b/pkg/apiclient/application/forwarder_overwrite_test.go
@@ -531,7 +531,7 @@ func TestForwarder_StreamErrorPanicsWithErrAbortHandler(t *testing.T) {
 }
 
 // failingResponseWriter delegates Header/WriteHeader to the real ResponseWriter
-// but routes Write through a separate writer that can simulate failures. The
+// but routes Write through a separate writer that can simulate failures.
 type failingResponseWriter struct {
 	http.ResponseWriter
 	Writer io.Writer

--- a/pkg/apiclient/application/forwarder_overwrite_test.go
+++ b/pkg/apiclient/application/forwarder_overwrite_test.go
@@ -25,25 +25,6 @@ import (
 	"github.com/argoproj/argo-cd/v3/test"
 )
 
-func processApplicationListField(t *testing.T, v any, fields map[string]any, exclude bool) (any, error) {
-	t.Helper()
-	if appList, ok := v.(*v1alpha1.ApplicationList); ok {
-		var items []map[string]any
-		for i := range appList.Items {
-			converted, err := processAppFields(&appList.Items[i], fields, exclude)
-			if err != nil {
-				return nil, err
-			}
-			items = append(items, converted)
-		}
-		return map[string]any{
-			"items":    items,
-			"metadata": appList.ListMeta,
-		}, nil
-	}
-	return nil, errors.New("not an application list")
-}
-
 func TestProcessApplicationListField_SyncOperation(t *testing.T) {
 	t.Parallel()
 	list := v1alpha1.ApplicationList{
@@ -52,7 +33,7 @@ func TestProcessApplicationListField_SyncOperation(t *testing.T) {
 		}}}},
 	}
 
-	res, err := processApplicationListField(t, &list, map[string]any{"items.operation.sync": true}, false)
+	res, err := processApplicationListField(&list, map[string]any{"items.operation.sync": true}, false)
 	require.NoError(t, err)
 	resMap, ok := res.(map[string]any)
 	require.True(t, ok)
@@ -74,7 +55,7 @@ func TestProcessApplicationListField_SyncOperationMissing(t *testing.T) {
 		Items: []v1alpha1.Application{{Operation: nil}},
 	}
 
-	res, err := processApplicationListField(t, &list, map[string]any{"items.operation.sync": true}, false)
+	res, err := processApplicationListField(&list, map[string]any{"items.operation.sync": true}, false)
 	require.NoError(t, err)
 	resMap, ok := res.(map[string]any)
 	require.True(t, ok)
@@ -245,7 +226,7 @@ func TestStreamApplicationListJSON_MatchesProcessApplicationListField(t *testing
 	}
 
 	// Get result from the batch processApplicationListField
-	batchResult, err := processApplicationListField(t, list, fields, false)
+	batchResult, err := processApplicationListField(list, fields, false)
 	require.NoError(t, err)
 	batchJSON, err := json.Marshal(batchResult)
 	require.NoError(t, err)
@@ -377,7 +358,7 @@ func TestStreamApplicationListJSON_MatchesFieldFilter_AllFields(t *testing.T) {
 	}
 
 	// Batch (old path)
-	batchResult, err := processApplicationListField(t, list, fields, false)
+	batchResult, err := processApplicationListField(list, fields, false)
 	require.NoError(t, err)
 	batchJSON, err := json.Marshal(batchResult)
 	require.NoError(t, err)
@@ -412,7 +393,7 @@ func TestStreamApplicationListJSON_MatchesFieldFilter_Exclude(t *testing.T) {
 	// Exclude spec
 	fields := map[string]any{"items.spec": true}
 
-	batchResult, err := processApplicationListField(t, list, fields, true)
+	batchResult, err := processApplicationListField(list, fields, true)
 	require.NoError(t, err)
 	batchJSON, err := json.Marshal(batchResult)
 	require.NoError(t, err)
@@ -460,9 +441,7 @@ func TestForwarder_HeadersMatchForwardResponseMessage(t *testing.T) {
 	}
 
 	// --- Old path: UnaryForwarderWithFieldProcessor via ForwardResponseMessage ---
-	oldForwarder := argohttp.UnaryForwarderWithFieldProcessor(func(val any, fields map[string]any, exclude bool) (any, error) {
-		return processApplicationListField(t, val, fields, exclude)
-	})
+	oldForwarder := argohttp.UnaryForwarderWithFieldProcessor(processApplicationListField)
 	oldRec := httptest.NewRecorder()
 	oldReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/v1/applications?fields=items.metadata.name", http.NoBody)
 	oldForwarder(ctx, mux, nil, oldRec, oldReq, list, testOpt)

--- a/pkg/apiclient/application/forwarder_overwrite_test.go
+++ b/pkg/apiclient/application/forwarder_overwrite_test.go
@@ -1,10 +1,24 @@
 package application
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	gohttp "net/http"
+	"net/http/httptest"
 	"testing"
 
+	//nolint:staticcheck
+	"github.com/golang/protobuf/proto"
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	argohttp "github.com/argoproj/pkg/v2/grpc/http"
 
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v3/test"
@@ -52,4 +66,369 @@ func TestProcessApplicationListField_SyncOperationMissing(t *testing.T) {
 	_, ok, err = unstructured.NestedString(item, "operation")
 	require.NoError(t, err)
 	require.False(t, ok)
+}
+
+func TestStreamApplicationListJSON_WithFieldFilter(t *testing.T) {
+	list := &v1alpha1.ApplicationList{
+		ListMeta: metav1.ListMeta{ResourceVersion: "100"},
+		Items: []v1alpha1.Application{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "app1", Namespace: "default"},
+				Status:     v1alpha1.ApplicationStatus{Health: v1alpha1.AppHealthStatus{Status: "Healthy"}},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "app2", Namespace: "default"},
+				Status:     v1alpha1.ApplicationStatus{Health: v1alpha1.AppHealthStatus{Status: "Degraded"}},
+			},
+		},
+	}
+
+	fields := map[string]any{"items.metadata.name": true, "items.status.health": true}
+	var buf bytes.Buffer
+	err := streamApplicationListJSON(&buf, list, fields, false)
+	require.NoError(t, err)
+
+	var result map[string]any
+	err = json.Unmarshal(buf.Bytes(), &result)
+	require.NoError(t, err)
+
+	items, ok := result["items"].([]any)
+	require.True(t, ok)
+	assert.Len(t, items, 2)
+
+	item0 := items[0].(map[string]any)
+	metadata0 := item0["metadata"].(map[string]any)
+	assert.Equal(t, "app1", metadata0["name"])
+
+	item1 := items[1].(map[string]any)
+	metadata1 := item1["metadata"].(map[string]any)
+	assert.Equal(t, "app2", metadata1["name"])
+
+	meta := result["metadata"].(map[string]any)
+	assert.Equal(t, "100", meta["resourceVersion"])
+}
+
+func TestStreamApplicationListJSON_NoFieldFilter(t *testing.T) {
+	list := &v1alpha1.ApplicationList{
+		ListMeta: metav1.ListMeta{ResourceVersion: "42"},
+		Items: []v1alpha1.Application{
+			{ObjectMeta: metav1.ObjectMeta{Name: "myapp", Namespace: "ns"}},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := streamApplicationListJSON(&buf, list, nil, false)
+	require.NoError(t, err)
+
+	var result map[string]any
+	err = json.Unmarshal(buf.Bytes(), &result)
+	require.NoError(t, err)
+
+	items, ok := result["items"].([]any)
+	require.True(t, ok)
+	assert.Len(t, items, 1)
+
+	item0 := items[0].(map[string]any)
+	metadata0 := item0["metadata"].(map[string]any)
+	assert.Equal(t, "myapp", metadata0["name"])
+	assert.Equal(t, "ns", metadata0["namespace"])
+}
+
+func TestStreamApplicationListJSON_EmptyList(t *testing.T) {
+	list := &v1alpha1.ApplicationList{
+		ListMeta: metav1.ListMeta{ResourceVersion: "1"},
+		Items:    []v1alpha1.Application{},
+	}
+
+	var buf bytes.Buffer
+	err := streamApplicationListJSON(&buf, list, nil, false)
+	require.NoError(t, err)
+
+	var result map[string]any
+	err = json.Unmarshal(buf.Bytes(), &result)
+	require.NoError(t, err)
+
+	items, ok := result["items"].([]any)
+	require.True(t, ok)
+	assert.Empty(t, items)
+}
+
+func TestStreamApplicationListJSON_MatchesProcessApplicationListField(t *testing.T) {
+	list := &v1alpha1.ApplicationList{
+		ListMeta: metav1.ListMeta{ResourceVersion: "99"},
+		Items: []v1alpha1.Application{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "app1"},
+				Operation:  &v1alpha1.Operation{Sync: &v1alpha1.SyncOperation{Revision: "abc"}},
+				Status: v1alpha1.ApplicationStatus{
+					Health: v1alpha1.AppHealthStatus{Status: "Healthy"},
+					Sync:   v1alpha1.SyncStatus{Status: "Synced"},
+				},
+			},
+		},
+	}
+	fields := map[string]any{
+		"items.metadata.name":      true,
+		"items.operation.sync":     true,
+		"items.status.health":      true,
+		"items.status.sync.status": true,
+	}
+
+	// Get result from the batch processApplicationListField
+	batchResult, err := processApplicationListField(list, fields, false)
+	require.NoError(t, err)
+	batchJSON, err := json.Marshal(batchResult)
+	require.NoError(t, err)
+
+	// Get result from streaming
+	var buf bytes.Buffer
+	err = streamApplicationListJSON(&buf, list, fields, false)
+	require.NoError(t, err)
+
+	// Both should parse to equivalent structures
+	var batchParsed, streamParsed map[string]any
+	require.NoError(t, json.Unmarshal(batchJSON, &batchParsed))
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &streamParsed))
+	assert.Equal(t, batchParsed, streamParsed)
+}
+
+// TestStreamApplicationListJSON_MatchesJSONMarshal verifies that the unfiltered streaming
+// path produces the same parsed JSON as json.Marshal on the full ApplicationList struct.
+func TestStreamApplicationListJSON_MatchesJSONMarshal(t *testing.T) {
+	list := &v1alpha1.ApplicationList{
+		ListMeta: metav1.ListMeta{ResourceVersion: "200"},
+		Items: []v1alpha1.Application{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "app1",
+					Namespace: "ns1",
+					Labels:    map[string]string{"env": "prod"},
+				},
+				Spec: v1alpha1.ApplicationSpec{
+					Project: "default",
+					Sources: v1alpha1.ApplicationSources{{RepoURL: "https://github.com/example/repo"}},
+				},
+				Status: v1alpha1.ApplicationStatus{
+					Health: v1alpha1.AppHealthStatus{Status: "Healthy"},
+					Sync:   v1alpha1.SyncStatus{Status: "Synced"},
+					Resources: []v1alpha1.ResourceStatus{
+						{Group: "apps", Kind: "Deployment", Name: "nginx"},
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "app2", Namespace: "ns2"},
+				Operation:  &v1alpha1.Operation{Sync: &v1alpha1.SyncOperation{Revision: "def456"}},
+			},
+		},
+	}
+
+	// Old path: json.Marshal the full struct
+	oldJSON, err := json.Marshal(list)
+	require.NoError(t, err)
+
+	// New path: streaming
+	var buf bytes.Buffer
+	err = streamApplicationListJSON(&buf, list, nil, false)
+	require.NoError(t, err)
+
+	var oldParsed, newParsed map[string]any
+	require.NoError(t, json.Unmarshal(oldJSON, &oldParsed))
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &newParsed))
+	assert.Equal(t, oldParsed, newParsed)
+}
+
+// TestStreamApplicationListJSON_MatchesJSONMarshal_WithTypeMeta verifies TypeMeta fields
+// are preserved in the unfiltered streaming path.
+func TestStreamApplicationListJSON_MatchesJSONMarshal_WithTypeMeta(t *testing.T) {
+	list := &v1alpha1.ApplicationList{
+		TypeMeta: metav1.TypeMeta{Kind: "ApplicationList", APIVersion: "argoproj.io/v1alpha1"},
+		ListMeta: metav1.ListMeta{ResourceVersion: "300"},
+		Items: []v1alpha1.Application{
+			{ObjectMeta: metav1.ObjectMeta{Name: "app1"}},
+		},
+	}
+
+	oldJSON, err := json.Marshal(list)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	err = streamApplicationListJSON(&buf, list, nil, false)
+	require.NoError(t, err)
+
+	var oldParsed, newParsed map[string]any
+	require.NoError(t, json.Unmarshal(oldJSON, &oldParsed))
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &newParsed))
+	assert.Equal(t, oldParsed, newParsed)
+}
+
+// TestStreamApplicationListJSON_MatchesFieldFilter_AllFields exercises every entry
+// in the appFields map to ensure streaming and batch produce the same result.
+func TestStreamApplicationListJSON_MatchesFieldFilter_AllFields(t *testing.T) {
+	startedAt := metav1.Now()
+	finishedAt := metav1.Now()
+	list := &v1alpha1.ApplicationList{
+		ListMeta: metav1.ListMeta{ResourceVersion: "500"},
+		Items: []v1alpha1.Application{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "full-app",
+					Namespace:         "argocd",
+					Annotations:       map[string]string{"note": "test"},
+					Labels:            map[string]string{"team": "platform"},
+					CreationTimestamp: metav1.Now(),
+				},
+				Spec: v1alpha1.ApplicationSpec{Project: "default"},
+				Operation: &v1alpha1.Operation{
+					Sync: &v1alpha1.SyncOperation{Revision: "HEAD"},
+				},
+				Status: v1alpha1.ApplicationStatus{
+					Health:  v1alpha1.AppHealthStatus{Status: "Healthy"},
+					Sync:    v1alpha1.SyncStatus{Status: "Synced"},
+					Summary: v1alpha1.ApplicationSummary{Images: []string{"nginx:latest"}},
+					Resources: []v1alpha1.ResourceStatus{
+						{Group: "apps", Kind: "Deployment", Name: "web"},
+					},
+					OperationState: &v1alpha1.OperationState{
+						Phase:      "Succeeded",
+						StartedAt:  startedAt,
+						FinishedAt: &finishedAt,
+						SyncResult: &v1alpha1.SyncOperationResult{Revision: "abc123"},
+					},
+				},
+			},
+		},
+	}
+
+	// Build fields map with every known appField
+	fields := make(map[string]any)
+	for field := range appFields {
+		fields["items."+field] = true
+	}
+
+	// Batch (old path)
+	batchResult, err := processApplicationListField(list, fields, false)
+	require.NoError(t, err)
+	batchJSON, err := json.Marshal(batchResult)
+	require.NoError(t, err)
+
+	// Streaming (new path)
+	var buf bytes.Buffer
+	err = streamApplicationListJSON(&buf, list, fields, false)
+	require.NoError(t, err)
+
+	var batchParsed, streamParsed map[string]any
+	require.NoError(t, json.Unmarshal(batchJSON, &batchParsed))
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &streamParsed))
+	assert.Equal(t, batchParsed, streamParsed)
+}
+
+// TestStreamApplicationListJSON_MatchesFieldFilter_Exclude tests the exclude (negative) field selector.
+func TestStreamApplicationListJSON_MatchesFieldFilter_Exclude(t *testing.T) {
+	list := &v1alpha1.ApplicationList{
+		ListMeta: metav1.ListMeta{ResourceVersion: "600"},
+		Items: []v1alpha1.Application{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "app1", Namespace: "default"},
+				Spec:       v1alpha1.ApplicationSpec{Project: "myproject"},
+				Status: v1alpha1.ApplicationStatus{
+					Health: v1alpha1.AppHealthStatus{Status: "Healthy"},
+					Sync:   v1alpha1.SyncStatus{Status: "Synced"},
+				},
+			},
+		},
+	}
+
+	// Exclude spec
+	fields := map[string]any{"items.spec": true}
+
+	batchResult, err := processApplicationListField(list, fields, true)
+	require.NoError(t, err)
+	batchJSON, err := json.Marshal(batchResult)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	err = streamApplicationListJSON(&buf, list, fields, true)
+	require.NoError(t, err)
+
+	var batchParsed, streamParsed map[string]any
+	require.NoError(t, json.Unmarshal(batchJSON, &batchParsed))
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &streamParsed))
+	assert.Equal(t, batchParsed, streamParsed)
+}
+
+// TestForwarder_HeadersMatchForwardResponseMessage compares the HTTP headers produced by
+// our streaming forwarder against runtime.ForwardResponseMessage (via UnaryForwarderWithFieldProcessor)
+// to verify that gRPC metadata, trailers, Content-Type, and forward-response options are handled identically.
+func TestForwarder_HeadersMatchForwardResponseMessage(t *testing.T) {
+	list := &v1alpha1.ApplicationList{
+		ListMeta: metav1.ListMeta{ResourceVersion: "700"},
+		Items: []v1alpha1.Application{
+			{ObjectMeta: metav1.ObjectMeta{Name: "app1"}},
+		},
+	}
+
+	// Build context with gRPC server metadata
+	grpcMD := runtime.ServerMetadata{
+		HeaderMD: metadata.MD{
+			"x-request-id": []string{"req-123"},
+			"x-ratelimit":  []string{"100", "200"},
+		},
+		TrailerMD: metadata.MD{
+			"x-stream-id": []string{"stream-abc"},
+		},
+	}
+	ctx := runtime.NewServerMetadataContext(context.Background(), grpcMD)
+	mux := runtime.NewServeMux()
+
+	// Track whether forward-response opts are called
+	optCalled := false
+	testOpt := func(_ context.Context, w gohttp.ResponseWriter, _ proto.Message) error {
+		w.Header().Set("X-Test-Opt", "applied")
+		optCalled = true
+		return nil
+	}
+
+	// --- Old path: UnaryForwarderWithFieldProcessor via ForwardResponseMessage ---
+	oldForwarder := argohttp.UnaryForwarderWithFieldProcessor(processApplicationListField)
+	oldRec := httptest.NewRecorder()
+	oldReq := httptest.NewRequest(http.MethodGet, "/api/v1/applications?fields=items.metadata.name", nil)
+	oldForwarder(ctx, mux, nil, oldRec, oldReq, list, testOpt)
+	require.True(t, optCalled, "old path should call forward-response option")
+
+	// --- New path: streaming forwarder ---
+	optCalled = false
+	newRec := httptest.NewRecorder()
+	newReq := httptest.NewRequest(http.MethodGet, "/api/v1/applications?fields=items.metadata.name", nil)
+	forward_ApplicationService_List_0(ctx, mux, nil, newRec, newReq, list, testOpt)
+	require.True(t, optCalled, "new path should call forward-response option")
+
+	// Compare headers
+	assert.Equal(t, oldRec.Header().Get("Content-Type"), newRec.Header().Get("Content-Type"),
+		"Content-Type should match")
+	assert.Equal(t, "application/json", newRec.Header().Get("Content-Type"))
+
+	// gRPC metadata headers (Grpc-Metadata-* prefix)
+	assert.Equal(t, oldRec.Header().Values("Grpc-Metadata-X-Request-Id"), newRec.Header().Values("Grpc-Metadata-X-Request-Id"),
+		"gRPC metadata header x-request-id should match")
+	assert.Equal(t, oldRec.Header().Values("Grpc-Metadata-X-Ratelimit"), newRec.Header().Values("Grpc-Metadata-X-Ratelimit"),
+		"gRPC metadata header x-ratelimit should match")
+
+	// Trailer announcement headers
+	assert.Equal(t, oldRec.Header().Values("Trailer"), newRec.Header().Values("Trailer"),
+		"Trailer announcement headers should match")
+
+	// Trailer values
+	assert.Equal(t, oldRec.Header().Values("Grpc-Trailer-X-Stream-Id"), newRec.Header().Values("Grpc-Trailer-X-Stream-Id"),
+		"trailer values should match")
+
+	// Forward-response option header
+	assert.Equal(t, "applied", oldRec.Header().Get("X-Test-Opt"))
+	assert.Equal(t, "applied", newRec.Header().Get("X-Test-Opt"))
+
+	// Body should be equivalent JSON
+	var oldParsed, newParsed map[string]any
+	require.NoError(t, json.Unmarshal(oldRec.Body.Bytes(), &oldParsed))
+	require.NoError(t, json.Unmarshal(newRec.Body.Bytes(), &newParsed))
+	assert.Equal(t, oldParsed, newParsed)
 }

--- a/pkg/apiclient/application/forwarder_overwrite_test.go
+++ b/pkg/apiclient/application/forwarder_overwrite_test.go
@@ -590,7 +590,10 @@ func TestForwarder_StreamErrorPanicsWithErrAbortHandler(t *testing.T) {
 	if err == nil {
 		resp.Body.Close()
 	}
-	require.ErrorIs(t, err, io.EOF)
+	// The aborted connection surfaces as io.EOF or a connection reset
+	// depending on the platform and timing; either way the request must
+	// not complete cleanly.
+	require.Error(t, err, "aborted response must not complete cleanly")
 }
 
 // failingResponseWriter delegates Header/WriteHeader to the real ResponseWriter


### PR DESCRIPTION
Each list request builds the entire JSON response body in a `bytes.Buffer` before writing it to the client. For large application counts the buffer grows to tens or hundreds of MB per request, and under concurrent load these buffers stack up before GC can reclaim them. Write the list response directly to `http.ResponseWriter` instead of accumulating it in a `bytes.Buffer`. Since `http.ResponseWriter` implements `io.Writer` and is internally buffered by `net/http`, this eliminates the per-request spike entirely — bytes flow straight to the TCP stack as they are produced.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
