### PR TITLE
fix(hydrator): preserve all source type fields in GetDrySource()

### DIFF
--- a/controller/hydrator/hydrator.go
+++ b/controller/hydrator/hydrator.go
@@ -476,17 +476,9 @@ func (h *Hydrator) hydrate(logCtx *log.Entry, apps []*appv1.Application, project
 //
 // If the given target revision is empty, it uses the target revision from the app dry source spec.
 func (h *Hydrator) getManifests(ctx context.Context, app *appv1.Application, targetRevision string, project *appv1.AppProject) (revision string, pathDetails *commitclient.PathDetails, err error) {
-	drySource := appv1.ApplicationSource{
-		RepoURL:        app.Spec.SourceHydrator.DrySource.RepoURL,
-		Path:           app.Spec.SourceHydrator.DrySource.Path,
-		TargetRevision: app.Spec.SourceHydrator.DrySource.TargetRevision,
-		Helm:           app.Spec.SourceHydrator.DrySource.Helm,
-		Kustomize:      app.Spec.SourceHydrator.DrySource.Kustomize,
-		Directory:      app.Spec.SourceHydrator.DrySource.Directory,
-		Plugin:         app.Spec.SourceHydrator.DrySource.Plugin,
-	}
+	drySource := app.Spec.SourceHydrator.GetDrySource()
 	if targetRevision == "" {
-		targetRevision = app.Spec.SourceHydrator.DrySource.TargetRevision
+		targetRevision = drySource.TargetRevision
 	}
 
 	// TODO: enable signature verification

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -431,6 +431,10 @@ func (s SourceHydrator) GetDrySource() ApplicationSource {
 		RepoURL:        s.DrySource.RepoURL,
 		Path:           s.DrySource.Path,
 		TargetRevision: s.DrySource.TargetRevision,
+		Helm:           s.DrySource.Helm,
+		Kustomize:      s.DrySource.Kustomize,
+		Directory:      s.DrySource.Directory,
+		Plugin:         s.DrySource.Plugin,
 	}
 }
 

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -5202,7 +5202,7 @@ func TestGetDrySource_PreservesAllFields(t *testing.T) {
 			assert.Equal(t, tt.hydrator.DrySource.TargetRevision, source.TargetRevision)
 
 			// Verify source type fields are preserved
-			fieldMap := map[string]interface{}{
+			fieldMap := map[string]any{
 				"Helm":      source.Helm,
 				"Kustomize": source.Kustomize,
 				"Directory": source.Directory,

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -5087,3 +5087,149 @@ func TestSyncPolicyAutomatedSerialisation(t *testing.T) {
 		})
 	}
 }
+
+func TestGetDrySource_PreservesAllFields(t *testing.T) {
+	tests := []struct {
+		name       string
+		hydrator   SourceHydrator
+		wantNil    []string
+		wantNotNil []string
+	}{
+		{
+			name: "preserves Helm configuration",
+			hydrator: SourceHydrator{
+				DrySource: DrySource{
+					RepoURL:        "https://example.com/repo",
+					Path:           "charts",
+					TargetRevision: "main",
+					Helm: &ApplicationSourceHelm{
+						ValueFiles:  []string{"values.yaml"},
+						ReleaseName: "my-release",
+					},
+				},
+			},
+			wantNotNil: []string{"Helm"},
+			wantNil:    []string{"Kustomize", "Directory", "Plugin"},
+		},
+		{
+			name: "preserves Kustomize configuration",
+			hydrator: SourceHydrator{
+				DrySource: DrySource{
+					RepoURL:        "https://example.com/repo",
+					Path:           "overlays/prod",
+					TargetRevision: "main",
+					Kustomize: &ApplicationSourceKustomize{
+						NamePrefix: "prod-",
+						Images:     KustomizeImages{"nginx=nginx:1.21"},
+					},
+				},
+			},
+			wantNotNil: []string{"Kustomize"},
+			wantNil:    []string{"Helm", "Directory", "Plugin"},
+		},
+		{
+			name: "preserves Directory configuration",
+			hydrator: SourceHydrator{
+				DrySource: DrySource{
+					RepoURL:        "https://example.com/repo",
+					Path:           "manifests",
+					TargetRevision: "main",
+					Directory: &ApplicationSourceDirectory{
+						Recurse: true,
+						Jsonnet: ApplicationSourceJsonnet{
+							ExtVars: []JsonnetVar{{Name: "env", Value: "prod"}},
+						},
+					},
+				},
+			},
+			wantNotNil: []string{"Directory"},
+			wantNil:    []string{"Helm", "Kustomize", "Plugin"},
+		},
+		{
+			name: "preserves Plugin configuration",
+			hydrator: SourceHydrator{
+				DrySource: DrySource{
+					RepoURL:        "https://example.com/repo",
+					Path:           ".",
+					TargetRevision: "main",
+					Plugin: &ApplicationSourcePlugin{
+						Name: "my-plugin",
+						Env:  Env{{Name: "FOO", Value: "bar"}},
+					},
+				},
+			},
+			wantNotNil: []string{"Plugin"},
+			wantNil:    []string{"Helm", "Kustomize", "Directory"},
+		},
+		{
+			name: "preserves multiple source types",
+			hydrator: SourceHydrator{
+				DrySource: DrySource{
+					RepoURL:        "https://example.com/repo",
+					Path:           ".",
+					TargetRevision: "main",
+					Helm: &ApplicationSourceHelm{
+						ValueFiles: []string{"values.yaml"},
+					},
+					Kustomize: &ApplicationSourceKustomize{
+						NamePrefix: "test-",
+					},
+				},
+			},
+			wantNotNil: []string{"Helm", "Kustomize"},
+			wantNil:    []string{"Directory", "Plugin"},
+		},
+		{
+			name: "handles nil source types",
+			hydrator: SourceHydrator{
+				DrySource: DrySource{
+					RepoURL:        "https://example.com/repo",
+					Path:           ".",
+					TargetRevision: "main",
+				},
+			},
+			wantNil: []string{"Helm", "Kustomize", "Directory", "Plugin"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source := tt.hydrator.GetDrySource()
+
+			// Verify basic fields are always copied
+			assert.Equal(t, tt.hydrator.DrySource.RepoURL, source.RepoURL)
+			assert.Equal(t, tt.hydrator.DrySource.Path, source.Path)
+			assert.Equal(t, tt.hydrator.DrySource.TargetRevision, source.TargetRevision)
+
+			// Verify source type fields are preserved
+			fieldMap := map[string]interface{}{
+				"Helm":      source.Helm,
+				"Kustomize": source.Kustomize,
+				"Directory": source.Directory,
+				"Plugin":    source.Plugin,
+			}
+
+			for _, field := range tt.wantNotNil {
+				assert.NotNil(t, fieldMap[field], "expected %s to be preserved", field)
+			}
+
+			for _, field := range tt.wantNil {
+				assert.Nil(t, fieldMap[field], "expected %s to be nil", field)
+			}
+
+			// Verify exact equality for non-nil fields
+			if tt.hydrator.DrySource.Helm != nil {
+				assert.Equal(t, tt.hydrator.DrySource.Helm, source.Helm)
+			}
+			if tt.hydrator.DrySource.Kustomize != nil {
+				assert.Equal(t, tt.hydrator.DrySource.Kustomize, source.Kustomize)
+			}
+			if tt.hydrator.DrySource.Directory != nil {
+				assert.Equal(t, tt.hydrator.DrySource.Directory, source.Directory)
+			}
+			if tt.hydrator.DrySource.Plugin != nil {
+				assert.Equal(t, tt.hydrator.DrySource.Plugin, source.Plugin)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The `GetDrySource()` method was only copying `RepoURL`, `Path`, and `TargetRevision` from `DrySource` to `ApplicationSource`, causing **Helm**, **Kustomize**, **Directory**, and **Plugin** configuration fields to be lost when the dry source was reconstructed.

This resulted in incorrect manifest generation for applications using these source types in their dry source configuration.

Necessary for https://github.com/argoproj/argo-cd/pull/27009

## Solution

- Add the 4 missing fields (`Helm`, `Kustomize`, `Directory`, `Plugin`) to `GetDrySource()` method
- Refactor `getManifests()` in hydrator to use `GetDrySource()` instead of manual reconstruction
- Add comprehensive unit test validating all source type fields are preserved

## Testing

- New unit test `TestGetDrySource_PreservesAllFields` with 7 test cases covering:
  - Each source type individually (Helm, Kustomize, Directory, Plugin)
  - Multiple source types together
  - Nil handling
  - Exact field equality validation

## Impact

Applications using Helm, Kustomize, Directory, or Plugin configurations in their dry source will now generate manifests correctly with all configuration preserved.