### PR TITLE
fix: isolate UI extension loading failures to prevent cascade errors

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1311,7 +1311,7 @@ func (server *ArgoCDServer) serveExtensions(extensionsSharedPath string, w http.
 		}
 		if !files.IsSymlink(info) && !info.IsDir() && extensionsPattern.MatchString(info.Name()) {
 			processFile := func() error {
-				if _, err = fmt.Fprintf(w, "// source: %s/%s \n", filePath, info.Name()); err != nil {
+				if _, err = fmt.Fprintf(w, "// source: %s/%s \ntry {\n", filePath, info.Name()); err != nil {
 					return fmt.Errorf("failed to write to response: %w", err)
 				}
 
@@ -1325,11 +1325,15 @@ func (server *ArgoCDServer) serveExtensions(extensionsSharedPath string, w http.
 					return fmt.Errorf("failed to copy file '%s': %w", filePath, err)
 				}
 
+				if _, err = fmt.Fprintf(w, "\n} catch(e) { console.error('Extension %s failed to load:', e); }\n", info.Name()); err != nil {
+					return fmt.Errorf("failed to write to response: %w", err)
+				}
+
 				return nil
 			}
 
-			if processFile() != nil {
-				return fmt.Errorf("failed to serve extension file '%s': %w", filePath, processFile())
+			if err := processFile(); err != nil {
+				return fmt.Errorf("failed to serve extension file '%s': %w", filePath, err)
 			}
 		}
 		return nil

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1803,6 +1803,39 @@ func Test_enforceContentTypes(t *testing.T) {
 	})
 }
 
+func TestServeExtensions_IsolatesEachFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Write two extension files
+	err := os.WriteFile(filepath.Join(tmpDir, "extension-a.js"), []byte(`console.log("ext-a");`), 0o644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmpDir, "extension-b.js"), []byte(`console.log("ext-b");`), 0o644)
+	require.NoError(t, err)
+
+	argocd, closer := fakeServer(t)
+	defer closer()
+
+	w := httptest.NewRecorder()
+	argocd.serveExtensions(tmpDir, w)
+	body := w.Body.String()
+
+	// Each file must be wrapped in its own try/catch so a failure in one
+	// does not prevent subsequent extensions from loading.
+	assert.Contains(t, body, "try {")
+	assert.Contains(t, body, "} catch(e) {")
+	assert.Contains(t, body, `console.log("ext-a");`)
+	assert.Contains(t, body, `console.log("ext-b");`)
+
+	// Verify the try/catch for ext-a appears before ext-b's content
+	idxTry := strings.Index(body, "try {")
+	idxExtB := strings.Index(body, `console.log("ext-b");`)
+	assert.Less(t, idxTry, idxExtB, "try block should wrap ext-a before ext-b content appears")
+
+	// There should be two separate try/catch blocks (one per file)
+	assert.Equal(t, 2, strings.Count(body, "try {"), "each extension file should have its own try block")
+	assert.Equal(t, 2, strings.Count(body, "} catch(e) {"), "each extension file should have its own catch block")
+}
+
 func Test_StaticAssetsDir_no_symlink_traversal(t *testing.T) {
 	tmpDir := t.TempDir()
 	assetsDir := filepath.Join(tmpDir, "assets")


### PR DESCRIPTION
When multiple UI extensions are bundled into a single extensions.js payload, a runtime error thrown by any one extension halts browser evaluation of the entire script, silently dropping every extension that follows it in the file.

### The Fix:
Wrap each extension file's content in a per-file try/catch block in serveExtensions so that a runtime error in one extension logs to the console and execution continues with the remaining extensions.

Also fixes a pre-existing double-call bug where processFile() was invoked twice on error — once for the nil check and again to get the wrapped error value — which could cause partial content to be written twice.
### Result:
<img width="1679" height="410" alt="image" src="https://github.com/user-attachments/assets/fcab31d3-c590-40b3-99e9-3b1f8ac68f76" />

When an extension fails to load, the error is logged to the console, but execution continues. When multiple extensions fail, we can now see all the failures

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
