### PR TITLE
fix(server): Avoid error when attempting a second delete operation

### DIFF
--- a/server/application/application.go
+++ b/server/application/application.go
@@ -1174,7 +1174,10 @@ func (s *Server) Delete(ctx context.Context, q *application.ApplicationDeleteReq
 		if policyFinalizer == "" {
 			return nil, status.Errorf(codes.InvalidArgument, "invalid propagation policy: %s", *q.PropagationPolicy)
 		}
-		if !a.IsFinalizerPresent(policyFinalizer) {
+		// Kubernetes forbids adding finalizers to an object that is already being deleted,
+		// so skip the patch if the app is mid-deletion. The underlying Delete call below is
+		// still issued to keep the RPC idempotent for callers retrying a cascade delete.
+		if !a.IsFinalizerPresent(policyFinalizer) && a.DeletionTimestamp == nil {
 			a.SetCascadedDeletion(policyFinalizer)
 			patchFinalizer = true
 		}

--- a/server/application/application_test.go
+++ b/server/application/application_test.go
@@ -1858,6 +1858,46 @@ func TestDeleteApp(t *testing.T) {
 	})
 }
 
+func TestDeleteAppAlreadyDeleting(t *testing.T) {
+	ctx := t.Context()
+	appServer := newTestAppServer(t)
+	createReq := application.ApplicationCreateRequest{
+		Application: newTestApp(),
+	}
+	app, err := appServer.Create(ctx, &createReq)
+	require.NoError(t, err)
+
+	fakeAppCs := appServer.appclientset.(*deepCopyAppClientset).GetUnderlyingClientSet().(*apps.Clientset)
+	// Drop the default reactor so we can observe exactly which actions Delete issues.
+	fakeAppCs.ReactionChain = nil
+	patched := false
+	deleted := false
+	fakeAppCs.AddReactor("patch", "applications", func(_ kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+		patched = true
+		return true, nil, nil
+	})
+	fakeAppCs.AddReactor("delete", "applications", func(_ kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+		deleted = true
+		return true, nil, nil
+	})
+	now := metav1.Now()
+	fakeAppCs.AddReactor("get", "applications", func(_ kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, &v1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				DeletionTimestamp: &now,
+			},
+			Spec: v1alpha1.ApplicationSpec{Source: &v1alpha1.ApplicationSource{}},
+		}, nil
+	})
+	appServer.appclientset = fakeAppCs
+
+	trueVar := true
+	_, err = appServer.Delete(ctx, &application.ApplicationDeleteRequest{Name: &app.Name, Cascade: &trueVar})
+	require.NoError(t, err)
+	assert.False(t, patched, "finalizer patch must not be attempted on an app already being deleted")
+	assert.True(t, deleted, "delete call should still be issued so the RPC stays idempotent")
+}
+
 func TestDeleteResourcesRBAC(t *testing.T) {
 	ctx := t.Context()
 	//nolint:staticcheck
@@ -2743,7 +2783,7 @@ func TestGetManifests_SourceHydrator(t *testing.T) {
 
 	_, err := appServer.GetManifests(t.Context(), &application.ApplicationManifestQuery{
 		Name:     &testApp.Name,
-		Revision: ptr.To("some-revision"),
+		Revision: new("some-revision"),
 	})
 	require.NoError(t, err)
 	mockRepoServiceClient.AssertExpectations(t)


### PR DESCRIPTION
This avoids an error that could occur when a user does `argocd app delete --cascade=false` on an app with post-delete finalizers, the app is stuck because the cluster is unreachable/some other error, then the user tries `argocd app delete --cascade=true` as an escalation, and it blows up with:

```
rpc error: code = InvalidArgument desc = error patching application with finalizers:
Application.argoproj.io "my-app" is invalid:
metadata.finalizers: Forbidden: no new finalizers can be added if the object is being deleted,
found new finalizers []string{"resources-finalizer.argocd.argoproj.io"}
```

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
