### PR TITLE
test: add t.Parallel() to util jwt, crypto, and password tests (#27423)

### DIFF
--- a/util/crypto/crypto_test.go
+++ b/util/crypto/crypto_test.go
@@ -18,6 +18,7 @@ func newKey() ([]byte, error) {
 }
 
 func TestEncryptDecrypt_Successful(t *testing.T) {
+	t.Parallel()
 	key, err := newKey()
 	require.NoError(t, err)
 	encrypted, err := Encrypt([]byte("test"), key)
@@ -30,6 +31,7 @@ func TestEncryptDecrypt_Successful(t *testing.T) {
 }
 
 func TestEncryptDecrypt_Failed(t *testing.T) {
+	t.Parallel()
 	key, err := newKey()
 	require.NoError(t, err)
 	encrypted, err := Encrypt([]byte("test"), key)

--- a/util/jwt/jwt_test.go
+++ b/util/jwt/jwt_test.go
@@ -10,12 +10,14 @@ import (
 )
 
 func TestGetSingleStringScope(t *testing.T) {
+	t.Parallel()
 	claims := jwt.MapClaims{"groups": "my-org:my-team"}
 	groups := GetScopeValues(claims, []string{"groups"})
 	assert.Contains(t, groups, "my-org:my-team")
 }
 
 func TestGetMultipleListScopes(t *testing.T) {
+	t.Parallel()
 	claims := jwt.MapClaims{"groups1": []string{"my-org:my-team1"}, "groups2": []string{"my-org:my-team2"}}
 	groups := GetScopeValues(claims, []string{"groups1", "groups2"})
 	assert.Contains(t, groups, "my-org:my-team1")
@@ -23,11 +25,13 @@ func TestGetMultipleListScopes(t *testing.T) {
 }
 
 func TestClaims(t *testing.T) {
+	t.Parallel()
 	assert.Nil(t, Claims(nil))
 	assert.NotNil(t, Claims(jwt.MapClaims{}))
 }
 
 func TestIsMember(t *testing.T) {
+	t.Parallel()
 	assert.False(t, IsMember(jwt.MapClaims{}, nil, []string{"groups"}))
 	assert.False(t, IsMember(jwt.MapClaims{"groups": []string{""}}, []string{"my-group"}, []string{"groups"}))
 	assert.False(t, IsMember(jwt.MapClaims{"groups": []string{"my-group"}}, []string{""}, []string{"groups"}))
@@ -35,11 +39,13 @@ func TestIsMember(t *testing.T) {
 }
 
 func TestGetGroups(t *testing.T) {
+	t.Parallel()
 	assert.Empty(t, GetGroups(jwt.MapClaims{}, []string{"groups"}))
 	assert.Equal(t, []string{"foo"}, GetGroups(jwt.MapClaims{"groups": []string{"foo"}}, []string{"groups"}))
 }
 
 func TestIssuedAtTime_Int64(t *testing.T) {
+	t.Parallel()
 	// Tuesday, 1 December 2020 14:00:00
 	claims := jwt.MapClaims{"iat": int64(1606831200)}
 	issuedAt, err := IssuedAtTime(claims)
@@ -49,12 +55,14 @@ func TestIssuedAtTime_Int64(t *testing.T) {
 }
 
 func TestIssuedAtTime_Error_NoInt(t *testing.T) {
+	t.Parallel()
 	claims := jwt.MapClaims{"iat": 1606831200}
 	_, err := IssuedAtTime(claims)
 	assert.Error(t, err)
 }
 
 func TestIssuedAtTime_Error_Missing(t *testing.T) {
+	t.Parallel()
 	claims := jwt.MapClaims{}
 	iat, err := IssuedAtTime(claims)
 	require.Error(t, err)
@@ -62,6 +70,7 @@ func TestIssuedAtTime_Error_Missing(t *testing.T) {
 }
 
 func TestIsValid(t *testing.T) {
+	t.Parallel()
 	assert.True(t, IsValid("foo.bar.foo"))
 	assert.True(t, IsValid("foo.bar.foo.bar"))
 	assert.False(t, IsValid("foo.bar"))
@@ -70,6 +79,7 @@ func TestIsValid(t *testing.T) {
 }
 
 func TestGetUserIdentifier(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name   string
 		claims jwt.MapClaims
@@ -131,6 +141,7 @@ func TestGetUserIdentifier(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := GetUserIdentifier(tt.claims)
 			assert.Equal(t, tt.want, got)
 		})

--- a/util/password/password_test.go
+++ b/util/password/password_test.go
@@ -20,17 +20,20 @@ func testPasswordHasher(t *testing.T, h PasswordHasher) {
 }
 
 func TestBcryptPasswordHasher(t *testing.T) {
+	t.Parallel()
 	// Use the default work factor
 	h := BcryptPasswordHasher{0}
 	testPasswordHasher(t, h)
 }
 
 func TestDummyPasswordHasher(t *testing.T) {
+	t.Parallel()
 	h := DummyPasswordHasher{}
 	testPasswordHasher(t, h)
 }
 
 func TestPasswordHashing(t *testing.T) {
+	t.Parallel()
 	const (
 		defaultPassword = "Hello, world!"
 		blankPassword   = ""


### PR DESCRIPTION
Related to #27423

## Description

Adds t.Parallel() to a focused chunk of safe, independent unit tests in the util/ package. These tests have no shared mutable state and are safe to run concurrently. This is part of the larger effort to reduce overall test execution time.

## Changes

- **util/jwt/jwt_test.go**: Added t.Parallel() to all 10 top-level test functions and to subtests inside TestGetUserIdentifier.
- **util/crypto/crypto_test.go**: Added t.Parallel() to both test functions.
- **util/password/password_test.go**: Added t.Parallel() to all 3 test functions.

## Verification

ok  	github.com/argoproj/argo-cd/v3/util/jwt	0.354s
ok  	github.com/argoproj/argo-cd/v3/util/crypto	0.756s
ok  	github.com/argoproj/argo-cd/v3/util/password	0.696s
All tests pass.

## Checklist

* [x] I have signed off all my commits as required by DCO.
* [x] The title of the PR states what changed and the related issues number.
* [x] The title conforms to semantic PR title formatting.
* [x] This is a test improvement; no docs or UI changes required.
* [x] My build is green (go test passes).
* [x] I have added a brief description of why this PR is necessary and what it solves.
