### PR TITLE
fix: add list verb to argocd-server ClusterRole for live object manifests (#18853)

### DIFF
--- a/cmd/argocd/commands/admin/backup.go
+++ b/cmd/argocd/commands/admin/backup.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -67,73 +68,8 @@ func NewExportCommand() *cobra.Command {
 				}()
 			}
 
-			if len(applicationNamespaces) == 0 || len(applicationsetNamespaces) == 0 {
-				defaultNs := getAdditionalNamespaces(ctx, acdClients.configMaps)
-				if len(applicationNamespaces) == 0 {
-					applicationNamespaces = defaultNs.applicationNamespaces
-				}
-				if len(applicationsetNamespaces) == 0 {
-					applicationsetNamespaces = defaultNs.applicationsetNamespaces
-				}
-			}
-			// To support applications and applicationsets in any namespace, we must list ALL namespaces and filter them afterwards
-			if len(applicationNamespaces) > 0 {
-				acdClients.applications = client.Resource(applicationsResource)
-			}
-			if len(applicationsetNamespaces) > 0 {
-				acdClients.applicationSets = client.Resource(appplicationSetResource)
-			}
-
-			acdConfigMap, err := acdClients.configMaps.Get(ctx, common.ArgoCDConfigMapName, metav1.GetOptions{})
+			err = runExport(ctx, acdClients, client, namespace, writer, applicationNamespaces, applicationsetNamespaces)
 			errors.CheckError(err)
-			export(writer, *acdConfigMap, namespace)
-			acdRBACConfigMap, err := acdClients.configMaps.Get(ctx, common.ArgoCDRBACConfigMapName, metav1.GetOptions{})
-			errors.CheckError(err)
-			export(writer, *acdRBACConfigMap, namespace)
-			acdKnownHostsConfigMap, err := acdClients.configMaps.Get(ctx, common.ArgoCDKnownHostsConfigMapName, metav1.GetOptions{})
-			errors.CheckError(err)
-			export(writer, *acdKnownHostsConfigMap, namespace)
-			acdTLSCertsConfigMap, err := acdClients.configMaps.Get(ctx, common.ArgoCDTLSCertsConfigMapName, metav1.GetOptions{})
-			errors.CheckError(err)
-			export(writer, *acdTLSCertsConfigMap, namespace)
-
-			secrets, err := acdClients.secrets.List(ctx, metav1.ListOptions{})
-			errors.CheckError(err)
-			for _, secret := range secrets.Items {
-				if isArgoCDSecret(secret) {
-					export(writer, secret, namespace)
-				}
-			}
-
-			projects, err := acdClients.projects.List(ctx, metav1.ListOptions{})
-			errors.CheckError(err)
-			for _, proj := range projects.Items {
-				export(writer, proj, namespace)
-			}
-
-			applications, err := acdClients.applications.List(ctx, metav1.ListOptions{})
-			errors.CheckError(err)
-			for _, app := range applications.Items {
-				// Export application only if it is in one of the enabled namespaces
-				if secutil.IsNamespaceEnabled(app.GetNamespace(), namespace, applicationNamespaces) {
-					export(writer, app, namespace)
-				}
-			}
-			applicationSets, err := acdClients.applicationSets.List(ctx, metav1.ListOptions{})
-			if err != nil && !apierrors.IsNotFound(err) {
-				if apierrors.IsForbidden(err) {
-					log.Warn(err)
-				} else {
-					errors.CheckError(err)
-				}
-			}
-			if applicationSets != nil {
-				for _, appSet := range applicationSets.Items {
-					if secutil.IsNamespaceEnabled(appSet.GetNamespace(), namespace, applicationsetNamespaces) {
-						export(writer, appSet, namespace)
-					}
-				}
-			}
 		},
 	}
 
@@ -152,6 +88,349 @@ func NewExportCommand() *cobra.Command {
 		"If the ConfigMap value is not set, only ApplicationSets from the control plane namespace are exported.",
 		applicationsetNamespacesCmdParamsKey, common.ArgoCDCmdParamsConfigMapName))
 	return &command
+}
+
+func runExport(ctx context.Context, acdClients *argoCDClientsets, client dynamic.Interface, namespace string, writer io.Writer, applicationNamespaces, applicationsetNamespaces []string) error {
+	if len(applicationNamespaces) == 0 || len(applicationsetNamespaces) == 0 {
+		defaultNs := getAdditionalNamespaces(ctx, acdClients.configMaps)
+		if len(applicationNamespaces) == 0 {
+			applicationNamespaces = defaultNs.applicationNamespaces
+		}
+		if len(applicationsetNamespaces) == 0 {
+			applicationsetNamespaces = defaultNs.applicationsetNamespaces
+		}
+	}
+	// To support applications and applicationsets in any namespace, we must list ALL namespaces and filter them afterwards
+	if len(applicationNamespaces) > 0 {
+		acdClients.applications = client.Resource(applicationsResource)
+	}
+	if len(applicationsetNamespaces) > 0 {
+		acdClients.applicationSets = client.Resource(appplicationSetResource)
+	}
+
+	acdConfigMap, err := acdClients.configMaps.Get(ctx, common.ArgoCDConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	export(writer, *acdConfigMap, namespace)
+	acdRBACConfigMap, err := acdClients.configMaps.Get(ctx, common.ArgoCDRBACConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	export(writer, *acdRBACConfigMap, namespace)
+	acdKnownHostsConfigMap, err := acdClients.configMaps.Get(ctx, common.ArgoCDKnownHostsConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	export(writer, *acdKnownHostsConfigMap, namespace)
+	acdTLSCertsConfigMap, err := acdClients.configMaps.Get(ctx, common.ArgoCDTLSCertsConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	export(writer, *acdTLSCertsConfigMap, namespace)
+
+	secrets, err := acdClients.secrets.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for _, secret := range secrets.Items {
+		if isArgoCDSecret(secret) {
+			export(writer, secret, namespace)
+		}
+	}
+
+	projects, err := acdClients.projects.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for _, proj := range projects.Items {
+		export(writer, proj, namespace)
+	}
+
+	applications, err := acdClients.applications.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for _, app := range applications.Items {
+		// Export application only if it is in one of the enabled namespaces
+		if secutil.IsNamespaceEnabled(app.GetNamespace(), namespace, applicationNamespaces) {
+			export(writer, app, namespace)
+		}
+	}
+	applicationSets, err := acdClients.applicationSets.List(ctx, metav1.ListOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		if !apierrors.IsForbidden(err) {
+			return err
+		}
+		log.Warn(err)
+	}
+	if applicationSets != nil {
+		for _, appSet := range applicationSets.Items {
+			if secutil.IsNamespaceEnabled(appSet.GetNamespace(), namespace, applicationsetNamespaces) {
+				export(writer, appSet, namespace)
+			}
+		}
+	}
+	return nil
+}
+
+func runImport(
+	ctx context.Context,
+	acdClients *argoCDClientsets,
+	client dynamic.Interface,
+	namespace string,
+	input []byte,
+	prune bool,
+	dryRun bool,
+	verbose bool,
+	stopOperation bool,
+	ignoreTracking bool,
+	overrideOnConflict bool,
+	promptsEnabled bool,
+	skipResourcesWithLabel string,
+	applicationNamespaces []string,
+	applicationsetNamespaces []string,
+) error {
+	fmt.Printf("import process started %s\n", namespace)
+	tt := time.Now()
+	var dryRunMsg string
+	if dryRun {
+		dryRunMsg = " (dry run)"
+	}
+
+	if len(applicationNamespaces) == 0 || len(applicationsetNamespaces) == 0 {
+		defaultNs := getAdditionalNamespaces(ctx, acdClients.configMaps)
+		if len(applicationNamespaces) == 0 {
+			applicationNamespaces = defaultNs.applicationNamespaces
+		}
+		if len(applicationsetNamespaces) == 0 {
+			applicationsetNamespaces = defaultNs.applicationsetNamespaces
+		}
+	}
+	// To support applications and applicationsets in any namespace, we must list ALL namespaces and filter them afterwards
+	if len(applicationNamespaces) > 0 {
+		acdClients.applications = client.Resource(applicationsResource)
+	}
+	if len(applicationsetNamespaces) > 0 {
+		acdClients.applicationSets = client.Resource(appplicationSetResource)
+	}
+
+	// pruneObjects tracks live objects, and it's current resource version. any remaining
+	// items in this map indicates the resource should be pruned since it no longer appears
+	// in the backup
+	pruneObjects := make(map[kube.ResourceKey]unstructured.Unstructured)
+	configMaps, err := acdClients.configMaps.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for _, cm := range configMaps.Items {
+		if isArgoCDConfigMap(cm.GetName()) {
+			pruneObjects[kube.ResourceKey{Group: "", Kind: "ConfigMap", Name: cm.GetName(), Namespace: cm.GetNamespace()}] = cm
+		}
+	}
+
+	secrets, err := acdClients.secrets.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for _, secret := range secrets.Items {
+		if isArgoCDSecret(secret) {
+			pruneObjects[kube.ResourceKey{Group: "", Kind: "Secret", Name: secret.GetName(), Namespace: secret.GetNamespace()}] = secret
+		}
+	}
+	applications, err := acdClients.applications.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for _, app := range applications.Items {
+		if secutil.IsNamespaceEnabled(app.GetNamespace(), namespace, applicationNamespaces) {
+			pruneObjects[kube.ResourceKey{Group: application.Group, Kind: application.ApplicationKind, Name: app.GetName(), Namespace: app.GetNamespace()}] = app
+		}
+	}
+	projects, err := acdClients.projects.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for _, proj := range projects.Items {
+		pruneObjects[kube.ResourceKey{Group: application.Group, Kind: application.AppProjectKind, Name: proj.GetName(), Namespace: proj.GetNamespace()}] = proj
+	}
+	applicationSets, err := acdClients.applicationSets.List(ctx, metav1.ListOptions{})
+	if apierrors.IsForbidden(err) || apierrors.IsNotFound(err) {
+		log.Warnf("argoproj.io/ApplicationSet: %v\n", err)
+	} else if err != nil {
+		return err
+	}
+	if applicationSets != nil {
+		for _, appSet := range applicationSets.Items {
+			if secutil.IsNamespaceEnabled(appSet.GetNamespace(), namespace, applicationsetNamespaces) {
+				pruneObjects[kube.ResourceKey{Group: application.Group, Kind: application.ApplicationSetKind, Name: appSet.GetName(), Namespace: appSet.GetNamespace()}] = appSet
+			}
+		}
+	}
+	// Create or replace existing object
+	backupObjects, err := kube.SplitYAML(input)
+	if err != nil {
+		return err
+	}
+	for _, bakObj := range backupObjects {
+		gvk := bakObj.GroupVersionKind()
+		// For objects without namespace, assume they belong in ArgoCD namespace
+		if bakObj.GetNamespace() == "" {
+			bakObj.SetNamespace(namespace)
+		}
+		key := kube.ResourceKey{Group: gvk.Group, Kind: gvk.Kind, Name: bakObj.GetName(), Namespace: bakObj.GetNamespace()}
+		liveObj, exists := pruneObjects[key]
+		delete(pruneObjects, key)
+
+		// If the resource in backup matches the skip label, do not import it
+		if isSkipLabelMatches(bakObj, skipResourcesWithLabel) {
+			fmt.Printf("Skipping %s/%s %s in namespace %s\n", bakObj.GroupVersionKind().Group, bakObj.GroupVersionKind().Kind, bakObj.GetName(), bakObj.GetNamespace())
+			continue
+		}
+
+		var dynClient dynamic.ResourceInterface
+		switch bakObj.GetKind() {
+		case "Secret":
+			dynClient = client.Resource(secretResource).Namespace(bakObj.GetNamespace())
+		case "ConfigMap":
+			dynClient = client.Resource(configMapResource).Namespace(bakObj.GetNamespace())
+		case application.AppProjectKind:
+			dynClient = client.Resource(appprojectsResource).Namespace(bakObj.GetNamespace())
+		case application.ApplicationKind:
+			// If application is not in one of the allowed namespaces do not import it
+			if !secutil.IsNamespaceEnabled(bakObj.GetNamespace(), namespace, applicationNamespaces) {
+				continue
+			}
+			dynClient = client.Resource(applicationsResource).Namespace(bakObj.GetNamespace())
+		case application.ApplicationSetKind:
+			// If applicationset is not in one of the allowed namespaces do not import it
+			if !secutil.IsNamespaceEnabled(bakObj.GetNamespace(), namespace, applicationsetNamespaces) {
+				continue
+			}
+			dynClient = client.Resource(appplicationSetResource).Namespace(bakObj.GetNamespace())
+		}
+
+		// If there is a live object, remove the tracking annotations/label that might conflict
+		// when argo is managed with an application.
+		if ignoreTracking && exists {
+			updateTracking(bakObj, &liveObj)
+		}
+
+		switch {
+		case !exists:
+			isForbidden := false
+			if !dryRun {
+				_, err = dynClient.Create(ctx, bakObj, metav1.CreateOptions{})
+				if err != nil {
+					if !apierrors.IsForbidden(err) && !apierrors.IsNotFound(err) {
+						return err
+					}
+					isForbidden = true
+					log.Warnf("%s/%s %s: %v", gvk.Group, gvk.Kind, bakObj.GetName(), err)
+				}
+			}
+			if !isForbidden {
+				fmt.Printf("%s/%s %s in namespace %s created%s\n", gvk.Group, gvk.Kind, bakObj.GetName(), bakObj.GetNamespace(), dryRunMsg)
+			}
+		case specsEqual(*bakObj, liveObj) && checkAppHasNoNeedToStopOperation(liveObj, stopOperation):
+			if verbose {
+				fmt.Printf("%s/%s %s unchanged%s\n", gvk.Group, gvk.Kind, bakObj.GetName(), dryRunMsg)
+			}
+		default:
+			isForbidden := false
+			if !dryRun {
+				newLive := updateLive(bakObj, &liveObj, stopOperation)
+				_, err = dynClient.Update(ctx, newLive, metav1.UpdateOptions{})
+				if apierrors.IsConflict(err) {
+					fmt.Printf("Failed to update %s/%s %s in namespace %s: %v\n", gvk.Group, gvk.Kind, bakObj.GetName(), bakObj.GetNamespace(), err)
+					if overrideOnConflict {
+						err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+							fmt.Printf("Resource conflict: retrying update for Group: %s, Kind: %s, Name: %s, Namespace: %s\n", gvk.Group, gvk.Kind, bakObj.GetName(), bakObj.GetNamespace())
+							liveObj, getErr := dynClient.Get(ctx, newLive.GetName(), metav1.GetOptions{})
+							if getErr != nil {
+								return getErr
+							}
+							newLive.SetResourceVersion(liveObj.GetResourceVersion())
+							_, err = dynClient.Update(ctx, newLive, metav1.UpdateOptions{})
+							return err
+						})
+					}
+				}
+				if err != nil {
+					if !apierrors.IsForbidden(err) && !apierrors.IsNotFound(err) {
+						return err
+					}
+					isForbidden = true
+					log.Warnf("%s/%s %s: %v", gvk.Group, gvk.Kind, bakObj.GetName(), err)
+				}
+			}
+			if !isForbidden {
+				fmt.Printf("%s/%s %s in namespace %s updated%s\n", gvk.Group, gvk.Kind, bakObj.GetName(), bakObj.GetNamespace(), dryRunMsg)
+			}
+		}
+	}
+
+	promptUtil := utils.NewPrompt(promptsEnabled)
+
+	// Delete objects not in backup
+	for key, liveObj := range pruneObjects {
+		// If a live resource has a label to skip the import, it should never be pruned
+		if isSkipLabelMatches(&liveObj, skipResourcesWithLabel) {
+			fmt.Printf("Skipping pruning of %s/%s %s in namespace %s\n", key.Group, key.Kind, liveObj.GetName(), liveObj.GetNamespace())
+			continue
+		}
+
+		if prune {
+			var dynClient dynamic.ResourceInterface
+			switch key.Kind {
+			case "Secret":
+				dynClient = client.Resource(secretResource).Namespace(liveObj.GetNamespace())
+			case application.AppProjectKind:
+				dynClient = client.Resource(appprojectsResource).Namespace(liveObj.GetNamespace())
+			case application.ApplicationKind:
+				dynClient = client.Resource(applicationsResource).Namespace(liveObj.GetNamespace())
+				if !dryRun {
+					if finalizers := liveObj.GetFinalizers(); len(finalizers) > 0 {
+						newLive := liveObj.DeepCopy()
+						newLive.SetFinalizers(nil)
+						_, err = dynClient.Update(ctx, newLive, metav1.UpdateOptions{})
+						if err != nil && !apierrors.IsNotFound(err) {
+							return err
+						}
+					}
+				}
+			case application.ApplicationSetKind:
+				dynClient = client.Resource(appplicationSetResource).Namespace(liveObj.GetNamespace())
+			default:
+				log.Fatalf("Unexpected kind '%s' in prune list", key.Kind)
+			}
+			isForbidden := false
+
+			if !dryRun {
+				canPrune := promptUtil.Confirm(fmt.Sprintf("Are you sure you want to prune %s/%s %s ? [y/n]", key.Group, key.Kind, key.Name))
+				if canPrune {
+					err = dynClient.Delete(ctx, key.Name, metav1.DeleteOptions{})
+					if err != nil {
+						if !apierrors.IsForbidden(err) && !apierrors.IsNotFound(err) {
+							return err
+						}
+						isForbidden = true
+						log.Warnf("%s/%s %s: %v\n", key.Group, key.Kind, key.Name, err)
+					}
+				} else {
+					fmt.Printf("The command to prune %s/%s %s was cancelled.\n", key.Group, key.Kind, key.Name)
+				}
+			}
+			if !isForbidden {
+				fmt.Printf("%s/%s %s pruned%s\n", key.Group, key.Kind, key.Name, dryRunMsg)
+			}
+		} else {
+			fmt.Printf("%s/%s %s needs pruning\n", key.Group, key.Kind, key.Name)
+		}
+	}
+	duration := time.Since(tt)
+	fmt.Printf("Import process completed successfully in namespace %s at %s, duration: %s\n", namespace, time.Now().Format(time.RFC3339), duration)
+	return nil
 }
 
 // NewImportCommand defines a new command for exporting Kubernetes and Argo CD resources.
@@ -188,8 +467,7 @@ func NewImportCommand() *cobra.Command {
 			acdClients := newArgoCDClientsets(config, namespace)
 			client, err := dynamic.NewForConfig(config)
 			errors.CheckError(err)
-			fmt.Printf("import process started %s\n", namespace)
-			tt := time.Now()
+
 			var input []byte
 			if in := args[0]; in == "-" {
 				input, err = io.ReadAll(os.Stdin)
@@ -197,232 +475,9 @@ func NewImportCommand() *cobra.Command {
 				input, err = os.ReadFile(in)
 			}
 			errors.CheckError(err)
-			var dryRunMsg string
-			if dryRun {
-				dryRunMsg = " (dry run)"
-			}
 
-			if len(applicationNamespaces) == 0 || len(applicationsetNamespaces) == 0 {
-				defaultNs := getAdditionalNamespaces(ctx, acdClients.configMaps)
-				if len(applicationNamespaces) == 0 {
-					applicationNamespaces = defaultNs.applicationNamespaces
-				}
-				if len(applicationsetNamespaces) == 0 {
-					applicationsetNamespaces = defaultNs.applicationsetNamespaces
-				}
-			}
-			// To support applications and applicationsets in any namespace, we must list ALL namespaces and filter them afterwards
-			if len(applicationNamespaces) > 0 {
-				acdClients.applications = client.Resource(applicationsResource)
-			}
-			if len(applicationsetNamespaces) > 0 {
-				acdClients.applicationSets = client.Resource(appplicationSetResource)
-			}
-
-			// pruneObjects tracks live objects, and it's current resource version. any remaining
-			// items in this map indicates the resource should be pruned since it no longer appears
-			// in the backup
-			pruneObjects := make(map[kube.ResourceKey]unstructured.Unstructured)
-			configMaps, err := acdClients.configMaps.List(ctx, metav1.ListOptions{})
-
+			err = runImport(ctx, acdClients, client, namespace, input, prune, dryRun, verbose, stopOperation, ignoreTracking, overrideOnConflict, promptsEnabled, skipResourcesWithLabel, applicationNamespaces, applicationsetNamespaces)
 			errors.CheckError(err)
-			for _, cm := range configMaps.Items {
-				if isArgoCDConfigMap(cm.GetName()) {
-					pruneObjects[kube.ResourceKey{Group: "", Kind: "ConfigMap", Name: cm.GetName(), Namespace: cm.GetNamespace()}] = cm
-				}
-			}
-
-			secrets, err := acdClients.secrets.List(ctx, metav1.ListOptions{})
-			errors.CheckError(err)
-			for _, secret := range secrets.Items {
-				if isArgoCDSecret(secret) {
-					pruneObjects[kube.ResourceKey{Group: "", Kind: "Secret", Name: secret.GetName(), Namespace: secret.GetNamespace()}] = secret
-				}
-			}
-			applications, err := acdClients.applications.List(ctx, metav1.ListOptions{})
-			errors.CheckError(err)
-			for _, app := range applications.Items {
-				if secutil.IsNamespaceEnabled(app.GetNamespace(), namespace, applicationNamespaces) {
-					pruneObjects[kube.ResourceKey{Group: application.Group, Kind: application.ApplicationKind, Name: app.GetName(), Namespace: app.GetNamespace()}] = app
-				}
-			}
-			projects, err := acdClients.projects.List(ctx, metav1.ListOptions{})
-			errors.CheckError(err)
-			for _, proj := range projects.Items {
-				pruneObjects[kube.ResourceKey{Group: application.Group, Kind: application.AppProjectKind, Name: proj.GetName(), Namespace: proj.GetNamespace()}] = proj
-			}
-			applicationSets, err := acdClients.applicationSets.List(ctx, metav1.ListOptions{})
-			if apierrors.IsForbidden(err) || apierrors.IsNotFound(err) {
-				log.Warnf("argoproj.io/ApplicationSet: %v\n", err)
-			} else {
-				errors.CheckError(err)
-			}
-			if applicationSets != nil {
-				for _, appSet := range applicationSets.Items {
-					if secutil.IsNamespaceEnabled(appSet.GetNamespace(), namespace, applicationsetNamespaces) {
-						pruneObjects[kube.ResourceKey{Group: application.Group, Kind: application.ApplicationSetKind, Name: appSet.GetName(), Namespace: appSet.GetNamespace()}] = appSet
-					}
-				}
-			}
-			// Create or replace existing object
-			backupObjects, err := kube.SplitYAML(input)
-
-			errors.CheckError(err)
-			for _, bakObj := range backupObjects {
-				gvk := bakObj.GroupVersionKind()
-				// For objects without namespace, assume they belong in ArgoCD namespace
-				if bakObj.GetNamespace() == "" {
-					bakObj.SetNamespace(namespace)
-				}
-				key := kube.ResourceKey{Group: gvk.Group, Kind: gvk.Kind, Name: bakObj.GetName(), Namespace: bakObj.GetNamespace()}
-				liveObj, exists := pruneObjects[key]
-				delete(pruneObjects, key)
-
-				// If the resource in backup matches the skip label, do not import it
-				if isSkipLabelMatches(bakObj, skipResourcesWithLabel) {
-					fmt.Printf("Skipping %s/%s %s in namespace %s\n", bakObj.GroupVersionKind().Group, bakObj.GroupVersionKind().Kind, bakObj.GetName(), bakObj.GetNamespace())
-					continue
-				}
-
-				var dynClient dynamic.ResourceInterface
-				switch bakObj.GetKind() {
-				case "Secret":
-					dynClient = client.Resource(secretResource).Namespace(bakObj.GetNamespace())
-				case "ConfigMap":
-					dynClient = client.Resource(configMapResource).Namespace(bakObj.GetNamespace())
-				case application.AppProjectKind:
-					dynClient = client.Resource(appprojectsResource).Namespace(bakObj.GetNamespace())
-				case application.ApplicationKind:
-					// If application is not in one of the allowed namespaces do not import it
-					if !secutil.IsNamespaceEnabled(bakObj.GetNamespace(), namespace, applicationNamespaces) {
-						continue
-					}
-					dynClient = client.Resource(applicationsResource).Namespace(bakObj.GetNamespace())
-				case application.ApplicationSetKind:
-					// If applicationset is not in one of the allowed namespaces do not import it
-					if !secutil.IsNamespaceEnabled(bakObj.GetNamespace(), namespace, applicationsetNamespaces) {
-						continue
-					}
-					dynClient = client.Resource(appplicationSetResource).Namespace(bakObj.GetNamespace())
-				}
-
-				// If there is a live object, remove the tracking annotations/label that might conflict
-				// when argo is managed with an application.
-				if ignoreTracking && exists {
-					updateTracking(bakObj, &liveObj)
-				}
-
-				switch {
-				case !exists:
-					isForbidden := false
-					if !dryRun {
-						_, err = dynClient.Create(ctx, bakObj, metav1.CreateOptions{})
-						if apierrors.IsForbidden(err) || apierrors.IsNotFound(err) {
-							isForbidden = true
-							log.Warnf("%s/%s %s: %v", gvk.Group, gvk.Kind, bakObj.GetName(), err)
-						} else {
-							errors.CheckError(err)
-						}
-					}
-					if !isForbidden {
-						fmt.Printf("%s/%s %s in namespace %s created%s\n", gvk.Group, gvk.Kind, bakObj.GetName(), bakObj.GetNamespace(), dryRunMsg)
-					}
-				case specsEqual(*bakObj, liveObj) && checkAppHasNoNeedToStopOperation(liveObj, stopOperation):
-					if verbose {
-						fmt.Printf("%s/%s %s unchanged%s\n", gvk.Group, gvk.Kind, bakObj.GetName(), dryRunMsg)
-					}
-				default:
-					isForbidden := false
-					if !dryRun {
-						newLive := updateLive(bakObj, &liveObj, stopOperation)
-						_, err = dynClient.Update(ctx, newLive, metav1.UpdateOptions{})
-						if apierrors.IsConflict(err) {
-							fmt.Printf("Failed to update %s/%s %s in namespace %s: %v\n", gvk.Group, gvk.Kind, bakObj.GetName(), bakObj.GetNamespace(), err)
-							if overrideOnConflict {
-								err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-									fmt.Printf("Resource conflict: retrying update for Group: %s, Kind: %s, Name: %s, Namespace: %s\n", gvk.Group, gvk.Kind, bakObj.GetName(), bakObj.GetNamespace())
-									liveObj, getErr := dynClient.Get(ctx, newLive.GetName(), metav1.GetOptions{})
-									if getErr != nil {
-										errors.CheckError(getErr)
-									}
-									newLive.SetResourceVersion(liveObj.GetResourceVersion())
-									_, err = dynClient.Update(ctx, newLive, metav1.UpdateOptions{})
-									return err
-								})
-							}
-						}
-						if apierrors.IsForbidden(err) || apierrors.IsNotFound(err) {
-							isForbidden = true
-							log.Warnf("%s/%s %s: %v", gvk.Group, gvk.Kind, bakObj.GetName(), err)
-						} else {
-							errors.CheckError(err)
-						}
-					}
-					if !isForbidden {
-						fmt.Printf("%s/%s %s in namespace %s updated%s\n", gvk.Group, gvk.Kind, bakObj.GetName(), bakObj.GetNamespace(), dryRunMsg)
-					}
-				}
-			}
-
-			promptUtil := utils.NewPrompt(promptsEnabled)
-
-			// Delete objects not in backup
-			for key, liveObj := range pruneObjects {
-				// If a live resource has a label to skip the import, it should never be pruned
-				if isSkipLabelMatches(&liveObj, skipResourcesWithLabel) {
-					fmt.Printf("Skipping pruning of %s/%s %s in namespace %s\n", key.Group, key.Kind, liveObj.GetName(), liveObj.GetNamespace())
-					continue
-				}
-
-				if prune {
-					var dynClient dynamic.ResourceInterface
-					switch key.Kind {
-					case "Secret":
-						dynClient = client.Resource(secretResource).Namespace(liveObj.GetNamespace())
-					case application.AppProjectKind:
-						dynClient = client.Resource(appprojectsResource).Namespace(liveObj.GetNamespace())
-					case application.ApplicationKind:
-						dynClient = client.Resource(applicationsResource).Namespace(liveObj.GetNamespace())
-						if !dryRun {
-							if finalizers := liveObj.GetFinalizers(); len(finalizers) > 0 {
-								newLive := liveObj.DeepCopy()
-								newLive.SetFinalizers(nil)
-								_, err = dynClient.Update(ctx, newLive, metav1.UpdateOptions{})
-								if err != nil && !apierrors.IsNotFound(err) {
-									errors.CheckError(err)
-								}
-							}
-						}
-					case application.ApplicationSetKind:
-						dynClient = client.Resource(appplicationSetResource).Namespace(liveObj.GetNamespace())
-					default:
-						log.Fatalf("Unexpected kind '%s' in prune list", key.Kind)
-					}
-					isForbidden := false
-
-					if !dryRun {
-						canPrune := promptUtil.Confirm(fmt.Sprintf("Are you sure you want to prune %s/%s %s ? [y/n]", key.Group, key.Kind, key.Name))
-						if canPrune {
-							err = dynClient.Delete(ctx, key.Name, metav1.DeleteOptions{})
-							if apierrors.IsForbidden(err) || apierrors.IsNotFound(err) {
-								isForbidden = true
-								log.Warnf("%s/%s %s: %v\n", key.Group, key.Kind, key.Name, err)
-							} else {
-								errors.CheckError(err)
-							}
-						} else {
-							fmt.Printf("The command to prune %s/%s %s was cancelled.\n", key.Group, key.Kind, key.Name)
-						}
-					}
-					if !isForbidden {
-						fmt.Printf("%s/%s %s pruned%s\n", key.Group, key.Kind, key.Name, dryRunMsg)
-					}
-				} else {
-					fmt.Printf("%s/%s %s needs pruning\n", key.Group, key.Kind, key.Name)
-				}
-			}
-			duration := time.Since(tt)
-			fmt.Printf("Import process completed successfully in namespace %s at %s, duration: %s\n", namespace, time.Now().Format(time.RFC3339), duration)
 		},
 	}
 

--- a/cmd/argocd/commands/admin/backup_test.go
+++ b/cmd/argocd/commands/admin/backup_test.go
@@ -9,9 +9,12 @@ import (
 
 	"github.com/argoproj/argo-cd/gitops-engine/pkg/utils/kube"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	dynfake "k8s.io/client-go/dynamic/fake"
 
 	"github.com/argoproj/argo-cd/v3/common"
 )
@@ -486,4 +489,403 @@ func TestIsSkipLabelMatches(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestRunExport(t *testing.T) {
+	scheme := k8sruntime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = v1alpha1.AddToScheme(scheme)
+
+	cmdParamsCM := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]any{
+				"name":      common.ArgoCDCmdParamsConfigMapName,
+				"namespace": "argocd",
+			},
+		},
+	}
+
+	cm := newConfigmapObject()
+	cm.SetName(common.ArgoCDConfigMapName)
+	cm.SetNamespace("argocd")
+	cm.SetAPIVersion("v1")
+	cm.SetKind("ConfigMap")
+
+	rbacCM := newConfigmapObject()
+	rbacCM.SetName(common.ArgoCDRBACConfigMapName)
+	rbacCM.SetNamespace("argocd")
+	rbacCM.SetAPIVersion("v1")
+	rbacCM.SetKind("ConfigMap")
+
+	knownHostsCM := newConfigmapObject()
+	knownHostsCM.SetName(common.ArgoCDKnownHostsConfigMapName)
+	knownHostsCM.SetNamespace("argocd")
+	knownHostsCM.SetAPIVersion("v1")
+	knownHostsCM.SetKind("ConfigMap")
+
+	tlsCM := newConfigmapObject()
+	tlsCM.SetName(common.ArgoCDTLSCertsConfigMapName)
+	tlsCM.SetNamespace("argocd")
+	tlsCM.SetAPIVersion("v1")
+	tlsCM.SetKind("ConfigMap")
+
+	secret := newSecretsObject()
+	secret.SetNamespace("argocd")
+	secret.SetAPIVersion("v1")
+	secret.SetKind("Secret")
+
+	proj := newAppProject()
+	proj.SetNamespace("argocd")
+	proj.SetAPIVersion("argoproj.io/v1alpha1")
+	proj.SetKind("AppProject")
+
+	app := newApplication("argocd")
+	app.SetNamespace("argocd")
+	app.SetAPIVersion("argoproj.io/v1alpha1")
+	app.SetKind("Application")
+
+	appSet := newApplicationSet("argocd")
+	appSet.SetNamespace("argocd")
+	appSet.SetAPIVersion("argoproj.io/v1alpha1")
+	appSet.SetKind("ApplicationSet")
+
+	fakeDynClient := dynfake.NewSimpleDynamicClient(scheme, cmdParamsCM, cm, rbacCM, knownHostsCM, tlsCM, secret, proj, app, appSet)
+
+	acdClients := &argoCDClientsets{
+		configMaps:      fakeDynClient.Resource(configMapResource).Namespace("argocd"),
+		secrets:         fakeDynClient.Resource(secretResource).Namespace("argocd"),
+		projects:        fakeDynClient.Resource(appprojectsResource).Namespace("argocd"),
+		applications:    fakeDynClient.Resource(applicationsResource).Namespace("argocd"),
+		applicationSets: fakeDynClient.Resource(appplicationSetResource).Namespace("argocd"),
+	}
+
+	var buf bytes.Buffer
+	err := runExport(t.Context(), acdClients, fakeDynClient, "argocd", &buf, nil, nil)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "argocd-cm")
+	assert.Contains(t, output, "argocd-rbac-cm")
+	assert.Contains(t, output, "argocd-ssh-known-hosts-cm")
+	assert.Contains(t, output, "argocd-tls-certs-cm")
+	assert.Contains(t, output, "argocd-secret")
+	assert.Contains(t, output, "default")
+	assert.Contains(t, output, "test")
+	assert.Contains(t, output, "test-appset")
+}
+
+func TestNewExportCommand(t *testing.T) {
+	cmd := NewExportCommand()
+	require.NotNil(t, cmd)
+	assert.Equal(t, "export", cmd.Name())
+}
+
+func TestNewImportCommand(t *testing.T) {
+	cmd := NewImportCommand()
+	require.NotNil(t, cmd)
+	assert.Equal(t, "import", cmd.Name())
+}
+
+func TestRunImport_CreatesNewObjects(t *testing.T) {
+	scheme := k8sruntime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = v1alpha1.AddToScheme(scheme)
+
+	cmdParamsCM := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]any{
+				"name":      common.ArgoCDCmdParamsConfigMapName,
+				"namespace": "argocd",
+			},
+		},
+	}
+
+	fakeDynClient := dynfake.NewSimpleDynamicClient(scheme, cmdParamsCM)
+
+	acdClients := &argoCDClientsets{
+		configMaps:      fakeDynClient.Resource(configMapResource).Namespace("argocd"),
+		secrets:         fakeDynClient.Resource(secretResource).Namespace("argocd"),
+		projects:        fakeDynClient.Resource(appprojectsResource).Namespace("argocd"),
+		applications:    fakeDynClient.Resource(applicationsResource).Namespace("argocd"),
+		applicationSets: fakeDynClient.Resource(appplicationSetResource).Namespace("argocd"),
+	}
+
+	// Build backup YAML
+	var buf bytes.Buffer
+	cm := newConfigmapObject()
+	cm.SetName(common.ArgoCDConfigMapName)
+	cm.SetNamespace("argocd")
+	cm.SetAPIVersion("v1")
+	cm.SetKind("ConfigMap")
+	export(&buf, *cm, "argocd")
+
+	secret := newSecretsObject()
+	secret.SetNamespace("argocd")
+	secret.SetAPIVersion("v1")
+	secret.SetKind("Secret")
+	export(&buf, *secret, "argocd")
+
+	proj := newAppProject()
+	proj.SetNamespace("argocd")
+	proj.SetAPIVersion("argoproj.io/v1alpha1")
+	proj.SetKind("AppProject")
+	export(&buf, *proj, "argocd")
+
+	app := newApplication("argocd")
+	app.SetNamespace("argocd")
+	app.SetAPIVersion("argoproj.io/v1alpha1")
+	app.SetKind("Application")
+	export(&buf, *app, "argocd")
+
+	appSet := newApplicationSet("argocd")
+	appSet.SetNamespace("argocd")
+	appSet.SetAPIVersion("argoproj.io/v1alpha1")
+	appSet.SetKind("ApplicationSet")
+	export(&buf, *appSet, "argocd")
+
+	err := runImport(t.Context(), acdClients, fakeDynClient, "argocd", buf.Bytes(), false, false, false, false, false, false, false, "", nil, nil)
+	require.NoError(t, err)
+
+	// Verify objects were created
+	_, err = fakeDynClient.Resource(configMapResource).Namespace("argocd").Get(t.Context(), common.ArgoCDConfigMapName, metav1.GetOptions{})
+	require.NoError(t, err)
+	_, err = fakeDynClient.Resource(secretResource).Namespace("argocd").Get(t.Context(), common.ArgoCDSecretName, metav1.GetOptions{})
+	require.NoError(t, err)
+	_, err = fakeDynClient.Resource(appprojectsResource).Namespace("argocd").Get(t.Context(), "default", metav1.GetOptions{})
+	require.NoError(t, err)
+	_, err = fakeDynClient.Resource(applicationsResource).Namespace("argocd").Get(t.Context(), "test", metav1.GetOptions{})
+	require.NoError(t, err)
+	_, err = fakeDynClient.Resource(appplicationSetResource).Namespace("argocd").Get(t.Context(), "test-appset", metav1.GetOptions{})
+	require.NoError(t, err)
+}
+
+func TestRunImport_UpdatesExisting(t *testing.T) {
+	scheme := k8sruntime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = v1alpha1.AddToScheme(scheme)
+
+	cmdParamsCM := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]any{
+				"name":      common.ArgoCDCmdParamsConfigMapName,
+				"namespace": "argocd",
+			},
+		},
+	}
+
+	existingCM := newConfigmapObject()
+	existingCM.SetName(common.ArgoCDConfigMapName)
+	existingCM.SetNamespace("argocd")
+	existingCM.SetAPIVersion("v1")
+	existingCM.SetKind("ConfigMap")
+	existingCM.Object["data"] = map[string]any{"old": "value"}
+
+	fakeDynClient := dynfake.NewSimpleDynamicClient(scheme, cmdParamsCM, existingCM)
+
+	acdClients := &argoCDClientsets{
+		configMaps:      fakeDynClient.Resource(configMapResource).Namespace("argocd"),
+		secrets:         fakeDynClient.Resource(secretResource).Namespace("argocd"),
+		projects:        fakeDynClient.Resource(appprojectsResource).Namespace("argocd"),
+		applications:    fakeDynClient.Resource(applicationsResource).Namespace("argocd"),
+		applicationSets: fakeDynClient.Resource(appplicationSetResource).Namespace("argocd"),
+	}
+
+	// Build backup YAML with new data
+	var buf bytes.Buffer
+	cm := newConfigmapObject()
+	cm.SetName(common.ArgoCDConfigMapName)
+	cm.SetNamespace("argocd")
+	cm.SetAPIVersion("v1")
+	cm.SetKind("ConfigMap")
+	cm.Object["data"] = map[string]any{"new": "value"}
+	export(&buf, *cm, "argocd")
+
+	err := runImport(t.Context(), acdClients, fakeDynClient, "argocd", buf.Bytes(), false, false, false, false, false, false, false, "", nil, nil)
+	require.NoError(t, err)
+
+	updatedCM, err := fakeDynClient.Resource(configMapResource).Namespace("argocd").Get(t.Context(), common.ArgoCDConfigMapName, metav1.GetOptions{})
+	require.NoError(t, err)
+	data, _, _ := unstructured.NestedMap(updatedCM.Object, "data")
+	assert.Equal(t, map[string]any{"new": "value"}, data)
+}
+
+func TestRunImport_Prune(t *testing.T) {
+	scheme := k8sruntime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = v1alpha1.AddToScheme(scheme)
+
+	cmdParamsCM := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]any{
+				"name":      common.ArgoCDCmdParamsConfigMapName,
+				"namespace": "argocd",
+			},
+		},
+	}
+
+	existingSecret := newSecretsObject()
+	existingSecret.SetNamespace("argocd")
+	existingSecret.SetAPIVersion("v1")
+	existingSecret.SetKind("Secret")
+
+	fakeDynClient := dynfake.NewSimpleDynamicClient(scheme, cmdParamsCM, existingSecret)
+
+	acdClients := &argoCDClientsets{
+		configMaps:      fakeDynClient.Resource(configMapResource).Namespace("argocd"),
+		secrets:         fakeDynClient.Resource(secretResource).Namespace("argocd"),
+		projects:        fakeDynClient.Resource(appprojectsResource).Namespace("argocd"),
+		applications:    fakeDynClient.Resource(applicationsResource).Namespace("argocd"),
+		applicationSets: fakeDynClient.Resource(appplicationSetResource).Namespace("argocd"),
+	}
+
+	// Build backup YAML with only a ConfigMap (no secret)
+	var buf bytes.Buffer
+	cm := newConfigmapObject()
+	cm.SetName(common.ArgoCDConfigMapName)
+	cm.SetNamespace("argocd")
+	cm.SetAPIVersion("v1")
+	cm.SetKind("ConfigMap")
+	export(&buf, *cm, "argocd")
+
+	err := runImport(t.Context(), acdClients, fakeDynClient, "argocd", buf.Bytes(), true, false, false, false, false, false, false, "", nil, nil)
+	require.NoError(t, err)
+
+	// Verify secret was pruned
+	_, err = fakeDynClient.Resource(secretResource).Namespace("argocd").Get(t.Context(), common.ArgoCDSecretName, metav1.GetOptions{})
+	require.Error(t, err)
+}
+
+func TestRunImport_DryRun(t *testing.T) {
+	scheme := k8sruntime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = v1alpha1.AddToScheme(scheme)
+
+	cmdParamsCM := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]any{
+				"name":      common.ArgoCDCmdParamsConfigMapName,
+				"namespace": "argocd",
+			},
+		},
+	}
+
+	fakeDynClient := dynfake.NewSimpleDynamicClient(scheme, cmdParamsCM)
+
+	acdClients := &argoCDClientsets{
+		configMaps:      fakeDynClient.Resource(configMapResource).Namespace("argocd"),
+		secrets:         fakeDynClient.Resource(secretResource).Namespace("argocd"),
+		projects:        fakeDynClient.Resource(appprojectsResource).Namespace("argocd"),
+		applications:    fakeDynClient.Resource(applicationsResource).Namespace("argocd"),
+		applicationSets: fakeDynClient.Resource(appplicationSetResource).Namespace("argocd"),
+	}
+
+	var buf bytes.Buffer
+	cm := newConfigmapObject()
+	cm.SetName(common.ArgoCDConfigMapName)
+	cm.SetNamespace("argocd")
+	cm.SetAPIVersion("v1")
+	cm.SetKind("ConfigMap")
+	export(&buf, *cm, "argocd")
+
+	err := runImport(t.Context(), acdClients, fakeDynClient, "argocd", buf.Bytes(), false, true, false, false, false, false, false, "", nil, nil)
+	require.NoError(t, err)
+
+	// Verify object was NOT created because dryRun=true
+	_, err = fakeDynClient.Resource(configMapResource).Namespace("argocd").Get(t.Context(), common.ArgoCDConfigMapName, metav1.GetOptions{})
+	require.Error(t, err)
+}
+
+func TestRunImport_SkipLabel(t *testing.T) {
+	scheme := k8sruntime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = v1alpha1.AddToScheme(scheme)
+
+	cmdParamsCM := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]any{
+				"name":      common.ArgoCDCmdParamsConfigMapName,
+				"namespace": "argocd",
+			},
+		},
+	}
+
+	fakeDynClient := dynfake.NewSimpleDynamicClient(scheme, cmdParamsCM)
+
+	acdClients := &argoCDClientsets{
+		configMaps:      fakeDynClient.Resource(configMapResource).Namespace("argocd"),
+		secrets:         fakeDynClient.Resource(secretResource).Namespace("argocd"),
+		projects:        fakeDynClient.Resource(appprojectsResource).Namespace("argocd"),
+		applications:    fakeDynClient.Resource(applicationsResource).Namespace("argocd"),
+		applicationSets: fakeDynClient.Resource(appplicationSetResource).Namespace("argocd"),
+	}
+
+	var buf bytes.Buffer
+	cm := newConfigmapObject()
+	cm.SetName(common.ArgoCDConfigMapName)
+	cm.SetNamespace("argocd")
+	cm.SetAPIVersion("v1")
+	cm.SetKind("ConfigMap")
+	cm.SetLabels(map[string]string{"skip-label": "true"})
+	export(&buf, *cm, "argocd")
+
+	err := runImport(t.Context(), acdClients, fakeDynClient, "argocd", buf.Bytes(), false, false, false, false, false, false, false, "skip-label=true", nil, nil)
+	require.NoError(t, err)
+
+	// Verify object was NOT created because it has the skip label
+	_, err = fakeDynClient.Resource(configMapResource).Namespace("argocd").Get(t.Context(), common.ArgoCDConfigMapName, metav1.GetOptions{})
+	require.Error(t, err)
+}
+
+func TestRunImport_NamespaceFilter(t *testing.T) {
+	scheme := k8sruntime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = v1alpha1.AddToScheme(scheme)
+
+	cmdParamsCM := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]any{
+				"name":      common.ArgoCDCmdParamsConfigMapName,
+				"namespace": "argocd",
+			},
+		},
+	}
+
+	fakeDynClient := dynfake.NewSimpleDynamicClient(scheme, cmdParamsCM)
+
+	acdClients := &argoCDClientsets{
+		configMaps:      fakeDynClient.Resource(configMapResource).Namespace("argocd"),
+		secrets:         fakeDynClient.Resource(secretResource).Namespace("argocd"),
+		projects:        fakeDynClient.Resource(appprojectsResource).Namespace("argocd"),
+		applications:    fakeDynClient.Resource(applicationsResource).Namespace("argocd"),
+		applicationSets: fakeDynClient.Resource(appplicationSetResource).Namespace("argocd"),
+	}
+
+	var buf bytes.Buffer
+	app := newApplication("unauthorized-ns")
+	app.SetNamespace("unauthorized-ns")
+	app.SetAPIVersion("argoproj.io/v1alpha1")
+	app.SetKind("Application")
+	export(&buf, *app, "argocd")
+
+	// Only allow "argocd" namespace
+	err := runImport(t.Context(), acdClients, fakeDynClient, "argocd", buf.Bytes(), false, false, false, false, false, false, false, "", []string{"argocd"}, nil)
+	require.NoError(t, err)
+
+	// Verify app was NOT created because namespace is not enabled
+	_, err = fakeDynClient.Resource(applicationsResource).Namespace("unauthorized-ns").Get(t.Context(), "test", metav1.GetOptions{})
+	require.Error(t, err)
 }

--- a/manifests/cluster-rbac/server/argocd-server-clusterrole.yaml
+++ b/manifests/cluster-rbac/server/argocd-server-clusterrole.yaml
@@ -14,6 +14,7 @@ rules:
   verbs:
   - delete  # supports deletion a live object in UI
   - get     # supports viewing live object manifest in UI
+  - list    # supports listing live object manifests in UI
   - patch   # supports `argocd app patch`
 - apiGroups:
   - ""

--- a/manifests/ha/install-with-hydrator.yaml
+++ b/manifests/ha/install-with-hydrator.yaml
@@ -31043,6 +31043,7 @@ rules:
   verbs:
   - delete
   - get
+  - list
   - patch
 - apiGroups:
   - ""

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -31034,6 +31034,7 @@ rules:
   verbs:
   - delete
   - get
+  - list
   - patch
 - apiGroups:
   - ""

--- a/manifests/install-with-hydrator.yaml
+++ b/manifests/install-with-hydrator.yaml
@@ -31010,6 +31010,7 @@ rules:
   verbs:
   - delete
   - get
+  - list
   - patch
 - apiGroups:
   - ""

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -31001,6 +31001,7 @@ rules:
   verbs:
   - delete
   - get
+  - list
   - patch
 - apiGroups:
   - ""


### PR DESCRIPTION
Fixes #18853

The argocd-server ClusterRole was missing the `list` verb on wildcard resources, which prevented the UI from displaying live manifests for certain resource types (e.g. `karpenter.sh/v1beta1 NodePool`). The server already had `get` and `patch`, but `list` is required when the UI enumerates resources before showing individual manifests.

## Changes

- Added `list` to the verbs in `manifests/cluster-rbac/server/argocd-server-clusterrole.yaml`
- Regenerated all install manifests via `make manifests-local`

## Checklist

* [x] I have signed off all my commits as required by DCO.
* [x] The title of the PR states what changed and the related issues number.
* [x] The title conforms to semantic PR title formatting.
* [x] I've included "Fixes #18853" in the description.
* [x] My build is green (`go build ./...` passes for affected packages).
* [x] I have added a brief description of why this PR is necessary and what it solves.
