### PR TITLE
docs: redirect previous-version banner to stable page instead of homepage (#26857)

### DIFF
--- a/docs/assets/versions.js
+++ b/docs/assets/versions.js
@@ -139,10 +139,11 @@ window.addEventListener("DOMContentLoaded", function() {
   var headerHeight = document.getElementsByClassName("md-header")[0].offsetHeight;
   const currentVersion = getCurrentVersion();
   if (currentVersion && currentVersion !== "stable") {
+    var stableUrl = window.location.href.replace(VERSION_REGEX, '/en/stable/');
     if (currentVersion === "latest") {
-      document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for an unreleased version of Argo CD, <a href='https://argo-cd.readthedocs.io/en/stable/'>view the latest stable version.</a></div>";
+      document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for an unreleased version of Argo CD, <a href='" + stableUrl + "'>view the latest stable version.</a></div>";
     } else {
-      document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for a previous version of Argo CD, <a href='https://argo-cd.readthedocs.io/en/stable/'>view the latest stable version.</a></div>";
+      document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for a previous version of Argo CD, <a href='" + stableUrl + "'>view the latest stable version.</a></div>";
     }
     var bannerHeight = document.getElementById('announce-msg').offsetHeight + margin;
     document.querySelector("header.md-header").style.top = bannerHeight + "px";


### PR DESCRIPTION
Fixes #26857

## Description

The version warning banner on documentation pages always linked to the docs homepage (https://argo-cd.readthedocs.io/en/stable/) regardless of which page the user was reading. This change replaces the hard-coded URL with a dynamic one that preserves the current page path, so users land on the stable equivalent of the page they were already viewing.

### Before
Clicking the banner on https://argo-cd.readthedocs.io/en/latest/user-guide/ redirected to https://argo-cd.readthedocs.io/en/stable/ (docs homepage).

### After
Clicking the banner on https://argo-cd.readthedocs.io/en/latest/user-guide/ redirects to https://argo-cd.readthedocs.io/en/stable/user-guide/.

## Changes

- docs/assets/versions.js: Compute stableUrl by replacing the matched version segment in the current URL with /en/stable/, then use that URL in the banner'\''s anchor tag.

## Checklist

* [x] I have signed off all my commits as required by DCO.
* [x] The title of the PR states what changed and the related issues number.
* [x] The title of the PR conforms to semantic PR title formatting.
* [x] I have included "Fixes #26857" in the description to automatically close the associated issue.
* [x] This PR is a documentation update itself.
* [x] I have added a brief description of why this PR is necessary and what this PR solves.
