### PR TITLE
fix(ui): prevent Sync Status panel from getting too wide with long branch names

### DIFF
--- a/ui/src/app/applications/components/application-status-panel/application-status-panel.scss
+++ b/ui/src/app/applications/components/application-status-panel/application-status-panel.scss
@@ -176,6 +176,10 @@
             font-weight: 500;
             padding-left: 8px;
             margin-bottom: 2px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            @include responsive-widths();
         }
 
         &__status-button {


### PR DESCRIPTION
Fixes #27200

When syncing from a branch with a long name, the revision text in the Sync Status panel had no width constraint, causing the panel to expand and other panels to wrap.

Added `overflow: hidden`, `text-overflow: ellipsis`, `white-space: nowrap`, and the existing `responsive-widths` mixin to the `__revision` element in `application-status-panel.scss`. This matches the overflow handling already applied to `__item-name` and `__item-value` (lines 209-213 in the same file).

---
*This change was made with AI assistance.*