### PR TITLE
feat(cli): persist port-forward settings during argocd login (#20565)

### DIFF
--- a/cmd/argocd/commands/login.go
+++ b/cmd/argocd/commands/login.go
@@ -155,12 +155,14 @@ argocd login cd.argoproj.io --core`,
 				localCfg = &localconfig.LocalConfig{}
 			}
 			localCfg.UpsertServer(localconfig.Server{
-				Server:          server,
-				PlainText:       clientOpts.PlainText,
-				Insecure:        clientOpts.Insecure,
-				GRPCWeb:         clientOpts.GRPCWeb,
-				GRPCWebRootPath: clientOpts.GRPCWebRootPath,
-				Core:            clientOpts.Core,
+				Server:               server,
+				PlainText:            clientOpts.PlainText,
+				Insecure:             clientOpts.Insecure,
+				GRPCWeb:              clientOpts.GRPCWeb,
+				GRPCWebRootPath:      clientOpts.GRPCWebRootPath,
+				Core:                 clientOpts.Core,
+				PortForward:          clientOpts.PortForward,
+				PortForwardNamespace: clientOpts.PortForwardNamespace,
 			})
 			localCfg.UpsertUser(localconfig.User{
 				Name:         ctxName,

--- a/cmd/argocd/commands/relogin.go
+++ b/cmd/argocd/commands/relogin.go
@@ -48,15 +48,17 @@ func NewReloginCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 			var tokenString string
 			var refreshToken string
 			reloginOpts := argocdclient.ClientOptions{
-				ConfigPath:        "",
-				ServerAddr:        configCtx.Server.Server,
-				Insecure:          configCtx.Server.Insecure,
-				ClientCertFile:    clientOpts.ClientCertFile,
-				ClientCertKeyFile: clientOpts.ClientCertKeyFile,
-				GRPCWeb:           clientOpts.GRPCWeb,
-				GRPCWebRootPath:   clientOpts.GRPCWebRootPath,
-				PlainText:         configCtx.Server.PlainText,
-				Headers:           clientOpts.Headers,
+				ConfigPath:           "",
+				ServerAddr:           configCtx.Server.Server,
+				Insecure:             configCtx.Server.Insecure,
+				ClientCertFile:       clientOpts.ClientCertFile,
+				ClientCertKeyFile:    clientOpts.ClientCertKeyFile,
+				GRPCWeb:              clientOpts.GRPCWeb,
+				GRPCWebRootPath:      clientOpts.GRPCWebRootPath,
+				PlainText:            configCtx.Server.PlainText,
+				PortForward:          configCtx.Server.PortForward,
+				PortForwardNamespace: configCtx.Server.PortForwardNamespace,
+				Headers:              clientOpts.Headers,
 			}
 			acdClient := headless.NewClientOrDie(&reloginOpts, c)
 			claims, err := configCtx.User.Claims()

--- a/pkg/apiclient/apiclient.go
+++ b/pkg/apiclient/apiclient.go
@@ -197,6 +197,11 @@ func NewClient(opts *ClientOptions) (Client, error) {
 			c.AuthToken = configCtx.User.AuthToken
 			c.RefreshToken = configCtx.User.RefreshToken
 			ctxName = configCtx.Name
+			// Apply saved port-forward settings if not explicitly set via CLI
+			if !opts.PortForward && opts.PortForwardNamespace == "" {
+				opts.PortForward = configCtx.Server.PortForward
+				opts.PortForwardNamespace = configCtx.Server.PortForwardNamespace
+			}
 		}
 	}
 	if opts.UserAgent != "" {

--- a/util/localconfig/localconfig.go
+++ b/util/localconfig/localconfig.go
@@ -56,6 +56,10 @@ type Server struct {
 	PlainText bool `json:"plain-text,omitempty"`
 	// Core indicates to talk to Kubernetes API without using Argo CD API server
 	Core bool `json:"core,omitempty"`
+	// PortForward indicates to connect to a random argocd-server port using port forwarding
+	PortForward bool `json:"port-forward,omitempty"`
+	// PortForwardNamespace is the namespace name which should be used for port forwarding
+	PortForwardNamespace string `json:"port-forward-namespace,omitempty"`
 }
 
 // User contains user authentication information


### PR DESCRIPTION
Fixes #20565

## Description

When using argocd login --port-forward --port-forward-namespace argocd, subsequent commands still required the --port-forward flags because the settings were not persisted to the local config file (~/.config/argocd/config).

This change saves port-forward settings during login and restores them automatically on subsequent commands, similar to how PlainText, Insecure, GRPCWeb, and Core are already handled.

## Changes

- **util/localconfig/localconfig.go**: Added PortForward and PortForwardNamespace fields to the Server struct.
- **cmd/argocd/commands/login.go**: Persists the new fields during login.
- **pkg/apiclient/apiclient.go**: Loads saved port-forward settings from local config when creating the API client, unless explicitly overridden by CLI flags.
- **cmd/argocd/commands/relogin.go**: Preserves the fields during relogin.

## How to test

1. argocd login --port-forward --port-forward-namespace argocd
2. argocd app list (should work without passing --port-forward again)
3. Check ~/.config/argocd/config — it should contain port-forward: true and port-forward-namespace: argocd

## Checklist

* [x] I have signed off all my commits as required by DCO.
* [x] The title of the PR states what changed and the related issues number.
* [x] The title conforms to semantic PR title formatting.
* [x] I've included Fixes #20565 in the description.
* [x] This is a CLI enhancement; no UI or docs changes required.
* [x] My build is green (go test passes for affected packages).
* [x] I have added a brief description of why this PR is necessary and what it solves.
