### PR TITLE
fix(ui): correct size of progressing spinner icon (#23573)

### DIFF
--- a/ui/src/app/applications/components/utils.scss
+++ b/ui/src/app/applications/components/utils.scss
@@ -46,9 +46,9 @@ i.utils-health-status-icon {
 
 .icon.spin {
     animation: spin 2s linear infinite; 
-    width: 0.5em;
-    height: 0.5em;
-    vertical-align: -0.05em;
+    width: 1em;
+    height: 1em;
+    vertical-align: -0.125em;
     overflow: visible;
 }
 


### PR DESCRIPTION
Closes #23573

## Problem

The SpinningIcon SVG used for Progressing/Hydrating states had CSS dimensions of 0.5em x 0.5em, making it humorously tiny and nearly invisible.

## Changes

This increases the icon to 1em x 1em with proper vertical alignment so it matches other status icons.

## Checklist

* [x] Fixed CSS dimensions
* [x] Verified alignment