### PR TITLE
fix(appcontroller): application controller in core mode fails to sync when server.secretkey is missing (#26793)

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -475,11 +475,11 @@ func (server *ArgoCDServer) logInClusterWarnings() error {
 	}
 	if len(inClusterSecrets) > 0 {
 		// Don't make this call unless we actually have in-cluster secrets, to save time.
-		dbSettings, err := server.settingsMgr.GetSettings()
+		inClusterEnabled, err := server.settingsMgr.IsInClusterEnabled()
 		if err != nil {
-			return fmt.Errorf("could not get DB settings: %w", err)
+			return fmt.Errorf("could not check if in-cluster is enabled: %w", err)
 		}
-		if !dbSettings.InClusterEnabled {
+		if !inClusterEnabled {
 			for _, clusterName := range inClusterSecrets {
 				log.Warnf("cluster %q uses in-cluster server address but it's disabled in Argo CD settings", clusterName)
 			}

--- a/util/db/cluster.go
+++ b/util/db/cluster.go
@@ -24,6 +24,10 @@ import (
 	"github.com/argoproj/argo-cd/v3/util/settings"
 )
 
+const (
+	errCheckingInClusterEnabled = "%s: error checking if in-cluster is enabled: %v"
+)
+
 var (
 	localCluster = appv1.Cluster{
 		Name:            "in-cluster",
@@ -65,11 +69,10 @@ func (db *db) ListClusters(_ context.Context) (*appv1.ClusterList, error) {
 	clusterList := appv1.ClusterList{
 		Items: make([]appv1.Cluster, 0),
 	}
-	settings, err := db.settingsMgr.GetSettings()
+	inClusterEnabled, err := db.settingsMgr.IsInClusterEnabled()
 	if err != nil {
-		return nil, err
+		log.Warnf(errCheckingInClusterEnabled, "ListClusters", err)
 	}
-	inClusterEnabled := settings.InClusterEnabled
 	hasInClusterCredentials := false
 	for _, clusterSecret := range clusterSecrets {
 		cluster, err := SecretToCluster(clusterSecret)
@@ -95,11 +98,11 @@ func (db *db) ListClusters(_ context.Context) (*appv1.ClusterList, error) {
 // CreateCluster creates a cluster
 func (db *db) CreateCluster(ctx context.Context, c *appv1.Cluster) (*appv1.Cluster, error) {
 	if c.Server == appv1.KubernetesInternalAPIServerAddr {
-		settings, err := db.settingsMgr.GetSettings()
+		inClusterEnabled, err := db.settingsMgr.IsInClusterEnabled()
 		if err != nil {
-			return nil, err
+			log.Warnf(errCheckingInClusterEnabled, "CreateCluster", err)
 		}
-		if !settings.InClusterEnabled {
+		if !inClusterEnabled {
 			return nil, status.Errorf(codes.InvalidArgument, "cannot register cluster: in-cluster has been disabled")
 		}
 	}
@@ -145,13 +148,12 @@ func (db *db) WatchClusters(ctx context.Context,
 	handleModEvent func(oldCluster *appv1.Cluster, newCluster *appv1.Cluster),
 	handleDeleteEvent func(clusterServer string),
 ) error {
-	argoSettings, err := db.settingsMgr.GetSettings()
+	inClusterEnabled, err := db.settingsMgr.IsInClusterEnabled()
 	if err != nil {
-		return err
+		log.Warnf(errCheckingInClusterEnabled, "WatchClusters", err)
 	}
-
 	localCls := db.getLocalCluster()
-	if argoSettings.InClusterEnabled {
+	if inClusterEnabled {
 		localCls, err = db.GetCluster(ctx, appv1.KubernetesInternalAPIServerAddr)
 		if err != nil {
 			return fmt.Errorf("could not get local cluster: %w", err)
@@ -170,7 +172,7 @@ func (db *db) WatchClusters(ctx context.Context,
 				return
 			}
 			if cluster.Server == appv1.KubernetesInternalAPIServerAddr {
-				if argoSettings.InClusterEnabled {
+				if inClusterEnabled {
 					// change local cluster event to modified, since it cannot be added at runtime
 					handleModEvent(localCls, cluster)
 					localCls = cluster
@@ -198,7 +200,7 @@ func (db *db) WatchClusters(ctx context.Context,
 		},
 
 		func(secret *corev1.Secret) {
-			if string(secret.Data["server"]) == appv1.KubernetesInternalAPIServerAddr && argoSettings.InClusterEnabled {
+			if string(secret.Data["server"]) == appv1.KubernetesInternalAPIServerAddr && inClusterEnabled {
 				// change local cluster event to modified, since it cannot be deleted at runtime, unless disabled.
 				newLocalCls := db.getLocalCluster()
 				handleModEvent(localCls, newLocalCls)
@@ -229,11 +231,11 @@ func (db *db) getClusterSecret(server string) (*corev1.Secret, error) {
 // GetCluster returns a cluster from a query
 func (db *db) GetCluster(_ context.Context, server string) (*appv1.Cluster, error) {
 	if server == appv1.KubernetesInternalAPIServerAddr {
-		argoSettings, err := db.settingsMgr.GetSettings()
+		inClusterEnabled, err := db.settingsMgr.IsInClusterEnabled()
 		if err != nil {
-			return nil, err
+			log.Warnf(errCheckingInClusterEnabled, "GetCluster", err)
 		}
-		if !argoSettings.InClusterEnabled {
+		if !inClusterEnabled {
 			return nil, status.Errorf(codes.NotFound, "cluster %q is disabled", server)
 		}
 	}
@@ -279,10 +281,6 @@ func (db *db) GetProjectClusters(_ context.Context, project string) ([]*appv1.Cl
 }
 
 func (db *db) GetClusterServersByName(_ context.Context, name string) ([]string, error) {
-	argoSettings, err := db.settingsMgr.GetSettings()
-	if err != nil {
-		return nil, err
-	}
 	informer, err := db.settingsMgr.GetSecretsInformer()
 	if err != nil {
 		return nil, err
@@ -294,7 +292,12 @@ func (db *db) GetClusterServersByName(_ context.Context, name string) ([]string,
 		return nil, err
 	}
 
-	if len(localClusterSecrets) == 0 && db.getLocalCluster().Name == name && argoSettings.InClusterEnabled {
+	inClusterEnabled, err := db.settingsMgr.IsInClusterEnabled()
+	if err != nil {
+		log.Warnf(errCheckingInClusterEnabled, "GetClusterServersByName", err)
+	}
+
+	if len(localClusterSecrets) == 0 && db.getLocalCluster().Name == name && inClusterEnabled {
 		return []string{appv1.KubernetesInternalAPIServerAddr}, nil
 	}
 
@@ -306,7 +309,7 @@ func (db *db) GetClusterServersByName(_ context.Context, name string) ([]string,
 	for i := range secrets {
 		s := secrets[i].(*corev1.Secret)
 		server := strings.TrimRight(string(s.Data["server"]), "/")
-		if !argoSettings.InClusterEnabled && server == appv1.KubernetesInternalAPIServerAddr {
+		if !inClusterEnabled && server == appv1.KubernetesInternalAPIServerAddr {
 			continue
 		}
 		res = append(res, server)

--- a/util/db/cluster_norace_test.go
+++ b/util/db/cluster_norace_test.go
@@ -130,6 +130,44 @@ func TestWatchClusters_LocalClusterModifications(t *testing.T) {
 	assert.True(t, completed, "Failed due to timeout")
 }
 
+func TestWatchClusters_MissingServerSecretKey(t *testing.T) {
+	// !race:
+	// Intermittent failure when running with -race, likely due to race condition
+	// https://github.com/argoproj/argo-cd/issues/4755
+	emptyArgoCDConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      common.ArgoCDConfigMapName,
+			Namespace: fakeNamespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/part-of": "argocd",
+			},
+		},
+		Data: map[string]string{},
+	}
+	argoCDSecretWithoutSecretKey := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      common.ArgoCDSecretName,
+			Namespace: fakeNamespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/part-of": "argocd",
+			},
+		},
+		Data: map[string][]byte{
+			"admin.password": nil,
+		},
+	}
+	kubeclientset := fake.NewClientset(emptyArgoCDConfigMap, argoCDSecretWithoutSecretKey)
+	settingsManager := settings.NewSettingsManager(t.Context(), kubeclientset, fakeNamespace)
+	db := NewDB(fakeNamespace, settingsManager, kubeclientset)
+	completed := runWatchTest(t, db, []func(old *v1alpha1.Cluster, new *v1alpha1.Cluster){
+		func(old *v1alpha1.Cluster, new *v1alpha1.Cluster) {
+			assert.Nil(t, old)
+			assert.Equal(t, v1alpha1.KubernetesInternalAPIServerAddr, new.Server)
+		},
+	})
+	assert.True(t, completed, "WatchClusters should work even when server.secretkey is missing")
+}
+
 func TestWatchClusters_LocalClusterModificationsWhenDisabled(t *testing.T) {
 	// !race:
 	// Intermittent failure when running TestWatchClusters_LocalClusterModifications with -race, likely due to race condition

--- a/util/db/cluster_test.go
+++ b/util/db/cluster_test.go
@@ -661,6 +661,161 @@ func TestGetClusterServersByName(t *testing.T) {
 	})
 }
 
+func TestCreateCluster_MissingServerSecretKey(t *testing.T) {
+	emptyArgoCDConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      common.ArgoCDConfigMapName,
+			Namespace: fakeNamespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/part-of": "argocd",
+			},
+		},
+		Data: map[string]string{},
+	}
+	argoCDSecretWithoutSecretKey := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      common.ArgoCDSecretName,
+			Namespace: fakeNamespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/part-of": "argocd",
+			},
+		},
+		Data: map[string][]byte{
+			"admin.password": nil,
+		},
+	}
+
+	t.Run("in-cluster creation succeeds when server.secretkey is missing", func(t *testing.T) {
+		kubeclientset := fake.NewClientset(emptyArgoCDConfigMap, argoCDSecretWithoutSecretKey)
+		settingsManager := settings.NewSettingsManager(t.Context(), kubeclientset, fakeNamespace)
+		db := NewDB(fakeNamespace, settingsManager, kubeclientset)
+
+		_, err := db.CreateCluster(t.Context(), &v1alpha1.Cluster{
+			Server: v1alpha1.KubernetesInternalAPIServerAddr,
+			Name:   "in-cluster",
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("external cluster creation succeeds when server.secretkey is missing", func(t *testing.T) {
+		kubeclientset := fake.NewClientset(emptyArgoCDConfigMap, argoCDSecretWithoutSecretKey)
+		settingsManager := settings.NewSettingsManager(t.Context(), kubeclientset, fakeNamespace)
+		db := NewDB(fakeNamespace, settingsManager, kubeclientset)
+
+		_, err := db.CreateCluster(t.Context(), &v1alpha1.Cluster{
+			Server: "https://my-external-cluster",
+			Name:   "external",
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("in-cluster creation rejected when explicitly disabled even with missing server.secretkey", func(t *testing.T) {
+		argoCDConfigMapWithInClusterDisabled := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      common.ArgoCDConfigMapName,
+				Namespace: fakeNamespace,
+				Labels: map[string]string{
+					"app.kubernetes.io/part-of": "argocd",
+				},
+			},
+			Data: map[string]string{"cluster.inClusterEnabled": "false"},
+		}
+		kubeclientset := fake.NewClientset(argoCDConfigMapWithInClusterDisabled, argoCDSecretWithoutSecretKey)
+		settingsManager := settings.NewSettingsManager(t.Context(), kubeclientset, fakeNamespace)
+		db := NewDB(fakeNamespace, settingsManager, kubeclientset)
+
+		_, err := db.CreateCluster(t.Context(), &v1alpha1.Cluster{
+			Server: v1alpha1.KubernetesInternalAPIServerAddr,
+			Name:   "in-cluster",
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "in-cluster has been disabled")
+	})
+}
+
+func TestListClusters_MissingServerSecretKey(t *testing.T) {
+	emptyArgoCDConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      common.ArgoCDConfigMapName,
+			Namespace: fakeNamespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/part-of": "argocd",
+			},
+		},
+		Data: map[string]string{},
+	}
+	argoCDSecretWithoutSecretKey := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      common.ArgoCDSecretName,
+			Namespace: fakeNamespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/part-of": "argocd",
+			},
+		},
+		Data: map[string][]byte{
+			"admin.password": nil,
+		},
+	}
+
+	t.Run("lists clusters including implicit in-cluster when server.secretkey is missing", func(t *testing.T) {
+		externalClusterSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mycluster",
+				Namespace: fakeNamespace,
+				Labels: map[string]string{
+					common.LabelKeySecretType: common.LabelValueSecretTypeCluster,
+				},
+			},
+			Data: map[string][]byte{
+				"server": []byte("https://my-external-cluster"),
+				"name":   []byte("external"),
+			},
+		}
+		kubeclientset := fake.NewClientset(externalClusterSecret, emptyArgoCDConfigMap, argoCDSecretWithoutSecretKey)
+		settingsManager := settings.NewSettingsManager(t.Context(), kubeclientset, fakeNamespace)
+		db := NewDB(fakeNamespace, settingsManager, kubeclientset)
+
+		clusters, err := db.ListClusters(t.Context())
+		require.NoError(t, err)
+		require.Len(t, clusters.Items, 2)
+	})
+}
+
+func TestGetClusterServersByName_MissingServerSecretKey(t *testing.T) {
+	emptyArgoCDConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      common.ArgoCDConfigMapName,
+			Namespace: fakeNamespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/part-of": "argocd",
+			},
+		},
+		Data: map[string]string{},
+	}
+	argoCDSecretWithoutSecretKey := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      common.ArgoCDSecretName,
+			Namespace: fakeNamespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/part-of": "argocd",
+			},
+		},
+		Data: map[string][]byte{
+			"admin.password": nil,
+		},
+	}
+
+	t.Run("returns in-cluster when server.secretkey is missing", func(t *testing.T) {
+		kubeclientset := fake.NewClientset(emptyArgoCDConfigMap, argoCDSecretWithoutSecretKey)
+		settingsManager := settings.NewSettingsManager(t.Context(), kubeclientset, fakeNamespace)
+		db := NewDB(fakeNamespace, settingsManager, kubeclientset)
+
+		servers, err := db.GetClusterServersByName(t.Context(), "in-cluster")
+		require.NoError(t, err)
+		require.ElementsMatch(t, []string{v1alpha1.KubernetesInternalAPIServerAddr}, servers)
+	})
+}
+
 // TestClusterRaceConditionClusterSecrets reproduces a race condition
 // on the cluster secrets. The test isn't asserting anything because
 // before the fix it would cause a panic from concurrent map iteration and map write

--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -104,8 +104,6 @@ type ArgoCDSettings struct {
 	PasswordPattern string `json:"passwordPattern,omitempty"`
 	// BinaryUrls contains the URLs for downloading argocd binaries
 	BinaryUrls map[string]string `json:"binaryUrls,omitempty"`
-	// InClusterEnabled indicates whether to allow in-cluster server address
-	InClusterEnabled bool `json:"inClusterEnabled"`
 	// ServerRBACLogEnforceEnable temporary var indicates whether rbac will be enforced on logs
 	ServerRBACLogEnforceEnable bool `json:"serverRBACLogEnforceEnable"`
 	// MaxPodLogsToRender the maximum number of pod logs to render
@@ -549,6 +547,10 @@ const (
 
 	// application sync with impersonation feature is disabled by default.
 	defaultImpersonationEnabledFlag = false
+
+	// defaultInClusterEnabledFlag is the default value when the in-cluster setting
+	// cannot be read from the configmap or is not explicitly set by the user.
+	defaultInClusterEnabledFlag = true
 )
 
 var sourceTypeToEnableGenerationKey = map[v1alpha1.ApplicationSourceType]string{
@@ -1264,6 +1266,7 @@ func (mgr *SettingsManager) GetSettings() (*ArgoCDSettings, error) {
 	if err := mgr.updateSettingsFromSecret(&settings, argoCDSecret, secrets); err != nil {
 		errs = append(errs, err)
 	}
+	updateSettingsFromConfigMap(&settings, argoCDCM)
 	if len(errs) > 0 {
 		return &settings, errors.Join(errs...)
 	}
@@ -1437,7 +1440,6 @@ func updateSettingsFromConfigMap(settings *ArgoCDSettings, argoCDCM *corev1.Conf
 			settings.MaxPodLogsToRender = val
 		}
 	}
-	settings.InClusterEnabled = argoCDCM.Data[inClusterEnabledKey] != "false"
 	settings.ExecEnabled = argoCDCM.Data[execEnabledKey] == "true"
 	execShells := argoCDCM.Data[execShellsKey]
 	if execShells != "" {
@@ -2318,4 +2320,16 @@ func (mgr *SettingsManager) GetAllowedNodeLabels() []string {
 		labelKeys = append(labelKeys, k)
 	}
 	return labelKeys
+}
+
+// IsInClusterEnabled returns false if in-cluster is explicitly disabled in argocd-cm configmap, true otherwise
+func (mgr *SettingsManager) IsInClusterEnabled() (bool, error) {
+	argoCDCM, err := mgr.getConfigMap()
+	if err != nil {
+		return defaultInClusterEnabledFlag, fmt.Errorf("error checking %s property in configmap: %w", inClusterEnabledKey, err)
+	}
+	if inClusterEnabled, ok := argoCDCM.Data[inClusterEnabledKey]; ok {
+		return inClusterEnabled != "false", nil
+	}
+	return defaultInClusterEnabledFlag, nil
 }

--- a/util/settings/settings_test.go
+++ b/util/settings/settings_test.go
@@ -178,6 +178,13 @@ func TestInClusterServerAddressEnabled(t *testing.T) {
 }
 
 func TestInClusterServerAddressEnabledByDefault(t *testing.T) {
+	_, settingsManager := fixtures(map[string]string{})
+	enabled, err := settingsManager.IsInClusterEnabled()
+	require.NoError(t, err)
+	require.True(t, enabled)
+}
+
+func TestGetSettings_InClusterIsEnabledWithMissingServerSecretKey(t *testing.T) {
 	kubeClient := fake.NewClientset(
 		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -198,15 +205,15 @@ func TestInClusterServerAddressEnabledByDefault(t *testing.T) {
 				},
 			},
 			Data: map[string][]byte{
-				"admin.password":   nil,
-				"server.secretkey": nil,
+				"admin.password": nil,
 			},
 		},
 	)
 	settingsManager := NewSettingsManager(t.Context(), kubeClient, "default")
-	settings, err := settingsManager.GetSettings()
+	// IsInClusterEnabled reads ConfigMap directly and does not depend on server.secretkey
+	enabled, err := settingsManager.IsInClusterEnabled()
 	require.NoError(t, err)
-	assert.True(t, settings.InClusterEnabled)
+	require.True(t, enabled)
 }
 
 func TestGetAppInstanceLabelKey(t *testing.T) {
@@ -1858,6 +1865,49 @@ func TestIsImpersonationEnabled(t *testing.T) {
 		"when user enables the flag in argocd-cm config map, IsImpersonationEnabled() must return user set value")
 	require.NoError(t, err,
 		"when user enables the flag in argocd-cm config map, IsImpersonationEnabled() must not return any error")
+}
+
+func TestIsInClusterEnabled(t *testing.T) {
+	// When there is no argocd-cm itself,
+	// Then IsInClusterEnabled() must return true (default value) and an error with appropriate error message.
+	kubeClient := fake.NewClientset()
+	settingsManager := NewSettingsManager(t.Context(), kubeClient, "default")
+	enabled, err := settingsManager.IsInClusterEnabled()
+	require.True(t, enabled,
+		"with no argocd-cm config map, IsInClusterEnabled() must return true (default value)")
+	require.ErrorContains(t, err, "configmap \"argocd-cm\" not found",
+		"with no argocd-cm config map, IsInClusterEnabled() must return an error")
+
+	// When there is no in-cluster flag present in the argocd-cm,
+	// Then IsInClusterEnabled() must return true (default value) and nil error.
+	_, settingsManager = fixtures(map[string]string{})
+	enabled, err = settingsManager.IsInClusterEnabled()
+	require.True(t, enabled,
+		"with empty argocd-cm config map, IsInClusterEnabled() must return true (default value)")
+	require.NoError(t, err,
+		"with empty argocd-cm config map, IsInClusterEnabled() must not return any error")
+
+	// When user disables in-cluster explicitly,
+	// Then IsInClusterEnabled() must return false and nil error.
+	_, settingsManager = fixtures(map[string]string{
+		"cluster.inClusterEnabled": "false",
+	})
+	enabled, err = settingsManager.IsInClusterEnabled()
+	require.False(t, enabled,
+		"when user sets the flag to false in argocd-cm config map, IsInClusterEnabled() must return false")
+	require.NoError(t, err,
+		"when user sets the flag to false in argocd-cm config map, IsInClusterEnabled() must not return any error")
+
+	// When user enables in-cluster explicitly,
+	// Then IsInClusterEnabled() must return true and nil error.
+	_, settingsManager = fixtures(map[string]string{
+		"cluster.inClusterEnabled": "true",
+	})
+	enabled, err = settingsManager.IsInClusterEnabled()
+	require.True(t, enabled,
+		"when user sets the flag to true in argocd-cm config map, IsInClusterEnabled() must return true")
+	require.NoError(t, err,
+		"when user sets the flag to true in argocd-cm config map, IsInClusterEnabled() must not return any error")
 }
 
 func TestSettingsManager_GetHideSecretAnnotations(t *testing.T) {


### PR DESCRIPTION
cherry-pick of PR https://github.com/argoproj/argo-cd/pull/26793/
Fixes https://github.com/argoproj/argo-cd/issues/12903
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
