### PR TITLE
fix(ui): clarify repository credential templates

### DIFF
--- a/ui/src/app/settings/components/repos-list/repos-list.helpers.test.tsx
+++ b/ui/src/app/settings/components/repos-list/repos-list.helpers.test.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import * as renderer from 'react-test-renderer';
+
+import {CREDENTIALS_COLUMN_LABEL, CREDENTIAL_TEMPLATE_STATUS_LABEL, CredentialTemplateStatus} from './repos-list.helpers';
+
+test('credential column label is expanded', () => {
+    expect(CREDENTIALS_COLUMN_LABEL).toBe('Credentials');
+});
+
+test('CredentialTemplateStatus renders a key icon and clear status text', () => {
+    const root = renderer.create(<CredentialTemplateStatus />).root;
+
+    expect(root.findByType('i').props.className).toContain('fa fa-key');
+    expect(root.findByType('span').children.join('')).toContain(CREDENTIAL_TEMPLATE_STATUS_LABEL);
+});

--- a/ui/src/app/settings/components/repos-list/repos-list.helpers.tsx
+++ b/ui/src/app/settings/components/repos-list/repos-list.helpers.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+
+import {Repo} from '../../../shared/components';
+
+export const CREDENTIALS_COLUMN_LABEL = 'Credentials';
+export const CREDENTIAL_TEMPLATE_STATUS_LABEL = 'Configured';
+
+export const CredentialTemplateUrl = ({url}: {url: string}) => (
+    <div className='repos-list__credential-template-url'>
+        <i className='icon argo-icon-git' />
+        <Repo url={url} />
+    </div>
+);
+
+export const CredentialTemplateStatus = () => (
+    <span className='repos-list__credential-template-status'>
+        <i className='fa fa-key' /> {CREDENTIAL_TEMPLATE_STATUS_LABEL}
+    </span>
+);

--- a/ui/src/app/settings/components/repos-list/repos-list.scss
+++ b/ui/src/app/settings/components/repos-list/repos-list.scss
@@ -2,6 +2,13 @@
 @import 'node_modules/argo-ui/src/styles/theme';
 
 .repos-list {
+    &__credential-template-status,
+    &__credential-template-url {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+    }
+
     &__top-panel {
         padding: 1em;
         & > .columns:first-child {

--- a/ui/src/app/settings/components/repos-list/repos-list.tsx
+++ b/ui/src/app/settings/components/repos-list/repos-list.tsx
@@ -8,6 +8,7 @@ import {CheckboxField, ConnectionStateIcon, DataLoader, EmptyState, ErrorNotific
 import * as models from '../../../shared/models';
 import {services} from '../../../shared/services';
 import {RepoDetails} from '../repo-details/repo-details';
+import {CREDENTIALS_COLUMN_LABEL, CredentialTemplateStatus, CredentialTemplateUrl} from './repos-list.helpers';
 
 require('./repos-list.scss');
 
@@ -986,17 +987,17 @@ export const ReposList = ({match, location}: RouteComponentProps) => {
                                     <div className='argo-table-list__head'>
                                         <div className='row'>
                                             <div className='columns small-9'>CREDENTIALS TEMPLATE URL</div>
-                                            <div className='columns small-3'>CREDS</div>
+                                            <div className='columns small-3'>{CREDENTIALS_COLUMN_LABEL}</div>
                                         </div>
                                     </div>
                                     {creds.map(repo => (
                                         <div className='argo-table-list__row' key={repo.url}>
                                             <div className='row'>
                                                 <div className='columns small-9'>
-                                                    <i className='icon argo-icon-git' /> <Repo url={repo.url} />
+                                                    <CredentialTemplateUrl url={repo.url} />
                                                 </div>
                                                 <div className='columns small-3'>
-                                                    -
+                                                    <CredentialTemplateStatus />
                                                     <DropDownMenu
                                                         anchor={() => (
                                                             <button className='argo-button argo-button--light argo-button--lg argo-button--short'>
@@ -1101,17 +1102,17 @@ export const ReposList = ({match, location}: RouteComponentProps) => {
                                         <div className='argo-table-list__head'>
                                             <div className='row'>
                                                 <div className='columns small-9'>CREDENTIALS TEMPLATE URL</div>
-                                                <div className='columns small-3'>CREDS</div>
+                                                <div className='columns small-3'>{CREDENTIALS_COLUMN_LABEL}</div>
                                             </div>
                                         </div>
                                         {creds.map(repo => (
                                             <div className='argo-table-list__row' key={repo.url}>
                                                 <div className='row'>
                                                     <div className='columns small-9'>
-                                                        <i className='icon argo-icon-git' /> <Repo url={repo.url} />
+                                                        <CredentialTemplateUrl url={repo.url} />
                                                     </div>
                                                     <div className='columns small-3'>
-                                                        -
+                                                        <CredentialTemplateStatus />
                                                         <DropDownMenu
                                                             anchor={() => (
                                                                 <button className='argo-button argo-button--light argo-button--lg argo-button--short'>


### PR DESCRIPTION
## Summary
- replace the abbreviated `CREDS` column label with `Credentials` on the repository credential template tables
- replace the ambiguous `-` placeholder with a key icon plus `Configured`
- add shared UI helpers and a focused test so the credential-template presentation stays consistent in both read and write sections

Closes #12273.

## Validation
- `/Users/nutakki/Library/pnpm/pnpm --dir ui install --frozen-lockfile`
- `/Users/nutakki/Library/pnpm/pnpm --dir ui test -- --runInBand src/app/settings/components/repos-list/repos-list.helpers.test.tsx`
- `/Users/nutakki/Library/pnpm/pnpm --dir ui exec eslint --no-warn-ignored src/app/settings/components/repos-list/repos-list.tsx src/app/settings/components/repos-list/repos-list.helpers.tsx`

## Manual check
- Verified locally in a real browser against this branch running on an OrbStack-backed `kind` cluster (`kind-argo-pr-27415`) with Argo CD resources installed from `manifests/install-with-hydrator.yaml`.
- Ran the local `redis`, `repo-server`, `api-server`, and `ui` processes from this branch against that cluster and seeded real `repo-creds` / `repo-write-creds` secrets in the `argocd` namespace to exercise both credential-template tables.
- Confirmed the read and write credential-template sections both show `Credentials` as the column label and `Configured` with the key icon instead of the old `-` placeholder.
