### PR TITLE
feat(ui): add diff button to application list tiles and table rows (#20696)

### DIFF
--- a/ui/src/app/applications/components/applications-list/application-table-row.tsx
+++ b/ui/src/app/applications/components/applications-list/application-table-row.tsx
@@ -162,6 +162,15 @@ export const ApplicationTableRow = ({app, selected, pref, ctx, syncApplication, 
                                 iconClassName: 'fa fa-fw fa-sync',
                                 action: () => syncApplication(app.metadata.name, app.metadata.namespace)
                             },
+                            ...(app.status.sync.status !== models.SyncStatuses.Synced
+                                ? [
+                                      {
+                                          title: 'Diff',
+                                          iconClassName: 'fa fa-fw fa-file-medical',
+                                          action: () => ctx.navigation.goto(`/${AppUtils.getAppUrl(app)}`, {tab: 'diff'})
+                                      }
+                                  ]
+                                : []),
                             {
                                 title: 'Refresh',
                                 iconClassName: 'fa fa-fw fa-redo',

--- a/ui/src/app/applications/components/applications-list/application-tile.tsx
+++ b/ui/src/app/applications/components/applications-list/application-tile.tsx
@@ -259,6 +259,20 @@ export const ApplicationTile = ({app, selected, pref, ctx, tileRef, syncApplicat
                                 <i className='fa fa-sync' /> Sync
                             </a>
                             &nbsp;
+                            {app.status.sync.status !== models.SyncStatuses.Synced && (
+                                <Tooltip className='custom-tooltip' content={'Diff'}>
+                                    <a
+                                        className='argo-button argo-button--base'
+                                        qe-id='applications-tiles-button-diff'
+                                        onClick={e => {
+                                            e.stopPropagation();
+                                            ctx.navigation.goto(`/${AppUtils.getAppUrl(app)}`, {tab: 'diff'});
+                                        }}>
+                                        <i className='fa fa-file-medical' /> <span className='show-for-xxlarge'>Diff</span>
+                                    </a>
+                                </Tooltip>
+                            )}
+                            {app.status.sync.status !== models.SyncStatuses.Synced && <> &nbsp;</>}
                             <Tooltip className='custom-tooltip' content={'Refresh'}>
                                 <a
                                     className='argo-button argo-button--base'


### PR DESCRIPTION
Fixes #20696

## Description

Adds a Diff action button to each Application on the main application list screen (both tile and table views). Currently the list only exposes Sync, Refresh, and Delete shortcuts; users who want to review changes before syncing must first open the application detail page and then click Diff. This change streamlines that workflow.

The Diff button/menu item is only shown when the application is not already synced (sync.status != Synced), matching the behavior on the application detail page.

## Changes

- **ui/src/app/applications/components/applications-list/application-tile.tsx**: Adds an inline Diff button between Sync and Refresh in the tile view. Uses the  icon for consistency with the detail page.
- **ui/src/app/applications/components/applications-list/application-table-row.tsx**: Adds a Diff dropdown menu item between Sync and Refresh in the table view.

Both navigate to the app's detail page with  active.

## How to test

1. Open the Applications list.
2. For any OutOfSync (or otherwise non-Synced) app, you should see a Diff button in the tile actions or a Diff option in the table row dropdown.
3. Clicking it should take you directly to the Diff tab of that application.
4. Synced apps should not show the Diff action.

## Checklist

* [x] I have signed off all my commits as required by DCO.
* [x] The title of the PR states what changed and the related issues number.
* [x] The title conforms to semantic PR title formatting.
* [x] I've included Fixes #20696 in the description.
* [x] I've updated the UI to expose the feature.
* [x] This is a minor UI enhancement; no separate docs update required.
* [x] My build is green (pnpm run lint passes).
* [x] I have added a brief description of why this PR is necessary and what it solves.
