### PR TITLE
fix(cli): allow ARGOCD_OPTS to accept multiple identical parameters

### DIFF
--- a/util/config/env.go
+++ b/util/config/env.go
@@ -11,7 +11,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var flags map[string]string
+var flags map[string][]string
 
 func init() {
 	err := LoadFlags()
@@ -21,7 +21,7 @@ func init() {
 }
 
 func LoadFlags() error {
-	flags = make(map[string]string)
+	flags = make(map[string][]string)
 
 	opts, err := shellquote.Split(os.Getenv("ARGOCD_OPTS"))
 	if err != nil {
@@ -33,37 +33,34 @@ func LoadFlags() error {
 		switch {
 		case strings.HasPrefix(opt, "--"):
 			if key != "" {
-				flags[key] = "true"
+				flags[key] = append(flags[key], "true")
 			}
 			key = strings.TrimPrefix(opt, "--")
+			// pkg shellquota doesn't recognize `=` so that the opts in format `foo=bar` could not work.
+			// issue ref: https://github.com/argoproj/argo-cd/issues/6822
+			if strings.Contains(key, "=") {
+				kv := strings.SplitN(key, "=", 2)
+				actualKey, actualValue := kv[0], kv[1]
+				flags[actualKey] = append(flags[actualKey], actualValue)
+				key = ""
+			}
 		case key != "":
-			flags[key] = opt
+			flags[key] = append(flags[key], opt)
 			key = ""
 		default:
 			return errors.New("ARGOCD_OPTS invalid at '" + opt + "'")
 		}
 	}
 	if key != "" {
-		flags[key] = "true"
-	}
-	// pkg shellquota doesn't recognize `=` so that the opts in format `foo=bar` could not work.
-	// issue ref: https://github.com/argoproj/argo-cd/issues/6822
-	for k, v := range flags {
-		if strings.Contains(k, "=") && v == "true" {
-			kv := strings.SplitN(k, "=", 2)
-			actualKey, actualValue := kv[0], kv[1]
-			if _, ok := flags[actualKey]; !ok {
-				flags[actualKey] = actualValue
-			}
-		}
+		flags[key] = append(flags[key], "true")
 	}
 	return nil
 }
 
 func GetFlag(key, fallback string) string {
 	val, ok := flags[key]
-	if ok {
-		return val
+	if ok && len(val) > 0 {
+		return val[len(val)-1]
 	}
 	return fallback
 }
@@ -74,11 +71,11 @@ func GetBoolFlag(key string) bool {
 
 func GetIntFlag(key string, fallback int) int {
 	val, ok := flags[key]
-	if !ok {
+	if !ok || len(val) == 0 {
 		return fallback
 	}
 
-	v, err := strconv.Atoi(val)
+	v, err := strconv.Atoi(val[len(val)-1])
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -86,19 +83,26 @@ func GetIntFlag(key string, fallback int) int {
 }
 
 func GetStringSliceFlag(key string, fallback []string) []string {
-	val, ok := flags[key]
+	vals, ok := flags[key]
 	if !ok {
 		return fallback
 	}
 
-	if val == "" {
+	var result []string
+	for _, val := range vals {
+		if val == "" {
+			continue
+		}
+		stringReader := strings.NewReader(val)
+		csvReader := csv.NewReader(stringReader)
+		v, err := csvReader.Read()
+		if err != nil {
+			log.Fatal(err)
+		}
+		result = append(result, v...)
+	}
+	if len(result) == 0 && len(vals) > 0 && vals[len(vals)-1] == "" {
 		return []string{}
 	}
-	stringReader := strings.NewReader(val)
-	csvReader := csv.NewReader(stringReader)
-	v, err := csvReader.Read()
-	if err != nil {
-		log.Fatal(err)
-	}
-	return v
+	return result
 }

--- a/util/config/env.go
+++ b/util/config/env.go
@@ -59,7 +59,7 @@ func LoadFlags() error {
 
 func GetFlag(key, fallback string) string {
 	val, ok := flags[key]
-	if ok && len(val) > 0 {
+	if ok {
 		return val[len(val)-1]
 	}
 	return fallback
@@ -71,7 +71,7 @@ func GetBoolFlag(key string) bool {
 
 func GetIntFlag(key string, fallback int) int {
 	val, ok := flags[key]
-	if !ok || len(val) == 0 {
+	if !ok {
 		return fallback
 	}
 
@@ -101,7 +101,7 @@ func GetStringSliceFlag(key string, fallback []string) []string {
 		}
 		result = append(result, v...)
 	}
-	if len(result) == 0 && len(vals) > 0 && vals[len(vals)-1] == "" {
+	if len(result) == 0 && vals[len(vals)-1] == "" {
 		return []string{}
 	}
 	return result

--- a/util/config/env_test.go
+++ b/util/config/env_test.go
@@ -113,6 +113,26 @@ func TestStringSliceFlagAtEnd(t *testing.T) {
 	assert.Equal(t, "Strict-Transport-Security: max-age=31536000", strings[0])
 }
 
+func TestMultipleStringSliceFlag(t *testing.T) {
+	loadOpts(t, "--header='CF-Access-Client-Id: foo' --header='CF-Access-Client-Secret: bar' --header 'And-Another: baz'")
+	strings := GetStringSliceFlag("header", []string{})
+
+	assert.Len(t, strings, 3)
+	assert.Equal(t, "CF-Access-Client-Id: foo", strings[0])
+	assert.Equal(t, "CF-Access-Client-Secret: bar", strings[1])
+	assert.Equal(t, "And-Another: baz", strings[2])
+}
+
+func TestMultipleStringSliceFlagWithEquals(t *testing.T) {
+	loadOpts(t, "--header='CF-Access-Client-Id: foo' --header='CF-Access-Client-Secret: bar' --header='And-Another: baz'")
+	strings := GetStringSliceFlag("header", []string{})
+
+	assert.Len(t, strings, 3)
+	assert.Equal(t, "CF-Access-Client-Id: foo", strings[0])
+	assert.Equal(t, "CF-Access-Client-Secret: bar", strings[1])
+	assert.Equal(t, "And-Another: baz", strings[2])
+}
+
 func TestFlagAtStart(t *testing.T) {
 	loadOpts(t, "--foo bar")
 

--- a/util/config/env_test.go
+++ b/util/config/env_test.go
@@ -146,7 +146,7 @@ func TestStringSliceFlagWithOnlyEmptyValue(t *testing.T) {
 	loadOpts(t, "--header=''")
 	strings := GetStringSliceFlag("header", []string{"fallback"})
 
-	assert.Len(t, strings, 0)
+	assert.Empty(t, strings)
 }
 
 func TestFlagAtStart(t *testing.T) {

--- a/util/config/env_test.go
+++ b/util/config/env_test.go
@@ -133,6 +133,22 @@ func TestMultipleStringSliceFlagWithEquals(t *testing.T) {
 	assert.Equal(t, "And-Another: baz", strings[2])
 }
 
+func TestMultipleStringSliceFlagWithEmptyValue(t *testing.T) {
+	loadOpts(t, "--header='foo' --header='' --header='bar'")
+	strings := GetStringSliceFlag("header", []string{})
+
+	assert.Len(t, strings, 2)
+	assert.Equal(t, "foo", strings[0])
+	assert.Equal(t, "bar", strings[1])
+}
+
+func TestStringSliceFlagWithOnlyEmptyValue(t *testing.T) {
+	loadOpts(t, "--header=''")
+	strings := GetStringSliceFlag("header", []string{"fallback"})
+
+	assert.Len(t, strings, 0)
+}
+
 func TestFlagAtStart(t *testing.T) {
 	loadOpts(t, "--foo bar")
 


### PR DESCRIPTION
fix(cli): allow ARGOCD_OPTS to accept multiple identical parameters (#24065)

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->

Fixes #24065

**What this PR solves:**
When setting `ARGOCD_OPTS` via the environment to pass multiple identical parameters like `--header`, the CLI would only process the final occurrence because the internal options parser utilized a flat `map[string]string` dictionary that indiscriminately overwrote existing keys. This broke API communication attempting to apply multiple `CF-Access-Client` authentication headers.

**What this PR changes:**
- Changed the `flags` variable inside `util/config/env.go` from `map[string]string` to `map[string][]string` to natively accumulate parameters passed multiple times without losing tracking data.
- Rewrote the `=` parsing block logic natively inside the main loop iteration resolving long-standing bugs with parsing `--key=val` attributes.
- Updated `GetStringSliceFlag` to proactively loop and map across all occurrences in the slice safely instead of strictly indexing.
- Implemented `GetFlag` and `GetIntFlag` adjustments properly ensuring last-argument priority when searching for non-slice standard terminal flags, mimicking POSIX UNIX CLI flag protocol. 
- Added `TestMultipleStringSliceFlag` and `TestMultipleStringSliceFlagWithEquals` to `util/config/env_test.go` confirming safe slice manipulation across duplicates.
