### PR TITLE
feat(webhook): fetch changed files from Azure DevOps Diffs API

### DIFF
--- a/util/webhook/testdata/azuredevops-git-push-event.json
+++ b/util/webhook/testdata/azuredevops-git-push-event.json
@@ -5,31 +5,31 @@
   "eventType": "git.push",
   "publisherId": "tfs",
   "message": {
-    "text": "Alexander Matyushentsev pushed updates to alex-test:master\r\n(https://dev.azure.com/alexander0053/alex-test/_git/alex-test/#version=GBmaster)",
-    "html": "Alexander Matyushentsev pushed updates to <a href=\"https://dev.azure.com/alexander0053/alex-test/_git/alex-test/\">alex-test</a>:<a href=\"https://dev.azure.com/alexander0053/alex-test/_git/alex-test/#version=GBmaster\">master</a>",
-    "markdown": "Alexander Matyushentsev pushed updates to [alex-test](https://dev.azure.com/alexander0053/alex-test/_git/alex-test/):[master](https://dev.azure.com/alexander0053/alex-test/_git/alex-test/#version=GBmaster)"
+    "text": "Test User pushed updates to my-repo:master\r\n(https://dev.azure.com/my-org/my-project/_git/my-repo/#version=GBmaster)",
+    "html": "Test User pushed updates to <a href=\"https://dev.azure.com/my-org/my-project/_git/my-repo/\">my-repo</a>:<a href=\"https://dev.azure.com/my-org/my-project/_git/my-repo/#version=GBmaster\">master</a>",
+    "markdown": "Test User pushed updates to [my-repo](https://dev.azure.com/my-org/my-project/_git/my-repo/):[master](https://dev.azure.com/my-org/my-project/_git/my-repo/#version=GBmaster)"
   },
   "detailedMessage": {
-    "text": "Alexander Matyushentsev pushed a commit to alex-test:master\r\n - draft 298a79aa (https://dev.azure.com/alexander0053/alex-test/_git/alex-test/commit/298a79aa1552799a70718a0ee914d153d5a1a76b)",
-    "html": "Alexander Matyushentsev pushed a commit to <a href=\"https://dev.azure.com/alexander0053/alex-test/_git/alex-test/\">alex-test</a>:<a href=\"https://dev.azure.com/alexander0053/alex-test/_git/alex-test/#version=GBmaster\">master</a>\r\n<ul>\r\n<li>draft <a href=\"https://dev.azure.com/alexander0053/alex-test/_git/alex-test/commit/298a79aa1552799a70718a0ee914d153d5a1a76b\">298a79aa</a></li>\r\n</ul>",
-    "markdown": "Alexander Matyushentsev pushed a commit to [alex-test](https://dev.azure.com/alexander0053/alex-test/_git/alex-test/):[master](https://dev.azure.com/alexander0053/alex-test/_git/alex-test/#version=GBmaster)\r\n* draft [298a79aa](https://dev.azure.com/alexander0053/alex-test/_git/alex-test/commit/298a79aa1552799a70718a0ee914d153d5a1a76b)"
+    "text": "Test User pushed a commit to my-repo:master\r\n - draft 298a79aa (https://dev.azure.com/my-org/my-project/_git/my-repo/commit/298a79aa1552799a70718a0ee914d153d5a1a76b)",
+    "html": "Test User pushed a commit to <a href=\"https://dev.azure.com/my-org/my-project/_git/my-repo/\">my-repo</a>:<a href=\"https://dev.azure.com/my-org/my-project/_git/my-repo/#version=GBmaster\">master</a>\r\n<ul>\r\n<li>draft <a href=\"https://dev.azure.com/my-org/my-project/_git/my-repo/commit/298a79aa1552799a70718a0ee914d153d5a1a76b\">298a79aa</a></li>\r\n</ul>",
+    "markdown": "Test User pushed a commit to [my-repo](https://dev.azure.com/my-org/my-project/_git/my-repo/):[master](https://dev.azure.com/my-org/my-project/_git/my-repo/#version=GBmaster)\r\n* draft [298a79aa](https://dev.azure.com/my-org/my-project/_git/my-repo/commit/298a79aa1552799a70718a0ee914d153d5a1a76b)"
   },
   "resource": {
     "commits": [
       {
         "commitId": "298a79aa1552799a70718a0ee914d153d5a1a76b",
         "author": {
-          "name": "Alexander Matyushentsev",
+          "name": "Test User",
           "email": "AMatyushentsev@gmail.com",
           "date": "2023-08-09T00:45:39Z"
         },
         "committer": {
-          "name": "Alexander Matyushentsev",
+          "name": "Test User",
           "email": "AMatyushentsev@gmail.com",
           "date": "2023-08-09T00:45:39Z"
         },
-        "comment": "draft\n\nSigned-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>",
-        "url": "https://dev.azure.com/alexander0053/_apis/git/repositories/ba2967cc-02c2-414c-8d10-1b99197cbaa6/commits/298a79aa1552799a70718a0ee914d153d5a1a76b"
+        "comment": "draft\n\nSigned-off-by: Test User <AMatyushentsev@gmail.com>",
+        "url": "https://dev.azure.com/my-org/_apis/git/repositories/ba2967cc-02c2-414c-8d10-1b99197cbaa6/commits/298a79aa1552799a70718a0ee914d153d5a1a76b"
       }
     ],
     "refUpdates": [
@@ -41,50 +41,50 @@
     ],
     "repository": {
       "id": "ba2967cc-02c2-414c-8d10-1b99197cbaa6",
-      "name": "alex-test",
-      "url": "https://dev.azure.com/alexander0053/_apis/git/repositories/ba2967cc-02c2-414c-8d10-1b99197cbaa6",
+      "name": "my-repo",
+      "url": "https://dev.azure.com/my-org/_apis/git/repositories/ba2967cc-02c2-414c-8d10-1b99197cbaa6",
       "project": {
         "id": "ab1c194f-94fa-4d1a-87ff-e9458637d060",
-        "name": "alex-test",
-        "url": "https://dev.azure.com/alexander0053/_apis/projects/ab1c194f-94fa-4d1a-87ff-e9458637d060",
+        "name": "my-repo",
+        "url": "https://dev.azure.com/my-org/_apis/projects/ab1c194f-94fa-4d1a-87ff-e9458637d060",
         "state": "wellFormed",
         "visibility": "unchanged",
         "lastUpdateTime": "0001-01-01T00:00:00"
       },
       "defaultBranch": "refs/heads/master",
-      "remoteUrl": "https://dev.azure.com/alexander0053/alex-test/_git/alex-test"
+      "remoteUrl": "https://dev.azure.com/my-org/my-project/_git/my-repo"
     },
     "pushedBy": {
-      "displayName": "Alexander Matyushentsev",
+      "displayName": "Test User",
       "url": "https://spsprodcus4.vssps.visualstudio.com/A7a73fd0c-d080-434d-a8b4-0b4c0217e290/_apis/Identities/07220d5e-521c-683d-982c-726e80086d08",
       "_links": {
         "avatar": {
-          "href": "https://dev.azure.com/alexander0053/_apis/GraphProfile/MemberAvatars/aad.MDcyMjBkNWUtNTIxYy03ODNkLTk4MmMtNzI2ZTgwMDg2ZDA4"
+          "href": "https://dev.azure.com/my-org/_apis/GraphProfile/MemberAvatars/aad.MDcyMjBkNWUtNTIxYy03ODNkLTk4MmMtNzI2ZTgwMDg2ZDA4"
         }
       },
       "id": "07220d5e-521c-683d-982c-726e80086d08",
-      "uniqueName": "alexander@akuity.onmicrosoft.com",
-      "imageUrl": "https://dev.azure.com/alexander0053/_api/_common/identityImage?id=07220d5e-521c-683d-982c-726e80086d08",
+      "uniqueName": "testuser@example.com",
+      "imageUrl": "https://dev.azure.com/my-org/_api/_common/identityImage?id=07220d5e-521c-683d-982c-726e80086d08",
       "descriptor": "aad.MDcyMjBkNWUtNTIxYy03ODNkLTk4MmMtNzI2ZTgwMDg2ZDA4"
     },
     "pushId": 4,
     "date": "2023-08-09T00:45:42.8315767Z",
-    "url": "https://dev.azure.com/alexander0053/_apis/git/repositories/ba2967cc-02c2-414c-8d10-1b99197cbaa6/pushes/4",
+    "url": "https://dev.azure.com/my-org/_apis/git/repositories/ba2967cc-02c2-414c-8d10-1b99197cbaa6/pushes/4",
     "_links": {
       "self": {
-        "href": "https://dev.azure.com/alexander0053/_apis/git/repositories/ba2967cc-02c2-414c-8d10-1b99197cbaa6/pushes/4"
+        "href": "https://dev.azure.com/my-org/_apis/git/repositories/ba2967cc-02c2-414c-8d10-1b99197cbaa6/pushes/4"
       },
       "repository": {
-        "href": "https://dev.azure.com/alexander0053/ab1c194f-94fa-4d1a-87ff-e9458637d060/_apis/git/repositories/ba2967cc-02c2-414c-8d10-1b99197cbaa6"
+        "href": "https://dev.azure.com/my-org/ab1c194f-94fa-4d1a-87ff-e9458637d060/_apis/git/repositories/ba2967cc-02c2-414c-8d10-1b99197cbaa6"
       },
       "commits": {
-        "href": "https://dev.azure.com/alexander0053/_apis/git/repositories/ba2967cc-02c2-414c-8d10-1b99197cbaa6/pushes/4/commits"
+        "href": "https://dev.azure.com/my-org/_apis/git/repositories/ba2967cc-02c2-414c-8d10-1b99197cbaa6/pushes/4/commits"
       },
       "pusher": {
         "href": "https://spsprodcus4.vssps.visualstudio.com/A7a73fd0c-d080-434d-a8b4-0b4c0217e290/_apis/Identities/07220d5e-521c-683d-982c-726e80086d08"
       },
       "refs": {
-        "href": "https://dev.azure.com/alexander0053/ab1c194f-94fa-4d1a-87ff-e9458637d060/_apis/git/repositories/ba2967cc-02c2-414c-8d10-1b99197cbaa6/refs/heads/master"
+        "href": "https://dev.azure.com/my-org/ab1c194f-94fa-4d1a-87ff-e9458637d060/_apis/git/repositories/ba2967cc-02c2-414c-8d10-1b99197cbaa6/refs/heads/master"
       }
     }
   },
@@ -92,15 +92,15 @@
   "resourceContainers": {
     "collection": {
       "id": "d54a3f95-82a0-47c4-8444-00da7391d976",
-      "baseUrl": "https://dev.azure.com/alexander0053/"
+      "baseUrl": "https://dev.azure.com/my-org/"
     },
     "account": {
       "id": "7a73fd0c-d080-434d-a8b4-0b4c0217e290",
-      "baseUrl": "https://dev.azure.com/alexander0053/"
+      "baseUrl": "https://dev.azure.com/my-org/"
     },
     "project": {
       "id": "ab1c194f-94fa-4d1a-87ff-e9458637d060",
-      "baseUrl": "https://dev.azure.com/alexander0053/"
+      "baseUrl": "https://dev.azure.com/my-org/"
     }
   },
   "createdDate": "2023-08-09T00:45:49.3448928Z"

--- a/util/webhook/testdata/azuredevops-git-push-event.json
+++ b/util/webhook/testdata/azuredevops-git-push-event.json
@@ -20,15 +20,15 @@
         "commitId": "298a79aa1552799a70718a0ee914d153d5a1a76b",
         "author": {
           "name": "Test User",
-          "email": "AMatyushentsev@gmail.com",
+          "email": "test-user@example.com",
           "date": "2023-08-09T00:45:39Z"
         },
         "committer": {
           "name": "Test User",
-          "email": "AMatyushentsev@gmail.com",
+          "email": "test-user@example.com",
           "date": "2023-08-09T00:45:39Z"
         },
-        "comment": "draft\n\nSigned-off-by: Test User <AMatyushentsev@gmail.com>",
+        "comment": "draft\n\nSigned-off-by: Test User <test-user@example.com>",
         "url": "https://dev.azure.com/my-org/_apis/git/repositories/ba2967cc-02c2-414c-8d10-1b99197cbaa6/commits/298a79aa1552799a70718a0ee914d153d5a1a76b"
       }
     ],

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -359,7 +359,8 @@ type changeInfo struct {
 }
 
 type adoDiffsResponse struct {
-	Changes []adoDiffChange `json:"changes"`
+	Changes            []adoDiffChange `json:"changes"`
+	AllChangesIncluded bool            `json:"allChangesIncluded"`
 }
 
 type adoDiffChange struct {
@@ -797,13 +798,16 @@ func fetchChangedFilesFromADO(ctx context.Context, repo *v1alpha1.Repository, re
 	if err := json.NewDecoder(resp.Body).Decode(&diffsResp); err != nil {
 		return nil, fmt.Errorf("error decoding Azure DevOps diffs API response: %w", err)
 	}
+	if !diffsResp.AllChangesIncluded {
+		return nil, fmt.Errorf("Azure DevOps diffs API response was truncated (more than 2000 files changed); falling back to full refresh")
+	}
 	changedFiles := make([]string, 0, len(diffsResp.Changes))
 	for _, c := range diffsResp.Changes {
 		if !c.Item.IsFolder && c.Item.Path != "" {
 			changedFiles = append(changedFiles, strings.TrimPrefix(c.Item.Path, "/"))
 		}
 	}
-	log.Debugf("Azure DevOps changed files between %s..%s: %v", shaBefore, shaAfter, changedFiles)
+	log.Debugf("Azure DevOps diffs API returned %d changed files between %s..%s", len(changedFiles), shaBefore, shaAfter)
 	return changedFiles, nil
 }
 

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -187,7 +188,28 @@ func (a *ArgoCDWebhookHandler) affectedRevisionInfo(payloadIf any) (webURLs []st
 			change.shaBefore = ParseRevision(payload.Resource.RefUpdates[0].OldObjectID)
 			touchedHead = payload.Resource.RefUpdates[0].Name == payload.Resource.Repository.DefaultBranch
 		}
-		// unfortunately, Azure DevOps doesn't provide a list of changed files
+		// The webhook payload does not include changed files. Fetch them from the Azure DevOps
+		// REST API using the repository credentials already stored in ArgoCD. The repo lookup
+		// acts as the SSRF guard: we only proceed if the repository is registered in ArgoCD.
+		{
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			argoRepo, err := a.lookupRepositoryWithCredsTemplate(ctx, payload.Resource.Repository.RemoteURL)
+			if err != nil {
+				log.Warnf("error finding repository for Azure DevOps webhook URL %s: %v", payload.Resource.Repository.RemoteURL, err)
+				break
+			}
+			if argoRepo == nil {
+				log.Debugf("no repository configured for Azure DevOps webhook URL %s, skipping changed files lookup", payload.Resource.Repository.RemoteURL)
+				break
+			}
+			adoChangedFiles, err := fetchChangedFilesFromADO(ctx, argoRepo, payload.Resource.Repository.RemoteURL, payload.Resource.Repository.ID, change.shaBefore, change.shaAfter)
+			if err != nil {
+				log.Warnf("error fetching changed files from Azure DevOps diffs API: %v", err)
+				break
+			}
+			changedFiles = append(changedFiles, adoChangedFiles...)
+		}
 	case github.PushPayload:
 		// See: https://developer.github.com/v3/activity/events/types/#pushevent
 		webURLs = append(webURLs, payload.Repository.HTMLURL)
@@ -334,6 +356,20 @@ func (a *ArgoCDWebhookHandler) affectedRevisionInfo(payloadIf any) (webURLs []st
 type changeInfo struct {
 	shaBefore string
 	shaAfter  string
+}
+
+type adoDiffsResponse struct {
+	Changes []adoDiffChange `json:"changes"`
+}
+
+type adoDiffChange struct {
+	Item       adoDiffItem `json:"item"`
+	ChangeType string      `json:"changeType"`
+}
+
+type adoDiffItem struct {
+	Path     string `json:"path"`
+	IsFolder bool   `json:"isFolder"`
 }
 
 // HandleEvent handles webhook events for repo push events
@@ -559,6 +595,43 @@ func (a *ArgoCDWebhookHandler) lookupRepository(ctx context.Context, repoURL str
 	return repository, nil
 }
 
+// lookupRepositoryWithCredsTemplate returns credentials for a given URL by checking individual
+// repository secrets first, then falling back to credentials templates (matched by URL prefix).
+// Returns nil if no credentials are found.
+func (a *ArgoCDWebhookHandler) lookupRepositoryWithCredsTemplate(ctx context.Context, repoURL string) (*v1alpha1.Repository, error) {
+	repo, err := a.lookupRepository(ctx, repoURL)
+	if err != nil || repo != nil {
+		return repo, err
+	}
+
+	// No specific repo found — check credentials templates, which match by URL prefix.
+	credURLs, err := a.db.ListRepositoryCredentials(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error listing repository credentials: %w", err)
+	}
+	normalizedRepoURL := git.NormalizeGitURL(repoURL)
+	var bestMatchURL string
+	for _, credURL := range credURLs {
+		if strings.HasPrefix(normalizedRepoURL, git.NormalizeGitURL(credURL)) && len(credURL) > len(bestMatchURL) {
+			bestMatchURL = credURL
+		}
+	}
+	if bestMatchURL == "" {
+		return nil, nil
+	}
+	creds, err := a.db.GetRepositoryCredentials(ctx, bestMatchURL)
+	if err != nil {
+		return nil, fmt.Errorf("error getting credentials template for %q: %w", bestMatchURL, err)
+	}
+	log.Debugf("found matching credentials template %q for URL %s", bestMatchURL, repoURL)
+	return &v1alpha1.Repository{
+		Repo:        repoURL,
+		Username:    creds.Username,
+		Password:    creds.Password,
+		BearerToken: creds.BearerToken,
+	}, nil
+}
+
 func sourceRevisionHasChanged(source v1alpha1.ApplicationSource, revision string, touchedHead bool) bool {
 	targetRev := ParseRevision(source.TargetRevision)
 	if targetRev == "HEAD" || targetRev == "" { // revision is head
@@ -670,6 +743,67 @@ func fetchDiffStatFromBitbucket(_ context.Context, bbClient *bb.Client, owner, r
 		}
 	}
 	log.Debugf("changed files for spec %s: %v", spec, changedFiles)
+	return changedFiles, nil
+}
+
+// parseADOBaseURL extracts the base URL (scheme://host/{org}/{project}) from an Azure DevOps
+// Git repository remote URL (https://dev.azure.com/{org}/{project}/_git/{repo}).
+func parseADOBaseURL(repoURL string) (string, error) {
+	u, err := url.Parse(repoURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse Azure DevOps URL %q: %w", repoURL, err)
+	}
+	// path is "/{org}/{project}/_git/{repo}" — we need scheme://host/{org}/{project}
+	parts := strings.SplitN(strings.TrimPrefix(u.Path, "/"), "/", 3)
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return "", fmt.Errorf("cannot extract organization and project from Azure DevOps URL %q", repoURL)
+	}
+	return fmt.Sprintf("%s://%s/%s/%s", u.Scheme, u.Host, parts[0], parts[1]), nil
+}
+
+// fetchChangedFilesFromADO retrieves the list of files changed between two commits by calling
+// the Azure DevOps Diffs REST API.
+// See: https://learn.microsoft.com/en-us/rest/api/azure/devops/git/diffs/get
+func fetchChangedFilesFromADO(ctx context.Context, repo *v1alpha1.Repository, repoURL, repoID, shaBefore, shaAfter string) ([]string, error) {
+	baseURL, err := parseADOBaseURL(repoURL)
+	if err != nil {
+		return nil, err
+	}
+	// $top=2000 fetches up to 2000 file changes; large push sets beyond this limit will fall
+	// back to refreshing all matching applications.
+	apiURL := fmt.Sprintf(
+		"%s/_apis/git/repositories/%s/diffs/commits?baseVersion=%s&baseVersionType=commit&targetVersion=%s&targetVersionType=commit&$top=2000&api-version=7.1",
+		baseURL, url.PathEscape(repoID), url.QueryEscape(shaBefore), url.QueryEscape(shaAfter),
+	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Azure DevOps diffs API request: %w", err)
+	}
+	if repo.Username != "" || repo.Password != "" {
+		req.SetBasicAuth(repo.Username, repo.Password)
+	} else if repo.BearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+repo.BearerToken)
+	}
+	log.Debugf("fetching changed files from Azure DevOps diffs API: %s", apiURL)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error calling Azure DevOps diffs API: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Azure DevOps diffs API returned unexpected status %d", resp.StatusCode)
+	}
+	var diffsResp adoDiffsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&diffsResp); err != nil {
+		return nil, fmt.Errorf("error decoding Azure DevOps diffs API response: %w", err)
+	}
+	changedFiles := make([]string, 0, len(diffsResp.Changes))
+	for _, c := range diffsResp.Changes {
+		if !c.Item.IsFolder && c.Item.Path != "" {
+			changedFiles = append(changedFiles, strings.TrimPrefix(c.Item.Path, "/"))
+		}
+	}
+	log.Debugf("Azure DevOps changed files between %s..%s: %v", shaBefore, shaAfter, changedFiles)
 	return changedFiles, nil
 }
 

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -785,7 +785,7 @@ func fetchChangedFilesFromADO(ctx context.Context, repo *v1alpha1.Repository, re
 		"%s/_apis/git/repositories/%s/diffs/commits?baseVersion=%s&baseVersionType=commit&targetVersion=%s&targetVersionType=commit&$top=2000&api-version=7.1",
 		baseURL, url.PathEscape(repoID), url.QueryEscape(shaBefore), url.QueryEscape(shaAfter),
 	)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("error creating Azure DevOps diffs API request: %w", err)
 	}
@@ -801,14 +801,14 @@ func fetchChangedFilesFromADO(ctx context.Context, repo *v1alpha1.Repository, re
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Azure DevOps diffs API returned unexpected status %d", resp.StatusCode)
+		return nil, fmt.Errorf("azure DevOps diffs API returned unexpected status %d", resp.StatusCode)
 	}
 	var diffsResp adoDiffsResponse
 	if err := json.NewDecoder(resp.Body).Decode(&diffsResp); err != nil {
 		return nil, fmt.Errorf("error decoding Azure DevOps diffs API response: %w", err)
 	}
 	if !diffsResp.AllChangesIncluded {
-		return nil, fmt.Errorf("Azure DevOps diffs API response was truncated (more than 2000 files changed); falling back to full refresh")
+		return nil, errors.New("azure DevOps diffs API response was truncated (more than 2000 files changed); falling back to full refresh")
 	}
 	changedFiles := make([]string, 0, len(diffsResp.Changes))
 	for _, c := range diffsResp.Changes {

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -747,15 +747,24 @@ func fetchDiffStatFromBitbucket(_ context.Context, bbClient *bb.Client, owner, r
 	return changedFiles, nil
 }
 
-// parseADOBaseURL extracts the base URL (scheme://host/{org}/{project}) from an Azure DevOps
-// Git repository remote URL (https://dev.azure.com/{org}/{project}/_git/{repo}).
+// parseADOBaseURL extracts the base URL used to construct Azure DevOps REST API requests.
+// It supports both the modern format (https://dev.azure.com/{org}/{project}/_git/{repo})
+// and the legacy format (https://{org}.visualstudio.com/{project}/_git/{repo}).
 func parseADOBaseURL(repoURL string) (string, error) {
 	u, err := url.Parse(repoURL)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse Azure DevOps URL %q: %w", repoURL, err)
 	}
-	// path is "/{org}/{project}/_git/{repo}" — we need scheme://host/{org}/{project}
 	parts := strings.SplitN(strings.TrimPrefix(u.Path, "/"), "/", 3)
+	// Legacy format: https://{org}.visualstudio.com/{project}/_git/{repo}
+	// The org is in the host; the first path segment is the project.
+	if strings.HasSuffix(u.Host, ".visualstudio.com") {
+		if len(parts) < 1 || parts[0] == "" {
+			return "", fmt.Errorf("cannot extract project from Azure DevOps URL %q", repoURL)
+		}
+		return fmt.Sprintf("%s://%s/%s", u.Scheme, u.Host, parts[0]), nil
+	}
+	// Modern format: https://dev.azure.com/{org}/{project}/_git/{repo}
 	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
 		return "", fmt.Errorf("cannot extract organization and project from Azure DevOps URL %q", repoURL)
 	}

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -789,7 +789,7 @@ func fetchChangedFilesFromADO(ctx context.Context, repo *v1alpha1.Repository, re
 	if err != nil {
 		return nil, fmt.Errorf("error creating Azure DevOps diffs API request: %w", err)
 	}
-	if repo.Username != "" || repo.Password != "" {
+	if repo.Username != "" && repo.Password != "" {
 		req.SetBasicAuth(repo.Username, repo.Password)
 	} else if repo.BearerToken != "" {
 		req.Header.Set("Authorization", "Bearer "+repo.BearerToken)

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -756,6 +756,8 @@ func fetchDiffStatFromBitbucket(_ context.Context, bbClient *bb.Client, owner, r
 // parseADOBaseURL extracts the base URL used to construct Azure DevOps REST API requests.
 // It supports both the modern format (https://dev.azure.com/{org}/{project}/_git/{repo})
 // and the legacy format (https://{org}.visualstudio.com/{project}/_git/{repo}).
+// SSH URLs (e.g. git@ssh.dev.azure.com:v3/{org}/{project}/{repo}) are not supported
+// because SSH keys cannot be used to authenticate the Azure DevOps REST API.
 func parseADOBaseURL(repoURL string) (string, error) {
 	u, err := url.Parse(repoURL)
 	if err != nil {

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -596,6 +596,10 @@ func (a *ArgoCDWebhookHandler) storePreviouslyCachedManifests(app *v1alpha1.Appl
 func (a *ArgoCDWebhookHandler) lookupAndFetchADOChangedFiles(repoURL, repoID, shaBefore, shaAfter string) []string {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
+	if shaBefore == "" || shaAfter == "" {
+		log.Debugf("skipping Azure DevOps changed files lookup for URL %s because the commit range is empty", repoURL)
+		return nil
+	}
 	argoRepo, err := a.lookupRepositoryWithCredsTemplate(ctx, repoURL)
 	if err != nil {
 		log.Warnf("error finding repository for Azure DevOps webhook URL %s: %v", repoURL, err)
@@ -605,11 +609,7 @@ func (a *ArgoCDWebhookHandler) lookupAndFetchADOChangedFiles(repoURL, repoID, sh
 		log.Debugf("no repository configured for Azure DevOps webhook URL %s, skipping changed files lookup", repoURL)
 		return nil
 	}
-	httpClientFactory := a.adoHTTPClientFactory
-	if httpClientFactory == nil {
-		httpClientFactory = newADOHTTPClient
-	}
-	changedFiles, err := fetchChangedFilesFromADO(ctx, httpClientFactory(argoRepo), argoRepo, repoID, shaBefore, shaAfter)
+	changedFiles, err := fetchChangedFilesFromADO(ctx, a.adoHTTPClientFactory(argoRepo), argoRepo, repoID, shaBefore, shaAfter)
 	if err != nil {
 		log.Warnf("error fetching changed files from Azure DevOps diffs API: %v", err)
 		return nil
@@ -636,7 +636,7 @@ func (a *ArgoCDWebhookHandler) lookupRepository(ctx context.Context, repoURL str
 
 // lookupRepositoryWithCredsTemplate returns credentials for a given URL by checking individual
 // repository secrets first, then falling back to credentials templates (matched by URL prefix).
-// Returns nil if no credentials are found.
+// Returns nil if no repository or credentials template is found.
 func (a *ArgoCDWebhookHandler) lookupRepositoryWithCredsTemplate(ctx context.Context, repoURL string) (*v1alpha1.Repository, error) {
 	repo, err := a.lookupRepository(ctx, repoURL)
 	if err != nil || repo != nil {
@@ -854,7 +854,7 @@ func fetchChangedFilesFromADO(ctx context.Context, httpClient *http.Client, repo
 		return nil, fmt.Errorf("error decoding Azure DevOps diffs API response: %w", err)
 	}
 	if !diffsResp.AllChangesIncluded {
-		return nil, errors.New("azure DevOps diffs API response was truncated (more than 2000 files changed); falling back to full refresh")
+		return nil, fmt.Errorf("azure DevOps diffs API response was truncated (more than %d files changed); falling back to full refresh", adoDiffsMaxPageSize)
 	}
 	changedFiles := make([]string, 0, len(diffsResp.Changes))
 	for _, c := range diffsResp.Changes {

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -198,7 +198,7 @@ func (a *ArgoCDWebhookHandler) startWorkerPool(webhookParallelism int) {
 				if !ok {
 					return
 				}
-				guard.RecoverAndLog(func() { a.HandleEvent(payload) }, compLog, panicMsgServer)
+				guard.RecoverAndLog(func() { a.HandleEvent(context.Background(), payload) }, compLog, panicMsgServer)
 			}
 		})
 	}
@@ -211,7 +211,7 @@ func ParseRevision(ref string) string {
 
 // affectedRevisionInfo examines a payload from a webhook event, and extracts the repo web URL,
 // the revision, and whether, or not this affected origin/HEAD (the default branch of the repository)
-func (a *ArgoCDWebhookHandler) affectedRevisionInfo(payloadIf any) (webURLs []string, revision string, change changeInfo, touchedHead bool, changedFiles []string) {
+func (a *ArgoCDWebhookHandler) affectedRevisionInfo(ctx context.Context, payloadIf any) (webURLs []string, revision string, change changeInfo, touchedHead bool, changedFiles []string) {
 	switch payload := payloadIf.(type) {
 	case azuredevops.GitPushEvent:
 		// See: https://learn.microsoft.com/en-us/azure/devops/service-hooks/events?view=azure-devops#git.push
@@ -223,6 +223,7 @@ func (a *ArgoCDWebhookHandler) affectedRevisionInfo(payloadIf any) (webURLs []st
 			touchedHead = payload.Resource.RefUpdates[0].Name == payload.Resource.Repository.DefaultBranch
 		}
 		changedFiles = append(changedFiles, a.lookupAndFetchADOChangedFiles(
+			ctx,
 			payload.Resource.Repository.RemoteURL,
 			payload.Resource.Repository.ID,
 			change.shaBefore,
@@ -392,7 +393,7 @@ type adoDiffItem struct {
 }
 
 // HandleEvent handles webhook events for repo push events
-func (a *ArgoCDWebhookHandler) HandleEvent(payload any) {
+func (a *ArgoCDWebhookHandler) HandleEvent(ctx context.Context, payload any) {
 	webhookHandlersInFlight.Inc()
 	defer webhookHandlersInFlight.Dec()
 
@@ -406,7 +407,7 @@ func (a *ArgoCDWebhookHandler) HandleEvent(payload any) {
 		a.HandleRegistryEvent(e)
 		return
 	}
-	webURLs, revision, change, touchedHead, changedFiles := a.affectedRevisionInfo(payload)
+	webURLs, revision, change, touchedHead, changedFiles := a.affectedRevisionInfo(ctx, payload)
 	// NOTE: the webURL does not include the .git extension
 	if len(webURLs) == 0 {
 		log.Info("Ignoring webhook event")
@@ -599,13 +600,13 @@ func (a *ArgoCDWebhookHandler) storePreviouslyCachedManifests(app *v1alpha1.Appl
 
 // lookupAndFetchADOChangedFiles fetches the list of changed files for an Azure DevOps push event.
 // The repo lookup acts as the SSRF guard: we only proceed if the repository is registered in ArgoCD.
-func (a *ArgoCDWebhookHandler) lookupAndFetchADOChangedFiles(repoURL, repoID, shaBefore, shaAfter string) []string {
+func (a *ArgoCDWebhookHandler) lookupAndFetchADOChangedFiles(ctx context.Context, repoURL, repoID, shaBefore, shaAfter string) []string {
 	if shaBefore == "" || shaAfter == "" || shaBefore == adoNullSHA || shaAfter == adoNullSHA {
 		log.Debugf("skipping Azure DevOps changed files lookup for URL %s because the commit range is empty or includes the null SHA used for branch creation or deletion", repoURL)
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	argoRepo, err := a.lookupRepositoryWithCredsTemplate(ctx, repoURL)
 	if err != nil {

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -107,6 +107,7 @@ type ArgoCDWebhookHandler struct {
 	settingsSrc            settingsSource
 	queue                  chan any
 	maxWebhookPayloadSizeB int64
+	adoHTTPClientFactory   func(repo *v1alpha1.Repository) *http.Client
 }
 
 func NewHandler(namespace string, applicationNamespaces []string, webhookParallelism int, appClientset appclientset.Interface, appsLister alpha1.ApplicationLister,
@@ -174,6 +175,7 @@ func NewHandler(namespace string, applicationNamespaces []string, webhookParalle
 		queue:                  make(chan any, payloadQueueSize),
 		maxWebhookPayloadSizeB: maxWebhookPayloadSizeB,
 		appsLister:             appsLister,
+		adoHTTPClientFactory:   newADOHTTPClient,
 	}
 
 	acdWebhook.startWorkerPool(webhookParallelism)
@@ -603,7 +605,11 @@ func (a *ArgoCDWebhookHandler) lookupAndFetchADOChangedFiles(repoURL, repoID, sh
 		log.Debugf("no repository configured for Azure DevOps webhook URL %s, skipping changed files lookup", repoURL)
 		return nil
 	}
-	changedFiles, err := fetchChangedFilesFromADO(ctx, argoRepo, repoID, shaBefore, shaAfter)
+	httpClientFactory := a.adoHTTPClientFactory
+	if httpClientFactory == nil {
+		httpClientFactory = newADOHTTPClient
+	}
+	changedFiles, err := fetchChangedFilesFromADO(ctx, httpClientFactory(argoRepo), argoRepo, repoID, shaBefore, shaAfter)
 	if err != nil {
 		log.Warnf("error fetching changed files from Azure DevOps diffs API: %v", err)
 		return nil
@@ -645,12 +651,9 @@ func (a *ArgoCDWebhookHandler) lookupRepositoryWithCredsTemplate(ctx context.Con
 		return nil, nil
 	}
 	log.Debugf("found matching credentials template for URL %s", repoURL)
-	return &v1alpha1.Repository{
-		Repo:        repoURL,
-		Username:    creds.Username,
-		Password:    creds.Password,
-		BearerToken: creds.BearerToken,
-	}, nil
+	repo = &v1alpha1.Repository{Repo: repoURL}
+	repo.CopyCredentialsFrom(creds)
+	return repo, nil
 }
 
 func sourceRevisionHasChanged(source v1alpha1.ApplicationSource, revision string, touchedHead bool) bool {
@@ -807,10 +810,14 @@ func setADOAuthHeader(req *http.Request, repo *v1alpha1.Repository) bool {
 	return false
 }
 
+func newADOHTTPClient(repo *v1alpha1.Repository) *http.Client {
+	return git.GetRepoHTTPClient(repo.Repo, repo.IsInsecure(), repo.GetGitCreds(&git.NoopCredsStore{}), repo.Proxy, repo.NoProxy)
+}
+
 // fetchChangedFilesFromADO retrieves the list of files changed between two commits by calling
 // the Azure DevOps Diffs REST API.
 // See: https://learn.microsoft.com/en-us/rest/api/azure/devops/git/diffs/get
-func fetchChangedFilesFromADO(ctx context.Context, repo *v1alpha1.Repository, repoID, shaBefore, shaAfter string) ([]string, error) {
+func fetchChangedFilesFromADO(ctx context.Context, httpClient *http.Client, repo *v1alpha1.Repository, repoID, shaBefore, shaAfter string) ([]string, error) {
 	baseURL, err := parseADOBaseURL(repo.Repo)
 	if err != nil {
 		return nil, err
@@ -834,7 +841,7 @@ func fetchChangedFilesFromADO(ctx context.Context, repo *v1alpha1.Repository, re
 		return nil, nil
 	}
 	log.Debugf("fetching changed files from Azure DevOps diffs API: %s", apiURL)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("error calling Azure DevOps diffs API: %w", err)
 	}

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -793,6 +793,20 @@ func parseADOBaseURL(repoURL string) (string, error) {
 	return fmt.Sprintf("%s://%s/%s/%s", u.Scheme, u.Host, parts[0], parts[1]), nil
 }
 
+// setADOAuthHeader sets the Authorization header on the request based on the repository credentials.
+// Returns true if credentials were applied, false if none are configured.
+func setADOAuthHeader(req *http.Request, repo *v1alpha1.Repository) bool {
+	if repo.Username != "" && repo.Password != "" {
+		req.SetBasicAuth(repo.Username, repo.Password)
+		return true
+	}
+	if repo.BearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+repo.BearerToken)
+		return true
+	}
+	return false
+}
+
 // fetchChangedFilesFromADO retrieves the list of files changed between two commits by calling
 // the Azure DevOps Diffs REST API.
 // See: https://learn.microsoft.com/en-us/rest/api/azure/devops/git/diffs/get
@@ -815,10 +829,9 @@ func fetchChangedFilesFromADO(ctx context.Context, repo *v1alpha1.Repository, re
 	if err != nil {
 		return nil, fmt.Errorf("error creating Azure DevOps diffs API request: %w", err)
 	}
-	if repo.Username != "" && repo.Password != "" {
-		req.SetBasicAuth(repo.Username, repo.Password)
-	} else if repo.BearerToken != "" {
-		req.Header.Set("Authorization", "Bearer "+repo.BearerToken)
+	if !setADOAuthHeader(req, repo) {
+		log.Warnf("no credentials configured for Azure DevOps repository %s; falling back to full refresh", repo.Repo)
+		return nil, nil
 	}
 	log.Debugf("fetching changed files from Azure DevOps diffs API: %s", apiURL)
 	resp, err := http.DefaultClient.Do(req)

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -97,6 +97,8 @@ var (
 	})
 )
 
+var errNoADOCredentials = errors.New("no supported Azure DevOps REST API credentials configured")
+
 var _ settingsSource = &settings.SettingsManager{}
 
 type ArgoCDWebhookHandler struct {
@@ -619,6 +621,10 @@ func (a *ArgoCDWebhookHandler) lookupAndFetchADOChangedFiles(ctx context.Context
 	}
 	changedFiles, err := fetchChangedFilesFromADO(ctx, a.adoHTTPClientFactory(argoRepo), argoRepo, repoID, shaBefore, shaAfter)
 	if err != nil {
+		if errors.Is(err, errNoADOCredentials) {
+			log.Warnf("no supported Azure DevOps REST API credentials configured for repository %s; falling back to full refresh", repoURL)
+			return nil
+		}
 		log.Warnf("error fetching changed files from Azure DevOps diffs API: %v", err)
 		return nil
 	}
@@ -845,8 +851,7 @@ func fetchChangedFilesFromADO(ctx context.Context, httpClient *http.Client, repo
 		return nil, fmt.Errorf("error creating Azure DevOps diffs API request: %w", err)
 	}
 	if !setADOAuthHeader(req, repo) {
-		log.Warnf("no supported Azure DevOps REST API credentials configured for repository %s; falling back to full refresh", repo.Repo)
-		return nil, nil
+		return nil, errNoADOCredentials
 	}
 	log.Debugf("fetching changed files from Azure DevOps diffs API: %s", apiURL)
 	resp, err := httpClient.Do(req)

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -58,6 +59,19 @@ const usernameRegex = `[\w\.][\w\.-]{0,30}[\w\.\$-]?`
 const payloadQueueSize = 50000
 
 const panicMsgServer = "panic while processing api-server webhook event"
+
+const (
+	// adoDiffsAPIVersion is the Azure DevOps REST API version used for the Diffs endpoint.
+	// The api-version parameter is required for all ADO REST calls.
+	// See: https://learn.microsoft.com/en-us/rest/api/azure/devops/git/diffs/get?view=azure-devops-rest-7.1
+	adoDiffsAPIVersion = "7.1"
+
+	// adoDiffsMaxPageSize is the maximum number of file changes requested per call to the ADO Diffs API.
+	// The endpoint defaults to 100; this value is aligned with the documented maximum of the related
+	// Pull Request Iteration Changes endpoint. Pushes exceeding this limit fall back to a full refresh.
+	// See: https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-request-iteration-changes/get?view=azure-devops-rest-7.1
+	adoDiffsMaxPageSize = 2000
+)
 
 var (
 	webhookManifestCacheWarmDisabled = os.Getenv("ARGOCD_WEBHOOK_MANIFEST_CACHE_WARM_DISABLED") == "true"
@@ -787,12 +801,16 @@ func fetchChangedFilesFromADO(ctx context.Context, repo *v1alpha1.Repository, re
 	if err != nil {
 		return nil, err
 	}
-	// $top=2000 fetches up to 2000 file changes; large push sets beyond this limit will fall
-	// back to refreshing all matching applications.
-	apiURL := fmt.Sprintf(
-		"%s/_apis/git/repositories/%s/diffs/commits?baseVersion=%s&baseVersionType=commit&targetVersion=%s&targetVersionType=commit&$top=2000&api-version=7.1",
-		baseURL, url.PathEscape(repoID), url.QueryEscape(shaBefore), url.QueryEscape(shaAfter),
-	)
+	params := url.Values{
+		"baseVersion":       {shaBefore},
+		"baseVersionType":   {"commit"},
+		"targetVersion":     {shaAfter},
+		"targetVersionType": {"commit"},
+		"$top":              {strconv.Itoa(adoDiffsMaxPageSize)},
+		"api-version":       {adoDiffsAPIVersion},
+	}
+	apiURL := fmt.Sprintf("%s/_apis/git/repositories/%s/diffs/commits?%s",
+		baseURL, url.PathEscape(repoID), params.Encode())
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("error creating Azure DevOps diffs API request: %w", err)

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -622,27 +622,15 @@ func (a *ArgoCDWebhookHandler) lookupRepositoryWithCredsTemplate(ctx context.Con
 	if err != nil || repo != nil {
 		return repo, err
 	}
-
-	// No specific repo found — check credentials templates, which match by URL prefix.
-	credURLs, err := a.db.ListRepositoryCredentials(ctx)
+	creds, err := a.db.GetRepositoryCredentials(ctx, repoURL)
 	if err != nil {
-		return nil, fmt.Errorf("error listing repository credentials: %w", err)
+		return nil, fmt.Errorf("error getting repository credentials for %q: %w", repoURL, err)
 	}
-	normalizedRepoURL := git.NormalizeGitURL(repoURL)
-	var bestMatchURL string
-	for _, credURL := range credURLs {
-		if strings.HasPrefix(normalizedRepoURL, git.NormalizeGitURL(credURL)) && len(credURL) > len(bestMatchURL) {
-			bestMatchURL = credURL
-		}
-	}
-	if bestMatchURL == "" {
+	if creds == nil {
+		log.Debugf("no repository or credentials template found for Azure DevOps URL %s", repoURL)
 		return nil, nil
 	}
-	creds, err := a.db.GetRepositoryCredentials(ctx, bestMatchURL)
-	if err != nil {
-		return nil, fmt.Errorf("error getting credentials template for %q: %w", bestMatchURL, err)
-	}
-	log.Debugf("found matching credentials template %q for URL %s", bestMatchURL, repoURL)
+	log.Debugf("found matching credentials template for URL %s", repoURL)
 	return &v1alpha1.Repository{
 		Repo:        repoURL,
 		Username:    creds.Username,

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -589,7 +589,7 @@ func (a *ArgoCDWebhookHandler) lookupAndFetchADOChangedFiles(repoURL, repoID, sh
 		log.Debugf("no repository configured for Azure DevOps webhook URL %s, skipping changed files lookup", repoURL)
 		return nil
 	}
-	changedFiles, err := fetchChangedFilesFromADO(ctx, argoRepo, repoURL, repoID, shaBefore, shaAfter)
+	changedFiles, err := fetchChangedFilesFromADO(ctx, argoRepo, repoID, shaBefore, shaAfter)
 	if err != nil {
 		log.Warnf("error fetching changed files from Azure DevOps diffs API: %v", err)
 		return nil
@@ -780,8 +780,8 @@ func parseADOBaseURL(repoURL string) (string, error) {
 // fetchChangedFilesFromADO retrieves the list of files changed between two commits by calling
 // the Azure DevOps Diffs REST API.
 // See: https://learn.microsoft.com/en-us/rest/api/azure/devops/git/diffs/get
-func fetchChangedFilesFromADO(ctx context.Context, repo *v1alpha1.Repository, repoURL, repoID, shaBefore, shaAfter string) ([]string, error) {
-	baseURL, err := parseADOBaseURL(repoURL)
+func fetchChangedFilesFromADO(ctx context.Context, repo *v1alpha1.Repository, repoID, shaBefore, shaAfter string) ([]string, error) {
+	baseURL, err := parseADOBaseURL(repo.Repo)
 	if err != nil {
 		return nil, err
 	}

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -71,6 +71,11 @@ const (
 	// Pull Request Iteration Changes endpoint. Pushes exceeding this limit fall back to a full refresh.
 	// See: https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-request-iteration-changes/get?view=azure-devops-rest-7.1
 	adoDiffsMaxPageSize = 2000
+
+	// adoNullSHA is the all-zeros object ID used by Azure DevOps to signal a non-existent commit.
+	// It appears as newObjectId on branch deletion events and as oldObjectId on branch creation events.
+	// Diffing against this SHA is not meaningful and the Diffs API returns 404 for such requests.
+	adoNullSHA = "0000000000000000000000000000000000000000"
 )
 
 var (
@@ -594,12 +599,13 @@ func (a *ArgoCDWebhookHandler) storePreviouslyCachedManifests(app *v1alpha1.Appl
 // lookupAndFetchADOChangedFiles fetches the list of changed files for an Azure DevOps push event.
 // The repo lookup acts as the SSRF guard: we only proceed if the repository is registered in ArgoCD.
 func (a *ArgoCDWebhookHandler) lookupAndFetchADOChangedFiles(repoURL, repoID, shaBefore, shaAfter string) []string {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	if shaBefore == "" || shaAfter == "" {
-		log.Debugf("skipping Azure DevOps changed files lookup for URL %s because the commit range is empty", repoURL)
+	if shaBefore == "" || shaAfter == "" || shaBefore == adoNullSHA || shaAfter == adoNullSHA {
+		log.Debugf("skipping Azure DevOps changed files lookup for URL %s because the commit range is empty or includes the null SHA used for branch creation or deletion", repoURL)
 		return nil
 	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 	argoRepo, err := a.lookupRepositoryWithCredsTemplate(ctx, repoURL)
 	if err != nil {
 		log.Warnf("error finding repository for Azure DevOps webhook URL %s: %v", repoURL, err)

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -837,7 +837,7 @@ func fetchChangedFilesFromADO(ctx context.Context, httpClient *http.Client, repo
 		return nil, fmt.Errorf("error creating Azure DevOps diffs API request: %w", err)
 	}
 	if !setADOAuthHeader(req, repo) {
-		log.Warnf("no credentials configured for Azure DevOps repository %s; falling back to full refresh", repo.Repo)
+		log.Warnf("no supported Azure DevOps REST API credentials configured for repository %s; falling back to full refresh", repo.Repo)
 		return nil, nil
 	}
 	log.Debugf("fetching changed files from Azure DevOps diffs API: %s", apiURL)

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -199,7 +200,28 @@ func (a *ArgoCDWebhookHandler) affectedRevisionInfo(payloadIf any) (webURLs []st
 			change.shaBefore = ParseRevision(payload.Resource.RefUpdates[0].OldObjectID)
 			touchedHead = payload.Resource.RefUpdates[0].Name == payload.Resource.Repository.DefaultBranch
 		}
-		// unfortunately, Azure DevOps doesn't provide a list of changed files
+		// The webhook payload does not include changed files. Fetch them from the Azure DevOps
+		// REST API using the repository credentials already stored in ArgoCD. The repo lookup
+		// acts as the SSRF guard: we only proceed if the repository is registered in ArgoCD.
+		{
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			argoRepo, err := a.lookupRepositoryWithCredsTemplate(ctx, payload.Resource.Repository.RemoteURL)
+			if err != nil {
+				log.Warnf("error finding repository for Azure DevOps webhook URL %s: %v", payload.Resource.Repository.RemoteURL, err)
+				break
+			}
+			if argoRepo == nil {
+				log.Debugf("no repository configured for Azure DevOps webhook URL %s, skipping changed files lookup", payload.Resource.Repository.RemoteURL)
+				break
+			}
+			adoChangedFiles, err := fetchChangedFilesFromADO(ctx, argoRepo, payload.Resource.Repository.RemoteURL, payload.Resource.Repository.ID, change.shaBefore, change.shaAfter)
+			if err != nil {
+				log.Warnf("error fetching changed files from Azure DevOps diffs API: %v", err)
+				break
+			}
+			changedFiles = append(changedFiles, adoChangedFiles...)
+		}
 	case github.PushPayload:
 		// See: https://developer.github.com/v3/activity/events/types/#pushevent
 		webURLs = append(webURLs, payload.Repository.HTMLURL)
@@ -346,6 +368,20 @@ func (a *ArgoCDWebhookHandler) affectedRevisionInfo(payloadIf any) (webURLs []st
 type changeInfo struct {
 	shaBefore string
 	shaAfter  string
+}
+
+type adoDiffsResponse struct {
+	Changes []adoDiffChange `json:"changes"`
+}
+
+type adoDiffChange struct {
+	Item       adoDiffItem `json:"item"`
+	ChangeType string      `json:"changeType"`
+}
+
+type adoDiffItem struct {
+	Path     string `json:"path"`
+	IsFolder bool   `json:"isFolder"`
 }
 
 // HandleEvent handles webhook events for repo push events
@@ -571,6 +607,43 @@ func (a *ArgoCDWebhookHandler) lookupRepository(ctx context.Context, repoURL str
 	return repository, nil
 }
 
+// lookupRepositoryWithCredsTemplate returns credentials for a given URL by checking individual
+// repository secrets first, then falling back to credentials templates (matched by URL prefix).
+// Returns nil if no credentials are found.
+func (a *ArgoCDWebhookHandler) lookupRepositoryWithCredsTemplate(ctx context.Context, repoURL string) (*v1alpha1.Repository, error) {
+	repo, err := a.lookupRepository(ctx, repoURL)
+	if err != nil || repo != nil {
+		return repo, err
+	}
+
+	// No specific repo found — check credentials templates, which match by URL prefix.
+	credURLs, err := a.db.ListRepositoryCredentials(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error listing repository credentials: %w", err)
+	}
+	normalizedRepoURL := git.NormalizeGitURL(repoURL)
+	var bestMatchURL string
+	for _, credURL := range credURLs {
+		if strings.HasPrefix(normalizedRepoURL, git.NormalizeGitURL(credURL)) && len(credURL) > len(bestMatchURL) {
+			bestMatchURL = credURL
+		}
+	}
+	if bestMatchURL == "" {
+		return nil, nil
+	}
+	creds, err := a.db.GetRepositoryCredentials(ctx, bestMatchURL)
+	if err != nil {
+		return nil, fmt.Errorf("error getting credentials template for %q: %w", bestMatchURL, err)
+	}
+	log.Debugf("found matching credentials template %q for URL %s", bestMatchURL, repoURL)
+	return &v1alpha1.Repository{
+		Repo:        repoURL,
+		Username:    creds.Username,
+		Password:    creds.Password,
+		BearerToken: creds.BearerToken,
+	}, nil
+}
+
 func sourceRevisionHasChanged(source v1alpha1.ApplicationSource, revision string, touchedHead bool) bool {
 	targetRev := ParseRevision(source.TargetRevision)
 	if targetRev == "HEAD" || targetRev == "" { // revision is head
@@ -682,6 +755,67 @@ func fetchDiffStatFromBitbucket(_ context.Context, bbClient *bb.Client, owner, r
 		}
 	}
 	log.Debugf("changed files for spec %s: %v", spec, changedFiles)
+	return changedFiles, nil
+}
+
+// parseADOBaseURL extracts the base URL (scheme://host/{org}/{project}) from an Azure DevOps
+// Git repository remote URL (https://dev.azure.com/{org}/{project}/_git/{repo}).
+func parseADOBaseURL(repoURL string) (string, error) {
+	u, err := url.Parse(repoURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse Azure DevOps URL %q: %w", repoURL, err)
+	}
+	// path is "/{org}/{project}/_git/{repo}" — we need scheme://host/{org}/{project}
+	parts := strings.SplitN(strings.TrimPrefix(u.Path, "/"), "/", 3)
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return "", fmt.Errorf("cannot extract organization and project from Azure DevOps URL %q", repoURL)
+	}
+	return fmt.Sprintf("%s://%s/%s/%s", u.Scheme, u.Host, parts[0], parts[1]), nil
+}
+
+// fetchChangedFilesFromADO retrieves the list of files changed between two commits by calling
+// the Azure DevOps Diffs REST API.
+// See: https://learn.microsoft.com/en-us/rest/api/azure/devops/git/diffs/get
+func fetchChangedFilesFromADO(ctx context.Context, repo *v1alpha1.Repository, repoURL, repoID, shaBefore, shaAfter string) ([]string, error) {
+	baseURL, err := parseADOBaseURL(repoURL)
+	if err != nil {
+		return nil, err
+	}
+	// $top=2000 fetches up to 2000 file changes; large push sets beyond this limit will fall
+	// back to refreshing all matching applications.
+	apiURL := fmt.Sprintf(
+		"%s/_apis/git/repositories/%s/diffs/commits?baseVersion=%s&baseVersionType=commit&targetVersion=%s&targetVersionType=commit&$top=2000&api-version=7.1",
+		baseURL, url.PathEscape(repoID), url.QueryEscape(shaBefore), url.QueryEscape(shaAfter),
+	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Azure DevOps diffs API request: %w", err)
+	}
+	if repo.Username != "" || repo.Password != "" {
+		req.SetBasicAuth(repo.Username, repo.Password)
+	} else if repo.BearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+repo.BearerToken)
+	}
+	log.Debugf("fetching changed files from Azure DevOps diffs API: %s", apiURL)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error calling Azure DevOps diffs API: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Azure DevOps diffs API returned unexpected status %d", resp.StatusCode)
+	}
+	var diffsResp adoDiffsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&diffsResp); err != nil {
+		return nil, fmt.Errorf("error decoding Azure DevOps diffs API response: %w", err)
+	}
+	changedFiles := make([]string, 0, len(diffsResp.Changes))
+	for _, c := range diffsResp.Changes {
+		if !c.Item.IsFolder && c.Item.Path != "" {
+			changedFiles = append(changedFiles, strings.TrimPrefix(c.Item.Path, "/"))
+		}
+	}
+	log.Debugf("Azure DevOps changed files between %s..%s: %v", shaBefore, shaAfter, changedFiles)
 	return changedFiles, nil
 }
 

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -759,15 +759,24 @@ func fetchDiffStatFromBitbucket(_ context.Context, bbClient *bb.Client, owner, r
 	return changedFiles, nil
 }
 
-// parseADOBaseURL extracts the base URL (scheme://host/{org}/{project}) from an Azure DevOps
-// Git repository remote URL (https://dev.azure.com/{org}/{project}/_git/{repo}).
+// parseADOBaseURL extracts the base URL used to construct Azure DevOps REST API requests.
+// It supports both the modern format (https://dev.azure.com/{org}/{project}/_git/{repo})
+// and the legacy format (https://{org}.visualstudio.com/{project}/_git/{repo}).
 func parseADOBaseURL(repoURL string) (string, error) {
 	u, err := url.Parse(repoURL)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse Azure DevOps URL %q: %w", repoURL, err)
 	}
-	// path is "/{org}/{project}/_git/{repo}" — we need scheme://host/{org}/{project}
 	parts := strings.SplitN(strings.TrimPrefix(u.Path, "/"), "/", 3)
+	// Legacy format: https://{org}.visualstudio.com/{project}/_git/{repo}
+	// The org is in the host; the first path segment is the project.
+	if strings.HasSuffix(u.Host, ".visualstudio.com") {
+		if len(parts) < 1 || parts[0] == "" {
+			return "", fmt.Errorf("cannot extract project from Azure DevOps URL %q", repoURL)
+		}
+		return fmt.Sprintf("%s://%s/%s", u.Scheme, u.Host, parts[0]), nil
+	}
+	// Modern format: https://dev.azure.com/{org}/{project}/_git/{repo}
 	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
 		return "", fmt.Errorf("cannot extract organization and project from Azure DevOps URL %q", repoURL)
 	}

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -801,7 +801,7 @@ func fetchChangedFilesFromADO(ctx context.Context, repo *v1alpha1.Repository, re
 	if err != nil {
 		return nil, fmt.Errorf("error creating Azure DevOps diffs API request: %w", err)
 	}
-	if repo.Username != "" || repo.Password != "" {
+	if repo.Username != "" && repo.Password != "" {
 		req.SetBasicAuth(repo.Username, repo.Password)
 	} else if repo.BearerToken != "" {
 		req.Header.Set("Authorization", "Bearer "+repo.BearerToken)

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -200,28 +200,12 @@ func (a *ArgoCDWebhookHandler) affectedRevisionInfo(payloadIf any) (webURLs []st
 			change.shaBefore = ParseRevision(payload.Resource.RefUpdates[0].OldObjectID)
 			touchedHead = payload.Resource.RefUpdates[0].Name == payload.Resource.Repository.DefaultBranch
 		}
-		// The webhook payload does not include changed files. Fetch them from the Azure DevOps
-		// REST API using the repository credentials already stored in ArgoCD. The repo lookup
-		// acts as the SSRF guard: we only proceed if the repository is registered in ArgoCD.
-		{
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer cancel()
-			argoRepo, err := a.lookupRepositoryWithCredsTemplate(ctx, payload.Resource.Repository.RemoteURL)
-			if err != nil {
-				log.Warnf("error finding repository for Azure DevOps webhook URL %s: %v", payload.Resource.Repository.RemoteURL, err)
-				break
-			}
-			if argoRepo == nil {
-				log.Debugf("no repository configured for Azure DevOps webhook URL %s, skipping changed files lookup", payload.Resource.Repository.RemoteURL)
-				break
-			}
-			adoChangedFiles, err := fetchChangedFilesFromADO(ctx, argoRepo, payload.Resource.Repository.RemoteURL, payload.Resource.Repository.ID, change.shaBefore, change.shaAfter)
-			if err != nil {
-				log.Warnf("error fetching changed files from Azure DevOps diffs API: %v", err)
-				break
-			}
-			changedFiles = append(changedFiles, adoChangedFiles...)
-		}
+		changedFiles = append(changedFiles, a.lookupAndFetchADOChangedFiles(
+			payload.Resource.Repository.RemoteURL,
+			payload.Resource.Repository.ID,
+			change.shaBefore,
+			change.shaAfter,
+		)...)
 	case github.PushPayload:
 		// See: https://developer.github.com/v3/activity/events/types/#pushevent
 		webURLs = append(webURLs, payload.Repository.HTMLURL)
@@ -589,6 +573,28 @@ func (a *ArgoCDWebhookHandler) storePreviouslyCachedManifests(app *v1alpha1.Appl
 	}
 
 	return nil
+}
+
+// lookupAndFetchADOChangedFiles fetches the list of changed files for an Azure DevOps push event.
+// The repo lookup acts as the SSRF guard: we only proceed if the repository is registered in ArgoCD.
+func (a *ArgoCDWebhookHandler) lookupAndFetchADOChangedFiles(repoURL, repoID, shaBefore, shaAfter string) []string {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	argoRepo, err := a.lookupRepositoryWithCredsTemplate(ctx, repoURL)
+	if err != nil {
+		log.Warnf("error finding repository for Azure DevOps webhook URL %s: %v", repoURL, err)
+		return nil
+	}
+	if argoRepo == nil {
+		log.Debugf("no repository configured for Azure DevOps webhook URL %s, skipping changed files lookup", repoURL)
+		return nil
+	}
+	changedFiles, err := fetchChangedFilesFromADO(ctx, argoRepo, repoURL, repoID, shaBefore, shaAfter)
+	if err != nil {
+		log.Warnf("error fetching changed files from Azure DevOps diffs API: %v", err)
+		return nil
+	}
+	return changedFiles
 }
 
 // lookupRepository returns a repository with its credentials for a given URL. If there are no matching repository secret found,

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -211,6 +211,11 @@ func ParseRevision(ref string) string {
 	return refParts[len(refParts)-1]
 }
 
+func (a *ArgoCDWebhookHandler) azureDevOpsWebhookAuthConfigured() bool {
+	// The Azure DevOps webhook parser requires BasicAuth when either value is configured.
+	return a.settings.GetWebhookAzureDevOpsUsername() != "" || a.settings.GetWebhookAzureDevOpsPassword() != ""
+}
+
 // affectedRevisionInfo examines a payload from a webhook event, and extracts the repo web URL,
 // the revision, and whether, or not this affected origin/HEAD (the default branch of the repository)
 func (a *ArgoCDWebhookHandler) affectedRevisionInfo(ctx context.Context, payloadIf any) (webURLs []string, revision string, change changeInfo, touchedHead bool, changedFiles []string) {
@@ -224,13 +229,17 @@ func (a *ArgoCDWebhookHandler) affectedRevisionInfo(ctx context.Context, payload
 			change.shaBefore = ParseRevision(payload.Resource.RefUpdates[0].OldObjectID)
 			touchedHead = payload.Resource.RefUpdates[0].Name == payload.Resource.Repository.DefaultBranch
 		}
-		changedFiles = append(changedFiles, a.lookupAndFetchADOChangedFiles(
-			ctx,
-			payload.Resource.Repository.RemoteURL,
-			payload.Resource.Repository.ID,
-			change.shaBefore,
-			change.shaAfter,
-		)...)
+		if a.azureDevOpsWebhookAuthConfigured() {
+			changedFiles = append(changedFiles, a.lookupAndFetchADOChangedFiles(
+				ctx,
+				payload.Resource.Repository.RemoteURL,
+				payload.Resource.Repository.ID,
+				change.shaBefore,
+				change.shaAfter,
+			)...)
+		} else {
+			log.Debugf("skipping Azure DevOps changed files lookup for URL %s because Azure DevOps webhook authentication is not configured", payload.Resource.Repository.RemoteURL)
+		}
 	case github.PushPayload:
 		// See: https://developer.github.com/v3/activity/events/types/#pushevent
 		webURLs = append(webURLs, payload.Repository.HTMLURL)

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -797,7 +797,7 @@ func fetchChangedFilesFromADO(ctx context.Context, repo *v1alpha1.Repository, re
 		"%s/_apis/git/repositories/%s/diffs/commits?baseVersion=%s&baseVersionType=commit&targetVersion=%s&targetVersionType=commit&$top=2000&api-version=7.1",
 		baseURL, url.PathEscape(repoID), url.QueryEscape(shaBefore), url.QueryEscape(shaAfter),
 	)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("error creating Azure DevOps diffs API request: %w", err)
 	}
@@ -813,14 +813,14 @@ func fetchChangedFilesFromADO(ctx context.Context, repo *v1alpha1.Repository, re
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Azure DevOps diffs API returned unexpected status %d", resp.StatusCode)
+		return nil, fmt.Errorf("azure DevOps diffs API returned unexpected status %d", resp.StatusCode)
 	}
 	var diffsResp adoDiffsResponse
 	if err := json.NewDecoder(resp.Body).Decode(&diffsResp); err != nil {
 		return nil, fmt.Errorf("error decoding Azure DevOps diffs API response: %w", err)
 	}
 	if !diffsResp.AllChangesIncluded {
-		return nil, fmt.Errorf("Azure DevOps diffs API response was truncated (more than 2000 files changed); falling back to full refresh")
+		return nil, errors.New("azure DevOps diffs API response was truncated (more than 2000 files changed); falling back to full refresh")
 	}
 	changedFiles := make([]string, 0, len(diffsResp.Changes))
 	for _, c := range diffsResp.Changes {

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -371,7 +371,8 @@ type changeInfo struct {
 }
 
 type adoDiffsResponse struct {
-	Changes []adoDiffChange `json:"changes"`
+	Changes            []adoDiffChange `json:"changes"`
+	AllChangesIncluded bool            `json:"allChangesIncluded"`
 }
 
 type adoDiffChange struct {
@@ -809,13 +810,16 @@ func fetchChangedFilesFromADO(ctx context.Context, repo *v1alpha1.Repository, re
 	if err := json.NewDecoder(resp.Body).Decode(&diffsResp); err != nil {
 		return nil, fmt.Errorf("error decoding Azure DevOps diffs API response: %w", err)
 	}
+	if !diffsResp.AllChangesIncluded {
+		return nil, fmt.Errorf("Azure DevOps diffs API response was truncated (more than 2000 files changed); falling back to full refresh")
+	}
 	changedFiles := make([]string, 0, len(diffsResp.Changes))
 	for _, c := range diffsResp.Changes {
 		if !c.Item.IsFolder && c.Item.Path != "" {
 			changedFiles = append(changedFiles, strings.TrimPrefix(c.Item.Path, "/"))
 		}
 	}
-	log.Debugf("Azure DevOps changed files between %s..%s: %v", shaBefore, shaAfter, changedFiles)
+	log.Debugf("Azure DevOps diffs API returned %d changed files between %s..%s", len(changedFiles), shaBefore, shaAfter)
 	return changedFiles, nil
 }
 

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -61,8 +61,9 @@ const payloadQueueSize = 50000
 const panicMsgServer = "panic while processing api-server webhook event"
 
 const (
-	// adoDiffsAPIVersion is the Azure DevOps REST API version used for the Diffs endpoint.
-	// The api-version parameter is required for all ADO REST calls.
+	// adoDiffsAPIVersion pins the Azure DevOps REST API version for the Diffs endpoint.
+	// The Diffs endpoint documents api-version as a required query parameter, so keep it
+	// explicit instead of relying on undocumented server-side defaults.
 	// See: https://learn.microsoft.com/en-us/rest/api/azure/devops/git/diffs/get?view=azure-devops-rest-7.1
 	adoDiffsAPIVersion = "7.1"
 

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -1455,6 +1455,40 @@ func Test_affectedRevisionInfo_azuredevops_changed_files(t *testing.T) {
 	require.Equal(t, []string{"apps/my-app/values.yaml", "apps/my-app/deployment.yaml"}, changedFiles)
 }
 
+func Test_affectedRevisionInfo_azuredevops_multiple_ref_updates(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	// Register mock only for the first refUpdate's SHAs. If the code were to call
+	// the API with any other SHA pair, httpmock would return "no responder found" and
+	// the test would fail, confirming that only RefUpdates[0] is used.
+	const adoDiffsAPIURL = "https://dev.azure.com/alexander0053/alex-test/_apis/git/repositories/" +
+		"ba2967cc-02c2-414c-8d10-1b99197cbaa6/diffs/commits" +
+		"?baseVersion=fa51eeb1e50b98293ce281e6d5492b9decae613b" +
+		"&baseVersionType=commit" +
+		"&targetVersion=298a79aa1552799a70718a0ee914d153d5a1a76b" +
+		"&targetVersionType=commit" +
+		"&$top=2000&api-version=7.1"
+	httpmock.RegisterResponder("GET", adoDiffsAPIURL, getADODiffsResponderFn())
+
+	eventJSON, err := os.ReadFile("testdata/azuredevops-git-push-event.json")
+	require.NoError(t, err)
+	var payload azuredevops.GitPushEvent
+	require.NoError(t, json.Unmarshal(eventJSON, &payload))
+
+	// Append a second refUpdate with different SHAs to simulate a multi-ref push.
+	payload.Resource.RefUpdates = append(payload.Resource.RefUpdates, azuredevops.RefUpdate{
+		Name:        "refs/heads/other-branch",
+		OldObjectID: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		NewObjectID: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+	})
+
+	h := NewMockHandlerForADOCallback(nil, []string{})
+	_, _, _, _, changedFiles := h.affectedRevisionInfo(payload)
+	// Only the first refUpdate's SHAs were used; changed files are still resolved correctly.
+	require.Equal(t, []string{"apps/my-app/values.yaml", "apps/my-app/deployment.yaml"}, changedFiles)
+}
+
 func TestLookupRepository(t *testing.T) {
 	mockCtx, cancel := context.WithDeadline(t.Context(), time.Now().Add(10*time.Second))
 	defer cancel()

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -1713,6 +1713,14 @@ func TestFetchChangedFilesFromADO(t *testing.T) {
 	)
 	httpmock.RegisterResponder("GET", validAPIURL, getADODiffsResponderFn())
 
+	// Legacy visualstudio.com format: base URL is scheme://host/{project} (no org in path).
+	legacyAPIURL := fmt.Sprintf(
+		"https://myorg.visualstudio.com/myproject/_apis/git/repositories/%s/diffs/commits"+
+			"?baseVersion=%s&baseVersionType=commit&targetVersion=%s&targetVersionType=commit&$top=2000&api-version=7.1",
+		testRepoID, testShaBefore, testShaAfter,
+	)
+	httpmock.RegisterResponder("GET", legacyAPIURL, getADODiffsResponderFn())
+
 	truncatedAPIURL := fmt.Sprintf(
 		"https://dev.azure.com/myorg/myproject/_apis/git/repositories/%s/diffs/commits"+
 			"?baseVersion=%s&baseVersionType=commit&targetVersion=%s&targetVersionType=commit&$top=2000&api-version=7.1",
@@ -1761,6 +1769,14 @@ func TestFetchChangedFilesFromADO(t *testing.T) {
 			shaBefore: "0000000000000000000000000000000000000000",
 			shaAfter:  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			expectErr: true,
+		},
+		{
+			name:          "returns changed files for legacy visualstudio.com URL",
+			repoURL:       "https://myorg.visualstudio.com/myproject/_git/myrepo",
+			repoID:        testRepoID,
+			shaBefore:     testShaBefore,
+			shaAfter:      testShaAfter,
+			expectedFiles: []string{"apps/my-app/values.yaml", "apps/my-app/deployment.yaml"},
 		},
 		{
 			name:      "returns error for URL without org and project",

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -98,6 +98,7 @@ func NewMockHandler(reactor *reactorDef, applicationNamespaces []string, objects
 func NewMockHandlerWithPayloadLimit(reactor *reactorDef, applicationNamespaces []string, maxPayloadSize int64, objects ...runtime.Object) *ArgoCDWebhookHandler {
 	mockDB := &mocks.ArgoDB{}
 	mockDB.EXPECT().ListRepositories(mock.Anything).Return([]*v1alpha1.Repository{}, nil).Maybe()
+	mockDB.EXPECT().ListRepositoryCredentials(mock.Anything).Return([]string{}, nil).Maybe()
 	return newMockHandler(reactor, applicationNamespaces, maxPayloadSize, mockDB, &settings.ArgoCDSettings{}, objects...)
 }
 
@@ -123,6 +124,36 @@ func NewMockHandlerForBitbucketCallback(reactor *reactorDef, applicationNamespac
 	argoSettings := settings.ArgoCDSettings{WebhookBitbucketUUID: "abcd-efgh-ijkl-mnop"}
 	defaultMaxPayloadSize := int64(50) * 1024 * 1024
 	return newMockHandler(reactor, applicationNamespaces, defaultMaxPayloadSize, mockDB, &argoSettings, objects...)
+}
+
+func NewMockHandlerForADOCallback(reactor *reactorDef, applicationNamespaces []string, objects ...runtime.Object) *ArgoCDWebhookHandler {
+	mockDB := &mocks.ArgoDB{}
+	mockDB.EXPECT().ListRepositories(mock.Anything).Return(
+		[]*v1alpha1.Repository{
+			{
+				Repo:     "https://dev.azure.com/alexander0053/alex-test/_git/alex-test",
+				Username: "test-user",
+				Password: "test-pat",
+			},
+		}, nil)
+	mockDB.EXPECT().ListRepositoryCredentials(mock.Anything).Return([]string{}, nil).Maybe()
+	defaultMaxPayloadSize := int64(50) * 1024 * 1024
+	return newMockHandler(reactor, applicationNamespaces, defaultMaxPayloadSize, mockDB, &settings.ArgoCDSettings{}, objects...)
+}
+
+func NewMockHandlerForADOCredsTemplateCallback(reactor *reactorDef, applicationNamespaces []string, objects ...runtime.Object) *ArgoCDWebhookHandler {
+	mockDB := &mocks.ArgoDB{}
+	mockDB.EXPECT().ListRepositories(mock.Anything).Return([]*v1alpha1.Repository{}, nil)
+	mockDB.EXPECT().ListRepositoryCredentials(mock.Anything).Return(
+		[]string{"https://dev.azure.com/alexander0053"}, nil)
+	mockDB.EXPECT().GetRepositoryCredentials(mock.Anything, "https://dev.azure.com/alexander0053").Return(
+		&v1alpha1.RepoCreds{
+			URL:      "https://dev.azure.com/alexander0053",
+			Username: "test-user",
+			Password: "test-pat",
+		}, nil)
+	defaultMaxPayloadSize := int64(50) * 1024 * 1024
+	return newMockHandler(reactor, applicationNamespaces, defaultMaxPayloadSize, mockDB, &settings.ArgoCDSettings{}, objects...)
 }
 
 type fakeAppsLister struct {
@@ -1378,6 +1409,52 @@ func Test_affectedRevisionInfo_bitbucket_changed_files(t *testing.T) {
 	}
 }
 
+func Test_affectedRevisionInfo_azuredevops_changed_files_via_creds_template(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	const adoDiffsAPIURL = "https://dev.azure.com/alexander0053/alex-test/_apis/git/repositories/" +
+		"ba2967cc-02c2-414c-8d10-1b99197cbaa6/diffs/commits" +
+		"?baseVersion=fa51eeb1e50b98293ce281e6d5492b9decae613b" +
+		"&baseVersionType=commit" +
+		"&targetVersion=298a79aa1552799a70718a0ee914d153d5a1a76b" +
+		"&targetVersionType=commit" +
+		"&$top=2000&api-version=7.1"
+	httpmock.RegisterResponder("GET", adoDiffsAPIURL, getADODiffsResponderFn())
+
+	eventJSON, err := os.ReadFile("testdata/azuredevops-git-push-event.json")
+	require.NoError(t, err)
+	var payload azuredevops.GitPushEvent
+	require.NoError(t, json.Unmarshal(eventJSON, &payload))
+
+	h := NewMockHandlerForADOCredsTemplateCallback(nil, []string{})
+	_, _, _, _, changedFiles := h.affectedRevisionInfo(payload)
+	require.Equal(t, []string{"apps/my-app/values.yaml", "apps/my-app/deployment.yaml"}, changedFiles)
+}
+
+func Test_affectedRevisionInfo_azuredevops_changed_files(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	const adoDiffsAPIURL = "https://dev.azure.com/alexander0053/alex-test/_apis/git/repositories/" +
+		"ba2967cc-02c2-414c-8d10-1b99197cbaa6/diffs/commits" +
+		"?baseVersion=fa51eeb1e50b98293ce281e6d5492b9decae613b" +
+		"&baseVersionType=commit" +
+		"&targetVersion=298a79aa1552799a70718a0ee914d153d5a1a76b" +
+		"&targetVersionType=commit" +
+		"&$top=2000&api-version=7.1"
+	httpmock.RegisterResponder("GET", adoDiffsAPIURL, getADODiffsResponderFn())
+
+	eventJSON, err := os.ReadFile("testdata/azuredevops-git-push-event.json")
+	require.NoError(t, err)
+	var payload azuredevops.GitPushEvent
+	require.NoError(t, json.Unmarshal(eventJSON, &payload))
+
+	h := NewMockHandlerForADOCallback(nil, []string{})
+	_, _, _, _, changedFiles := h.affectedRevisionInfo(payload)
+	require.Equal(t, []string{"apps/my-app/values.yaml", "apps/my-app/deployment.yaml"}, changedFiles)
+}
+
 func TestLookupRepository(t *testing.T) {
 	mockCtx, cancel := context.WithDeadline(t.Context(), time.Now().Add(10*time.Second))
 	defer cancel()
@@ -1531,6 +1608,119 @@ func TestFetchDiffStatBitbucketClient(t *testing.T) {
 	}
 }
 
+func TestParseADOBaseURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		repoURL     string
+		expectedURL string
+		expectErr   bool
+	}{
+		{
+			name:        "standard HTTPS URL",
+			repoURL:     "https://dev.azure.com/myorg/myproject/_git/myrepo",
+			expectedURL: "https://dev.azure.com/myorg/myproject",
+		},
+		{
+			name:        "real-world ADO URL",
+			repoURL:     "https://dev.azure.com/alexander0053/alex-test/_git/alex-test",
+			expectedURL: "https://dev.azure.com/alexander0053/alex-test",
+		},
+		{
+			name:      "URL with only org segment",
+			repoURL:   "https://dev.azure.com/myorg",
+			expectErr: true,
+		},
+		{
+			name:      "URL with empty project segment",
+			repoURL:   "https://dev.azure.com/myorg/",
+			expectErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseADOBaseURL(tt.repoURL)
+			if tt.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedURL, result)
+			}
+		})
+	}
+}
+
+func TestFetchChangedFilesFromADO(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	const (
+		testRepoURL   = "https://dev.azure.com/myorg/myproject/_git/myrepo"
+		testRepoID    = "ba2967cc-02c2-414c-8d10-1b99197cbaa6"
+		testShaBefore = "fa51eeb1e50b98293ce281e6d5492b9decae613b"
+		testShaAfter  = "298a79aa1552799a70718a0ee914d153d5a1a76b"
+	)
+
+	validAPIURL := fmt.Sprintf(
+		"https://dev.azure.com/myorg/myproject/_apis/git/repositories/%s/diffs/commits"+
+			"?baseVersion=%s&baseVersionType=commit&targetVersion=%s&targetVersionType=commit&$top=2000&api-version=7.1",
+		testRepoID, testShaBefore, testShaAfter,
+	)
+	httpmock.RegisterResponder("GET", validAPIURL, getADODiffsResponderFn())
+
+	repo := &v1alpha1.Repository{
+		Repo:     testRepoURL,
+		Username: "test-user",
+		Password: "test-pat",
+	}
+
+	tests := []struct {
+		name          string
+		repoURL       string
+		repoID        string
+		shaBefore     string
+		shaAfter      string
+		expectedFiles []string
+		expectErr     bool
+	}{
+		{
+			name:          "returns changed files for valid diff",
+			repoURL:       testRepoURL,
+			repoID:        testRepoID,
+			shaBefore:     testShaBefore,
+			shaAfter:      testShaAfter,
+			expectedFiles: []string{"apps/my-app/values.yaml", "apps/my-app/deployment.yaml"},
+		},
+		{
+			name:      "returns error for unregistered SHA pair",
+			repoURL:   testRepoURL,
+			repoID:    testRepoID,
+			shaBefore: "0000000000000000000000000000000000000000",
+			shaAfter:  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			expectErr: true,
+		},
+		{
+			name:      "returns error for URL without org and project",
+			repoURL:   "https://dev.azure.com",
+			repoID:    testRepoID,
+			shaBefore: testShaBefore,
+			shaAfter:  testShaAfter,
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			changedFiles, err := fetchChangedFilesFromADO(t.Context(), repo, tt.repoURL, tt.repoID, tt.shaBefore, tt.shaAfter)
+			if tt.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedFiles, changedFiles)
+			}
+		})
+	}
+}
+
 func TestIsHeadTouched(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
@@ -1639,6 +1829,34 @@ func getDiffstatResponderFn() func(req *http.Request) (*http.Response, error) {
 		resp, err := httpmock.NewJsonResponse(200, diffStatRes)
 		if err != nil {
 			return httpmock.NewStringResponse(500, ""), nil
+		}
+		return resp, nil
+	}
+}
+
+// getADODiffsResponderFn returns a httpmock responder for the Azure DevOps Diffs REST API.
+func getADODiffsResponderFn() func(req *http.Request) (*http.Response, error) {
+	return func(_ *http.Request) (*http.Response, error) {
+		diffsResp := adoDiffsResponse{
+			Changes: []adoDiffChange{
+				{
+					Item:       adoDiffItem{Path: "/apps/my-app/values.yaml", IsFolder: false},
+					ChangeType: "edit",
+				},
+				{
+					Item:       adoDiffItem{Path: "/apps/my-app/deployment.yaml", IsFolder: false},
+					ChangeType: "add",
+				},
+				{
+					// folder entries should be excluded from the changed files list
+					Item:       adoDiffItem{Path: "/apps/my-app", IsFolder: true},
+					ChangeType: "edit",
+				},
+			},
+		}
+		resp, err := httpmock.NewJsonResponse(http.StatusOK, diffsResp)
+		if err != nil {
+			return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
 		}
 		return resp, nil
 	}

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -1654,10 +1654,12 @@ func TestFetchChangedFilesFromADO(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 
 	const (
-		testRepoURL   = "https://dev.azure.com/myorg/myproject/_git/myrepo"
-		testRepoID    = "ba2967cc-02c2-414c-8d10-1b99197cbaa6"
-		testShaBefore = "fa51eeb1e50b98293ce281e6d5492b9decae613b"
-		testShaAfter  = "298a79aa1552799a70718a0ee914d153d5a1a76b"
+		testRepoURL        = "https://dev.azure.com/myorg/myproject/_git/myrepo"
+		testRepoID         = "ba2967cc-02c2-414c-8d10-1b99197cbaa6"
+		testShaBefore      = "fa51eeb1e50b98293ce281e6d5492b9decae613b"
+		testShaAfter       = "298a79aa1552799a70718a0ee914d153d5a1a76b"
+		testShaBeforeLarge = "1111111111111111111111111111111111111111"
+		testShaAfterLarge  = "2222222222222222222222222222222222222222"
 	)
 
 	validAPIURL := fmt.Sprintf(
@@ -1666,6 +1668,16 @@ func TestFetchChangedFilesFromADO(t *testing.T) {
 		testRepoID, testShaBefore, testShaAfter,
 	)
 	httpmock.RegisterResponder("GET", validAPIURL, getADODiffsResponderFn())
+
+	truncatedAPIURL := fmt.Sprintf(
+		"https://dev.azure.com/myorg/myproject/_apis/git/repositories/%s/diffs/commits"+
+			"?baseVersion=%s&baseVersionType=commit&targetVersion=%s&targetVersionType=commit&$top=2000&api-version=7.1",
+		testRepoID, testShaBeforeLarge, testShaAfterLarge,
+	)
+	httpmock.RegisterResponder("GET", truncatedAPIURL, func(_ *http.Request) (*http.Response, error) {
+		resp, _ := httpmock.NewJsonResponse(http.StatusOK, adoDiffsResponse{AllChangesIncluded: false})
+		return resp, nil
+	})
 
 	repo := &v1alpha1.Repository{
 		Repo:     testRepoURL,
@@ -1689,6 +1701,14 @@ func TestFetchChangedFilesFromADO(t *testing.T) {
 			shaBefore:     testShaBefore,
 			shaAfter:      testShaAfter,
 			expectedFiles: []string{"apps/my-app/values.yaml", "apps/my-app/deployment.yaml"},
+		},
+		{
+			name:      "returns error when diff is truncated (allChangesIncluded=false)",
+			repoURL:   testRepoURL,
+			repoID:    testRepoID,
+			shaBefore: testShaBeforeLarge,
+			shaAfter:  testShaAfterLarge,
+			expectErr: true,
 		},
 		{
 			name:      "returns error for unregistered SHA pair",
@@ -1838,6 +1858,7 @@ func getDiffstatResponderFn() func(req *http.Request) (*http.Response, error) {
 func getADODiffsResponderFn() func(req *http.Request) (*http.Response, error) {
 	return func(_ *http.Request) (*http.Response, error) {
 		diffsResp := adoDiffsResponse{
+			AllChangesIncluded: true,
 			Changes: []adoDiffChange{
 				{
 					Item:       adoDiffItem{Path: "/apps/my-app/values.yaml", IsFolder: false},

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -1660,6 +1660,16 @@ func TestParseADOBaseURL(t *testing.T) {
 			expectedURL: "https://dev.azure.com/alexander0053/alex-test",
 		},
 		{
+			name:        "legacy visualstudio.com URL",
+			repoURL:     "https://myorg.visualstudio.com/myproject/_git/myrepo",
+			expectedURL: "https://myorg.visualstudio.com/myproject",
+		},
+		{
+			name:      "legacy visualstudio.com URL missing project",
+			repoURL:   "https://myorg.visualstudio.com/",
+			expectErr: true,
+		},
+		{
 			name:      "URL with only org segment",
 			repoURL:   "https://dev.azure.com/myorg",
 			expectErr: true,

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -99,6 +99,7 @@ func NewMockHandlerWithPayloadLimit(reactor *reactorDef, applicationNamespaces [
 	mockDB := &mocks.ArgoDB{}
 	mockDB.EXPECT().ListRepositories(mock.Anything).Return([]*v1alpha1.Repository{}, nil).Maybe()
 	mockDB.EXPECT().ListRepositoryCredentials(mock.Anything).Return([]string{}, nil).Maybe()
+	mockDB.EXPECT().GetRepositoryCredentials(mock.Anything, mock.Anything).Return(nil, nil).Maybe()
 	return newMockHandler(reactor, applicationNamespaces, maxPayloadSize, mockDB, &settings.ArgoCDSettings{}, objects...)
 }
 
@@ -144,9 +145,7 @@ func NewMockHandlerForADOCallback(reactor *reactorDef, applicationNamespaces []s
 func NewMockHandlerForADOCredsTemplateCallback(reactor *reactorDef, applicationNamespaces []string, objects ...runtime.Object) *ArgoCDWebhookHandler {
 	mockDB := &mocks.ArgoDB{}
 	mockDB.EXPECT().ListRepositories(mock.Anything).Return([]*v1alpha1.Repository{}, nil)
-	mockDB.EXPECT().ListRepositoryCredentials(mock.Anything).Return(
-		[]string{"https://dev.azure.com/alexander0053"}, nil)
-	mockDB.EXPECT().GetRepositoryCredentials(mock.Anything, "https://dev.azure.com/alexander0053").Return(
+	mockDB.EXPECT().GetRepositoryCredentials(mock.Anything, "https://dev.azure.com/alexander0053/alex-test/_git/alex-test").Return(
 		&v1alpha1.RepoCreds{
 			URL:      "https://dev.azure.com/alexander0053",
 			Username: "test-user",

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -1730,12 +1730,6 @@ func TestFetchChangedFilesFromADO(t *testing.T) {
 		return resp, nil
 	})
 
-	repo := &v1alpha1.Repository{
-		Repo:     testRepoURL,
-		Username: "test-user",
-		Password: "test-pat",
-	}
-
 	tests := []struct {
 		name          string
 		repoURL       string
@@ -1789,7 +1783,12 @@ func TestFetchChangedFilesFromADO(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			changedFiles, err := fetchChangedFilesFromADO(t.Context(), repo, tt.repoURL, tt.repoID, tt.shaBefore, tt.shaAfter)
+			repo := &v1alpha1.Repository{
+				Repo:     tt.repoURL,
+				Username: "test-user",
+				Password: "test-pat",
+			}
+			changedFiles, err := fetchChangedFilesFromADO(t.Context(), repo, tt.repoID, tt.shaBefore, tt.shaAfter)
 			if tt.expectErr {
 				require.Error(t, err)
 			} else {

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -1545,6 +1545,61 @@ func Test_affectedRevisionInfo_azuredevops_multiple_ref_updates(t *testing.T) {
 	require.Equal(t, []string{"apps/my-app/values.yaml", "apps/my-app/deployment.yaml"}, changedFiles)
 }
 
+func Test_affectedRevisionInfo_azuredevops_no_ref_updates_skips_changed_files_lookup(t *testing.T) {
+	eventJSON, err := os.ReadFile("testdata/azuredevops-git-push-event.json")
+	require.NoError(t, err)
+	var payload azuredevops.GitPushEvent
+	require.NoError(t, json.Unmarshal(eventJSON, &payload))
+	payload.Resource.RefUpdates = nil
+
+	h := NewMockHandlerForADOCallback(nil, []string{})
+	h.adoHTTPClientFactory = func(*v1alpha1.Repository) *http.Client {
+		t.Fatal("ADO HTTP client should not be created when the webhook has no ref updates")
+		return nil
+	}
+	_, _, _, _, changedFiles := h.affectedRevisionInfo(payload)
+	require.Empty(t, changedFiles)
+}
+
+func TestLookupAndFetchADOChangedFiles_RepositoryLookupError(t *testing.T) {
+	hook := test.NewGlobal()
+	defer hook.Reset()
+
+	mockDB := &mocks.ArgoDB{}
+	mockDB.EXPECT().ListRepositories(mock.Anything).Return(nil, errors.New("list failed"))
+	h := newMockHandler(nil, []string{}, int64(50)*1024*1024, mockDB, &settings.ArgoCDSettings{})
+	h.adoHTTPClientFactory = func(*v1alpha1.Repository) *http.Client {
+		t.Fatal("ADO HTTP client should not be created when repository lookup fails")
+		return nil
+	}
+
+	changedFiles := h.lookupAndFetchADOChangedFiles(testADORepoURL, testADORepoID, testADOShaBefore, testADOShaAfter)
+	require.Empty(t, changedFiles)
+	assertLogContainsSubstr(t, hook, "error finding repository for Azure DevOps webhook URL")
+}
+
+func TestLookupAndFetchADOChangedFiles_FetchError(t *testing.T) {
+	hook := test.NewGlobal()
+	defer hook.Reset()
+
+	mockDB := &mocks.ArgoDB{}
+	mockDB.EXPECT().ListRepositories(mock.Anything).Return([]*v1alpha1.Repository{{
+		Repo:     testADORepoURL,
+		Username: "test-user",
+		Password: "test-pat",
+	}}, nil)
+	h := newMockHandler(nil, []string{}, int64(50)*1024*1024, mockDB, &settings.ArgoCDSettings{})
+	h.adoHTTPClientFactory = func(*v1alpha1.Repository) *http.Client {
+		return &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("ado request failed")
+		})}
+	}
+
+	changedFiles := h.lookupAndFetchADOChangedFiles(testADORepoURL, testADORepoID, testADOShaBefore, testADOShaAfter)
+	require.Empty(t, changedFiles)
+	assertLogContainsSubstr(t, hook, "error fetching changed files from Azure DevOps diffs API")
+}
+
 func TestLookupRepository(t *testing.T) {
 	mockCtx, cancel := context.WithDeadline(t.Context(), time.Now().Add(10*time.Second))
 	defer cancel()
@@ -1855,6 +1910,86 @@ func TestFetchChangedFilesFromADO_NoCredentials(t *testing.T) {
 	changedFiles, err := fetchChangedFilesFromADO(t.Context(), client, repo, "some-repo-id", "sha-before", "sha-after")
 	require.NoError(t, err)
 	require.Nil(t, changedFiles)
+}
+
+func TestSetADOAuthHeader(t *testing.T) {
+	tests := []struct {
+		name        string
+		repo        *v1alpha1.Repository
+		wantApplied bool
+		wantBasic   bool
+		wantUser    string
+		wantPass    string
+		wantBearer  string
+	}{
+		{
+			name:        "basic auth with username and password",
+			repo:        &v1alpha1.Repository{Username: "test-user", Password: "test-pat"},
+			wantApplied: true,
+			wantBasic:   true,
+			wantUser:    "test-user",
+			wantPass:    "test-pat",
+		},
+		{
+			name:        "bearer token without password",
+			repo:        &v1alpha1.Repository{Username: "test-user", BearerToken: "test-token"},
+			wantApplied: true,
+			wantBearer:  "Bearer test-token",
+		},
+		{
+			name:        "bearer token only",
+			repo:        &v1alpha1.Repository{BearerToken: "test-token"},
+			wantApplied: true,
+			wantBearer:  "Bearer test-token",
+		},
+		{
+			name: "no supported credentials",
+			repo: &v1alpha1.Repository{},
+		},
+		{
+			name: "incomplete basic auth",
+			repo: &v1alpha1.Repository{Username: "test-user"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://dev.azure.com/my-org/my-project/_apis", http.NoBody)
+			require.NoError(t, err)
+
+			applied := setADOAuthHeader(req, tt.repo)
+			require.Equal(t, tt.wantApplied, applied)
+
+			user, pass, ok := req.BasicAuth()
+			require.Equal(t, tt.wantBasic, ok)
+			require.Equal(t, tt.wantUser, user)
+			require.Equal(t, tt.wantPass, pass)
+			if tt.wantBearer != "" {
+				require.Equal(t, tt.wantBearer, req.Header.Get("Authorization"))
+			} else if !tt.wantBasic {
+				require.Empty(t, req.Header.Get("Authorization"))
+			}
+		})
+	}
+}
+
+func TestFetchChangedFilesFromADO_BearerTokenAuth(t *testing.T) {
+	client := newADODiffsTestClient(t, func(req *http.Request) (int, adoDiffsResponse) {
+		require.Equal(t, "/myorg/myproject/_apis/git/repositories/"+testADORepoID+"/diffs/commits", req.URL.Path)
+		require.Equal(t, "Bearer test-token", req.Header.Get("Authorization"))
+		_, _, ok := req.BasicAuth()
+		require.False(t, ok)
+		return http.StatusOK, adoDiffsTestResponse()
+	})
+	repo := &v1alpha1.Repository{
+		Repo:        "https://dev.azure.com/myorg/myproject/_git/myrepo",
+		Username:    "test-user",
+		BearerToken: "test-token",
+	}
+
+	changedFiles, err := fetchChangedFilesFromADO(t.Context(), client, repo, testADORepoID, testADOShaBefore, testADOShaAfter)
+	require.NoError(t, err)
+	require.Equal(t, []string{"apps/my-app/values.yaml", "apps/my-app/deployment.yaml"}, changedFiles)
 }
 
 func TestNewADOHTTPClientUsesRepositoryTransportSettings(t *testing.T) {

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -78,6 +78,13 @@ const (
 	testADOShaAfter  = "298a79aa1552799a70718a0ee914d153d5a1a76b"
 )
 
+func newADOWebhookSettings() *settings.ArgoCDSettings {
+	return &settings.ArgoCDSettings{
+		WebhookAzureDevOpsUsername: "webhook-user",
+		WebhookAzureDevOpsPassword: "webhook-pass",
+	}
+}
+
 type roundTripFunc func(req *http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -142,6 +149,10 @@ func NewMockHandlerForBitbucketCallback(reactor *reactorDef, applicationNamespac
 }
 
 func NewMockHandlerForADOCallback(reactor *reactorDef, applicationNamespaces []string, objects ...runtime.Object) *ArgoCDWebhookHandler {
+	return newMockHandlerForADOCallbackWithSettings(reactor, applicationNamespaces, newADOWebhookSettings(), objects...)
+}
+
+func newMockHandlerForADOCallbackWithSettings(reactor *reactorDef, applicationNamespaces []string, argoSettings *settings.ArgoCDSettings, objects ...runtime.Object) *ArgoCDWebhookHandler {
 	mockDB := &mocks.ArgoDB{}
 	mockDB.EXPECT().ListRepositories(mock.Anything).Return(
 		[]*v1alpha1.Repository{
@@ -153,7 +164,7 @@ func NewMockHandlerForADOCallback(reactor *reactorDef, applicationNamespaces []s
 		}, nil)
 	mockDB.EXPECT().ListRepositoryCredentials(mock.Anything).Return([]string{}, nil).Maybe()
 	defaultMaxPayloadSize := int64(50) * 1024 * 1024
-	return newMockHandler(reactor, applicationNamespaces, defaultMaxPayloadSize, mockDB, &settings.ArgoCDSettings{}, objects...)
+	return newMockHandler(reactor, applicationNamespaces, defaultMaxPayloadSize, mockDB, argoSettings, objects...)
 }
 
 func NewMockHandlerForADOCredsTemplateCallback(reactor *reactorDef, applicationNamespaces []string, objects ...runtime.Object) *ArgoCDWebhookHandler {
@@ -168,7 +179,7 @@ func NewMockHandlerForADOCredsTemplateCallback(reactor *reactorDef, applicationN
 			NoProxy:  "localhost",
 		}, nil)
 	defaultMaxPayloadSize := int64(50) * 1024 * 1024
-	return newMockHandler(reactor, applicationNamespaces, defaultMaxPayloadSize, mockDB, &settings.ArgoCDSettings{}, objects...)
+	return newMockHandler(reactor, applicationNamespaces, defaultMaxPayloadSize, mockDB, newADOWebhookSettings(), objects...)
 }
 
 type fakeAppsLister struct {
@@ -1515,6 +1526,57 @@ func Test_affectedRevisionInfo_azuredevops_changed_files(t *testing.T) {
 	}
 	_, _, _, _, changedFiles := h.affectedRevisionInfo(t.Context(), payload)
 	require.Equal(t, []string{"apps/my-app/values.yaml", "apps/my-app/deployment.yaml"}, changedFiles)
+}
+
+func Test_affectedRevisionInfo_azuredevops_without_webhook_auth_skips_changed_files_lookup(t *testing.T) {
+	eventJSON, err := os.ReadFile("testdata/azuredevops-git-push-event.json")
+	require.NoError(t, err)
+	var payload azuredevops.GitPushEvent
+	require.NoError(t, json.Unmarshal(eventJSON, &payload))
+
+	h := newMockHandlerForADOCallbackWithSettings(nil, []string{}, &settings.ArgoCDSettings{})
+	h.adoHTTPClientFactory = func(*v1alpha1.Repository) *http.Client {
+		t.Fatal("ADO HTTP client should not be created when Azure DevOps webhook authentication is not configured")
+		return nil
+	}
+	_, _, _, _, changedFiles := h.affectedRevisionInfo(t.Context(), payload)
+	require.Empty(t, changedFiles)
+}
+
+func TestAzureDevOpsWebhookAuthConfigured(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings *settings.ArgoCDSettings
+		expected bool
+	}{
+		{
+			name:     "no username or password",
+			settings: &settings.ArgoCDSettings{},
+			expected: false,
+		},
+		{
+			name:     "username only",
+			settings: &settings.ArgoCDSettings{WebhookAzureDevOpsUsername: "webhook-user"},
+			expected: true,
+		},
+		{
+			name:     "password only",
+			settings: &settings.ArgoCDSettings{WebhookAzureDevOpsPassword: "webhook-pass"},
+			expected: true,
+		},
+		{
+			name:     "username and password",
+			settings: newADOWebhookSettings(),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &ArgoCDWebhookHandler{settings: tt.settings}
+			require.Equal(t, tt.expected, h.azureDevOpsWebhookAuthConfigured())
+		})
+	}
 }
 
 func Test_affectedRevisionInfo_azuredevops_multiple_ref_updates(t *testing.T) {

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -132,7 +132,7 @@ func NewMockHandlerForADOCallback(reactor *reactorDef, applicationNamespaces []s
 	mockDB.EXPECT().ListRepositories(mock.Anything).Return(
 		[]*v1alpha1.Repository{
 			{
-				Repo:     "https://dev.azure.com/alexander0053/alex-test/_git/alex-test",
+				Repo:     "https://dev.azure.com/my-org/my-project/_git/my-repo",
 				Username: "test-user",
 				Password: "test-pat",
 			},
@@ -145,9 +145,9 @@ func NewMockHandlerForADOCallback(reactor *reactorDef, applicationNamespaces []s
 func NewMockHandlerForADOCredsTemplateCallback(reactor *reactorDef, applicationNamespaces []string, objects ...runtime.Object) *ArgoCDWebhookHandler {
 	mockDB := &mocks.ArgoDB{}
 	mockDB.EXPECT().ListRepositories(mock.Anything).Return([]*v1alpha1.Repository{}, nil)
-	mockDB.EXPECT().GetRepositoryCredentials(mock.Anything, "https://dev.azure.com/alexander0053/alex-test/_git/alex-test").Return(
+	mockDB.EXPECT().GetRepositoryCredentials(mock.Anything, "https://dev.azure.com/my-org/my-project/_git/my-repo").Return(
 		&v1alpha1.RepoCreds{
-			URL:      "https://dev.azure.com/alexander0053",
+			URL:      "https://dev.azure.com/my-org",
 			Username: "test-user",
 			Password: "test-pat",
 		}, nil)
@@ -230,7 +230,7 @@ func TestAzureDevOpsCommitEvent(t *testing.T) {
 	close(h.queue)
 	h.Wait()
 	assert.Equal(t, http.StatusOK, w.Code)
-	expectedLogResult := "Received push event repo: https://dev.azure.com/alexander0053/alex-test/_git/alex-test, revision: master, touchedHead: true"
+	expectedLogResult := "Received push event repo: https://dev.azure.com/my-org/my-project/_git/my-repo, revision: master, touchedHead: true"
 	assertLogContains(t, hook, expectedLogResult)
 	hook.Reset()
 }
@@ -1412,7 +1412,7 @@ func Test_affectedRevisionInfo_azuredevops_changed_files_via_creds_template(t *t
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
-	const adoDiffsAPIURL = "https://dev.azure.com/alexander0053/alex-test/_apis/git/repositories/" +
+	const adoDiffsAPIURL = "https://dev.azure.com/my-org/my-project/_apis/git/repositories/" +
 		"ba2967cc-02c2-414c-8d10-1b99197cbaa6/diffs/commits" +
 		"?baseVersion=fa51eeb1e50b98293ce281e6d5492b9decae613b" +
 		"&baseVersionType=commit" +
@@ -1435,7 +1435,7 @@ func Test_affectedRevisionInfo_azuredevops_changed_files(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
-	const adoDiffsAPIURL = "https://dev.azure.com/alexander0053/alex-test/_apis/git/repositories/" +
+	const adoDiffsAPIURL = "https://dev.azure.com/my-org/my-project/_apis/git/repositories/" +
 		"ba2967cc-02c2-414c-8d10-1b99197cbaa6/diffs/commits" +
 		"?baseVersion=fa51eeb1e50b98293ce281e6d5492b9decae613b" +
 		"&baseVersionType=commit" +
@@ -1461,7 +1461,7 @@ func Test_affectedRevisionInfo_azuredevops_multiple_ref_updates(t *testing.T) {
 	// Register mock only for the first refUpdate's SHAs. If the code were to call
 	// the API with any other SHA pair, httpmock would return "no responder found" and
 	// the test would fail, confirming that only RefUpdates[0] is used.
-	const adoDiffsAPIURL = "https://dev.azure.com/alexander0053/alex-test/_apis/git/repositories/" +
+	const adoDiffsAPIURL = "https://dev.azure.com/my-org/my-project/_apis/git/repositories/" +
 		"ba2967cc-02c2-414c-8d10-1b99197cbaa6/diffs/commits" +
 		"?baseVersion=fa51eeb1e50b98293ce281e6d5492b9decae613b" +
 		"&baseVersionType=commit" +
@@ -1655,8 +1655,8 @@ func TestParseADOBaseURL(t *testing.T) {
 		},
 		{
 			name:        "real-world ADO URL",
-			repoURL:     "https://dev.azure.com/alexander0053/alex-test/_git/alex-test",
-			expectedURL: "https://dev.azure.com/alexander0053/alex-test",
+			repoURL:     "https://dev.azure.com/my-org/my-project/_git/my-repo",
+			expectedURL: "https://dev.azure.com/my-org/my-project",
 		},
 		{
 			name:        "legacy visualstudio.com URL",

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -1799,6 +1799,16 @@ func TestFetchChangedFilesFromADO(t *testing.T) {
 	}
 }
 
+
+func TestFetchChangedFilesFromADO_NoCredentials(t *testing.T) {
+	repo := &v1alpha1.Repository{
+		Repo: "https://dev.azure.com/myorg/myproject/_git/myrepo",
+	}
+	changedFiles, err := fetchChangedFilesFromADO(t.Context(), repo, "some-repo-id", "sha-before", "sha-after")
+	require.NoError(t, err)
+	require.Nil(t, changedFiles)
+}
+
 func TestIsHeadTouched(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -1944,7 +1944,7 @@ func TestFetchChangedFilesFromADO_NoCredentials(t *testing.T) {
 	})}
 
 	changedFiles, err := fetchChangedFilesFromADO(t.Context(), client, repo, "some-repo-id", "sha-before", "sha-after")
-	require.NoError(t, err)
+	require.ErrorIs(t, err, errNoADOCredentials)
 	require.Nil(t, changedFiles)
 }
 

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -700,7 +700,7 @@ func Test_affectedRevisionInfo_appRevisionHasChanged(t *testing.T) {
 		t.Run(testCopy.name, func(t *testing.T) {
 			t.Parallel()
 			h := NewMockHandler(nil, []string{})
-			_, revisionFromHook, _, _, _ := h.affectedRevisionInfo(testCopy.hookPayload)
+			_, revisionFromHook, _, _, _ := h.affectedRevisionInfo(t.Context(), testCopy.hookPayload)
 			if got := sourceRevisionHasChanged(sourceWithRevision(testCopy.targetRevision), revisionFromHook, false); got != testCopy.hasChanged {
 				t.Errorf("sourceRevisionHasChanged() = %v, want %v", got, testCopy.hasChanged)
 			}
@@ -1415,7 +1415,7 @@ func Test_affectedRevisionInfo_bitbucket_changed_files(t *testing.T) {
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
 			h := NewMockHandlerForBitbucketCallback(nil, []string{})
-			_, revisionFromHook, change, touchHead, changedFiles := h.affectedRevisionInfo(testCase.hookPayload)
+			_, revisionFromHook, change, touchHead, changedFiles := h.affectedRevisionInfo(t.Context(), testCase.hookPayload)
 			require.Equal(t, testCase.revision, revisionFromHook)
 			require.Equal(t, testCase.expectedTouchHead, touchHead)
 			require.Equal(t, testCase.expectedChangedFiles, changedFiles)
@@ -1494,7 +1494,7 @@ func Test_affectedRevisionInfo_azuredevops_changed_files_via_creds_template(t *t
 		require.Equal(t, "localhost", repo.NoProxy)
 		return client
 	}
-	_, _, _, _, changedFiles := h.affectedRevisionInfo(payload)
+	_, _, _, _, changedFiles := h.affectedRevisionInfo(t.Context(), payload)
 	require.Equal(t, []string{"apps/my-app/values.yaml", "apps/my-app/deployment.yaml"}, changedFiles)
 }
 
@@ -1513,7 +1513,7 @@ func Test_affectedRevisionInfo_azuredevops_changed_files(t *testing.T) {
 	h.adoHTTPClientFactory = func(*v1alpha1.Repository) *http.Client {
 		return client
 	}
-	_, _, _, _, changedFiles := h.affectedRevisionInfo(payload)
+	_, _, _, _, changedFiles := h.affectedRevisionInfo(t.Context(), payload)
 	require.Equal(t, []string{"apps/my-app/values.yaml", "apps/my-app/deployment.yaml"}, changedFiles)
 }
 
@@ -1540,7 +1540,7 @@ func Test_affectedRevisionInfo_azuredevops_multiple_ref_updates(t *testing.T) {
 	h.adoHTTPClientFactory = func(*v1alpha1.Repository) *http.Client {
 		return client
 	}
-	_, _, _, _, changedFiles := h.affectedRevisionInfo(payload)
+	_, _, _, _, changedFiles := h.affectedRevisionInfo(t.Context(), payload)
 	// Only the first refUpdate's SHAs were used; changed files are still resolved correctly.
 	require.Equal(t, []string{"apps/my-app/values.yaml", "apps/my-app/deployment.yaml"}, changedFiles)
 }
@@ -1557,7 +1557,7 @@ func Test_affectedRevisionInfo_azuredevops_no_ref_updates_skips_changed_files_lo
 		t.Fatal("ADO HTTP client should not be created when the webhook has no ref updates")
 		return nil
 	}
-	_, _, _, _, changedFiles := h.affectedRevisionInfo(payload)
+	_, _, _, _, changedFiles := h.affectedRevisionInfo(t.Context(), payload)
 	require.Empty(t, changedFiles)
 }
 
@@ -1591,7 +1591,7 @@ func TestLookupAndFetchADOChangedFiles_SkipsNonDiffableRange(t *testing.T) {
 				t.Fatal("ADO HTTP client should not be created for non-diffable commit range")
 				return nil
 			}
-			changedFiles := h.lookupAndFetchADOChangedFiles(testADORepoURL, testADORepoID, tt.shaBefore, tt.shaAfter)
+			changedFiles := h.lookupAndFetchADOChangedFiles(t.Context(), testADORepoURL, testADORepoID, tt.shaBefore, tt.shaAfter)
 			require.Empty(t, changedFiles)
 		})
 	}
@@ -1609,7 +1609,7 @@ func TestLookupAndFetchADOChangedFiles_RepositoryLookupError(t *testing.T) {
 		return nil
 	}
 
-	changedFiles := h.lookupAndFetchADOChangedFiles(testADORepoURL, testADORepoID, testADOShaBefore, testADOShaAfter)
+	changedFiles := h.lookupAndFetchADOChangedFiles(t.Context(), testADORepoURL, testADORepoID, testADOShaBefore, testADOShaAfter)
 	require.Empty(t, changedFiles)
 	assertLogContainsSubstr(t, hook, "error finding repository for Azure DevOps webhook URL")
 }
@@ -1631,7 +1631,7 @@ func TestLookupAndFetchADOChangedFiles_FetchError(t *testing.T) {
 		})}
 	}
 
-	changedFiles := h.lookupAndFetchADOChangedFiles(testADORepoURL, testADORepoID, testADOShaBefore, testADOShaAfter)
+	changedFiles := h.lookupAndFetchADOChangedFiles(t.Context(), testADORepoURL, testADORepoID, testADOShaBefore, testADOShaAfter)
 	require.Empty(t, changedFiles)
 	assertLogContainsSubstr(t, hook, "error fetching changed files from Azure DevOps diffs API")
 }

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -1847,7 +1847,12 @@ func TestFetchChangedFilesFromADO_NoCredentials(t *testing.T) {
 	repo := &v1alpha1.Repository{
 		Repo: "https://dev.azure.com/myorg/myproject/_git/myrepo",
 	}
-	changedFiles, err := fetchChangedFilesFromADO(t.Context(), &http.Client{}, repo, "some-repo-id", "sha-before", "sha-after")
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		t.Fatal("HTTP client should not be called when no supported ADO REST API credentials are configured")
+		return nil, nil
+	})}
+
+	changedFiles, err := fetchChangedFilesFromADO(t.Context(), client, repo, "some-repo-id", "sha-before", "sha-after")
 	require.NoError(t, err)
 	require.Nil(t, changedFiles)
 }

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"text/template"
@@ -68,6 +69,19 @@ type reactorDef struct {
 	verb     string
 	resource string
 	reaction kubetesting.ReactionFunc
+}
+
+const (
+	testADORepoURL   = "https://dev.azure.com/my-org/my-project/_git/my-repo"
+	testADORepoID    = "ba2967cc-02c2-414c-8d10-1b99197cbaa6"
+	testADOShaBefore = "fa51eeb1e50b98293ce281e6d5492b9decae613b"
+	testADOShaAfter  = "298a79aa1552799a70718a0ee914d153d5a1a76b"
+)
+
+type roundTripFunc func(req *http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }
 
 func assertLogContains(t *testing.T, hook *test.Hook, msg string) {
@@ -132,7 +146,7 @@ func NewMockHandlerForADOCallback(reactor *reactorDef, applicationNamespaces []s
 	mockDB.EXPECT().ListRepositories(mock.Anything).Return(
 		[]*v1alpha1.Repository{
 			{
-				Repo:     "https://dev.azure.com/my-org/my-project/_git/my-repo",
+				Repo:     testADORepoURL,
 				Username: "test-user",
 				Password: "test-pat",
 			},
@@ -145,11 +159,13 @@ func NewMockHandlerForADOCallback(reactor *reactorDef, applicationNamespaces []s
 func NewMockHandlerForADOCredsTemplateCallback(reactor *reactorDef, applicationNamespaces []string, objects ...runtime.Object) *ArgoCDWebhookHandler {
 	mockDB := &mocks.ArgoDB{}
 	mockDB.EXPECT().ListRepositories(mock.Anything).Return([]*v1alpha1.Repository{}, nil)
-	mockDB.EXPECT().GetRepositoryCredentials(mock.Anything, "https://dev.azure.com/my-org/my-project/_git/my-repo").Return(
+	mockDB.EXPECT().GetRepositoryCredentials(mock.Anything, testADORepoURL).Return(
 		&v1alpha1.RepoCreds{
 			URL:      "https://dev.azure.com/my-org",
 			Username: "test-user",
 			Password: "test-pat",
+			Proxy:    "http://proxy.example.com:8080",
+			NoProxy:  "localhost",
 		}, nil)
 	defaultMaxPayloadSize := int64(50) * 1024 * 1024
 	return newMockHandler(reactor, applicationNamespaces, defaultMaxPayloadSize, mockDB, &settings.ArgoCDSettings{}, objects...)
@@ -1408,18 +1424,64 @@ func Test_affectedRevisionInfo_bitbucket_changed_files(t *testing.T) {
 	}
 }
 
-func Test_affectedRevisionInfo_azuredevops_changed_files_via_creds_template(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
+func newADODiffsTestClient(t *testing.T, handler func(req *http.Request) (int, adoDiffsResponse)) *http.Client {
+	t.Helper()
+	return &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		statusCode, diffsResp := handler(req)
+		respBody, err := json.Marshal(diffsResp)
+		require.NoError(t, err)
+		return &http.Response{
+			StatusCode: statusCode,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(bytes.NewReader(respBody)),
+			Request:    req,
+		}, nil
+	})}
+}
 
-	const adoDiffsAPIURL = "https://dev.azure.com/my-org/my-project/_apis/git/repositories/" +
-		"ba2967cc-02c2-414c-8d10-1b99197cbaa6/diffs/commits" +
-		"?%24top=2000&api-version=7.1" +
-		"&baseVersion=fa51eeb1e50b98293ce281e6d5492b9decae613b" +
-		"&baseVersionType=commit" +
-		"&targetVersion=298a79aa1552799a70718a0ee914d153d5a1a76b" +
-		"&targetVersionType=commit"
-	httpmock.RegisterResponder("GET", adoDiffsAPIURL, getADODiffsResponderFn())
+func requireADODiffsRequest(t *testing.T, req *http.Request, expectedPath, expectedShaBefore, expectedShaAfter string) {
+	t.Helper()
+	require.Equal(t, http.MethodGet, req.Method)
+	require.Equal(t, expectedPath, req.URL.Path)
+	query := req.URL.Query()
+	require.Equal(t, expectedShaBefore, query.Get("baseVersion"))
+	require.Equal(t, "commit", query.Get("baseVersionType"))
+	require.Equal(t, expectedShaAfter, query.Get("targetVersion"))
+	require.Equal(t, "commit", query.Get("targetVersionType"))
+	require.Equal(t, strconv.Itoa(adoDiffsMaxPageSize), query.Get("$top"))
+	require.Equal(t, adoDiffsAPIVersion, query.Get("api-version"))
+	username, password, ok := req.BasicAuth()
+	require.True(t, ok)
+	require.Equal(t, "test-user", username)
+	require.Equal(t, "test-pat", password)
+}
+
+func adoDiffsTestResponse() adoDiffsResponse {
+	return adoDiffsResponse{
+		AllChangesIncluded: true,
+		Changes: []adoDiffChange{
+			{
+				Item:       adoDiffItem{Path: "/apps/my-app/values.yaml", IsFolder: false},
+				ChangeType: "edit",
+			},
+			{
+				Item:       adoDiffItem{Path: "/apps/my-app/deployment.yaml", IsFolder: false},
+				ChangeType: "add",
+			},
+			{
+				// Folder entries should be excluded from the changed files list.
+				Item:       adoDiffItem{Path: "/apps/my-app", IsFolder: true},
+				ChangeType: "edit",
+			},
+		},
+	}
+}
+
+func Test_affectedRevisionInfo_azuredevops_changed_files_via_creds_template(t *testing.T) {
+	client := newADODiffsTestClient(t, func(req *http.Request) (int, adoDiffsResponse) {
+		requireADODiffsRequest(t, req, "/my-org/my-project/_apis/git/repositories/"+testADORepoID+"/diffs/commits", testADOShaBefore, testADOShaAfter)
+		return http.StatusOK, adoDiffsTestResponse()
+	})
 
 	eventJSON, err := os.ReadFile("testdata/azuredevops-git-push-event.json")
 	require.NoError(t, err)
@@ -1427,22 +1489,20 @@ func Test_affectedRevisionInfo_azuredevops_changed_files_via_creds_template(t *t
 	require.NoError(t, json.Unmarshal(eventJSON, &payload))
 
 	h := NewMockHandlerForADOCredsTemplateCallback(nil, []string{})
+	h.adoHTTPClientFactory = func(repo *v1alpha1.Repository) *http.Client {
+		require.Equal(t, "http://proxy.example.com:8080", repo.Proxy)
+		require.Equal(t, "localhost", repo.NoProxy)
+		return client
+	}
 	_, _, _, _, changedFiles := h.affectedRevisionInfo(payload)
 	require.Equal(t, []string{"apps/my-app/values.yaml", "apps/my-app/deployment.yaml"}, changedFiles)
 }
 
 func Test_affectedRevisionInfo_azuredevops_changed_files(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
-
-	const adoDiffsAPIURL = "https://dev.azure.com/my-org/my-project/_apis/git/repositories/" +
-		"ba2967cc-02c2-414c-8d10-1b99197cbaa6/diffs/commits" +
-		"?%24top=2000&api-version=7.1" +
-		"&baseVersion=fa51eeb1e50b98293ce281e6d5492b9decae613b" +
-		"&baseVersionType=commit" +
-		"&targetVersion=298a79aa1552799a70718a0ee914d153d5a1a76b" +
-		"&targetVersionType=commit"
-	httpmock.RegisterResponder("GET", adoDiffsAPIURL, getADODiffsResponderFn())
+	client := newADODiffsTestClient(t, func(req *http.Request) (int, adoDiffsResponse) {
+		requireADODiffsRequest(t, req, "/my-org/my-project/_apis/git/repositories/"+testADORepoID+"/diffs/commits", testADOShaBefore, testADOShaAfter)
+		return http.StatusOK, adoDiffsTestResponse()
+	})
 
 	eventJSON, err := os.ReadFile("testdata/azuredevops-git-push-event.json")
 	require.NoError(t, err)
@@ -1450,25 +1510,19 @@ func Test_affectedRevisionInfo_azuredevops_changed_files(t *testing.T) {
 	require.NoError(t, json.Unmarshal(eventJSON, &payload))
 
 	h := NewMockHandlerForADOCallback(nil, []string{})
+	h.adoHTTPClientFactory = func(*v1alpha1.Repository) *http.Client {
+		return client
+	}
 	_, _, _, _, changedFiles := h.affectedRevisionInfo(payload)
 	require.Equal(t, []string{"apps/my-app/values.yaml", "apps/my-app/deployment.yaml"}, changedFiles)
 }
 
 func Test_affectedRevisionInfo_azuredevops_multiple_ref_updates(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
-
-	// Register mock only for the first refUpdate's SHAs. If the code were to call
-	// the API with any other SHA pair, httpmock would return "no responder found" and
-	// the test would fail, confirming that only RefUpdates[0] is used.
-	const adoDiffsAPIURL = "https://dev.azure.com/my-org/my-project/_apis/git/repositories/" +
-		"ba2967cc-02c2-414c-8d10-1b99197cbaa6/diffs/commits" +
-		"?%24top=2000&api-version=7.1" +
-		"&baseVersion=fa51eeb1e50b98293ce281e6d5492b9decae613b" +
-		"&baseVersionType=commit" +
-		"&targetVersion=298a79aa1552799a70718a0ee914d153d5a1a76b" +
-		"&targetVersionType=commit"
-	httpmock.RegisterResponder("GET", adoDiffsAPIURL, getADODiffsResponderFn())
+	client := newADODiffsTestClient(t, func(req *http.Request) (int, adoDiffsResponse) {
+		// Only the first refUpdate's SHAs should be used.
+		requireADODiffsRequest(t, req, "/my-org/my-project/_apis/git/repositories/"+testADORepoID+"/diffs/commits", testADOShaBefore, testADOShaAfter)
+		return http.StatusOK, adoDiffsTestResponse()
+	})
 
 	eventJSON, err := os.ReadFile("testdata/azuredevops-git-push-event.json")
 	require.NoError(t, err)
@@ -1483,6 +1537,9 @@ func Test_affectedRevisionInfo_azuredevops_multiple_ref_updates(t *testing.T) {
 	})
 
 	h := NewMockHandlerForADOCallback(nil, []string{})
+	h.adoHTTPClientFactory = func(*v1alpha1.Repository) *http.Client {
+		return client
+	}
 	_, _, _, _, changedFiles := h.affectedRevisionInfo(payload)
 	// Only the first refUpdate's SHAs were used; changed files are still resolved correctly.
 	require.Equal(t, []string{"apps/my-app/values.yaml", "apps/my-app/deployment.yaml"}, changedFiles)
@@ -1693,41 +1750,28 @@ func TestParseADOBaseURL(t *testing.T) {
 }
 
 func TestFetchChangedFilesFromADO(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
-
 	const (
 		testRepoURL        = "https://dev.azure.com/myorg/myproject/_git/myrepo"
-		testRepoID         = "ba2967cc-02c2-414c-8d10-1b99197cbaa6"
-		testShaBefore      = "fa51eeb1e50b98293ce281e6d5492b9decae613b"
-		testShaAfter       = "298a79aa1552799a70718a0ee914d153d5a1a76b"
 		testShaBeforeLarge = "1111111111111111111111111111111111111111"
 		testShaAfterLarge  = "2222222222222222222222222222222222222222"
 	)
 
-	validAPIURL := fmt.Sprintf(
-		"https://dev.azure.com/myorg/myproject/_apis/git/repositories/%s/diffs/commits"+
-			"?%%24top=%d&api-version=%s&baseVersion=%s&baseVersionType=commit&targetVersion=%s&targetVersionType=commit",
-		testRepoID, adoDiffsMaxPageSize, adoDiffsAPIVersion, testShaBefore, testShaAfter,
-	)
-	httpmock.RegisterResponder("GET", validAPIURL, getADODiffsResponderFn())
-
-	// Legacy visualstudio.com format: base URL is scheme://host/{project} (no org in path).
-	legacyAPIURL := fmt.Sprintf(
-		"https://myorg.visualstudio.com/myproject/_apis/git/repositories/%s/diffs/commits"+
-			"?%%24top=%d&api-version=%s&baseVersion=%s&baseVersionType=commit&targetVersion=%s&targetVersionType=commit",
-		testRepoID, adoDiffsMaxPageSize, adoDiffsAPIVersion, testShaBefore, testShaAfter,
-	)
-	httpmock.RegisterResponder("GET", legacyAPIURL, getADODiffsResponderFn())
-
-	truncatedAPIURL := fmt.Sprintf(
-		"https://dev.azure.com/myorg/myproject/_apis/git/repositories/%s/diffs/commits"+
-			"?%%24top=%d&api-version=%s&baseVersion=%s&baseVersionType=commit&targetVersion=%s&targetVersionType=commit",
-		testRepoID, adoDiffsMaxPageSize, adoDiffsAPIVersion, testShaBeforeLarge, testShaAfterLarge,
-	)
-	httpmock.RegisterResponder("GET", truncatedAPIURL, func(_ *http.Request) (*http.Response, error) {
-		resp, _ := httpmock.NewJsonResponse(http.StatusOK, adoDiffsResponse{AllChangesIncluded: false})
-		return resp, nil
+	client := newADODiffsTestClient(t, func(req *http.Request) (int, adoDiffsResponse) {
+		switch req.URL.Path {
+		case "/myorg/myproject/_apis/git/repositories/" + testADORepoID + "/diffs/commits":
+			if req.URL.Query().Get("baseVersion") == testShaBeforeLarge {
+				requireADODiffsRequest(t, req, req.URL.Path, testShaBeforeLarge, testShaAfterLarge)
+				return http.StatusOK, adoDiffsResponse{AllChangesIncluded: false}
+			}
+			if req.URL.Query().Get("baseVersion") == testADOShaBefore {
+				requireADODiffsRequest(t, req, req.URL.Path, testADOShaBefore, testADOShaAfter)
+				return http.StatusOK, adoDiffsTestResponse()
+			}
+		case "/myproject/_apis/git/repositories/" + testADORepoID + "/diffs/commits":
+			requireADODiffsRequest(t, req, req.URL.Path, testADOShaBefore, testADOShaAfter)
+			return http.StatusOK, adoDiffsTestResponse()
+		}
+		return http.StatusNotFound, adoDiffsResponse{AllChangesIncluded: true}
 	})
 
 	tests := []struct {
@@ -1742,15 +1786,15 @@ func TestFetchChangedFilesFromADO(t *testing.T) {
 		{
 			name:          "returns changed files for valid diff",
 			repoURL:       testRepoURL,
-			repoID:        testRepoID,
-			shaBefore:     testShaBefore,
-			shaAfter:      testShaAfter,
+			repoID:        testADORepoID,
+			shaBefore:     testADOShaBefore,
+			shaAfter:      testADOShaAfter,
 			expectedFiles: []string{"apps/my-app/values.yaml", "apps/my-app/deployment.yaml"},
 		},
 		{
 			name:      "returns error when diff is truncated (allChangesIncluded=false)",
 			repoURL:   testRepoURL,
-			repoID:    testRepoID,
+			repoID:    testADORepoID,
 			shaBefore: testShaBeforeLarge,
 			shaAfter:  testShaAfterLarge,
 			expectErr: true,
@@ -1758,7 +1802,7 @@ func TestFetchChangedFilesFromADO(t *testing.T) {
 		{
 			name:      "returns error for unregistered SHA pair",
 			repoURL:   testRepoURL,
-			repoID:    testRepoID,
+			repoID:    testADORepoID,
 			shaBefore: "0000000000000000000000000000000000000000",
 			shaAfter:  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			expectErr: true,
@@ -1766,17 +1810,17 @@ func TestFetchChangedFilesFromADO(t *testing.T) {
 		{
 			name:          "returns changed files for legacy visualstudio.com URL",
 			repoURL:       "https://myorg.visualstudio.com/myproject/_git/myrepo",
-			repoID:        testRepoID,
-			shaBefore:     testShaBefore,
-			shaAfter:      testShaAfter,
+			repoID:        testADORepoID,
+			shaBefore:     testADOShaBefore,
+			shaAfter:      testADOShaAfter,
 			expectedFiles: []string{"apps/my-app/values.yaml", "apps/my-app/deployment.yaml"},
 		},
 		{
 			name:      "returns error for URL without org and project",
 			repoURL:   "https://dev.azure.com",
-			repoID:    testRepoID,
-			shaBefore: testShaBefore,
-			shaAfter:  testShaAfter,
+			repoID:    testADORepoID,
+			shaBefore: testADOShaBefore,
+			shaAfter:  testADOShaAfter,
 			expectErr: true,
 		},
 	}
@@ -1788,7 +1832,7 @@ func TestFetchChangedFilesFromADO(t *testing.T) {
 				Username: "test-user",
 				Password: "test-pat",
 			}
-			changedFiles, err := fetchChangedFilesFromADO(t.Context(), repo, tt.repoID, tt.shaBefore, tt.shaAfter)
+			changedFiles, err := fetchChangedFilesFromADO(t.Context(), client, repo, tt.repoID, tt.shaBefore, tt.shaAfter)
 			if tt.expectErr {
 				require.Error(t, err)
 			} else {
@@ -1799,14 +1843,41 @@ func TestFetchChangedFilesFromADO(t *testing.T) {
 	}
 }
 
-
 func TestFetchChangedFilesFromADO_NoCredentials(t *testing.T) {
 	repo := &v1alpha1.Repository{
 		Repo: "https://dev.azure.com/myorg/myproject/_git/myrepo",
 	}
-	changedFiles, err := fetchChangedFilesFromADO(t.Context(), repo, "some-repo-id", "sha-before", "sha-after")
+	changedFiles, err := fetchChangedFilesFromADO(t.Context(), &http.Client{}, repo, "some-repo-id", "sha-before", "sha-after")
 	require.NoError(t, err)
 	require.Nil(t, changedFiles)
+}
+
+func TestNewADOHTTPClientUsesRepositoryTransportSettings(t *testing.T) {
+	repo := &v1alpha1.Repository{
+		Repo:     testADORepoURL,
+		Username: "test-user",
+		Password: "test-pat",
+		Proxy:    "http://proxy.example.com:8080",
+		NoProxy:  "localhost",
+	}
+
+	client := newADOHTTPClient(repo)
+	require.NotNil(t, client)
+	require.Positive(t, client.Timeout)
+	transport, ok := client.Transport.(*http.Transport)
+	require.True(t, ok)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://dev.azure.com/my-org/my-project/_apis", http.NoBody)
+	require.NoError(t, err)
+	proxyURL, err := transport.Proxy(req)
+	require.NoError(t, err)
+	require.Equal(t, "http://proxy.example.com:8080", proxyURL.String())
+
+	noProxyReq, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://localhost/_apis", http.NoBody)
+	require.NoError(t, err)
+	proxyURL, err = transport.Proxy(noProxyReq)
+	require.NoError(t, err)
+	require.Nil(t, proxyURL)
 }
 
 func TestIsHeadTouched(t *testing.T) {
@@ -1917,35 +1988,6 @@ func getDiffstatResponderFn() func(req *http.Request) (*http.Response, error) {
 		resp, err := httpmock.NewJsonResponse(200, diffStatRes)
 		if err != nil {
 			return httpmock.NewStringResponse(500, ""), nil
-		}
-		return resp, nil
-	}
-}
-
-// getADODiffsResponderFn returns a httpmock responder for the Azure DevOps Diffs REST API.
-func getADODiffsResponderFn() func(req *http.Request) (*http.Response, error) {
-	return func(_ *http.Request) (*http.Response, error) {
-		diffsResp := adoDiffsResponse{
-			AllChangesIncluded: true,
-			Changes: []adoDiffChange{
-				{
-					Item:       adoDiffItem{Path: "/apps/my-app/values.yaml", IsFolder: false},
-					ChangeType: "edit",
-				},
-				{
-					Item:       adoDiffItem{Path: "/apps/my-app/deployment.yaml", IsFolder: false},
-					ChangeType: "add",
-				},
-				{
-					// folder entries should be excluded from the changed files list
-					Item:       adoDiffItem{Path: "/apps/my-app", IsFolder: true},
-					ChangeType: "edit",
-				},
-			},
-		}
-		resp, err := httpmock.NewJsonResponse(http.StatusOK, diffsResp)
-		if err != nil {
-			return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
 		}
 		return resp, nil
 	}

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -1414,11 +1414,11 @@ func Test_affectedRevisionInfo_azuredevops_changed_files_via_creds_template(t *t
 
 	const adoDiffsAPIURL = "https://dev.azure.com/my-org/my-project/_apis/git/repositories/" +
 		"ba2967cc-02c2-414c-8d10-1b99197cbaa6/diffs/commits" +
-		"?baseVersion=fa51eeb1e50b98293ce281e6d5492b9decae613b" +
+		"?%24top=2000&api-version=7.1" +
+		"&baseVersion=fa51eeb1e50b98293ce281e6d5492b9decae613b" +
 		"&baseVersionType=commit" +
 		"&targetVersion=298a79aa1552799a70718a0ee914d153d5a1a76b" +
-		"&targetVersionType=commit" +
-		"&$top=2000&api-version=7.1"
+		"&targetVersionType=commit"
 	httpmock.RegisterResponder("GET", adoDiffsAPIURL, getADODiffsResponderFn())
 
 	eventJSON, err := os.ReadFile("testdata/azuredevops-git-push-event.json")
@@ -1437,11 +1437,11 @@ func Test_affectedRevisionInfo_azuredevops_changed_files(t *testing.T) {
 
 	const adoDiffsAPIURL = "https://dev.azure.com/my-org/my-project/_apis/git/repositories/" +
 		"ba2967cc-02c2-414c-8d10-1b99197cbaa6/diffs/commits" +
-		"?baseVersion=fa51eeb1e50b98293ce281e6d5492b9decae613b" +
+		"?%24top=2000&api-version=7.1" +
+		"&baseVersion=fa51eeb1e50b98293ce281e6d5492b9decae613b" +
 		"&baseVersionType=commit" +
 		"&targetVersion=298a79aa1552799a70718a0ee914d153d5a1a76b" +
-		"&targetVersionType=commit" +
-		"&$top=2000&api-version=7.1"
+		"&targetVersionType=commit"
 	httpmock.RegisterResponder("GET", adoDiffsAPIURL, getADODiffsResponderFn())
 
 	eventJSON, err := os.ReadFile("testdata/azuredevops-git-push-event.json")
@@ -1463,11 +1463,11 @@ func Test_affectedRevisionInfo_azuredevops_multiple_ref_updates(t *testing.T) {
 	// the test would fail, confirming that only RefUpdates[0] is used.
 	const adoDiffsAPIURL = "https://dev.azure.com/my-org/my-project/_apis/git/repositories/" +
 		"ba2967cc-02c2-414c-8d10-1b99197cbaa6/diffs/commits" +
-		"?baseVersion=fa51eeb1e50b98293ce281e6d5492b9decae613b" +
+		"?%24top=2000&api-version=7.1" +
+		"&baseVersion=fa51eeb1e50b98293ce281e6d5492b9decae613b" +
 		"&baseVersionType=commit" +
 		"&targetVersion=298a79aa1552799a70718a0ee914d153d5a1a76b" +
-		"&targetVersionType=commit" +
-		"&$top=2000&api-version=7.1"
+		"&targetVersionType=commit"
 	httpmock.RegisterResponder("GET", adoDiffsAPIURL, getADODiffsResponderFn())
 
 	eventJSON, err := os.ReadFile("testdata/azuredevops-git-push-event.json")
@@ -1707,23 +1707,23 @@ func TestFetchChangedFilesFromADO(t *testing.T) {
 
 	validAPIURL := fmt.Sprintf(
 		"https://dev.azure.com/myorg/myproject/_apis/git/repositories/%s/diffs/commits"+
-			"?baseVersion=%s&baseVersionType=commit&targetVersion=%s&targetVersionType=commit&$top=2000&api-version=7.1",
-		testRepoID, testShaBefore, testShaAfter,
+			"?%%24top=%d&api-version=%s&baseVersion=%s&baseVersionType=commit&targetVersion=%s&targetVersionType=commit",
+		testRepoID, adoDiffsMaxPageSize, adoDiffsAPIVersion, testShaBefore, testShaAfter,
 	)
 	httpmock.RegisterResponder("GET", validAPIURL, getADODiffsResponderFn())
 
 	// Legacy visualstudio.com format: base URL is scheme://host/{project} (no org in path).
 	legacyAPIURL := fmt.Sprintf(
 		"https://myorg.visualstudio.com/myproject/_apis/git/repositories/%s/diffs/commits"+
-			"?baseVersion=%s&baseVersionType=commit&targetVersion=%s&targetVersionType=commit&$top=2000&api-version=7.1",
-		testRepoID, testShaBefore, testShaAfter,
+			"?%%24top=%d&api-version=%s&baseVersion=%s&baseVersionType=commit&targetVersion=%s&targetVersionType=commit",
+		testRepoID, adoDiffsMaxPageSize, adoDiffsAPIVersion, testShaBefore, testShaAfter,
 	)
 	httpmock.RegisterResponder("GET", legacyAPIURL, getADODiffsResponderFn())
 
 	truncatedAPIURL := fmt.Sprintf(
 		"https://dev.azure.com/myorg/myproject/_apis/git/repositories/%s/diffs/commits"+
-			"?baseVersion=%s&baseVersionType=commit&targetVersion=%s&targetVersionType=commit&$top=2000&api-version=7.1",
-		testRepoID, testShaBeforeLarge, testShaAfterLarge,
+			"?%%24top=%d&api-version=%s&baseVersion=%s&baseVersionType=commit&targetVersion=%s&targetVersionType=commit",
+		testRepoID, adoDiffsMaxPageSize, adoDiffsAPIVersion, testShaBeforeLarge, testShaAfterLarge,
 	)
 	httpmock.RegisterResponder("GET", truncatedAPIURL, func(_ *http.Request) (*http.Response, error) {
 		resp, _ := httpmock.NewJsonResponse(http.StatusOK, adoDiffsResponse{AllChangesIncluded: false})

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -1561,6 +1561,42 @@ func Test_affectedRevisionInfo_azuredevops_no_ref_updates_skips_changed_files_lo
 	require.Empty(t, changedFiles)
 }
 
+func TestLookupAndFetchADOChangedFiles_SkipsNonDiffableRange(t *testing.T) {
+	tests := []struct {
+		name      string
+		shaBefore string
+		shaAfter  string
+	}{
+		{
+			name:      "branch deletion (shaAfter is null SHA)",
+			shaBefore: testADOShaBefore,
+			shaAfter:  adoNullSHA,
+		},
+		{
+			name:      "branch creation (shaBefore is null SHA)",
+			shaBefore: adoNullSHA,
+			shaAfter:  testADOShaAfter,
+		},
+		{
+			name:      "empty commit range (no refUpdates)",
+			shaBefore: "",
+			shaAfter:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := NewMockHandlerForADOCallback(nil, []string{})
+			h.adoHTTPClientFactory = func(*v1alpha1.Repository) *http.Client {
+				t.Fatal("ADO HTTP client should not be created for non-diffable commit range")
+				return nil
+			}
+			changedFiles := h.lookupAndFetchADOChangedFiles(testADORepoURL, testADORepoID, tt.shaBefore, tt.shaAfter)
+			require.Empty(t, changedFiles)
+		})
+	}
+}
+
 func TestLookupAndFetchADOChangedFiles_RepositoryLookupError(t *testing.T) {
 	hook := test.NewGlobal()
 	defer hook.Reset()
@@ -1858,7 +1894,7 @@ func TestFetchChangedFilesFromADO(t *testing.T) {
 			name:      "returns error for unregistered SHA pair",
 			repoURL:   testRepoURL,
 			repoID:    testADORepoID,
-			shaBefore: "0000000000000000000000000000000000000000",
+			shaBefore: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
 			shaAfter:  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			expectErr: true,
 		},


### PR DESCRIPTION
## Summary

Fixes #18969

### Problem

Azure DevOps push webhook payloads do not include file-level change information. There is no equivalent to GitHub/GitLab's `commits[].added/modified/removed` fields. As a result, Argo CD currently cannot populate `changedFiles` when processing ADO push events and falls back to refreshing all applications on every push, effectively disabling path-based refresh optimization in monorepo setups that rely on the `argocd.argoproj.io/manifest-generate-paths` annotation.

### Solution

This PR queries the [Azure DevOps Git Diffs REST API](https://learn.microsoft.com/en-us/rest/api/azure/devops/git/diffs/get) to retrieve the list of files changed between the `before` and `after` commit SHAs carried in the push event:

```http
GET .../_apis/git/repositories/{repoId}/diffs/commits
    ?baseVersion={shaBefore}&baseVersionType=commit
    &targetVersion={shaAfter}&targetVersionType=commit
    &$top=2000&api-version=7.1
```

**URL formats**: both the modern `https://dev.azure.com/{org}/{project}/_git/{repo}` and the legacy `https://{org}.visualstudio.com/{project}/_git/{repo}` formats are supported via `parseADOBaseURL`.

**Ref handling**: the diff is fetched using the SHAs from the first ref update in the payload, matching the current ADO webhook behavior already used to determine `revision` and `touchedHead`. Support for multiple ref updates is unchanged by this PR.

**Branch creation/deletion**: Azure DevOps uses the all-zero object ID to represent a non-existent commit (`oldObjectId` on branch creation and `newObjectId` on branch deletion). These ranges are not diffable through the Diffs API, so the changed-files lookup is skipped and normal webhook processing falls back to refreshing all matching applications.

**Change types**: all change types returned by the API (add, edit, delete, rename) are included in the `changedFiles` list using their resulting path. For rename operations, only the new (destination) path is included. Folder entries from the ADO diff response are excluded; Argo CD evaluates `manifest-generate-paths` against changed file paths, and directory paths in the annotation still match when changed files are under that directory.

**Deduplication**: the ADO Diffs API computes the cumulative diff between two commit SHAs, so duplicate file paths are not expected from the cumulative diff response in practice, and no additional deduplication is currently performed.

**Multiple commits per push**: because the payload provides a single before/after SHA per ref update rather than per individual commit, the Diffs API naturally returns the cumulative diff across all commits included in the push.

**Truncation**: if the diff exceeds 2000 files, the API sets `allChangesIncluded: false` in the response. In that case the handler treats this as an error and falls back to refreshing all matching applications rather than silently using an incomplete file list. This preserves correctness at the cost of potentially triggering a full refresh.

**Credentials**: resolved using the existing repository credential resolution logic, first checking for a directly registered repository, then falling back to credentials templates via longest prefix match. Basic/PAT credentials and bearer token credentials are supported. If no supported credentials are available, the ADO REST API request is not sent unauthenticated; the handler logs a warning and falls back to a full refresh.

**HTTP client configuration**: the ADO REST API call uses a repository-aware HTTP client created from the configured Argo CD repository settings, so repository TLS, proxy/noProxy, transport, and credential-related HTTP behavior are honored instead of using `http.DefaultClient`.

**SSRF protection**: the ADO diffs lookup is only attempted after repository/credentials resolution against Argo CD's configured repositories and credential templates. If no match is found, the changed-files lookup is skipped and normal webhook processing continues.

**Performance**: at most one additional API call is made for diffable ADO push events. The call is performed synchronously during webhook processing with a 10-second context timeout. No retries and no caching are currently implemented. On any API error (4xx, 5xx, timeout, truncation), missing credentials, or non-diffable commit range, the handler falls back to refreshing all matching applications, ensuring the push event is still processed.

**Observability**: a warning is logged when the diff fetch fails or when supported ADO REST API credentials are missing and fallback is triggered. Debug logs include the number of changed files retrieved and skip reasons for cases where the diff lookup is not attempted.

## Test Plan

- [x] Unit tests for `fetchChangedFilesFromADO`: valid diff response, legacy `visualstudio.com` repository URL, truncated diff (`allChangesIncluded: false`), ADO API error, malformed repository URL
- [x] Unit tests for `parseADOBaseURL`: modern `dev.azure.com` URL, legacy `visualstudio.com` URL, missing project/invalid URL
- [x] Unit tests for ADO authentication header handling: Basic/PAT, bearer token, incomplete credentials, and no credentials
- [x] ADO diff lookup does not send unauthenticated API requests when no supported credentials are configured
- [x] ADO diff lookup uses repository-aware HTTP client configuration, including proxy/noProxy behavior
- [x] ADO branch creation/deletion events with the all-zero object ID skip the Diffs API lookup and fall back to full refresh
- [x] Integration-style test for `affectedRevisionInfo` with ADO push fixture using direct repository credentials
- [x] Integration-style test for `affectedRevisionInfo` with ADO push fixture using credentials template fallback
- [x] `affectedRevisionInfo` falls back to refreshing all matching applications when diff lookup fails
- [x] Error paths for repository lookup failures and ADO fetch failures are covered at the handler level
- [x] ADO push payload with multiple `refUpdates` continues to use the first entry, matching existing `revision`/`touchedHead` behavior
- [x] Handles push events with multiple commits; cumulative diff is computed between push before/after SHAs
- [x] ADO tests use injected HTTP clients/fake transports instead of global HTTP mocking
- [x] Validated end-to-end in a live Argo CD environment against Azure DevOps: only applications whose `manifest-generate-paths` matched the changed files were refreshed