### PR TITLE
feat: Preserve port forward settings after login

### DIFF
--- a/cmd/argocd/commands/login.go
+++ b/cmd/argocd/commands/login.go
@@ -155,12 +155,14 @@ argocd login cd.argoproj.io --core`,
 				localCfg = &localconfig.LocalConfig{}
 			}
 			localCfg.UpsertServer(localconfig.Server{
-				Server:          server,
-				PlainText:       clientOpts.PlainText,
-				Insecure:        clientOpts.Insecure,
-				GRPCWeb:         clientOpts.GRPCWeb,
-				GRPCWebRootPath: clientOpts.GRPCWebRootPath,
-				Core:            clientOpts.Core,
+				Server:               server,
+				PlainText:            clientOpts.PlainText,
+				Insecure:             clientOpts.Insecure,
+				GRPCWeb:              clientOpts.GRPCWeb,
+				GRPCWebRootPath:      clientOpts.GRPCWebRootPath,
+				Core:                 clientOpts.Core,
+				PortForward:          clientOpts.PortForward,
+				PortForwardNamespace: clientOpts.PortForwardNamespace,
 			})
 			localCfg.UpsertUser(localconfig.User{
 				Name:         ctxName,

--- a/pkg/apiclient/apiclient.go
+++ b/pkg/apiclient/apiclient.go
@@ -132,17 +132,19 @@ type ClientOptions struct {
 }
 
 type client struct {
-	ServerAddr      string
-	PlainText       bool
-	Insecure        bool
-	CertPEMData     []byte
-	ClientCert      *tls.Certificate
-	AuthToken       string
-	RefreshToken    string
-	UserAgent       string
-	GRPCWeb         bool
-	GRPCWebRootPath string
-	Headers         []string
+	ServerAddr           string
+	PlainText            bool
+	Insecure             bool
+	CertPEMData          []byte
+	ClientCert           *tls.Certificate
+	AuthToken            string
+	RefreshToken         string
+	UserAgent            string
+	GRPCWeb              bool
+	GRPCWebRootPath      string
+	PortForward          bool
+	PortForwardNamespace string
+	Headers              []string
 
 	proxyMutex      *sync.Mutex
 	proxyListener   net.Listener
@@ -261,6 +263,12 @@ func NewClient(opts *ClientOptions) (Client, error) {
 	}
 	if opts.GRPCWebRootPath != "" {
 		c.GRPCWebRootPath = opts.GRPCWebRootPath
+	}
+	if opts.PortForward {
+		c.PortForward = opts.PortForward
+	}
+	if opts.PortForwardNamespace != "" {
+		c.PortForwardNamespace = opts.PortForwardNamespace
 	}
 
 	if opts.HttpRetryMax > 0 {

--- a/util/localconfig/localconfig.go
+++ b/util/localconfig/localconfig.go
@@ -56,6 +56,10 @@ type Server struct {
 	PlainText bool `json:"plain-text,omitempty"`
 	// Core indicates to talk to Kubernetes API without using Argo CD API server
 	Core bool `json:"core,omitempty"`
+	// PortForward indicates to use port forwarding when connecting to server
+	PortForward bool `json:"port-forward,omitempty"`
+	// PortForwardNamespace is the namespace to use for port forwarding
+	PortForwardNamespace string `json:"port-forward-namespace,omitempty"`
 }
 
 // User contains user authentication information


### PR DESCRIPTION
Fixes #20565

Right now if you run:

argocd login localhost --port-forward --port-forward-namespace argocd

It logs you in fine, but then every subsequent command requires you to add those same flags again. It's really annoying - I was doing this for months without realizing it was a bug.

This PR adds the missing fields so these settings get saved into your local config just like all the other connection flags (GRPCWeb, insecure, plaintext etc). No extra logic, just added the fields in the 3 places they were missing, following the exact same pattern that already existed for all other flags.
No breaking changes. Backwards compatible. Old config files continue to work exactly as before.
Tested locally, works perfectly now.
