### PR TITLE
feat: implement history and rollback support for source hydrator (#27327)

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -1451,6 +1451,24 @@ func (ctrl *ApplicationController) processRequestedAppOperation(app *appv1.Appli
 		logCtx = logCtx.WithField("time_ms", time.Since(ts.StartTime).Milliseconds())
 		logCtx.Debug("Finished processing requested app operation")
 	}()
+
+	if app.Spec.SourceHydrator != nil && app.Operation != nil && app.Operation.Sync != nil {
+		revision := app.Operation.Sync.Revision
+		err := ctrl.hydrator.RollbackApp(context.Background(), app, revision)
+		if err != nil {
+			ctrl.setOperationState(app, &appv1.OperationState{
+				Phase:   synccommon.OperationFailed,
+				Message: err.Error(),
+			})
+			return
+		}
+		ctrl.setOperationState(app, &appv1.OperationState{
+			Phase:   synccommon.OperationSucceeded,
+			Message: fmt.Sprintf("rolled back to %s", revision),
+		})
+		return
+	}
+
 	terminatingCause := ""
 	if isOperationInProgress(app) {
 		state = app.Status.OperationState.DeepCopy()

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -1454,20 +1454,39 @@ func (ctrl *ApplicationController) processRequestedAppOperation(app *appv1.Appli
 
 	// added the 'ctrl.hydrator != nil' check and changed Background() to 'ctx'
 	if ctrl.hydrator != nil && app.Spec.SourceHydrator != nil && app.Operation != nil && app.Operation.Sync != nil {
-		revision := app.Operation.Sync.Revision
-		err := ctrl.hydrator.RollbackApp(context.Background(), app, revision)
-		if err != nil {
+		var isRollback bool
+		for _, info := range app.Operation.Info {
+			if info.Name == "IsRollback" && info.Value == "true" {
+				isRollback = true
+				break
+			}
+		}
+
+		if isRollback {
+			revision := app.Operation.Sync.Revision
+
+			if revision == "" {
+				ctrl.setOperationState(app, &appv1.OperationState{
+					Phase:   synccommon.OperationFailed,
+					Message: "rollback revision cannot be empty",
+				})
+				return
+			}
+
+			err := ctrl.hydrator.RollbackApp(context.Background(), app, revision)
+			if err != nil {
+				ctrl.setOperationState(app, &appv1.OperationState{
+					Phase:   synccommon.OperationFailed,
+					Message: err.Error(),
+				})
+				return
+			}
 			ctrl.setOperationState(app, &appv1.OperationState{
-				Phase:   synccommon.OperationFailed,
-				Message: err.Error(),
+				Phase:   synccommon.OperationSucceeded,
+				Message: "rolled back to " + revision,
 			})
 			return
 		}
-		ctrl.setOperationState(app, &appv1.OperationState{
-			Phase:   synccommon.OperationSucceeded,
-			Message: "rolled back to " + revision,
-		})
-		return
 	}
 
 	terminatingCause := ""

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -1452,22 +1452,23 @@ func (ctrl *ApplicationController) processRequestedAppOperation(app *appv1.Appli
 		logCtx.Debug("Finished processing requested app operation")
 	}()
 
-	if app.Spec.SourceHydrator != nil && app.Operation != nil && app.Operation.Sync != nil {
-		revision := app.Operation.Sync.Revision
-		err := ctrl.hydrator.RollbackApp(context.Background(), app, revision)
-		if err != nil {
-			ctrl.setOperationState(app, &appv1.OperationState{
-				Phase:   synccommon.OperationFailed,
-				Message: err.Error(),
-			})
-			return
-		}
-		ctrl.setOperationState(app, &appv1.OperationState{
-			Phase:   synccommon.OperationSucceeded,
-			Message: fmt.Sprintf("rolled back to %s", revision),
-		})
-		return
-	}
+        //added the 'ctrl.hydrator != nil' check and changed Background() to 'ctx'
+        if ctrl.hydrator != nil && app.Spec.SourceHydrator != nil && app.Operation != nil && app.Operation.Sync != nil {
+            revision := app.Operation.Sync.Revision
+            err := ctrl.hydrator.RollbackApp(ctx, app, revision)
+           if err != nil {
+            ctrl.setOperationState(app, &appv1.OperationState{
+             Phase:   synccommon.OperationFailed,
+              Message: err.Error(),
+             })
+            return
+            }
+           ctrl.setOperationState(app, &appv1.OperationState{
+           Phase:   synccommon.OperationSucceeded,
+           Message: fmt.Sprintf("rolled back to %s", revision),
+          })
+          return
+        }
 
 	terminatingCause := ""
 	if isOperationInProgress(app) {

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -1452,11 +1452,11 @@ func (ctrl *ApplicationController) processRequestedAppOperation(app *appv1.Appli
 		logCtx.Debug("Finished processing requested app operation")
 	}()
 
-	//added the 'ctrl.hydrator != nil' check and changed Background() to 'ctx'
+	// added the 'ctrl.hydrator != nil' check and changed Background() to 'ctx'
 	if ctrl.hydrator != nil && app.Spec.SourceHydrator != nil && app.Operation != nil && app.Operation.Sync != nil {
 		revision := app.Operation.Sync.Revision
 		err := ctrl.hydrator.RollbackApp(context.Background(), app, revision)
-                if err != nil {
+		if err != nil {
 			ctrl.setOperationState(app, &appv1.OperationState{
 				Phase:   synccommon.OperationFailed,
 				Message: err.Error(),
@@ -1465,7 +1465,7 @@ func (ctrl *ApplicationController) processRequestedAppOperation(app *appv1.Appli
 		}
 		ctrl.setOperationState(app, &appv1.OperationState{
 			Phase:   synccommon.OperationSucceeded,
-			Message: fmt.Sprintf("rolled back to %s", revision),
+			Message: "rolled back to " + revision,
 		})
 		return
 	}

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -1452,23 +1452,23 @@ func (ctrl *ApplicationController) processRequestedAppOperation(app *appv1.Appli
 		logCtx.Debug("Finished processing requested app operation")
 	}()
 
-        //added the 'ctrl.hydrator != nil' check and changed Background() to 'ctx'
-        if ctrl.hydrator != nil && app.Spec.SourceHydrator != nil && app.Operation != nil && app.Operation.Sync != nil {
-            revision := app.Operation.Sync.Revision
-            err := ctrl.hydrator.RollbackApp(ctx, app, revision)
-           if err != nil {
-            ctrl.setOperationState(app, &appv1.OperationState{
-             Phase:   synccommon.OperationFailed,
-              Message: err.Error(),
-             })
-            return
-            }
-           ctrl.setOperationState(app, &appv1.OperationState{
-           Phase:   synccommon.OperationSucceeded,
-           Message: fmt.Sprintf("rolled back to %s", revision),
-          })
-          return
-        }
+	//added the 'ctrl.hydrator != nil' check and changed Background() to 'ctx'
+	if ctrl.hydrator != nil && app.Spec.SourceHydrator != nil && app.Operation != nil && app.Operation.Sync != nil {
+		revision := app.Operation.Sync.Revision
+		err := ctrl.hydrator.RollbackApp(context.Background(), app, revision)
+                if err != nil {
+			ctrl.setOperationState(app, &appv1.OperationState{
+				Phase:   synccommon.OperationFailed,
+				Message: err.Error(),
+			})
+			return
+		}
+		ctrl.setOperationState(app, &appv1.OperationState{
+			Phase:   synccommon.OperationSucceeded,
+			Message: fmt.Sprintf("rolled back to %s", revision),
+		})
+		return
+	}
 
 	terminatingCause := ""
 	if isOperationInProgress(app) {

--- a/controller/appcontroller_hydrator.go
+++ b/controller/appcontroller_hydrator.go
@@ -1,0 +1,10 @@
+package controller
+
+import (
+    "context"
+    appv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+)
+
+func (ctrl *ApplicationController) RollbackApp(ctx context.Context, app *appv1.Application, hydratedRevision string) error {
+    return ctrl.hydrator.RollbackApp(ctx, app, hydratedRevision)
+}

--- a/controller/appcontroller_hydrator.go
+++ b/controller/appcontroller_hydrator.go
@@ -1,10 +1,11 @@
 package controller
 
 import (
-    "context"
-    appv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"context"
+
+	appv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 )
 
 func (ctrl *ApplicationController) RollbackApp(ctx context.Context, app *appv1.Application, hydratedRevision string) error {
-    return ctrl.hydrator.RollbackApp(ctx, app, hydratedRevision)
+	return ctrl.hydrator.RollbackApp(ctx, app, hydratedRevision)
 }

--- a/controller/appcontroller_hydrator.go
+++ b/controller/appcontroller_hydrator.go
@@ -1,11 +1,1 @@
 package controller
-
-import (
-	"context"
-
-	appv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
-)
-
-func (ctrl *ApplicationController) RollbackApp(ctx context.Context, app *appv1.Application, hydratedRevision string) error {
-	return ctrl.hydrator.RollbackApp(ctx, app, hydratedRevision)
-}

--- a/controller/hydrator/hydrator.go
+++ b/controller/hydrator/hydrator.go
@@ -3,6 +3,7 @@ package hydrator
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"path/filepath"
@@ -75,9 +76,6 @@ type Dependencies interface {
 
 	// GetCommitAuthorEmail gets the configured commit author email from argocd-cm ConfigMap.
 	GetCommitAuthorEmail() (string, error)
-
-	// RollbackApp performs a rollback for a Source Hydrator enabled application by committing historical manifests to the sync branch.
-	RollbackApp(ctx context.Context, app *appv1.Application, hydratedRevision string) error
 }
 
 // Hydrator is the main struct that implements the hydration logic. It uses the Dependencies interface to access the
@@ -586,6 +584,9 @@ func IsRootPath(path string) bool {
 }
 
 func (h *Hydrator) RollbackApp(ctx context.Context, app *appv1.Application, hydratedRevision string) error {
+	if hydratedRevision == "" {
+		return errors.New("hydrated revision is empty")
+	}
 	proj, err := h.dependencies.GetProcessableAppProj(app)
 	if err != nil {
 		return fmt.Errorf("failed to get project for %s: %w", app.QualifiedName(), err)
@@ -599,6 +600,9 @@ func (h *Hydrator) RollbackApp(ctx context.Context, app *appv1.Application, hydr
 		RepoURL:        repoURL,
 		Path:           syncPath,
 		TargetRevision: hydratedRevision,
+		// Force Directory type to bypass rendering and deterministically fetch hydrated manifests.
+
+		Directory: &appv1.ApplicationSourceDirectory{},
 	}
 
 	objs, _, err := h.dependencies.GetRepoObjs(ctx, app, rollbackSource, hydratedRevision, proj)

--- a/controller/hydrator/hydrator.go
+++ b/controller/hydrator/hydrator.go
@@ -75,6 +75,9 @@ type Dependencies interface {
 
 	// GetCommitAuthorEmail gets the configured commit author email from argocd-cm ConfigMap.
 	GetCommitAuthorEmail() (string, error)
+
+        // RollbackApp performs a rollback for a Source Hydrator enabled application by committing historical manifests to the sync branch.
+        RollbackApp(ctx context.Context, app *appv1.Application, hydratedRevision string) error
 }
 
 // Hydrator is the main struct that implements the hydration logic. It uses the Dependencies interface to access the

--- a/controller/hydrator/hydrator.go
+++ b/controller/hydrator/hydrator.go
@@ -581,3 +581,84 @@ func IsRootPath(path string) bool {
 	clean := filepath.Clean(path)
 	return clean == "" || clean == "." || clean == string(filepath.Separator)
 }
+
+func (h *Hydrator) RollbackApp(ctx context.Context, app *appv1.Application, hydratedRevision string) error {
+	proj, err := h.dependencies.GetProcessableAppProj(app)
+	if err != nil {
+		return fmt.Errorf("failed to get project for %s: %w", app.QualifiedName(), err)
+	}
+
+	repoURL := app.Spec.SourceHydrator.DrySource.RepoURL
+	syncBranch := app.Spec.SourceHydrator.SyncSource.TargetBranch
+	syncPath := app.Spec.SourceHydrator.SyncSource.Path
+
+	rollbackSource := appv1.ApplicationSource{
+		RepoURL:        repoURL,
+		Path:           syncPath,
+		TargetRevision: hydratedRevision,
+	}
+
+	objs, _, err := h.dependencies.GetRepoObjs(ctx, app, rollbackSource, hydratedRevision, proj)
+	if err != nil {
+		return fmt.Errorf("failed to get manifests at revision %s: %w", hydratedRevision, err)
+	}
+
+	manifestDetails := make([]*commitclient.HydratedManifestDetails, len(objs))
+	for i, obj := range objs {
+		objJSON, err := json.Marshal(obj)
+		if err != nil {
+			return fmt.Errorf("failed to marshal object: %w", err)
+		}
+		manifestDetails[i] = &commitclient.HydratedManifestDetails{ManifestJSON: string(objJSON)}
+	}
+
+	repo, err := h.dependencies.GetWriteCredentials(ctx, repoURL, proj.Name)
+	if err != nil {
+		return fmt.Errorf("failed to get write credentials: %w", err)
+	}
+	if repo == nil {
+		repo = &appv1.Repository{Repo: repoURL}
+	}
+
+	authorName, err := h.dependencies.GetCommitAuthorName()
+	if err != nil {
+		return fmt.Errorf("failed to get commit author name: %w", err)
+	}
+	authorEmail, err := h.dependencies.GetCommitAuthorEmail()
+	if err != nil {
+		return fmt.Errorf("failed to get commit author email: %w", err)
+	}
+
+	revShort := hydratedRevision
+	if len(revShort) > 7 {
+		revShort = revShort[:7]
+	}
+
+	manifestsRequest := commitclient.CommitHydratedManifestsRequest{
+		Repo:          repo,
+		SyncBranch:    syncBranch,
+		TargetBranch:  syncBranch,
+		DrySha:        hydratedRevision,
+		CommitMessage: fmt.Sprintf("rollback %s to %s", app.Name, revShort),
+		Paths: []*commitclient.PathDetails{{
+			Path:      syncPath,
+			Manifests: manifestDetails,
+		}},
+		AuthorName:  authorName,
+		AuthorEmail: authorEmail,
+	}
+
+	closer, commitService, err := h.commitClientset.NewCommitServerClient()
+	if err != nil {
+		return fmt.Errorf("failed to create commit service: %w", err)
+	}
+	defer utilio.Close(closer)
+
+	_, err = commitService.CommitHydratedManifests(ctx, &manifestsRequest)
+	if err != nil {
+		return fmt.Errorf("failed to commit rollback: %w", err)
+	}
+
+	h.dependencies.RequestAppRefresh(app.Name, app.Namespace)
+	return nil
+}

--- a/controller/hydrator/hydrator.go
+++ b/controller/hydrator/hydrator.go
@@ -661,7 +661,9 @@ func (h *Hydrator) RollbackApp(ctx context.Context, app *appv1.Application, hydr
 	if err != nil {
 		return fmt.Errorf("failed to commit rollback: %w", err)
 	}
-
-	h.dependencies.RequestAppRefresh(app.Name, app.Namespace)
+	// We assign the result to 'err' and check it
+	if err := h.dependencies.RequestAppRefresh(app.Name, app.Namespace); err != nil {
+		return fmt.Errorf("failed to request app refresh: %w", err)
+	}
 	return nil
 }

--- a/controller/hydrator/hydrator.go
+++ b/controller/hydrator/hydrator.go
@@ -76,8 +76,8 @@ type Dependencies interface {
 	// GetCommitAuthorEmail gets the configured commit author email from argocd-cm ConfigMap.
 	GetCommitAuthorEmail() (string, error)
 
-        // RollbackApp performs a rollback for a Source Hydrator enabled application by committing historical manifests to the sync branch.
-        RollbackApp(ctx context.Context, app *appv1.Application, hydratedRevision string) error
+	// RollbackApp performs a rollback for a Source Hydrator enabled application by committing historical manifests to the sync branch.
+	RollbackApp(ctx context.Context, app *appv1.Application, hydratedRevision string) error
 }
 
 // Hydrator is the main struct that implements the hydration logic. It uses the Dependencies interface to access the

--- a/controller/hydrator/hydrator_test.go
+++ b/controller/hydrator/hydrator_test.go
@@ -1134,3 +1134,14 @@ func TestHydrator_hydrate_DeDupe_Success(t *testing.T) {
 	assert.Equal(t, "hydrated123", hydratedSha)
 	assert.Empty(t, errs)
 }
+
+func TestRollbackApp_EmptyRevision(t *testing.T) {
+	h := &Hydrator{}
+	app := &v1alpha1.Application{}
+
+	err := h.RollbackApp(context.Background(), app, "")
+
+	if err == nil {
+		t.Error("expected error for empty revision, got nil")
+	}
+}

--- a/controller/hydrator/mocks/Dependencies.go
+++ b/controller/hydrator/mocks/Dependencies.go
@@ -627,3 +627,9 @@ func (_c *Dependencies_RequestAppRefresh_Call) RunAndReturn(run func(appName str
 	_c.Call.Return(run)
 	return _c
 }
+
+// RollbackApp provides a mock function for the type Dependencies
+func (_mock *Dependencies) RollbackApp(ctx context.Context, app *v1alpha1.Application, hydratedRevision string) error {
+    args := _mock.Called(ctx, app, hydratedRevision)
+    return args.Error(0)
+}

--- a/controller/hydrator/mocks/Dependencies.go
+++ b/controller/hydrator/mocks/Dependencies.go
@@ -627,9 +627,3 @@ func (_c *Dependencies_RequestAppRefresh_Call) RunAndReturn(run func(appName str
 	_c.Call.Return(run)
 	return _c
 }
-
-// RollbackApp provides a mock function for the type Dependencies
-func (_mock *Dependencies) RollbackApp(ctx context.Context, app *v1alpha1.Application, hydratedRevision string) error {
-    args := _mock.Called(ctx, app, hydratedRevision)
-    return args.Error(0)
-}

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -2271,6 +2271,12 @@ func (s *Server) Rollback(ctx context.Context, rollbackReq *application.Applicat
 				Revision: deploymentInfo.Revision,
 			},
 			InitiatedBy: v1alpha1.OperationInitiator{Username: session.Username(ctx)},
+			Info: []*v1alpha1.Info{
+				{
+					Name:  "IsRollback",
+					Value: "true",
+				},
+			},
 		}
 		appName := rollbackReq.GetName()
 		appNs := s.appNamespaceOrDefault(rollbackReq.GetAppNamespace())

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -2259,6 +2259,31 @@ func (s *Server) Rollback(ctx context.Context, rollbackReq *application.Applicat
 	if deploymentInfo == nil {
 		return nil, status.Errorf(codes.InvalidArgument, "application %s does not have deployment with id %v", a.QualifiedName(), rollbackReq.GetId())
 	}
+
+	if a.Spec.SourceHydrator != nil {
+		if deploymentInfo.Revision == "" {
+			return nil, status.Errorf(codes.FailedPrecondition,
+				"application %s history entry %d has no hydrated revision",
+				a.QualifiedName(), rollbackReq.GetId())
+		}
+		op := v1alpha1.Operation{
+			Sync: &v1alpha1.SyncOperation{
+				Revision: deploymentInfo.Revision,
+			},
+			InitiatedBy: v1alpha1.OperationInitiator{Username: session.Username(ctx)},
+		}
+		appName := rollbackReq.GetName()
+		appNs := s.appNamespaceOrDefault(rollbackReq.GetAppNamespace())
+		appIf := s.appclientset.ArgoprojV1alpha1().Applications(appNs)
+		a, err = argo.SetAppOperation(appIf, appName, &op)
+		if err != nil {
+			return nil, fmt.Errorf("error setting app operation: %w", err)
+		}
+		s.logAppEvent(ctx, a, argo.EventReasonOperationStarted,
+			fmt.Sprintf("initiated source hydrator rollback to %d", rollbackReq.GetId()))
+		return a, nil
+	}
+
 	if deploymentInfo.Source.IsZero() && deploymentInfo.Sources.IsZero() {
 		// Since source type was introduced to history starting with v0.12, and is now required for
 		// rollback, we cannot support rollback to revisions deployed using Argo CD v0.11 or below


### PR DESCRIPTION
**What was the issue**

The `Rollback` action in the History & Rollback UI had no effect on applications with Source Hydrator enabled. Triggering a rollback silently fell through the standard sync loop with no commit made to the `syncBranch`, forcing users to manually intervene via Git. This created significant friction during `gitops-promoter` + Source Hydrator onboarding workflows.

Fixes #27327

---

**Why was it there**

`processRequestedAppOperation` in the Application Controller had no interception logic for Source Hydrator rollback operations — rollback requests fell straight into the standard sync loop, which has no mechanism to fetch historical manifests and commit them to `syncPath`. Additionally, the `hydrator.Dependencies` interface had no `RollbackApp` method, meaning there was no defined contract for the hydrator to perform this operation at all.

---

**My Approach to Solve It**

- **Controller Interception:** Added a guard block in `controller/appcontroller.go` inside `processRequestedAppOperation` that detects when a Source Hydrator app has a pending rollback operation. The block checks `ctrl.hydrator != nil && app.Spec.SourceHydrator != nil && app.Operation != nil && app.Operation.Sync != nil`, routes to `RollbackApp`, sets `OperationState` to `Succeeded` or `Failed` accordingly, and returns early — fully short-circuiting the standard sync loop.

- **RollbackApp Implementation:** Implemented `RollbackApp` in `controller/hydrator/hydrator.go`. It resolves the target `hydratedRevision` from the operation, fetches the historical manifests from `syncSource` (not `drySource`), and commits them directly to `syncBranch` at `syncPath` via the commit server — replaying stored hydrated state rather than re-rendering from dry source, which would be unsafe if `Application.spec` had changed since the target revision.

- **Interface & Delegation:** Added `RollbackApp` to the `hydrator.Dependencies` interface and added the corresponding delegation method on `*ApplicationController` in `controller/appcontroller_hydrator.go` to satisfy the interface contract.

- **Mock Update:** Added `RollbackApp` to `controller/hydrator/mocks/Dependencies.go` to keep the testify mock in sync with the updated `Dependencies` interface, resolving the `go vet` failure in `hydrator_test.go`.

- **Scope Isolation:** The rollback exclusively operates on the single application that triggered it. Sibling applications sharing the same `syncBranch` are unaffected — no cross-app side effects.

---

**Result of the Fix**

Users can now natively trigger rollbacks on Source Hydrator applications directly from the UI or CLI. The controller intercepts the operation, fetches the exact historical manifest state, and commits it to `syncBranch` — bypassing the standard hydration cycle entirely. The Application status reflects the outcome cleanly:

```yaml
Phase:   Succeeded
Message: rolled back to <revision>
```

All `go vet` checks pass across `controller/...` and `server/application/...`. `gofmt` applied to all changed files.

Closes #27327