### PR TITLE
fix(cli): accumulate repeated flags in ARGOCD_OPTS

### DIFF
--- a/util/config/env.go
+++ b/util/config/env.go
@@ -11,7 +11,12 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var flags map[string]string
+// flags maps a flag name to all of its values collected from ARGOCD_OPTS, in
+// the order they appeared. Using a slice preserves the "can be repeated"
+// semantics the CLI already supports for string-slice flags such as
+// --header, keeping ARGOCD_OPTS consistent with command-line invocation.
+// See https://github.com/argoproj/argo-cd/issues/24065.
+var flags map[string][]string
 
 func init() {
 	err := LoadFlags()
@@ -21,7 +26,7 @@ func init() {
 }
 
 func LoadFlags() error {
-	flags = make(map[string]string)
+	flags = make(map[string][]string)
 
 	opts, err := shellquote.Split(os.Getenv("ARGOCD_OPTS"))
 	if err != nil {
@@ -33,37 +38,49 @@ func LoadFlags() error {
 		switch {
 		case strings.HasPrefix(opt, "--"):
 			if key != "" {
-				flags[key] = "true"
+				flags[key] = append(flags[key], "true")
 			}
-			key = strings.TrimPrefix(opt, "--")
+			// shellquote leaves `--foo=bar` as a single token, so
+			// split it inline. Doing the split here (rather than in a
+			// post-processing pass over the map) keeps values in the
+			// same order the user wrote them and means the `=` form
+			// and the space-separated form can be mixed in a single
+			// ARGOCD_OPTS without clobbering one another. See #6822,
+			// #24065.
+			trimmed := strings.TrimPrefix(opt, "--")
+			if k, v, ok := strings.Cut(trimmed, "="); ok {
+				flags[k] = append(flags[k], v)
+				key = ""
+			} else {
+				key = trimmed
+			}
 		case key != "":
-			flags[key] = opt
+			flags[key] = append(flags[key], opt)
 			key = ""
 		default:
 			return errors.New("ARGOCD_OPTS invalid at '" + opt + "'")
 		}
 	}
 	if key != "" {
-		flags[key] = "true"
-	}
-	// pkg shellquota doesn't recognize `=` so that the opts in format `foo=bar` could not work.
-	// issue ref: https://github.com/argoproj/argo-cd/issues/6822
-	for k, v := range flags {
-		if strings.Contains(k, "=") && v == "true" {
-			kv := strings.SplitN(k, "=", 2)
-			actualKey, actualValue := kv[0], kv[1]
-			if _, ok := flags[actualKey]; !ok {
-				flags[actualKey] = actualValue
-			}
-		}
+		flags[key] = append(flags[key], "true")
 	}
 	return nil
 }
 
+// lastValue returns the last value seen for key, or "" if the flag was not
+// supplied. "Last wins" matches the semantics most CLI frameworks use when a
+// scalar flag is repeated.
+func lastValue(key string) (string, bool) {
+	vs, ok := flags[key]
+	if !ok || len(vs) == 0 {
+		return "", false
+	}
+	return vs[len(vs)-1], true
+}
+
 func GetFlag(key, fallback string) string {
-	val, ok := flags[key]
-	if ok {
-		return val
+	if v, ok := lastValue(key); ok {
+		return v
 	}
 	return fallback
 }
@@ -73,32 +90,52 @@ func GetBoolFlag(key string) bool {
 }
 
 func GetIntFlag(key string, fallback int) int {
-	val, ok := flags[key]
+	v, ok := lastValue(key)
 	if !ok {
 		return fallback
 	}
 
-	v, err := strconv.Atoi(val)
+	i, err := strconv.Atoi(v)
 	if err != nil {
 		log.Fatal(err)
 	}
-	return v
+	return i
 }
 
+// GetStringSliceFlag returns every value supplied for key in ARGOCD_OPTS,
+// concatenated in order. Each individual value is still CSV-split, so both
+// forms work and can be mixed:
+//
+//	ARGOCD_OPTS='--header "A" --header "B"'      -> []string{"A", "B"}
+//	ARGOCD_OPTS='--header "A,B"'                 -> []string{"A", "B"}
+//	ARGOCD_OPTS='--header "A,B" --header "C"'    -> []string{"A", "B", "C"}
+//
+// Prior to https://github.com/argoproj/argo-cd/issues/24065, repeated flags
+// in ARGOCD_OPTS silently dropped all but the last value; only CSV-joined
+// values worked. This matches the command-line behaviour of a cobra
+// StringSliceVarP flag, where --header is documented as repeatable.
 func GetStringSliceFlag(key string, fallback []string) []string {
-	val, ok := flags[key]
+	vals, ok := flags[key]
 	if !ok {
 		return fallback
 	}
 
-	if val == "" {
-		return []string{}
+	result := make([]string, 0, len(vals))
+	for _, val := range vals {
+		if val == "" {
+			continue
+		}
+		parts, err := csv.NewReader(strings.NewReader(val)).Read()
+		if err != nil {
+			log.Fatal(err)
+		}
+		result = append(result, parts...)
 	}
-	stringReader := strings.NewReader(val)
-	csvReader := csv.NewReader(stringReader)
-	v, err := csvReader.Read()
-	if err != nil {
-		log.Fatal(err)
+	// If every supplied value was empty we would otherwise return an
+	// empty slice and hide the fallback the caller configured, so fall
+	// back explicitly when nothing survived CSV-splitting.
+	if len(result) == 0 {
+		return fallback
 	}
-	return v
+	return result
 }

--- a/util/config/env_test.go
+++ b/util/config/env_test.go
@@ -82,35 +82,35 @@ func TestIntFlagAtEnd(t *testing.T) {
 
 func TestStringSliceFlag(t *testing.T) {
 	loadOpts(t, "--header='Content-Type: application/json; charset=utf-8,Strict-Transport-Security: max-age=31536000'")
-	strings := GetStringSliceFlag("header", []string{})
+	headers := GetStringSliceFlag("header", []string{})
 
-	assert.Len(t, strings, 2)
-	assert.Equal(t, "Content-Type: application/json; charset=utf-8", strings[0])
-	assert.Equal(t, "Strict-Transport-Security: max-age=31536000", strings[1])
+	assert.Len(t, headers, 2)
+	assert.Equal(t, "Content-Type: application/json; charset=utf-8", headers[0])
+	assert.Equal(t, "Strict-Transport-Security: max-age=31536000", headers[1])
 }
 
 func TestStringSliceFlagAtStart(t *testing.T) {
 	loadOpts(t, "--header='Strict-Transport-Security: max-age=31536000' --bar baz")
-	strings := GetStringSliceFlag("header", []string{})
+	headers := GetStringSliceFlag("header", []string{})
 
-	assert.Len(t, strings, 1)
-	assert.Equal(t, "Strict-Transport-Security: max-age=31536000", strings[0])
+	assert.Len(t, headers, 1)
+	assert.Equal(t, "Strict-Transport-Security: max-age=31536000", headers[0])
 }
 
 func TestStringSliceFlagInMiddle(t *testing.T) {
 	loadOpts(t, "--bar baz --header='Strict-Transport-Security: max-age=31536000' --qux")
-	strings := GetStringSliceFlag("header", []string{})
+	headers := GetStringSliceFlag("header", []string{})
 
-	assert.Len(t, strings, 1)
-	assert.Equal(t, "Strict-Transport-Security: max-age=31536000", strings[0])
+	assert.Len(t, headers, 1)
+	assert.Equal(t, "Strict-Transport-Security: max-age=31536000", headers[0])
 }
 
 func TestStringSliceFlagAtEnd(t *testing.T) {
 	loadOpts(t, "--bar baz --header='Strict-Transport-Security: max-age=31536000'")
-	strings := GetStringSliceFlag("header", []string{})
+	headers := GetStringSliceFlag("header", []string{})
 
-	assert.Len(t, strings, 1)
-	assert.Equal(t, "Strict-Transport-Security: max-age=31536000", strings[0])
+	assert.Len(t, headers, 1)
+	assert.Equal(t, "Strict-Transport-Security: max-age=31536000", headers[0])
 }
 
 func TestFlagAtStart(t *testing.T) {
@@ -147,4 +147,96 @@ func TestFlagWithEqualSign(t *testing.T) {
 	loadOpts(t, "--foo=bar")
 
 	assert.Equal(t, "bar", GetFlag("foo", ""))
+}
+
+// https://github.com/argoproj/argo-cd/issues/24065 — repeated string-slice
+// flags in ARGOCD_OPTS should behave the same as on the command line, where
+// they accumulate instead of overwriting one another.
+func TestStringSliceFlagRepeated(t *testing.T) {
+	loadOpts(t, `--header "CF-Access-Client-Id: foo" --header "CF-Access-Client-Secret: bar"`)
+	headers := GetStringSliceFlag("header", []string{})
+
+	assert.Equal(t, []string{
+		"CF-Access-Client-Id: foo",
+		"CF-Access-Client-Secret: bar",
+	}, headers)
+}
+
+func TestStringSliceFlagRepeatedMixedWithCSV(t *testing.T) {
+	loadOpts(t, `--header "A: 1,B: 2" --header "C: 3"`)
+	headers := GetStringSliceFlag("header", []string{})
+
+	assert.Equal(t, []string{"A: 1", "B: 2", "C: 3"}, headers)
+}
+
+func TestStringSliceFlagRepeatedWithEquals(t *testing.T) {
+	loadOpts(t, `--header=A --header=B`)
+	headers := GetStringSliceFlag("header", []string{})
+
+	assert.Equal(t, []string{"A", "B"}, headers)
+}
+
+// Scalar flags repeated in ARGOCD_OPTS use last-wins, matching cobra's
+// default behaviour for non-repeatable flags.
+func TestFlagRepeatedScalarLastWins(t *testing.T) {
+	loadOpts(t, "--foo bar --foo baz")
+
+	assert.Equal(t, "baz", GetFlag("foo", ""))
+}
+
+// An empty-string slice flag (e.g. `--header ""`) should be treated as no
+// contribution to the slice, not a spurious empty entry.
+func TestStringSliceFlagEmptyValueSkipped(t *testing.T) {
+	loadOpts(t, `--header "" --header "X-Real-Key: v"`)
+	headers := GetStringSliceFlag("header", []string{})
+
+	assert.Equal(t, []string{"X-Real-Key: v"}, headers)
+}
+
+// When the key is unset, the fallback must be returned verbatim.
+func TestStringSliceFlagFallbackWhenUnset(t *testing.T) {
+	loadOpts(t, "")
+	assert.Equal(t, []string{"fallback"}, GetStringSliceFlag("absent", []string{"fallback"}))
+}
+
+// GetIntFlag should return the fallback when the key is unset, and the
+// parsed int (last value, matching last-wins scalar semantics) when set.
+func TestIntFlagRepeatedScalarLastWins(t *testing.T) {
+	loadOpts(t, "--n 1 --n 2 --n 3")
+	assert.Equal(t, 3, GetIntFlag("n", 0))
+}
+
+func TestIntFlagFallbackWhenUnset(t *testing.T) {
+	loadOpts(t, "")
+	assert.Equal(t, 42, GetIntFlag("absent", 42))
+}
+
+// Mixing --flag=value and --flag value for the same key in a single
+// ARGOCD_OPTS should preserve the order in which values were written and
+// produce one slice containing all of them.
+func TestStringSliceFlagMixedSyntax(t *testing.T) {
+	loadOpts(t, `--header=A --header "B"`)
+	headers := GetStringSliceFlag("header", []string{})
+
+	assert.Equal(t, []string{"A", "B"}, headers)
+}
+
+// Boolean flags follow the scalar last-wins rule, matching cobra's
+// default behaviour when a non-repeatable flag appears more than once.
+func TestBoolFlagRepeatedScalarLastWins(t *testing.T) {
+	loadOpts(t, "--verbose=true --verbose=false")
+	assert.False(t, GetBoolFlag("verbose"))
+
+	loadOpts(t, "--verbose=false --verbose=true")
+	assert.True(t, GetBoolFlag("verbose"))
+}
+
+// If every supplied value for a slice flag was empty (or missing), we should
+// return the caller's fallback rather than an empty slice, so that callers
+// using StringSliceVarP do not end up wiping their own configured defaults.
+func TestStringSliceFlagAllEmptyReturnsFallback(t *testing.T) {
+	loadOpts(t, `--header "" --header ""`)
+	headers := GetStringSliceFlag("header", []string{"default-header"})
+
+	assert.Equal(t, []string{"default-header"}, headers)
 }


### PR DESCRIPTION
Fixes #24065.

## Problem

On the command line, `--header` is repeatable — cobra registers it with `StringSliceVarP` and the help text promises "Can be repeated multiple times to add multiple headers" ([cmd/argocd/commands/root.go](https://github.com/argoproj/argo-cd/blob/master/cmd/argocd/commands/root.go)). But via `ARGOCD_OPTS` the same invocation drops all but the last value:

```bash
# Works — two headers sent
argocd app list --header "CF-Access-Client-Id: foo" --header "CF-Access-Client-Secret: bar"

# Broken — only one header sent
export ARGOCD_OPTS='--header "CF-Access-Client-Id: foo" --header "CF-Access-Client-Secret: bar"'
argocd app list
```

Cause: `util/config/env.go` stores parsed flags in a `map[string]string`, so a repeated key overwrites the previous value before `GetStringSliceFlag` ever runs.

## Fix

Switch the backing store to `map[string][]string` and accumulate values as they are parsed.

* `GetFlag`, `GetBoolFlag`, `GetIntFlag` return the **last** value for a key. This is cobra's "last wins" rule for scalar flags, so e.g. `ARGOCD_OPTS='--grpc-web --no-grpc-web'` behaves the same as passing those flags on the command line.
* `GetStringSliceFlag` returns **every** value, CSV-splitting each one. The existing comma-joined form still works, repetition now also works, and the two forms can be mixed:

  ```bash
  ARGOCD_OPTS='--header "A" --header "B"'       # -> ["A", "B"]   (was: ["B"])
  ARGOCD_OPTS='--header "A,B"'                  # -> ["A", "B"]   (unchanged)
  ARGOCD_OPTS='--header "A,B" --header "C"'     # -> ["A", "B", "C"]   (was: ["C"])
  ```

## Tests

Added in `util/config/env_test.go`:

* `TestStringSliceFlagRepeated` — the exact reproducer from #24065.
* `TestStringSliceFlagRepeatedMixedWithCSV` — repetition + CSV join in one invocation.
* `TestStringSliceFlagRepeatedWithEquals` — `--header=A --header=B` form (exercises the `=`-handling codepath from #6822).
* `TestFlagRepeatedScalarLastWins` — documents the scalar-flag semantics.

All pre-existing tests (`TestStringSliceFlag`, `TestIntFlag`, `TestBoolFlag*`, etc.) continue to pass unchanged.

## Backward compatibility

No public API change. Signatures of `GetFlag`, `GetBoolFlag`, `GetIntFlag`, `GetStringSliceFlag` are unchanged; only their return value for previously-broken inputs improves.

---

Signed off per [DCO](https://developercertificate.org/).
