### PR TITLE
fix(ui): avoid minimatch namespace calls

### DIFF
--- a/ui/src/app/applications/components/applications-list/applications-filter.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-filter.tsx
@@ -1,5 +1,4 @@
 import {useData, Checkbox} from 'argo-ui/v2';
-import * as minimatch from 'minimatch';
 import * as React from 'react';
 import {
     Application,
@@ -20,6 +19,8 @@ import {createMetadataSelector} from '../selectors';
 import {ComparisonStatusIcon, getAppAllSources, getAppSetHealthStatus, HealthStatusIcon, getOperationStateTitle} from '../utils';
 import {formatClusterQueryParam} from '../../../shared/utils';
 import {COLORS} from '../../../shared/components/colors';
+
+const minimatch = require('minimatch');
 
 export interface FilterResult {
     sync: boolean;

--- a/ui/src/app/applications/components/resource-icon.tsx
+++ b/ui/src/app/applications/components/resource-icon.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {resourceIcons} from './resources';
 import {resourceIconGroups as resourceCustomizations} from './resource-customizations';
-import * as minimatch from 'minimatch';
+const minimatch = require('minimatch');
 
 export const ResourceIcon = ({group, kind, customStyle}: {group: string; kind: string; customStyle?: React.CSSProperties}) => {
     if (kind === 'node') {

--- a/ui/src/app/shared/services/extensions-service.test.ts
+++ b/ui/src/app/shared/services/extensions-service.test.ts
@@ -1,0 +1,16 @@
+import {ExtensionsService} from './extensions-service';
+
+describe('ExtensionsService', () => {
+    it('matches wildcard resource extensions when resolving resource tabs', () => {
+        const service = new ExtensionsService();
+        const group = '*.interop26935.example.io';
+        const kind = 'Widget26935';
+        const title = 'Wildcard extension';
+
+        (window as any).extensionsAPI.registerResourceExtension((() => null) as any, group, kind, title);
+
+        expect(service.getResourceTabs('team.interop26935.example.io', kind)).toEqual(
+            expect.arrayContaining([expect.objectContaining({group, kind, title})])
+        );
+    });
+});

--- a/ui/src/app/shared/services/extensions-service.ts
+++ b/ui/src/app/shared/services/extensions-service.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as minimatch from 'minimatch';
+const minimatch = require('minimatch');
 
 import {Application, ApplicationTree, State} from '../models';
 


### PR DESCRIPTION
## Summary
- switch the UI `minimatch` call sites to a callable CommonJS import
- add regression coverage for wildcard resource extension matching

## Root Cause
The UI imported `minimatch` with `import * as minimatch from 'minimatch'` and then invoked it as `minimatch(...)`. Under the current webpack/esbuild pipeline this can resolve to a namespace object instead of the callable export, which causes the browser error reported in #26935.

## What Changed
- updated the `minimatch` imports in resource icon matching, application list filters, and extension resource tab matching
- added a regression test that exercises wildcard resource extension resolution

## Validation
- `pnpm test -- --runInBand src/app/applications/components/resource-icon.test.tsx src/app/shared/services/extensions-service.test.ts`
- `pnpm build`
