### PR TITLE
fix(ui): preserve YAML literal blocks in resource diff (#12173)

### DIFF
--- a/ui/src/app/applications/components/application-resources-diff/application-resources-diff.tsx
+++ b/ui/src/app/applications/components/application-resources-diff/application-resources-diff.tsx
@@ -20,8 +20,8 @@ export const ApplicationResourcesDiff = (props: ApplicationResourcesDiffProps) =
             const diffText = props.states
                 .map(state => {
                     return {
-                        a: state.normalizedLiveState ? jsYaml.dump(state.normalizedLiveState, {indent: 2}) : '',
-                        b: state.predictedLiveState ? jsYaml.dump(state.predictedLiveState, {indent: 2}) : '',
+                        a: state.normalizedLiveState ? jsYaml.dump(state.normalizedLiveState, {indent: 2, lineWidth: Infinity}) : '',
+                        b: state.predictedLiveState ? jsYaml.dump(state.predictedLiveState, {indent: 2, lineWidth: Infinity}) : '',
                         hook: state.hook,
                         // doubles as sort order
                         name: (state.group || '') + '/' + state.kind + '/' + (state.namespace ? state.namespace + '/' : '') + state.name


### PR DESCRIPTION
Fixes #12173

When viewing a diff in the Argo CD UI, js-yaml was converting YAML literal blocks (using `|`) into folded blocks (using `>`) because its default `lineWidth: 80` caused it to choose folded style for wrapping purposes.

Since the backend sends JSON (which has no scalar style metadata), js-yaml makes its own decision about block styles. When a multi-line string contains lines longer than 80 characters, it chooses `>` (folded). This causes literal blocks from the original manifest to appear as folded blocks in the diff view.

This adds `lineWidth: Infinity` to the `jsYaml.dump()` calls in the diff component so that multi-line strings naturally render as literal blocks (`|` or `|-`), while single-line strings remain plain scalars.

## Changes

- `ui/src/app/applications/components/application-resources-diff/application-resources-diff.tsx`: added `lineWidth: Infinity` to both `jsYaml.dump()` calls

## Checklist

* [x] I have signed off all my commits as required by DCO.
* [x] The title of the PR states what changed and the related issues number.
* [x] The title conforms to semantic PR title formatting.
* [x] I've included "Fixes #12173" in the description.
* [x] My build is green (`pnpm exec eslint` passes for the changed file).
* [x] I have added a brief description of why this PR is necessary and what it solves.
