### PR TITLE
fix: log sanitized error details when cluster secret unmarshal fails (#27148)

### DIFF
--- a/util/db/cluster.go
+++ b/util/db/cluster.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"slices"
@@ -28,6 +29,22 @@ import (
 const (
 	errCheckingInClusterEnabled = "%s: error checking if in-cluster is enabled: %v"
 )
+
+// sanitizeUnmarshalError extracts safe diagnostic details from a JSON unmarshal
+// error without including the raw error message, which could contain fragments
+// of the secret data being parsed.
+func sanitizeUnmarshalError(err error) string {
+	var syntaxErr *json.SyntaxError
+	var typeErr *json.UnmarshalTypeError
+	switch {
+	case errors.As(err, &syntaxErr):
+		return fmt.Sprintf("json syntax error at byte offset %d", syntaxErr.Offset)
+	case errors.As(err, &typeErr):
+		return fmt.Sprintf("cannot unmarshal into field %q", typeErr.Field)
+	default:
+		return "invalid cluster secret data"
+	}
+}
 
 var (
 	localCluster = appv1.Cluster{
@@ -81,7 +98,7 @@ func (db *db) ListClusters(_ context.Context) (*appv1.ClusterList, error) {
 	for _, clusterSecret := range clusterSecrets {
 		cluster, err := SecretToCluster(clusterSecret)
 		if err != nil {
-			log.Errorf("could not unmarshal cluster secret %s", clusterSecret.Name)
+			log.Errorf("could not unmarshal cluster secret %s: %s", clusterSecret.Name, sanitizeUnmarshalError(err))
 			continue
 		}
 		if cluster.Server == appv1.KubernetesInternalAPIServerAddr {
@@ -172,7 +189,7 @@ func (db *db) WatchClusters(ctx context.Context,
 		func(secret *corev1.Secret) {
 			cluster, err := SecretToCluster(secret)
 			if err != nil {
-				log.Errorf("could not unmarshal cluster secret %s", secret.Name)
+				log.Errorf("could not unmarshal cluster secret %s: %s", secret.Name, sanitizeUnmarshalError(err))
 				return
 			}
 			if cluster.Server == appv1.KubernetesInternalAPIServerAddr {
@@ -189,12 +206,12 @@ func (db *db) WatchClusters(ctx context.Context,
 		func(oldSecret *corev1.Secret, newSecret *corev1.Secret) {
 			oldCluster, err := SecretToCluster(oldSecret)
 			if err != nil {
-				log.Errorf("could not unmarshal cluster secret %s", oldSecret.Name)
+				log.Errorf("could not unmarshal cluster secret %s: %s", oldSecret.Name, sanitizeUnmarshalError(err))
 				return
 			}
 			newCluster, err := SecretToCluster(newSecret)
 			if err != nil {
-				log.Errorf("could not unmarshal cluster secret %s", newSecret.Name)
+				log.Errorf("could not unmarshal cluster secret %s: %s", newSecret.Name, sanitizeUnmarshalError(err))
 				return
 			}
 			if newCluster.Server == appv1.KubernetesInternalAPIServerAddr {
@@ -345,7 +362,7 @@ func (db *db) UpdateCluster(ctx context.Context, c *appv1.Cluster) (*appv1.Clust
 	}
 	cluster, err := SecretToCluster(clusterSecret)
 	if err != nil {
-		log.Errorf("could not unmarshal cluster secret %s", clusterSecret.Name)
+		log.Errorf("could not unmarshal cluster secret %s: %s", clusterSecret.Name, sanitizeUnmarshalError(err))
 		return nil, err
 	}
 	return cluster, db.settingsMgr.ResyncInformers()

--- a/util/db/cluster_test.go
+++ b/util/db/cluster_test.go
@@ -182,7 +182,7 @@ func TestSanitizeUnmarshalError(t *testing.T) {
 	t.Run("json type error", func(t *testing.T) {
 		err := &json.UnmarshalTypeError{Field: "tlsClientConfig.insecure"}
 		msg := sanitizeUnmarshalError(err)
-		assert.Equal(t, `cannot unmarshal into field "tlsClientConfig.insecure"`, msg)
+		assert.Equal(t, "cannot unmarshal into field \"tlsClientConfig.insecure\"", msg)
 	})
 
 	t.Run("wrapped json syntax error", func(t *testing.T) {

--- a/util/db/cluster_test.go
+++ b/util/db/cluster_test.go
@@ -2,6 +2,8 @@ package db
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -168,6 +170,79 @@ func Test_secretToCluster_InvalidConfig(t *testing.T) {
 	cluster, err := SecretToCluster(secret)
 	require.Error(t, err)
 	assert.Nil(t, cluster)
+}
+
+func TestSanitizeUnmarshalError(t *testing.T) {
+	t.Run("json syntax error", func(t *testing.T) {
+		err := &json.SyntaxError{Offset: 42}
+		msg := sanitizeUnmarshalError(err)
+		assert.Equal(t, "json syntax error at byte offset 42", msg)
+	})
+
+	t.Run("json type error", func(t *testing.T) {
+		err := &json.UnmarshalTypeError{Field: "tlsClientConfig.insecure"}
+		msg := sanitizeUnmarshalError(err)
+		assert.Equal(t, `cannot unmarshal into field "tlsClientConfig.insecure"`, msg)
+	})
+
+	t.Run("wrapped json syntax error", func(t *testing.T) {
+		inner := &json.SyntaxError{Offset: 10}
+		err := fmt.Errorf("failed to unmarshal cluster config: %w", inner)
+		msg := sanitizeUnmarshalError(err)
+		assert.Equal(t, "json syntax error at byte offset 10", msg)
+	})
+
+	t.Run("unknown error type", func(t *testing.T) {
+		err := fmt.Errorf("some other error")
+		msg := sanitizeUnmarshalError(err)
+		assert.Equal(t, "invalid cluster secret data", msg)
+	})
+}
+
+func TestListClusters_SkipsInvalidSecrets(t *testing.T) {
+	validSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "valid-cluster",
+			Namespace: fakeNamespace,
+			Labels: map[string]string{
+				common.LabelKeySecretType: common.LabelValueSecretTypeCluster,
+			},
+		},
+		Data: map[string][]byte{
+			"server": []byte("http://valid-cluster"),
+			"name":   []byte("valid"),
+			"config": []byte("{}"),
+		},
+	}
+	invalidSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "invalid-cluster",
+			Namespace: fakeNamespace,
+			Labels: map[string]string{
+				common.LabelKeySecretType: common.LabelValueSecretTypeCluster,
+			},
+		},
+		Data: map[string][]byte{
+			"server": []byte("http://invalid-cluster"),
+			"name":   []byte("invalid"),
+			"config": []byte("not-valid-json"),
+		},
+	}
+	kubeclientset := fake.NewClientset(validSecret, invalidSecret)
+	settingsManager := settings.NewSettingsManager(t.Context(), kubeclientset, fakeNamespace)
+	db := NewDB(fakeNamespace, settingsManager, kubeclientset)
+
+	clusters, err := db.ListClusters(t.Context())
+	require.NoError(t, err)
+
+	// The invalid secret should be skipped, and the valid one should still be returned
+	// along with the in-cluster default.
+	var servers []string
+	for _, c := range clusters.Items {
+		servers = append(servers, c.Server)
+	}
+	assert.Contains(t, servers, "http://valid-cluster")
+	assert.NotContains(t, servers, "http://invalid-cluster")
 }
 
 func TestUpdateCluster(t *testing.T) {


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

## Summary

When `SecretToCluster` fails, the error was logged without any diagnostic details, making it difficult for operators to debug why a cluster secret could not be parsed.

A prior attempt (#27151) to fix this by logging the raw error was correctly rejected because `json.Unmarshal` errors can contain fragments of the data being parsed, which in this case is sensitive cluster configuration (TLS certs, tokens, credentials).

This PR introduces `sanitizeUnmarshalError`, which uses `errors.As` to extract only safe diagnostic information:

- **`*json.SyntaxError`**: logs the byte offset (e.g., `json syntax error at byte offset 42`)
- **`*json.UnmarshalTypeError`**: logs the field name (e.g., `cannot unmarshal into field "tlsClientConfig.insecure"`)
- **Unknown error types**: logs a generic message (`invalid cluster secret data`)

This gives operators enough context to diagnose the issue (e.g., "the JSON is malformed at byte 42" or "the field type doesn't match") without any risk of leaking secret data into application logs.

All five call sites in `cluster.go` that previously discarded the error have been updated.

## Example log output

Before:
```
level=error msg="could not unmarshal cluster secret my-cluster"
```

After:
```
level=error msg="could not unmarshal cluster secret my-cluster: json syntax error at byte offset 2"
```

## Validation

- New unit tests for `sanitizeUnmarshalError` covering all three error classification paths (syntax error, type error, unknown) plus wrapped errors.
- New integration test for `ListClusters` verifying that invalid secrets are skipped while valid ones are still returned.
- Full `util/db` test suite passes.

Closes #27148