### PR TITLE
fix(ui): hide misleading author/comment in sync status and last sync (#20586)

### DIFF
--- a/ui/src/app/applications/components/application-status-panel/application-status-panel.tsx
+++ b/ui/src/app/applications/components/application-status-panel/application-status-panel.tsx
@@ -314,6 +314,7 @@ export const ApplicationStatusPanel = ({application, showDiff, showOperation, sh
                                 type={revisionType}
                                 revision={revision}
                                 versionId={utils.getAppCurrentVersion(application)}
+                                hideAuthorComment={true}
                             />
                         </div>
                     )}
@@ -355,6 +356,7 @@ export const ApplicationStatusPanel = ({application, showDiff, showOperation, sh
                             type={revisionType}
                             revision={operationStateRevision}
                             versionId={utils.getAppCurrentVersion(application)}
+                            hideAuthorComment={true}
                         />
                     )) || <div className='application-status-panel__item-name'>{appOperationState.message}</div>}
                 </div>

--- a/ui/src/app/applications/components/application-status-panel/revision-metadata-panel.tsx
+++ b/ui/src/app/applications/components/application-status-panel/revision-metadata-panel.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import {Timestamp} from '../../../shared/components/timestamp';
 import {services} from '../../../shared/services';
 
-export const RevisionMetadataPanel = (props: {appName: string; appNamespace: string; type: string; revision: string; versionId: number}) => {
+export const RevisionMetadataPanel = (props: {appName: string; appNamespace: string; type: string; revision: string; versionId: number; hideAuthorComment?: boolean}) => {
     if (props.type === 'helm') {
         return null;
     }
@@ -38,11 +38,18 @@ export const RevisionMetadataPanel = (props: {appName: string; appNamespace: str
                         placement='bottom'
                         allowHTML={true}>
                         <div className='application-status-panel__item-name'>
-                            {m.authors && (
+                            {props.hideAuthorComment ? (
                                 <div className='application-status-panel__item__row'>
-                                    <div>Author:</div>
-                                    <div>{m.authors}</div>
+                                    <div>Revision:</div>
+                                    <div>{props.revision.slice(0, 7)}</div>
                                 </div>
+                            ) : (
+                                m.authors && (
+                                    <div className='application-status-panel__item__row'>
+                                        <div>Author:</div>
+                                        <div>{m.authors}</div>
+                                    </div>
+                                )
                             )}
                         </div>
                     </Tooltip>
@@ -90,18 +97,27 @@ export const RevisionMetadataPanel = (props: {appName: string; appNamespace: str
                     placement='bottom'
                     allowHTML={true}>
                     <div className='application-status-panel__item-name'>
-                        {m.author && (
+                        {props.hideAuthorComment ? (
                             <div className='application-status-panel__item__row'>
-                                <div>Author:</div>
-                                <div>
-                                    {m.author} - {m.signatureInfo}
-                                </div>
+                                <div>Revision:</div>
+                                <div>{props.revision.slice(0, 7)}</div>
                             </div>
+                        ) : (
+                            <>
+                                {m.author && (
+                                    <div className='application-status-panel__item__row'>
+                                        <div>Author:</div>
+                                        <div>
+                                            {m.author} - {m.signatureInfo}
+                                        </div>
+                                    </div>
+                                )}
+                                <div className='application-status-panel__item__row'>
+                                    <div>Comment:</div>
+                                    <div>{m.message?.split('\n')[0].slice(0, 64)}</div>
+                                </div>
+                            </>
                         )}
-                        <div className='application-status-panel__item__row'>
-                            <div>Comment:</div>
-                            <div>{m.message?.split('\n')[0].slice(0, 64)}</div>
-                        </div>
                     </div>
                 </Tooltip>
             )}


### PR DESCRIPTION
Fixes #20586

## Description

The Sync Status and Last Sync sections displayed PR author and comment information that is often misleading because Argo CD shows the most recent PR/commit metadata, not necessarily the one that actually updated the application. This caused confusion for users (23 +1s on the issue).

This change hides the Author and Comment inline rows in the Sync Status and Last Sync panels, replacing them with a concise Revision identifier. The full metadata (author, date, tags, signature, message) is still accessible via the tooltip on hover.

The SOURCE HYDRATOR panel is left unchanged.

## Changes

- **ui/src/app/applications/components/application-status-panel/revision-metadata-panel.tsx**: Added optional  prop. When true, renders a compact "Revision: <sha>" row instead of Author/Comment.
- **ui/src/app/applications/components/application-status-panel/application-status-panel.tsx**: Passed  to  in SYNC STATUS and LAST SYNC sections.

## How to test

1. Open an Application detail page.
2. In the Sync Status and Last Sync panels, verify that Author/Comment rows are no longer shown inline.
3. Verify that a "Revision: <sha>" row is shown instead.
4. Hover over the revision row to confirm the tooltip still shows full metadata.
5. Verify the SOURCE HYDRATOR panel (if present) still shows full metadata inline.

## Checklist

* [x] I have signed off all my commits as required by DCO.
* [x] The title of the PR states what changed and the related issues number.
* [x] The title conforms to semantic PR title formatting.
* [x] I've included Fixes #20586 in the description.
* [x] I've updated the UI.
* [x] This is a minor UI enhancement; no separate docs update required.
* [x] My build is green (pnpm run lint passes).
* [x] I have added a brief description of why this PR is necessary and what it solves.
