### PR TITLE
fix(ci): openssf scorecard doesn't allow global vars

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -14,10 +14,6 @@ concurrency:
 # Declare default permissions as read only.
 permissions: read-all
 
-env:
-  # a workaround to disable harden runner
-  STEP_SECURITY_HARDEN_RUNNER: ${{ vars.disable_harden_runner }}
-
 jobs:
   analysis:
     name: Scorecards analysis


### PR DESCRIPTION
The OpenSSF Scorecard workflow started failing after we added the harden runner: https://github.com/argoproj/argo-cd/actions/runs/24062120813/job/70180293143

> 2026/04/07 03:02:35 error processing signature: error sending scorecard results to webapp: http response 400, status: 400 Bad Request, error: {"code":400,"message":"workflow verification failed: workflow verification failed: workflow contains global env vars or defaults, see https://github.com/ossf/scorecard-action#workflow-restrictions for details."}

Let's just get rid of the "disable" var. It's fine, the OpenSSF Scorecard workflow isn't super critical. If it's down for a while, we'll live.