### PR TITLE
feat: add argocd_cluster_events_ignored_total metric

### DIFF
--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -604,6 +604,8 @@ func (c *liveStateCache) getCluster(cluster *appv1.Cluster) (clustercache.Cluste
 		c.lock.RUnlock()
 
 		if cacheSettings.ignoreResourceUpdatesEnabled && oldRes != nil && newRes != nil && skipResourceUpdate(resInfo(oldRes), resInfo(newRes)) {
+			gvk := ref.GroupVersionKind()
+			c.metricsServer.IncClusterEventsIgnoredCount(cluster.Server, gvk.Group, gvk.Kind)
 			// Additional check for debug level so we don't need to evaluate the
 			// format string in case of non-debug scenarios
 			if log.GetLevel() >= log.DebugLevel {

--- a/controller/metrics/metrics.go
+++ b/controller/metrics/metrics.go
@@ -39,6 +39,7 @@ type MetricsServer struct {
 	orphanedResourcesGauge            *prometheus.GaugeVec
 	k8sRequestCounter                 *prometheus.CounterVec
 	clusterEventsCounter              *prometheus.CounterVec
+	clusterEventsIgnoredCounter       *prometheus.CounterVec
 	redisRequestCounter               *prometheus.CounterVec
 	reconcileHistogram                *prometheus.HistogramVec
 	redisRequestHistogram             *prometheus.HistogramVec
@@ -116,6 +117,11 @@ var (
 	clusterEventsCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "argocd_cluster_events_total",
 		Help: "Number of processes k8s resource events.",
+	}, append(descClusterDefaultLabels, "group", "kind"))
+
+	clusterEventsIgnoredCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "argocd_cluster_events_ignored_total",
+		Help: "Number of k8s resource events ignored by ignoreResourceUpdates rules.",
 	}, append(descClusterDefaultLabels, "group", "kind"))
 
 	redisRequestCounter = prometheus.NewCounterVec(
@@ -204,6 +210,7 @@ func NewMetricsServer(addr string, appLister applister.ApplicationLister, appFil
 	registry.MustRegister(orphanedResourcesGauge)
 	registry.MustRegister(reconcileHistogram)
 	registry.MustRegister(clusterEventsCounter)
+	registry.MustRegister(clusterEventsIgnoredCounter)
 	registry.MustRegister(redisRequestCounter)
 	registry.MustRegister(redisRequestHistogram)
 	registry.MustRegister(resourceEventsProcessingHistogram)
@@ -226,6 +233,7 @@ func NewMetricsServer(addr string, appLister applister.ApplicationLister, appFil
 		orphanedResourcesGauge:            orphanedResourcesGauge,
 		reconcileHistogram:                reconcileHistogram,
 		clusterEventsCounter:              clusterEventsCounter,
+		clusterEventsIgnoredCounter:       clusterEventsIgnoredCounter,
 		redisRequestCounter:               redisRequestCounter,
 		redisRequestHistogram:             redisRequestHistogram,
 		resourceEventsProcessingHistogram: resourceEventsProcessingHistogram,
@@ -281,6 +289,11 @@ func (m *MetricsServer) SetOrphanedResourcesMetric(app *argoappv1.Application, n
 // IncClusterEventsCount increments the number of cluster events
 func (m *MetricsServer) IncClusterEventsCount(server, group, kind string) {
 	m.clusterEventsCounter.WithLabelValues(server, group, kind).Inc()
+}
+
+// IncClusterEventsIgnoredCount increments the number of cluster events ignored by ignoreResourceUpdates rules
+func (m *MetricsServer) IncClusterEventsIgnoredCount(server, group, kind string) {
+	m.clusterEventsIgnoredCounter.WithLabelValues(server, group, kind).Inc()
 }
 
 // IncKubernetesRequest increments the kubernetes requests counter for an application
@@ -339,6 +352,7 @@ func (m *MetricsServer) SetExpiration(cacheExpiration time.Duration) error {
 		m.orphanedResourcesGauge.Reset()
 		m.k8sRequestCounter.Reset()
 		m.clusterEventsCounter.Reset()
+		m.clusterEventsIgnoredCounter.Reset()
 		m.redisRequestCounter.Reset()
 		m.reconcileHistogram.Reset()
 		m.redisRequestHistogram.Reset()

--- a/controller/metrics/metrics_test.go
+++ b/controller/metrics/metrics_test.go
@@ -718,7 +718,7 @@ argocd_cluster_events_ignored_total{group="",kind="Pod",server="https://localhos
 	metricsServ.Handler.ServeHTTP(rr, req)
 	assert.Equal(t, http.StatusOK, rr.Code)
 	body := rr.Body.String()
-	log.Println(body)
+	t.Log(body)
 	assertMetricsPrinted(t, expectedMetrics, body)
 }
 

--- a/controller/metrics/metrics_test.go
+++ b/controller/metrics/metrics_test.go
@@ -693,6 +693,35 @@ workqueue_unfinished_work_seconds{controller="test",name="test"}
 	assertMetricsPrinted(t, expectedMetrics, body)
 }
 
+func TestMetricsClusterEventsIgnored(t *testing.T) {
+	cancel, appLister := newFakeLister(t.Context())
+	defer cancel()
+	mockDB := mocks.NewArgoDB(t)
+	metricsServ, err := NewMetricsServer("localhost:8082", appLister, appFilter, noOpHealthCheck, []string{}, []string{}, mockDB)
+	require.NoError(t, err)
+
+	expectedMetrics := `
+# HELP argocd_cluster_events_ignored_total Number of k8s resource events ignored by ignoreResourceUpdates rules.
+# TYPE argocd_cluster_events_ignored_total counter
+argocd_cluster_events_ignored_total{group="apps",kind="Deployment",server="https://localhost:6443"} 3
+argocd_cluster_events_ignored_total{group="",kind="Pod",server="https://localhost:6443"} 1
+`
+
+	metricsServ.IncClusterEventsIgnoredCount("https://localhost:6443", "apps", "Deployment")
+	metricsServ.IncClusterEventsIgnoredCount("https://localhost:6443", "apps", "Deployment")
+	metricsServ.IncClusterEventsIgnoredCount("https://localhost:6443", "apps", "Deployment")
+	metricsServ.IncClusterEventsIgnoredCount("https://localhost:6443", "", "Pod")
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/metrics", http.NoBody)
+	require.NoError(t, err)
+	rr := httptest.NewRecorder()
+	metricsServ.Handler.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code)
+	body := rr.Body.String()
+	log.Println(body)
+	assertMetricsPrinted(t, expectedMetrics, body)
+}
+
 func TestGoMetrics(t *testing.T) {
 	cancel, appLister := newFakeLister(t.Context())
 	defer cancel()

--- a/docs/operator-manual/metrics.md
+++ b/docs/operator-manual/metrics.md
@@ -21,6 +21,7 @@ Metrics about applications. Scraped at the `argocd-metrics:8082/metrics` endpoin
 | `argocd_cluster_cache_age_seconds`                |   gauge   | Cluster cache age in seconds.                                                                                                               |
 | `argocd_cluster_connection_status`                |   gauge   | The k8s cluster current connection status.                                                                                                  |
 | `argocd_cluster_events_total`                     |  counter  | Number of processes k8s resource events.                                                                                                    |
+| `argocd_cluster_events_ignored_total`             |  counter  | Number of k8s resource events ignored by `ignoreResourceUpdates` rules.                                                                     |
 | `argocd_cluster_info`                             |   gauge   | Information about cluster.                                                                                                                  |
 | `argocd_redis_request_duration`                   | histogram | Redis requests duration.                                                                                                                    |
 | `argocd_redis_request_total`                      |  counter  | Number of redis requests executed during application reconciliation                                                                         |


### PR DESCRIPTION
Closes #27519

## Description

Adds a Prometheus counter `argocd_cluster_events_ignored_total` that tracks k8s resource events
filtered by `ignoreResourceUpdates` rules. This enables operators to measure rule effectiveness
without debug logging (which increases log volume 8-17x at scale).

Uses the same labels (`server`, `group`, `kind`) as the existing `argocd_cluster_events_total`.

## Checklist

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/27519) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.