### PR TITLE
fix(applicationset): accept non-string ClusterDecision scalar values

### DIFF
--- a/applicationset/generators/duck_type.go
+++ b/applicationset/generators/duck_type.go
@@ -163,8 +163,26 @@ func (g *DuckTypeGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.A
 			"server": cluster.Server,
 		}
 
+		// ClusterDecisionResource status decisions are backed by
+		// Kubernetes unstructured objects, so scalar values can be any
+		// JSON type: strings, but also int64 (e.g. OCM PlacementDecision's
+		// new `score` field), bool, float64, or nil. Unconditionally
+		// type-asserting every value to string panicked with
+		// `interface conversion: interface {} is int64, not string` and
+		// killed the ApplicationSet controller reconcile loop (#27264).
+		// Stringify non-string scalars; skip composite map/slice values
+		// that cannot be flattened into a template parameter.
 		for key, value := range clusterDecision.(map[string]any) {
-			params[key] = value.(string)
+			switch v := value.(type) {
+			case string:
+				params[key] = v
+			case nil:
+				params[key] = ""
+			case int64, int32, int, float64, float32, bool:
+				params[key] = fmt.Sprintf("%v", v)
+			default:
+				log.Debugf("duck-type cluster decision key %q has unsupported value type %T; skipping", key, v)
+			}
 		}
 
 		for key, value := range appSetGenerator.ClusterDecisionResource.Values {


### PR DESCRIPTION
## Description

The duck-type ApplicationSet generator unconditionally type-asserted every value in the `ClusterDecisionResource` status decision map to string. Any Kubernetes unstructured scalar that isn't a string — `int64` (e.g. OCM PlacementDecision's new `score` field), `bool`, `float64`, or `nil` — panicked with:

```
interface conversion: interface {} is int64, not string
```

The panic killed the ApplicationSet controller reconcile goroutine every cycle, so the ApplicationSet never produced apps.

## Fix

Stringify non-string scalars via `fmt.Sprintf("%v")`, treat `nil` as empty, and skip composite `map` / `slice` values with a Debug log rather than letting the panic propagate.

Fixes #27264.

## Checklist

- [x] `go build ./applicationset/...` green.
- [x] `go test ./applicationset/generators/... -count=1` passes.
- [x] `gofmt` clean.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>
