### PR TITLE
fix(applicationset): fix crash when using unquoted booleans or numbers in generators #26974

### DIFF
--- a/applicationset/generators/list.go
+++ b/applicationset/generators/list.go
@@ -58,18 +58,10 @@ func (g *ListGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.Appli
 						return nil, errors.New("error parsing values map")
 					}
 					for k, v := range values {
-						value, ok := v.(string)
-						if !ok {
-							return nil, fmt.Errorf("error parsing value as string %w", err)
-						}
-						params["values."+k] = value
+						params["values."+k] = fmt.Sprintf("%v", v)
 					}
 				} else {
-					v, ok := value.(string)
-					if !ok {
-						return nil, fmt.Errorf("error parsing value as string %w", err)
-					}
-					params[key] = v
+					params[key] = fmt.Sprintf("%v", value)
 				}
 				res[i] = params
 			}

--- a/applicationset/generators/list.go
+++ b/applicationset/generators/list.go
@@ -58,10 +58,18 @@ func (g *ListGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.Appli
 						return nil, errors.New("error parsing values map")
 					}
 					for k, v := range values {
-						params["values."+k] = fmt.Sprintf("%v", v)
+						val, err := getParamValue(v, k)
+						if err != nil {
+							return nil, err
+						}
+						params["values."+k] = val
 					}
 				} else {
-					params[key] = fmt.Sprintf("%v", value)
+					val, err := getParamValue(value, key)
+					if err != nil {
+						return nil, err
+					}
+					params[key] = val
 				}
 				res[i] = params
 			}
@@ -79,4 +87,17 @@ func (g *ListGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.Appli
 	}
 
 	return res, nil
+}
+
+func getParamValue(value any, key string) (string, error) {
+	switch v := value.(type) {
+	case string:
+		return v, nil
+	case bool, float64, int, int64:
+		return fmt.Sprintf("%v", v), nil
+	case nil:
+		return "", nil
+	default:
+		return "", fmt.Errorf("unsupported value type %T for key %q: nested objects and arrays are not supported in non-GoTemplate mode", value, key)
+	}
 }

--- a/applicationset/generators/list.go
+++ b/applicationset/generators/list.go
@@ -38,42 +38,20 @@ func (g *ListGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.Appli
 		return nil, ErrEmptyAppSetGenerator
 	}
 
-	res := make([]map[string]any, len(appSetGenerator.List.Elements))
+	res := make([]map[string]any, 0, len(appSetGenerator.List.Elements))
 
-	for i, tmpItem := range appSetGenerator.List.Elements {
-		params := map[string]any{}
+	for _, tmpItem := range appSetGenerator.List.Elements {
 		var element map[string]any
 		err := json.Unmarshal(tmpItem.Raw, &element)
 		if err != nil {
 			return nil, fmt.Errorf("error unmarshling list element %w", err)
 		}
 
-		if appSet.Spec.GoTemplate {
-			res[i] = element
-		} else {
-			for key, value := range element {
-				if key == "values" {
-					values, ok := (value).(map[string]any)
-					if !ok {
-						return nil, errors.New("error parsing values map")
-					}
-					for k, v := range values {
-						val, err := getParamValue(v, k)
-						if err != nil {
-							return nil, err
-						}
-						params["values."+k] = val
-					}
-				} else {
-					val, err := getParamValue(value, key)
-					if err != nil {
-						return nil, err
-					}
-					params[key] = val
-				}
-				res[i] = params
-			}
+		processed, err := processElement(element, appSet.Spec.GoTemplate)
+		if err != nil {
+			return nil, err
 		}
+		res = append(res, processed)
 	}
 
 	// Append elements from ElementsYaml to the response
@@ -83,17 +61,55 @@ func (g *ListGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.Appli
 		if err != nil {
 			return nil, fmt.Errorf("error unmarshling decoded ElementsYaml %w", err)
 		}
-		res = append(res, yamlElements...)
+		for _, element := range yamlElements {
+			processed, err := processElement(element, appSet.Spec.GoTemplate)
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, processed)
+		}
 	}
 
 	return res, nil
+}
+
+func processElement(element map[string]any, goTemplate bool) (map[string]any, error) {
+	if goTemplate {
+		return element, nil
+	}
+	params := make(map[string]any)
+	for key, value := range element {
+		if key == "values" {
+			values, ok := (value).(map[string]any)
+			if !ok {
+				return nil, errors.New("error parsing values map")
+			}
+			for k, v := range values {
+				val, err := getParamValue(v, k)
+				if err != nil {
+					return nil, err
+				}
+				params["values."+k] = val
+			}
+		} else {
+			val, err := getParamValue(value, key)
+			if err != nil {
+				return nil, err
+			}
+			params[key] = val
+		}
+	}
+	return params, nil
 }
 
 func getParamValue(value any, key string) (string, error) {
 	switch v := value.(type) {
 	case string:
 		return v, nil
-	case bool, float64, int, int64:
+	case bool, float64:
+		return fmt.Sprintf("%v", v), nil
+	// JSON unmarshals to float64, but we keep int/int64 for safety also for use in manual maps/tests
+	case int, int64:
 		return fmt.Sprintf("%v", v), nil
 	case nil:
 		return "", nil

--- a/applicationset/generators/list_test.go
+++ b/applicationset/generators/list_test.go
@@ -22,6 +22,16 @@ func TestGenerateListParams(t *testing.T) {
 		}, {
 			elements: []apiextensionsv1.JSON{{Raw: []byte(`{"cluster": "cluster","url": "url","values":{"foo":"bar"}}`)}},
 			expected: []map[string]any{{"cluster": "cluster", "url": "url", "values.foo": "bar"}},
+		}, {
+			elements: []apiextensionsv1.JSON{{Raw: []byte(`{"name": "test", "syncPrune": true, "number": 123, "values": {"innerBool": false}}`)}},
+			expected: []map[string]any{
+				{
+					"name":             "test",
+					"syncPrune":        "true",
+					"number":           "123",
+					"values.innerBool": "false",
+				},
+			},
 		},
 	}
 

--- a/applicationset/generators/list_test.go
+++ b/applicationset/generators/list_test.go
@@ -32,6 +32,15 @@ func TestGenerateListParams(t *testing.T) {
 					"values.innerBool": "false",
 				},
 			},
+		}, {
+			elements: []apiextensionsv1.JSON{{Raw: []byte(`{"name": "test", "float": 1.5, "nullable": null}`)}},
+			expected: []map[string]any{
+				{
+					"name":     "test",
+					"float":    "1.5",
+					"nullable": "",
+				},
+			},
 		},
 	}
 
@@ -56,6 +65,44 @@ func TestGenerateListParams(t *testing.T) {
 	}
 }
 
+func TestGenerateListParamsError(t *testing.T) {
+	testCases := []struct {
+		name     string
+		elements []apiextensionsv1.JSON
+	}{
+		{
+			name:     "nested array",
+			elements: []apiextensionsv1.JSON{{Raw: []byte(`{"cluster": "cluster", "tags": ["prod", "us-east"]}`)}},
+		},
+		{
+			name:     "nested object",
+			elements: []apiextensionsv1.JSON{{Raw: []byte(`{"cluster": "cluster", "nested": {"key": "value"}}`)}},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			listGenerator := NewListGenerator()
+
+			applicationSetInfo := argoprojiov1alpha1.ApplicationSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "set",
+				},
+				Spec: argoprojiov1alpha1.ApplicationSetSpec{},
+			}
+
+			_, err := listGenerator.GenerateParams(&argoprojiov1alpha1.ApplicationSetGenerator{
+				List: &argoprojiov1alpha1.ListGenerator{
+					Elements: testCase.elements,
+				},
+			}, &applicationSetInfo, nil)
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "nested objects and arrays are not supported in non-GoTemplate mode")
+		})
+	}
+}
+
 func TestGenerateListParamsGoTemplate(t *testing.T) {
 	testCases := []struct {
 		elements []apiextensionsv1.JSON
@@ -67,6 +114,9 @@ func TestGenerateListParamsGoTemplate(t *testing.T) {
 		}, {
 			elements: []apiextensionsv1.JSON{{Raw: []byte(`{"cluster": "cluster","url": "url","values":{"foo":"bar"}}`)}},
 			expected: []map[string]any{{"cluster": "cluster", "url": "url", "values": map[string]any{"foo": "bar"}}},
+		}, {
+			elements: []apiextensionsv1.JSON{{Raw: []byte(`{"name": "test", "float": 1.5, "nullable": null}`)}},
+			expected: []map[string]any{{"name": "test", "float": 1.5, "nullable": nil}},
 		},
 	}
 

--- a/applicationset/generators/list_test.go
+++ b/applicationset/generators/list_test.go
@@ -142,3 +142,81 @@ func TestGenerateListParamsGoTemplate(t *testing.T) {
 		assert.ElementsMatch(t, testCase.expected, got)
 	}
 }
+
+func TestGenerateListParamsYaml(t *testing.T) {
+	testCases := []struct {
+		name         string
+		elementsYaml string
+		goTemplate   bool
+		expected     []map[string]any
+		expectedErr  string
+	}{
+		{
+			name:         "primitives",
+			elementsYaml: "- name: test\n  syncPrune: true\n  number: 123",
+			expected: []map[string]any{
+				{
+					"name":      "test",
+					"syncPrune": "true",
+					"number":    "123",
+				},
+			},
+		},
+		{
+			name:         "values",
+			elementsYaml: "- name: test\n  values:\n    foo: bar",
+			expected: []map[string]any{
+				{
+					"name":       "test",
+					"values.foo": "bar",
+				},
+			},
+		},
+		{
+			name:         "go template",
+			elementsYaml: "- name: test\n  number: 123\n  values:\n    foo: bar",
+			goTemplate:   true,
+			expected: []map[string]any{
+				{
+					"name":   "test",
+					"number": float64(123),
+					"values": map[string]any{"foo": "bar"},
+				},
+			},
+		},
+		{
+			name:         "nested error",
+			elementsYaml: "- name: test\n  nested: {foo: bar}",
+			expectedErr:  "not supported",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			listGenerator := NewListGenerator()
+
+			applicationSetInfo := argoprojiov1alpha1.ApplicationSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "set",
+				},
+				Spec: argoprojiov1alpha1.ApplicationSetSpec{
+					GoTemplate: testCase.goTemplate,
+				},
+			}
+
+			got, err := listGenerator.GenerateParams(&argoprojiov1alpha1.ApplicationSetGenerator{
+				List: &argoprojiov1alpha1.ListGenerator{
+					ElementsYaml: testCase.elementsYaml,
+				},
+			}, &applicationSetInfo, nil)
+
+			if testCase.expectedErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), testCase.expectedErr)
+			} else {
+				require.NoError(t, err)
+				assert.ElementsMatch(t, testCase.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR fixes a bug in the ApplicationSet controller where List/~~DuckType~~ generators fail or crash if they find nonstring primitive types like bools/integers.


  ### **The Problem**

  With goTemplate disabled (defaults to fast), the generators are performing strict type assertions on values, they expect values to be strings. This causes reconciliation to fail when a  user provide a JSON boolean or number.

  **Root Cause:**

   1. List Generator (applicationset/generators/list.go):
       * Previous Logic ([61-65](https://github.com/argoproj/argo-cd/blob/85a5abb90e57f536423d43a972fabe3488793a83/applicationset/generators/list.go#L61-L65) and [68-72](https://github.com/argoproj/argo-cd/blob/85a5abb90e57f536423d43a972fabe3488793a83/applicationset/generators/list.go#L68-L72)): 
       * Failure: These strict .(string) assertions return an error for bool/int types. Also, the %w was wrapping a nil error, leading to confusing logs.


~~Adjacent issue found during the investigaton~~

   ~~2. DuckType Generator (applicationset/generators/duck_type.go):~~
       ~~* Previous Logic ([167](https://github.com/argoproj/argo-cd/blob/85a5abb90e57f536423d43a972fabe3488793a83/applicationset/generators/duck_type.go#L167))~~
       ~~* Failure: This forces all discovered fields from external resources to be strings, leading to crashes if the resource contained boolean flags like  "isProduction: true" or numeric values. This also broke
         goTemplate: true mode because it strips the original types.~~



  ### **The Fix**

  Changes:
   * List Generator: Updated logic using fmt.Sprintf("%v", value) if goTemplate is disabled. This safely converts all JSON primitives to strings.
   ~~* DuckType Generator: Updated/modified to respect the goTemplate setting. It now keeps original types when goTemplate: true is set (fixing a secondary bug where it would crash on non-strings even in GoTemplate
     mode) and uses fmt.Sprintf for string conversion when it is disabled.~~
     

  ### **Discussion: GoTemplate vs. Fast Template AKA the million dollar question**

  While enabling goTemplate: true would technically ignore the strict string assertion in the List generator, thus invalidating the issue #26974 I believe this PR goes further and is necessary due to:
  
   1. Safer/resilient defaults? goTemplate: false is the default. Users normally expect standard JSON/YAML primitives (like bool for a sync flag) to work without "hacky" workarounds like the one I proposed on the issue.
   ~~2. Fixes DuckType: The DuckType generator was broken even for GoTemplate users, as it was forcing strings and discarding the original types needed for template logic.~~
   3. Consistency: This aligns the generators with how Argo CD handles labels and metadata internally, as far as I could tell reading the code around.

**and finally:**

   * applicationset/generators/list_test.go: I added regression tests for bool and int elements.
   * Verified that all tests in applicationset/generators/... this morning 22-04-2026 and pass with Go 1.26.2.
   *  ~~applicationset/generators/duck_type_test.go: I added regression tests verifying string conversion in standard mode and type preservation in GoTemplate mode.~~

Closes issue: #26974 


### **EDIT: Removed my fix/implementation for ducktype since its being addressed here #27265**