### PR TITLE
fix: ignore PostDelete hooks from live resources in sync status

### DIFF
--- a/controller/state.go
+++ b/controller/state.go
@@ -794,6 +794,16 @@ func (m *appStateManager) CompareAppState(app *v1alpha1.Application, project *v1
 	}
 	targetObjsForSync, hasPreDeleteHooks, hasPostDeleteHooks := partitionTargetObjsForSync(targetObjs)
 
+	// Remove PostDelete hooks from live objects map before reconciliation. PostDelete hooks are only executed during
+	// application deletion and should not be considered during normal sync status calculation. Any live resource
+	// that matches a PostDelete hook in the manifest should be ignored, as these hooks are never expected to exist
+	// during normal application operation. Fixes #21579.
+	for key, obj := range liveObjByKey {
+		if isPostDeleteHook(obj) {
+			delete(liveObjByKey, key)
+		}
+	}
+
 	reconciliation := sync.Reconcile(targetObjsForSync, liveObjByKey, app.Spec.Destination.Namespace, infoProvider)
 	ts.AddCheckpoint("live_ms")
 


### PR DESCRIPTION
PostDelete hooks are only executed during application deletion and
should not be considered during normal sync status calculation.

Previously, when an unrelated live resource existed with the same name
as a PostDelete hook, Argo CD would incorrectly mark the application as
OutOfSync because it treated the live resource as an orphaned resource
that should be pruned.

This fix removes PostDelete hooks from the live resources map exactly
like they are already removed from the target resources list before
reconciliation.

Fixes #21579