### PR TITLE
fix(ui): prevent sync status panel overflow on long branch names

### DIFF
--- a/ui/src/app/applications/components/application-status-panel/application-status-panel.scss
+++ b/ui/src/app/applications/components/application-status-panel/application-status-panel.scss
@@ -135,6 +135,7 @@
     &__item-value {
         display: flex;
         align-items: baseline;
+        min-width: 0;
         margin-bottom: 0.5em;
         font-weight: 500;
         padding: 2px 0px;
@@ -176,6 +177,11 @@
             font-weight: 500;
             padding-left: 8px;
             margin-bottom: 2px;
+            max-width: $row-width;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            @include responsive-widths();
         }
 
         &__status-button {


### PR DESCRIPTION
## Summary
- allow the sync status value row to shrink by setting `min-width: 0` on the item-value flex container
- add ellipsis truncation to the revision text block to prevent long branch names from widening the panel
- keep the existing responsive width mixin so truncation follows current breakpoints

## Test plan
- Open an application synced from a very long branch name
- Verify the `SYNC STATUS` panel stays within normal width
- Verify revision text is truncated with ellipsis instead of forcing horizontal growth

Fixes #27200