### PR TITLE
chore: wrap error returns with context in util/cache

### DIFF
--- a/util/cache/appstate/cache.go
+++ b/util/cache/appstate/cache.go
@@ -61,7 +61,10 @@ func appManagedResourcesKey(appName string) string {
 
 func (c *Cache) GetAppManagedResources(appName string, res *[]*appv1.ResourceDiff) error {
 	err := c.GetItem(appManagedResourcesKey(appName), &res)
-	return err
+	if err != nil {
+		return fmt.Errorf("failed to get managed resources for app %q: %w", appName, err)
+	}
+	return nil
 }
 
 func (c *Cache) SetAppManagedResources(appName string, managedResources []*appv1.ResourceDiff) error {
@@ -85,17 +88,20 @@ func clusterInfoKey(server string) string {
 
 func (c *Cache) GetAppResourcesTree(appName string, res *appv1.ApplicationTree) error {
 	err := c.GetItem(appResourcesTreeKey(appName, 0), &res)
+	if err != nil {
+		return fmt.Errorf("failed to get resources tree for app %q: %w", appName, err)
+	}
 	if res.ShardsCount > 1 {
 		for i := int64(1); i < res.ShardsCount; i++ {
 			var shard appv1.ApplicationTree
 			err = c.GetItem(appResourcesTreeKey(appName, i), &shard)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to get resources tree shard %d for app %q: %w", i, appName, err)
 			}
 			res.Merge(&shard)
 		}
 	}
-	return err
+	return nil
 }
 
 func (c *Cache) OnAppResourcesTreeChanged(ctx context.Context, appName string, callback func() error) error {
@@ -105,7 +111,7 @@ func (c *Cache) OnAppResourcesTreeChanged(ctx context.Context, appName string, c
 func (c *Cache) SetAppResourcesTree(appName string, resourcesTree *appv1.ApplicationTree) error {
 	if resourcesTree == nil {
 		if err := c.SetItem(appResourcesTreeKey(appName, 0), resourcesTree, c.appStateCacheExpiration, true); err != nil {
-			return err
+			return fmt.Errorf("failed to delete resources tree for app %q: %w", appName, err)
 		}
 	} else {
 		// Splitting resource tree into shards reduces number of Redis SET calls and therefore amount of traffic sent
@@ -113,7 +119,7 @@ func (c *Cache) SetAppResourcesTree(appName string, resourcesTree *appv1.Applica
 		// forwards request to Redis only if shard actually changes.
 		for i, shard := range resourcesTree.GetShards(treeShardSize) {
 			if err := c.SetItem(appResourcesTreeKey(appName, int64(i)), shard, c.appStateCacheExpiration, false); err != nil {
-				return err
+				return fmt.Errorf("failed to set resources tree shard %d for app %q: %w", i, appName, err)
 			}
 		}
 	}
@@ -127,5 +133,8 @@ func (c *Cache) SetClusterInfo(server string, info *appv1.ClusterInfo) error {
 
 func (c *Cache) GetClusterInfo(server string, res *appv1.ClusterInfo) error {
 	err := c.GetItem(clusterInfoKey(server), &res)
-	return err
+	if err != nil {
+		return fmt.Errorf("failed to get cluster info for server %q: %w", server, err)
+	}
+	return nil
 }

--- a/util/cache/inmemory.go
+++ b/util/cache/inmemory.go
@@ -31,7 +31,7 @@ func (i *InMemoryCache) Set(item *Item) error {
 	var buf bytes.Buffer
 	err := gob.NewEncoder(&buf).Encode(item.Object)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to encode cache item for key %q: %w", item.Key, err)
 	}
 	if item.CacheActionOpts.DisableOverwrite {
 		// go-redis doesn't throw an error on Set with NX, so absorbing here to keep the interface consistent

--- a/util/cache/redis.go
+++ b/util/cache/redis.go
@@ -94,7 +94,7 @@ func (r *redisCache) unmarshal(data []byte, obj any) error {
 	if r.redisCompressionType == RedisCompressionGZip {
 		gzipReader, err := gzip.NewReader(buf)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to create gzip reader for cache decompression: %w", err)
 		}
 		reader = gzipReader
 	}
@@ -121,7 +121,7 @@ func (r *redisCache) Set(item *Item) error {
 
 	val, err := r.marshal(item.Object)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to marshal cache item for key %q: %w", item.Key, err)
 	}
 
 	return r.cache.Set(&rediscache.Item{
@@ -139,7 +139,7 @@ func (r *redisCache) Get(key string, obj any) error {
 		err = ErrCacheMiss
 	}
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get cache item for key %q: %w", key, err)
 	}
 	return r.unmarshal(data, obj)
 }
@@ -159,7 +159,7 @@ func (r *redisCache) OnUpdated(ctx context.Context, key string, callback func() 
 			return nil
 		case <-ch:
 			if err := callback(); err != nil {
-				return err
+				return fmt.Errorf("failed to execute cache update callback for key %q: %w", key, err)
 			}
 		}
 	}

--- a/util/cache/twolevelclient.go
+++ b/util/cache/twolevelclient.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -55,14 +56,17 @@ func (c *twoLevelClient) Get(key string, obj any) error {
 	if err == nil {
 		_ = c.inMemoryCache.Set(&Item{Key: key, Object: obj})
 	}
-	return err
+	if err != nil {
+		return fmt.Errorf("failed to get key %q from external cache: %w", key, err)
+	}
+	return nil
 }
 
 // Delete deletes cache for given key in both in-memory and external cache.
 func (c *twoLevelClient) Delete(key string) error {
 	err := c.inMemoryCache.Delete(key)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to delete key %q from in-memory cache: %w", key, err)
 	}
 	return c.externalCache.Delete(key)
 }


### PR DESCRIPTION
## Summary

Wrap bare `return err` statements with `fmt.Errorf` to provide additional context for debugging in `util/cache/`.

- **`redis.go`**: 3 error returns wrapped (gzip reader, marshal, get, update callback)
- **`twolevelclient.go`**: 2 error returns wrapped (external cache get, in-memory delete)
- **`inmemory.go`**: 1 error return wrapped (gob encode)
- **`appstate/cache.go`**: 6 error returns wrapped (managed resources, resource tree shards, cluster info)

Intentionally left unwrapped: Redis hook pass-throughs in `redis.go` (metrics hook) and `redis_hook.go` (reconnect hook) — these implement go-redis hook interfaces that require transparent error forwarding.

Fixes part of #10592

## Example

```go
// Before
return err

// After
return fmt.Errorf("failed to get resources tree shard %d for app %q: %w", i, appName, err)
```

## Test plan
- [ ] All existing tests pass — error wrapping with `%w` preserves `errors.Is`/`errors.As` behavior
- [ ] No new functionality added; only error messages enhanced