### PR TITLE
fix(controller): preserve tracking-id annotation when normalizing CRD targets

### DIFF
--- a/controller/sync.go
+++ b/controller/sync.go
@@ -419,8 +419,11 @@ func (m *appStateManager) SyncAppState(app *v1alpha1.Application, project *v1alp
 //   - copies ignored fields from the matching live resources: apply normalizer to the live resource,
 //     calculates the patch performed by normalizer and applies the patch to the target resource
 func normalizeTargetResources(cr *comparisonResult) ([]*unstructured.Unstructured, error) {
-	// normalize live and target resources
-	normalized, err := diff.Normalize(cr.reconciliationResult.Live, cr.reconciliationResult.Target, cr.diffConfig)
+	// normalize live and target resources without applying the resource-tracking
+	// migration, since the patch derived below would otherwise fold tracking-id
+	// mutations into ignored-field updates and strip the annotation on CRDs
+	// (RFC 7396 JSON Merge Patch encodes deletions as explicit nulls).
+	normalized, err := diff.NormalizeIgnoredFields(cr.reconciliationResult.Live, cr.reconciliationResult.Target, cr.diffConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/controller/sync_test.go
+++ b/controller/sync_test.go
@@ -361,6 +361,7 @@ func TestNormalizeTargetResources(t *testing.T) {
 		t.Helper()
 		dc, err := diff.NewDiffConfigBuilder().
 			WithDiffSettings(ignores, nil, true, normalizers.IgnoreNormalizerOpts{}).
+			WithTracking(common.LabelKeyAppInstance, string(v1alpha1.TrackingMethodAnnotation)).
 			WithNoCache().
 			Build()
 		require.NoError(t, err)
@@ -458,6 +459,35 @@ func TestNormalizeTargetResources(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, ok)
 		assert.Equal(t, int64(4), replicas)
+	})
+	t.Run("preserves tracking-id annotation on CRD when migrating from label-based tracking", func(t *testing.T) {
+		// given
+		// Regression: with RespectIgnoreDifferences=true and live still carrying only the
+		// legacy instance label (pre-3.0), the tracking-id annotation on the target must
+		// survive normalization. CRDs fall back to RFC 7396 JSON Merge Patch, which encodes
+		// deletions as explicit nulls, so without the fix, the resource-tracking migration
+		// leaks into the patch and strips the annotation.
+		ignores := []v1alpha1.ResourceIgnoreDifferences{
+			{
+				Group:        "argoproj.io",
+				Kind:         "Rollout",
+				JSONPointers: []string{"/spec/replicas"},
+			},
+		}
+		f := setup(t, ignores)
+		live := test.YamlToUnstructured(testdata.LiveRolloutYaml)
+		target := test.YamlToUnstructured(testdata.TargetRolloutYaml)
+		f.comparisonResult.reconciliationResult.Live = []*unstructured.Unstructured{live}
+		f.comparisonResult.reconciliationResult.Target = []*unstructured.Unstructured{target}
+
+		// when
+		targets, err := normalizeTargetResources(f.comparisonResult)
+
+		// then
+		require.NoError(t, err)
+		require.Len(t, targets, 1)
+		assert.Equal(t, target.GetAnnotations()[common.AnnotationKeyAppInstance], targets[0].GetAnnotations()[common.AnnotationKeyAppInstance])
+		assert.NotContains(t, targets[0].GetLabels(), common.LabelKeyAppInstance, "patched target must not gain the legacy instance label from live")
 	})
 	t.Run("will keep new array entries not found in live state if not ignored", func(t *testing.T) {
 		t.Skip("limitation in the current implementation")

--- a/controller/testdata/data.go
+++ b/controller/testdata/data.go
@@ -21,6 +21,12 @@ var (
 	//go:embed target-httpproxy.yaml
 	TargetHTTPProxy string
 
+	//go:embed live-rollout.yaml
+	LiveRolloutYaml string
+
+	//go:embed target-rollout.yaml
+	TargetRolloutYaml string
+
 	//go:embed live-deployment-env-vars.yaml
 	LiveDeploymentEnvVarsYaml string
 

--- a/controller/testdata/live-rollout.yaml
+++ b/controller/testdata/live-rollout.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: guestbook
+  namespace: default
+  labels:
+    app.kubernetes.io/instance: guestbook
+spec:
+  replicas: 5
+  selector:
+    matchLabels:
+      app: guestbook
+  template:
+    metadata:
+      labels:
+        app: guestbook
+    spec:
+      containers:
+        - name: guestbook
+          image: 'quay.io/argoprojlabs/argocd-e2e-container:0.1'

--- a/controller/testdata/target-rollout.yaml
+++ b/controller/testdata/target-rollout.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: guestbook
+  namespace: default
+  annotations:
+    argocd.argoproj.io/tracking-id: 'guestbook:argoproj.io/Rollout:default/guestbook'
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: guestbook
+  template:
+    metadata:
+      labels:
+        app: guestbook
+    spec:
+      containers:
+        - name: guestbook
+          image: 'quay.io/argoprojlabs/argocd-e2e-container:0.1'

--- a/util/argo/diff/diff.go
+++ b/util/argo/diff/diff.go
@@ -298,7 +298,7 @@ func StateDiff(live, config *unstructured.Unstructured, diffConfig DiffConfig) (
 // StateDiffs will apply all required normalizations and calculate the diffs between
 // the live and the config/desired states.
 func StateDiffs(lives, configs []*unstructured.Unstructured, diffConfig DiffConfig) (*diff.DiffResultList, error) {
-	normResults, err := preDiffNormalize(lives, configs, diffConfig)
+	normResults, err := preDiffNormalize(lives, configs, diffConfig, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to perform pre-diff normalization: %w", err)
 	}
@@ -411,7 +411,11 @@ func (c *diffConfig) DiffFromCache(appName string) (bool, []*v1alpha1.ResourceDi
 
 // preDiffNormalize applies the normalization of live and target resources before invoking
 // the diff. None of the attributes in the lives and targets params will be modified.
-func preDiffNormalize(lives, targets []*unstructured.Unstructured, diffConfig DiffConfig) (*NormalizationResult, error) {
+//
+// When skipResourceTracking is true, the resource-tracking migration step is skipped so the
+// target's tracking metadata is preserved as-is. Sync paths that derive a patch from this
+// output need this to avoid leaking tracking-id mutations into the patch.
+func preDiffNormalize(lives, targets []*unstructured.Unstructured, diffConfig DiffConfig, skipResourceTracking bool) (*NormalizationResult, error) {
 	if diffConfig == nil {
 		return nil, errors.New("preDiffNormalize error: diffConfig can not be nil")
 	}
@@ -424,8 +428,10 @@ func preDiffNormalize(lives, targets []*unstructured.Unstructured, diffConfig Di
 	for i := range targets {
 		target := safeDeepCopy(targets[i])
 		live := safeDeepCopy(lives[i])
-		resourceTracking := argo.NewResourceTracking()
-		_ = resourceTracking.Normalize(target, live, diffConfig.AppLabelKey(), diffConfig.TrackingMethod())
+		if !skipResourceTracking {
+			resourceTracking := argo.NewResourceTracking()
+			_ = resourceTracking.Normalize(target, live, diffConfig.AppLabelKey(), diffConfig.TrackingMethod())
+		}
 		// just normalize on managed fields if live and target aren't nil as we just care
 		// about conflicting fields
 		if live != nil && target != nil {

--- a/util/argo/diff/normalize.go
+++ b/util/argo/diff/normalize.go
@@ -11,7 +11,18 @@ import (
 // Normalize applies the full normalization on the lives and configs resources based
 // on the provided DiffConfig.
 func Normalize(lives, configs []*unstructured.Unstructured, diffConfig DiffConfig) (*NormalizationResult, error) {
-	result, err := preDiffNormalize(lives, configs, diffConfig)
+	return normalize(lives, configs, diffConfig, false)
+}
+
+// NormalizeIgnoredFields is like Normalize but skips the resource-tracking migration step,
+// so the target's tracking metadata is preserved. Used by sync paths that derive a patch
+// from the normalized output, where tracking-id mutations must not leak into the patch.
+func NormalizeIgnoredFields(lives, configs []*unstructured.Unstructured, diffConfig DiffConfig) (*NormalizationResult, error) {
+	return normalize(lives, configs, diffConfig, true)
+}
+
+func normalize(lives, configs []*unstructured.Unstructured, diffConfig DiffConfig, skipResourceTracking bool) (*NormalizationResult, error) {
+	result, err := preDiffNormalize(lives, configs, diffConfig, skipResourceTracking)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

When `RespectIgnoreDifferences=true` and a live resource still carries only the legacy `app.kubernetes.io/instance` label (e.g., applications migrating to the 3.0 default of annotation-based tracking), `normalizeTargetResources` strips the `argocd.argoproj.io/tracking-id` annotation from the target during sync. The result is that the synced object never gets the new tracking annotation. This can lead to orphaned resources if a sync later deletes a CRD.

Related: #23334, #23687

### Root cause

`normalizeTargetResources` calls `diff.Normalize`, which internally invokes `resourceTracking.Normalize` to add the tracking-id annotation to the live object and remove the legacy label. It then derives a JSON merge patch from the difference between the original and normalized live, and applies that patch to the target.

For built-in types this is fine: a strategic merge patch is built with `IgnoreDeletions: true`, so the removed label doesn't leak into the patch. For CRDs there is no strategic merge metadata, so the code falls back to `jsonpatch.CreateMergePatch` (RFC 7396), which encodes the removed legacy label as an explicit `null`. Applying that patch to the target wipes the tracking-id annotation along with the legacy label.

### Fix

Add `diff.NormalizeIgnoredFields`, a sibling of `diff.Normalize` that skips the resource-tracking migration step. Use it from `normalizeTargetResources` so the target's tracking metadata is preserved as-is. The diff path (`StateDiffs`) is unchanged.

I am admittedly not super confident in the fix, but I hope the failing test helps surface the problem if a maintainer has a better idea on how to approach a fix.

## Checklist

- [x] Either (a) I've created an enhancement proposal and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
- [ ] I've included \"Closes [ISSUE #]\" or \"Fixes [ISSUE #]\" in the description to automatically close the associated issue.
- [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
- [x] Does this PR require documentation updates?
- [ ] I've updated documentation as required by this PR.
- [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
- [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
- [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
- [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
- [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
- [ ] Optional. My organization is added to USERS.md.
- [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).