### PR TITLE
fix: correct grammar and capitalization in CLI help text

### DIFF
--- a/cmd/argocd/commands/completion.go
+++ b/cmd/argocd/commands/completion.go
@@ -196,7 +196,7 @@ __argocd_custom_func() {
 func NewCompletionCommand() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "completion SHELL",
-		Short: "output shell completion code for the specified shell (bash, zsh or fish)",
+		Short: "Output shell completion code for the specified shell (bash, zsh or fish)",
 		Long: `Write bash, zsh or fish shell completion code to standard output.
 
 For bash, ensure you have bash completions installed and enabled.

--- a/cmd/argocd/commands/root.go
+++ b/cmd/argocd/commands/root.go
@@ -38,7 +38,7 @@ func NewCommand() *cobra.Command {
 
 	command := &cobra.Command{
 		Use:   common.CommandCLI,
-		Short: "argocd controls a Argo CD server",
+		Short: "argocd controls an Argo CD server",
 		Run: func(c *cobra.Command, args []string) {
 			c.HelpFunc()(c, args)
 		},

--- a/docs/user-guide/commands/argocd.md
+++ b/docs/user-guide/commands/argocd.md
@@ -2,7 +2,7 @@
 
 ## argocd
 
-argocd controls a Argo CD server
+argocd controls an Argo CD server
 
 ```
 argocd [flags]

--- a/docs/user-guide/commands/argocd.md
+++ b/docs/user-guide/commands/argocd.md
@@ -48,7 +48,7 @@ argocd [flags]
 * [argocd appset](argocd_appset.md)	 - Manage ApplicationSets
 * [argocd cert](argocd_cert.md)	 - Manage repository certificates and SSH known hosts entries
 * [argocd cluster](argocd_cluster.md)	 - Manage cluster credentials
-* [argocd completion](argocd_completion.md)	 - output shell completion code for the specified shell (bash, zsh or fish)
+* [argocd completion](argocd_completion.md)	 - Output shell completion code for the specified shell (bash, zsh or fish)
 * [argocd configure](argocd_configure.md)	 - Manage local configuration
 * [argocd context](argocd_context.md)	 - Switch between contexts
 * [argocd gpg](argocd_gpg.md)	 - Manage GPG keys used for signature verification

--- a/docs/user-guide/commands/argocd_account.md
+++ b/docs/user-guide/commands/argocd_account.md
@@ -74,7 +74,7 @@ argocd account [flags]
 
 ### SEE ALSO
 
-* [argocd](argocd.md)	 - argocd controls a Argo CD server
+* [argocd](argocd.md)	 - argocd controls an Argo CD server
 * [argocd account bcrypt](argocd_account_bcrypt.md)	 - Generate bcrypt hash for any password
 * [argocd account can-i](argocd_account_can-i.md)	 - Can I
 * [argocd account delete-token](argocd_account_delete-token.md)	 - Deletes account token

--- a/docs/user-guide/commands/argocd_admin.md
+++ b/docs/user-guide/commands/argocd_admin.md
@@ -58,7 +58,7 @@ $ argocd admin initial-password reset
 
 ### SEE ALSO
 
-* [argocd](argocd.md)	 - argocd controls a Argo CD server
+* [argocd](argocd.md)	 - argocd controls an Argo CD server
 * [argocd admin app](argocd_admin_app.md)	 - Manage applications configuration
 * [argocd admin cluster](argocd_admin_cluster.md)	 - Manage clusters configuration
 * [argocd admin dashboard](argocd_admin_dashboard.md)	 - Starts Argo CD Web UI locally

--- a/docs/user-guide/commands/argocd_app.md
+++ b/docs/user-guide/commands/argocd_app.md
@@ -71,7 +71,7 @@ argocd app [flags]
 
 ### SEE ALSO
 
-* [argocd](argocd.md)	 - argocd controls a Argo CD server
+* [argocd](argocd.md)	 - argocd controls an Argo CD server
 * [argocd app actions](argocd_app_actions.md)	 - Manage Resource actions
 * [argocd app add-source](argocd_app_add-source.md)	 - Adds a source to the list of sources in the application
 * [argocd app confirm-deletion](argocd_app_confirm-deletion.md)	 - Confirms deletion/pruning of an application resources

--- a/docs/user-guide/commands/argocd_appset.md
+++ b/docs/user-guide/commands/argocd_appset.md
@@ -78,7 +78,7 @@ argocd appset [flags]
 
 ### SEE ALSO
 
-* [argocd](argocd.md)	 - argocd controls a Argo CD server
+* [argocd](argocd.md)	 - argocd controls an Argo CD server
 * [argocd appset create](argocd_appset_create.md)	 - Create one or more ApplicationSets
 * [argocd appset delete](argocd_appset_delete.md)	 - Delete one or more ApplicationSets
 * [argocd appset generate](argocd_appset_generate.md)	 - Generate apps of ApplicationSet rendered templates

--- a/docs/user-guide/commands/argocd_cert.md
+++ b/docs/user-guide/commands/argocd_cert.md
@@ -81,7 +81,7 @@ argocd cert [flags]
 
 ### SEE ALSO
 
-* [argocd](argocd.md)	 - argocd controls a Argo CD server
+* [argocd](argocd.md)	 - argocd controls an Argo CD server
 * [argocd cert add-ssh](argocd_cert_add-ssh.md)	 - Add SSH known host entries for repository servers
 * [argocd cert add-tls](argocd_cert_add-tls.md)	 - Add TLS certificate data for connecting to repository server SERVERNAME
 * [argocd cert list](argocd_cert_list.md)	 - List configured certificates

--- a/docs/user-guide/commands/argocd_cluster.md
+++ b/docs/user-guide/commands/argocd_cluster.md
@@ -78,7 +78,7 @@ argocd cluster [flags]
 
 ### SEE ALSO
 
-* [argocd](argocd.md)	 - argocd controls a Argo CD server
+* [argocd](argocd.md)	 - argocd controls an Argo CD server
 * [argocd cluster add](argocd_cluster_add.md)	 - argocd cluster add CONTEXT
 * [argocd cluster get](argocd_cluster_get.md)	 - Get cluster information
 * [argocd cluster list](argocd_cluster_list.md)	 - List configured clusters

--- a/docs/user-guide/commands/argocd_completion.md
+++ b/docs/user-guide/commands/argocd_completion.md
@@ -2,7 +2,7 @@
 
 ## argocd completion
 
-output shell completion code for the specified shell (bash, zsh or fish)
+Output shell completion code for the specified shell (bash, zsh or fish)
 
 ### Synopsis
 
@@ -95,5 +95,5 @@ $ . $PROFILE
 
 ### SEE ALSO
 
-* [argocd](argocd.md)	 - argocd controls a Argo CD server
+* [argocd](argocd.md)	 - argocd controls an Argo CD server
 

--- a/docs/user-guide/commands/argocd_configure.md
+++ b/docs/user-guide/commands/argocd_configure.md
@@ -69,5 +69,5 @@ argocd configure --prompts-enabled=false
 
 ### SEE ALSO
 
-* [argocd](argocd.md)	 - argocd controls a Argo CD server
+* [argocd](argocd.md)	 - argocd controls an Argo CD server
 

--- a/docs/user-guide/commands/argocd_context.md
+++ b/docs/user-guide/commands/argocd_context.md
@@ -61,5 +61,5 @@ argocd context cd.argoproj.io --delete
 
 ### SEE ALSO
 
-* [argocd](argocd.md)	 - argocd controls a Argo CD server
+* [argocd](argocd.md)	 - argocd controls an Argo CD server
 

--- a/docs/user-guide/commands/argocd_gpg.md
+++ b/docs/user-guide/commands/argocd_gpg.md
@@ -58,7 +58,7 @@ argocd gpg [flags]
 
 ### SEE ALSO
 
-* [argocd](argocd.md)	 - argocd controls a Argo CD server
+* [argocd](argocd.md)	 - argocd controls an Argo CD server
 * [argocd gpg add](argocd_gpg_add.md)	 - Adds a GPG public key to the server's keyring
 * [argocd gpg get](argocd_gpg_get.md)	 - Get the GPG public key with ID <KEYID> from the server
 * [argocd gpg list](argocd_gpg_list.md)	 - List configured GPG public keys

--- a/docs/user-guide/commands/argocd_login.md
+++ b/docs/user-guide/commands/argocd_login.md
@@ -72,5 +72,5 @@ argocd login cd.argoproj.io --core
 
 ### SEE ALSO
 
-* [argocd](argocd.md)	 - argocd controls a Argo CD server
+* [argocd](argocd.md)	 - argocd controls an Argo CD server
 

--- a/docs/user-guide/commands/argocd_logout.md
+++ b/docs/user-guide/commands/argocd_logout.md
@@ -63,5 +63,5 @@ argocd logout cd.argoproj.io
 
 ### SEE ALSO
 
-* [argocd](argocd.md)	 - argocd controls a Argo CD server
+* [argocd](argocd.md)	 - argocd controls an Argo CD server
 

--- a/docs/user-guide/commands/argocd_proj.md
+++ b/docs/user-guide/commands/argocd_proj.md
@@ -74,7 +74,7 @@ argocd proj [flags]
 
 ### SEE ALSO
 
-* [argocd](argocd.md)	 - argocd controls a Argo CD server
+* [argocd](argocd.md)	 - argocd controls an Argo CD server
 * [argocd proj add-destination](argocd_proj_add-destination.md)	 - Add project destination
 * [argocd proj add-destination-service-account](argocd_proj_add-destination-service-account.md)	 - Add project destination's default service account
 * [argocd proj add-orphaned-ignore](argocd_proj_add-orphaned-ignore.md)	 - Add a resource to orphaned ignore list

--- a/docs/user-guide/commands/argocd_relogin.md
+++ b/docs/user-guide/commands/argocd_relogin.md
@@ -72,5 +72,5 @@ argocd login cd.argoproj.io --core
 
 ### SEE ALSO
 
-* [argocd](argocd.md)	 - argocd controls a Argo CD server
+* [argocd](argocd.md)	 - argocd controls an Argo CD server
 

--- a/docs/user-guide/commands/argocd_repo.md
+++ b/docs/user-guide/commands/argocd_repo.md
@@ -76,7 +76,7 @@ argocd repo rm https://github.com/yourusername/your-repo.git
 
 ### SEE ALSO
 
-* [argocd](argocd.md)	 - argocd controls a Argo CD server
+* [argocd](argocd.md)	 - argocd controls an Argo CD server
 * [argocd repo add](argocd_repo_add.md)	 - Add git, oci or helm repository connection parameters
 * [argocd repo get](argocd_repo_get.md)	 - Get a configured repository by URL
 * [argocd repo list](argocd_repo_list.md)	 - List configured repositories

--- a/docs/user-guide/commands/argocd_repocreds.md
+++ b/docs/user-guide/commands/argocd_repocreds.md
@@ -71,7 +71,7 @@ argocd repocreds [flags]
 
 ### SEE ALSO
 
-* [argocd](argocd.md)	 - argocd controls a Argo CD server
+* [argocd](argocd.md)	 - argocd controls an Argo CD server
 * [argocd repocreds add](argocd_repocreds_add.md)	 - Add git repository connection parameters
 * [argocd repocreds list](argocd_repocreds_list.md)	 - List configured repository credentials
 * [argocd repocreds rm](argocd_repocreds_rm.md)	 - Remove repository credentials

--- a/docs/user-guide/commands/argocd_version.md
+++ b/docs/user-guide/commands/argocd_version.md
@@ -78,5 +78,5 @@ argocd version [flags]
 
 ### SEE ALSO
 
-* [argocd](argocd.md)	 - argocd controls a Argo CD server
+* [argocd](argocd.md)	 - argocd controls an Argo CD server
 


### PR DESCRIPTION
## Summary

Fixes two minor but real inconsistencies in the CLI help text 
found by reading the source code directly.

Fixes #27636

## Changes

**1. root.go — grammatical fix**
`"argocd controls a Argo CD server"` 
→ `"argocd controls an Argo CD server"`

"a" before a vowel sound should be "an". This text appears 
every time a user runs `argocd help`.

**2. completion.go — capitalization consistency**
`"output shell completion code..."` 
→ `"Output shell completion code..."`

Every other command description starts with a capital letter. 
The completion command was the only exception.

## How to verify

Run `argocd help` and observe both fixes in the output.