### PR TITLE
fix(ui): prevent pie chart clipping for single-slice data (#27239)

### DIFF
--- a/ui/src/app/applications/components/applications-list/applications-list.scss
+++ b/ui/src/app/applications/components/applications-list/applications-list.scss
@@ -206,6 +206,10 @@
 
     .chart {
         justify-content: space-evenly;
+
+        svg {
+            overflow: visible;
+        }
     }
 }
 i.menu_icon {


### PR DESCRIPTION
Closes #27239

## Problem

When a pie chart in the Applications summary has only one non-zero slice, the SVG could be clipped by its container.

## Changes

Added overflow: visible to the chart SVG so the full circle is rendered without truncation.

## Checklist

* [x] Added CSS fix
* [x] Verified no impact on multi-slice charts