### PR TITLE
fix: ApplicationSet DuckType Generator panics on non-string values in Clus…

### DIFF
--- a/applicationset/generators/duck_type.go
+++ b/applicationset/generators/duck_type.go
@@ -164,7 +164,7 @@ func (g *DuckTypeGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.A
 		}
 
 		for key, value := range clusterDecision.(map[string]any) {
-			params[key] = value.(string)
+			params[key] = fmt.Sprintf("%v", value)
 		}
 
 		for key, value := range appSetGenerator.ClusterDecisionResource.Values {
@@ -200,12 +200,12 @@ func buildClusterDecisions(duckResources *unstructured.UnstructuredList, statusL
 func findCluster(clustersFromArgoCD []utils.ClusterSpecifier, cluster any, matchKey string, statusListKey string) *utils.ClusterSpecifier {
 	log.Infof("cluster: %v", cluster)
 	matchValue := cluster.(map[string]any)[matchKey]
-	if matchValue == nil || matchValue.(string) == "" {
+	if matchValue == nil || fmt.Sprintf("%v", matchValue) == "" {
 		log.Warningf("matchKey=%v not found in \"%v\" list: %v\n", matchKey, statusListKey, cluster.(map[string]any))
 		return nil // no match
 	}
 
-	strMatchValue := matchValue.(string)
+	strMatchValue := fmt.Sprintf("%v", matchValue)
 	log.WithField(matchKey, strMatchValue).Debug("validate against ArgoCD")
 
 	for _, argoCluster := range clustersFromArgoCD {

--- a/applicationset/generators/duck_type_test.go
+++ b/applicationset/generators/duck_type_test.go
@@ -119,6 +119,27 @@ func TestGenerateParamsForDuckType(t *testing.T) {
 		},
 	}
 
+	duckTypeWithNonStringValues := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resourceAPIVersion,
+			"kind":       "Duck",
+			"metadata": map[string]any{
+				"name":      resourceName,
+				"namespace": "namespace",
+				"labels":    map[string]any{"duck": "all-species"},
+			},
+			"status": map[string]any{
+				"decisions": []any{
+					map[string]any{
+						"clusterName": "staging-01",
+						"reason":      "",
+						"score":       int64(0),
+					},
+				},
+			},
+		},
+	}
+
 	duckTypeEmpty := &unstructured.Unstructured{
 		Object: map[string]any{
 			"apiVersion": resourceAPIVersion,
@@ -182,6 +203,16 @@ func TestGenerateParamsForDuckType(t *testing.T) {
 				{"clusterName": "production-01", "name": "production-01", "server": "https://production-01.example.com"},
 
 				{"clusterName": "staging-01", "name": "staging-01", "server": "https://staging-01.example.com"},
+			},
+			expectedError: nil,
+		},
+		{
+			name:         "non-string values in cluster decisions are converted to strings",
+			resourceName: resourceName,
+			resource:     duckTypeWithNonStringValues,
+			values:       nil,
+			expected: []map[string]any{
+				{"clusterName": "staging-01", "reason": "", "score": "0", "name": "staging-01", "server": "https://staging-01.example.com"},
 			},
 			expectedError: nil,
 		},


### PR DESCRIPTION
…terDecisionResource status

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Fixes https://github.com/argoproj/argo-cd/issues/27264

Without the PR, the ApplicationSet DuckType Generator always panics on non-string values whenever clusterDecisionResource defines non-string value field. 

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
