### PR TITLE
docs: Add AI/LLM usage disclosure checkbox to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,7 @@ Checklist:
 * [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
 * [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
 * [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
-* [ ] I have used LLM/AI/Agent tools to assist with this PR, and I take full responsibility for all code and content submitted.
+* [ ] I have used LLM/AI/Agent tools to assist with this PR, and I take full responsibility for all code and content submitted [Generative AI Contribution Policy](https://github.com/argoproj/argoproj/blob/main/community/genai.md)
 * [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
 * [ ] Optional. My organization is added to USERS.md.
 * [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,7 @@ Checklist:
 * [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
 * [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
 * [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
-* [ ] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR.
+* [ ] I have used LLM/AI/Agent tools to assist with this PR, and I take full responsibility for all code and content submitted.
 * [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
 * [ ] Optional. My organization is added to USERS.md.
 * [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,7 @@ Checklist:
 * [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
 * [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
 * [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
+* [ ] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR.
 * [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
 * [ ] Optional. My organization is added to USERS.md.
 * [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).


### PR DESCRIPTION
Closes #27282 
### Summary
Add an optional checkbox to the pull request template that allows contributors to disclose whether they used LLM/AI/Agent tools to assist in authoring the PR, while affirming their full responsibility for all submitted code and content.

### Motivation
The Argoproj organization already has a published [Generative AI Contribution Policy](https://github.com/argoproj/argoproj/blob/main/community/genai.md) that encourages contributors to be transparent about AI tool usage and requires them to take full human responsibility for any AI-assisted contributions.

However, the current PR template in argoproj/argo-cd has no dedicated field for this disclosure. Contributors who want to be transparent have no standard place to do so, and reviewers have no consistent signal to look for.

Adding a checkbox to the PR template makes compliance with the existing policy easier, more visible, and consistent across all contributions.

A similar checkbox already exists in Argo Rollouts
https://github.com/argoproj/argo-rollouts/blob/master/.github/pull_request_template.md

Proposal
Add the following optional checkbox to .github/pull_request_template.md:

 * [ ] I have used LLM/AI/Agent tools to assist with this PR, and I take full responsibility for all code and content submitted



<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->




Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
