### PR TITLE
fix: resolve ARM token resource from AZURE_AUTHORITY_HOST for sovereign cloud ACR auth

### DIFF
--- a/util/helm/creds.go
+++ b/util/helm/creds.go
@@ -9,15 +9,16 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+
 	gocache "github.com/patrickmn/go-cache"
 	log "github.com/sirupsen/logrus"
 
 	argoutils "github.com/argoproj/argo-cd/v3/util"
-	"github.com/argoproj/argo-cd/v3/util/env"
 	"github.com/argoproj/argo-cd/v3/util/workloadidentity"
 )
 
@@ -181,7 +182,7 @@ func (creds AzureWorkloadIdentityCreds) getAccessTokenAfterChallenge(ctx context
 	realm := tokenParams["realm"]
 	service := tokenParams["service"]
 
-	armTokenScope := env.StringFromEnv("AZURE_ARM_TOKEN_RESOURCE", "https://management.core.windows.net")
+	armTokenScope := getARMTokenResource()
 	armAccessToken, err := creds.tokenProvider.GetToken(armTokenScope + "/.default")
 	if err != nil {
 		return "", fmt.Errorf("failed to get Azure access token: %w", err)
@@ -291,4 +292,42 @@ func (creds AzureWorkloadIdentityCreds) challengeAzureContainerRegistry(ctx cont
 	}
 
 	return tokenParams, nil
+}
+
+// getARMTokenResource returns the Azure Resource Manager token resource/audience
+// for the current cloud environment. This is needed for the ACR OAuth2 token
+// exchange (/oauth2/exchange) on sovereign clouds, where the ARM resource
+// differs from the commercial default.
+//
+// Resolution order:
+//  1. AZURE_ARM_TOKEN_RESOURCE env var (explicit override for any cloud)
+//  2. AZURE_AUTHORITY_HOST env var (injected by the AKS Workload Identity
+//     mutating webhook into every labeled pod)
+//  3. Default: commercial (https://management.core.windows.net)
+func getARMTokenResource() string {
+	// Allow explicit override for any cloud environment
+	if v := os.Getenv("AZURE_ARM_TOKEN_RESOURCE"); v != "" {
+		return v
+	}
+
+	// Resolve from AZURE_AUTHORITY_HOST, which is injected by the AKS Workload
+	// Identity webhook into pods labeled with azure.workload.identity/use: "true".
+	// Note: AZURE_ENVIRONMENT is NOT injected into workload pods by the webhook,
+	// only AZURE_AUTHORITY_HOST, AZURE_CLIENT_ID, AZURE_TENANT_ID, and
+	// AZURE_FEDERATED_TOKEN_FILE are injected.
+	// Ref: https://azure.github.io/azure-workload-identity/docs/installation/mutating-admission-webhook.html
+	//
+	// For clouds not listed here, set AZURE_ARM_TOKEN_RESOURCE explicitly.
+	authorityHost := strings.TrimRight(os.Getenv("AZURE_AUTHORITY_HOST"), "/")
+	switch authorityHost {
+	// Azure US Government (FairFax, GCC)
+	case "https://login.microsoftonline.us":
+		return "https://management.core.usgovcloudapi.net"
+	// Azure China (Mooncake)
+	case "https://login.partner.microsoftonline.cn":
+		return "https://management.core.chinacloudapi.cn"
+	// Azure Public (Commercial) or unrecognized
+	default:
+		return "https://management.core.windows.net"
+	}
 }

--- a/util/helm/creds_test.go
+++ b/util/helm/creds_test.go
@@ -377,3 +377,56 @@ func TestGetAccessToken_ReuseTokenIfExistingIsNotExpired(t *testing.T) {
 func resetAzureTokenCache() {
 	azureTokenCache = gocache.New(gocache.NoExpiration, 0)
 }
+
+func TestGetARMTokenResource(t *testing.T) {
+	tests := []struct {
+		name           string
+		armResourceEnv string
+		authorityHost  string
+		want           string
+	}{
+		{
+			name:           "explicit override wins over authority host",
+			armResourceEnv: "https://custom.example.com",
+			authorityHost:  "https://login.microsoftonline.us",
+			want:           "https://custom.example.com",
+		},
+		{
+			name:          "us government authority host",
+			authorityHost: "https://login.microsoftonline.us",
+			want:          "https://management.core.usgovcloudapi.net",
+		},
+		{
+			name:          "us government authority host with trailing slash",
+			authorityHost: "https://login.microsoftonline.us/",
+			want:          "https://management.core.usgovcloudapi.net",
+		},
+		{
+			name:          "china authority host",
+			authorityHost: "https://login.partner.microsoftonline.cn",
+			want:          "https://management.core.chinacloudapi.cn",
+		},
+		{
+			name:          "commercial authority host",
+			authorityHost: "https://login.microsoftonline.com",
+			want:          "https://management.core.windows.net",
+		},
+		{
+			name: "unset env returns commercial default",
+			want: "https://management.core.windows.net",
+		},
+		{
+			name:          "unknown authority host falls back to commercial default",
+			authorityHost: "https://login.example.gov",
+			want:          "https://management.core.windows.net",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("AZURE_ARM_TOKEN_RESOURCE", tc.armResourceEnv)
+			t.Setenv("AZURE_AUTHORITY_HOST", tc.authorityHost)
+			assert.Equal(t, tc.want, getARMTokenResource())
+		})
+	}
+}


### PR DESCRIPTION
## Summary

When using Azure Workload Identity (`useAzureWorkloadIdentity: "true"`) with Helm OCI registries on Azure sovereign clouds, the repo-server fails to pull charts from ACR with `401 Unauthorized`.

## Root Cause

In `util/helm/creds.go`, the ARM token scope for the ACR refresh token exchange is hardcoded to the commercial endpoint:

```go
armTokenScope := env.StringFromEnv("AZURE_ARM_TOKEN_RESOURCE", "https://management.core.windows.net")
```

On sovereign clouds, the ARM resource endpoint differs. The token is obtained with the correct authority (`AZURE_AUTHORITY_HOST` is properly injected by the WI webhook), but the token audience/scope targets the commercial ARM resource, which the sovereign ACR `/oauth2/exchange` endpoint rejects.

## Fix

Resolve the ARM token resource from `AZURE_AUTHORITY_HOST` — the only cloud-identifying env var injected by the AKS Workload Identity mutating webhook into workload pods. (`AZURE_ENVIRONMENT` is NOT injected into pods, only into the webhook controller itself.)

Ref: https://azure.github.io/azure-workload-identity/docs/installation/mutating-admission-webhook.html

| Cloud | Authority Host | ARM Token Resource |
|-------|---------------|-------------------|
| Public (Commercial) | `login.microsoftonline.com` | `management.core.windows.net` |
| US Government (FairFax/GCC) | `login.microsoftonline.us` | `management.core.usgovcloudapi.net` |
| China (Mooncake) | `login.partner.microsoftonline.cn` | `management.core.chinacloudapi.cn` |

For other cloud environments, operators can set `AZURE_ARM_TOKEN_RESOURCE` env var explicitly on the repo-server.

## Testing

- Validated on a production Azure Government (FairFax) AKS cluster running ArgoCD v3.3.3
- Before: `401 Unauthorized` on every `GenerateManifest` call for Helm OCI charts
- After: All charts pull successfully from Gov ACR
- Commercial clusters unaffected (default value unchanged)

## Checklist

- [x] Either (a) I have created an [Enhancement Proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the EP process.
- [x] The title of the PR states what changed and the related issues number (used for the curved changelog).
- [x] I have signed off all my commits with `DCO`