### PR TITLE
feat(ui): show last refresh time in application sync status panel (#20591)

### DIFF
--- a/ui/src/app/applications/components/application-status-panel/application-status-panel.tsx
+++ b/ui/src/app/applications/components/application-status-panel/application-status-panel.tsx
@@ -317,6 +317,11 @@ export const ApplicationStatusPanel = ({application, showDiff, showOperation, sh
                             />
                         </div>
                     )}
+                {application.status.reconciledAt && (
+                    <div className='application-status-panel__item-name'>
+                        Last refreshed <Timestamp date={application.status.reconciledAt} />
+                    </div>
+                )}
             </div>
             {appOperationState && (
                 <div className='application-status-panel__item'>

--- a/ui/src/app/shared/models.ts
+++ b/ui/src/app/shared/models.ts
@@ -527,6 +527,7 @@ export interface ApplicationSummary {
 
 export interface ApplicationStatus {
     observedAt: models.Time;
+    reconciledAt?: models.Time;
     resources: ResourceStatus[];
     sync: SyncStatus;
     conditions?: ApplicationCondition[];


### PR DESCRIPTION
Fixes #20591

## Description

Adds a 'Last refreshed' timestamp to the SYNC STATUS section of the application status panel. This helps users quickly diagnose when an application was last refreshed against git, which is a common source of confusion when Argo CD does not appear to pick up recent changes.

The timestamp is rendered using the existing <Timestamp> component (e.g. "2 minutes ago (Apr 18, 2025 2:30 PM)") for consistency with the LAST SYNC section.

## Changes

- **ui/src/app/shared/models.ts**: Added  to the  interface. The  field already exists in the Go backend API but was missing from the TypeScript model.
- **ui/src/app/applications/components/application-status-panel/application-status-panel.tsx**: Inside the SYNC STATUS panel, conditionally renders a "Last refreshed <Timestamp ... />" line when  is present.

## Screenshots / How to test

1. Open any Application detail page in the Argo CD UI.
2. Look at the SYNC STATUS panel.
3. You should see a line like: "Last refreshed 5 minutes ago (Apr 18, 2025 2:30 PM)".

## Checklist

* [x] Either (a) I've created an enhancement proposal and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the Title of the PR guidelines.
* [x] I've included "Fixes #20591" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] This is a minor UI enhancement that is self-documenting; no docs update required.
* [x] I have signed off all my commits as required by DCO.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green.
* [x] My new feature complies with the feature status guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
