### PR TITLE
fix(cli): allow repeated flags in ARGOCD_OPTS env var (#24065)

### DIFF
--- a/util/config/env.go
+++ b/util/config/env.go
@@ -37,7 +37,11 @@ func LoadFlags() error {
 			}
 			key = strings.TrimPrefix(opt, "--")
 		case key != "":
-			flags[key] = opt
+			if existing, ok := flags[key]; ok {
+				flags[key] = existing + "," + opt
+			} else {
+				flags[key] = opt
+			}
 			key = ""
 		default:
 			return errors.New("ARGOCD_OPTS invalid at '" + opt + "'")


### PR DESCRIPTION
Closes #24065

## Problem

ARGOCD_OPTS stored flags in a map[string]string, so specifying the same flag twice (e.g. --header foo --header bar) would silently overwrite the first value.

## Changes

Duplicate flag values are now joined with commas so StringSlice flags like --header work correctly when repeated.

## Checklist

* [x] Modified LoadFlags to join duplicate values
* [x] Verified GetStringSliceFlag parses joined values correctly