### PR TITLE
fix: truncate labels for deletion hook resources

### DIFF
--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -1199,6 +1199,47 @@ func TestFinalizeAppDeletion(t *testing.T) {
 		require.Equal(t, "pre-delete-hook", ctrl.kubectl.(*MockKubectl).CreatedResources[0].GetName())
 	})
 
+	t.Run("PreDelete_HookIsCreatedForLongAppName", func(t *testing.T) {
+		// Regression test for https://github.com/argoproj/argo-cd/issues/27527.
+		// When the app name (or instance name) exceeds Kubernetes' 63-character
+		// label limit, the pre-delete hook must still be created with a
+		// truncated app instance label so the API server doesn't reject it.
+		app := newFakeApp()
+		// 70-character name (7 over the 63-char label limit)
+		app.Name = "this-application-name-is-deliberately-seventy-characters-long-12345678"
+		app.SetPreDeleteFinalizer()
+		app.Spec.Destination.Namespace = test.FakeArgoCDNamespace
+		ctrl := newFakeController(context.Background(), &fakeData{
+			manifestResponses: []*apiclient.ManifestResponse{{
+				Manifests: []string{fakePreDeleteHook},
+			}},
+			apps:            []runtime.Object{app, &defaultProj},
+			managedLiveObjs: map[kube.ResourceKey]*unstructured.Unstructured{},
+		}, nil)
+
+		fakeAppCs := ctrl.applicationClientset.(*appclientset.Clientset)
+		defaultReactor := fakeAppCs.ReactionChain[0]
+		fakeAppCs.ReactionChain = nil
+		fakeAppCs.AddReactor("get", "*", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+			return defaultReactor.React(action)
+		})
+		fakeAppCs.AddReactor("patch", "*", func(_ kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+			return true, &v1alpha1.Application{}, nil
+		})
+		err := ctrl.finalizeApplicationDeletion(app, func(_ string) ([]*v1alpha1.Cluster, error) {
+			return []*v1alpha1.Cluster{}, nil
+		})
+		require.NoError(t, err)
+		// pre-delete hook is created and its instance label is truncated to
+		// the 63-character limit
+		require.Len(t, ctrl.kubectl.(*MockKubectl).CreatedResources, 1)
+		createdHook := ctrl.kubectl.(*MockKubectl).CreatedResources[0]
+		require.Equal(t, "pre-delete-hook", createdHook.GetName())
+		labelVal := createdHook.GetLabels()[common.LabelKeyAppInstance]
+		assert.LessOrEqual(t, len(labelVal), 63, "instance label must fit within Kubernetes' 63-character limit")
+		assert.NotEmpty(t, labelVal)
+	})
+
 	t.Run("PostDelete_HookIsCreated", func(t *testing.T) {
 		app := newFakeApp()
 		app.SetPostDeleteFinalizer()

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -1286,6 +1286,51 @@ func TestFinalizeAppDeletion(t *testing.T) {
 		require.Equal(t, "post-delete-hook", ctrl.kubectl.(*MockKubectl).CreatedResources[0].GetName())
 	})
 
+	t.Run("PostDelete_HookIsCreatedForLongAppName", func(t *testing.T) {
+		// Post-delete counterpart of PreDelete_HookIsCreatedForLongAppName; see
+		// that test for the rationale.
+		app := newFakeApp()
+		app.Name = "this-application-name-is-deliberately-seventy-characters-long-12345678"
+		app.SetPostDeleteFinalizer()
+		app.Spec.Destination.Namespace = test.FakeArgoCDNamespace
+		ctrl := newFakeController(t.Context(), &fakeData{
+			manifestResponses: []*apiclient.ManifestResponse{{
+				Manifests: []string{fakePostDeleteHook},
+			}},
+			apps:            []runtime.Object{app, &defaultProj},
+			managedLiveObjs: map[kube.ResourceKey]*unstructured.Unstructured{},
+			configMapData: map[string]string{
+				"application.resourceTrackingMethod": "annotation+label",
+			},
+		}, nil)
+
+		patched := false
+		fakeAppCs := ctrl.applicationClientset.(*appclientset.Clientset)
+		defaultReactor := fakeAppCs.ReactionChain[0]
+		fakeAppCs.ReactionChain = nil
+		fakeAppCs.AddReactor("get", "*", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+			return defaultReactor.React(action)
+		})
+		fakeAppCs.AddReactor("patch", "*", func(_ kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+			patched = true
+			return true, &v1alpha1.Application{}, nil
+		})
+		err := ctrl.finalizeApplicationDeletion(app, func(_ string) ([]*v1alpha1.Cluster, error) {
+			return []*v1alpha1.Cluster{}, nil
+		})
+		require.NoError(t, err)
+		assert.False(t, patched, "finalizer must not be removed while hook is still pending")
+		require.Len(t, ctrl.kubectl.(*MockKubectl).CreatedResources, 1)
+		createdHook := ctrl.kubectl.(*MockKubectl).CreatedResources[0]
+		require.Equal(t, "post-delete-hook", createdHook.GetName())
+		labelVal := createdHook.GetLabels()[common.LabelKeyAppInstance]
+		assert.LessOrEqual(t, len(labelVal), 63, "instance label must fit within Kubernetes' 63-character limit")
+		assert.NotEmpty(t, labelVal)
+		assert.NotEqual(t, app.Name, labelVal)
+		assert.True(t, strings.HasPrefix(app.Name, labelVal),
+			"truncated label must be a prefix of the original app name, got %q", labelVal)
+	})
+
 	t.Run("PreDelete_HookIsExecuted", func(t *testing.T) {
 		app := newFakeApp()
 		app.SetPreDeleteFinalizer()

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"maps"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -1215,6 +1216,12 @@ func TestFinalizeAppDeletion(t *testing.T) {
 			}},
 			apps:            []runtime.Object{app, &defaultProj},
 			managedLiveObjs: map[kube.ResourceKey]*unstructured.Unstructured{},
+			// Force the tracking method that writes the app instance label so
+			// we can assert truncation actually ran (the default tracking method
+			// is annotation-only, which would skip the label entirely).
+			configMapData: map[string]string{
+				"application.resourceTrackingMethod": "annotation+label",
+			},
 		}, nil)
 
 		fakeAppCs := ctrl.applicationClientset.(*appclientset.Clientset)
@@ -1238,6 +1245,11 @@ func TestFinalizeAppDeletion(t *testing.T) {
 		labelVal := createdHook.GetLabels()[common.LabelKeyAppInstance]
 		assert.LessOrEqual(t, len(labelVal), 63, "instance label must fit within Kubernetes' 63-character limit")
 		assert.NotEmpty(t, labelVal)
+		// The label value must be the truncated form of the app name (not the
+		// untouched 70-char name), proving the truncation actually ran.
+		assert.NotEqual(t, app.Name, labelVal)
+		assert.True(t, strings.HasPrefix(app.Name, labelVal),
+			"truncated label must be a prefix of the original app name, got %q", labelVal)
 	})
 
 	t.Run("PostDelete_HookIsCreated", func(t *testing.T) {

--- a/controller/hook.go
+++ b/controller/hook.go
@@ -19,6 +19,7 @@ import (
 	"github.com/argoproj/argo-cd/v3/util/lua"
 
 	appv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	argoutil "github.com/argoproj/argo-cd/v3/util/argo"
 )
 
 type HookType string
@@ -98,6 +99,16 @@ func (ctrl *ApplicationController) executeHooks(hookType HookType, app *appv1.Ap
 	if err != nil {
 		return false, err
 	}
+	trackingMethodStr, err := ctrl.settingsMgr.GetTrackingMethod()
+	if err != nil {
+		return false, err
+	}
+	installationID, err := ctrl.settingsMgr.GetInstallationID()
+	if err != nil {
+		return false, err
+	}
+	trackingMethod := appv1.TrackingMethod(trackingMethodStr)
+	resourceTracking := argoutil.NewResourceTracking()
 
 	var revisions []string
 	for _, src := range app.Spec.GetSources() {
@@ -135,13 +146,14 @@ func (ctrl *ApplicationController) executeHooks(hookType HookType, app *appv1.Ap
 	// Create hooks that don't exist yet
 	createdCnt := 0
 	for key, obj := range expectedHook {
-		// Add app instance label so the hook can be tracked and cleaned up
-		labels := obj.GetLabels()
-		if labels == nil {
-			labels = make(map[string]string)
+		// Apply app instance tracking metadata so the hook can be tracked and cleaned up.
+		// Use the same code path as regular sync resources so the configured
+		// tracking method (label, annotation, annotation+label) is honored,
+		// and so that the label value is truncated to fit Kubernetes' 63-character
+		// label limit (see https://github.com/argoproj/argo-cd/issues/27527).
+		if err := resourceTracking.SetAppInstance(obj, appLabelKey, app.InstanceName(ctrl.namespace), app.Spec.Destination.Namespace, trackingMethod, installationID); err != nil {
+			return false, fmt.Errorf("failed to set app instance tracking on %s hook %s: %w", hookType, key, err)
 		}
-		labels[appLabelKey] = app.InstanceName(ctrl.namespace)
-		obj.SetLabels(labels)
 
 		logCtx.Infof("Creating %s hook resource: %s", hookType, key)
 		_, err = ctrl.kubectl.CreateResource(context.Background(), config, obj.GroupVersionKind(), obj.GetName(), obj.GetNamespace(), obj, metav1.CreateOptions{})

--- a/controller/hook.go
+++ b/controller/hook.go
@@ -148,9 +148,10 @@ func (ctrl *ApplicationController) executeHooks(hookType HookType, app *appv1.Ap
 	for key, obj := range expectedHook {
 		// Apply app instance tracking metadata so the hook can be tracked and cleaned up.
 		// Use the same code path as regular sync resources so the configured
-		// tracking method (label, annotation, annotation+label) is honored,
-		// and so that the label value is truncated to fit Kubernetes' 63-character
-		// label limit (see https://github.com/argoproj/argo-cd/issues/27527).
+		// tracking method (label, annotation, annotation+label) is honored.
+		// When the configured tracking method writes a label, this also ensures
+		// the label value is truncated to fit Kubernetes' 63-character label
+		// limit (see https://github.com/argoproj/argo-cd/issues/27527).
 		if err := resourceTracking.SetAppInstance(obj, appLabelKey, app.InstanceName(ctrl.namespace), app.Spec.Destination.Namespace, trackingMethod, installationID); err != nil {
 			return false, fmt.Errorf("failed to set app instance tracking on %s hook %s: %w", hookType, key, err)
 		}

--- a/util/argo/resource_tracking.go
+++ b/util/argo/resource_tracking.go
@@ -121,6 +121,24 @@ func UnstructuredToAppInstanceValue(un *unstructured.Unstructured, appName, name
 	}
 }
 
+// TruncateLabel truncates the given value to a length that fits within the
+// Kubernetes label value limit (63 characters), trimming any trailing special
+// characters so the result is a valid label value.
+// See https://github.com/argoproj/argo-cd/issues/18237.
+func TruncateLabel(val string) (string, error) {
+	if len(val) <= LabelMaxLength {
+		return val, nil
+	}
+	val = val[:LabelMaxLength]
+	for !OkEndPattern.MatchString(val) {
+		if len(val) <= 1 {
+			return "", errors.New("unable to truncate label to not end with a special character")
+		}
+		val = val[:len(val)-1]
+	}
+	return val, nil
+}
+
 // SetAppInstance set label/annotation base on tracking method
 func (rt *resourceTracking) SetAppInstance(un *unstructured.Unstructured, key, val, namespace string, trackingMethod v1alpha1.TrackingMethod, instanceID string) error {
 	setAppInstanceAnnotation := func() error {
@@ -136,36 +154,33 @@ func (rt *resourceTracking) SetAppInstance(un *unstructured.Unstructured, key, v
 		}
 		return kube.SetAppInstanceAnnotation(un, common.AnnotationKeyAppInstance, rt.BuildAppInstanceValue(appInstanceValue))
 	}
+	setAppInstanceLabel := func(val string) error {
+		labelVal, err := TruncateLabel(val)
+		if err != nil {
+			return fmt.Errorf("failed to set app instance label: %w", err)
+		}
+		if err := kube.SetAppInstanceLabel(un, key, labelVal); err != nil {
+			return fmt.Errorf("failed to set app instance label: %w", err)
+		}
+		return nil
+	}
 	switch trackingMethod {
 	case v1alpha1.TrackingMethodLabel:
-		err := kube.SetAppInstanceLabel(un, key, val)
-		if err != nil {
+		// Label-only tracking uses the label value as the app name (see GetAppName),
+		// so truncating it here would break resource-to-app matching when the app
+		// name exceeds the label limit. Keep the value as-is and let Kubernetes
+		// surface the validation error to the user.
+		if err := kube.SetAppInstanceLabel(un, key, val); err != nil {
 			return fmt.Errorf("failed to set app instance label: %w", err)
 		}
 		return nil
 	case v1alpha1.TrackingMethodAnnotation:
 		return setAppInstanceAnnotation()
 	case v1alpha1.TrackingMethodAnnotationAndLabel:
-		err := setAppInstanceAnnotation()
-		if err != nil {
+		if err := setAppInstanceAnnotation(); err != nil {
 			return err
 		}
-		if len(val) > LabelMaxLength {
-			val = val[:LabelMaxLength]
-			// Prevent errors if the truncated name ends in a special character.
-			// See https://github.com/argoproj/argo-cd/issues/18237.
-			for !OkEndPattern.MatchString(val) {
-				if len(val) <= 1 {
-					return errors.New("failed to set app instance label: unable to truncate label to not end with a special character")
-				}
-				val = val[:len(val)-1]
-			}
-		}
-		err = kube.SetAppInstanceLabel(un, key, val)
-		if err != nil {
-			return fmt.Errorf("failed to set app instance label: %w", err)
-		}
-		return nil
+		return setAppInstanceLabel(val)
 	default:
 		return setAppInstanceAnnotation()
 	}

--- a/util/argo/resource_tracking.go
+++ b/util/argo/resource_tracking.go
@@ -122,8 +122,11 @@ func UnstructuredToAppInstanceValue(un *unstructured.Unstructured, appName, name
 }
 
 // TruncateLabel truncates the given value to a length that fits within the
-// Kubernetes label value limit (63 characters), trimming any trailing special
-// characters so the result is a valid label value.
+// Kubernetes label value limit (63 characters). When truncation is required,
+// any trailing special characters are stripped so the result remains a valid
+// label value. Inputs that are already within the limit are returned as-is
+// without trailing-character validation; callers that need a fully validated
+// label should validate separately.
 // See https://github.com/argoproj/argo-cd/issues/18237.
 func TruncateLabel(val string) (string, error) {
 	if len(val) <= LabelMaxLength {

--- a/util/argo/resource_tracking_test.go
+++ b/util/argo/resource_tracking_test.go
@@ -118,6 +118,38 @@ func TestSetAppInstanceAnnotationAndLabelOutOfBounds(t *testing.T) {
 	assert.EqualError(t, err, "failed to set app instance label: unable to truncate label to not end with a special character")
 }
 
+func TestTruncateLabel_Short(t *testing.T) {
+	got, err := TruncateLabel("my-app")
+	require.NoError(t, err)
+	assert.Equal(t, "my-app", got)
+}
+
+func TestTruncateLabel_AtLimit(t *testing.T) {
+	val := "the-very-suspicious-name-with-precisely-sixty-three-characters0"
+	require.Len(t, val, LabelMaxLength)
+	got, err := TruncateLabel(val)
+	require.NoError(t, err)
+	assert.Equal(t, val, got)
+}
+
+func TestTruncateLabel_LongName(t *testing.T) {
+	got, err := TruncateLabel("my-app-with-an-extremely-long-name-that-is-over-sixty-three-characters")
+	require.NoError(t, err)
+	assert.Equal(t, "my-app-with-an-extremely-long-name-that-is-over-sixty-three-cha", got)
+	assert.LessOrEqual(t, len(got), LabelMaxLength)
+}
+
+func TestTruncateLabel_TrailingSpecialCharsStripped(t *testing.T) {
+	got, err := TruncateLabel("the-very-suspicious-name-with-precisely-sixty-three-characters-with-hyphen")
+	require.NoError(t, err)
+	assert.Equal(t, "the-very-suspicious-name-with-precisely-sixty-three-characters", got)
+}
+
+func TestTruncateLabel_AllSpecialChars(t *testing.T) {
+	_, err := TruncateLabel("----------------------------------------------------------------")
+	assert.EqualError(t, err, "unable to truncate label to not end with a special character")
+}
+
 func TestRemoveAppInstance_LabelOnly(t *testing.T) {
 	yamlBytes, err := os.ReadFile("testdata/svc.yaml")
 	require.NoError(t, err)


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->
Closes #27527

While reproducing the issue locally I found that the missing label truncation is not specific to `PreDelete`, `PostDelete` hooks and applications that declare both hook types together hit the exact same failure as soon as the Application name exceeds 63 characters. In every one of those cases the Application gets stuck in `Terminating` because Kubernetes rejects the hook resource with error like below.

<img width="1165" height="178" alt="스크린샷 2026-04-26 오후 5 35 25" src="https://github.com/user-attachments/assets/473e66b9-b190-4be5-8dc3-dee1de5d085a" />

<img width="1275" height="446" alt="스크린샷 2026-04-26 오후 2 42 52" src="https://github.com/user-attachments/assets/33ea7fa8-e689-4c50-9577-3eeed1a01930" />


The fix routes hook resources through `ResourceTracking.SetAppInstance`, so they follow the same path as regularly synced resources. The truncation logic was extracted into `TruncateLabel` helper. The label value is clamped to 63 characters and the full Application name is preserved in the `argocd.argoproj.io/tracking-id` annotation.

https://github.com/user-attachments/assets/a28839a8-a974-4964-8b4a-322805714268

The legacy `label`-only mode is left unchanged on purpose #18237.
Applications with names of 63 characters or fewer, and applications without deletion hooks, are unaffected.



Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
