### PR TITLE
fix(ui): enhance Bitbucket Server URL handling in ui for repo and revision links

### DIFF
--- a/ui/src/app/shared/components/revision.tsx
+++ b/ui/src/app/shared/components/revision.tsx
@@ -10,7 +10,14 @@ export const Revision = ({repoUrl, revision, path, isForPath, children}: {repoUr
     const hasPath = path && path !== '.';
     let url = revisionUrl(repoUrl, revision, hasPath);
     if (url !== null && hasPath) {
-        url += '/' + path;
+        // For Bitbucket Server the URL ends with ?at=REF; the path must be inserted
+        // before the query param to produce /browse/PATH?at=REF.
+        const qIndex = url.indexOf('?');
+        if (qIndex >= 0) {
+            url = url.slice(0, qIndex) + '/' + path + url.slice(qIndex);
+        } else {
+            url += '/' + path;
+        }
     }
     const content = children || (isSHA(revision) ? (revision.startsWith('sha256:') ? revision.substr(0, 14) : revision.substr(0, 7)) : revision);
     return url !== null ? (

--- a/ui/src/app/shared/components/urls.test.ts
+++ b/ui/src/app/shared/components/urls.test.ts
@@ -51,6 +51,53 @@ test('bitbucket.org', () => {
     );
 });
 
+// for self-hosted Bitbucket Server installations
+// Clone URLs use /scm/ prefix; browse URLs use /users/ or /projects/ prefix.
+test('bitbucket server (self-hosted, personal repo, HTTPS)', () => {
+    expect(repoUrl('https://bitbucket.gob.amadeus.net/scm/~paraj5/helm-repo.git')).toBe(
+        'https://bitbucket.gob.amadeus.net/users/paraj5/repos/helm-repo',
+    );
+    expect(revisionUrl('https://bitbucket.gob.amadeus.net/scm/~paraj5/helm-repo.git', 'abc1234', false)).toBe(
+        'https://bitbucket.gob.amadeus.net/users/paraj5/repos/helm-repo/commits/abc1234',
+    );
+    expect(revisionUrl('https://bitbucket.gob.amadeus.net/scm/~paraj5/helm-repo.git', 'main', false)).toBe(
+        'https://bitbucket.gob.amadeus.net/users/paraj5/repos/helm-repo/browse?at=refs%2Fheads%2Fmain',
+    );
+    expect(revisionUrl('https://bitbucket.gob.amadeus.net/scm/~paraj5/helm-repo.git', '', false)).toBe(
+        'https://bitbucket.gob.amadeus.net/users/paraj5/repos/helm-repo/browse',
+    );
+    expect(revisionUrl('https://bitbucket.gob.amadeus.net/scm/~paraj5/helm-repo.git', 'HEAD', false)).toBe(
+        'https://bitbucket.gob.amadeus.net/users/paraj5/repos/helm-repo/browse',
+    );
+});
+
+test('bitbucket server (self-hosted, project repo, HTTPS)', () => {
+    expect(repoUrl('https://bitbucket.gob.amadeus.net/scm/MYPROJECT/helm-repo.git')).toBe(
+        'https://bitbucket.gob.amadeus.net/projects/MYPROJECT/repos/helm-repo',
+    );
+    expect(revisionUrl('https://bitbucket.gob.amadeus.net/scm/MYPROJECT/helm-repo.git', 'abc1234', false)).toBe(
+        'https://bitbucket.gob.amadeus.net/projects/MYPROJECT/repos/helm-repo/commits/abc1234',
+    );
+    expect(revisionUrl('https://bitbucket.gob.amadeus.net/scm/MYPROJECT/helm-repo.git', 'main', false)).toBe(
+        'https://bitbucket.gob.amadeus.net/projects/MYPROJECT/repos/helm-repo/browse?at=refs%2Fheads%2Fmain',
+    );
+    expect(revisionUrl('https://bitbucket.gob.amadeus.net/scm/MYPROJECT/helm-repo.git', '', false)).toBe(
+        'https://bitbucket.gob.amadeus.net/projects/MYPROJECT/repos/helm-repo/browse',
+    );
+    expect(revisionUrl('https://bitbucket.gob.amadeus.net/scm/MYPROJECT/helm-repo.git', 'HEAD', false)).toBe(
+        'https://bitbucket.gob.amadeus.net/projects/MYPROJECT/repos/helm-repo/browse',
+    );
+});
+
+test('bitbucket server (self-hosted, SSH)', () => {
+    expect(repoUrl('git@bitbucket.gob.amadeus.net:scm/~paraj5/helm-repo.git')).toBe(
+        'https://bitbucket.gob.amadeus.net/users/paraj5/repos/helm-repo',
+    );
+    expect(repoUrl('git@bitbucket.gob.amadeus.net:scm/MYPROJECT/helm-repo.git')).toBe(
+        'https://bitbucket.gob.amadeus.net/projects/MYPROJECT/repos/helm-repo',
+    );
+});
+
 test('empty url', () => {
     expect(repoUrl('')).toBe(null);
 });

--- a/ui/src/app/shared/components/urls.test.ts
+++ b/ui/src/app/shared/components/urls.test.ts
@@ -54,47 +54,62 @@ test('bitbucket.org', () => {
 // for self-hosted Bitbucket Server installations
 // Clone URLs use /scm/ prefix; browse URLs use /users/ or /projects/ prefix.
 test('bitbucket server (self-hosted, personal repo, HTTPS)', () => {
-    expect(repoUrl('https://bitbucket.gob.amadeus.net/scm/~paraj5/helm-repo.git')).toBe(
-        'https://bitbucket.gob.amadeus.net/users/paraj5/repos/helm-repo',
+    expect(repoUrl('https://bitbucket.example.com/scm/~user/repo-name.git')).toBe(
+        'https://bitbucket.example.com/users/user/repos/repo-name',
     );
-    expect(revisionUrl('https://bitbucket.gob.amadeus.net/scm/~paraj5/helm-repo.git', 'abc1234', false)).toBe(
-        'https://bitbucket.gob.amadeus.net/users/paraj5/repos/helm-repo/commits/abc1234',
+    expect(revisionUrl('https://bitbucket.example.com/scm/~user/repo-name.git', 'abc1234', false)).toBe(
+        'https://bitbucket.example.com/users/user/repos/repo-name/commits/abc1234',
     );
-    expect(revisionUrl('https://bitbucket.gob.amadeus.net/scm/~paraj5/helm-repo.git', 'main', false)).toBe(
-        'https://bitbucket.gob.amadeus.net/users/paraj5/repos/helm-repo/browse?at=refs%2Fheads%2Fmain',
+    expect(revisionUrl('https://bitbucket.example.com/scm/~user/repo-name.git', 'main', false)).toBe(
+        'https://bitbucket.example.com/users/user/repos/repo-name/browse?at=main',
     );
-    expect(revisionUrl('https://bitbucket.gob.amadeus.net/scm/~paraj5/helm-repo.git', '', false)).toBe(
-        'https://bitbucket.gob.amadeus.net/users/paraj5/repos/helm-repo/browse',
+    expect(revisionUrl('https://bitbucket.example.com/scm/~user/repo-name.git', 'v1.0.0', false)).toBe(
+        'https://bitbucket.example.com/users/user/repos/repo-name/browse?at=v1.0.0',
     );
-    expect(revisionUrl('https://bitbucket.gob.amadeus.net/scm/~paraj5/helm-repo.git', 'HEAD', false)).toBe(
-        'https://bitbucket.gob.amadeus.net/users/paraj5/repos/helm-repo/browse',
+    expect(revisionUrl('https://bitbucket.example.com/scm/~user/repo-name.git', '', false)).toBe(
+        'https://bitbucket.example.com/users/user/repos/repo-name/browse',
+    );
+    expect(revisionUrl('https://bitbucket.example.com/scm/~user/repo-name.git', 'HEAD', false)).toBe(
+        'https://bitbucket.example.com/users/user/repos/repo-name/browse',
     );
 });
 
 test('bitbucket server (self-hosted, project repo, HTTPS)', () => {
-    expect(repoUrl('https://bitbucket.gob.amadeus.net/scm/MYPROJECT/helm-repo.git')).toBe(
-        'https://bitbucket.gob.amadeus.net/projects/MYPROJECT/repos/helm-repo',
+    expect(repoUrl('https://bitbucket.example.com/scm/MYPROJECT/repo-name.git')).toBe(
+        'https://bitbucket.example.com/projects/MYPROJECT/repos/repo-name',
     );
-    expect(revisionUrl('https://bitbucket.gob.amadeus.net/scm/MYPROJECT/helm-repo.git', 'abc1234', false)).toBe(
-        'https://bitbucket.gob.amadeus.net/projects/MYPROJECT/repos/helm-repo/commits/abc1234',
+    expect(revisionUrl('https://bitbucket.example.com/scm/MYPROJECT/repo-name.git', 'abc1234', false)).toBe(
+        'https://bitbucket.example.com/projects/MYPROJECT/repos/repo-name/commits/abc1234',
     );
-    expect(revisionUrl('https://bitbucket.gob.amadeus.net/scm/MYPROJECT/helm-repo.git', 'main', false)).toBe(
-        'https://bitbucket.gob.amadeus.net/projects/MYPROJECT/repos/helm-repo/browse?at=refs%2Fheads%2Fmain',
+    expect(revisionUrl('https://bitbucket.example.com/scm/MYPROJECT/repo-name.git', 'main', false)).toBe(
+        'https://bitbucket.example.com/projects/MYPROJECT/repos/repo-name/browse?at=main',
     );
-    expect(revisionUrl('https://bitbucket.gob.amadeus.net/scm/MYPROJECT/helm-repo.git', '', false)).toBe(
-        'https://bitbucket.gob.amadeus.net/projects/MYPROJECT/repos/helm-repo/browse',
+    expect(revisionUrl('https://bitbucket.example.com/scm/MYPROJECT/repo-name.git', 'v1.0.0', false)).toBe(
+        'https://bitbucket.example.com/projects/MYPROJECT/repos/repo-name/browse?at=v1.0.0',
     );
-    expect(revisionUrl('https://bitbucket.gob.amadeus.net/scm/MYPROJECT/helm-repo.git', 'HEAD', false)).toBe(
-        'https://bitbucket.gob.amadeus.net/projects/MYPROJECT/repos/helm-repo/browse',
+    expect(revisionUrl('https://bitbucket.example.com/scm/MYPROJECT/repo-name.git', '', false)).toBe(
+        'https://bitbucket.example.com/projects/MYPROJECT/repos/repo-name/browse',
+    );
+    expect(revisionUrl('https://bitbucket.example.com/scm/MYPROJECT/repo-name.git', 'HEAD', false)).toBe(
+        'https://bitbucket.example.com/projects/MYPROJECT/repos/repo-name/browse',
     );
 });
 
 test('bitbucket server (self-hosted, SSH)', () => {
-    expect(repoUrl('git@bitbucket.gob.amadeus.net:scm/~paraj5/helm-repo.git')).toBe(
-        'https://bitbucket.gob.amadeus.net/users/paraj5/repos/helm-repo',
+    expect(repoUrl('git@bitbucket.example.com:scm/~user/repo-name.git')).toBe(
+        'https://bitbucket.example.com/users/user/repos/repo-name',
     );
-    expect(repoUrl('git@bitbucket.gob.amadeus.net:scm/MYPROJECT/helm-repo.git')).toBe(
-        'https://bitbucket.gob.amadeus.net/projects/MYPROJECT/repos/helm-repo',
+    expect(repoUrl('git@bitbucket.example.com:scm/MYPROJECT/repo-name.git')).toBe(
+        'https://bitbucket.example.com/projects/MYPROJECT/repos/repo-name',
+    );
+});
+
+test('bitbucket server (self-hosted, HTTP with explicit port)', () => {
+    expect(repoUrl('http://bitbucket.example.com:7990/scm/MYPROJECT/repo-name.git')).toBe(
+        'http://bitbucket.example.com:7990/projects/MYPROJECT/repos/repo-name',
+    );
+    expect(revisionUrl('http://bitbucket.example.com:7990/scm/MYPROJECT/repo-name.git', 'main', false)).toBe(
+        'http://bitbucket.example.com:7990/projects/MYPROJECT/repos/repo-name/browse?at=main',
     );
 });
 

--- a/ui/src/app/shared/components/urls.ts
+++ b/ui/src/app/shared/components/urls.ts
@@ -4,8 +4,33 @@ import {isValidURL} from '../../shared/utils';
 
 const GitUrlParse = require('git-url-parse');
 
+// Returns true for self-hosted Bitbucket Server instances.
+// git-url-parse sets source='bitbucket-server' for HTTPS clone URLs (which contain /scm/
+// in their path) and for SCP-style SSH clone URLs that also include /scm/. For SSH clone
+// URLs without the /scm/ prefix (e.g. ssh://git@HOST:7999/PROJECT/repo.git) it does not
+// set that source, so we additionally check the resource hostname.
+function isBitbucketServer(parsed: GitUrl): boolean {
+    return parsed.source === 'bitbucket-server' ||
+        (parsed.resource.startsWith('bitbucket') && parsed.source !== 'bitbucket.org');
+}
+
 function supportedSource(parsed: GitUrl): boolean {
-    return parsed.resource.startsWith('github') || ['gitlab.com', 'bitbucket.org'].indexOf(parsed.source) >= 0;
+    return parsed.resource.startsWith('github') || parsed.source === 'bitbucket.org' ||
+        isBitbucketServer(parsed) || parsed.source === 'gitlab.com';
+}
+
+// Bitbucket Server browse URLs differ from clone URLs:
+//   clone:  https://HOST/scm/~user/repo.git  or  https://HOST/scm/PROJECTKEY/repo.git
+//   browse: https://HOST/users/user/repos/repo  or  https://HOST/projects/PROJECTKEY/repos/repo
+function bitbucketServerBrowseUrl(parsed: GitUrl): string {
+    const host = `https://${parsed.resource}`;
+    const repoName = parsed.name;
+    const owner = parsed.owner;
+    // Personal repos use the ~ prefix in the clone URL owner
+    if (owner.startsWith('~')) {
+        return `${host}/users/${owner.slice(1)}/repos/${repoName}`;
+    }
+    return `${host}/projects/${owner}/repos/${repoName}`;
 }
 
 function protocol(proto: string): string {
@@ -17,6 +42,16 @@ export function repoUrl(url: string): string {
         const parsed = GitUrlParse(url);
 
         if (!supportedSource(parsed)) {
+            return null;
+        }
+
+        // Self-hosted Bitbucket Server has a different browse URL structure
+        // from its clone URLs, so reconstruct it using the known pattern.
+        if (isBitbucketServer(parsed)) {
+            const browseUrl = bitbucketServerBrowseUrl(parsed);
+            if (isValidURL(browseUrl)) {
+                return browseUrl;
+            }
             return null;
         }
 
@@ -37,9 +72,31 @@ export function revisionUrl(url: string, revision: string, forPath: boolean): st
     } catch {
         return null;
     }
+
+    if (!supportedSource(parsed)) {
+        return null;
+    }
+
+    // Bitbucket Server uses /commits/SHA for bare commit links, and /browse[/PATH]?at=REF
+    // for branch and path links. The Revision component (revision.tsx) inserts the path
+    // segment BEFORE the ?at= query param, so we return only the base browse URL here.
+    // When revision is empty or HEAD, omit ?at= so Bitbucket Server uses its default branch.
+    if (isBitbucketServer(parsed)) {
+        const base = bitbucketServerBrowseUrl(parsed);
+        if (isSHA(revision) && !forPath) {
+            return `${base}/commits/${revision}`;
+        }
+        const ref = revision || '';
+        if (!ref || ref === 'HEAD') {
+            return `${base}/browse`;
+        }
+        const atRef = isSHA(revision) ? revision : `refs/heads/${revision}`;
+        return `${base}/browse?at=${encodeURIComponent(atRef)}`;
+    }
+
     let urlSubPath = isSHA(revision) ? 'commit' : 'tree';
 
-    if (url.indexOf('bitbucket') >= 0) {
+    if (parsed.source === 'bitbucket.org') {
         // The reason for the condition of 'forPath' is that when we build nested path, we need to use 'src'
         urlSubPath = isSHA(revision) && !forPath ? 'commits' : 'src';
     }
@@ -48,10 +105,6 @@ export function revisionUrl(url: string, revision: string, forPath: boolean): st
     // Ref: https://docs.gitlab.com/ee/update/deprecations.html#legacy-urls-replaced-or-removed
     if (parsed.source === 'gitlab.com') {
         urlSubPath = '-/' + urlSubPath;
-    }
-
-    if (!supportedSource(parsed)) {
-        return null;
     }
 
     return `${protocol(parsed.protocol)}://${parsed.resource}/${parsed.owner}/${parsed.name}/${urlSubPath}/${revision || 'HEAD'}`;

--- a/ui/src/app/shared/components/urls.ts
+++ b/ui/src/app/shared/components/urls.ts
@@ -10,13 +10,11 @@ const GitUrlParse = require('git-url-parse');
 // URLs without the /scm/ prefix (e.g. ssh://git@HOST:7999/PROJECT/repo.git) it does not
 // set that source, so we additionally check the resource hostname.
 function isBitbucketServer(parsed: GitUrl): boolean {
-    return parsed.source === 'bitbucket-server' ||
-        (parsed.resource.startsWith('bitbucket') && parsed.source !== 'bitbucket.org');
+    return parsed.source === 'bitbucket-server' || (parsed.resource.startsWith('bitbucket') && parsed.source !== 'bitbucket.org');
 }
 
 function supportedSource(parsed: GitUrl): boolean {
-    return parsed.resource.startsWith('github') || parsed.source === 'bitbucket.org' ||
-        isBitbucketServer(parsed) || parsed.source === 'gitlab.com';
+    return parsed.resource.startsWith('github') || parsed.source === 'bitbucket.org' || isBitbucketServer(parsed) || parsed.source === 'gitlab.com';
 }
 
 // Bitbucket Server browse URLs differ from clone URLs:

--- a/ui/src/app/shared/components/urls.ts
+++ b/ui/src/app/shared/components/urls.ts
@@ -21,14 +21,14 @@ function supportedSource(parsed: GitUrl): boolean {
 //   clone:  https://HOST/scm/~user/repo.git  or  https://HOST/scm/PROJECTKEY/repo.git
 //   browse: https://HOST/users/user/repos/repo  or  https://HOST/projects/PROJECTKEY/repos/repo
 function bitbucketServerBrowseUrl(parsed: GitUrl): string {
-    const host = `https://${parsed.resource}`;
-    const repoName = parsed.name;
+    const port = parsed.port ? `:${parsed.port}` : '';
+    const host = `${protocol(parsed.protocol)}://${parsed.resource}${port}`;
     const owner = parsed.owner;
     // Personal repos use the ~ prefix in the clone URL owner
     if (owner.startsWith('~')) {
-        return `${host}/users/${owner.slice(1)}/repos/${repoName}`;
+        return `${host}/users/${owner.slice(1)}/repos/${parsed.name}`;
     }
-    return `${host}/projects/${owner}/repos/${repoName}`;
+    return `${host}/projects/${owner}/repos/${parsed.name}`;
 }
 
 function protocol(proto: string): string {
@@ -84,12 +84,10 @@ export function revisionUrl(url: string, revision: string, forPath: boolean): st
         if (isSHA(revision) && !forPath) {
             return `${base}/commits/${revision}`;
         }
-        const ref = revision || '';
-        if (!ref || ref === 'HEAD') {
+        if (!revision || revision === 'HEAD') {
             return `${base}/browse`;
         }
-        const atRef = isSHA(revision) ? revision : `refs/heads/${revision}`;
-        return `${base}/browse?at=${encodeURIComponent(atRef)}`;
+        return `${base}/browse?at=${encodeURIComponent(revision)}`;
     }
 
     let urlSubPath = isSHA(revision) ? 'commit' : 'tree';


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->
In UI, if the repo url and revision are from BitBucket server it's not clickable where as for other git it is working good.

Bitbucket Server (self-hosted) has a fundamentally different URL structure, Previously it had no special handling for Bitbucket Server, so it used to fell through to the generic path.


#### Before Fix
<img width="1736" height="978" alt="Screenshot 2026-04-27 112011" src="https://github.com/user-attachments/assets/44cdd8ed-be98-4567-8d17-60463e08fa47" />

#### After Fix
<img width="2071" height="878" alt="Screenshot 2026-04-29 140230" src="https://github.com/user-attachments/assets/4c47afd6-bc5e-48c8-b1c1-18219776215e" />


Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
