### PR TITLE
ci: enable Renovate kubernetes manager for Dex image bumps (#23089)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,14 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "kubernetes": {
+    "enabled": true
+  },
+  "packageRules": [
+    {
+      "description": "Ignore Argo CD's own image updates in manifests — these are managed by the release process",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["quay.io/argoproj/argocd"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
Fixes #23089

## Description

Enables Renovate's built-in kubernetes manager so it can detect and propose updates for container images in Kubernetes manifests (e.g. Dex, Redis). To avoid unwanted PRs for images managed by the release process, Argo CD's own image is explicitly ignored.

## Changes

- **renovate.json**: Added  and a  entry that disables docker updates for .

## How it works

Renovate will now scan YAML files under  that contain Kubernetes resources and detect container image references. When a new version of  is available, Renovate will open a PR similar to #23088.

## Checklist

* [x] I have signed off all my commits as required by DCO.
* [x] The title of the PR states what changed and the related issues number.
* [x] The title conforms to semantic PR title formatting.
* [x] I've included Fixes #23089 in the description.
* [x] This is a CI/config change; no tests or docs required.
* [x] I have added a brief description of why this PR is necessary and what it solves.
