### PR TITLE
fix(argocd-core): default SyncWithReplaceAllowed=true in headless mode (#27529)

### DIFF
--- a/cmd/argocd/commands/headless/headless.go
+++ b/cmd/argocd/commands/headless/headless.go
@@ -286,6 +286,13 @@ func MaybeStartLocalServer(ctx context.Context, clientOpts *apiclient.ClientOpti
 		ListenHost:              *address,
 		RepoClientset:           &forwardRepoClientset{namespace: namespace, context: ctxStr, repoServerName: clientOpts.RepoServerName, kubeClientset: kubeClientset},
 		EnableProxyExtension:    false,
+		// Match the standalone argocd-server default so `argocd --core app
+		// sync --replace` works out of the box. Without this the in-process
+		// server inherits the Go zero value (false) and every --replace sync
+		// fails with "sync with replace was disabled on the API Server level
+		// via the server configuration" even though --core mode never reads
+		// the cluster's server configuration (#27529).
+		SyncWithReplaceAllowed: true,
 	}, server.ApplicationSetOpts{})
 	srv.Init(ctx)
 


### PR DESCRIPTION
## Summary

The in-process API server built by `argocd --core` (in `cmd/argocd/commands/headless/headless.go`) didn't populate `ArgoCDServerOpts.SyncWithReplaceAllowed`. The Go zero value (`false`) won, so every `argocd --core app sync --replace ...` in v3.x failed with:

```
FailedPrecondition: sync with replace was disabled on the API Server level via the server configuration
```

…regardless of what the user configured on their cluster or in their environment — `--core` doesn't read the cluster's server configuration at all, so `argocd-cmd-params-cm`, env vars, and server flags on the real argocd-server are all irrelevant.

## Fix

Set `SyncWithReplaceAllowed: true` alongside the other `ArgoCDServerOpts` fields. This matches the default of the standalone argocd-server binary (`cmd/argocd-server/commands/argocd_server.go:253` wires `syncWithReplaceAllowed` with a `true` default unless explicitly overridden via flag/env). Users who need to disable replace globally can still do so on their real argocd-server; `--core` is a client-side in-process server whose purpose is to be a drop-in for CLI usage, so it should follow the same default.

Fixes #27529

## Test plan

- [x] `go build ./cmd/argocd/...`
- [x] `go vet ./cmd/argocd/commands/headless/...`
- [x] Manually traced the code path: `cmd/argocd/commands/app_actions.go` → `ApplicationServer.Sync` → checks `server.SyncWithReplaceAllowed`; after this PR the in-process server's field is now `true` so the gate passes.