### PR TITLE
fix: prevent delete hooks from running on non-cascading app deletion

### DIFF
--- a/server/application/application.go
+++ b/server/application/application.go
@@ -1171,9 +1171,21 @@ func (s *Server) Delete(ctx context.Context, q *application.ApplicationDeleteReq
 			a.SetCascadedDeletion(policyFinalizer)
 			patchFinalizer = true
 		}
-	} else if a.CascadedDeletion() {
-		a.UnSetCascadedDeletion()
-		patchFinalizer = true
+	} else {
+		if a.CascadedDeletion() {
+			a.UnSetCascadedDeletion()
+			patchFinalizer = true
+		}
+
+		// Non-cascading deletes must not be blocked by delete-hook finalizers.
+		if a.HasPreDeleteFinalizer() || a.HasPreDeleteFinalizer("cleanup") {
+			a.UnSetPreDeleteFinalizerAll()
+			patchFinalizer = true
+		}
+		if a.HasPostDeleteFinalizer() || a.HasPostDeleteFinalizer("cleanup") {
+			a.UnSetPostDeleteFinalizerAll()
+			patchFinalizer = true
+		}
 	}
 
 	if patchFinalizer {

--- a/test/e2e/hook_test.go
+++ b/test/e2e/hook_test.go
@@ -96,7 +96,7 @@ func TestPreDeleteHookFailureAndRetry(t *testing.T) {
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		When().
-		Delete(false). // Non-blocking delete
+		Delete(true).
 		Then().
 		// App should still exist because pre-delete hook failed
 		Expect(Condition(ApplicationConditionDeletionError, "")).


### PR DESCRIPTION
## Summary

This PR fixes an issue where deleting an Application with non-cascading deletion triggers delete hooks.

When `argocd app delete --cascade=false` is used with post/pre delete hooks, delete-hook finalizers remain on the Application which makes the controller run the delete-hooks.

This change updates the delete path so non-cascading deletion removes delete-hook finalizers and prevents pre-delete/post-delete hooks from running.

## What Changed

Strip pre-delete and post-delete finalizers during non-cascading application deletion

Fixes #27278 