### PR TITLE
fix(server): disable directory listing for /assets/

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1480,9 +1480,37 @@ func (server *ArgoCDServer) newStaticAssetsHandler() func(http.ResponseWriter, *
 				}
 				w.Header().Set("Cache-Control", cacheControl)
 			}
-			http.FileServer(server.staticAssets).ServeHTTP(w, r)
+			// 404 requests that resolve to a directory so http.FileServer
+			// does not render the auto-generated index page (which exposed
+			// /assets/, /assets/fonts/, etc. as a directory listing; #27375).
+			http.FileServer(noListingFileSystem{server.staticAssets}).ServeHTTP(w, r)
 		}
 	}
+}
+
+// noListingFileSystem wraps an http.FileSystem so directories served by
+// http.FileServer return 404 rather than an auto-generated listing.
+// Regular files are served unchanged; files whose Stat reports IsDir()
+// return the same error http.FileServer would get for a missing file.
+type noListingFileSystem struct {
+	fs http.FileSystem
+}
+
+func (n noListingFileSystem) Open(name string) (http.File, error) {
+	f, err := n.fs.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	if info.IsDir() {
+		_ = f.Close()
+		return nil, os.ErrNotExist
+	}
+	return f, nil
 }
 
 var mainJsBundleRegex = regexp.MustCompile(`^main\.[0-9a-f]{20}\.js$`)


### PR DESCRIPTION
## Description

`http.FileServer` auto-generates a directory listing when the request resolves to a directory, which leaked the contents of `/assets/`, `/assets/fonts/`, `/assets/images/` etc. over an unauthenticated HTTPS `GET`:

```
$ curl https://<argocd-server>/assets/
<pre>
<a href="favicon/">favicon/</a>
<a href="fonts/">fonts/</a>
<a href="fonts.css">fonts.css</a>
<a href="images/">images/</a>
<a href="scripts/">scripts/</a>
</pre>
```

The only consumers of these paths are the UI bundle's explicit requests for individual files; there is no legitimate use case for browsing them.

## Fix

Wrap the static `http.FileSystem` so `Open()` returns `os.ErrNotExist` when the requested path resolves to a directory. `http.FileServer` converts that to a normal 404 and no HTML listing is rendered. Regular files are served unchanged.

Fixes #27375.

## Checklist

- [x] `go build ./server/...` green.
- [x] `go test ./server/ -count=1` passes.
- [x] `gofmt` clean.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>
