### PR TITLE
fix(ui): prevent pie chart clipping on single-slice data (#27239)

### DIFF
--- a/ui/src/app/applications/components/applications-list/applications-list.scss
+++ b/ui/src/app/applications/components/applications-list/applications-list.scss
@@ -206,6 +206,10 @@
 
     .chart {
         justify-content: space-evenly;
+
+        svg {
+            overflow: visible;
+        }
     }
 }
 i.menu_icon {


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an enhancement proposal and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] Does this PR require documentation updates? No.
* [x] I have signed off all my commits as required by DCO.

## Description

The summary pie chart appears slightly clipped when only one slice has a non-zero value.

**Root cause**: `react-svg-piechart` renders a single-slice chart as an `<ellipse>` with `cx=cy=50`, `rx=ry=50`, and `strokeWidth=1` inside a `viewBox="0 0 100 100"`. The stroke extends 0.5px beyond the viewBox boundary, causing SVG clipping. Multi-slice charts use arc paths that don't hit the exact boundary, so they aren't affected.

**Fix**: Add `overflow: visible` to the chart SVG so the stroke renders fully. This is a one-line CSS change scoped to `.chart svg`.

Fixes #27239