### PR TITLE
fix: cancel log stream goroutines on client disconnect

### DIFF
--- a/server/application/application.go
+++ b/server/application/application.go
@@ -1908,17 +1908,23 @@ func (s *Server) PodLogs(q *application.ApplicationPodLogsQuery, ws application.
 			// if k8s failed to start steaming logs (typically because Pod is not ready yet)
 			// then the error should be shown in the UI so that user know the reason
 			if err != nil {
-				logStream <- logEntry{line: err.Error()}
+				select {
+				case logStream <- logEntry{line: err.Error()}:
+				case <-ws.Context().Done():
+				}
 			} else {
-				parseLogsStream(podName, stream, logStream)
+				parseLogsStream(ws.Context(), podName, stream, logStream)
 			}
 			close(logStream)
 		}()
 	}
 
-	logStream := mergeLogStreams(streams, time.Millisecond*100)
+	logStream := mergeLogStreams(ws.Context(), streams, time.Millisecond*100)
 	sentCount := int64(0)
-	done := make(chan error)
+	// Buffered so the goroutine below can always send and exit, even if PodLogs has already
+	// returned due to client disconnect (ws.Context().Done). Without this, the goroutine
+	// would block on "done <- err" forever, leaking memory via bufio and mergeLogStreams buffers.
+	done := make(chan error, 1)
 	go func() {
 		for entry := range logStream {
 			if entry.err != nil {

--- a/server/application/logs.go
+++ b/server/application/logs.go
@@ -2,6 +2,7 @@ package application
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"io"
 	"strings"
@@ -17,8 +18,9 @@ type logEntry struct {
 	err       error
 }
 
-// parseLogsStream converts given ReadCloser into channel that emits log entries
-func parseLogsStream(podName string, stream io.ReadCloser, ch chan logEntry) {
+// parseLogsStream converts given ReadCloser into channel that emits log entries.
+// It stops early if ctx is cancelled, avoiding goroutine leaks when the caller disconnects.
+func parseLogsStream(ctx context.Context, podName string, stream io.ReadCloser, ch chan logEntry) {
 	bufReader := bufio.NewReader(stream)
 	eof := false
 	for !eof {
@@ -30,7 +32,10 @@ func parseLogsStream(podName string, stream io.ReadCloser, ch chan logEntry) {
 				break
 			}
 		} else if err != nil && !errors.Is(err, io.EOF) {
-			ch <- logEntry{err: err}
+			select {
+			case ch <- logEntry{err: err}:
+			case <-ctx.Done():
+			}
 			break
 		}
 
@@ -39,13 +44,20 @@ func parseLogsStream(podName string, stream io.ReadCloser, ch chan logEntry) {
 		timeStampStr := parts[0]
 		logTime, err := time.Parse(time.RFC3339Nano, timeStampStr)
 		if err != nil {
-			ch <- logEntry{err: err}
+			select {
+			case ch <- logEntry{err: err}:
+			case <-ctx.Done():
+			}
 			break
 		}
 
 		lines := strings.Join(parts[1:], " ")
 		for line := range strings.SplitSeq(lines, "\r") {
-			ch <- logEntry{line: line, timeStamp: logTime, podName: podName}
+			select {
+			case ch <- logEntry{line: line, timeStamp: logTime, podName: podName}:
+			case <-ctx.Done():
+				return
+			}
 		}
 	}
 }
@@ -53,7 +65,8 @@ func parseLogsStream(podName string, stream io.ReadCloser, ch chan logEntry) {
 // mergeLogStreams merge two stream of logs and ensures that merged logs are sorted by timestamp.
 // The implementation uses merge sort: method reads next log entry from each stream if one of streams is empty
 // it waits for no longer than specified duration and then merges available entries.
-func mergeLogStreams(streams []chan logEntry, bufferingDuration time.Duration) chan logEntry {
+// ctx cancellation causes all internal goroutines to exit promptly, preventing goroutine and memory leaks.
+func mergeLogStreams(ctx context.Context, streams []chan logEntry, bufferingDuration time.Duration) chan logEntry {
 	merged := make(chan logEntry)
 
 	// buffer of received log entries for each stream
@@ -70,7 +83,17 @@ func mergeLogStreams(streams []chan logEntry, bufferingDuration time.Duration) c
 				lock.Lock()
 				entriesPerStream[index] = append(entriesPerStream[index], next)
 				lock.Unlock()
-				process <- struct{}{}
+				select {
+				case process <- struct{}{}:
+				case <-ctx.Done():
+					// drain remaining entries so parseLogsStream goroutine can exit
+					for range streams[index] {
+					}
+					if atomic.AddInt32(&streamsCount, -1) == 0 {
+						close(process)
+					}
+					return
+				}
 			}
 			// stop processing after all streams got closed
 			if atomic.AddInt32(&streamsCount, -1) == 0 {
@@ -111,7 +134,11 @@ func mergeLogStreams(streams []chan logEntry, bufferingDuration time.Duration) c
 		}
 		lock.Unlock()
 		for i := range entries {
-			merged <- entries[i]
+			select {
+			case merged <- entries[i]:
+			case <-ctx.Done():
+				return false
+			}
 		}
 		return len(entries) > 0
 	}
@@ -120,11 +147,11 @@ func mergeLogStreams(streams []chan logEntry, bufferingDuration time.Duration) c
 	var sentAt time.Time
 
 	ticker := time.NewTicker(bufferingDuration)
-	done := make(chan struct{})
+	tickerDone := make(chan struct{})
 	go func() {
 		for {
 			select {
-			case <-done:
+			case <-tickerDone:
 				return
 			case <-ticker.C:
 				sentAtLock.Lock()
@@ -133,18 +160,30 @@ func mergeLogStreams(streams []chan logEntry, bufferingDuration time.Duration) c
 					_ = send(true)
 					sentAt = time.Now()
 				}
-
 				sentAtLock.Unlock()
 			}
 		}
 	}()
 
 	go func() {
-		for range process {
-			if send(false) {
-				sentAtLock.Lock()
-				sentAt = time.Now()
-				sentAtLock.Unlock()
+	loop:
+		for {
+			select {
+			case _, ok := <-process:
+				if !ok {
+					break loop
+				}
+				if send(false) {
+					sentAtLock.Lock()
+					sentAt = time.Now()
+					sentAtLock.Unlock()
+				}
+			case <-ctx.Done():
+				// client disconnected: stop immediately without flushing
+				ticker.Stop()
+				tickerDone <- struct{}{}
+				close(merged)
+				return
 			}
 		}
 
@@ -152,10 +191,10 @@ func mergeLogStreams(streams []chan logEntry, bufferingDuration time.Duration) c
 
 		ticker.Stop()
 		// ticker.Stop() does not close the channel, and it does not wait for the channel to be drained. So we need to
-		// explicitly prevent the gorountine from leaking by closing the channel. We also need to prevent the goroutine
+		// explicitly prevent the goroutine from leaking by closing the channel. We also need to prevent the goroutine
 		// from calling `send` again, because `send` pushes to the `merged` channel which we're about to close.
 		// This describes the approach nicely: https://stackoverflow.com/questions/17797754/ticker-stop-behaviour-in-golang
-		done <- struct{}{}
+		tickerDone <- struct{}{}
 		close(merged)
 	}()
 	return merged

--- a/server/application/logs_test.go
+++ b/server/application/logs_test.go
@@ -1,6 +1,7 @@
 package application
 
 import (
+	"context"
 	"io"
 	"strings"
 	"testing"
@@ -16,7 +17,7 @@ func TestParseLogsStream_Successful(t *testing.T) {
 
 	res := make(chan logEntry)
 	go func() {
-		parseLogsStream("test", r, res)
+		parseLogsStream(context.Background(), "test", r, res)
 		close(res)
 	}()
 
@@ -39,7 +40,7 @@ func TestParseLogsStream_ParsingError(t *testing.T) {
 
 	res := make(chan logEntry)
 	go func() {
-		parseLogsStream("test", r, res)
+		parseLogsStream(context.Background(), "test", r, res)
 		close(res)
 	}()
 
@@ -55,19 +56,19 @@ func TestParseLogsStream_ParsingError(t *testing.T) {
 func TestMergeLogStreams(t *testing.T) {
 	first := make(chan logEntry)
 	go func() {
-		parseLogsStream("first", io.NopCloser(strings.NewReader(`2021-02-09T00:00:01Z 1
+		parseLogsStream(context.Background(), "first", io.NopCloser(strings.NewReader(`2021-02-09T00:00:01Z 1
 2021-02-09T00:00:03Z 3`)), first)
 		close(first)
 	}()
 
 	second := make(chan logEntry)
 	go func() {
-		parseLogsStream("second", io.NopCloser(strings.NewReader(`2021-02-09T00:00:02Z 2
+		parseLogsStream(context.Background(), "second", io.NopCloser(strings.NewReader(`2021-02-09T00:00:02Z 2
 2021-02-09T00:00:04Z 4`)), second)
 		close(second)
 	}()
 
-	merged := mergeLogStreams([]chan logEntry{first, second}, time.Second)
+	merged := mergeLogStreams(context.Background(), []chan logEntry{first, second}, time.Second)
 	var lines []string
 	for entry := range merged {
 		lines = append(lines, entry.line)
@@ -83,18 +84,18 @@ func TestMergeLogStreams_RaceCondition(_ *testing.T) {
 		second := make(chan logEntry)
 
 		go func() {
-			parseLogsStream("first", io.NopCloser(strings.NewReader(`2021-02-09T00:00:01Z 1`)), first)
+			parseLogsStream(context.Background(), "first", io.NopCloser(strings.NewReader(`2021-02-09T00:00:01Z 1`)), first)
 			time.Sleep(time.Duration(i%3) * time.Millisecond)
 			close(first)
 		}()
 
 		go func() {
-			parseLogsStream("second", io.NopCloser(strings.NewReader(`2021-02-09T00:00:02Z 2`)), second)
+			parseLogsStream(context.Background(), "second", io.NopCloser(strings.NewReader(`2021-02-09T00:00:02Z 2`)), second)
 			time.Sleep(time.Duration((i+1)%3) * time.Millisecond)
 			close(second)
 		}()
 
-		merged := mergeLogStreams([]chan logEntry{first, second}, 1*time.Millisecond)
+		merged := mergeLogStreams(context.Background(), []chan logEntry{first, second}, 1*time.Millisecond)
 
 		// Drain the channel
 		for range merged {
@@ -103,5 +104,41 @@ func TestMergeLogStreams_RaceCondition(_ *testing.T) {
 		// This test intentionally doesn't test the order of the output. Under these intense conditions, the test would
 		// fail often due to out of order entries. This test is only meant to reproduce a race between a channel writer
 		// and channel closer.
+	}
+}
+
+// TestMergeLogStreams_ContextCancellation verifies that cancelling the context causes mergeLogStreams
+// to close the merged channel promptly, allowing all internal goroutines to exit without leaking.
+func TestMergeLogStreams_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// unbuffered pipe: write end will block until someone reads
+	pr, pw := io.Pipe()
+
+	ch := make(chan logEntry)
+	go func() {
+		parseLogsStream(ctx, "test", pr, ch)
+		close(ch)
+	}()
+
+	merged := mergeLogStreams(ctx, []chan logEntry{ch}, time.Second)
+
+	// cancel before the pipe produces any data
+	cancel()
+	_ = pw.Close()
+
+	// merged must be closed (context cancelled), not block forever
+	done := make(chan struct{})
+	go func() {
+		for range merged {
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// merged closed promptly — no leak
+	case <-time.After(5 * time.Second):
+		t.Fatal("mergeLogStreams did not close merged channel after context cancellation")
 	}
 }


### PR DESCRIPTION
Closes #12031

Fixes goroutine leak in PodLogs when the client disconnects mid-stream.

When the gRPC context is cancelled, PodLogs returns but the log-sending goroutine blocks on `done <- err` forever (done was unbuffered). This keeps mergeLogStreams and parseLogsStream goroutines alive, accumulating bufio buffers until the process is restarted.

Fix: make done buffered, pass context to mergeLogStreams and parseLogsStream so all goroutines exit promptly on disconnect.