### PR TITLE
feat(webhook): Add manifest-generate-paths annotation support for BitBucket Server

### DIFF
--- a/docs/operator-manual/webhook.md
+++ b/docs/operator-manual/webhook.md
@@ -133,6 +133,31 @@ The webhook handler uses this OAuth token to make the API request to the origina
 If the Argo CD webhook handler cannot find a matching repository credential, the list of changed files would remain empty.
 If errors occur during the callback, the list of changed files will be empty.
 
+### Special handling for BitBucket Server (Data Center)
+
+BitBucket Server (Data Center) does not include the list of changed files in the webhook request body.
+This prevents the [Manifest Paths Annotation](high_availability.md#manifest-paths-annotation) feature from working correctly for monorepos hosted on BitBucket Server.
+
+Argo CD addresses this by making an API callback to the originating BitBucket Server to retrieve the changed files via the [Repository Changes REST API](https://developer.atlassian.com/server/bitbucket/rest/v901/api-group-repository/#api-api-latest-projects-projectkey-repos-repositoryslug-changes-get).
+
+**Requirements:**
+
+- The webhook **must be authenticated**: `webhook.bitbucketserver.secret` must be set in `argocd-secret`. This is required to prevent SSRF attacks — Argo CD will only perform the API callback when the incoming webhook request has been verified against the shared secret.
+- The repository **must have credentials** stored in Argo CD (basic auth or bearer token). If no matching repository credential is found, the changed files list will remain empty and all apps pointing to the repository will be refreshed.
+
+**How it works:**
+
+1. When an authenticated `repo:refs_changed` webhook event is received from BitBucket Server, Argo CD extracts the `fromHash` and `toHash` for the pushed commit.
+2. Argo CD looks up the repository credential for the HTTP clone URL of the repository.
+3. Using the stored credential, it calls the BitBucket Server REST API (`/rest/api/1.0/projects/{projectKey}/repos/{repoSlug}/changes?since={fromHash}&until={toHash}`) to retrieve the changed file paths.
+4. Argo CD also calls the default branch API (`/rest/api/1.0/projects/{projectKey}/repos/{repoSlug}/branches/default`) to accurately determine whether the push touched the repository's default (HEAD) branch.
+5. Only applications whose `manifest-generate-paths` annotation matches a changed file are refreshed.
+
+If any errors occur during the API callback, the changed files list will be empty and all apps pointing to the repository will be refreshed (safe fallback behavior).
+
+This feature supports both regular projects (e.g., `~MYPROJECT`) and personal projects (e.g., `~username`) on BitBucket Server. The project key and repository slug are taken directly from the webhook payload.
+
+
 ## 3. Webhook Configuration for OCI-Compliant Registries
 
 In addition to Git webhooks, Argo CD supports webhooks from OCI-compliant container registries. This enables instant application refresh when

--- a/docs/operator-manual/webhook.md
+++ b/docs/operator-manual/webhook.md
@@ -135,27 +135,24 @@ If errors occur during the callback, the list of changed files will be empty.
 
 ### Special handling for BitBucket Server (Data Center)
 
-BitBucket Server (Data Center) does not include the list of changed files in the webhook request body.
+BitBucket Server (Data Center) does not include the list of changed files in the webhook payload.
 This prevents the [Manifest Paths Annotation](high_availability.md#manifest-paths-annotation) feature from working correctly for monorepos hosted on BitBucket Server.
 
-Argo CD addresses this by making an API callback to the originating BitBucket Server to retrieve the changed files via the [Repository Changes REST API](https://developer.atlassian.com/server/bitbucket/rest/v901/api-group-repository/#api-api-latest-projects-projectkey-repos-repositoryslug-changes-get).
+To enable changed-file detection, set the webhook secret in `argocd-secret`:
+
+```bash
+kubectl patch secret argocd-secret -n argocd \
+  --type=merge \
+  -p '{"stringData": {"webhook.bitbucketserver.secret": "<your-secret>"}}'
+```
 
 **Requirements:**
 
-- The webhook **must be authenticated**: `webhook.bitbucketserver.secret` must be set in `argocd-secret`. This is required to prevent SSRF attacks — Argo CD will only perform the API callback when the incoming webhook request has been verified against the shared secret.
-- The repository **must have credentials** stored in Argo CD (basic auth or bearer token). If no matching repository credential is found, the changed files list will remain empty and all apps pointing to the repository will be refreshed.
+- The webhook **must be authenticated**: `webhook.bitbucketserver.secret` must be set in `argocd-secret`. Argo CD will only fetch changed files when the incoming webhook has been verified against the shared secret (required to prevent SSRF).
+- The repository **must have credentials** stored in Argo CD (basic auth or bearer token). If no matching credential is found, all apps pointing to the repository will be refreshed (safe fallback).
 
-**How it works:**
-
-1. When an authenticated `repo:refs_changed` webhook event is received from BitBucket Server, Argo CD extracts the `fromHash` and `toHash` for the pushed commit.
-2. Argo CD looks up the repository credential for the HTTP clone URL of the repository.
-3. Using the stored credential, it calls the BitBucket Server REST API (`/rest/api/1.0/projects/{projectKey}/repos/{repoSlug}/changes?since={fromHash}&until={toHash}`) to retrieve the changed file paths.
-4. Argo CD also calls the default branch API (`/rest/api/1.0/projects/{projectKey}/repos/{repoSlug}/branches/default`) to accurately determine whether the push touched the repository's default (HEAD) branch.
-5. Only applications whose `manifest-generate-paths` annotation matches a changed file are refreshed.
-
-If any errors occur during the API callback, the changed files list will be empty and all apps pointing to the repository will be refreshed (safe fallback behavior).
-
-This feature supports both regular projects (e.g., `~MYPROJECT`) and personal projects (e.g., `~username`) on BitBucket Server. The project key and repository slug are taken directly from the webhook payload.
+> [!NOTE]
+> If changed-file detection fails for any reason, Argo CD falls back to refreshing all apps pointing to the repository — the same behavior as when no secret is configured.
 
 
 ## 3. Webhook Configuration for OCI-Compliant Registries

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -388,37 +388,11 @@ func (a *ArgoCDWebhookHandler) affectedRevisionInfo(payloadIf any) (webURLs []st
 		// Get changed files only for authenticated webhooks.
 		// When WebhookBitbucketServerSecret is set, webhook requests are validated before processing.
 		if a.settings.GetWebhookBitbucketServerSecret() != "" && httpCloneURL != "" {
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer cancel()
-			argoRepo, err := a.lookupRepository(ctx, httpCloneURL)
+			bbFiles, headTouched, err := a.fetchBBServerChangedFiles(httpCloneURL, payload.Repository.Project.Key, payload.Repository.Slug, change.shaBefore, change.shaAfter, revision)
 			if err != nil {
-				log.Warnf("error trying to find a matching repo for URL %s: %v", httpCloneURL, err)
-				break
-			}
-			if argoRepo == nil {
-				log.Debugf("no Bitbucket Server repository configured for URL %s, skipping changed files fetch", httpCloneURL)
-				break
-			}
-			serverURL, err := extractBBServerBaseURL(httpCloneURL)
-			if err != nil {
-				log.Warnf("error extracting Bitbucket Server base URL from %s: %v", httpCloneURL, err)
-				break
-			}
-			bbClient := newBitbucketServerClient(ctx, argoRepo, serverURL)
-			log.Debugf("created Bitbucket Server client with base URL '%s'", serverURL)
-			projectKey := payload.Repository.Project.Key
-			repoSlug := payload.Repository.Slug
-			bbServerChangedFiles, err := fetchChangesFromBitbucketServer(bbClient, projectKey, repoSlug, change.shaBefore, change.shaAfter)
-			if err != nil {
-				log.Warnf("error fetching changed files from Bitbucket Server: %v", err)
+				log.Warnf("error fetching Bitbucket Server changed files: %v", err)
 			} else {
-				changedFiles = append(changedFiles, bbServerChangedFiles...)
-			}
-			headTouched, err := isBBServerHeadTouched(bbClient, projectKey, repoSlug, revision)
-			if err != nil {
-				log.Warnf("error fetching Bitbucket Server default branch: %v", err)
-				// touchedHead remains true as a safe default
-			} else {
+				changedFiles = append(changedFiles, bbFiles...)
 				touchedHead = headTouched
 			}
 		}
@@ -819,6 +793,51 @@ func isHeadTouched(ctx context.Context, bbClient *bb.Client, owner, repoSlug, re
 	return bbRepo.Mainbranch.Name == revision, nil
 }
 
+// bbServerAPITimeout is the timeout for outbound Bitbucket Server REST API calls made during
+// webhook processing. It matches the analogous timeout used for Bitbucket Cloud API calls.
+// 10 seconds gives enough headroom for a single paginated sequence of /changes requests while
+// keeping the overall webhook handler responsive.
+const bbServerAPITimeout = 10 * time.Second
+
+// fetchBBServerChangedFiles calls the Bitbucket Server REST API to obtain the set of changed
+// files and whether the push touched the repository's default branch. The context (and its
+// cancel) are fully contained inside this function so they are never leaked via a deferred
+// cancel on the caller's stack.
+func (a *ArgoCDWebhookHandler) fetchBBServerChangedFiles(httpCloneURL, projectKey, repoSlug, fromHash, toHash, revision string) ([]string, bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), bbServerAPITimeout)
+	defer cancel()
+
+	argoRepo, err := a.lookupRepository(ctx, httpCloneURL)
+	if err != nil {
+		return nil, true, fmt.Errorf("error looking up repository for URL %s: %w", httpCloneURL, err)
+	}
+	if argoRepo == nil {
+		log.Debugf("no Bitbucket Server repository configured for URL %s, skipping changed files fetch", httpCloneURL)
+		return nil, true, nil
+	}
+	serverURL, err := extractBBServerBaseURL(httpCloneURL)
+	if err != nil {
+		return nil, true, fmt.Errorf("error extracting Bitbucket Server base URL from %s: %w", httpCloneURL, err)
+	}
+	bbClient := newBitbucketServerClient(ctx, argoRepo, serverURL)
+	log.Debugf("created Bitbucket Server client with base URL '%s'", serverURL)
+
+	changedFiles, err := fetchChangesFromBitbucketServer(bbClient, projectKey, repoSlug, fromHash, toHash)
+	if err != nil {
+		log.Warnf("error fetching changed files from Bitbucket Server: %v", err)
+		changedFiles = nil
+	}
+	// Default to true (safe fallback) if the API call fails.
+	touchedHead := true
+	headTouched, err := isBBServerHeadTouched(bbClient, projectKey, repoSlug, revision)
+	if err != nil {
+		log.Warnf("error fetching Bitbucket Server default branch: %v", err)
+	} else {
+		touchedHead = headTouched
+	}
+	return changedFiles, touchedHead, nil
+}
+
 // extractBBServerBaseURL extracts the scheme and host from a Bitbucket Server clone URL.
 // For example, "https://bitbucketserver/scm/project/repo.git" returns "https://bitbucketserver".
 func extractBBServerBaseURL(cloneURL string) (string, error) {
@@ -856,33 +875,46 @@ func newBitbucketServerClient(ctx context.Context, repository *v1alpha1.Reposito
 // by calling the Bitbucket Server changes REST API.
 func fetchChangesFromBitbucketServer(client *bitbucketv1.APIClient, projectKey, repoSlug, fromHash, toHash string) ([]string, error) {
 	log.Debugf("invoking Bitbucket Server changes call: [ProjectKey:%s, RepoSlug:%s, since:%s, until:%s]", projectKey, repoSlug, fromHash, toHash)
-	opts := map[string]any{
-		"since": fromHash,
-		"until": toHash,
-	}
-	resp, err := client.DefaultApi.GetChanges(projectKey, repoSlug, opts)
-	if err != nil {
-		return nil, fmt.Errorf("error fetching changes from Bitbucket Server: %w", err)
-	}
-	values, ok := resp.Values["values"].([]any)
-	if !ok {
-		return []string{}, nil
-	}
-	changedFiles := make([]string, 0, len(values))
-	for _, v := range values {
-		entry, ok := v.(map[string]any)
+	var changedFiles []string
+	start := 0
+	for {
+		opts := map[string]any{
+			"since": fromHash,
+			"until": toHash,
+			"start": start,
+		}
+		resp, err := client.DefaultApi.GetChanges(projectKey, repoSlug, opts)
+		if err != nil {
+			return nil, fmt.Errorf("error fetching changes from Bitbucket Server: %w", err)
+		}
+		values, ok := resp.Values["values"].([]any)
 		if !ok {
-			continue
+			break
 		}
-		pathObj, ok := entry["path"].(map[string]any)
+		for _, v := range values {
+			entry, ok := v.(map[string]any)
+			if !ok {
+				continue
+			}
+			pathObj, ok := entry["path"].(map[string]any)
+			if !ok {
+				continue
+			}
+			filePath, ok := pathObj["toString"].(string)
+			if !ok || filePath == "" {
+				continue
+			}
+			changedFiles = append(changedFiles, filePath)
+		}
+		isLastPage, _ := resp.Values["isLastPage"].(bool)
+		if isLastPage {
+			break
+		}
+		nextStart, ok := resp.Values["nextPageStart"].(float64)
 		if !ok {
-			continue
+			break
 		}
-		filePath, ok := pathObj["toString"].(string)
-		if !ok || filePath == "" {
-			continue
-		}
-		changedFiles = append(changedFiles, filePath)
+		start = int(nextStart)
 	}
 	log.Debugf("Bitbucket Server changed files: %v", changedFiles)
 	return changedFiles, nil

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -404,11 +404,7 @@ func (a *ArgoCDWebhookHandler) affectedRevisionInfo(payloadIf any) (webURLs []st
 				log.Warnf("error extracting Bitbucket Server base URL from %s: %v", httpCloneURL, err)
 				break
 			}
-			bbClient, err := newBitbucketServerClient(ctx, argoRepo, serverURL)
-			if err != nil {
-				log.Warnf("error creating Bitbucket Server client: %v", err)
-				break
-			}
+			bbClient := newBitbucketServerClient(ctx, argoRepo, serverURL)
 			log.Debugf("created Bitbucket Server client with base URL '%s'", serverURL)
 			projectKey := payload.Repository.Project.Key
 			repoSlug := payload.Repository.Slug
@@ -837,7 +833,7 @@ func extractBBServerBaseURL(cloneURL string) (string, error) {
 }
 
 // newBitbucketServerClient creates a new Bitbucket Server API client for the given repository credentials and server URL.
-func newBitbucketServerClient(ctx context.Context, repository *v1alpha1.Repository, serverURL string) (*bitbucketv1.APIClient, error) {
+func newBitbucketServerClient(ctx context.Context, repository *v1alpha1.Repository, serverURL string) *bitbucketv1.APIClient {
 	// Ensure the base path ends with /rest for the Bitbucket Server REST API
 	if !strings.HasSuffix(serverURL, "/rest") {
 		serverURL = strings.TrimSuffix(serverURL, "/") + "/rest"
@@ -853,7 +849,7 @@ func newBitbucketServerClient(ctx context.Context, repository *v1alpha1.Reposito
 			ctx = context.WithValue(ctx, bitbucketv1.ContextAccessToken, repository.BearerToken)
 		}
 	}
-	return bitbucketv1.NewAPIClient(ctx, bitbucketConfig), nil
+	return bitbucketv1.NewAPIClient(ctx, bitbucketConfig)
 }
 
 // fetchChangesFromBitbucketServer retrieves the list of files changed between fromHash and toHash

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -860,7 +860,7 @@ func newBitbucketServerClient(ctx context.Context, repository *v1alpha1.Reposito
 // by calling the Bitbucket Server changes REST API.
 func fetchChangesFromBitbucketServer(client *bitbucketv1.APIClient, projectKey, repoSlug, fromHash, toHash string) ([]string, error) {
 	log.Debugf("invoking Bitbucket Server changes call: [ProjectKey:%s, RepoSlug:%s, since:%s, until:%s]", projectKey, repoSlug, fromHash, toHash)
-	opts := map[string]interface{}{
+	opts := map[string]any{
 		"since": fromHash,
 		"until": toHash,
 	}
@@ -868,17 +868,17 @@ func fetchChangesFromBitbucketServer(client *bitbucketv1.APIClient, projectKey, 
 	if err != nil {
 		return nil, fmt.Errorf("error fetching changes from Bitbucket Server: %w", err)
 	}
-	values, ok := resp.Values["values"].([]interface{})
+	values, ok := resp.Values["values"].([]any)
 	if !ok {
 		return []string{}, nil
 	}
 	changedFiles := make([]string, 0, len(values))
 	for _, v := range values {
-		entry, ok := v.(map[string]interface{})
+		entry, ok := v.(map[string]any)
 		if !ok {
 			continue
 		}
-		pathObj, ok := entry["path"].(map[string]interface{})
+		pathObj, ok := entry["path"].(map[string]any)
 		if !ok {
 			continue
 		}

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -798,7 +798,7 @@ func isHeadTouched(ctx context.Context, bbClient *bb.Client, owner, repoSlug, re
 const bbServerAPITimeout = 10 * time.Second
 
 // fetchBBServerChangedFiles calls the Bitbucket Server REST API to obtain the set of changed
-// files and whether the push touched the repository's default branch. 
+// files and whether the push touched the repository's default branch.
 func (a *ArgoCDWebhookHandler) fetchBBServerChangedFiles(httpCloneURL, projectKey, repoSlug, fromHash, toHash, revision string) ([]string, bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), bbServerAPITimeout)
 	defer cancel()

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -22,6 +22,7 @@ import (
 	alpha1 "github.com/argoproj/argo-cd/v3/pkg/client/listers/application/v1alpha1"
 
 	"github.com/Masterminds/semver/v3"
+	bitbucketv1 "github.com/gfleury/go-bitbucket-v1"
 	"github.com/go-playground/webhooks/v6/azuredevops"
 	"github.com/go-playground/webhooks/v6/bitbucket"
 	bitbucketserver "github.com/go-playground/webhooks/v6/bitbucket-server"
@@ -346,20 +347,27 @@ func (a *ArgoCDWebhookHandler) affectedRevisionInfo(payloadIf any) (webURLs []st
 			}
 		}
 
-	// Bitbucket does not include a list of changed files anywhere in it's payload
-	// so we cannot update changedFiles for this type of payload
 	case bitbucketserver.RepositoryReferenceChangedPayload:
-
+		var httpCloneURL string
 		// Webhook module does not parse the inner links
 		if payload.Repository.Links != nil {
 			clone, ok := payload.Repository.Links["clone"].([]any)
 			if ok {
 				for _, l := range clone {
-					link := l.(map[string]any)
-					if link["name"] == "http" || link["name"] == "ssh" {
-						if href, ok := link["href"].(string); ok {
-							webURLs = append(webURLs, href)
-						}
+					link, ok := l.(map[string]any)
+					if !ok {
+						continue
+					}
+					href, ok := link["href"].(string)
+					if !ok {
+						continue
+					}
+					switch link["name"] {
+					case "http":
+						httpCloneURL = href
+						webURLs = append(webURLs, href)
+					case "ssh":
+						webURLs = append(webURLs, href)
 					}
 				}
 			}
@@ -367,16 +375,57 @@ func (a *ArgoCDWebhookHandler) affectedRevisionInfo(payloadIf any) (webURLs []st
 
 		// TODO: bitbucket includes multiple changes as part of a single event.
 		// We only pick the first but need to consider how to handle multiple
-		for _, change := range payload.Changes {
-			revision = ParseRevision(change.Reference.ID)
+		for _, refChange := range payload.Changes {
+			revision = ParseRevision(refChange.Reference.ID)
+			change.shaBefore = refChange.FromHash
+			change.shaAfter = refChange.ToHash
 			break
 		}
-		// Not actually sure how to check if the incoming change affected HEAD just by examining the
-		// payload alone. To be safe, we just return true and let the controller check for himself.
+		// Default to true as a safe fallback. When WebhookBitbucketServerSecret is set,
+		// the actual default branch is determined via the API below and touchedHead is updated.
 		touchedHead = true
 
-		// Bitbucket does not include a list of changed files anywhere in it's payload
-		// so we cannot update changedFiles for this type of payload
+		// Get changed files only for authenticated webhooks.
+		// When WebhookBitbucketServerSecret is set, webhook requests are validated before processing.
+		if a.settings.GetWebhookBitbucketServerSecret() != "" && httpCloneURL != "" {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			argoRepo, err := a.lookupRepository(ctx, httpCloneURL)
+			if err != nil {
+				log.Warnf("error trying to find a matching repo for URL %s: %v", httpCloneURL, err)
+				break
+			}
+			if argoRepo == nil {
+				log.Debugf("no Bitbucket Server repository configured for URL %s, skipping changed files fetch", httpCloneURL)
+				break
+			}
+			serverURL, err := extractBBServerBaseURL(httpCloneURL)
+			if err != nil {
+				log.Warnf("error extracting Bitbucket Server base URL from %s: %v", httpCloneURL, err)
+				break
+			}
+			bbClient, err := newBitbucketServerClient(ctx, argoRepo, serverURL)
+			if err != nil {
+				log.Warnf("error creating Bitbucket Server client: %v", err)
+				break
+			}
+			log.Debugf("created Bitbucket Server client with base URL '%s'", serverURL)
+			projectKey := payload.Repository.Project.Key
+			repoSlug := payload.Repository.Slug
+			bbServerChangedFiles, err := fetchChangesFromBitbucketServer(bbClient, projectKey, repoSlug, change.shaBefore, change.shaAfter)
+			if err != nil {
+				log.Warnf("error fetching changed files from Bitbucket Server: %v", err)
+			} else {
+				changedFiles = append(changedFiles, bbServerChangedFiles...)
+			}
+			headTouched, err := isBBServerHeadTouched(bbClient, projectKey, repoSlug, revision)
+			if err != nil {
+				log.Warnf("error fetching Bitbucket Server default branch: %v", err)
+				// touchedHead remains true as a safe default
+			} else {
+				touchedHead = headTouched
+			}
+		}
 
 	case gogsclient.PushPayload:
 		revision = ParseRevision(payload.Ref)
@@ -772,6 +821,88 @@ func isHeadTouched(ctx context.Context, bbClient *bb.Client, owner, repoSlug, re
 		return false, err
 	}
 	return bbRepo.Mainbranch.Name == revision, nil
+}
+
+// extractBBServerBaseURL extracts the scheme and host from a Bitbucket Server clone URL.
+// For example, "https://bitbucketserver/scm/project/repo.git" returns "https://bitbucketserver".
+func extractBBServerBaseURL(cloneURL string) (string, error) {
+	u, err := url.Parse(cloneURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse Bitbucket Server clone URL '%s': %w", cloneURL, err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("invalid Bitbucket Server clone URL '%s': missing scheme or host", cloneURL)
+	}
+	return u.Scheme + "://" + u.Host, nil
+}
+
+// newBitbucketServerClient creates a new Bitbucket Server API client for the given repository credentials and server URL.
+func newBitbucketServerClient(ctx context.Context, repository *v1alpha1.Repository, serverURL string) (*bitbucketv1.APIClient, error) {
+	// Ensure the base path ends with /rest for the Bitbucket Server REST API
+	if !strings.HasSuffix(serverURL, "/rest") {
+		serverURL = strings.TrimSuffix(serverURL, "/") + "/rest"
+	}
+	bitbucketConfig := bitbucketv1.NewConfiguration(serverURL)
+	if repository != nil {
+		if repository.Username != "" && repository.Password != "" {
+			ctx = context.WithValue(ctx, bitbucketv1.ContextBasicAuth, bitbucketv1.BasicAuth{
+				UserName: repository.Username,
+				Password: repository.Password,
+			})
+		} else if repository.BearerToken != "" {
+			ctx = context.WithValue(ctx, bitbucketv1.ContextAccessToken, repository.BearerToken)
+		}
+	}
+	return bitbucketv1.NewAPIClient(ctx, bitbucketConfig), nil
+}
+
+// fetchChangesFromBitbucketServer retrieves the list of files changed between fromHash and toHash
+// by calling the Bitbucket Server changes REST API.
+func fetchChangesFromBitbucketServer(client *bitbucketv1.APIClient, projectKey, repoSlug, fromHash, toHash string) ([]string, error) {
+	log.Debugf("invoking Bitbucket Server changes call: [ProjectKey:%s, RepoSlug:%s, since:%s, until:%s]", projectKey, repoSlug, fromHash, toHash)
+	opts := map[string]interface{}{
+		"since": fromHash,
+		"until": toHash,
+	}
+	resp, err := client.DefaultApi.GetChanges(projectKey, repoSlug, opts)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching changes from Bitbucket Server: %w", err)
+	}
+	values, ok := resp.Values["values"].([]interface{})
+	if !ok {
+		return []string{}, nil
+	}
+	changedFiles := make([]string, 0, len(values))
+	for _, v := range values {
+		entry, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		pathObj, ok := entry["path"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		filePath, ok := pathObj["toString"].(string)
+		if !ok || filePath == "" {
+			continue
+		}
+		changedFiles = append(changedFiles, filePath)
+	}
+	log.Debugf("Bitbucket Server changed files: %v", changedFiles)
+	return changedFiles, nil
+}
+
+// isBBServerHeadTouched returns true if the push updated the repository's default branch.
+func isBBServerHeadTouched(client *bitbucketv1.APIClient, projectKey, repoSlug, revision string) (bool, error) {
+	resp, err := client.DefaultApi.GetDefaultBranch(projectKey, repoSlug)
+	if err != nil {
+		return false, err
+	}
+	branch, err := bitbucketv1.GetBranchResponse(resp)
+	if err != nil {
+		return false, err
+	}
+	return branch.DisplayID == revision, nil
 }
 
 func (a *ArgoCDWebhookHandler) Handler(w http.ResponseWriter, r *http.Request) {

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -874,6 +874,11 @@ func newBitbucketServerClient(ctx context.Context, repository *v1alpha1.Reposito
 	return bitbucketv1.NewAPIClient(ctx, bitbucketConfig)
 }
 
+// bbServerChangesPageLimit is the page size used when fetching changed files from the Bitbucket Server
+// changes API. It minimizes the round trips. If the server admin has configured a lower hard max, the server
+// silently caps each page at that value and the pagination loop still terminates correctly via isLastPage.
+const bbServerChangesPageLimit = 1000
+
 // fetchChangesFromBitbucketServer retrieves the list of files changed between fromHash and toHash
 // by calling the Bitbucket Server changes REST API.
 func fetchChangesFromBitbucketServer(client *bitbucketv1.APIClient, projectKey, repoSlug, fromHash, toHash string) ([]string, error) {
@@ -885,6 +890,7 @@ func fetchChangesFromBitbucketServer(client *bitbucketv1.APIClient, projectKey, 
 			"since": fromHash,
 			"until": toHash,
 			"start": start,
+			"limit": bbServerChangesPageLimit,
 		}
 		resp, err := client.DefaultApi.GetChanges(projectKey, repoSlug, opts)
 		if err != nil {

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -794,15 +794,11 @@ func isHeadTouched(ctx context.Context, bbClient *bb.Client, owner, repoSlug, re
 }
 
 // bbServerAPITimeout is the timeout for outbound Bitbucket Server REST API calls made during
-// webhook processing. It matches the analogous timeout used for Bitbucket Cloud API calls.
-// 10 seconds gives enough headroom for a single paginated sequence of /changes requests while
-// keeping the overall webhook handler responsive.
+// webhook processing.
 const bbServerAPITimeout = 10 * time.Second
 
 // fetchBBServerChangedFiles calls the Bitbucket Server REST API to obtain the set of changed
-// files and whether the push touched the repository's default branch. The context (and its
-// cancel) are fully contained inside this function so they are never leaked via a deferred
-// cancel on the caller's stack.
+// files and whether the push touched the repository's default branch. 
 func (a *ArgoCDWebhookHandler) fetchBBServerChangedFiles(httpCloneURL, projectKey, repoSlug, fromHash, toHash, revision string) ([]string, bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), bbServerAPITimeout)
 	defer cancel()
@@ -847,6 +843,13 @@ func extractBBServerBaseURL(cloneURL string) (string, error) {
 	}
 	if u.Scheme == "" || u.Host == "" {
 		return "", fmt.Errorf("invalid Bitbucket Server clone URL '%s': missing scheme or host", cloneURL)
+	}
+	// Bitbucket Server clone URLs always contain "/scm/" as the separator between the
+	// server base path and the project/repo path. Everything before "/scm/" is the
+	// server base URL, which may include a subpath when Bitbucket is deployed under a
+	// context path (e.g. https://mycompany.com/bitbucket/scm/... → https://mycompany.com/bitbucket).
+	if idx := strings.Index(u.Path, "/scm/"); idx >= 0 {
+		return u.Scheme + "://" + u.Host + u.Path[:idx], nil
 	}
 	return u.Scheme + "://" + u.Host, nil
 }

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -1876,4 +1876,291 @@ func TestProcessAppRefresh(t *testing.T) {
 
 		assert.Contains(t, hook.LastEntry().Message, "Requested app 'test-app' hydration")
 	})
+func NewMockHandlerForBitbucketServerCallback(reactor *reactorDef, applicationNamespaces []string, objects ...runtime.Object) *ArgoCDWebhookHandler {
+	mockDB := &mocks.ArgoDB{}
+	mockDB.EXPECT().ListRepositories(mock.Anything).Return(
+		[]*v1alpha1.Repository{
+			{
+				Repo:     "https://bitbucketserver/scm/myproject/test-repo.git",
+				Username: "testuser",
+				Password: "testpassword",
+			},
+		}, nil)
+	argoSettings := settings.ArgoCDSettings{WebhookBitbucketServerSecret: "my-bb-server-secret"}
+	defaultMaxPayloadSize := int64(50) * 1024 * 1024
+	return newMockHandler(reactor, applicationNamespaces, defaultMaxPayloadSize, mockDB, &argoSettings, objects...)
+}
+
+// getBBServerChangesResponderFn returns a httpmock responder for the Bitbucket Server changes API
+func getBBServerChangesResponderFn() func(req *http.Request) (*http.Response, error) {
+	return func(_ *http.Request) (*http.Response, error) {
+		changesResp := map[string]interface{}{
+			"values": []interface{}{
+				map[string]interface{}{
+					"contentId":     "abc123",
+					"fromContentId": "def456",
+					"path": map[string]interface{}{
+						"components": []interface{}{"guestbook", "guestbook-ui-deployment.yaml"},
+						"parent":     "guestbook",
+						"name":       "guestbook-ui-deployment.yaml",
+						"extension":  "yaml",
+						"toString":   "guestbook/guestbook-ui-deployment.yaml",
+					},
+					"type":     "MODIFY",
+					"nodeType": "FILE",
+				},
+			},
+			"isLastPage": true,
+			"start":      0,
+			"limit":      25,
+			"size":       1,
+		}
+		resp, err := httpmock.NewJsonResponse(200, changesResp)
+		if err != nil {
+			return httpmock.NewStringResponse(500, ""), nil
+		}
+		return resp, nil
+	}
+}
+
+// getBBServerDefaultBranchResponderFn returns a httpmock responder for the Bitbucket Server default branch API
+func getBBServerDefaultBranchResponderFn(defaultBranch string) func(req *http.Request) (*http.Response, error) {
+	return func(_ *http.Request) (*http.Response, error) {
+		branchResp := map[string]interface{}{
+			"id":           "refs/heads/" + defaultBranch,
+			"displayId":    defaultBranch,
+			"type":         "BRANCH",
+			"isDefault":    true,
+			"latestCommit": "abc123",
+		}
+		resp, err := httpmock.NewJsonResponse(200, branchResp)
+		if err != nil {
+			return httpmock.NewStringResponse(500, ""), nil
+		}
+		return resp, nil
+	}
+}
+
+func Test_affectedRevisionInfo_bbserver_changed_files(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	httpmock.RegisterResponder("GET",
+		`=~^https://bitbucketserver/rest/api/1.0/projects/MYPROJECT/repos/test-repo/changes`,
+		getBBServerChangesResponderFn())
+	httpmock.RegisterResponder("GET",
+		"https://bitbucketserver/rest/api/1.0/projects/MYPROJECT/repos/test-repo/branches/default",
+		getBBServerDefaultBranchResponderFn("master"))
+
+	bbServerPayload := func(branchName, projectKey, repoSlug, fromHash, toHash string) bitbucketserver.RepositoryReferenceChangedPayload {
+		return bitbucketserver.RepositoryReferenceChangedPayload{
+			Changes: []bitbucketserver.RepositoryChange{
+				{
+					Reference:   bitbucketserver.RepositoryReference{ID: "refs/heads/" + branchName},
+					ReferenceID: "refs/heads/" + branchName,
+					FromHash:    fromHash,
+					ToHash:      toHash,
+					Type:        "UPDATE",
+				},
+			},
+			Repository: bitbucketserver.Repository{
+				Slug: repoSlug,
+				Project: bitbucketserver.Project{
+					Key: projectKey,
+				},
+				Links: map[string]interface{}{
+					"clone": []interface{}{
+						map[string]interface{}{
+							"href": "https://bitbucketserver/scm/" + strings.ToLower(projectKey) + "/" + repoSlug + ".git",
+							"name": "http",
+						},
+						map[string]interface{}{
+							"href": "ssh://git@bitbucketserver:7999/" + strings.ToLower(projectKey) + "/" + repoSlug + ".git",
+							"name": "ssh",
+						},
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name                 string
+		revision             string
+		hookPayload          bitbucketserver.RepositoryReferenceChangedPayload
+		expectedTouchHead    bool
+		expectedChangedFiles []string
+		expectedChangeInfo   changeInfo
+	}{
+		{
+			name:                 "push to non-default branch",
+			revision:             "feature-branch",
+			hookPayload:          bbServerPayload("feature-branch", "MYPROJECT", "test-repo", "abcdef", "ghijkl"),
+			expectedTouchHead:    false,
+			expectedChangedFiles: []string{"guestbook/guestbook-ui-deployment.yaml"},
+			expectedChangeInfo:   changeInfo{shaBefore: "abcdef", shaAfter: "ghijkl"},
+		},
+		{
+			name:                 "push to default branch",
+			revision:             "master",
+			hookPayload:          bbServerPayload("master", "MYPROJECT", "test-repo", "abcdef", "ghijkl"),
+			expectedTouchHead:    true,
+			expectedChangedFiles: []string{"guestbook/guestbook-ui-deployment.yaml"},
+			expectedChangeInfo:   changeInfo{shaBefore: "abcdef", shaAfter: "ghijkl"},
+		},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			h := NewMockHandlerForBitbucketServerCallback(nil, []string{})
+			_, revisionFromHook, change, touchHead, changedFiles := h.affectedRevisionInfo(testCase.hookPayload)
+			require.Equal(t, testCase.revision, revisionFromHook)
+			require.Equal(t, testCase.expectedTouchHead, touchHead)
+			require.Equal(t, testCase.expectedChangedFiles, changedFiles)
+			require.Equal(t, testCase.expectedChangeInfo, change)
+		})
+	}
+}
+
+func TestExtractBBServerBaseURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		cloneURL    string
+		expected    string
+		expectedErr string
+	}{
+		{
+			name:     "standard http clone URL",
+			cloneURL: "https://bitbucketserver/scm/myproject/test-repo.git",
+			expected: "https://bitbucketserver",
+		},
+		{
+			name:     "personal project clone URL",
+			cloneURL: "https://bitbucketserver/scm/~testuser/test_a.git",
+			expected: "https://bitbucketserver",
+		},
+		{
+			name:        "invalid URL missing host",
+			cloneURL:    "/scm/myproject/test-repo.git",
+			expectedErr: "invalid Bitbucket Server clone URL",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := extractBBServerBaseURL(tt.cloneURL)
+			if tt.expectedErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.expectedErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestFetchChangesFromBitbucketServer(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	httpmock.RegisterResponder("GET",
+		`=~^https://bitbucketserver/rest/api/1.0/projects/MYPROJECT/repos/test-repo/changes`,
+		getBBServerChangesResponderFn())
+
+	client, err := newBitbucketServerClient(t.Context(), &v1alpha1.Repository{}, "https://bitbucketserver")
+	require.NoError(t, err)
+
+	tt := []struct {
+		name                string
+		projectKey          string
+		repoSlug            string
+		fromHash            string
+		toHash              string
+		expectedLen         int
+		expectedFileChanged string
+		expectedErrString   string
+	}{
+		{
+			name:                "valid project and repo",
+			projectKey:          "MYPROJECT",
+			repoSlug:            "test-repo",
+			fromHash:            "abcdef",
+			toHash:              "ghijkl",
+			expectedLen:         1,
+			expectedFileChanged: "guestbook/guestbook-ui-deployment.yaml",
+		},
+		{
+			name:              "unknown repo",
+			projectKey:        "MYPROJECT",
+			repoSlug:          "unknown-repo",
+			fromHash:          "abcdef",
+			toHash:            "ghijkl",
+			expectedErrString: "error fetching changes from Bitbucket Server",
+		},
+	}
+	for _, test := range tt {
+		t.Run(test.name, func(t *testing.T) {
+			changedFiles, err := fetchChangesFromBitbucketServer(client, test.projectKey, test.repoSlug, test.fromHash, test.toHash)
+			if test.expectedErrString == "" {
+				require.NoError(t, err)
+				require.Len(t, changedFiles, test.expectedLen)
+				require.Equal(t, test.expectedFileChanged, changedFiles[0])
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), test.expectedErrString)
+			}
+		})
+	}
+}
+
+func TestIsBBServerHeadTouched(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	httpmock.RegisterResponder("GET",
+		"https://bitbucketserver/rest/api/1.0/projects/MYPROJECT/repos/test-repo/branches/default",
+		getBBServerDefaultBranchResponderFn("master"))
+
+	client, err := newBitbucketServerClient(t.Context(), &v1alpha1.Repository{}, "https://bitbucketserver")
+	require.NoError(t, err)
+
+	tt := []struct {
+		name              string
+		projectKey        string
+		repoSlug          string
+		revision          string
+		expectedTouchHead bool
+		expectedErrString string
+	}{
+		{
+			name:              "revision matches default branch",
+			projectKey:        "MYPROJECT",
+			repoSlug:          "test-repo",
+			revision:          "master",
+			expectedTouchHead: true,
+		},
+		{
+			name:              "revision does not match default branch",
+			projectKey:        "MYPROJECT",
+			repoSlug:          "test-repo",
+			revision:          "feature-branch",
+			expectedTouchHead: false,
+		},
+		{
+			name:              "unknown repo returns error",
+			projectKey:        "MYPROJECT",
+			repoSlug:          "unknown-repo",
+			revision:          "master",
+			expectedErrString: "https://bitbucketserver/rest/api/1.0/projects/MYPROJECT/repos/unknown-repo",
+		},
+	}
+	for _, test := range tt {
+		t.Run(test.name, func(t *testing.T) {
+			touchedHead, err := isBBServerHeadTouched(client, test.projectKey, test.repoSlug, test.revision)
+			if test.expectedErrString == "" {
+				require.NoError(t, err)
+				require.Equal(t, test.expectedTouchHead, touchedHead)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), test.expectedErrString)
+				require.False(t, touchedHead)
+			}
+		})
+	}
 }

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -2165,6 +2165,11 @@ func TestExtractBBServerBaseURL(t *testing.T) {
 			expected: "https://bitbucketserver",
 		},
 		{
+			name:     "bitbucket server deployed under a subpath",
+			cloneURL: "https://mycompany.com/bitbucket/scm/myproject/test-repo.git",
+			expected: "https://mycompany.com/bitbucket",
+		},
+		{
 			name:        "invalid URL missing host",
 			cloneURL:    "/scm/myproject/test-repo.git",
 			expectedErr: "invalid Bitbucket Server clone URL",

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -1969,7 +1969,7 @@ func getBBServer401ResponderFn() func(req *http.Request) (*http.Response, error)
 // getBBServerPagedChangesResponderFn returns a two-page responder for the changes API.
 func getBBServerPagedChangesResponderFn() func(req *http.Request) (*http.Response, error) {
 	callCount := 0
-	return func(req *http.Request) (*http.Response, error) {
+	return func(_ *http.Request) (*http.Response, error) {
 		callCount++
 		var body map[string]any
 		if callCount == 1 {

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -1885,6 +1885,16 @@ func NewMockHandlerForBitbucketServerCallback(reactor *reactorDef, applicationNa
 				Username: "testuser",
 				Password: "testpassword",
 			},
+			{
+				Repo:     "https://bitbucketserver/scm/myproject/paged-repo.git",
+				Username: "testuser",
+				Password: "testpassword",
+			},
+			{
+				Repo:     "https://bitbucketserver/scm/myproject/auth-error-repo.git",
+				Username: "testuser",
+				Password: "testpassword",
+			},
 		}, nil)
 	argoSettings := settings.ArgoCDSettings{WebhookBitbucketServerSecret: "my-bb-server-secret"}
 	defaultMaxPayloadSize := int64(50) * 1024 * 1024
@@ -1941,6 +1951,53 @@ func getBBServerDefaultBranchResponderFn(defaultBranch string) func(req *http.Re
 	}
 }
 
+func NewMockHandlerForBitbucketServerNoSecret(reactor *reactorDef, applicationNamespaces []string, objects ...runtime.Object) *ArgoCDWebhookHandler {
+	mockDB := &mocks.ArgoDB{}
+	// No ListRepositories expectation because it must never be called without a secret.
+	argoSettings := settings.ArgoCDSettings{} // no WebhookBitbucketServerSecret
+	defaultMaxPayloadSize := int64(50) * 1024 * 1024
+	return newMockHandler(reactor, applicationNamespaces, defaultMaxPayloadSize, mockDB, &argoSettings, objects...)
+}
+
+// getBBServer401ResponderFn returns a 401 Unauthorized responder to simulate auth errors.
+func getBBServer401ResponderFn() func(req *http.Request) (*http.Response, error) {
+	return func(_ *http.Request) (*http.Response, error) {
+		return httpmock.NewStringResponse(401, `{"errors":[{"message":"Unauthenticated"}]}`), nil
+	}
+}
+
+// getBBServerPagedChangesResponderFn returns a two-page responder for the changes API.
+func getBBServerPagedChangesResponderFn() func(req *http.Request) (*http.Response, error) {
+	callCount := 0
+	return func(req *http.Request) (*http.Response, error) {
+		callCount++
+		var body map[string]any
+		if callCount == 1 {
+			body = map[string]any{
+				"values": []any{
+					map[string]any{"path": map[string]any{"toString": "base/deployment.yaml"}},
+				},
+				"isLastPage":    false,
+				"nextPageStart": float64(1),
+				"limit":         1,
+			}
+		} else {
+			body = map[string]any{
+				"values": []any{
+					map[string]any{"path": map[string]any{"toString": "base/service.yaml"}},
+				},
+				"isLastPage": true,
+				"limit":      1,
+			}
+		}
+		resp, err := httpmock.NewJsonResponse(200, body)
+		if err != nil {
+			return httpmock.NewStringResponse(500, ""), nil
+		}
+		return resp, nil
+	}
+}
+
 func Test_affectedRevisionInfo_bbserver_changed_files(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
@@ -1950,7 +2007,17 @@ func Test_affectedRevisionInfo_bbserver_changed_files(t *testing.T) {
 	httpmock.RegisterResponder("GET",
 		"https://bitbucketserver/rest/api/1.0/projects/MYPROJECT/repos/test-repo/branches/default",
 		getBBServerDefaultBranchResponderFn("master"))
+	httpmock.RegisterResponder("GET",
+		`=~^https://bitbucketserver/rest/api/1.0/projects/MYPROJECT/repos/paged-repo/changes`,
+		getBBServerPagedChangesResponderFn())
+	httpmock.RegisterResponder("GET",
+		"https://bitbucketserver/rest/api/1.0/projects/MYPROJECT/repos/paged-repo/branches/default",
+		getBBServerDefaultBranchResponderFn("master"))
+	httpmock.RegisterResponder("GET",
+		`=~^https://bitbucketserver/rest/api/1.0/projects/MYPROJECT/repos/auth-error-repo/`,
+		getBBServer401ResponderFn())
 
+	// payload with both HTTP and SSH clone links
 	bbServerPayload := func(branchName, projectKey, repoSlug, fromHash, toHash string) bitbucketserver.RepositoryReferenceChangedPayload {
 		return bitbucketserver.RepositoryReferenceChangedPayload{
 			Changes: []bitbucketserver.RepositoryChange{
@@ -1983,10 +2050,25 @@ func Test_affectedRevisionInfo_bbserver_changed_files(t *testing.T) {
 		}
 	}
 
+	// payload with SSH clone link only (no HTTP)
+	bbServerSSHOnlyPayload := func(branchName, projectKey, repoSlug, fromHash, toHash string) bitbucketserver.RepositoryReferenceChangedPayload {
+		p := bbServerPayload(branchName, projectKey, repoSlug, fromHash, toHash)
+		p.Repository.Links = map[string]any{
+			"clone": []any{
+				map[string]any{
+					"href": "ssh://git@bitbucketserver:7999/" + strings.ToLower(projectKey) + "/" + repoSlug + ".git",
+					"name": "ssh",
+				},
+			},
+		}
+		return p
+	}
+
 	tests := []struct {
 		name                 string
 		revision             string
 		hookPayload          bitbucketserver.RepositoryReferenceChangedPayload
+		handler              func() *ArgoCDWebhookHandler
 		expectedTouchHead    bool
 		expectedChangedFiles []string
 		expectedChangeInfo   changeInfo
@@ -1995,6 +2077,7 @@ func Test_affectedRevisionInfo_bbserver_changed_files(t *testing.T) {
 			name:                 "push to non-default branch",
 			revision:             "feature-branch",
 			hookPayload:          bbServerPayload("feature-branch", "MYPROJECT", "test-repo", "abcdef", "ghijkl"),
+			handler:              func() *ArgoCDWebhookHandler { return NewMockHandlerForBitbucketServerCallback(nil, []string{}) },
 			expectedTouchHead:    false,
 			expectedChangedFiles: []string{"guestbook/guestbook-ui-deployment.yaml"},
 			expectedChangeInfo:   changeInfo{shaBefore: "abcdef", shaAfter: "ghijkl"},
@@ -2003,14 +2086,58 @@ func Test_affectedRevisionInfo_bbserver_changed_files(t *testing.T) {
 			name:                 "push to default branch",
 			revision:             "master",
 			hookPayload:          bbServerPayload("master", "MYPROJECT", "test-repo", "abcdef", "ghijkl"),
+			handler:              func() *ArgoCDWebhookHandler { return NewMockHandlerForBitbucketServerCallback(nil, []string{}) },
 			expectedTouchHead:    true,
 			expectedChangedFiles: []string{"guestbook/guestbook-ui-deployment.yaml"},
+			expectedChangeInfo:   changeInfo{shaBefore: "abcdef", shaAfter: "ghijkl"},
+		},
+		{
+			// Without a secret the API must never be called; changed files stay nil and
+			// touchedHead defaults to true (safe fallback).
+			name:                 "no secret configured - no API call, touchedHead defaults to true",
+			revision:             "master",
+			hookPayload:          bbServerPayload("master", "MYPROJECT", "test-repo", "abcdef", "ghijkl"),
+			handler:              func() *ArgoCDWebhookHandler { return NewMockHandlerForBitbucketServerNoSecret(nil, []string{}) },
+			expectedTouchHead:    true,
+			expectedChangedFiles: nil,
+			expectedChangeInfo:   changeInfo{shaBefore: "abcdef", shaAfter: "ghijkl"},
+		},
+		{
+			// When only an SSH clone URL is present httpCloneURL remains empty and the API
+			// block is skipped, same as no-secret.
+			name:                 "SSH-only clone URL - API skipped, touchedHead defaults to true",
+			revision:             "master",
+			hookPayload:          bbServerSSHOnlyPayload("master", "MYPROJECT", "test-repo", "abcdef", "ghijkl"),
+			handler:              func() *ArgoCDWebhookHandler { return NewMockHandlerForBitbucketServerCallback(nil, []string{}) },
+			expectedTouchHead:    true,
+			expectedChangedFiles: nil,
+			expectedChangeInfo:   changeInfo{shaBefore: "abcdef", shaAfter: "ghijkl"},
+		},
+		{
+			// Changes API returns two pages; both pages should be collected.
+			name:                 "paginated changes response",
+			revision:             "master",
+			hookPayload:          bbServerPayload("master", "MYPROJECT", "paged-repo", "abcdef", "ghijkl"),
+			handler:              func() *ArgoCDWebhookHandler { return NewMockHandlerForBitbucketServerCallback(nil, []string{}) },
+			expectedTouchHead:    true,
+			expectedChangedFiles: []string{"base/deployment.yaml", "base/service.yaml"},
+			expectedChangeInfo:   changeInfo{shaBefore: "abcdef", shaAfter: "ghijkl"},
+		},
+		{
+			// When the Bitbucket Server API returns a 401 error changed files stay nil and
+			// touchedHead defaults to true so the controller performs a safe full-refresh.
+			name:                 "API auth error - no changed files, touchedHead defaults to true",
+			revision:             "master",
+			hookPayload:          bbServerPayload("master", "MYPROJECT", "auth-error-repo", "abcdef", "ghijkl"),
+			handler:              func() *ArgoCDWebhookHandler { return NewMockHandlerForBitbucketServerCallback(nil, []string{}) },
+			expectedTouchHead:    true,
+			expectedChangedFiles: nil,
 			expectedChangeInfo:   changeInfo{shaBefore: "abcdef", shaAfter: "ghijkl"},
 		},
 	}
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
-			h := NewMockHandlerForBitbucketServerCallback(nil, []string{})
+			h := testCase.handler()
 			_, revisionFromHook, change, touchHead, changedFiles := h.affectedRevisionInfo(testCase.hookPayload)
 			require.Equal(t, testCase.revision, revisionFromHook)
 			require.Equal(t, testCase.expectedTouchHead, touchHead)
@@ -2107,6 +2234,55 @@ func TestFetchChangesFromBitbucketServer(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFetchChangesFromBitbucketServerPaginated(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	// Stateful responder: first call returns page 1, second returns page 2 (last).
+	callCount := 0
+	httpmock.RegisterResponder("GET",
+		`=~^https://bitbucketserver/rest/api/1.0/projects/MYPROJECT/repos/paged-repo/changes`,
+		func(_ *http.Request) (*http.Response, error) {
+			callCount++
+			var body map[string]any
+			if callCount == 1 {
+				body = map[string]any{
+					"values": []any{
+						map[string]any{
+							"path": map[string]any{"toString": "file1.yaml"},
+						},
+					},
+					"isLastPage":    false,
+					"nextPageStart": float64(1),
+					"limit":         1,
+					"size":          1,
+				}
+			} else {
+				body = map[string]any{
+					"values": []any{
+						map[string]any{
+							"path": map[string]any{"toString": "file2.yaml"},
+						},
+					},
+					"isLastPage": true,
+					"limit":      1,
+					"size":       1,
+				}
+			}
+			resp, err := httpmock.NewJsonResponse(200, body)
+			if err != nil {
+				return httpmock.NewStringResponse(500, ""), nil
+			}
+			return resp, nil
+		})
+
+	client := newBitbucketServerClient(t.Context(), &v1alpha1.Repository{}, "https://bitbucketserver")
+	changedFiles, err := fetchChangesFromBitbucketServer(client, "MYPROJECT", "paged-repo", "abcdef", "ghijkl")
+	require.NoError(t, err)
+	require.Equal(t, 2, callCount, "expected two API calls for two pages")
+	require.Equal(t, []string{"file1.yaml", "file2.yaml"}, changedFiles)
 }
 
 func TestIsBBServerHeadTouched(t *testing.T) {

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -1894,13 +1894,13 @@ func NewMockHandlerForBitbucketServerCallback(reactor *reactorDef, applicationNa
 // getBBServerChangesResponderFn returns a httpmock responder for the Bitbucket Server changes API
 func getBBServerChangesResponderFn() func(req *http.Request) (*http.Response, error) {
 	return func(_ *http.Request) (*http.Response, error) {
-		changesResp := map[string]interface{}{
-			"values": []interface{}{
-				map[string]interface{}{
+		changesResp := map[string]any{
+			"values": []any{
+				map[string]any{
 					"contentId":     "abc123",
 					"fromContentId": "def456",
-					"path": map[string]interface{}{
-						"components": []interface{}{"guestbook", "guestbook-ui-deployment.yaml"},
+					"path": map[string]any{
+						"components": []any{"guestbook", "guestbook-ui-deployment.yaml"},
 						"parent":     "guestbook",
 						"name":       "guestbook-ui-deployment.yaml",
 						"extension":  "yaml",
@@ -1926,7 +1926,7 @@ func getBBServerChangesResponderFn() func(req *http.Request) (*http.Response, er
 // getBBServerDefaultBranchResponderFn returns a httpmock responder for the Bitbucket Server default branch API
 func getBBServerDefaultBranchResponderFn(defaultBranch string) func(req *http.Request) (*http.Response, error) {
 	return func(_ *http.Request) (*http.Response, error) {
-		branchResp := map[string]interface{}{
+		branchResp := map[string]any{
 			"id":           "refs/heads/" + defaultBranch,
 			"displayId":    defaultBranch,
 			"type":         "BRANCH",
@@ -1967,13 +1967,13 @@ func Test_affectedRevisionInfo_bbserver_changed_files(t *testing.T) {
 				Project: bitbucketserver.Project{
 					Key: projectKey,
 				},
-				Links: map[string]interface{}{
-					"clone": []interface{}{
-						map[string]interface{}{
+				Links: map[string]any{
+					"clone": []any{
+						map[string]any{
 							"href": "https://bitbucketserver/scm/" + strings.ToLower(projectKey) + "/" + repoSlug + ".git",
 							"name": "http",
 						},
-						map[string]interface{}{
+						map[string]any{
 							"href": "ssh://git@bitbucketserver:7999/" + strings.ToLower(projectKey) + "/" + repoSlug + ".git",
 							"name": "ssh",
 						},

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -1966,7 +1966,7 @@ func getBBServer401ResponderFn() func(req *http.Request) (*http.Response, error)
 	}
 }
 
-// getBBServerPagedChangesResponderFn returns a two-page responder for the changes API.
+// getBBServerPagedChangesResponderFn returns a two-page stateful responder for the Bitbucket Server changes API.
 func getBBServerPagedChangesResponderFn() func(req *http.Request) (*http.Response, error) {
 	callCount := 0
 	return func(_ *http.Request) (*http.Response, error) {
@@ -2245,49 +2245,15 @@ func TestFetchChangesFromBitbucketServerPaginated(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
-	// Stateful responder: first call returns page 1, second returns page 2 (last).
-	callCount := 0
 	httpmock.RegisterResponder("GET",
 		`=~^https://bitbucketserver/rest/api/1.0/projects/MYPROJECT/repos/paged-repo/changes`,
-		func(_ *http.Request) (*http.Response, error) {
-			callCount++
-			var body map[string]any
-			if callCount == 1 {
-				body = map[string]any{
-					"values": []any{
-						map[string]any{
-							"path": map[string]any{"toString": "file1.yaml"},
-						},
-					},
-					"isLastPage":    false,
-					"nextPageStart": float64(1),
-					"limit":         1,
-					"size":          1,
-				}
-			} else {
-				body = map[string]any{
-					"values": []any{
-						map[string]any{
-							"path": map[string]any{"toString": "file2.yaml"},
-						},
-					},
-					"isLastPage": true,
-					"limit":      1,
-					"size":       1,
-				}
-			}
-			resp, err := httpmock.NewJsonResponse(200, body)
-			if err != nil {
-				return httpmock.NewStringResponse(500, ""), nil
-			}
-			return resp, nil
-		})
+		getBBServerPagedChangesResponderFn())
 
 	client := newBitbucketServerClient(t.Context(), &v1alpha1.Repository{}, "https://bitbucketserver")
 	changedFiles, err := fetchChangesFromBitbucketServer(client, "MYPROJECT", "paged-repo", "abcdef", "ghijkl")
 	require.NoError(t, err)
-	require.Equal(t, 2, callCount, "expected two API calls for two pages")
-	require.Equal(t, []string{"file1.yaml", "file2.yaml"}, changedFiles)
+	require.Equal(t, 2, httpmock.GetTotalCallCount(), "expected two API calls for two pages")
+	require.Equal(t, []string{"base/deployment.yaml", "base/service.yaml"}, changedFiles)
 }
 
 func TestIsBBServerHeadTouched(t *testing.T) {

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -1876,6 +1876,8 @@ func TestProcessAppRefresh(t *testing.T) {
 
 		assert.Contains(t, hook.LastEntry().Message, "Requested app 'test-app' hydration")
 	})
+}
+
 func NewMockHandlerForBitbucketServerCallback(reactor *reactorDef, applicationNamespaces []string, objects ...runtime.Object) *ArgoCDWebhookHandler {
 	mockDB := &mocks.ArgoDB{}
 	mockDB.EXPECT().ListRepositories(mock.Anything).Return(

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -2064,8 +2064,7 @@ func TestFetchChangesFromBitbucketServer(t *testing.T) {
 		`=~^https://bitbucketserver/rest/api/1.0/projects/MYPROJECT/repos/test-repo/changes`,
 		getBBServerChangesResponderFn())
 
-	client, err := newBitbucketServerClient(t.Context(), &v1alpha1.Repository{}, "https://bitbucketserver")
-	require.NoError(t, err)
+	client := newBitbucketServerClient(t.Context(), &v1alpha1.Repository{}, "https://bitbucketserver")
 
 	tt := []struct {
 		name                string
@@ -2117,8 +2116,7 @@ func TestIsBBServerHeadTouched(t *testing.T) {
 		"https://bitbucketserver/rest/api/1.0/projects/MYPROJECT/repos/test-repo/branches/default",
 		getBBServerDefaultBranchResponderFn("master"))
 
-	client, err := newBitbucketServerClient(t.Context(), &v1alpha1.Repository{}, "https://bitbucketserver")
-	require.NoError(t, err)
+	client := newBitbucketServerClient(t.Context(), &v1alpha1.Repository{}, "https://bitbucketserver")
 
 	tt := []struct {
 		name              string


### PR DESCRIPTION
### Summary
Bitbucket Server (Data Center) webhooks did not populate the changed-files list, so the annotation (`manifest-generate-paths`)  had no effect, every push refreshed every app regardless of which files changed.

This PR adds API-based changed-file fetching for Bitbucket Server, matching the existing behavior already implemented for Bitbucket Cloud (PR #21811).

### Changes
When a `WebhookBitbucketServerSecret` is configured, the handler now calls the Bitbucket Server REST API (/rest/api/1.0/projects/{key}/repos/{slug}/changes) to fetch the list of changed files for a push, and the default-branch API (/branches/default) to accurately determine whether HEAD was touched.




Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
