### PR TITLE
fix: missing import

### DIFF
--- a/server/application/application_test.go
+++ b/server/application/application_test.go
@@ -2743,7 +2743,7 @@ func TestGetManifests_SourceHydrator(t *testing.T) {
 
 	_, err := appServer.GetManifests(t.Context(), &application.ApplicationManifestQuery{
 		Name:     &testApp.Name,
-		Revision: ptr.To("some-revision"),
+		Revision: new("some-revision"),
 	})
 	require.NoError(t, err)
 	mockRepoServiceClient.AssertExpectations(t)


### PR DESCRIPTION
Small miss since https://github.com/argoproj/argo-cd/pull/24670 wasn't up to date when merged.