### PR TITLE
feat: support Azure AD groups claims overflow via Microsoft Graph API

### DIFF
--- a/docs/operator-manual/user-management/microsoft.md
+++ b/docs/operator-manual/user-management/microsoft.md
@@ -124,6 +124,85 @@
 
    Refer to [operator-manual/argocd-rbac-cm.yaml](https://github.com/argoproj/argo-cd/blob/master/docs/operator-manual/argocd-rbac-cm.yaml) for all of the available variables.
 
+## Azure AD Groups Overflow Resolution (200+ Groups)
+
+### Overview
+
+Azure AD / Entra ID access tokens can contain a maximum of 200 groups. When a user belongs to more
+than 200 groups, Azure AD sets overflow indicators (`_claim_names` and `_claim_sources`) in the ID
+token instead of including the `groups` claim. This causes users to have no group-based RBAC
+permissions in Argo CD.
+
+Argo CD can automatically detect this overflow and resolve it by calling the Microsoft Graph API to
+fetch the complete list of group memberships.
+
+### Prerequisites
+
+1. The Azure AD app registration must have the **User.Read** delegated permission. This is granted by
+   default when following the [Setup permissions](#setup-permissions-for-entra-id-application) steps
+   above. Azure AD automatically includes approved permissions in the access token's `scp` claim
+   without needing to explicitly request them in `requestedScopes`.
+
+### Configuration
+
+Add the following to your `argocd-cm` ConfigMap under `oidc.config`:
+
+```yaml
+oidc.config: |
+  name: Azure
+  issuer: https://login.microsoftonline.com/{tenant_id}/v2.0
+  clientID: {client_id}
+  clientSecret: $oidc.azure.clientSecret
+  requestedScopes:
+    - openid
+    - profile
+    - email
+  azure:
+    enableUserGroupOverageClaim: true
+```
+
+### Configuration Options
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `enableUserGroupOverageClaim` | `false` | Enable automatic overflow resolution via Graph API |
+| `graphApiEndpoint` | `https://graph.microsoft.com/v1.0` | Graph API base URL (override for sovereign clouds) |
+| `userGroupOverageClaimCacheExpiration` | Token expiry | Cache duration for resolved groups (e.g., `10m`) |
+
+#### Sovereign Clouds
+
+For Azure Government, Azure China, or other sovereign clouds, override the Graph API endpoint:
+
+```yaml
+azure:
+  enableUserGroupOverageClaim: true
+  graphApiEndpoint: https://graph.microsoft.us/v1.0  # Azure Government
+```
+
+### How It Works
+
+1. **Detection**: Argo CD checks the ID token for overflow indicators (`_claim_names` and
+   `_claim_sources`).
+2. **Scope Check**: Verifies the access token contains the `User.Read` scope.
+3. **Graph API Call**: Calls `POST /me/getMemberGroups` to fetch all group IDs (up to 2048).
+4. **Caching**: Encrypts and caches the resolved groups for the duration of the token or a
+   configured expiration.
+5. **RBAC Integration**: The resolved group IDs are added to the user's claims for RBAC evaluation.
+
+### Troubleshooting
+
+| Symptom | Cause | Solution |
+|---------|-------|----------|
+| User still has 0 groups despite 200+ memberships | Feature not enabled | Set `enableUserGroupOverageClaim: true` |
+| Logs show "access token missing User.Read scope" | Missing permission | Verify the **User.Read** delegated permission is granted on the app registration in Azure AD |
+| Logs show "insufficient permissions for Graph API" | App permission denied | Verify app permissions in Azure AD |
+| Logs show "no access token cached" | Token expired | User must re-authenticate |
+
+> [!WARNING]
+> Graph API failures (missing scope, permission denied, network errors) will cause authentication
+> to fail with a 401 Unauthorized response. This is consistent with how the UserInfo endpoint
+> behaves. Ensure the prerequisites above are met to avoid authentication issues.
+
 ## Entra ID SAML Enterprise App Auth using Dex
 ### Configure a new Entra ID Enterprise App
 

--- a/docs/operator-manual/user-management/microsoft.md
+++ b/docs/operator-manual/user-management/microsoft.md
@@ -185,6 +185,8 @@ azure:
    `_claim_sources`).
 2. **Scope Check**: Verifies the access token contains the `User.Read` scope.
 3. **Graph API Call**: Calls `POST /me/getMemberGroups` to fetch all group IDs (up to 2048).
+   Only security-enabled groups are returned (not distribution lists), which is appropriate
+   for RBAC evaluation.
 4. **Caching**: Encrypts and caches the resolved groups for the duration of the token or a
    configured expiration.
 5. **RBAC Integration**: The resolved group IDs are added to the user's claims for RBAC evaluation.
@@ -199,9 +201,15 @@ azure:
 | Logs show "no access token cached" | Token expired | User must re-authenticate |
 
 > [!WARNING]
+> This feature depends on the Microsoft Graph API being reachable at authentication time. If the
+> Graph API is unavailable (network issues, outage, etc.), users with 200+ group memberships will
+> be unable to authenticate until service is restored. Users with fewer than 200 groups are
+> unaffected since their groups are included directly in the ID token.
+>
 > Graph API failures (missing scope, permission denied, network errors) will cause authentication
 > to fail with a 401 Unauthorized response. This is consistent with how the UserInfo endpoint
-> behaves. Ensure the prerequisites above are met to avoid authentication issues.
+> behaves. Only enable this feature if you need group-based RBAC for users with 200+ groups, and
+> ensure the prerequisites above are met to avoid authentication issues.
 
 ## Entra ID SAML Enterprise App Auth using Dex
 ### Configure a new Entra ID Enterprise App

--- a/server/server.go
+++ b/server/server.go
@@ -1578,7 +1578,7 @@ func (server *ArgoCDServer) getClaims(ctx context.Context) (jwt.Claims, string, 
 	finalClaims := claims
 	oidcConfig := server.settings.OIDCConfig()
 	if oidcConfig != nil || server.settings.IsDexConfigured() {
-		updatedClaims, err := server.ssoClientApp.SetGroupsFromUserInfo(ctx, claims, util_session.SessionManagerClaimsIssuer)
+		updatedClaims, err := server.ssoClientApp.SetGroupsClaimFromEndpoint(ctx, claims, util_session.SessionManagerClaimsIssuer)
 		if err != nil {
 			return claims, "", status.Errorf(codes.Unauthenticated, "invalid session: %v", err)
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -1574,7 +1574,7 @@ func (server *ArgoCDServer) getClaims(ctx context.Context) (jwt.Claims, string, 
 	finalClaims := claims
 	oidcConfig := server.settings.OIDCConfig()
 	if oidcConfig != nil || server.settings.IsDexConfigured() {
-		updatedClaims, err := server.ssoClientApp.SetGroupsFromUserInfo(ctx, claims, util_session.SessionManagerClaimsIssuer)
+		updatedClaims, err := server.ssoClientApp.SetGroupsClaimFromEndpoint(ctx, claims, util_session.SessionManagerClaimsIssuer)
 		if err != nil {
 			return claims, "", status.Errorf(codes.Unauthenticated, "invalid session: %v", err)
 		}

--- a/util/oidc/oidc.go
+++ b/util/oidc/oidc.go
@@ -580,6 +580,11 @@ func (a *ClientApp) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	}
 	// save the accessToken in memory for later use
 	sub := jwtutil.StringField(claims, "sub")
+
+	// Invalidate cached groups from previous sessions so a fresh login picks up updated memberships
+	_ = a.clientCache.Delete(FormatUserInfoResponseCacheKey(sub))
+	_ = a.clientCache.Delete(FormatAzureGroupsOverageResponseCacheKey(sub))
+
 	err = a.SetValueInEncryptedCache(ctx, FormatAccessTokenCacheKey(sub), []byte(token.AccessToken), GetTokenExpiration(claims))
 	if err != nil {
 		claimsJSON, _ := json.Marshal(claims)
@@ -881,12 +886,14 @@ func createClaimsAuthenticationRequestParameter(requestedClaims map[string]*oidc
 	return oauth2.SetAuthURLParam("claims", string(claimsRequestRAW)), nil
 }
 
-// SetGroupsFromUserInfo takes a claims object and adds groups claim from userinfo endpoint if available
-// This is required by some SSO implementations as they don't provide the groups claim in the ID token
-// If querying the UserInfo endpoint fails, we return an error to indicate the session is invalid
-// we assume that everywhere in argocd jwt.MapClaims is used as type for interface jwt.Claims
-// otherwise this would cause a panic
-func (a *ClientApp) SetGroupsFromUserInfo(ctx context.Context, claims jwt.Claims, sessionManagerClaimsIssuer string) (jwt.MapClaims, error) {
+// SetGroupsClaimFromEndpoint takes a claims object and adds groups claim from either:
+// - the UserInfo endpoint if enabled
+// - the Microsoft Graph API if Azure groups overage claim is detected and enabled
+// This is required by some SSO implementations as they don't provide the groups claim in the ID token.
+// If querying the endpoint fails, we return an error to indicate the session is invalid.
+// We assume that everywhere in argocd jwt.MapClaims is used as type for interface jwt.Claims
+// otherwise this would cause a panic.
+func (a *ClientApp) SetGroupsClaimFromEndpoint(ctx context.Context, claims jwt.Claims, sessionManagerClaimsIssuer string) (jwt.MapClaims, error) {
 	var groupClaims jwt.MapClaims
 	var ok bool
 	if groupClaims, ok = claims.(jwt.MapClaims); !ok {
@@ -896,19 +903,36 @@ func (a *ClientApp) SetGroupsFromUserInfo(ctx context.Context, claims jwt.Claims
 			}
 		}
 	}
+
 	iss := jwtutil.StringField(groupClaims, "iss")
-	if iss != sessionManagerClaimsIssuer && a.settings.UserInfoGroupsEnabled() && a.settings.UserInfoPath() != "" {
-		userInfo, unauthorized, err := a.GetUserInfo(ctx, groupClaims, a.settings.IssuerURL(), a.settings.UserInfoPath())
-		if unauthorized {
-			return groupClaims, fmt.Errorf("error while quering userinfo endpoint: %w", err)
+	if iss != sessionManagerClaimsIssuer {
+		// Path 1: UserInfo endpoint
+		if a.settings.UserInfoGroupsEnabled() && a.settings.UserInfoPath() != "" {
+			userInfo, unauthorized, err := a.GetUserInfo(ctx, groupClaims, a.settings.IssuerURL(), a.settings.UserInfoPath())
+			if unauthorized {
+				return groupClaims, fmt.Errorf("error while querying userinfo endpoint: %w", err)
+			}
+			if err != nil {
+				return groupClaims, fmt.Errorf("error fetching user info endpoint: %w", err)
+			}
+			if groupClaims["sub"] != userInfo["sub"] {
+				return groupClaims, errors.New("subject of claims from user info endpoint didn't match subject of idToken, see https://openid.net/specs/openid-connect-core-1_0.html#UserInfo")
+			}
+			groupClaims["groups"] = userInfo["groups"]
+			return groupClaims, nil
 		}
-		if err != nil {
-			return groupClaims, fmt.Errorf("error fetching user info endpoint: %w", err)
+
+		// Path 2: Azure AD groups overage claim resolution via Microsoft Graph API
+		if a.settings.AzureUserGroupOverageClaimEnabled() && a.settings.AzureGraphAPIEndpoint() != "" {
+			groups, err := a.GetUserGroupsFromAzureOverageClaim(ctx, groupClaims, a.settings.AzureGraphAPIEndpoint())
+			if err != nil {
+				return groupClaims, fmt.Errorf("error fetching groups from Azure overage claim: %w", err)
+			}
+			if len(groups) > 0 {
+				groupClaims["groups"] = groups
+			}
+			return groupClaims, nil
 		}
-		if groupClaims["sub"] != userInfo["sub"] {
-			return groupClaims, errors.New("subject of claims from user info endpoint didn't match subject of idToken, see https://openid.net/specs/openid-connect-core-1_0.html#UserInfo")
-		}
-		groupClaims["groups"] = userInfo["groups"]
 	}
 
 	return groupClaims, nil

--- a/util/oidc/oidc.go
+++ b/util/oidc/oidc.go
@@ -582,8 +582,12 @@ func (a *ClientApp) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	sub := jwtutil.StringField(claims, "sub")
 
 	// Invalidate cached groups from previous sessions so a fresh login picks up updated memberships
-	_ = a.clientCache.Delete(FormatUserInfoResponseCacheKey(sub))
-	_ = a.clientCache.Delete(FormatAzureGroupsOverageResponseCacheKey(sub))
+	if err := a.clientCache.Delete(FormatUserInfoResponseCacheKey(sub)); err != nil {
+		log.Warnf("failed to invalidate UserInfo cache for %s: %v", sub, err)
+	}
+	if err := a.clientCache.Delete(FormatAzureGroupsOverageResponseCacheKey(sub)); err != nil {
+		log.Warnf("failed to invalidate Azure groups overage cache for %s: %v", sub, err)
+	}
 
 	err = a.SetValueInEncryptedCache(ctx, FormatAccessTokenCacheKey(sub), []byte(token.AccessToken), GetTokenExpiration(claims))
 	if err != nil {

--- a/util/oidc/oidc.go
+++ b/util/oidc/oidc.go
@@ -580,6 +580,11 @@ func (a *ClientApp) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	}
 	// save the accessToken in memory for later use
 	sub := jwtutil.StringField(claims, "sub")
+
+	// Invalidate cached groups from previous sessions so a fresh login picks up updated memberships
+	_ = a.clientCache.Delete(FormatUserInfoResponseCacheKey(sub))
+	_ = a.clientCache.Delete(FormatAzureGroupsOverageResponseCacheKey(sub))
+
 	err = a.SetValueInEncryptedCache(ctx, FormatAccessTokenCacheKey(sub), []byte(token.AccessToken), GetTokenExpiration(claims))
 	if err != nil {
 		claimsJSON, _ := json.Marshal(claims)
@@ -882,12 +887,14 @@ func createClaimsAuthenticationRequestParameter(requestedClaims map[string]*oidc
 	return oauth2.SetAuthURLParam("claims", string(claimsRequestRAW)), nil
 }
 
-// SetGroupsFromUserInfo takes a claims object and adds groups claim from userinfo endpoint if available
-// This is required by some SSO implementations as they don't provide the groups claim in the ID token
-// If querying the UserInfo endpoint fails, we return an error to indicate the session is invalid
-// we assume that everywhere in argocd jwt.MapClaims is used as type for interface jwt.Claims
-// otherwise this would cause a panic
-func (a *ClientApp) SetGroupsFromUserInfo(ctx context.Context, claims jwt.Claims, sessionManagerClaimsIssuer string) (jwt.MapClaims, error) {
+// SetGroupsClaimFromEndpoint takes a claims object and adds groups claim from either:
+// - the UserInfo endpoint if enabled
+// - the Microsoft Graph API if Azure groups overage claim is detected and enabled
+// This is required by some SSO implementations as they don't provide the groups claim in the ID token.
+// If querying the endpoint fails, we return an error to indicate the session is invalid.
+// We assume that everywhere in argocd jwt.MapClaims is used as type for interface jwt.Claims
+// otherwise this would cause a panic.
+func (a *ClientApp) SetGroupsClaimFromEndpoint(ctx context.Context, claims jwt.Claims, sessionManagerClaimsIssuer string) (jwt.MapClaims, error) {
 	var groupClaims jwt.MapClaims
 	var ok bool
 	if groupClaims, ok = claims.(jwt.MapClaims); !ok {
@@ -897,19 +904,37 @@ func (a *ClientApp) SetGroupsFromUserInfo(ctx context.Context, claims jwt.Claims
 			}
 		}
 	}
+
 	iss := jwtutil.StringField(groupClaims, "iss")
-	if iss != sessionManagerClaimsIssuer && a.settings.UserInfoGroupsEnabled() && a.settings.UserInfoPath() != "" {
-		userInfo, unauthorized, err := a.GetUserInfo(ctx, groupClaims, a.settings.IssuerURL(), a.settings.UserInfoBaseURL(), a.settings.UserInfoPath())
-		if unauthorized {
-			return groupClaims, fmt.Errorf("error while quering userinfo endpoint: %w", err)
+	if iss != sessionManagerClaimsIssuer {
+		// Path 1: UserInfo endpoint — mutually exclusive with Path 2 (Azure overage).
+		// For Entra ID, UserInfo returns the same data as the ID token, so both are never needed.
+		if a.settings.UserInfoGroupsEnabled() && a.settings.UserInfoPath() != "" {
+			userInfo, unauthorized, err := a.GetUserInfo(ctx, groupClaims, a.settings.IssuerURL(), a.settings.UserInfoBaseURL(), a.settings.UserInfoPath())
+			if unauthorized {
+				return groupClaims, fmt.Errorf("error while querying userinfo endpoint: %w", err)
+			}
+			if err != nil {
+				return groupClaims, fmt.Errorf("error fetching user info endpoint: %w", err)
+			}
+			if groupClaims["sub"] != userInfo["sub"] {
+				return groupClaims, errors.New("subject of claims from user info endpoint didn't match subject of idToken, see https://openid.net/specs/openid-connect-core-1_0.html#UserInfo")
+			}
+			groupClaims["groups"] = userInfo["groups"]
+			return groupClaims, nil
 		}
-		if err != nil {
-			return groupClaims, fmt.Errorf("error fetching user info endpoint: %w", err)
+
+		// Path 2: Azure AD groups overage claim resolution via Microsoft Graph API
+		if a.settings.AzureUserGroupOverageClaimEnabled() && a.settings.AzureGraphAPIEndpoint() != "" {
+			groups, err := a.GetUserGroupsFromAzureOverageClaim(ctx, groupClaims, a.settings.AzureGraphAPIEndpoint())
+			if err != nil {
+				return groupClaims, fmt.Errorf("error fetching groups from Azure overage claim: %w", err)
+			}
+			if len(groups) > 0 {
+				groupClaims["groups"] = groups
+			}
+			return groupClaims, nil
 		}
-		if groupClaims["sub"] != userInfo["sub"] {
-			return groupClaims, errors.New("subject of claims from user info endpoint didn't match subject of idToken, see https://openid.net/specs/openid-connect-core-1_0.html#UserInfo")
-		}
-		groupClaims["groups"] = userInfo["groups"]
 	}
 
 	return groupClaims, nil

--- a/util/oidc/oidc_azure.go
+++ b/util/oidc/oidc_azure.go
@@ -1,0 +1,225 @@
+package oidc
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/argoproj/argo-cd/v3/util/cache"
+	"github.com/argoproj/argo-cd/v3/util/crypto"
+	jwtutil "github.com/argoproj/argo-cd/v3/util/jwt"
+)
+
+const (
+	// AzureGroupsOverageResponseCachePrefix is the cache key prefix for Azure AD groups overage responses.
+	AzureGroupsOverageResponseCachePrefix = "azure_groups_overage_response"
+
+	// requiredGraphScope is the OAuth2 scope needed to call the Microsoft Graph API for group membership.
+	requiredGraphScope = "User.Read"
+
+	// memberGroupsEndpoint is the Graph API endpoint that returns group IDs for the signed-in user.
+	memberGroupsEndpoint = "/me/getMemberGroups"
+)
+
+// GetUserGroupsFromAzureOverageClaim detects the Azure AD groups overage claim and, when present,
+// fetches the user's group memberships from the Microsoft Graph API. Results are encrypted and cached.
+// Returns nil groups (not an error) when no overage is detected.
+func (a *ClientApp) GetUserGroupsFromAzureOverageClaim(ctx context.Context, groupClaims jwt.MapClaims, graphAPIURL string) ([]string, error) {
+	sub := jwtutil.StringField(groupClaims, "sub")
+
+	if !hasAzureGroupsClaimOverflow(groupClaims) {
+		log.Debugf("Azure AD groups overage claim not detected for user %s", sub)
+		return nil, nil
+	}
+
+	log.Infof("Azure AD groups overage claim detected for user %s, resolving via Graph API", sub)
+
+	// Check cache first
+	clientCacheKey := FormatAzureGroupsOverageResponseCacheKey(sub)
+	cachedGroupsBytes, err := a.GetValueFromEncryptedCache(ctx, clientCacheKey)
+	if err != nil {
+		log.Warnf("failed to read Azure groups overage cache for %s: %v", sub, err)
+	}
+	if cachedGroupsBytes != nil {
+		var groups []string
+		if err := json.Unmarshal(cachedGroupsBytes, &groups); err == nil {
+			return groups, nil
+		}
+		log.Errorf("cannot unmarshal cached Azure groups for %s: %v", sub, err)
+	}
+
+	// Get access token from cache
+	accessTokenBytes, err := a.GetValueFromEncryptedCache(ctx, FormatAccessTokenCacheKey(sub))
+	if err != nil {
+		return nil, fmt.Errorf("could not read access token from cache for %s: %w", sub, err)
+	}
+	if accessTokenBytes == nil {
+		return nil, fmt.Errorf("no access token cached for %s, user must re-authenticate", sub)
+	}
+
+	accessTokenStr := string(accessTokenBytes)
+	if !hasUserReadScope(accessTokenStr) {
+		return nil, errors.New("access token missing User.Read scope; ensure the User.Read delegated permission is granted on the app registration in Azure AD")
+	}
+
+	graphURL := strings.TrimSuffix(graphAPIURL, "/") + memberGroupsEndpoint
+	groups, err := a.fetchGroupsFromGraphAPI(ctx, accessTokenStr, graphURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch groups from Graph API for %s: %w", sub, err)
+	}
+
+	log.Infof("Successfully resolved %d groups for user %s via Graph API", len(groups), sub)
+
+	// Cache the result
+	a.cacheAzureGroupsOverageResponse(clientCacheKey, groups, groupClaims)
+
+	return groups, nil
+}
+
+// cacheAzureGroupsOverageResponse encrypts and caches the resolved groups.
+func (a *ClientApp) cacheAzureGroupsOverageResponse(cacheKey string, groups []string, claims jwt.MapClaims) {
+	rawGroups, err := json.Marshal(groups)
+	if err != nil {
+		log.Errorf("could not marshal groups to json for caching: %v", err)
+		return
+	}
+	encGroups, err := crypto.Encrypt(rawGroups, a.encryptionKey)
+	if err != nil {
+		log.Errorf("could not encrypt groups for caching: %v", err)
+		return
+	}
+
+	var cacheExpiry time.Duration
+	tokenExpiry := GetTokenExpiration(claims)
+	settingExpiry := a.settings.AzureUserGroupOverageClaimCacheExpiration()
+	if settingExpiry > 0 && settingExpiry < tokenExpiry {
+		cacheExpiry = settingExpiry
+	} else {
+		cacheExpiry = tokenExpiry
+	}
+
+	if err := a.clientCache.Set(&cache.Item{
+		Key:    cacheKey,
+		Object: encGroups,
+		CacheActionOpts: cache.CacheActionOpts{
+			Expiration: cacheExpiry,
+		},
+	}); err != nil {
+		log.Errorf("could not cache Azure groups overage response: %v", err)
+	}
+}
+
+// fetchGroupsFromGraphAPI calls Microsoft Graph API POST /me/getMemberGroups to retrieve group IDs.
+// securityEnabledOnly is set to true to return only security groups (not distribution lists),
+// which is appropriate for RBAC evaluation.
+func (a *ClientApp) fetchGroupsFromGraphAPI(ctx context.Context, accessToken, graphURL string) ([]string, error) {
+	requestBody := map[string]bool{
+		"securityEnabledOnly": true,
+	}
+	bodyBytes, err := json.Marshal(requestBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request body: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, graphURL, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Graph API request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("graph API request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var response struct {
+			Value []string `json:"value"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+			return nil, fmt.Errorf("failed to decode Graph API response: %w", err)
+		}
+		return response.Value, nil
+
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return nil, fmt.Errorf("insufficient permissions for Graph API (status %d)", resp.StatusCode)
+
+	case http.StatusTooManyRequests:
+		return nil, fmt.Errorf("graph API rate limited (status %d)", resp.StatusCode)
+
+	default:
+		return nil, fmt.Errorf("graph API request failed with status %d", resp.StatusCode)
+	}
+}
+
+// hasAzureGroupsClaimOverflow checks if the ID token contains Azure AD groups overage indicators.
+// Azure AD sets _claim_names and _claim_sources when the user has more than 200 group memberships.
+func hasAzureGroupsClaimOverflow(claims jwt.MapClaims) bool {
+	claimSources, hasClaimSources := claims["_claim_sources"]
+	claimNames, hasClaimNames := claims["_claim_names"]
+
+	if !hasClaimSources || !hasClaimNames || claimSources == nil || claimNames == nil {
+		return false
+	}
+
+	claimNamesMap, ok := claimNames.(map[string]any)
+	if !ok {
+		return false
+	}
+
+	_, hasGroups := claimNamesMap["groups"]
+	return hasGroups
+}
+
+// hasUserReadScope checks if the access token contains the User.Read scope needed for Graph API calls.
+// The access token is parsed without verification since we only need to inspect the scp claim.
+func hasUserReadScope(accessToken string) bool {
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	claims := jwt.MapClaims{}
+
+	_, _, err := parser.ParseUnverified(accessToken, &claims)
+	if err != nil {
+		log.Warnf("Failed to parse access token for scope check: %v", err)
+		return false
+	}
+
+	scpRaw, exists := claims["scp"]
+	if !exists {
+		return false
+	}
+
+	switch scp := scpRaw.(type) {
+	case string:
+		for scope := range strings.FieldsSeq(scp) {
+			if strings.EqualFold(scope, requiredGraphScope) {
+				return true
+			}
+		}
+	case []any:
+		for _, scopeInterface := range scp {
+			if scopeStr, ok := scopeInterface.(string); ok {
+				if strings.EqualFold(scopeStr, requiredGraphScope) {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+// FormatAzureGroupsOverageResponseCacheKey returns the cache key for storing Azure AD groups overage responses.
+func FormatAzureGroupsOverageResponseCacheKey(sub string) string {
+	return fmt.Sprintf("%s_%s", AzureGroupsOverageResponseCachePrefix, sub)
+}

--- a/util/oidc/oidc_azure.go
+++ b/util/oidc/oidc_azure.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -84,7 +85,8 @@ func (a *ClientApp) GetUserGroupsFromAzureOverageClaim(ctx context.Context, grou
 	return groups, nil
 }
 
-// cacheAzureGroupsOverageResponse encrypts and caches the resolved groups.
+// cacheAzureGroupsOverageResponse encrypts and caches the resolved groups. Errors are logged
+// but not returned because the groups were already fetched successfully; caching is best-effort.
 func (a *ClientApp) cacheAzureGroupsOverageResponse(cacheKey string, groups []string, claims jwt.MapClaims) {
 	rawGroups, err := json.Marshal(groups)
 	if err != nil {
@@ -152,14 +154,9 @@ func (a *ClientApp) fetchGroupsFromGraphAPI(ctx context.Context, accessToken, gr
 		}
 		return response.Value, nil
 
-	case http.StatusUnauthorized, http.StatusForbidden:
-		return nil, fmt.Errorf("insufficient permissions for Graph API (status %d)", resp.StatusCode)
-
-	case http.StatusTooManyRequests:
-		return nil, fmt.Errorf("graph API rate limited (status %d)", resp.StatusCode)
-
 	default:
-		return nil, fmt.Errorf("graph API request failed with status %d", resp.StatusCode)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("graph API request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 }
 

--- a/util/oidc/oidc_azure_test.go
+++ b/util/oidc/oidc_azure_test.go
@@ -1,0 +1,309 @@
+package oidc
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/argoproj/argo-cd/v3/util"
+	"github.com/argoproj/argo-cd/v3/util/cache"
+	"github.com/argoproj/argo-cd/v3/util/crypto"
+	"github.com/argoproj/argo-cd/v3/util/settings"
+)
+
+func createTestJWT(t *testing.T, claims jwt.MapClaims) string {
+	t.Helper()
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenString, err := token.SignedString([]byte("test-secret"))
+	require.NoError(t, err)
+	return tokenString
+}
+
+func TestHasAzureGroupsClaimOverflow(t *testing.T) {
+	tests := []struct {
+		name     string
+		claims   jwt.MapClaims
+		expected bool
+	}{
+		{
+			name: "no overage indicators",
+			claims: jwt.MapClaims{
+				"sub": "user123",
+			},
+			expected: false,
+		},
+		{
+			name: "with overage claim",
+			claims: jwt.MapClaims{
+				"sub": "user123",
+				"_claim_sources": map[string]any{
+					"src1": map[string]any{
+						"endpoint": "https://graph.windows.net/tenant-id/users/user-id/getMemberObjects",
+					},
+				},
+				"_claim_names": map[string]any{
+					"groups": "src1",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "with _claim_names but no groups key",
+			claims: jwt.MapClaims{
+				"sub": "user123",
+				"_claim_sources": map[string]any{
+					"src1": map[string]any{},
+				},
+				"_claim_names": map[string]any{
+					"roles": "src1",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "with _claim_names but missing _claim_sources",
+			claims: jwt.MapClaims{
+				"sub": "user123",
+				"_claim_names": map[string]any{
+					"groups": "src1",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "with nil _claim_names",
+			claims: jwt.MapClaims{
+				"sub":            "user123",
+				"_claim_names":   nil,
+				"_claim_sources": map[string]any{},
+			},
+			expected: false,
+		},
+		{
+			name: "with multiple overage keys including groups",
+			claims: jwt.MapClaims{
+				"sub": "user123",
+				"_claim_sources": map[string]any{
+					"src1": map[string]any{},
+					"src2": map[string]any{},
+				},
+				"_claim_names": map[string]any{
+					"groups": "src1",
+					"roles":  "src2",
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasAzureGroupsClaimOverflow(tt.claims)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestHasUserReadScope(t *testing.T) {
+	tests := []struct {
+		name        string
+		accessToken string
+		expected    bool
+	}{
+		{
+			name:        "valid token with User.Read scope",
+			accessToken: createTestJWT(t, jwt.MapClaims{"scp": "User.Read profile email"}),
+			expected:    true,
+		},
+		{
+			name:        "valid token without User.Read scope",
+			accessToken: createTestJWT(t, jwt.MapClaims{"scp": "profile email"}),
+			expected:    false,
+		},
+		{
+			name:        "case insensitive User.Read",
+			accessToken: createTestJWT(t, jwt.MapClaims{"scp": "user.read profile"}),
+			expected:    true,
+		},
+		{
+			name:        "token without scp claim",
+			accessToken: createTestJWT(t, jwt.MapClaims{"sub": "user123"}),
+			expected:    false,
+		},
+		{
+			name:        "invalid token",
+			accessToken: "invalid.jwt.token",
+			expected:    false,
+		},
+		{
+			name:        "User.Read in array format",
+			accessToken: createTestJWT(t, jwt.MapClaims{"scp": []string{"User.Read", "profile"}}),
+			expected:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasUserReadScope(tt.accessToken)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetUserGroupsFromAzureOverageClaim(t *testing.T) {
+	overageClaims := jwt.MapClaims{
+		"sub": "user123",
+		"exp": float64(time.Now().Add(5 * time.Minute).Unix()),
+		"_claim_sources": map[string]any{
+			"src1": map[string]any{
+				"endpoint": "https://graph.windows.net/tenant-id/users/user-id/getMemberObjects",
+			},
+		},
+		"_claim_names": map[string]any{
+			"groups": "src1",
+		},
+	}
+
+	tests := []struct {
+		name           string
+		claims         jwt.MapClaims
+		idpHandler     func(w http.ResponseWriter, r *http.Request)
+		cacheItems     map[string]string // key -> value to pre-populate (will be encrypted)
+		expectedGroups []string
+		expectError    bool
+	}{
+		{
+			name:   "no overage claim returns nil",
+			claims: jwt.MapClaims{"sub": "user123", "exp": float64(time.Now().Add(5 * time.Minute).Unix())},
+			idpHandler: func(_ http.ResponseWriter, _ *http.Request) {
+				t.Fatal("Graph API should not be called when no overage claim")
+			},
+			expectedGroups: nil,
+			expectError:    false,
+		},
+		{
+			name:   "successful Graph API call",
+			claims: overageClaims,
+			idpHandler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				err := json.NewEncoder(w).Encode(map[string]any{
+					"value": []string{"group-id-1", "group-id-2"},
+				})
+				require.NoError(t, err)
+			},
+			cacheItems: map[string]string{
+				FormatAccessTokenCacheKey("user123"): createTestJWT(t, jwt.MapClaims{"scp": "User.Read profile email"}),
+			},
+			expectedGroups: []string{"group-id-1", "group-id-2"},
+			expectError:    false,
+		},
+		{
+			name:   "no access token in cache",
+			claims: overageClaims,
+			idpHandler: func(_ http.ResponseWriter, _ *http.Request) {
+				t.Fatal("Graph API should not be called without access token")
+			},
+			cacheItems:     nil,
+			expectedGroups: nil,
+			expectError:    true,
+		},
+		{
+			name:   "access token missing User.Read scope",
+			claims: overageClaims,
+			idpHandler: func(_ http.ResponseWriter, _ *http.Request) {
+				t.Fatal("Graph API should not be called without User.Read scope")
+			},
+			cacheItems: map[string]string{
+				FormatAccessTokenCacheKey("user123"): createTestJWT(t, jwt.MapClaims{"scp": "profile email"}),
+			},
+			expectedGroups: nil,
+			expectError:    true,
+		},
+		{
+			name:   "Graph API returns error",
+			claims: overageClaims,
+			idpHandler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusForbidden)
+			},
+			cacheItems: map[string]string{
+				FormatAccessTokenCacheKey("user123"): createTestJWT(t, jwt.MapClaims{"scp": "User.Read profile email"}),
+			},
+			expectedGroups: nil,
+			expectError:    true,
+		},
+		{
+			name:   "Graph API rate limited",
+			claims: overageClaims,
+			idpHandler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusTooManyRequests)
+			},
+			cacheItems: map[string]string{
+				FormatAccessTokenCacheKey("user123"): createTestJWT(t, jwt.MapClaims{"scp": "User.Read profile email"}),
+			},
+			expectedGroups: nil,
+			expectError:    true,
+		},
+		{
+			name:   "cached groups returned without Graph API call",
+			claims: overageClaims,
+			idpHandler: func(_ http.ResponseWriter, _ *http.Request) {
+				t.Fatal("Graph API should not be called when groups are cached")
+			},
+			cacheItems: map[string]string{
+				FormatAccessTokenCacheKey("user123"):                createTestJWT(t, jwt.MapClaims{"scp": "User.Read profile email"}),
+				FormatAzureGroupsOverageResponseCacheKey("user123"): `["cached-group-1","cached-group-2"]`,
+			},
+			expectedGroups: []string{"cached-group-1", "cached-group-2"},
+			expectError:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(tt.idpHandler))
+			defer ts.Close()
+
+			signature, err := util.MakeSignature(32)
+			require.NoError(t, err)
+			cdSettings := &settings.ArgoCDSettings{
+				ServerSignature: signature,
+				OIDCConfigRAW:   `{"azure": {"enableUserGroupOverageClaim": true}}`,
+			}
+			encryptionKey, err := cdSettings.GetServerEncryptionKey()
+			require.NoError(t, err)
+
+			testCache := cache.NewInMemoryCache(24 * time.Hour)
+			a, err := NewClientApp(cdSettings, "", nil, "/argo-cd", testCache)
+			require.NoError(t, err)
+
+			for key, value := range tt.cacheItems {
+				encValue, err := crypto.Encrypt([]byte(value), encryptionKey)
+				require.NoError(t, err)
+				err = a.clientCache.Set(&cache.Item{
+					Key:    key,
+					Object: encValue,
+				})
+				require.NoError(t, err)
+			}
+
+			groups, err := a.GetUserGroupsFromAzureOverageClaim(t.Context(), tt.claims, ts.URL)
+			assert.Equal(t, tt.expectedGroups, groups)
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestFormatAzureGroupsOverageResponseCacheKey(t *testing.T) {
+	key := FormatAzureGroupsOverageResponseCacheKey("user123")
+	assert.Equal(t, "azure_groups_overage_response_user123", key)
+}

--- a/util/oidc/oidc_azure_test.go
+++ b/util/oidc/oidc_azure_test.go
@@ -307,3 +307,211 @@ func TestFormatAzureGroupsOverageResponseCacheKey(t *testing.T) {
 	key := FormatAzureGroupsOverageResponseCacheKey("user123")
 	assert.Equal(t, "azure_groups_overage_response_user123", key)
 }
+
+func TestCacheAzureGroupsOverageResponse(t *testing.T) {
+	overageClaims := jwt.MapClaims{
+		"sub": "user123",
+		"exp": float64(time.Now().Add(5 * time.Minute).Unix()),
+		"_claim_sources": map[string]any{
+			"src1": map[string]any{},
+		},
+		"_claim_names": map[string]any{
+			"groups": "src1",
+		},
+	}
+
+	t.Run("successful cache write is readable", func(t *testing.T) {
+		signature, err := util.MakeSignature(32)
+		require.NoError(t, err)
+		cdSettings := &settings.ArgoCDSettings{
+			ServerSignature: signature,
+			OIDCConfigRAW:   `{"azure": {"enableUserGroupOverageClaim": true}}`,
+		}
+		encryptionKey, err := cdSettings.GetServerEncryptionKey()
+		require.NoError(t, err)
+
+		testCache := cache.NewInMemoryCache(24 * time.Hour)
+		a, err := NewClientApp(cdSettings, "", nil, "/argo-cd", testCache)
+		require.NoError(t, err)
+
+		groups := []string{"group-1", "group-2"}
+		cacheKey := FormatAzureGroupsOverageResponseCacheKey("user123")
+		a.cacheAzureGroupsOverageResponse(cacheKey, groups, overageClaims)
+
+		var encValue []byte
+		err = testCache.Get(cacheKey, &encValue)
+		require.NoError(t, err)
+
+		decrypted, err := crypto.Decrypt(encValue, encryptionKey)
+		require.NoError(t, err)
+
+		var got []string
+		err = json.Unmarshal(decrypted, &got)
+		require.NoError(t, err)
+		assert.Equal(t, groups, got)
+	})
+
+	t.Run("cache uses token expiry when no custom setting", func(t *testing.T) {
+		signature, err := util.MakeSignature(32)
+		require.NoError(t, err)
+		cdSettings := &settings.ArgoCDSettings{
+			ServerSignature: signature,
+			OIDCConfigRAW:   `{"azure": {"enableUserGroupOverageClaim": true}}`,
+		}
+
+		testCache := cache.NewInMemoryCache(24 * time.Hour)
+		a, err := NewClientApp(cdSettings, "", nil, "/argo-cd", testCache)
+		require.NoError(t, err)
+
+		groups := []string{"group-a"}
+		cacheKey := FormatAzureGroupsOverageResponseCacheKey("user123")
+		// No custom expiry configured — must fall back to token expiry without panic.
+		a.cacheAzureGroupsOverageResponse(cacheKey, groups, overageClaims)
+
+		var encValue []byte
+		err = testCache.Get(cacheKey, &encValue)
+		require.NoError(t, err)
+		assert.NotEmpty(t, encValue)
+	})
+
+	t.Run("cache uses custom expiry when shorter than token expiry", func(t *testing.T) {
+		signature, err := util.MakeSignature(32)
+		require.NoError(t, err)
+		// Set a custom expiry of 1 minute, shorter than the 5-minute token expiry.
+		cdSettings := &settings.ArgoCDSettings{
+			ServerSignature: signature,
+			OIDCConfigRAW:   `{"azure": {"enableUserGroupOverageClaim": true, "userGroupOverageClaimCacheExpiration": "1m"}}`,
+		}
+
+		testCache := cache.NewInMemoryCache(24 * time.Hour)
+		a, err := NewClientApp(cdSettings, "", nil, "/argo-cd", testCache)
+		require.NoError(t, err)
+
+		groups := []string{"group-b"}
+		cacheKey := FormatAzureGroupsOverageResponseCacheKey("user123")
+		a.cacheAzureGroupsOverageResponse(cacheKey, groups, overageClaims)
+
+		var encValue []byte
+		err = testCache.Get(cacheKey, &encValue)
+		require.NoError(t, err)
+		assert.NotEmpty(t, encValue)
+	})
+}
+
+func TestGetUserGroupsFromAzureOverageClaim_CacheHitAfterFetch(t *testing.T) {
+	overageClaims := jwt.MapClaims{
+		"sub": "user123",
+		"exp": float64(time.Now().Add(5 * time.Minute).Unix()),
+		"_claim_sources": map[string]any{
+			"src1": map[string]any{
+				"endpoint": "https://graph.windows.net/tenant-id/users/user-id/getMemberObjects",
+			},
+		},
+		"_claim_names": map[string]any{
+			"groups": "src1",
+		},
+	}
+
+	graphCallCount := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		graphCallCount++
+		w.Header().Set("Content-Type", "application/json")
+		err := json.NewEncoder(w).Encode(map[string]any{
+			"value": []string{"group-id-1", "group-id-2"},
+		})
+		require.NoError(t, err)
+	}))
+	defer ts.Close()
+
+	signature, err := util.MakeSignature(32)
+	require.NoError(t, err)
+	cdSettings := &settings.ArgoCDSettings{
+		ServerSignature: signature,
+		OIDCConfigRAW:   `{"azure": {"enableUserGroupOverageClaim": true}}`,
+	}
+	encryptionKey, err := cdSettings.GetServerEncryptionKey()
+	require.NoError(t, err)
+
+	testCache := cache.NewInMemoryCache(24 * time.Hour)
+	a, err := NewClientApp(cdSettings, "", nil, "/argo-cd", testCache)
+	require.NoError(t, err)
+
+	accessToken := createTestJWT(t, jwt.MapClaims{"scp": "User.Read profile email"})
+	encAccessToken, err := crypto.Encrypt([]byte(accessToken), encryptionKey)
+	require.NoError(t, err)
+	err = testCache.Set(&cache.Item{Key: FormatAccessTokenCacheKey("user123"), Object: encAccessToken})
+	require.NoError(t, err)
+
+	// First call — should hit the Graph API.
+	groups, err := a.GetUserGroupsFromAzureOverageClaim(t.Context(), overageClaims, ts.URL)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"group-id-1", "group-id-2"}, groups)
+	assert.Equal(t, 1, graphCallCount)
+
+	// Second call — groups should come from cache; Graph API must not be called again.
+	groups, err = a.GetUserGroupsFromAzureOverageClaim(t.Context(), overageClaims, ts.URL)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"group-id-1", "group-id-2"}, groups)
+	assert.Equal(t, 1, graphCallCount, "Graph API should only be called once; second call must use cache")
+}
+
+func TestGetUserGroupsFromAzureOverageClaim_CorruptCacheCallsAPI(t *testing.T) {
+	overageClaims := jwt.MapClaims{
+		"sub": "user123",
+		"exp": float64(time.Now().Add(5 * time.Minute).Unix()),
+		"_claim_sources": map[string]any{
+			"src1": map[string]any{
+				"endpoint": "https://graph.windows.net/tenant-id/users/user-id/getMemberObjects",
+			},
+		},
+		"_claim_names": map[string]any{
+			"groups": "src1",
+		},
+	}
+
+	graphCallCount := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		graphCallCount++
+		w.Header().Set("Content-Type", "application/json")
+		err := json.NewEncoder(w).Encode(map[string]any{
+			"value": []string{"group-from-api"},
+		})
+		require.NoError(t, err)
+	}))
+	defer ts.Close()
+
+	signature, err := util.MakeSignature(32)
+	require.NoError(t, err)
+	cdSettings := &settings.ArgoCDSettings{
+		ServerSignature: signature,
+		OIDCConfigRAW:   `{"azure": {"enableUserGroupOverageClaim": true}}`,
+	}
+	encryptionKey, err := cdSettings.GetServerEncryptionKey()
+	require.NoError(t, err)
+
+	testCache := cache.NewInMemoryCache(24 * time.Hour)
+	a, err := NewClientApp(cdSettings, "", nil, "/argo-cd", testCache)
+	require.NoError(t, err)
+
+	// Populate cache with corrupt (non-JSON) data that is still validly encrypted.
+	corruptData, err := crypto.Encrypt([]byte("not valid json"), encryptionKey)
+	require.NoError(t, err)
+	err = testCache.Set(&cache.Item{
+		Key:    FormatAzureGroupsOverageResponseCacheKey("user123"),
+		Object: corruptData,
+	})
+	require.NoError(t, err)
+
+	// Populate the access token cache so the Graph API call can proceed.
+	accessToken := createTestJWT(t, jwt.MapClaims{"scp": "User.Read profile email"})
+	encAccessToken, err := crypto.Encrypt([]byte(accessToken), encryptionKey)
+	require.NoError(t, err)
+	err = testCache.Set(&cache.Item{Key: FormatAccessTokenCacheKey("user123"), Object: encAccessToken})
+	require.NoError(t, err)
+
+	// Corrupt cache should be skipped and the Graph API called as fallback.
+	groups, err := a.GetUserGroupsFromAzureOverageClaim(t.Context(), overageClaims, ts.URL)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"group-from-api"}, groups)
+	assert.Equal(t, 1, graphCallCount, "Graph API should be called when cached data is corrupt")
+}

--- a/util/oidc/oidc_test.go
+++ b/util/oidc/oidc_test.go
@@ -1269,7 +1269,7 @@ func TestGetUserInfo(t *testing.T) {
 	}
 }
 
-func TestSetGroupsFromUserInfo(t *testing.T) {
+func TestSetGroupsClaimFromEndpoint(t *testing.T) {
 	tests := []struct {
 		name           string
 		inputClaims    jwt.MapClaims // function input
@@ -1323,7 +1323,7 @@ userInfoPath: /`,
 			a, err := NewClientApp(cdSettings, "", nil, "/argo-cd", userInfoCache)
 			require.NoError(t, err, "failed creating clientapp")
 
-			// prepoluate cache to predict what the GetUserInfo function will return to the SetGroupsFromUserInfo function (without having to mock the userinfo response)
+			// prepoluate cache to predict what the GetUserInfo function will return to the SetGroupsClaimFromEndpoint function (without having to mock the userinfo response)
 			encryptionKey, err := cdSettings.GetServerEncryptionKey()
 			require.NoError(t, err, "failed obtaining encryption key from settings")
 
@@ -1349,7 +1349,7 @@ userInfoPath: /`,
 				require.NoError(t, err, "failed setting item to in-memory cache")
 			}
 
-			receivedClaims, err := a.SetGroupsFromUserInfo(t.Context(), tt.inputClaims, "argocd")
+			receivedClaims, err := a.SetGroupsClaimFromEndpoint(t.Context(), tt.inputClaims, "argocd")
 			if tt.expectError {
 				require.Error(t, err)
 			} else {

--- a/util/oidc/oidc_test.go
+++ b/util/oidc/oidc_test.go
@@ -1336,7 +1336,7 @@ func TestGetUserInfo(t *testing.T) {
 	}
 }
 
-func TestSetGroupsFromUserInfo(t *testing.T) {
+func TestSetGroupsClaimFromEndpoint(t *testing.T) {
 	tests := []struct {
 		name           string
 		inputClaims    jwt.MapClaims // function input
@@ -1390,7 +1390,7 @@ userInfoPath: /`,
 			a, err := NewClientApp(cdSettings, "", nil, "/argo-cd", userInfoCache)
 			require.NoError(t, err, "failed creating clientapp")
 
-			// prepoluate cache to predict what the GetUserInfo function will return to the SetGroupsFromUserInfo function (without having to mock the userinfo response)
+			// prepoluate cache to predict what the GetUserInfo function will return to the SetGroupsClaimFromEndpoint function (without having to mock the userinfo response)
 			encryptionKey, err := cdSettings.GetServerEncryptionKey()
 			require.NoError(t, err, "failed obtaining encryption key from settings")
 
@@ -1416,7 +1416,7 @@ userInfoPath: /`,
 				require.NoError(t, err, "failed setting item to in-memory cache")
 			}
 
-			receivedClaims, err := a.SetGroupsFromUserInfo(t.Context(), tt.inputClaims, "argocd")
+			receivedClaims, err := a.SetGroupsClaimFromEndpoint(t.Context(), tt.inputClaims, "argocd")
 			if tt.expectError {
 				require.Error(t, err)
 			} else {

--- a/util/session/sessionmanager.go
+++ b/util/session/sessionmanager.go
@@ -535,7 +535,7 @@ func WithAuthMiddleware(disabled bool, isSSOConfigured bool, ssoClientApp *oidcu
 
 		finalClaims := claims
 		if isSSOConfigured {
-			finalClaims, err = ssoClientApp.SetGroupsFromUserInfo(ctx, claims, SessionManagerClaimsIssuer)
+			finalClaims, err = ssoClientApp.SetGroupsClaimFromEndpoint(ctx, claims, SessionManagerClaimsIssuer)
 			if err != nil {
 				http.Error(w, "Invalid session", http.StatusUnauthorized)
 				return

--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -221,7 +221,10 @@ type OIDCConfig struct {
 }
 
 type AzureOIDCConfig struct {
-	UseWorkloadIdentity bool `json:"useWorkloadIdentity,omitempty"`
+	UseWorkloadIdentity                  bool   `json:"useWorkloadIdentity,omitempty"`
+	EnableUserGroupOverageClaim          bool   `json:"enableUserGroupOverageClaim,omitempty"`
+	GraphAPIEndpoint                     string `json:"graphApiEndpoint,omitempty"`
+	UserGroupOverageClaimCacheExpiration string `json:"userGroupOverageClaimCacheExpiration,omitempty"`
 }
 
 var (
@@ -2085,6 +2088,42 @@ func (a *ArgoCDSettings) UseAzureWorkloadIdentity() bool {
 		return oidcConfig.Azure.UseWorkloadIdentity
 	}
 	return false
+}
+
+// AzureUserGroupOverageClaimEnabled returns whether group claims should be fetched from the Microsoft Graph API
+// when Azure AD returns a groups overage claim (user has 200+ group memberships).
+// See https://learn.microsoft.com/en-us/entra/identity-platform/access-token-claims-reference#groups-overage-claim
+func (a *ArgoCDSettings) AzureUserGroupOverageClaimEnabled() bool {
+	if oidcConfig := a.OIDCConfig(); oidcConfig != nil && oidcConfig.Azure != nil {
+		return oidcConfig.Azure.EnableUserGroupOverageClaim
+	}
+	return false
+}
+
+// AzureGraphAPIEndpoint returns the Microsoft Graph API endpoint URL.
+// Defaults to https://graph.microsoft.com/v1.0 for public cloud.
+// Can be overridden for sovereign clouds (e.g., https://graph.microsoft.us/v1.0).
+func (a *ArgoCDSettings) AzureGraphAPIEndpoint() string {
+	if oidcConfig := a.OIDCConfig(); oidcConfig != nil && oidcConfig.Azure != nil {
+		if oidcConfig.Azure.GraphAPIEndpoint != "" {
+			return oidcConfig.Azure.GraphAPIEndpoint
+		}
+		return "https://graph.microsoft.com/v1.0"
+	}
+	return ""
+}
+
+// AzureUserGroupOverageClaimCacheExpiration returns the cache duration for Azure groups overage claim results.
+func (a *ArgoCDSettings) AzureUserGroupOverageClaimCacheExpiration() time.Duration {
+	if oidcConfig := a.OIDCConfig(); oidcConfig != nil && oidcConfig.Azure != nil && oidcConfig.Azure.UserGroupOverageClaimCacheExpiration != "" {
+		cacheExpiration, err := time.ParseDuration(oidcConfig.Azure.UserGroupOverageClaimCacheExpiration)
+		if err != nil {
+			log.Warnf("Failed to parse 'oidc.config.azure.userGroupOverageClaimCacheExpiration' key: %v", err)
+			return 0
+		}
+		return cacheExpiration
+	}
+	return 0
 }
 
 // OIDCTLSConfig returns the TLS config for the OIDC provider. If an external provider is configured, returns a TLS

--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -223,7 +223,10 @@ type OIDCConfig struct {
 }
 
 type AzureOIDCConfig struct {
-	UseWorkloadIdentity bool `json:"useWorkloadIdentity,omitempty"`
+	UseWorkloadIdentity                  bool   `json:"useWorkloadIdentity,omitempty"`
+	EnableUserGroupOverageClaim          bool   `json:"enableUserGroupOverageClaim,omitempty"`
+	GraphAPIEndpoint                     string `json:"graphApiEndpoint,omitempty"`
+	UserGroupOverageClaimCacheExpiration string `json:"userGroupOverageClaimCacheExpiration,omitempty"`
 }
 
 var (
@@ -2111,6 +2114,42 @@ func (a *ArgoCDSettings) UseAzureWorkloadIdentity() bool {
 		return oidcConfig.Azure.UseWorkloadIdentity
 	}
 	return false
+}
+
+// AzureUserGroupOverageClaimEnabled returns whether group claims should be fetched from the Microsoft Graph API
+// when Azure AD returns a groups overage claim (user has 200+ group memberships).
+// See https://learn.microsoft.com/en-us/entra/identity-platform/access-token-claims-reference#groups-overage-claim
+func (a *ArgoCDSettings) AzureUserGroupOverageClaimEnabled() bool {
+	if oidcConfig := a.OIDCConfig(); oidcConfig != nil && oidcConfig.Azure != nil {
+		return oidcConfig.Azure.EnableUserGroupOverageClaim
+	}
+	return false
+}
+
+// AzureGraphAPIEndpoint returns the Microsoft Graph API endpoint URL.
+// Defaults to https://graph.microsoft.com/v1.0 for public cloud.
+// Can be overridden for sovereign clouds (e.g., https://graph.microsoft.us/v1.0).
+func (a *ArgoCDSettings) AzureGraphAPIEndpoint() string {
+	if oidcConfig := a.OIDCConfig(); oidcConfig != nil && oidcConfig.Azure != nil {
+		if oidcConfig.Azure.GraphAPIEndpoint != "" {
+			return oidcConfig.Azure.GraphAPIEndpoint
+		}
+		return "https://graph.microsoft.com/v1.0"
+	}
+	return ""
+}
+
+// AzureUserGroupOverageClaimCacheExpiration returns the cache duration for Azure groups overage claim results.
+func (a *ArgoCDSettings) AzureUserGroupOverageClaimCacheExpiration() time.Duration {
+	if oidcConfig := a.OIDCConfig(); oidcConfig != nil && oidcConfig.Azure != nil && oidcConfig.Azure.UserGroupOverageClaimCacheExpiration != "" {
+		cacheExpiration, err := time.ParseDuration(oidcConfig.Azure.UserGroupOverageClaimCacheExpiration)
+		if err != nil {
+			log.Warnf("Failed to parse 'oidc.config.azure.userGroupOverageClaimCacheExpiration' key: %v", err)
+			return 0
+		}
+		return cacheExpiration
+	}
+	return 0
 }
 
 // OIDCTLSConfig returns the TLS config for the OIDC provider. If an external provider is configured, returns a TLS

--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -1965,7 +1965,15 @@ func ValidateOIDCConfig(configStr string) error {
 		return err
 	}
 	err = ValidateExternalURL(settings.UserInfoBaseURL)
-	return err
+	if err != nil {
+		return err
+	}
+	if settings.Azure != nil && settings.Azure.GraphAPIEndpoint != "" {
+		if err := ValidateAzureGraphAPIEndpoint(settings.Azure.GraphAPIEndpoint); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // TLSConfig returns a tls.Config with the configured certificates
@@ -2126,15 +2134,46 @@ func (a *ArgoCDSettings) AzureUserGroupOverageClaimEnabled() bool {
 	return false
 }
 
+// knownGraphAPIHosts is the set of trusted Microsoft Graph API hostnames across all clouds.
+var knownGraphAPIHosts = map[string]bool{
+	"graph.microsoft.com":             true, // public cloud
+	"graph.microsoft.us":              true, // US Government
+	"graph.microsoft.de":              true, // Germany (legacy)
+	"microsoftgraph.chinacloudapi.cn": true, // China
+}
+
+const defaultGraphAPIEndpoint = "https://graph.microsoft.com/v1.0"
+
+// ValidateAzureGraphAPIEndpoint returns an error if endpoint is not a trusted Microsoft Graph API URL.
+// A valid endpoint must use the https scheme and a known Microsoft Graph hostname.
+func ValidateAzureGraphAPIEndpoint(endpoint string) error {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return fmt.Errorf("invalid graphApiEndpoint URL %q: %w", endpoint, err)
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("graphApiEndpoint %q must use https", endpoint)
+	}
+	if !knownGraphAPIHosts[u.Hostname()] {
+		return fmt.Errorf("graphApiEndpoint %q hostname is not a known Microsoft Graph API host", endpoint)
+	}
+	return nil
+}
+
 // AzureGraphAPIEndpoint returns the Microsoft Graph API endpoint URL.
 // Defaults to https://graph.microsoft.com/v1.0 for public cloud.
 // Can be overridden for sovereign clouds (e.g., https://graph.microsoft.us/v1.0).
+// Returns empty string if the configured endpoint fails validation, which disables the overage feature.
 func (a *ArgoCDSettings) AzureGraphAPIEndpoint() string {
 	if oidcConfig := a.OIDCConfig(); oidcConfig != nil && oidcConfig.Azure != nil {
 		if oidcConfig.Azure.GraphAPIEndpoint != "" {
+			if err := ValidateAzureGraphAPIEndpoint(oidcConfig.Azure.GraphAPIEndpoint); err != nil {
+				log.Warnf("Invalid graphApiEndpoint, Azure groups overage feature disabled: %v", err)
+				return ""
+			}
 			return oidcConfig.Azure.GraphAPIEndpoint
 		}
-		return "https://graph.microsoft.com/v1.0"
+		return defaultGraphAPIEndpoint
 	}
 	return ""
 }

--- a/util/settings/settings_test.go
+++ b/util/settings/settings_test.go
@@ -2130,6 +2130,139 @@ func TestUseAzureWorkloadIdentity(t *testing.T) {
 	}
 }
 
+func TestAzureUserGroupOverageClaimEnabled(t *testing.T) {
+	testCases := []struct {
+		Name           string
+		Settings       *ArgoCDSettings
+		ExpectedResult bool
+	}{
+		{
+			Name: "enabled and set to true",
+			Settings: &ArgoCDSettings{
+				OIDCConfigRAW: `{"azure": {"enableUserGroupOverageClaim": true}}`,
+			},
+			ExpectedResult: true,
+		},
+		{
+			Name: "enabled and set to false",
+			Settings: &ArgoCDSettings{
+				OIDCConfigRAW: `{"azure": {"enableUserGroupOverageClaim": false}}`,
+			},
+			ExpectedResult: false,
+		},
+		{
+			Name: "not defined with azure key present",
+			Settings: &ArgoCDSettings{
+				OIDCConfigRAW: `{"azure": {}}`,
+			},
+			ExpectedResult: false,
+		},
+		{
+			Name: "not defined",
+			Settings: &ArgoCDSettings{
+				OIDCConfigRAW: `{}`,
+			},
+			ExpectedResult: false,
+		},
+		{
+			Name:           "OIDC config not defined",
+			Settings:       &ArgoCDSettings{},
+			ExpectedResult: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			result := tc.Settings.AzureUserGroupOverageClaimEnabled()
+			require.Equal(t, tc.ExpectedResult, result)
+		})
+	}
+}
+
+func TestAzureGraphAPIEndpoint(t *testing.T) {
+	testCases := []struct {
+		Name           string
+		Settings       *ArgoCDSettings
+		ExpectedResult string
+	}{
+		{
+			Name: "default endpoint when azure section present",
+			Settings: &ArgoCDSettings{
+				OIDCConfigRAW: `{"azure": {}}`,
+			},
+			ExpectedResult: "https://graph.microsoft.com/v1.0",
+		},
+		{
+			Name: "custom endpoint for sovereign cloud",
+			Settings: &ArgoCDSettings{
+				OIDCConfigRAW: `{"azure": {"graphApiEndpoint": "https://graph.microsoft.us/v1.0"}}`,
+			},
+			ExpectedResult: "https://graph.microsoft.us/v1.0",
+		},
+		{
+			Name: "empty string when no azure section",
+			Settings: &ArgoCDSettings{
+				OIDCConfigRAW: `{}`,
+			},
+			ExpectedResult: "",
+		},
+		{
+			Name:           "empty string when no OIDC config",
+			Settings:       &ArgoCDSettings{},
+			ExpectedResult: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			result := tc.Settings.AzureGraphAPIEndpoint()
+			require.Equal(t, tc.ExpectedResult, result)
+		})
+	}
+}
+
+func TestAzureUserGroupOverageClaimCacheExpiration(t *testing.T) {
+	testCases := []struct {
+		Name           string
+		Settings       *ArgoCDSettings
+		ExpectedResult time.Duration
+	}{
+		{
+			Name: "valid duration",
+			Settings: &ArgoCDSettings{
+				OIDCConfigRAW: `{"azure": {"userGroupOverageClaimCacheExpiration": "10m"}}`,
+			},
+			ExpectedResult: 10 * time.Minute,
+		},
+		{
+			Name: "not configured",
+			Settings: &ArgoCDSettings{
+				OIDCConfigRAW: `{"azure": {}}`,
+			},
+			ExpectedResult: 0,
+		},
+		{
+			Name: "invalid duration returns 0",
+			Settings: &ArgoCDSettings{
+				OIDCConfigRAW: `{"azure": {"userGroupOverageClaimCacheExpiration": "invalid"}}`,
+			},
+			ExpectedResult: 0,
+		},
+		{
+			Name:           "no OIDC config",
+			Settings:       &ArgoCDSettings{},
+			ExpectedResult: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			result := tc.Settings.AzureUserGroupOverageClaimCacheExpiration()
+			require.Equal(t, tc.ExpectedResult, result)
+		})
+	}
+}
+
 func TestIsImpersonationEnabled(t *testing.T) {
 	// When there is no argocd-cm itself,
 	// Then IsImpersonationEnabled() must return false (default value) and an error with appropriate error message.

--- a/util/settings/settings_test.go
+++ b/util/settings/settings_test.go
@@ -2172,6 +2172,139 @@ func TestUseAzureWorkloadIdentity(t *testing.T) {
 	}
 }
 
+func TestAzureUserGroupOverageClaimEnabled(t *testing.T) {
+	testCases := []struct {
+		Name           string
+		Settings       *ArgoCDSettings
+		ExpectedResult bool
+	}{
+		{
+			Name: "enabled and set to true",
+			Settings: &ArgoCDSettings{
+				OIDCConfigRAW: `{"azure": {"enableUserGroupOverageClaim": true}}`,
+			},
+			ExpectedResult: true,
+		},
+		{
+			Name: "enabled and set to false",
+			Settings: &ArgoCDSettings{
+				OIDCConfigRAW: `{"azure": {"enableUserGroupOverageClaim": false}}`,
+			},
+			ExpectedResult: false,
+		},
+		{
+			Name: "not defined with azure key present",
+			Settings: &ArgoCDSettings{
+				OIDCConfigRAW: `{"azure": {}}`,
+			},
+			ExpectedResult: false,
+		},
+		{
+			Name: "not defined",
+			Settings: &ArgoCDSettings{
+				OIDCConfigRAW: `{}`,
+			},
+			ExpectedResult: false,
+		},
+		{
+			Name:           "OIDC config not defined",
+			Settings:       &ArgoCDSettings{},
+			ExpectedResult: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			result := tc.Settings.AzureUserGroupOverageClaimEnabled()
+			require.Equal(t, tc.ExpectedResult, result)
+		})
+	}
+}
+
+func TestAzureGraphAPIEndpoint(t *testing.T) {
+	testCases := []struct {
+		Name           string
+		Settings       *ArgoCDSettings
+		ExpectedResult string
+	}{
+		{
+			Name: "default endpoint when azure section present",
+			Settings: &ArgoCDSettings{
+				OIDCConfigRAW: `{"azure": {}}`,
+			},
+			ExpectedResult: "https://graph.microsoft.com/v1.0",
+		},
+		{
+			Name: "custom endpoint for sovereign cloud",
+			Settings: &ArgoCDSettings{
+				OIDCConfigRAW: `{"azure": {"graphApiEndpoint": "https://graph.microsoft.us/v1.0"}}`,
+			},
+			ExpectedResult: "https://graph.microsoft.us/v1.0",
+		},
+		{
+			Name: "empty string when no azure section",
+			Settings: &ArgoCDSettings{
+				OIDCConfigRAW: `{}`,
+			},
+			ExpectedResult: "",
+		},
+		{
+			Name:           "empty string when no OIDC config",
+			Settings:       &ArgoCDSettings{},
+			ExpectedResult: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			result := tc.Settings.AzureGraphAPIEndpoint()
+			require.Equal(t, tc.ExpectedResult, result)
+		})
+	}
+}
+
+func TestAzureUserGroupOverageClaimCacheExpiration(t *testing.T) {
+	testCases := []struct {
+		Name           string
+		Settings       *ArgoCDSettings
+		ExpectedResult time.Duration
+	}{
+		{
+			Name: "valid duration",
+			Settings: &ArgoCDSettings{
+				OIDCConfigRAW: `{"azure": {"userGroupOverageClaimCacheExpiration": "10m"}}`,
+			},
+			ExpectedResult: 10 * time.Minute,
+		},
+		{
+			Name: "not configured",
+			Settings: &ArgoCDSettings{
+				OIDCConfigRAW: `{"azure": {}}`,
+			},
+			ExpectedResult: 0,
+		},
+		{
+			Name: "invalid duration returns 0",
+			Settings: &ArgoCDSettings{
+				OIDCConfigRAW: `{"azure": {"userGroupOverageClaimCacheExpiration": "invalid"}}`,
+			},
+			ExpectedResult: 0,
+		},
+		{
+			Name:           "no OIDC config",
+			Settings:       &ArgoCDSettings{},
+			ExpectedResult: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			result := tc.Settings.AzureUserGroupOverageClaimCacheExpiration()
+			require.Equal(t, tc.ExpectedResult, result)
+		})
+	}
+}
+
 func TestIsImpersonationEnabled(t *testing.T) {
 	// When there is no argocd-cm itself,
 	// Then IsImpersonationEnabled() must return false (default value) and an error with appropriate error message.

--- a/util/settings/settings_test.go
+++ b/util/settings/settings_test.go
@@ -2242,6 +2242,27 @@ func TestAzureGraphAPIEndpoint(t *testing.T) {
 			ExpectedResult: "https://graph.microsoft.us/v1.0",
 		},
 		{
+			Name: "custom endpoint for China cloud",
+			Settings: &ArgoCDSettings{
+				OIDCConfigRAW: `{"azure": {"graphApiEndpoint": "https://microsoftgraph.chinacloudapi.cn/v1.0"}}`,
+			},
+			ExpectedResult: "https://microsoftgraph.chinacloudapi.cn/v1.0",
+		},
+		{
+			Name: "non-https endpoint returns empty string",
+			Settings: &ArgoCDSettings{
+				OIDCConfigRAW: `{"azure": {"graphApiEndpoint": "http://graph.microsoft.com/v1.0"}}`,
+			},
+			ExpectedResult: "",
+		},
+		{
+			Name: "non-Microsoft hostname returns empty string",
+			Settings: &ArgoCDSettings{
+				OIDCConfigRAW: `{"azure": {"graphApiEndpoint": "https://evil.example.com/v1.0"}}`,
+			},
+			ExpectedResult: "",
+		},
+		{
 			Name: "empty string when no azure section",
 			Settings: &ArgoCDSettings{
 				OIDCConfigRAW: `{}`,


### PR DESCRIPTION
## Context

When Azure AD users belong to 200+ groups, Microsoft omits the groups claim from the ID token and sets overflow indicators (_claim_names and _claim_sources). This leaves users with no group-based RBAC permissions.

This adds opt-in support to detect the overflow and fetch group memberships via the Microsoft Graph API POST /me/getMemberGroups. Results are encrypted and cached. Supports sovereign clouds via configurable graphApiEndpoint.

## Configuration

A new `enableUserGroupOverageClaim` option was enabled to opt-in to the group overage fetching.
Here is a full example:

```yaml
oidc.config: |
  name: Azure AD
  issuer: https://login.microsoftonline.com/<redacted>/v2.0
  clientID: <redacted>
  clientSecret: <redacted>
  azure:
    enableUserGroupOverageClaim: true
  requestedIDTokenClaims:
    groups:
      essential: true
  requestedScopes:
    - openid
    - profile
    - email
```

Closes #7127