### PR TITLE
fix(ui): remove N/A fields from unschedulable pod groups (#19870)

### DIFF
--- a/ui/src/app/applications/components/application-pod-view/pod-view.tsx
+++ b/ui/src/app/applications/components/application-pod-view/pod-view.tsx
@@ -394,10 +394,7 @@ function processTree(
                         kind: 'node',
                         name: 'Unschedulable',
                         pods: [p],
-                        info: [
-                            {name: 'Kernel Version', value: 'N/A'},
-                            {name: 'OS/Arch', value: 'N/A'}
-                        ],
+                        info: [],
                         hostResourcesInfo: [],
                         hostLabels: {}
                     };


### PR DESCRIPTION
Fixes #19870

Unschedulable pods showed "Kernel Version: N/A" and "OS/Arch: N/A" which is unhelpful since these values cannot be known for nodes that do not exist.

This removes the hardcoded N/A info array from the Unschedulable pseudo-group so those fields are simply not rendered.

## Changes

- `ui/src/app/applications/components/application-pod-view/pod-view.tsx`: changed `info` array from `[{name: 'Kernel Version', value: 'N/A'}, {name: 'OS/Arch', value: 'N/A'}]` to `[]`

## Checklist

* [x] I have signed off all my commits as required by DCO.
* [x] The title of the PR states what changed and the related issues number.
* [x] The title conforms to semantic PR title formatting.
* [x] I've included "Fixes #19870" in the description.
* [x] My build is green (`pnpm exec eslint` passes for the changed file).
* [x] I have added a brief description of why this PR is necessary and what it solves.
