### PR TITLE
feat(metrics): export daily active users gauge (#20801)

### DIFF
--- a/server/metrics/dau.go
+++ b/server/metrics/dau.go
@@ -1,0 +1,89 @@
+package metrics
+
+import (
+	"sync"
+	"time"
+)
+
+// DAUTracker tracks distinct active users over a sliding window.
+// It is safe for concurrent use.
+type DAUTracker struct {
+	mu      sync.RWMutex
+	window  time.Duration
+	users   map[string]time.Time
+	metrics *MetricsServer
+	ticker  *time.Ticker
+	stopCh  chan struct{}
+}
+
+// NewDAUTracker creates a new DAUTracker with the given window duration.
+// If metricsServer is non-nil, the gauge will be updated periodically.
+func NewDAUTracker(window time.Duration, metricsServer *MetricsServer) *DAUTracker {
+	return &DAUTracker{
+		window:  window,
+		users:   make(map[string]time.Time),
+		metrics: metricsServer,
+		stopCh:  make(chan struct{}),
+	}
+}
+
+// Start begins the background cleanup loop. Call Stop to terminate it.
+func (t *DAUTracker) Start(interval time.Duration) {
+	t.ticker = time.NewTicker(interval)
+	go func() {
+		for {
+			select {
+			case <-t.ticker.C:
+				t.cleanup()
+			case <-t.stopCh:
+				return
+			}
+		}
+	}()
+}
+
+// Stop terminates the background cleanup loop.
+func (t *DAUTracker) Stop() {
+	close(t.stopCh)
+	if t.ticker != nil {
+		t.ticker.Stop()
+	}
+}
+
+// RecordUser records that a user was active now.
+func (t *DAUTracker) RecordUser(userID string) {
+	if userID == "" {
+		return
+	}
+	t.mu.Lock()
+	t.users[userID] = time.Now()
+	t.mu.Unlock()
+}
+
+// Count returns the number of distinct users active within the window.
+func (t *DAUTracker) Count() int {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	cutoff := time.Now().Add(-t.window)
+	count := 0
+	for _, lastSeen := range t.users {
+		if lastSeen.After(cutoff) {
+			count++
+		}
+	}
+	return count
+}
+
+func (t *DAUTracker) cleanup() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	cutoff := time.Now().Add(-t.window)
+	for userID, lastSeen := range t.users {
+		if !lastSeen.After(cutoff) {
+			delete(t.users, userID)
+		}
+	}
+	if t.metrics != nil {
+		t.metrics.SetDailyActiveUsers(float64(len(t.users)))
+	}
+}

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -21,6 +21,7 @@ type MetricsServer struct {
 	extensionRequestCounter  *prometheus.CounterVec
 	extensionRequestDuration *prometheus.HistogramVec
 	loginRequestCounter      *prometheus.CounterVec
+	dailyActiveUsersGauge    prometheus.Gauge
 	PrometheusRegistry       *prometheus.Registry
 }
 
@@ -62,6 +63,12 @@ var (
 		},
 		[]string{"status"},
 	)
+	dailyActiveUsersGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "argocd_daily_active_users",
+			Help: "Number of distinct active users in the last 24 hours.",
+		},
+	)
 	argoVersion = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "argocd_info",
@@ -88,6 +95,7 @@ func NewMetricsServer(host string, port int) *MetricsServer {
 	registry.MustRegister(extensionRequestCounter)
 	registry.MustRegister(extensionRequestDuration)
 	registry.MustRegister(loginRequestCounter)
+	registry.MustRegister(dailyActiveUsersGauge)
 	registry.MustRegister(argoVersion)
 
 	kubectl.RegisterWithClientGo()
@@ -104,6 +112,7 @@ func NewMetricsServer(host string, port int) *MetricsServer {
 		extensionRequestDuration: extensionRequestDuration,
 		loginRequestCounter:      loginRequestCounter,
 		PrometheusRegistry:       registry,
+		dailyActiveUsersGauge:    dailyActiveUsersGauge,
 	}
 }
 
@@ -128,4 +137,9 @@ func (m *MetricsServer) ObserveExtensionRequestDuration(extension string, durati
 // status can be "success" or "failure"
 func (m *MetricsServer) IncLoginRequestCounter(status string) {
 	m.loginRequestCounter.WithLabelValues(status).Inc()
+}
+
+// SetDailyActiveUsers sets the daily active users gauge
+func (m *MetricsServer) SetDailyActiveUsers(count float64) {
+	m.dailyActiveUsersGauge.Set(count)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -215,6 +215,7 @@ type ArgoCDServer struct {
 	Shutdown           func()
 	terminateRequested atomic.Bool
 	available          atomic.Bool
+	dauTracker         *metrics.DAUTracker
 }
 
 type ArgoCDServerOpts struct {
@@ -568,6 +569,8 @@ func (server *ArgoCDServer) Run(ctx context.Context, listeners *Listeners) {
 		}
 	}()
 	metricsServ := metrics.NewMetricsServer(server.MetricsHost, server.MetricsPort)
+	server.dauTracker = metrics.NewDAUTracker(24*time.Hour, metricsServ)
+	server.dauTracker.Start(1 * time.Minute)
 	if server.RedisClient != nil {
 		cacheutil.CollectMetrics(server.RedisClient, metricsServ, server.userStateStorage.GetLockObject())
 	}
@@ -1519,6 +1522,9 @@ func (server *ArgoCDServer) Authenticate(ctx context.Context) (context.Context, 
 		// Add claims to the context to inspect for RBAC
 		//nolint:staticcheck
 		ctx = context.WithValue(ctx, "claims", claims)
+		if userID := util_session.GetUserIdentifier(ctx); userID != "" {
+			server.dauTracker.RecordUser(userID)
+		}
 		if newToken != "" {
 			// Session tokens that are expiring soon should be regenerated if user stays active.
 			// The renewed token is stored in outgoing ServerMetadata. Metadata is available to grpc-gateway


### PR DESCRIPTION
Fixes #20801

## Description

Adds a prometheus gauge argocd_daily_active_users that tracks the number of distinct users who have accessed the Argo CD server in the last 24 hours. This helps operators evaluate how many people actively use the tool.

## Changes

- **server/metrics/metrics.go**: Added dailyActiveUsersGauge and SetDailyActiveUsers helper.
- **server/metrics/dau.go**: Added DAUTracker with an in-memory sliding window. Records user IDs on authenticated requests and cleans up entries older than 24h via a background ticker.
- **server/server.go**: Instantiated the tracker during server startup and wired user recording into the Authenticate interceptor.

## How to test

1. Start the Argo CD server.
2. Make a few authenticated API/UI requests as different users.
3. curl http://localhost:8083/metrics | grep argocd_daily_active_users
4. The gauge should reflect the number of distinct users seen in the last 24h.

## Checklist

* [x] I have signed off all my commits as required by DCO.
* [x] The title of the PR states what changed and the related issues number.
* [x] The title conforms to semantic PR title formatting.
* [x] I've included Fixes #20801 in the description.
* [x] My build is green (go build passes).
* [x] I have added a brief description of why this PR is necessary and what it solves.
