### PR TITLE
fix(cli): improve timeout message for argocd app wait (#14705)

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -2939,7 +2939,7 @@ func waitOnApplicationStatus(ctx context.Context, acdClient argocdclient.Client,
 		_ = w.Flush()
 	}
 	_ = printFinalStatus(appWithLock.GetApp())
-	return nil, finalOperationState, fmt.Errorf("timed out (%ds) waiting for app %q match desired state", timeout, appName)
+	return nil, finalOperationState, fmt.Errorf("timed out after %ds waiting for app %q to match desired state", timeout, appName)
 }
 
 // setParameterOverrides updates an existing or appends a new parameter override in the application


### PR DESCRIPTION
Closes #14705

## Problem

The timeout message for argocd app wait was grammatically awkward.

## Changes

Updated the message to be clearer and grammatically correct.

## Checklist

* [x] Improved message wording