### PR TITLE
docs: fix typos

### DIFF
--- a/docs/developer-guide/running-locally.md
+++ b/docs/developer-guide/running-locally.md
@@ -212,7 +212,7 @@ export IMAGE_TAG=1.5.0-myrc
 
 > [!NOTE]
 > The image will be built for `linux/amd64` platform by default. If you are running on Mac with Apple chip (ARM),
-> you need to specify the correct buld platform by running:
+> you need to specify the correct build platform by running:
 > ```bash
 > export TARGET_ARCH=linux/arm64 
 > ```

--- a/docs/operator-manual/applicationset.yaml
+++ b/docs/operator-manual/applicationset.yaml
@@ -41,7 +41,7 @@ spec:
               - https://kubernetes.default.svc
               - https://some-other-cluster
 
-    # Git generator generates parametes either from directory structure of files within a git repo
+    # Git generator generates parameters either from directory structure of files within a git repo
     - git:
         repoURL: https://github.com/argoproj/argo-cd.git
         # OPTIONAL: use directory structure of git repo to generate parameters

--- a/docs/operator-manual/argocd-cm.yaml
+++ b/docs/operator-manual/argocd-cm.yaml
@@ -86,7 +86,7 @@ data:
     # Optional set of OIDC claims to request on the ID token.
     requestedIDTokenClaims: {"groups": {"essential": true}}
 
-  # Configuration to customize resource behavior (optional) can be configured via splitted sub keys.
+  # Configuration to customize resource behavior (optional) can be configured via split sub keys.
   # Keys are in the form: resource.customizations.ignoreDifferences.<group_kind>, resource.customizations.health.<group_kind>
   # resource.customizations.actions.<group_kind>, resource.customizations.knownTypeFields.<group_kind>
   # resource.customizations.ignoreResourceUpdates.<group_kind>
@@ -115,7 +115,7 @@ data:
     jsonPointers:
     - /metadata/resourceVersion
 
-  # Configuration to define customizations ignoring differences during watched resource updates can be configured via splitted sub key.
+  # Configuration to define customizations ignoring differences during watched resource updates can be configured via split sub key.
   resource.customizations.ignoreResourceUpdates.argoproj.io_Application: |
     jsonPointers:
     - /status

--- a/docs/operator-manual/notifications/examples.md
+++ b/docs/operator-manual/notifications/examples.md
@@ -125,7 +125,7 @@ data:
     send: [on-deployed-template]
 ```
 
-Now, with the setup above, a sync will send the list of images to your Slack application. For more information about integratin with Slack, see the [Slack integration guide](services/slack.md).
+Now, with the setup above, a sync will send the list of images to your Slack application. For more information about integration with Slack, see the [Slack integration guide](services/slack.md).
 
 ### Deduplicating images
 

--- a/docs/operator-manual/tls.md
+++ b/docs/operator-manual/tls.md
@@ -182,7 +182,7 @@ on how your workloads connect to the repository server.
 
 ### Configuring TLS to argocd-repo-server
 
-The componenets `argocd-server`, `argocd-application-controller`, `argocd-notifications-controller`, 
+The components `argocd-server`, `argocd-application-controller`, `argocd-notifications-controller`, 
 and `argocd-applicationset-controller` communicate with the `argocd-repo-server` 
 using a gRPC API over TLS. By default, `argocd-repo-server` generates a non-persistent, 
 self-signed certificate to use for its gRPC endpoint on startup. Because the 
@@ -190,7 +190,7 @@ self-signed certificate to use for its gRPC endpoint on startup. Because the
 is not available to outside consumers for verification. These components will use a 
 non-validating connection to the `argocd-repo-server` for this reason.
 
-To change this behavior to be more secure by having these componenets validate the TLS certificate of the
+To change this behavior to be more secure by having these components validate the TLS certificate of the
 `argocd-repo-server` endpoint, the following steps need to be performed:
 
 * Create a persistent TLS certificate to be used by `argocd-repo-server`, as

--- a/docs/operator-manual/upgrading/2.14-3.0.md
+++ b/docs/operator-manual/upgrading/2.14-3.0.md
@@ -272,7 +272,7 @@ curl -X POST -H "Authorization: Bearer $ARGOCD_TOKEN" -H "Content-Type: applicat
   }' "http://$YOUR_ARGOCD_URL/api/v1/applications/$YOUR_APP_NAME/sync"
 ```
 
-It is also possible to sync such an Applicaton using the UI, with `ApplyOutOfSyncOnly` option unchecked. However, currently, performing a sync without `ApplyOutOfSyncOnly` option is not possible using the CLI.
+It is also possible to sync such an Application using the UI, with `ApplyOutOfSyncOnly` option unchecked. However, currently, performing a sync without `ApplyOutOfSyncOnly` option is not possible using the CLI.
 
 ##### Other users
 

--- a/docs/operator-manual/upgrading/3.2-3.3.md
+++ b/docs/operator-manual/upgrading/3.2-3.3.md
@@ -29,7 +29,7 @@ When Argo CD is upgraded manually using plain manifests or Kustomize overlays, i
 Users upgrading Argo CD manually using `helm upgrade` are not impacted by this change, since Helm does not use client-side apply and does not result in creation of the `last-applied` annotation.
 
 #### Users who previously upgraded to 3.3.0 or 3.3.1
-In some cases, after upgrading to one of those versions and applying Server-Side Apply, the following error occured:   
+In some cases, after upgrading to one of those versions and applying Server-Side Apply, the following error occurred:   
 `one or more synchronization tasks completed unsuccessfully, reason: Failed to perform client-side apply migration: failed to perform client-side apply migration on manager kubectl-client-side-apply: error when patching "/dev/shm/2047509016": CustomResourceDefinition.apiextensions.k8s.io "applicationsets.argoproj.io" is invalid: metadata.annotations: Too long: may not be more than 262144 bytes`.
 
 Users that have configured the sync option `ClientSideApplyMigration=false` as a temporary remediation for the above error, should remove it after upgrading to `3.3.2`. Disabling `ClientSideApplyMigration` imposes a risk to encounter conflicts between K8s field managers in the future.

--- a/docs/operator-manual/user-management/gitlab-ci.md
+++ b/docs/operator-manual/user-management/gitlab-ci.md
@@ -68,7 +68,7 @@ deploy:
 
 ## Configuring RBAC
 
-When using ArgoCD global RBAC comfig map, you can define your `policy.csv` like so:
+When using ArgoCD global RBAC config map, you can define your `policy.csv` like so:
 
 ```yaml
 configs:

--- a/docs/proposals/002-ui-extensions.md
+++ b/docs/proposals/002-ui-extensions.md
@@ -142,7 +142,7 @@ We provide the entire application tree to accomplish two things:
 Further, if an Extension needs richer information than that provided by the Resource Tree, it can request additional information about a resource from the Argo CD API server.
 
 ```typescript
-interface Extention {
+interface Extension {
     ResourceTab: React.Component<{resource: any}>;
 }
 ```

--- a/docs/proposals/application-name-identifier.md
+++ b/docs/proposals/application-name-identifier.md
@@ -135,7 +135,7 @@ one in charge of a given resource.
 
 #### Include resource identifies in the `app.kubernetes.io/instance` annotation
 
-The `app.kubernetes.io/instance` annotation might be accidently added or copied
+The `app.kubernetes.io/instance` annotation might be accidentally added or copied
 same as label. To prevent Argo CD confusion the annotation value should include
 the identifier of the resource annotation was applied to. The resource identifier
 includes the group, kind, namespace and name of the resource. It is proposed to use `;`

--- a/docs/proposals/feature-bounties.md
+++ b/docs/proposals/feature-bounties.md
@@ -42,7 +42,7 @@ A bounty is a special proposal created under `docs/proposals/feature-bounties`.
 #### Claiming a Bounty
 * Argo will pay out bounties once a pull request implementing the requested features/changes/fixes is merged.
 * A bounty is limited to a single successful PR.
-* Those interested in working on the bounty are encouraged to comment on the issue, and users may team up to split a bounty if they prefer but collaboration is not required and users should not shame eachother for their preferences to work alone or together.
+* Those interested in working on the bounty are encouraged to comment on the issue, and users may team up to split a bounty if they prefer but collaboration is not required and users should not shame each other for their preferences to work alone or together.
 * A comment of interest does not constitute a claim and will not be treated as such.
 * The first pull request submitted that is ready for merge will be reviewed by maintainers. Maintainers will also consider any competing pull requests submitted within 24-hours. We expect this will be a very rare circumstance. If multiple, high-quality, merge ready pull requests are submitted, 3-5 Approvers for the sub-project will vote to decide the final pull request merged.
 


### PR DESCRIPTION
Fixes spelling mistakes across 11 docs, found using codespell.

Checklist:
* [x] This does not need to be in the release notes (typo fixes)
* [x] The title conforms to the PR title guidelines
* [x] I've updated documentation as required by this PR
* [x] I have signed off all my commits as required by DCO