### PR TITLE
test: fix helm test flake

### DIFF
--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -461,31 +461,16 @@ func TestGenerateManifest_RefOnlyShortCircuit(t *testing.T) {
 
 // Test that calling manifest generation on source helm reference helm files that when the revision is cached it does not call ls-remote
 func TestGenerateManifestsHelmWithRefs_CachedNoLsRemote(t *testing.T) {
-	dir := t.TempDir()
+	// Use os.MkdirTemp instead of t.TempDir() because the async goroutine in
+	// runManifestGenAsync sets directory permissions to 0o000 (via
+	// directoryPermissionInitializer) after GenerateManifest returns, racing
+	// with t.TempDir()'s implicit RemoveAll cleanup.
+	dir, mkErr := os.MkdirTemp("", "TestGenerateManifestsHelmWithRefs_CachedNoLsRemote")
+	require.NoError(t, mkErr)
 	repopath := dir + "/tmprepo"
 	cacheMocks := newCacheMocks()
 	t.Cleanup(func() {
 		cacheMocks.mockCache.StopRedisCallback()
-		// Best-effort: make all files writable so t.TempDir() can clean up.
-		// Ignore errors (e.g. git object files with restrictive permissions in CI)
-		// to avoid failing the test in the cleanup phase rather than the logic phase.
-		// We chmod *before* descending so that directories with restrictive permissions
-		// (e.g. git object dirs set to 0444) become accessible prior to listing their
-		// entries. filepath.WalkDir cannot be used here because it reads directory
-		// entries before calling the callback, so a dir with 0000/0444 perms would
-		// already fail before we get a chance to fix it.
-		var fixPerms func(string)
-		fixPerms = func(path string) {
-			_ = os.Chmod(path, 0o777)
-			entries, err := os.ReadDir(path)
-			if err != nil {
-				return
-			}
-			for _, e := range entries {
-				fixPerms(filepath.Join(path, e.Name()))
-			}
-		}
-		fixPerms(dir)
 	})
 	service := NewService(metrics.NewMetricsServer(), cacheMocks.cache, RepoServerInitConstants{ParallelismLimit: 1}, &git.NoopCredsStore{}, repopath)
 	var gitClient git.Client


### PR DESCRIPTION
Instead of trying to fix a race between `directoryPermissionInitializer` and the cleanup of `t.TempDir()`, let's just use `os.MkdirTemp`. A few lingering directories in `/tmp` is not a big deal. Should fix the flaky test.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
