### PR TITLE
fix: warn when ARGOCD_CONTROLLER_REPLICAS exceeds configured replicas (#19928)

### DIFF
--- a/controller/sharding/sharding.go
+++ b/controller/sharding/sharding.go
@@ -473,6 +473,23 @@ func GetClusterSharding(kubeClient kubernetes.Interface, settingsMgr *settings.S
 		replicasCount = int(*appControllerDeployment.Spec.Replicas)
 	} else {
 		replicasCount = env.ParseNumFromEnv(common.EnvControllerReplicas, 0, 0, math.MaxInt32)
+		// Warn if ARGOCD_CONTROLLER_REPLICAS exceeds the actual configured replicas
+		if replicasCount > 0 {
+			applicationControllerName := env.StringFromEnv(common.EnvAppControllerName, common.DefaultApplicationControllerName)
+			var actualReplicas int
+			appControllerStatefulSet, err := kubeClient.AppsV1().StatefulSets(settingsMgr.GetNamespace()).Get(context.Background(), applicationControllerName, metav1.GetOptions{})
+			if err == nil && appControllerStatefulSet != nil && appControllerStatefulSet.Spec.Replicas != nil {
+				actualReplicas = int(*appControllerStatefulSet.Spec.Replicas)
+			} else {
+				appControllerDeployment, err := kubeClient.AppsV1().Deployments(settingsMgr.GetNamespace()).Get(context.Background(), applicationControllerName, metav1.GetOptions{})
+				if err == nil && appControllerDeployment != nil && appControllerDeployment.Spec.Replicas != nil {
+					actualReplicas = int(*appControllerDeployment.Spec.Replicas)
+				}
+			}
+			if actualReplicas > 0 && replicasCount > actualReplicas {
+				log.Warnf("ARGOCD_CONTROLLER_REPLICAS (%d) exceeds the configured number of replicas in the Application Controller (%d). Sharding may not work as intended.", replicasCount, actualReplicas)
+			}
+		}
 	}
 	shardNumber := env.ParseNumFromEnv(common.EnvControllerShard, -1, -math.MaxInt32, math.MaxInt32)
 	if replicasCount > 1 {


### PR DESCRIPTION
Fixes #19928

When running in non-dynamic mode, the application controller reads the expected replica count from the `ARGOCD_CONTROLLER_REPLICAS` environment variable. If this value is set higher than the actual number of replicas configured in the Application Controller StatefulSet or Deployment, sharding will not work correctly because some shards will never be assigned to a running controller instance.

This adds a warning log during startup in the non-dynamic sharding path when the env var exceeds the actual replica count.

## Changes

- `controller/sharding/sharding.go`: after reading `ARGOCD_CONTROLLER_REPLICAS`, look up the actual StatefulSet/Deployment replica count and log a warning if the env var is higher.

## Checklist

* [x] I have signed off all my commits as required by DCO.
* [x] The title of the PR states what changed and the related issues number.
* [x] The title conforms to semantic PR title formatting.
* [x] I've included "Fixes #19928" in the description.
* [x] My build is green (`go build ./controller/sharding/...` and `go test ./controller/sharding/...` pass).
* [x] I have added a brief description of why this PR is necessary and what it solves.
