### PR TITLE
fix: keep cluster sync alive when a namespace is deleted or restricted

### DIFF
--- a/controller/clusterinfoupdater.go
+++ b/controller/clusterinfoupdater.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/argoproj/argo-cd/v3/common"
@@ -156,6 +157,9 @@ func (c *clusterInfoUpdater) getUpdatedClusterInfo(ctx context.Context, apps []*
 			clusterInfo.CacheInfo.LastCacheSyncTime = &syncTime
 			clusterInfo.CacheInfo.APIsCount = int64(info.APIsCount)
 			clusterInfo.CacheInfo.ResourcesCount = int64(info.ResourcesCount)
+			if len(info.SyncWarnings) > 0 {
+				clusterInfo.ConnectionState.Message = strings.Join(info.SyncWarnings, "; ")
+			}
 		default:
 			clusterInfo.ConnectionState.Status = appv1.ConnectionStatusFailed
 			clusterInfo.ConnectionState.Message = info.SyncError.Error()

--- a/controller/clusterinfoupdater_test.go
+++ b/controller/clusterinfoupdater_test.go
@@ -216,6 +216,42 @@ func TestGetUpdatedClusterInfo_AmbiguousName(t *testing.T) {
 	assert.Equal(t, int64(0), info.ApplicationsCount, "ambiguous name should not count app")
 }
 
+func TestGetUpdatedClusterInfo_SyncWarnings(t *testing.T) {
+	now := time.Now()
+	warnings := []string{
+		`namespace "deleted-ns": cannot list Pod (skipped): forbidden`,
+	}
+	info := &clustercache.ClusterInfo{
+		K8SVersion:        "1.28",
+		LastCacheSyncTime: &now,
+		SyncWarnings:      warnings,
+	}
+
+	updater := &clusterInfoUpdater{namespace: "fake-ns"}
+	cluster := v1alpha1.Cluster{Server: "https://example.com"}
+
+	clusterInfo := updater.getUpdatedClusterInfo(t.Context(), nil, cluster, info, metav1.Now())
+
+	assert.Equal(t, v1alpha1.ConnectionStatusSuccessful, clusterInfo.ConnectionState.Status)
+	assert.Contains(t, clusterInfo.ConnectionState.Message, "deleted-ns")
+}
+
+func TestGetUpdatedClusterInfo_NoSyncWarnings(t *testing.T) {
+	now := time.Now()
+	info := &clustercache.ClusterInfo{
+		K8SVersion:        "1.28",
+		LastCacheSyncTime: &now,
+	}
+
+	updater := &clusterInfoUpdater{namespace: "fake-ns"}
+	cluster := v1alpha1.Cluster{Server: "https://example.com"}
+
+	clusterInfo := updater.getUpdatedClusterInfo(t.Context(), nil, cluster, info, metav1.Now())
+
+	assert.Equal(t, v1alpha1.ConnectionStatusSuccessful, clusterInfo.ConnectionState.Status)
+	assert.Empty(t, clusterInfo.ConnectionState.Message)
+}
+
 func TestUpdateClusterLabels(t *testing.T) {
 	shouldNotBeInvoked := func(_ context.Context, _ *v1alpha1.Cluster) (*v1alpha1.Cluster, error) {
 		shouldNotHappen := errors.New("if an error happens here, something's wrong")

--- a/docs/operator-manual/declarative-setup.md
+++ b/docs/operator-manual/declarative-setup.md
@@ -604,6 +604,12 @@ disableCompression: boolean
 > To resolve this issue, you can increase the `ARGOCD_K8S_CLIENT_MAX_IDLE_CONNECTIONS` environment variable in the
 > Application controller.
 
+> [!NOTE]
+> If a namespace listed in `namespaces` is deleted or loses its RBAC grants, cluster cache sync still succeeds.
+> Inaccessible namespaces are skipped and a warning appears on the cluster connection message
+> (`argocd cluster list` → `MESSAGE` column). The remaining namespaces keep syncing normally. Skipped
+> namespaces are retried on the next full cache resync or when the cache is manually invalidated.
+
 > [!IMPORTANT]
 > Note that if you specify a command to run under `execProviderConfig`, that command must be available in the Argo CD image. See [BYOI (Build Your Own Image)](custom_tools.md#byoi-build-your-own-image).
 

--- a/gitops-engine/pkg/cache/cluster.go
+++ b/gitops-engine/pkg/cache/cluster.go
@@ -26,6 +26,7 @@ package cache
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"runtime/debug"
 	"slices"
@@ -91,6 +92,11 @@ const (
 	// RespectRbacStrict checks both api response for forbidden/unauthorized errors and SelfSubjectAccessReview
 	RespectRbacStrict
 )
+
+// errSkipNamespace is returned by a processApi callback to signal that the
+// current (GVK, namespace) pair should be skipped and iteration should
+// continue with the next namespace.
+var errSkipNamespace = errors.New("skip namespace: inaccessible (GVK, namespace) pair")
 
 // callState tracks whether action() has been called on a resource during hierarchy iteration.
 type callState int
@@ -285,6 +291,11 @@ type clusterCache struct {
 	// Using a set eliminates O(k) duplicate checking on insertions
 	// Used for cross-namespace hierarchy traversal; namespaced traversal still builds a graph
 	parentUIDToChildren map[types.UID]map[kube.ResourceKey]struct{}
+
+	// syncWarnings accumulates per-sync, operator-facing warnings (e.g. skipped inaccessible (GVK,ns) pairs).
+	// Reset at the start of each sync; written concurrently by GVK goroutines, so guarded by syncWarningsLock.
+	syncWarnings     []string
+	syncWarningsLock sync.Mutex
 }
 
 type clusterCacheSync struct {
@@ -1078,6 +1089,51 @@ func (c *clusterCache) checkPermission(ctx context.Context, reviewInterface auth
 	// checkPermission follows the same logic of determining namespace/cluster resource as the processApi function
 	// so if neither of the cases match it means the controller will not watch for it so it is safe to return true.
 	return true, nil
+}
+
+// checkNamespacePermission runs a self subject access review for a specific (GVK, namespace) pair
+// to check if the controller has permission to list the resource in that namespace.
+func (c *clusterCache) checkNamespacePermission(ctx context.Context, reviewInterface authType1.SelfSubjectAccessReviewInterface, api kube.APIResourceInfo, namespace string) (bool, error) {
+	sar := &authorizationv1.SelfSubjectAccessReview{
+		Spec: authorizationv1.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: &authorizationv1.ResourceAttributes{
+				Namespace: namespace,
+				Verb:      "list",
+				Group:     api.GroupVersionResource.Group,
+				Resource:  api.GroupVersionResource.Resource,
+			},
+		},
+	}
+	resp, err := reviewInterface.Create(ctx, sar, metav1.CreateOptions{})
+	if err != nil {
+		return false, fmt.Errorf("failed to create self subject access review: %w", err)
+	}
+	return resp != nil && resp.Status.Allowed, nil
+}
+
+func (c *clusterCache) recordSyncWarning(msg string) {
+	c.syncWarningsLock.Lock()
+	defer c.syncWarningsLock.Unlock()
+	c.syncWarnings = append(c.syncWarnings, msg)
+}
+
+// handleNamespacedListError classifies a list error for a (GVK, namespace) pair using SSAR.
+// If the error is not a 403 Forbidden, it is returned as-is.
+// If it is Forbidden and SSAR confirms no access, errSkipNamespace is returned and a warning is recorded.
+// If it is Forbidden but SSAR confirms access, the original error is returned (genuine/transient 403).
+func (c *clusterCache) handleNamespacedListError(ctx context.Context, reviewInterface authType1.SelfSubjectAccessReviewInterface, api kube.APIResourceInfo, namespace string, listErr error) error {
+	if !apierrors.IsForbidden(listErr) {
+		return listErr
+	}
+	allowed, err := c.checkNamespacePermission(ctx, reviewInterface, api, namespace)
+	if err != nil {
+		return fmt.Errorf("failed to verify access to %s in namespace %q: %w, original error=%v", api.GroupKind, namespace, err, listErr)
+	}
+	if allowed {
+		return listErr
+	}
+	c.recordSyncWarning(fmt.Sprintf("namespace %q: cannot list %s (skipped): %v", namespace, api.GroupKind, listErr))
+	return errSkipNamespace
 }
 
 // sync retrieves the current state of the cluster and stores relevant information in the clusterCache fields.

--- a/gitops-engine/pkg/cache/cluster.go
+++ b/gitops-engine/pkg/cache/cluster.go
@@ -30,6 +30,7 @@ import (
 	"fmt"
 	"runtime/debug"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -296,10 +297,11 @@ type clusterCache struct {
 	// Used for cross-namespace hierarchy traversal; namespaced traversal still builds a graph
 	parentUIDToChildren map[types.UID]map[kube.ResourceKey]struct{}
 
-	// syncWarnings accumulates per-sync, operator-facing warnings (e.g. skipped inaccessible (GVK,ns) pairs).
-	// Reset at the start of each sync; written concurrently by GVK goroutines, so guarded by syncWarningsLock.
-	syncWarnings     []string
-	syncWarningsLock sync.Mutex
+	// syncSkippedNs tracks namespaces where resource listing was denied during sync.
+	// Idempotent: re-skipping the same (GVK, ns) is a no-op.
+	// Reset at the start of each sync; written concurrently by GVK goroutines, so guarded by syncSkippedNsLock.
+	syncSkippedNs     map[string]map[schema.GroupKind]struct{}
+	syncSkippedNsLock sync.Mutex
 }
 
 type clusterCacheSync struct {
@@ -1138,10 +1140,47 @@ func (c *clusterCache) checkNamespacePermission(ctx context.Context, reviewInter
 	return resp != nil && resp.Status.Allowed, nil
 }
 
-func (c *clusterCache) recordSyncWarning(msg string) {
-	c.syncWarningsLock.Lock()
-	defer c.syncWarningsLock.Unlock()
-	c.syncWarnings = append(c.syncWarnings, msg)
+func (c *clusterCache) recordSkippedNamespace(ns string, gk schema.GroupKind) {
+	c.syncSkippedNsLock.Lock()
+	defer c.syncSkippedNsLock.Unlock()
+	if c.syncSkippedNs[ns] == nil {
+		c.syncSkippedNs[ns] = make(map[schema.GroupKind]struct{})
+	}
+	c.syncSkippedNs[ns][gk] = struct{}{}
+}
+
+// renderSkippedNamespaces collapses the per-(namespace, GroupKind) skip set into
+// one warning string per namespace, sorted deterministically.
+func renderSkippedNamespaces(skipped map[string]map[schema.GroupKind]struct{}) []string {
+	if len(skipped) == 0 {
+		return nil
+	}
+	namespaces := make([]string, 0, len(skipped))
+	for ns := range skipped {
+		namespaces = append(namespaces, ns)
+	}
+	slices.Sort(namespaces)
+
+	warnings := make([]string, 0, len(namespaces))
+	for _, ns := range namespaces {
+		gks := skipped[ns]
+		count := len(gks)
+		if count == 0 {
+			continue
+		}
+
+		if count <= 5 {
+			names := make([]string, 0, count)
+			for gk := range gks {
+				names = append(names, gk.String())
+			}
+			slices.Sort(names)
+			warnings = append(warnings, fmt.Sprintf("namespace %q: skipped, inaccessible (%s)", ns, strings.Join(names, ", ")))
+		} else {
+			warnings = append(warnings, fmt.Sprintf("namespace %q: skipped, inaccessible (%d resource types). If deleted, remove from cluster secret.", ns, count))
+		}
+	}
+	return warnings
 }
 
 // handleNamespacedListError classifies a list error for a (GVK, namespace) pair.
@@ -1158,7 +1197,8 @@ func (c *clusterCache) handleNamespacedListError(ctx context.Context, reviewInte
 	if allowed {
 		return listErr
 	}
-	c.recordSyncWarning(fmt.Sprintf("namespace %q: cannot list %s (skipped): %v", namespace, api.GroupKind, listErr))
+	c.log.V(1).Info("Skipping inaccessible resource in namespace", "namespace", namespace, "groupKind", api.GroupKind, "error", listErr)
+	c.recordSkippedNamespace(namespace, api.GroupKind)
 	return errSkipNamespace
 }
 
@@ -1224,7 +1264,9 @@ func (c *clusterCache) sync() (err error) {
 	c.namespacedResources = make(map[schema.GroupKind]bool)
 	c.parentUIDToChildren = make(map[types.UID]map[kube.ResourceKey]struct{})
 	syncLock.Unlock()
-	c.syncWarnings = nil
+	c.syncSkippedNsLock.Lock()
+	c.syncSkippedNs = make(map[string]map[schema.GroupKind]struct{})
+	c.syncSkippedNsLock.Unlock()
 	config := c.config
 	version, err := c.kubectl.GetServerVersion(config)
 	if err != nil {
@@ -1882,9 +1924,9 @@ func (c *clusterCache) GetClusterInfo() ClusterInfo {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 
-	c.syncWarningsLock.Lock()
-	warnings := append([]string(nil), c.syncWarnings...)
-	c.syncWarningsLock.Unlock()
+	c.syncSkippedNsLock.Lock()
+	warnings := renderSkippedNamespaces(c.syncSkippedNs)
+	c.syncSkippedNsLock.Unlock()
 
 	c.syncStatus.lock.Lock()
 	defer c.syncStatus.lock.Unlock()

--- a/gitops-engine/pkg/cache/cluster.go
+++ b/gitops-engine/pkg/cache/cluster.go
@@ -135,6 +135,8 @@ type ClusterInfo struct {
 	SyncError error
 	// APIResources holds list of API resources supported by the cluster
 	APIResources []kube.APIResourceInfo
+	// SyncWarnings holds warnings from the most recent sync (e.g. inaccessible namespaces)
+	SyncWarnings []string
 }
 
 // OnEventHandler is a function that handles Kubernetes event
@@ -268,9 +270,11 @@ type clusterCache struct {
 	resources map[kube.ResourceKey]*Resource
 	nsIndex   map[string]map[kube.ResourceKey]*Resource
 
-	kubectl          kube.Kubectl
-	log              logr.Logger
-	config           *rest.Config
+	kubectl kube.Kubectl
+	log     logr.Logger
+	config  *rest.Config
+	// clientset, when set, overrides the kubernetes clientset built from config (injectable for tests/SSAR).
+	clientset        kubernetes.Interface
 	namespaces       []string
 	clusterResources bool
 	settings         Settings
@@ -674,9 +678,9 @@ func (c *clusterCache) startMissingWatches() error {
 	if err != nil {
 		return fmt.Errorf("failed to create client: %w", err)
 	}
-	clientset, err := kubernetes.NewForConfig(c.config)
+	clientset, err := c.resolveClientset()
 	if err != nil {
-		return fmt.Errorf("failed to create clientset: %w", err)
+		return err
 	}
 	namespacedResources := make(map[schema.GroupKind]bool)
 	for i := range apis {
@@ -685,30 +689,49 @@ func (c *clusterCache) startMissingWatches() error {
 		if _, ok := c.apisMeta[api.GroupKind]; !ok {
 			ctx, cancel := context.WithCancel(context.Background())
 			c.apisMeta[api.GroupKind] = &apiMeta{namespaced: api.Meta.Namespaced, watchCancel: cancel}
+			watchStarted := false
 
 			err := c.processApi(client, api, func(resClient dynamic.ResourceInterface, ns string) error {
 				resourceVersion, err := c.loadInitialState(ctx, api, resClient, ns, false) // don't lock here, we are already in a lock before startMissingWatches is called inside watchEvents
-				if err != nil && c.isRestrictedResource(err) {
-					keep := false
-					if c.respectRBAC == RespectRbacStrict {
-						k, permErr := c.checkPermission(ctx, clientset.AuthorizationV1().SelfSubjectAccessReviews(), api)
-						if permErr != nil {
-							return fmt.Errorf("failed to check permissions for resource %s: %w, original error=%v", api.GroupKind.String(), permErr, err.Error())
+				if err != nil {
+					if ns != "" && apierrors.IsForbidden(err) {
+						skipErr := c.handleNamespacedListError(ctx, clientset.AuthorizationV1().SelfSubjectAccessReviews(), api, ns, err)
+						if errors.Is(skipErr, errSkipNamespace) {
+							return errSkipNamespace
 						}
-						keep = k
+						if skipErr != nil && skipErr != err {
+							return skipErr
+						}
 					}
-					// if we are not allowed to list the resource, remove it from the watch list
-					if !keep {
-						delete(c.apisMeta, api.GroupKind)
-						delete(namespacedResources, api.GroupKind)
-						return nil
+					// SSAR says allowed: not a namespace-level denial, let isRestrictedResource decide.
+					if c.isRestrictedResource(err) {
+						keep := false
+						if c.respectRBAC == RespectRbacStrict {
+							k, permErr := c.checkPermission(ctx, clientset.AuthorizationV1().SelfSubjectAccessReviews(), api)
+							if permErr != nil {
+								return fmt.Errorf("failed to check permissions for resource %s: %w, original error=%v", api.GroupKind.String(), permErr, err.Error())
+							}
+							keep = k
+						}
+						// if we are not allowed to list the resource, remove it from the watch list
+						if !keep {
+							delete(c.apisMeta, api.GroupKind)
+							delete(namespacedResources, api.GroupKind)
+							return nil
+						}
 					}
 				}
+				watchStarted = true
 				go c.watchEvents(ctx, api, resClient, ns, resourceVersion)
 				return nil
 			})
 			if err != nil {
 				return err
+			}
+			if !watchStarted {
+				cancel()
+				delete(c.apisMeta, api.GroupKind)
+				delete(namespacedResources, api.GroupKind)
 			}
 		}
 	}
@@ -1023,6 +1046,7 @@ func isAPIServiceAvailable(obj *unstructured.Unstructured) bool {
 // processApi processes all the resources for a given API. First we construct an API client for the given API. Then we
 // call the callback. If we're managing the whole cluster, we call the callback with the client and an empty namespace.
 // If we're managing specific namespaces, we call the callback for each namespace.
+// The callback may return errSkipNamespace to skip the current namespace and continue with the next one.
 func (c *clusterCache) processApi(client dynamic.Interface, api kube.APIResourceInfo, callback func(resClient dynamic.ResourceInterface, ns string) error) error {
 	resClient := client.Resource(api.GroupVersionResource)
 	switch {
@@ -1033,6 +1057,9 @@ func (c *clusterCache) processApi(client dynamic.Interface, api kube.APIResource
 	case len(c.namespaces) != 0 && api.Meta.Namespaced:
 		for _, ns := range c.namespaces {
 			err := callback(resClient.Namespace(ns), ns)
+			if errors.Is(err, errSkipNamespace) {
+				continue
+			}
 			if err != nil {
 				return err
 			}
@@ -1136,6 +1163,17 @@ func (c *clusterCache) handleNamespacedListError(ctx context.Context, reviewInte
 	return errSkipNamespace
 }
 
+func (c *clusterCache) resolveClientset() (kubernetes.Interface, error) {
+	if c.clientset != nil {
+		return c.clientset, nil
+	}
+	cs, err := kubernetes.NewForConfig(c.config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create clientset: %w", err)
+	}
+	return cs, nil
+}
+
 // sync retrieves the current state of the cluster and stores relevant information in the clusterCache fields.
 //
 // First we get some metadata from the cluster, like the server version, OpenAPI document, and the list of all API
@@ -1187,6 +1225,7 @@ func (c *clusterCache) sync() (err error) {
 	c.namespacedResources = make(map[schema.GroupKind]bool)
 	c.parentUIDToChildren = make(map[types.UID]map[kube.ResourceKey]struct{})
 	syncLock.Unlock()
+	c.syncWarnings = nil
 	config := c.config
 	version, err := c.kubectl.GetServerVersion(config)
 	if err != nil {
@@ -1218,9 +1257,9 @@ func (c *clusterCache) sync() (err error) {
 	if err != nil {
 		return fmt.Errorf("failed to create client: %w", err)
 	}
-	clientset, err := kubernetes.NewForConfig(config)
+	clientset, err := c.resolveClientset()
 	if err != nil {
-		return fmt.Errorf("failed to create clientset: %w", err)
+		return err
 	}
 
 	if c.batchEventsProcessing {
@@ -1237,8 +1276,9 @@ func (c *clusterCache) sync() (err error) {
 		c.apisMeta[api.GroupKind] = info
 		c.namespacedResources[api.GroupKind] = api.Meta.Namespaced
 		syncLock.Unlock()
+		watchStarted := false
 
-		return c.processApi(client, api, func(resClient dynamic.ResourceInterface, ns string) error {
+		err := c.processApi(client, api, func(resClient dynamic.ResourceInterface, ns string) error {
 			resourceVersion, err := c.listResources(ctx, resClient, func(listPager *pager.ListPager) error {
 				return listPager.EachListItem(context.Background(), metav1.ListOptions{}, func(obj runtime.Object) error {
 					if un, ok := obj.(*unstructured.Unstructured); !ok {
@@ -1253,6 +1293,16 @@ func (c *clusterCache) sync() (err error) {
 				})
 			})
 			if err != nil {
+				if ns != "" && apierrors.IsForbidden(err) {
+					skipErr := c.handleNamespacedListError(ctx, clientset.AuthorizationV1().SelfSubjectAccessReviews(), api, ns, err)
+					if errors.Is(skipErr, errSkipNamespace) {
+						return errSkipNamespace
+					}
+					if skipErr != nil && skipErr != err {
+						return skipErr
+					}
+				}
+				// SSAR says allowed: not a namespace-level denial, let isRestrictedResource decide
 				if c.isRestrictedResource(err) {
 					keep := false
 					if c.respectRBAC == RespectRbacStrict {
@@ -1274,10 +1324,19 @@ func (c *clusterCache) sync() (err error) {
 				return fmt.Errorf("failed to load initial state of resource %s: %w", api.GroupKind.String(), err)
 			}
 
+			watchStarted = true
 			go c.watchEvents(ctx, api, resClient, ns, resourceVersion)
 
 			return nil
 		})
+		if !watchStarted && err == nil {
+			cancel()
+			syncLock.Lock()
+			delete(c.apisMeta, api.GroupKind)
+			delete(c.namespacedResources, api.GroupKind)
+			syncLock.Unlock()
+		}
+		return err
 	})
 	if err != nil {
 		return fmt.Errorf("failed to sync cluster %s: %w", c.config.Host, err)
@@ -1826,6 +1885,9 @@ func (c *clusterCache) GetClusterInfo() ClusterInfo {
 	c.syncStatus.lock.Lock()
 	defer c.syncStatus.lock.Unlock()
 
+	c.syncWarningsLock.Lock()
+	warnings := append([]string(nil), c.syncWarnings...)
+	c.syncWarningsLock.Unlock()
 	return ClusterInfo{
 		APIsCount:         len(c.apisMeta),
 		K8SVersion:        c.serverVersion,
@@ -1834,6 +1896,7 @@ func (c *clusterCache) GetClusterInfo() ClusterInfo {
 		LastCacheSyncTime: c.syncStatus.syncTime,
 		SyncError:         c.syncStatus.syncError,
 		APIResources:      c.apiResources,
+		SyncWarnings:      warnings,
 	}
 }
 

--- a/gitops-engine/pkg/cache/cluster.go
+++ b/gitops-engine/pkg/cache/cluster.go
@@ -1137,7 +1137,13 @@ func (c *clusterCache) checkNamespacePermission(ctx context.Context, reviewInter
 	if err != nil {
 		return false, fmt.Errorf("failed to create self subject access review: %w", err)
 	}
-	return resp != nil && resp.Status.Allowed, nil
+	if resp == nil {
+		return false, fmt.Errorf("SSAR returned nil response for %s in namespace %q", api.GroupKind, namespace)
+	}
+	if resp.Status.Allowed {
+		return true, nil
+	}
+	return false, nil
 }
 
 func (c *clusterCache) recordSkippedNamespace(ns string, gk schema.GroupKind) {

--- a/gitops-engine/pkg/cache/cluster.go
+++ b/gitops-engine/pkg/cache/cluster.go
@@ -1144,10 +1144,9 @@ func (c *clusterCache) recordSyncWarning(msg string) {
 	c.syncWarnings = append(c.syncWarnings, msg)
 }
 
-// handleNamespacedListError classifies a list error for a (GVK, namespace) pair using SSAR.
-// If the error is not a 403 Forbidden, it is returned as-is.
-// If it is Forbidden and SSAR confirms no access, errSkipNamespace is returned and a warning is recorded.
-// If it is Forbidden but SSAR confirms access, the original error is returned (genuine/transient 403).
+// handleNamespacedListError classifies a list error for a (GVK, namespace) pair.
+// Forbidden → SSAR disambiguates: denied = skip with warning, allowed = propagate (genuine 403).
+// Anything else → propagate as-is.
 func (c *clusterCache) handleNamespacedListError(ctx context.Context, reviewInterface authType1.SelfSubjectAccessReviewInterface, api kube.APIResourceInfo, namespace string, listErr error) error {
 	if !apierrors.IsForbidden(listErr) {
 		return listErr
@@ -1882,12 +1881,13 @@ var ignoredRefreshResources = map[string]bool{
 func (c *clusterCache) GetClusterInfo() ClusterInfo {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	c.syncStatus.lock.Lock()
-	defer c.syncStatus.lock.Unlock()
 
 	c.syncWarningsLock.Lock()
 	warnings := append([]string(nil), c.syncWarnings...)
 	c.syncWarningsLock.Unlock()
+
+	c.syncStatus.lock.Lock()
+	defer c.syncStatus.lock.Unlock()
 	return ClusterInfo{
 		APIsCount:         len(c.apisMeta),
 		K8SVersion:        c.serverVersion,

--- a/gitops-engine/pkg/cache/cluster_test.go
+++ b/gitops-engine/pkg/cache/cluster_test.go
@@ -2866,9 +2866,6 @@ func BenchmarkIncrementalIndexBuild(b *testing.B) {
 }
 
 func TestSync_DeletedNamespace_DoesNotBlockSync(t *testing.T) {
-	// Arrange: cluster with a valid namespace and a deleted one.
-	// A deleted namespace returns 403 for every GVK (RoleBindings GC'd with the ns).
-	// SSAR denies every (GVK, deleted-ns) pair — the authoritative confirmation.
 	deletedNamespace := "deleted-ns"
 	validNamespace := "default"
 
@@ -2888,6 +2885,7 @@ func TestSync_DeletedNamespace_DoesNotBlockSync(t *testing.T) {
 	kubeFake.PrependReactor("create", "selfsubjectaccessreviews", func(action testcore.Action) (bool, runtime.Object, error) {
 		sar := action.(testcore.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
 		sar.Status.Allowed = false
+		sar.Status.Denied = true
 		return true, sar, nil
 	})
 
@@ -2928,6 +2926,7 @@ func TestCheckNamespacePermission_Denied(t *testing.T) {
 	kubeFake.PrependReactor("create", "selfsubjectaccessreviews", func(action testcore.Action) (bool, runtime.Object, error) {
 		sar := action.(testcore.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
 		sar.Status.Allowed = false
+		sar.Status.Denied = true
 		return true, sar, nil
 	})
 
@@ -2944,6 +2943,33 @@ func TestCheckNamespacePermission_Denied(t *testing.T) {
 	allowed, err := c.checkNamespacePermission(context.Background(), kubeFake.AuthorizationV1().SelfSubjectAccessReviews(), api, "restricted-ns")
 
 	require.NoError(t, err)
+	assert.False(t, allowed)
+}
+
+func TestCheckNamespacePermission_NoOpinionTreatedAsDenied(t *testing.T) {
+	kubeFake := kubefake.NewSimpleClientset()
+	kubeFake.PrependReactor("create", "selfsubjectaccessreviews", func(action testcore.Action) (bool, runtime.Object, error) {
+		sar := action.(testcore.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
+		// Neither Allowed nor Denied, e.g. a deleted namespace where the
+		// Role was garbage-collected and no deny rule exists.
+		sar.Status.Allowed = false
+		sar.Status.Denied = false
+		return true, sar, nil
+	})
+
+	api := kube.APIResourceInfo{
+		GroupVersionResource: schema.GroupVersionResource{
+			Group:    "apps",
+			Version:  "v1",
+			Resource: "deployments",
+		},
+		Meta: metav1.APIResource{Namespaced: true},
+	}
+
+	c := &clusterCache{}
+	allowed, err := c.checkNamespacePermission(context.Background(), kubeFake.AuthorizationV1().SelfSubjectAccessReviews(), api, "ambiguous-ns")
+
+	require.NoError(t, err, "no opinion should be treated as denied, not as an error")
 	assert.False(t, allowed)
 }
 
@@ -3030,6 +3056,7 @@ func TestHandleNamespacedListError(t *testing.T) {
 		name           string
 		listErr        error
 		ssarAllowed    bool
+		ssarDenied     bool
 		ssarReactorErr error
 		wantErr        error
 		wantWarning    string
@@ -3039,6 +3066,7 @@ func TestHandleNamespacedListError(t *testing.T) {
 			name:         "forbidden + SSAR denied → skip namespace with warning",
 			listErr:      forbiddenErr,
 			ssarAllowed:  false,
+			ssarDenied:   true,
 			wantErr:      errSkipNamespace,
 			wantWarning:  "cannot list",
 			wantSSARCall: true,
@@ -3080,6 +3108,7 @@ func TestHandleNamespacedListError(t *testing.T) {
 				}
 				sar := action.(testcore.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
 				sar.Status.Allowed = tc.ssarAllowed
+				sar.Status.Denied = tc.ssarDenied
 				return true, sar, nil
 			})
 
@@ -3118,9 +3147,6 @@ func TestHandleNamespacedListError(t *testing.T) {
 }
 
 func TestSync_RestrictedGVK_SkipsOnlyThatPair(t *testing.T) {
-	// SSAR denial is group-specific: deny requires Group=="apps" AND Resource=="deployments" AND Namespace=="restricted-ns",
-	// so an implementation that drops the Group and matches resource name only would wrongly get "allowed" and fail.
-
 	restrictedPod := testPod1()
 	restrictedPod.SetNamespace("restricted-ns")
 	restrictedPod.SetName("pod-in-restricted-ns")
@@ -3140,7 +3166,9 @@ func TestSync_RestrictedGVK_SkipsOnlyThatPair(t *testing.T) {
 	kubeFake.PrependReactor("create", "selfsubjectaccessreviews", func(action testcore.Action) (bool, runtime.Object, error) {
 		sar := action.(testcore.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
 		ra := sar.Spec.ResourceAttributes
-		sar.Status.Allowed = !(ra.Group == "apps" && ra.Resource == "deployments" && ra.Namespace == "restricted-ns")
+		denied := ra.Group == "apps" && ra.Resource == "deployments" && ra.Namespace == "restricted-ns"
+		sar.Status.Allowed = !denied
+		sar.Status.Denied = denied
 		return true, sar, nil
 	})
 
@@ -3178,8 +3206,6 @@ func TestSync_RestrictedGVK_SkipsOnlyThatPair(t *testing.T) {
 }
 
 func TestSync_ForbiddenWithSSARAllowed_FailsSync(t *testing.T) {
-	// This is the "transient/genuine failure" row of the disambiguation table:
-	// the original error must propagate and sync must fail (fail-fast preserved).
 	pod := testPod1()
 
 	kubeFake := kubefake.NewSimpleClientset()
@@ -3206,7 +3232,7 @@ func TestSync_ForbiddenWithSSARAllowed_FailsSync(t *testing.T) {
 	err := cluster.sync()
 
 	require.Error(t, err)
-	// The propagated error must be the original 403 Forbidden (not some other failure).
+	// The propagated error must be the original 403 Forbidden
 	assert.True(t, apierrors.IsForbidden(err), "the original 403 Forbidden must propagate")
 
 	assert.Empty(t, cluster.GetClusterInfo().SyncWarnings)
@@ -3228,14 +3254,16 @@ func TestStartMissingWatches_InaccessibleNamespace_Skips(t *testing.T) {
 	kubeFake.PrependReactor("create", "selfsubjectaccessreviews", func(action testcore.Action) (bool, runtime.Object, error) {
 		sar := action.(testcore.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
 		ra := sar.Spec.ResourceAttributes
-		sar.Status.Allowed = !(ra != nil && ra.Resource == "pods" && ra.Namespace == "default")
+		denied := ra != nil && ra.Resource == "pods" && ra.Namespace == "default"
+		sar.Status.Allowed = !denied
+		sar.Status.Denied = denied
 		return true, sar, nil
 	})
 
 	cluster := newClusterWithOptions(t, []UpdateSettingsFunc{setClientset(kubeFake)}, pod)
 	cluster.namespaces = []string{"default"}
 
-	// Initial clean sync (no 403 yet — populates apisMeta).
+	// Initial clean sync populates apisMeta, no 403 yet
 	require.NoError(t, cluster.EnsureSynced())
 
 	// Make Pods "missing": stopWatching removes apisMeta[gk].
@@ -3273,44 +3301,6 @@ func TestStartMissingWatches_InaccessibleNamespace_Skips(t *testing.T) {
 	assert.True(t, ssarConsulted, "startMissingWatches must consult SSAR before skipping a forbidden (GVK, namespace) pair")
 }
 
-func TestSync_SyncWarnings_AggregatesAcrossNamespaces(t *testing.T) {
-	pod := testPod1()
-
-	kubeFake := kubefake.NewSimpleClientset()
-	kubeFake.PrependReactor("create", "selfsubjectaccessreviews", func(action testcore.Action) (bool, runtime.Object, error) {
-		sar := action.(testcore.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
-		ra := sar.Spec.ResourceAttributes
-		sar.Status.Allowed = !(ra != nil && (ra.Namespace == "ns-a" || ra.Namespace == "ns-b"))
-		return true, sar, nil
-	})
-
-	cluster := newClusterWithOptions(t, []UpdateSettingsFunc{setClientset(kubeFake)}, pod)
-	cluster.namespaces = []string{"default", "ns-a", "ns-b"}
-
-	fakeClient := cluster.kubectl.(*kubetest.MockKubectlCmd).DynamicClient.(*fake.FakeDynamicClient)
-	fakeClient.PrependReactor("list", "*", func(action testcore.Action) (bool, runtime.Object, error) {
-		ns := action.GetNamespace()
-		if ns == "ns-a" || ns == "ns-b" {
-			return true, nil, apierrors.NewForbidden(
-				schema.GroupResource{Resource: action.GetResource().Resource}, "",
-				fmt.Errorf("namespace %q not found", ns),
-			)
-		}
-		return false, nil, nil
-	})
-
-	err := cluster.sync()
-
-	require.NoError(t, err)
-	_, ok := cluster.resources[getResourceKey(t, pod)]
-	assert.True(t, ok, "default pod should be cached")
-
-	joined := strings.Join(cluster.GetClusterInfo().SyncWarnings, "; ")
-	assert.Contains(t, joined, "ns-a", "warnings should mention ns-a")
-	assert.Contains(t, joined, "ns-b", "warnings should mention ns-b")
-	assert.GreaterOrEqual(t, len(cluster.GetClusterInfo().SyncWarnings), 2, "warnings should aggregate across skipped pairs")
-}
-
 func TestSync_SyncWarnings_ResetBetweenSyncs(t *testing.T) {
 	pod := testPod1()
 
@@ -3318,7 +3308,9 @@ func TestSync_SyncWarnings_ResetBetweenSyncs(t *testing.T) {
 	kubeFake.PrependReactor("create", "selfsubjectaccessreviews", func(action testcore.Action) (bool, runtime.Object, error) {
 		sar := action.(testcore.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
 		ra := sar.Spec.ResourceAttributes
-		sar.Status.Allowed = !(ra != nil && ra.Namespace == "deleted-ns")
+		denied := ra != nil && ra.Namespace == "deleted-ns"
+		sar.Status.Allowed = !denied
+		sar.Status.Denied = denied
 		return true, sar, nil
 	})
 
@@ -3340,7 +3332,6 @@ func TestSync_SyncWarnings_ResetBetweenSyncs(t *testing.T) {
 	require.NoError(t, cluster.sync())
 	require.NotEmpty(t, cluster.GetClusterInfo().SyncWarnings, "first sync should record warnings for deleted-ns")
 
-	// Simulate namespace recovering / removed from the list — no 403 in sync 2.
 	cluster.namespaces = []string{"default"}
 
 	require.NoError(t, cluster.sync())
@@ -3348,10 +3339,6 @@ func TestSync_SyncWarnings_ResetBetweenSyncs(t *testing.T) {
 }
 
 func TestCheckNamespacePermission_SSARIsGVKSpecific(t *testing.T) {
-	// Property: for ANY (api, namespace), checkNamespacePermission sends an SSAR whose
-	// ResourceAttributes carry the api's Group AND Resource, the given Namespace, and Verb "list".
-	// The cross-group resource-name collision row (apps vs extensions "deployments") ensures
-	// the implementation carries Group, not just Resource name.
 	tests := []struct {
 		name string
 		gvr  schema.GroupVersionResource

--- a/gitops-engine/pkg/cache/cluster_test.go
+++ b/gitops-engine/pkg/cache/cluster_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -16,9 +17,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -26,17 +29,16 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/fake"
+	kubefake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	testcore "k8s.io/client-go/testing"
 	"sigs.k8s.io/yaml"
 
-	"github.com/argoproj/argo-cd/gitops-engine/pkg/utils/kube"
-	"github.com/argoproj/argo-cd/gitops-engine/pkg/utils/kube/kubetest"
-	authorizationv1 "k8s.io/api/authorization/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	kubefake "k8s.io/client-go/kubernetes/fake"
+	"github.com/argoproj/argo-cd/gitops-engine/v3/pkg/utils/kube"
+	"github.com/argoproj/argo-cd/gitops-engine/v3/pkg/utils/kube/kubetest"
 )
 
 func init() {
@@ -96,7 +98,7 @@ func newCluster(tb testing.TB, objs ...runtime.Object) *clusterCache {
 	return cache
 }
 
-func newClusterWithOptions(_ testing.TB, opts []UpdateSettingsFunc, objs ...runtime.Object) *clusterCache {
+func newClusterWithOptions(tb testing.TB, opts []UpdateSettingsFunc, objs ...runtime.Object) *clusterCache {
 	client := fake.NewSimpleDynamicClient(scheme.Scheme, objs...)
 	reactor := client.ReactionChain[0]
 	client.PrependReactor("list", "*", func(action testcore.Action) (handled bool, ret runtime.Object, err error) {
@@ -139,6 +141,7 @@ func newClusterWithOptions(_ testing.TB, opts []UpdateSettingsFunc, objs ...runt
 		&rest.Config{Host: "https://test"},
 		opts...,
 	)
+	tb.Cleanup(func() { cache.Invalidate() })
 	return cache
 }
 
@@ -2861,8 +2864,65 @@ func BenchmarkIncrementalIndexBuild(b *testing.B) {
 	}
 }
 
+func TestSync_DeletedNamespace_DoesNotBlockSync(t *testing.T) {
+	// Arrange: cluster with a valid namespace and a deleted one.
+	// A deleted namespace returns 403 for every GVK (RoleBindings GC'd with the ns).
+	// SSAR denies every (GVK, deleted-ns) pair — the authoritative confirmation.
+	deletedNamespace := "deleted-ns"
+	validNamespace := "default"
+
+	pod := testPod1()
+	pod.SetNamespace(validNamespace)
+	validNs := &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Namespace",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: validNamespace,
+		},
+	}
+
+	kubeFake := kubefake.NewSimpleClientset()
+	kubeFake.PrependReactor("create", "selfsubjectaccessreviews", func(action testcore.Action) (bool, runtime.Object, error) {
+		sar := action.(testcore.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
+		sar.Status.Allowed = false
+		return true, sar, nil
+	})
+
+	cluster := newClusterWithOptions(t, []UpdateSettingsFunc{setClientset(kubeFake)}, pod, validNs)
+
+	fakeClient := cluster.kubectl.(*kubetest.MockKubectlCmd).DynamicClient.(*fake.FakeDynamicClient)
+	fakeClient.PrependReactor("list", "*", func(action testcore.Action) (bool, runtime.Object, error) {
+		if action.GetNamespace() == deletedNamespace {
+			return true, nil, apierrors.NewForbidden(
+				schema.GroupResource{Resource: action.GetResource().Resource}, "",
+				fmt.Errorf("namespace %q not found", deletedNamespace),
+			)
+		}
+		return false, nil, nil
+	})
+	cluster.namespaces = []string{validNamespace, deletedNamespace}
+
+	err := cluster.sync()
+
+	require.NoError(t, err)
+	_, ok := cluster.resources[getResourceKey(t, pod)]
+	assert.True(t, ok, "the default pod should be cached")
+	assert.Equal(t, []string{validNamespace, deletedNamespace}, cluster.namespaces, "namespaces must not be pruned")
+	info := cluster.GetClusterInfo()
+	assert.Contains(t, strings.Join(info.SyncWarnings, "; "), deletedNamespace, "a warning should mention %q", deletedNamespace)
+	ssarConsulted := false
+	for _, a := range kubeFake.Actions() {
+		if a.Matches("create", "selfsubjectaccessreviews") {
+			ssarConsulted = true
+			break
+		}
+	}
+	assert.True(t, ssarConsulted, "sync should consult SSAR before skipping a forbidden (GVK, namespace) pair")
+}
+
 func TestCheckNamespacePermission_Denied(t *testing.T) {
-	// Arrange: fake SSAR clientset that denies the access review.
 	kubeFake := kubefake.NewSimpleClientset()
 	kubeFake.PrependReactor("create", "selfsubjectaccessreviews", func(action testcore.Action) (bool, runtime.Object, error) {
 		sar := action.(testcore.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
@@ -2883,7 +2943,67 @@ func TestCheckNamespacePermission_Denied(t *testing.T) {
 	allowed, err := c.checkNamespacePermission(context.Background(), kubeFake.AuthorizationV1().SelfSubjectAccessReviews(), api, "restricted-ns")
 
 	require.NoError(t, err)
-	assert.False(t, allowed, "SSAR denied should return allowed=false")
+	assert.False(t, allowed)
+}
+
+func TestProcessApi_SkipSentinel_ContinuesToNextNamespace(t *testing.T) {
+	// processApi must:
+	// - continue to remaining namespaces when callback returns errSkipNamespace
+	// - return an ordinary error immediately (fail-fast)
+	api := kube.APIResourceInfo{
+		GroupVersionResource: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+		Meta:                 metav1.APIResource{Namespaced: true},
+	}
+
+	tests := []struct {
+		name          string
+		firstNsErr    error
+		wantBothCalls bool
+		wantErr       bool
+	}{
+		{
+			name:          "skip sentinel continues to second namespace",
+			firstNsErr:    errSkipNamespace,
+			wantBothCalls: true,
+			wantErr:       false,
+		},
+		{
+			name:          "ordinary error short-circuits",
+			firstNsErr:    fmt.Errorf("unexpected failure"),
+			wantBothCalls: false,
+			wantErr:       true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newCluster(t)
+			c.namespaces = []string{"ns1", "ns2"}
+
+			dynamicClient := c.kubectl.(*kubetest.MockKubectlCmd).DynamicClient
+
+			var calledFor []string
+			err := c.processApi(dynamicClient, api, func(resClient dynamic.ResourceInterface, ns string) error {
+				calledFor = append(calledFor, ns)
+				if ns == "ns1" {
+					return tc.firstNsErr
+				}
+				return nil
+			})
+
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			if tc.wantBothCalls {
+				assert.Equal(t, []string{"ns1", "ns2"}, calledFor, "both namespaces should be visited")
+			} else {
+				assert.Equal(t, []string{"ns1"}, calledFor, "second namespace must not be visited after ordinary error")
+			}
+		})
+	}
 }
 
 func TestHandleNamespacedListError_ClassifyForbiddenError(t *testing.T) {
@@ -3016,6 +3136,236 @@ func TestHandleNamespacedListError_ClassifyForbiddenError(t *testing.T) {
 	}
 }
 
+func TestSync_RestrictedGVK_SkipsOnlyThatPair(t *testing.T) {
+	// SSAR denial is group-specific: deny requires Group=="apps" AND Resource=="deployments" AND Namespace=="restricted-ns",
+	// so an implementation that drops the Group and matches resource name only would wrongly get "allowed" and fail.
+
+	restrictedPod := testPod1()
+	restrictedPod.SetNamespace("restricted-ns")
+	restrictedPod.SetName("pod-in-restricted-ns")
+	restrictedPod.SetUID("pod-restricted-uid")
+
+	restrictedDeploy := testDeploy()
+	restrictedDeploy.SetNamespace("restricted-ns")
+	restrictedDeploy.SetName("deploy-in-restricted-ns")
+	restrictedDeploy.SetUID("deploy-restricted-uid")
+
+	defaultDeploy := testDeploy()
+	defaultDeploy.SetNamespace("default")
+	defaultDeploy.SetName("deploy-in-default")
+	defaultDeploy.SetUID("deploy-default-uid")
+
+	kubeFake := kubefake.NewSimpleClientset()
+	kubeFake.PrependReactor("create", "selfsubjectaccessreviews", func(action testcore.Action) (bool, runtime.Object, error) {
+		sar := action.(testcore.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
+		ra := sar.Spec.ResourceAttributes
+		sar.Status.Allowed = !(ra.Group == "apps" && ra.Resource == "deployments" && ra.Namespace == "restricted-ns")
+		return true, sar, nil
+	})
+
+	cluster := newClusterWithOptions(t, []UpdateSettingsFunc{setClientset(kubeFake)}, restrictedPod, restrictedDeploy, defaultDeploy)
+	cluster.namespaces = []string{"default", "restricted-ns"}
+
+	fakeClient := cluster.kubectl.(*kubetest.MockKubectlCmd).DynamicClient.(*fake.FakeDynamicClient)
+	fakeClient.PrependReactor("list", "*", func(action testcore.Action) (bool, runtime.Object, error) {
+		if action.GetResource().Resource == "deployments" && action.GetNamespace() == "restricted-ns" {
+			return true, nil, apierrors.NewForbidden(
+				schema.GroupResource{Group: "apps", Resource: "deployments"}, "",
+				fmt.Errorf("forbidden"),
+			)
+		}
+		return false, nil, nil
+	})
+
+	err := cluster.sync()
+
+	require.NoError(t, err)
+
+	_, podCached := cluster.resources[getResourceKey(t, restrictedPod)]
+	assert.True(t, podCached, "Pod in restricted-ns must still be cached")
+
+	_, deployCached := cluster.resources[getResourceKey(t, restrictedDeploy)]
+	assert.False(t, deployCached, "Deployment in restricted-ns must be skipped")
+
+	joined := strings.Join(cluster.GetClusterInfo().SyncWarnings, "; ")
+	assert.Contains(t, joined, "restricted-ns", "warning must mention the restricted namespace")
+	assert.Contains(t, joined, "Deployment", "warning must mention the restricted resource kind")
+	assert.Contains(t, joined, "cannot list Deployment.apps (skipped)", "warning must use the operator-facing wording (Kind.group)")
+
+	_, defaultDeployCached := cluster.resources[getResourceKey(t, defaultDeploy)]
+	assert.True(t, defaultDeployCached, "Deployment in default must still be cached as skip is per-(GVK,namespace) pair, not cluster-wide")
+}
+
+func TestSync_ForbiddenWithSSARAllowed_FailsSync(t *testing.T) {
+	// This is the "transient/genuine failure" row of the disambiguation table:
+	// the original error must propagate and sync must fail (fail-fast preserved).
+	pod := testPod1()
+
+	kubeFake := kubefake.NewSimpleClientset()
+	kubeFake.PrependReactor("create", "selfsubjectaccessreviews", func(action testcore.Action) (bool, runtime.Object, error) {
+		sar := action.(testcore.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
+		sar.Status.Allowed = true
+		return true, sar, nil
+	})
+
+	cluster := newClusterWithOptions(t, []UpdateSettingsFunc{setClientset(kubeFake)}, pod)
+	cluster.namespaces = []string{"default"}
+
+	fakeClient := cluster.kubectl.(*kubetest.MockKubectlCmd).DynamicClient.(*fake.FakeDynamicClient)
+	fakeClient.PrependReactor("list", "*", func(action testcore.Action) (bool, runtime.Object, error) {
+		if action.GetResource().Resource == "pods" && action.GetNamespace() == "default" {
+			return true, nil, apierrors.NewForbidden(
+				schema.GroupResource{Resource: "pods"}, "",
+				fmt.Errorf("forbidden but allowed by RBAC"),
+			)
+		}
+		return false, nil, nil
+	})
+
+	err := cluster.sync()
+
+	require.Error(t, err)
+	// The propagated error must be the original 403 Forbidden (not some other failure).
+	assert.True(t, apierrors.IsForbidden(err), "the original 403 Forbidden must propagate")
+
+	assert.Empty(t, cluster.GetClusterInfo().SyncWarnings)
+
+	ssarConsulted := false
+	for _, a := range kubeFake.Actions() {
+		if a.Matches("create", "selfsubjectaccessreviews") {
+			ssarConsulted = true
+			break
+		}
+	}
+	assert.True(t, ssarConsulted, "sync should consult SSAR before deciding to propagate a forbidden (GVK, namespace) error")
+}
+
+func TestStartMissingWatches_InaccessibleNamespace_Skips(t *testing.T) {
+	pod := testPod1()
+
+	kubeFake := kubefake.NewSimpleClientset()
+	kubeFake.PrependReactor("create", "selfsubjectaccessreviews", func(action testcore.Action) (bool, runtime.Object, error) {
+		sar := action.(testcore.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
+		ra := sar.Spec.ResourceAttributes
+		sar.Status.Allowed = !(ra != nil && ra.Resource == "pods" && ra.Namespace == "default")
+		return true, sar, nil
+	})
+
+	cluster := newClusterWithOptions(t, []UpdateSettingsFunc{setClientset(kubeFake)}, pod)
+	cluster.namespaces = []string{"default"}
+
+	// Initial clean sync (no 403 yet — populates apisMeta).
+	require.NoError(t, cluster.EnsureSynced())
+
+	// Make Pods "missing": stopWatching removes apisMeta[gk].
+	podGK := pod.GroupVersionKind().GroupKind()
+	cluster.stopWatching(podGK, "default")
+
+	fakeClient := cluster.kubectl.(*kubetest.MockKubectlCmd).DynamicClient.(*fake.FakeDynamicClient)
+	fakeClient.PrependReactor("list", "*", func(action testcore.Action) (bool, runtime.Object, error) {
+		if action.GetResource().Resource == "pods" && action.GetNamespace() == "default" {
+			return true, nil, apierrors.NewForbidden(
+				schema.GroupResource{Resource: "pods"}, "",
+				fmt.Errorf("namespace inaccessible"),
+			)
+		}
+		return false, nil, nil
+	})
+
+	err := runSynced(&cluster.lock, func() error {
+		return cluster.startMissingWatches()
+	})
+
+	require.NoError(t, err)
+
+	joined := strings.Join(cluster.GetClusterInfo().SyncWarnings, "; ")
+	assert.Contains(t, joined, "default", "warning must mention the namespace")
+	assert.Contains(t, joined, "Pod", "warning must mention the resource kind")
+
+	ssarConsulted := false
+	for _, a := range kubeFake.Actions() {
+		if a.Matches("create", "selfsubjectaccessreviews") {
+			ssarConsulted = true
+			break
+		}
+	}
+	assert.True(t, ssarConsulted, "startMissingWatches must consult SSAR before skipping a forbidden (GVK, namespace) pair")
+}
+
+func TestSync_SyncWarnings_AggregatesAcrossNamespaces(t *testing.T) {
+	pod := testPod1()
+
+	kubeFake := kubefake.NewSimpleClientset()
+	kubeFake.PrependReactor("create", "selfsubjectaccessreviews", func(action testcore.Action) (bool, runtime.Object, error) {
+		sar := action.(testcore.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
+		ra := sar.Spec.ResourceAttributes
+		sar.Status.Allowed = !(ra != nil && (ra.Namespace == "ns-a" || ra.Namespace == "ns-b"))
+		return true, sar, nil
+	})
+
+	cluster := newClusterWithOptions(t, []UpdateSettingsFunc{setClientset(kubeFake)}, pod)
+	cluster.namespaces = []string{"default", "ns-a", "ns-b"}
+
+	fakeClient := cluster.kubectl.(*kubetest.MockKubectlCmd).DynamicClient.(*fake.FakeDynamicClient)
+	fakeClient.PrependReactor("list", "*", func(action testcore.Action) (bool, runtime.Object, error) {
+		ns := action.GetNamespace()
+		if ns == "ns-a" || ns == "ns-b" {
+			return true, nil, apierrors.NewForbidden(
+				schema.GroupResource{Resource: action.GetResource().Resource}, "",
+				fmt.Errorf("namespace %q not found", ns),
+			)
+		}
+		return false, nil, nil
+	})
+
+	err := cluster.sync()
+
+	require.NoError(t, err)
+	_, ok := cluster.resources[getResourceKey(t, pod)]
+	assert.True(t, ok, "default pod should be cached")
+
+	joined := strings.Join(cluster.GetClusterInfo().SyncWarnings, "; ")
+	assert.Contains(t, joined, "ns-a", "warnings should mention ns-a")
+	assert.Contains(t, joined, "ns-b", "warnings should mention ns-b")
+	assert.GreaterOrEqual(t, len(cluster.GetClusterInfo().SyncWarnings), 2, "warnings should aggregate across skipped pairs")
+}
+
+func TestSync_SyncWarnings_ResetBetweenSyncs(t *testing.T) {
+	pod := testPod1()
+
+	kubeFake := kubefake.NewSimpleClientset()
+	kubeFake.PrependReactor("create", "selfsubjectaccessreviews", func(action testcore.Action) (bool, runtime.Object, error) {
+		sar := action.(testcore.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
+		ra := sar.Spec.ResourceAttributes
+		sar.Status.Allowed = !(ra != nil && ra.Namespace == "deleted-ns")
+		return true, sar, nil
+	})
+
+	cluster := newClusterWithOptions(t, []UpdateSettingsFunc{setClientset(kubeFake)}, pod)
+	cluster.namespaces = []string{"default", "deleted-ns"}
+
+	fakeClient := cluster.kubectl.(*kubetest.MockKubectlCmd).DynamicClient.(*fake.FakeDynamicClient)
+
+	fakeClient.PrependReactor("list", "*", func(action testcore.Action) (bool, runtime.Object, error) {
+		if action.GetNamespace() == "deleted-ns" {
+			return true, nil, apierrors.NewForbidden(
+				schema.GroupResource{Resource: action.GetResource().Resource}, "",
+				fmt.Errorf("namespace %q not found", "deleted-ns"),
+			)
+		}
+		return false, nil, nil
+	})
+
+	require.NoError(t, cluster.sync())
+	require.NotEmpty(t, cluster.GetClusterInfo().SyncWarnings, "first sync should record warnings for deleted-ns")
+
+	// Simulate namespace recovering / removed from the list — no 403 in sync 2.
+	cluster.namespaces = []string{"default"}
+
+	require.NoError(t, cluster.sync())
+	assert.Empty(t, cluster.GetClusterInfo().SyncWarnings, "second clean sync must reset warnings from previous sync")
+}
+
 func TestCheckNamespacePermission_SSARIsGVKSpecific(t *testing.T) {
 	// Property: for ANY (api, namespace), checkNamespacePermission sends an SSAR whose
 	// ResourceAttributes carry the api's Group AND Resource, the given Namespace, and Verb "list".
@@ -3050,7 +3400,6 @@ func TestCheckNamespacePermission_SSARIsGVKSpecific(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			// Arrange: reactor captures the ResourceAttributes and approves the review.
 			kubeFake := kubefake.NewSimpleClientset()
 			var captured *authorizationv1.ResourceAttributes
 			kubeFake.PrependReactor("create", "selfsubjectaccessreviews", func(action testcore.Action) (bool, runtime.Object, error) {
@@ -3067,7 +3416,6 @@ func TestCheckNamespacePermission_SSARIsGVKSpecific(t *testing.T) {
 
 			c := &clusterCache{}
 
-			// Act
 			_, err := c.checkNamespacePermission(
 				context.Background(),
 				kubeFake.AuthorizationV1().SelfSubjectAccessReviews(),
@@ -3075,7 +3423,6 @@ func TestCheckNamespacePermission_SSARIsGVKSpecific(t *testing.T) {
 				tc.ns,
 			)
 
-			// Assert
 			require.NoError(t, err)
 			require.NotNil(t, captured, "SSAR must have been sent")
 			assert.Equal(t, tc.gvr.Group, captured.Group, "SSAR must carry the api's Group")

--- a/gitops-engine/pkg/cache/cluster_test.go
+++ b/gitops-engine/pkg/cache/cluster_test.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/sync/semaphore"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 
+	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -3035,12 +3036,12 @@ func TestHandleNamespacedListError(t *testing.T) {
 		wantSSARCall   bool
 	}{
 		{
-			name:                "forbidden + SSAR denied → skip namespace with warning",
-			listErr:             forbiddenErr,
-			ssarAllowed:         false,
-			wantErr:             errSkipNamespace,
-			wantWarning: "cannot list",
-			wantSSARCall:        true,
+			name:         "forbidden + SSAR denied → skip namespace with warning",
+			listErr:      forbiddenErr,
+			ssarAllowed:  false,
+			wantErr:      errSkipNamespace,
+			wantWarning:  "cannot list",
+			wantSSARCall: true,
 		},
 		{
 			name:         "forbidden + SSAR allowed → propagate original (genuine 403)",
@@ -3082,7 +3083,10 @@ func TestHandleNamespacedListError(t *testing.T) {
 				return true, sar, nil
 			})
 
-			c := &clusterCache{}
+			c := &clusterCache{
+				log:           logr.Discard(),
+				syncSkippedNs: make(map[string]map[schema.GroupKind]struct{}),
+			}
 
 			got := c.handleNamespacedListError(
 				context.Background(),
@@ -3095,12 +3099,10 @@ func TestHandleNamespacedListError(t *testing.T) {
 			assert.ErrorIs(t, got, tc.wantErr)
 
 			if tc.wantWarning != "" {
-				require.NotEmpty(t, c.syncWarnings, "expected a warning to be recorded")
-				warning := c.syncWarnings[0]
-				assert.Contains(t, warning, namespace)
-				assert.Contains(t, warning, tc.wantWarning)
+				require.Contains(t, c.syncSkippedNs, namespace, "expected namespace to be recorded as skipped")
+				assert.NotEmpty(t, c.syncSkippedNs[namespace], "expected at least one denied GroupKind")
 			} else {
-				assert.Empty(t, c.syncWarnings)
+				assert.Empty(t, c.syncSkippedNs)
 			}
 
 			ssarCalled := false
@@ -3168,8 +3170,8 @@ func TestSync_RestrictedGVK_SkipsOnlyThatPair(t *testing.T) {
 
 	joined := strings.Join(cluster.GetClusterInfo().SyncWarnings, "; ")
 	assert.Contains(t, joined, "restricted-ns", "warning must mention the restricted namespace")
-	assert.Contains(t, joined, "Deployment", "warning must mention the restricted resource kind")
-	assert.Contains(t, joined, "cannot list Deployment.apps (skipped)", "warning must use the operator-facing wording (Kind.group)")
+	assert.Contains(t, joined, "Deployment.apps", "warning must mention the denied GroupKind")
+	assert.Contains(t, joined, "inaccessible", "warning must indicate the namespace was inaccessible")
 
 	_, defaultDeployCached := cluster.resources[getResourceKey(t, defaultDeploy)]
 	assert.True(t, defaultDeployCached, "Deployment in default must still be cached as skip is per-(GVK,namespace) pair, not cluster-wide")
@@ -3408,6 +3410,99 @@ func TestCheckNamespacePermission_SSARIsGVKSpecific(t *testing.T) {
 			assert.Equal(t, tc.gvr.Resource, captured.Resource, "SSAR must carry the api's Resource")
 			assert.Equal(t, tc.ns, captured.Namespace, "SSAR must carry the given Namespace")
 			assert.Equal(t, "list", captured.Verb, "SSAR Verb must be \"list\"")
+		})
+	}
+}
+
+func TestRenderSkippedNamespaces(t *testing.T) {
+	gk := func(group, kind string) schema.GroupKind {
+		return schema.GroupKind{Group: group, Kind: kind}
+	}
+
+	tests := []struct {
+		name  string
+		input map[string]map[schema.GroupKind]struct{}
+		want  []string
+	}{
+		{
+			name:  "nil map",
+			input: nil,
+			want:  nil,
+		},
+		{
+			name:  "empty map",
+			input: map[string]map[schema.GroupKind]struct{}{},
+			want:  nil,
+		},
+		{
+			name: "empty inner map skipped",
+			input: map[string]map[schema.GroupKind]struct{}{
+				"ns1": {},
+			},
+			want: []string{},
+		},
+		{
+			name: "1 GVK — lists name",
+			input: map[string]map[schema.GroupKind]struct{}{
+				"ns1": {gk("apps", "Deployment"): {}},
+			},
+			want: []string{`namespace "ns1": skipped, inaccessible (Deployment.apps)`},
+		},
+		{
+			name: "3 GVKs — names sorted",
+			input: map[string]map[schema.GroupKind]struct{}{
+				"ns1": {
+					gk("", "Secret"):         {},
+					gk("apps", "Deployment"): {},
+					gk("", "ConfigMap"):      {},
+				},
+			},
+			want: []string{`namespace "ns1": skipped, inaccessible (ConfigMap, Deployment.apps, Secret)`},
+		},
+		{
+			name: "5 GVKs — still lists names",
+			input: map[string]map[schema.GroupKind]struct{}{
+				"ns1": {
+					gk("apps", "Deployment"): {},
+					gk("", "Pod"):            {},
+					gk("", "Service"):        {},
+					gk("", "ConfigMap"):      {},
+					gk("", "Secret"):         {},
+				},
+			},
+			want: []string{`namespace "ns1": skipped, inaccessible (ConfigMap, Deployment.apps, Pod, Secret, Service)`},
+		},
+		{
+			name: "6 GVKs — count with action hint",
+			input: map[string]map[schema.GroupKind]struct{}{
+				"ns1": {
+					gk("apps", "Deployment"): {},
+					gk("", "Pod"):            {},
+					gk("", "Service"):        {},
+					gk("", "ConfigMap"):      {},
+					gk("", "Secret"):         {},
+					gk("batch", "Job"):       {},
+				},
+			},
+			want: []string{`namespace "ns1": skipped, inaccessible (6 resource types). If deleted, remove from cluster secret.`},
+		},
+		{
+			name: "multiple namespaces sorted",
+			input: map[string]map[schema.GroupKind]struct{}{
+				"z-ns": {gk("", "Pod"): {}},
+				"a-ns": {gk("apps", "Deployment"): {}},
+			},
+			want: []string{
+				`namespace "a-ns": skipped, inaccessible (Deployment.apps)`,
+				`namespace "z-ns": skipped, inaccessible (Pod)`,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := renderSkippedNamespaces(tc.input)
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }

--- a/gitops-engine/pkg/cache/cluster_test.go
+++ b/gitops-engine/pkg/cache/cluster_test.go
@@ -32,8 +32,11 @@ import (
 	testcore "k8s.io/client-go/testing"
 	"sigs.k8s.io/yaml"
 
-	"github.com/argoproj/argo-cd/gitops-engine/v3/pkg/utils/kube"
-	"github.com/argoproj/argo-cd/gitops-engine/v3/pkg/utils/kube/kubetest"
+	"github.com/argoproj/argo-cd/gitops-engine/pkg/utils/kube"
+	"github.com/argoproj/argo-cd/gitops-engine/pkg/utils/kube/kubetest"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	kubefake "k8s.io/client-go/kubernetes/fake"
 )
 
 func init() {
@@ -2854,6 +2857,231 @@ func BenchmarkIncrementalIndexBuild(b *testing.B) {
 					cluster.addToParentUIDToChildren(child.parentUID, child.childKey)
 				}
 			}
+		})
+	}
+}
+
+func TestCheckNamespacePermission_Denied(t *testing.T) {
+	// Arrange: fake SSAR clientset that denies the access review.
+	kubeFake := kubefake.NewSimpleClientset()
+	kubeFake.PrependReactor("create", "selfsubjectaccessreviews", func(action testcore.Action) (bool, runtime.Object, error) {
+		sar := action.(testcore.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
+		sar.Status.Allowed = false
+		return true, sar, nil
+	})
+
+	api := kube.APIResourceInfo{
+		GroupVersionResource: schema.GroupVersionResource{
+			Group:    "apps",
+			Version:  "v1",
+			Resource: "deployments",
+		},
+		Meta: metav1.APIResource{Namespaced: true},
+	}
+
+	c := &clusterCache{}
+	allowed, err := c.checkNamespacePermission(context.Background(), kubeFake.AuthorizationV1().SelfSubjectAccessReviews(), api, "restricted-ns")
+
+	require.NoError(t, err)
+	assert.False(t, allowed, "SSAR denied should return allowed=false")
+}
+
+func TestHandleNamespacedListError_ClassifyForbiddenError(t *testing.T) {
+	api := kube.APIResourceInfo{
+		GroupVersionResource: schema.GroupVersionResource{
+			Group:    "apps",
+			Version:  "v1",
+			Resource: "deployments",
+		},
+		Meta: metav1.APIResource{Namespaced: true},
+	}
+	namespace := "target-ns"
+	forbiddenErr := apierrors.NewForbidden(
+		schema.GroupResource{Group: api.GroupVersionResource.Group, Resource: api.GroupVersionResource.Resource},
+		"",
+		fmt.Errorf("namespace %q not found", namespace),
+	)
+	genericErr := fmt.Errorf("generic connection failure")
+
+	tests := []struct {
+		name           string
+		listErr        error
+		ssarAllowed    bool
+		ssarReactorErr error
+		wantSkip       bool
+		wantOrigErr    bool
+		wantWarning    bool
+		wantSSARCall   bool
+	}{
+		{
+			name:         "forbidden + SSAR denied → errSkipNamespace + warning",
+			listErr:      forbiddenErr,
+			ssarAllowed:  false,
+			wantSkip:     true,
+			wantWarning:  true,
+			wantSSARCall: true,
+		},
+		{
+			name:         "forbidden + SSAR allowed → propagate original error, no warning",
+			listErr:      forbiddenErr,
+			ssarAllowed:  true,
+			wantOrigErr:  true,
+			wantWarning:  false,
+			wantSSARCall: true,
+		},
+		{
+			name:           "forbidden + SSAR call itself errors → propagate, no warning",
+			listErr:        forbiddenErr,
+			ssarReactorErr: fmt.Errorf("SSAR backend error"),
+			wantSkip:       false,
+			wantOrigErr:    false, // returns a wrapped SSAR error, not the original
+			wantWarning:    false,
+			wantSSARCall:   true,
+		},
+		{
+			name:         "non-forbidden error → propagate unchanged, no SSAR call, no warning",
+			listErr:      genericErr,
+			wantOrigErr:  true,
+			wantWarning:  false,
+			wantSSARCall: false,
+		},
+		{
+			name:         "NotFound error → propagate unchanged, no SSAR call, no warning",
+			listErr:      apierrors.NewNotFound(schema.GroupResource{Group: "apps", Resource: "deployments"}, "x"),
+			wantOrigErr:  true,
+			wantWarning:  false,
+			wantSSARCall: false,
+		},
+		{
+			name:         "Unauthorized error → propagate unchanged, no SSAR call, no warning",
+			listErr:      apierrors.NewUnauthorized("nope"),
+			wantOrigErr:  true,
+			wantWarning:  false,
+			wantSSARCall: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			kubeFake := kubefake.NewSimpleClientset()
+			kubeFake.PrependReactor("create", "selfsubjectaccessreviews", func(action testcore.Action) (bool, runtime.Object, error) {
+				if tc.ssarReactorErr != nil {
+					return true, nil, tc.ssarReactorErr
+				}
+				sar := action.(testcore.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
+				sar.Status.Allowed = tc.ssarAllowed
+				return true, sar, nil
+			})
+
+			c := &clusterCache{
+				syncWarnings: nil,
+			}
+
+			got := c.handleNamespacedListError(
+				context.Background(),
+				kubeFake.AuthorizationV1().SelfSubjectAccessReviews(),
+				api,
+				namespace,
+				tc.listErr,
+			)
+
+			if tc.wantSkip {
+				assert.ErrorIs(t, got, errSkipNamespace, "expected errSkipNamespace sentinel")
+			}
+			if tc.wantOrigErr {
+				assert.ErrorIs(t, got, tc.listErr, "expected original listErr propagated")
+			}
+			if !tc.wantSkip && !tc.wantOrigErr {
+				// SSAR error case: must return a non-nil error that is neither skip nor the original
+				require.Error(t, got)
+				assert.False(t, errors.Is(got, errSkipNamespace), "must not return skip sentinel on SSAR error")
+			}
+
+			if tc.wantWarning {
+				assert.True(t, len(c.syncWarnings) > 0, "expected a warning to be recorded")
+				assert.Contains(t, strings.Join(c.syncWarnings, " "), namespace, "warning must mention the namespace")
+			} else {
+				assert.Empty(t, c.syncWarnings, "expected no warnings recorded")
+			}
+
+			ssarCalled := false
+			for _, a := range kubeFake.Actions() {
+				if a.Matches("create", "selfsubjectaccessreviews") {
+					ssarCalled = true
+					break
+				}
+			}
+			assert.Equal(t, tc.wantSSARCall, ssarCalled, "SSAR should be consulted iff the error is Forbidden")
+		})
+	}
+}
+
+func TestCheckNamespacePermission_SSARIsGVKSpecific(t *testing.T) {
+	// Property: for ANY (api, namespace), checkNamespacePermission sends an SSAR whose
+	// ResourceAttributes carry the api's Group AND Resource, the given Namespace, and Verb "list".
+	// The cross-group resource-name collision row (apps vs extensions "deployments") ensures
+	// the implementation carries Group, not just Resource name.
+	tests := []struct {
+		name string
+		gvr  schema.GroupVersionResource
+		ns   string
+	}{
+		{
+			name: "apps/v1 deployments in ns1",
+			gvr:  schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+			ns:   "ns1",
+		},
+		{
+			name: "extensions/v1beta1 deployments in ns1 — same resource name, different group",
+			gvr:  schema.GroupVersionResource{Group: "extensions", Version: "v1beta1", Resource: "deployments"},
+			ns:   "ns1",
+		},
+		{
+			name: "core v1 pods in ns2",
+			gvr:  schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+			ns:   "ns2",
+		},
+		{
+			name: "example.com/v1 widgets in ns3 (CRD-like)",
+			gvr:  schema.GroupVersionResource{Group: "example.com", Version: "v1", Resource: "widgets"},
+			ns:   "ns3",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange: reactor captures the ResourceAttributes and approves the review.
+			kubeFake := kubefake.NewSimpleClientset()
+			var captured *authorizationv1.ResourceAttributes
+			kubeFake.PrependReactor("create", "selfsubjectaccessreviews", func(action testcore.Action) (bool, runtime.Object, error) {
+				sar := action.(testcore.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
+				captured = sar.Spec.ResourceAttributes
+				sar.Status.Allowed = true
+				return true, sar, nil
+			})
+
+			api := kube.APIResourceInfo{
+				GroupVersionResource: tc.gvr,
+				Meta:                 metav1.APIResource{Namespaced: true},
+			}
+
+			c := &clusterCache{}
+
+			// Act
+			_, err := c.checkNamespacePermission(
+				context.Background(),
+				kubeFake.AuthorizationV1().SelfSubjectAccessReviews(),
+				api,
+				tc.ns,
+			)
+
+			// Assert
+			require.NoError(t, err)
+			require.NotNil(t, captured, "SSAR must have been sent")
+			assert.Equal(t, tc.gvr.Group, captured.Group, "SSAR must carry the api's Group")
+			assert.Equal(t, tc.gvr.Resource, captured.Resource, "SSAR must carry the api's Resource")
+			assert.Equal(t, tc.ns, captured.Namespace, "SSAR must carry the given Namespace")
+			assert.Equal(t, "list", captured.Verb, "SSAR Verb must be \"list\"")
 		})
 	}
 }

--- a/gitops-engine/pkg/cache/cluster_test.go
+++ b/gitops-engine/pkg/cache/cluster_test.go
@@ -3006,7 +3006,7 @@ func TestProcessApi_SkipSentinel_ContinuesToNextNamespace(t *testing.T) {
 	}
 }
 
-func TestHandleNamespacedListError_ClassifyForbiddenError(t *testing.T) {
+func TestHandleNamespacedListError(t *testing.T) {
 	api := kube.APIResourceInfo{
 		GroupVersionResource: schema.GroupVersionResource{
 			Group:    "apps",
@@ -3021,6 +3021,8 @@ func TestHandleNamespacedListError_ClassifyForbiddenError(t *testing.T) {
 		"",
 		fmt.Errorf("namespace %q not found", namespace),
 	)
+	unauthorizedErr := apierrors.NewUnauthorized("nope")
+	ssarBackendErr := fmt.Errorf("SSAR backend error")
 	genericErr := fmt.Errorf("generic connection failure")
 
 	tests := []struct {
@@ -3028,55 +3030,42 @@ func TestHandleNamespacedListError_ClassifyForbiddenError(t *testing.T) {
 		listErr        error
 		ssarAllowed    bool
 		ssarReactorErr error
-		wantSkip       bool
-		wantOrigErr    bool
-		wantWarning    bool
+		wantErr        error
+		wantWarning    string
 		wantSSARCall   bool
 	}{
 		{
-			name:         "forbidden + SSAR denied → errSkipNamespace + warning",
-			listErr:      forbiddenErr,
-			ssarAllowed:  false,
-			wantSkip:     true,
-			wantWarning:  true,
-			wantSSARCall: true,
+			name:                "forbidden + SSAR denied → skip namespace with warning",
+			listErr:             forbiddenErr,
+			ssarAllowed:         false,
+			wantErr:             errSkipNamespace,
+			wantWarning: "cannot list",
+			wantSSARCall:        true,
 		},
 		{
-			name:         "forbidden + SSAR allowed → propagate original error, no warning",
+			name:         "forbidden + SSAR allowed → propagate original (genuine 403)",
 			listErr:      forbiddenErr,
 			ssarAllowed:  true,
-			wantOrigErr:  true,
-			wantWarning:  false,
+			wantErr:      forbiddenErr,
 			wantSSARCall: true,
 		},
 		{
-			name:           "forbidden + SSAR call itself errors → propagate, no warning",
+			name:           "forbidden + SSAR backend failure → propagate wrapped SSAR error",
 			listErr:        forbiddenErr,
-			ssarReactorErr: fmt.Errorf("SSAR backend error"),
-			wantSkip:       false,
-			wantOrigErr:    false, // returns a wrapped SSAR error, not the original
-			wantWarning:    false,
+			ssarReactorErr: ssarBackendErr,
+			wantErr:        ssarBackendErr,
 			wantSSARCall:   true,
 		},
 		{
-			name:         "non-forbidden error → propagate unchanged, no SSAR call, no warning",
+			name:         "generic error → propagate unchanged",
 			listErr:      genericErr,
-			wantOrigErr:  true,
-			wantWarning:  false,
+			wantErr:      genericErr,
 			wantSSARCall: false,
 		},
 		{
-			name:         "NotFound error → propagate unchanged, no SSAR call, no warning",
-			listErr:      apierrors.NewNotFound(schema.GroupResource{Group: "apps", Resource: "deployments"}, "x"),
-			wantOrigErr:  true,
-			wantWarning:  false,
-			wantSSARCall: false,
-		},
-		{
-			name:         "Unauthorized error → propagate unchanged, no SSAR call, no warning",
-			listErr:      apierrors.NewUnauthorized("nope"),
-			wantOrigErr:  true,
-			wantWarning:  false,
+			name:         "Unauthorized → propagate unchanged",
+			listErr:      unauthorizedErr,
+			wantErr:      unauthorizedErr,
 			wantSSARCall: false,
 		},
 	}
@@ -3093,9 +3082,7 @@ func TestHandleNamespacedListError_ClassifyForbiddenError(t *testing.T) {
 				return true, sar, nil
 			})
 
-			c := &clusterCache{
-				syncWarnings: nil,
-			}
+			c := &clusterCache{}
 
 			got := c.handleNamespacedListError(
 				context.Background(),
@@ -3105,23 +3092,15 @@ func TestHandleNamespacedListError_ClassifyForbiddenError(t *testing.T) {
 				tc.listErr,
 			)
 
-			if tc.wantSkip {
-				assert.ErrorIs(t, got, errSkipNamespace, "expected errSkipNamespace sentinel")
-			}
-			if tc.wantOrigErr {
-				assert.ErrorIs(t, got, tc.listErr, "expected original listErr propagated")
-			}
-			if !tc.wantSkip && !tc.wantOrigErr {
-				// SSAR error case: must return a non-nil error that is neither skip nor the original
-				require.Error(t, got)
-				assert.False(t, errors.Is(got, errSkipNamespace), "must not return skip sentinel on SSAR error")
-			}
+			assert.ErrorIs(t, got, tc.wantErr)
 
-			if tc.wantWarning {
-				assert.True(t, len(c.syncWarnings) > 0, "expected a warning to be recorded")
-				assert.Contains(t, strings.Join(c.syncWarnings, " "), namespace, "warning must mention the namespace")
+			if tc.wantWarning != "" {
+				require.NotEmpty(t, c.syncWarnings, "expected a warning to be recorded")
+				warning := c.syncWarnings[0]
+				assert.Contains(t, warning, namespace)
+				assert.Contains(t, warning, tc.wantWarning)
 			} else {
-				assert.Empty(t, c.syncWarnings, "expected no warnings recorded")
+				assert.Empty(t, c.syncWarnings)
 			}
 
 			ssarCalled := false
@@ -3131,7 +3110,7 @@ func TestHandleNamespacedListError_ClassifyForbiddenError(t *testing.T) {
 					break
 				}
 			}
-			assert.Equal(t, tc.wantSSARCall, ssarCalled, "SSAR should be consulted iff the error is Forbidden")
+			assert.Equal(t, tc.wantSSARCall, ssarCalled)
 		})
 	}
 }

--- a/gitops-engine/pkg/cache/settings.go
+++ b/gitops-engine/pkg/cache/settings.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
 	"github.com/argoproj/argo-cd/gitops-engine/v3/pkg/health"
@@ -181,5 +182,12 @@ func SetBatchEventsProcessing(batchProcessing bool) UpdateSettingsFunc {
 func SetEventProcessingInterval(interval time.Duration) UpdateSettingsFunc {
 	return func(cache *clusterCache) {
 		cache.eventProcessingInterval = interval
+	}
+}
+
+// setClientset allows overriding the kubernetes clientset built from config (injectable for tests/SSAR).
+func setClientset(cs kubernetes.Interface) UpdateSettingsFunc {
+	return func(cache *clusterCache) {
+		cache.clientset = cs
 	}
 }


### PR DESCRIPTION
## Checklist

- [x] Either (a) I have created an [Enhancement Proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the EP.
- [x] The title of the PR is something understandable by a user.
- [x] If a new feature is being implemented, I have added the documentation.
- [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.

Closes #24709.

## The problem

When a cluster secret has an explicit `namespaces` list, the cluster cache is a matrix: Rows are API kinds, columns are namespaces, each cell is one LIST plus one watch:

```
           default   app-ns   doomed-ns
Pod           ✓        ✓         ✓
Deployment    ✓        ✓         ✓
ConfigMap     ✓        ✓         ✓
```

Delete a namespace and a whole column dies. Kubernetes garbage-collects the Roles inside it, so every LIST returns 403. But the existing error handling (`respectRBAC` / `isRestrictedResource`) can only drop or keep a whole row. There's no way to skip one namespace for a kind while keeping the others. One dead cell kills the entire sync.

## Why 403 and not 404?

Kubernetes checks authorization before namespace existence. The Roles are garbage-collected with the namespace, so the response is always 403, never 404.

A 403 doesn't tell us whether the whole namespace is gone or just one RBAC rule was removed. If someone revoked access to secrets but pods are still fine, a per-namespace check would wrongly skip pods too. So we have to check every GVK.

## The fix

A namespaced 403 now triggers a `SelfSubjectAccessReview` per cell: "May I list this kind in this namespace?"

- **Not allowed** → skip that cell, record a warning. The row stays intact.
- **Allowed** → the 403 came from something else. Propagate the error, fail fast as before.

This runs before the existing `respectRBAC` logic. Any 403 it doesn't absorb still reaches `isRestrictedResource` unchanged.

Warnings show up on the cluster connection message (`argocd cluster list`, MESSAGE column). Skipped pairs are retried on every full cache resync. If the namespace becomes accessible again, no manual intervention is needed. If it's permanently gone, remove it from the cluster secret's `namespaces` field to clear the warning.

<img width="3805" height="1466" alt="image" src="https://github.com/user-attachments/assets/e262ce96-1beb-46e5-aa6c-94aa9b664821" />

## How to Test the Fix E2E yourself

The controller must run in-cluster as its ServiceAccount. `make start-local` won't work. It sets `ARGOCD_FAKE_IN_CLUSTER=true`, which uses your kubeconfig (cluster-admin) and never gets a 403.

```bash
# Create a kind cluster
kind create cluster --name argocd-test

# Build from this branch and load into kind
# On Apple Silicon, add TARGET_ARCH=linux/arm64
make image IMAGE_NAMESPACE=local IMAGE_TAG=dev
kind load docker-image local/argocd:dev --name argocd-test

# Install CRDs (not included in namespace-install)
kubectl create namespace argocd
kubectl apply --server-side --force-conflicts -k manifests/crds

# Deploy namespace-scoped ArgoCD (Roles, not ClusterRoles)
kubectl kustomize manifests/namespace-install \
  | sed 's|quay.io/argoproj/argocd:.*|local/argocd:dev|g; s/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g' \
  | kubectl apply -n argocd -f -
kubectl -n argocd rollout status statefulset/argocd-application-controller --timeout=120s

# Log in
kubectl -n argocd port-forward svc/argocd-server 8080:443 &
PASS=$(kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath='{.data.password}' | base64 -d)
argocd login localhost:8080 --username admin --password "$PASS" --insecure
```

Set up two namespaces with namespace-scoped Roles and a cluster secret:

```bash
kubectl create namespace app-ns
kubectl create namespace doomed-ns

# Roles (not ClusterRoles) garbage-collected when the namespace is deleted
for NS in app-ns doomed-ns; do
kubectl apply -f - <<EOF
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: argocd-managed
  namespace: $NS
rules:
- apiGroups: ["*"]
  resources: ["*"]
  verbs: ["*"]
---
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: argocd-managed
  namespace: $NS
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: argocd-managed
subjects:
- kind: ServiceAccount
  name: argocd-application-controller
  namespace: argocd
EOF
done

# Cluster secret with explicit namespaces
kubectl apply -f - <<'EOF'
apiVersion: v1
kind: Secret
metadata:
  name: in-cluster-namespaced
  namespace: argocd
  labels:
    argocd.argoproj.io/secret-type: cluster
type: Opaque
stringData:
  name: in-cluster-namespaced
  server: https://kubernetes.default.svc
  namespaces: "app-ns,doomed-ns"
  clusterResources: "false"
  config: |
    {
      "tlsClientConfig": {
        "insecure": true
      }
    }
EOF

# Deploy apps, verify both Healthy/Synced
argocd app create survivor \
  --repo https://github.com/argoproj/argocd-example-apps.git \
  --path guestbook \
  --dest-server https://kubernetes.default.svc \
  --dest-namespace app-ns
argocd app sync survivor

argocd app create doomed \
  --repo https://github.com/argoproj/argocd-example-apps.git \
  --path guestbook \
  --dest-server https://kubernetes.default.svc \
  --dest-namespace doomed-ns

argocd app sync doomed
```

Trigger and verify:

```bash
# Delete the namespace
kubectl delete namespace doomed-ns

# Invalidate cache: Settings → Clusters → click cluster → Invalidate Cache
# Or wait for the next full cache resync

# Expected: survivor stays Healthy/Synced, cluster status Successful,
# MESSAGE shows: namespace "doomed-ns": skipped, inaccessible (N resource types)
argocd cluster list
argocd app list
```

