### PR TITLE
feat(cli): add --file filter to argocd app list (#21052)

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -1851,6 +1851,7 @@ func NewApplicationListCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 		appNamespace string
 		cluster      string
 		path         string
+		files        []string
 	)
 	command := &cobra.Command{
 		Use:   "list",
@@ -1889,6 +1890,9 @@ func NewApplicationListCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 			if path != "" {
 				appList = argo.FilterByPath(appList, path)
 			}
+			if len(files) != 0 {
+				appList = argo.FilterByFiles(appList, files)
+			}
 
 			switch output {
 			case "yaml", "json":
@@ -1910,6 +1914,7 @@ func NewApplicationListCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 	command.Flags().StringVarP(&appNamespace, "app-namespace", "N", "", "Only list applications in namespace")
 	command.Flags().StringVarP(&cluster, "cluster", "c", "", "List apps by cluster name or url")
 	command.Flags().StringVarP(&path, "path", "P", "", "List apps by path")
+	command.Flags().StringArrayVarP(&files, "file", "f", []string{}, "Filter apps affected by the given files (evaluates path and manifest-generate-paths annotation)")
 	return command
 }
 

--- a/docs/user-guide/commands/argocd_app_list.md
+++ b/docs/user-guide/commands/argocd_app_list.md
@@ -27,6 +27,7 @@ argocd app list [flags]
 ```
   -N, --app-namespace string   Only list applications in namespace
   -c, --cluster string         List apps by cluster name or url
+  -f, --file stringArray       Filter apps affected by the given files (evaluates path and manifest-generate-paths annotation)
   -h, --help                   help for list
   -o, --output string          Output format. One of: wide|name|json|yaml (default "wide")
   -P, --path string            List apps by path

--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/argoproj/argo-cd/v3/util/app/path"
 	"github.com/argoproj/argo-cd/v3/util/gpg"
 
 	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
@@ -186,8 +187,33 @@ func FilterByPath(apps []argoappv1.Application, path string) []argoappv1.Applica
 	}
 	items := []argoappv1.Application{}
 	for i := range apps {
-		if apps[i].Spec.GetSource().Path == path {
-			items = append(items, apps[i])
+		for _, source := range apps[i].Spec.GetSources() {
+			if source.Path == path {
+				items = append(items, apps[i])
+				break
+			}
+		}
+	}
+	return items
+}
+
+// FilterByFiles returns applications that are affected by the given files,
+// evaluating each source's path and the manifest-generate-paths annotation.
+func FilterByFiles(apps []argoappv1.Application, files []string) []argoappv1.Application {
+	if len(files) == 0 {
+		return apps
+	}
+	items := []argoappv1.Application{}
+	for i := range apps {
+		for _, source := range apps[i].Spec.GetSources() {
+			refreshPaths := path.GetSourceRefreshPaths(&apps[i], source)
+			if len(refreshPaths) == 0 {
+				refreshPaths = []string{source.Path}
+			}
+			if path.AppFilesHaveChanged(refreshPaths, files) {
+				items = append(items, apps[i])
+				break
+			}
 		}
 	}
 	return items


### PR DESCRIPTION
Fixes #21052

## Description

Adds a --file / -f flag to argocd app list that filters applications affected by the given files. This is very useful for monorepo setups where filtering by --repo returns too many applications.

The filter evaluates each application's source path and the argocd.argoproj.io/manifest-generate-paths annotation to determine if a file change would affect the application. This uses the same path-matching logic already employed by the webhook refresh optimization.

Also updates the existing FilterByPath helper to properly support multi-source applications.

## Example usage



## Changes

- **util/argo/argo.go**: Added FilterByFiles using util/app/path matching logic. Updated FilterByPath to check all sources in multi-source apps.
- **cmd/argocd/commands/app.go**: Added --file / -f flag and wired it into the list command.

## Checklist

* [x] I have signed off all my commits as required by DCO.
* [x] The title of the PR states what changed and the related issues number.
* [x] The title conforms to semantic PR title formatting.
* [x] I've included Fixes #21052 in the description.
* [x] I've updated the CLI to expose the feature.
* [x] This is a minor CLI enhancement; no separate docs update required.
* [x] My build is green (go test passes for affected packages).
* [x] I have added a brief description of why this PR is necessary and what it solves.
