### PR TITLE
fix(applicationset): add Bitbucket Cloud webhook support

### DIFF
--- a/applicationset/generators/pull_request.go
+++ b/applicationset/generators/pull_request.go
@@ -26,12 +26,20 @@ type PullRequestGenerator struct {
 	client                    client.Client
 	selectServiceProviderFunc func(context.Context, *argoprojiov1alpha1.PullRequestGenerator, *argoprojiov1alpha1.ApplicationSet) (pullrequest.PullRequestService, error)
 	SCMConfig
+	PRHints *pullrequest.PRHintStore
+}
+
+// GetPRHints exposes the hint store via a local interface so NewWebhookHandler can
+// retrieve it without a concrete type import cycle.
+func (g *PullRequestGenerator) GetPRHints() *pullrequest.PRHintStore {
+	return g.PRHints
 }
 
 func NewPullRequestGenerator(client client.Client, scmConfig SCMConfig) Generator {
 	g := &PullRequestGenerator{
 		client:    client,
 		SCMConfig: scmConfig,
+		PRHints:   &pullrequest.PRHintStore{},
 	}
 	g.selectServiceProviderFunc = g.selectServiceProvider
 	return g
@@ -195,15 +203,15 @@ func (g *PullRequestGenerator) selectServiceProvider(ctx context.Context, genera
 			if err != nil {
 				return nil, fmt.Errorf("error fetching Secret Bearer token: %w", err)
 			}
-			return pullrequest.NewBitbucketCloudServiceBearerToken(providerConfig.API, appToken, providerConfig.Owner, providerConfig.Repo)
+			return pullrequest.NewBitbucketCloudServiceBearerToken(providerConfig.API, appToken, providerConfig.Owner, providerConfig.Repo, g.PRHints)
 		} else if providerConfig.BasicAuth != nil {
 			password, err := utils.GetSecretRef(ctx, g.client, providerConfig.BasicAuth.PasswordRef, applicationSetInfo.Namespace, g.tokenRefStrictMode)
 			if err != nil {
 				return nil, fmt.Errorf("error fetching Secret token: %w", err)
 			}
-			return pullrequest.NewBitbucketCloudServiceBasicAuth(providerConfig.API, providerConfig.BasicAuth.Username, password, providerConfig.Owner, providerConfig.Repo)
+			return pullrequest.NewBitbucketCloudServiceBasicAuth(providerConfig.API, providerConfig.BasicAuth.Username, password, providerConfig.Owner, providerConfig.Repo, g.PRHints)
 		}
-		return pullrequest.NewBitbucketCloudServiceNoAuth(providerConfig.API, providerConfig.Owner, providerConfig.Repo)
+		return pullrequest.NewBitbucketCloudServiceNoAuth(providerConfig.API, providerConfig.Owner, providerConfig.Repo, g.PRHints)
 	}
 	if generatorConfig.AzureDevOps != nil {
 		providerConfig := generatorConfig.AzureDevOps

--- a/applicationset/services/pull_request/bitbucket_cloud.go
+++ b/applicationset/services/pull_request/bitbucket_cloud.go
@@ -9,12 +9,14 @@ import (
 	"strings"
 
 	"github.com/ktrysmt/go-bitbucket"
+	log "github.com/sirupsen/logrus"
 )
 
 type BitbucketCloudService struct {
 	client         *bitbucket.Client
 	owner          string
 	repositorySlug string
+	hints          *PRHintStore
 }
 
 type BitbucketCloudPullRequest struct {
@@ -75,7 +77,7 @@ func parseURL(uri string) (*url.URL, error) {
 	return url, nil
 }
 
-func NewBitbucketCloudServiceBasicAuth(baseURL, username, password, owner, repositorySlug string) (PullRequestService, error) {
+func NewBitbucketCloudServiceBasicAuth(baseURL, username, password, owner, repositorySlug string, hints *PRHintStore) (PullRequestService, error) {
 	url, err := parseURL(baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing base url of %s for %s/%s: %w", baseURL, owner, repositorySlug, err)
@@ -91,10 +93,11 @@ func NewBitbucketCloudServiceBasicAuth(baseURL, username, password, owner, repos
 		client:         bitbucketClient,
 		owner:          owner,
 		repositorySlug: repositorySlug,
+		hints:          hints,
 	}, nil
 }
 
-func NewBitbucketCloudServiceBearerToken(baseURL, bearerToken, owner, repositorySlug string) (PullRequestService, error) {
+func NewBitbucketCloudServiceBearerToken(baseURL, bearerToken, owner, repositorySlug string, hints *PRHintStore) (PullRequestService, error) {
 	url, err := parseURL(baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing base url of %s for %s/%s: %w", baseURL, owner, repositorySlug, err)
@@ -106,15 +109,52 @@ func NewBitbucketCloudServiceBearerToken(baseURL, bearerToken, owner, repository
 	}
 	bitbucketClient.SetApiBaseURL(*url)
 
-	return &BitbucketCloudService{client: bitbucketClient, owner: owner, repositorySlug: repositorySlug}, nil
+	return &BitbucketCloudService{client: bitbucketClient, owner: owner, repositorySlug: repositorySlug, hints: hints}, nil
 }
 
-func NewBitbucketCloudServiceNoAuth(baseURL, owner, repositorySlug string) (PullRequestService, error) {
+func NewBitbucketCloudServiceNoAuth(baseURL, owner, repositorySlug string, hints *PRHintStore) (PullRequestService, error) {
 	// There is currently no method to explicitly not require auth
-	return NewBitbucketCloudServiceBearerToken(baseURL, "", owner, repositorySlug)
+	return NewBitbucketCloudServiceBearerToken(baseURL, "", owner, repositorySlug, hints)
+}
+
+// listBranchNames returns live branch names; refs are strongly consistent unlike commit objects.
+func (b *BitbucketCloudService) listBranchNames() (map[string]struct{}, error) {
+	names := map[string]struct{}{}
+	for page := 1; ; page++ {
+		resp, err := b.client.Repositories.Repository.ListBranches(&bitbucket.RepositoryBranchOptions{
+			Owner:    b.owner,
+			RepoSlug: b.repositorySlug,
+			Pagelen:  100,
+			PageNum:  page,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, br := range resp.Branches {
+			names[br.Name] = struct{}{}
+		}
+		if resp.Next == "" {
+			break
+		}
+	}
+	return names, nil
 }
 
 func (b *BitbucketCloudService) List(_ context.Context) ([]*PullRequest, error) {
+	// Drain hints before the API call so they are consumed regardless of API outcome.
+	var hinted []*PullRequest
+	if b.hints != nil {
+		hinted = b.hints.Take(b.owner, b.repositorySlug)
+	}
+
+	// Fetch live branches once; PRs whose source branch is gone are skipped.
+	// Fail-open on listing error: a transient API failure should not block previews.
+	branches, err := b.listBranchNames()
+	if err != nil {
+		log.WithError(err).Warnf("could not list branches for %s/%s; skipping deleted-branch filter", b.owner, b.repositorySlug)
+		branches = nil
+	}
+
 	opts := &bitbucket.PullRequestsOptions{
 		Owner:    b.owner,
 		RepoSlug: b.repositorySlug,
@@ -155,6 +195,17 @@ func (b *BitbucketCloudService) List(_ context.Context) ([]*PullRequest, error) 
 	}
 
 	for _, pull := range pulls {
+		if branches != nil {
+			if _, ok := branches[pull.Source.Branch.Name]; !ok {
+				log.WithFields(log.Fields{
+					"owner":  b.owner,
+					"repo":   b.repositorySlug,
+					"pr":     pull.ID,
+					"branch": pull.Source.Branch.Name,
+				}).Warn("skipping PR: source branch deleted")
+				continue
+			}
+		}
 		pullRequests = append(pullRequests, &PullRequest{
 			Number:       int64(pull.ID),
 			Title:        pull.Title,
@@ -163,6 +214,26 @@ func (b *BitbucketCloudService) List(_ context.Context) ([]*PullRequest, error) 
 			HeadSHA:      pull.Source.Commit.Hash,
 			Author:       pull.Author.Nickname,
 		})
+	}
+
+	// Merge hinted PRs not yet visible in the API (eventual-consistency lag).
+	// Apply the same branch filter so a stale hint for a deleted branch is dropped.
+	if len(hinted) > 0 {
+		seen := make(map[int64]struct{}, len(pullRequests))
+		for _, pr := range pullRequests {
+			seen[pr.Number] = struct{}{}
+		}
+		for _, pr := range hinted {
+			if _, exists := seen[pr.Number]; exists {
+				continue
+			}
+			if branches != nil {
+				if _, ok := branches[pr.Branch]; !ok {
+					continue
+				}
+			}
+			pullRequests = append(pullRequests, pr)
+		}
 	}
 
 	return pullRequests, nil

--- a/applicationset/services/pull_request/bitbucket_cloud_test.go
+++ b/applicationset/services/pull_request/bitbucket_cloud_test.go
@@ -43,6 +43,8 @@ func defaultHandlerCloud(t *testing.T) func(http.ResponseWriter, *http.Request) 
 						}
 					]
 				}`)
+		case "/repositories/OWNER/REPO/refs/branches?page=1&pagelen=100":
+			_, err = io.WriteString(w, `{"values":[{"name":"feature/foo-bar","target":{"hash":"1a8dd249c04a"}}],"next":""}`)
 		default:
 			t.Fail()
 		}
@@ -63,21 +65,21 @@ func TestParseUrlEmptyUrl(t *testing.T) {
 
 func TestInvalidBaseUrlBasicAuthCloud(t *testing.T) {
 	t.Parallel()
-	_, err := NewBitbucketCloudServiceBasicAuth("http:// example.org", "user", "password", "OWNER", "REPO")
+	_, err := NewBitbucketCloudServiceBasicAuth("http:// example.org", "user", "password", "OWNER", "REPO", nil)
 
 	require.Error(t, err)
 }
 
 func TestInvalidBaseUrlBearerTokenCloud(t *testing.T) {
 	t.Parallel()
-	_, err := NewBitbucketCloudServiceBearerToken("http:// example.org", "TOKEN", "OWNER", "REPO")
+	_, err := NewBitbucketCloudServiceBearerToken("http:// example.org", "TOKEN", "OWNER", "REPO", nil)
 
 	require.Error(t, err)
 }
 
 func TestInvalidBaseUrlNoAuthCloud(t *testing.T) {
 	t.Parallel()
-	_, err := NewBitbucketCloudServiceNoAuth("http:// example.org", "OWNER", "REPO")
+	_, err := NewBitbucketCloudServiceNoAuth("http:// example.org", "OWNER", "REPO", nil)
 
 	require.Error(t, err)
 }
@@ -89,7 +91,7 @@ func TestListPullRequestBearerTokenCloud(t *testing.T) {
 		defaultHandlerCloud(t)(w, r)
 	}))
 	defer ts.Close()
-	svc, err := NewBitbucketCloudServiceBearerToken(ts.URL, "TOKEN", "OWNER", "REPO")
+	svc, err := NewBitbucketCloudServiceBearerToken(ts.URL, "TOKEN", "OWNER", "REPO", nil)
 	require.NoError(t, err)
 	pullRequests, err := ListPullRequests(t.Context(), svc, []v1alpha1.PullRequestGeneratorFilter{})
 	require.NoError(t, err)
@@ -108,7 +110,7 @@ func TestListPullRequestNoAuthCloud(t *testing.T) {
 		defaultHandlerCloud(t)(w, r)
 	}))
 	defer ts.Close()
-	svc, err := NewBitbucketCloudServiceNoAuth(ts.URL, "OWNER", "REPO")
+	svc, err := NewBitbucketCloudServiceNoAuth(ts.URL, "OWNER", "REPO", nil)
 	require.NoError(t, err)
 	pullRequests, err := ListPullRequests(t.Context(), svc, []v1alpha1.PullRequestGeneratorFilter{})
 	require.NoError(t, err)
@@ -127,7 +129,7 @@ func TestListPullRequestBasicAuthCloud(t *testing.T) {
 		defaultHandlerCloud(t)(w, r)
 	}))
 	defer ts.Close()
-	svc, err := NewBitbucketCloudServiceBasicAuth(ts.URL, "user", "password", "OWNER", "REPO")
+	svc, err := NewBitbucketCloudServiceBasicAuth(ts.URL, "user", "password", "OWNER", "REPO", nil)
 	require.NoError(t, err)
 	pullRequests, err := ListPullRequests(t.Context(), svc, []v1alpha1.PullRequestGeneratorFilter{})
 	require.NoError(t, err)
@@ -211,6 +213,8 @@ func TestListPullRequestPaginationCloud(t *testing.T) {
 					}
 				]
 			}`, r.Host)
+		case "/repositories/OWNER/REPO/refs/branches?page=1&pagelen=100":
+			_, _ = io.WriteString(w, `{"values":[{"name":"feature-101"},{"name":"feature-102"},{"name":"feature-103"},{"name":"feature-200"},{"name":"feature/foo-bar"}],"next":""}`)
 		default:
 			t.Fail()
 		}
@@ -219,7 +223,7 @@ func TestListPullRequestPaginationCloud(t *testing.T) {
 		}
 	}))
 	defer ts.Close()
-	svc, err := NewBitbucketCloudServiceNoAuth(ts.URL, "OWNER", "REPO")
+	svc, err := NewBitbucketCloudServiceNoAuth(ts.URL, "OWNER", "REPO", nil)
 	require.NoError(t, err)
 	pullRequests, err := ListPullRequests(t.Context(), svc, []v1alpha1.PullRequestGeneratorFilter{})
 	require.NoError(t, err)
@@ -253,7 +257,7 @@ func TestListResponseErrorCloud(t *testing.T) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer ts.Close()
-	svc, _ := NewBitbucketCloudServiceNoAuth(ts.URL, "OWNER", "REPO")
+	svc, _ := NewBitbucketCloudServiceNoAuth(ts.URL, "OWNER", "REPO", nil)
 	_, err := ListPullRequests(t.Context(), svc, []v1alpha1.PullRequestGeneratorFilter{})
 	require.Error(t, err)
 }
@@ -273,12 +277,14 @@ func TestListResponseMalformedCloud(t *testing.T) {
 			if err != nil {
 				t.Fail()
 			}
+		case "/repositories/OWNER/REPO/refs/branches?page=1&pagelen=100":
+			_, _ = io.WriteString(w, `{"values":[{"name":"feature-101"},{"name":"feature-102"},{"name":"feature-103"},{"name":"feature-200"},{"name":"feature/foo-bar"}],"next":""}`)
 		default:
 			t.Fail()
 		}
 	}))
 	defer ts.Close()
-	svc, _ := NewBitbucketCloudServiceNoAuth(ts.URL, "OWNER", "REPO")
+	svc, _ := NewBitbucketCloudServiceNoAuth(ts.URL, "OWNER", "REPO", nil)
 	_, err := ListPullRequests(t.Context(), svc, []v1alpha1.PullRequestGeneratorFilter{})
 	require.Error(t, err)
 }
@@ -298,12 +304,14 @@ func TestListResponseMalformedValuesCloud(t *testing.T) {
 			if err != nil {
 				t.Fail()
 			}
+		case "/repositories/OWNER/REPO/refs/branches?page=1&pagelen=100":
+			_, _ = io.WriteString(w, `{"values":[{"name":"feature-101"},{"name":"feature-102"},{"name":"feature-103"},{"name":"feature-200"},{"name":"feature/foo-bar"}],"next":""}`)
 		default:
 			t.Fail()
 		}
 	}))
 	defer ts.Close()
-	svc, _ := NewBitbucketCloudServiceNoAuth(ts.URL, "OWNER", "REPO")
+	svc, _ := NewBitbucketCloudServiceNoAuth(ts.URL, "OWNER", "REPO", nil)
 	_, err := ListPullRequests(t.Context(), svc, []v1alpha1.PullRequestGeneratorFilter{})
 	require.Error(t, err)
 }
@@ -323,12 +331,14 @@ func TestListResponseEmptyCloud(t *testing.T) {
 			if err != nil {
 				t.Fail()
 			}
+		case "/repositories/OWNER/REPO/refs/branches?page=1&pagelen=100":
+			_, _ = io.WriteString(w, `{"values":[{"name":"feature-101"},{"name":"feature-102"},{"name":"feature-103"},{"name":"feature-200"},{"name":"feature/foo-bar"}],"next":""}`)
 		default:
 			t.Fail()
 		}
 	}))
 	defer ts.Close()
-	svc, err := NewBitbucketCloudServiceNoAuth(ts.URL, "OWNER", "REPO")
+	svc, err := NewBitbucketCloudServiceNoAuth(ts.URL, "OWNER", "REPO", nil)
 	require.NoError(t, err)
 	pullRequests, err := ListPullRequests(t.Context(), svc, []v1alpha1.PullRequestGeneratorFilter{})
 	require.NoError(t, err)
@@ -392,6 +402,8 @@ func TestListPullRequestBranchMatchCloud(t *testing.T) {
 					}
 				]
 			}`, r.Host)
+		case "/repositories/OWNER/REPO/refs/branches?page=1&pagelen=100":
+			_, err = io.WriteString(w, `{"values":[{"name":"feature-101"},{"name":"feature-102"},{"name":"feature-200"}],"next":""}`)
 		case "/repositories/OWNER/REPO/pullrequests/?pagelen=1&page=2":
 			_, err = fmt.Fprintf(w, `{
 				"size": 2,
@@ -431,7 +443,7 @@ func TestListPullRequestBranchMatchCloud(t *testing.T) {
 	}))
 	defer ts.Close()
 	regexp := `feature-1[\d]{2}`
-	svc, err := NewBitbucketCloudServiceNoAuth(ts.URL, "OWNER", "REPO")
+	svc, err := NewBitbucketCloudServiceNoAuth(ts.URL, "OWNER", "REPO", nil)
 	require.NoError(t, err)
 	pullRequests, err := ListPullRequests(t.Context(), svc, []v1alpha1.PullRequestGeneratorFilter{
 		{
@@ -458,7 +470,7 @@ func TestListPullRequestBranchMatchCloud(t *testing.T) {
 	}, *pullRequests[1])
 
 	regexp = `.*2$`
-	svc, err = NewBitbucketCloudServiceNoAuth(ts.URL, "OWNER", "REPO")
+	svc, err = NewBitbucketCloudServiceNoAuth(ts.URL, "OWNER", "REPO", nil)
 	require.NoError(t, err)
 	pullRequests, err = ListPullRequests(t.Context(), svc, []v1alpha1.PullRequestGeneratorFilter{
 		{
@@ -477,7 +489,7 @@ func TestListPullRequestBranchMatchCloud(t *testing.T) {
 	}, *pullRequests[0])
 
 	regexp = `[\d{2}`
-	svc, err = NewBitbucketCloudServiceNoAuth(ts.URL, "OWNER", "REPO")
+	svc, err = NewBitbucketCloudServiceNoAuth(ts.URL, "OWNER", "REPO", nil)
 	require.NoError(t, err)
 	_, err = ListPullRequests(t.Context(), svc, []v1alpha1.PullRequestGeneratorFilter{
 		{
@@ -520,7 +532,7 @@ func TestBitbucketCloudListReturnsRepositoryNotFoundError(t *testing.T) {
 		_, _ = w.Write([]byte(`{"message": "404 Project Not Found"}`))
 	})
 
-	svc, err := NewBitbucketCloudServiceNoAuth(server.URL, "nonexistent", "nonexistent")
+	svc, err := NewBitbucketCloudServiceNoAuth(server.URL, "nonexistent", "nonexistent", nil)
 	require.NoError(t, err)
 
 	prs, err := svc.List(t.Context())

--- a/applicationset/services/pull_request/hint_store.go
+++ b/applicationset/services/pull_request/hint_store.go
@@ -1,0 +1,39 @@
+package pull_request
+
+import "sync"
+
+// PRHintStore is a per-repo accumulator seeded from webhook payloads, letting
+// List() return newly-opened PRs before Bitbucket's list API reflects them.
+type PRHintStore struct {
+	m sync.Map // key: "owner/repo" → []*PullRequest
+}
+
+// Set appends prs to any already-stored hints for owner/repo so that rapid
+// back-to-back webhooks before the next reconcile don't drop earlier hints.
+func (s *PRHintStore) Set(owner, repo string, prs []*PullRequest) {
+	key := owner + "/" + repo
+	for {
+		existing, loaded := s.m.Load(key)
+		var next []*PullRequest
+		if loaded {
+			next = append(existing.([]*PullRequest), prs...)
+		} else {
+			next = prs
+		}
+		if swapped := s.m.CompareAndSwap(key, existing, next); swapped || !loaded {
+			if !loaded {
+				s.m.Store(key, next)
+			}
+			return
+		}
+	}
+}
+
+// Take consumes and returns all hints for the given repo. Returns nil if none are set.
+func (s *PRHintStore) Take(owner, repo string) []*PullRequest {
+	v, ok := s.m.LoadAndDelete(owner + "/" + repo)
+	if !ok {
+		return nil
+	}
+	return v.([]*PullRequest)
+}

--- a/applicationset/webhook/testdata/bitbucket-cloud-pull-request-created.json
+++ b/applicationset/webhook/testdata/bitbucket-cloud-pull-request-created.json
@@ -1,0 +1,62 @@
+{
+  "actor": {
+    "type": "user",
+    "nickname": "jsmith",
+    "display_name": "Jane Smith",
+    "uuid": "{12345678-abcd-1234-abcd-123456789012}"
+  },
+  "pullrequest": {
+    "id": 42,
+    "title": "Add feature X",
+    "state": "OPEN",
+    "author": {
+      "type": "user",
+      "nickname": "jsmith",
+      "uuid": "{12345678-abcd-1234-abcd-123456789012}"
+    },
+    "source": {
+      "branch": { "name": "feature/x" },
+      "commit": { "hash": "abc123" },
+      "repository": {
+        "type": "repository",
+        "full_name": "my-org/myrepo",
+        "name": "myrepo",
+        "owner": { "type": "team", "nickname": "my-org" },
+        "links": {
+          "html": { "href": "https://bitbucket.org/my-org/myrepo" }
+        }
+      }
+    },
+    "destination": {
+      "branch": { "name": "main" },
+      "commit": { "hash": "def456" },
+      "repository": {
+        "type": "repository",
+        "full_name": "my-org/myrepo",
+        "name": "myrepo",
+        "owner": { "type": "team", "nickname": "my-org" },
+        "links": {
+          "html": { "href": "https://bitbucket.org/my-org/myrepo" }
+        }
+      }
+    },
+    "links": {
+      "html": { "href": "https://bitbucket.org/my-org/myrepo/pull-requests/42" }
+    }
+  },
+  "repository": {
+    "type": "repository",
+    "full_name": "my-org/myrepo",
+    "name": "myrepo",
+    "owner": {
+      "type": "team",
+      "nickname": "my-org",
+      "uuid": "{aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee}"
+    },
+    "scm": "git",
+    "is_private": true,
+    "links": {
+      "html": { "href": "https://bitbucket.org/my-org/myrepo" }
+    }
+  }
+}

--- a/applicationset/webhook/testdata/bitbucket-cloud-pull-request-displayname.json
+++ b/applicationset/webhook/testdata/bitbucket-cloud-pull-request-displayname.json
@@ -1,0 +1,62 @@
+{
+  "actor": {
+    "type": "user",
+    "nickname": "jsmith",
+    "display_name": "Jane Smith",
+    "uuid": "{12345678-abcd-1234-abcd-123456789012}"
+  },
+  "pullrequest": {
+    "id": 42,
+    "title": "Add feature X",
+    "state": "OPEN",
+    "author": {
+      "type": "user",
+      "nickname": "jsmith",
+      "uuid": "{12345678-abcd-1234-abcd-123456789012}"
+    },
+    "source": {
+      "branch": { "name": "feature/x" },
+      "commit": { "hash": "abc123" },
+      "repository": {
+        "type": "repository",
+        "full_name": "my-org/myrepo",
+        "name": "My Repo Display Name",
+        "owner": { "type": "team", "nickname": "my-org" },
+        "links": {
+          "html": { "href": "https://bitbucket.org/my-org/myrepo" }
+        }
+      }
+    },
+    "destination": {
+      "branch": { "name": "main" },
+      "commit": { "hash": "def456" },
+      "repository": {
+        "type": "repository",
+        "full_name": "my-org/myrepo",
+        "name": "My Repo Display Name",
+        "owner": { "type": "team", "nickname": "my-org" },
+        "links": {
+          "html": { "href": "https://bitbucket.org/my-org/myrepo" }
+        }
+      }
+    },
+    "links": {
+      "html": { "href": "https://bitbucket.org/my-org/myrepo/pull-requests/42" }
+    }
+  },
+  "repository": {
+    "type": "repository",
+    "full_name": "my-org/myrepo",
+    "name": "My Repo Display Name",
+    "owner": {
+      "type": "team",
+      "nickname": "my-org",
+      "uuid": "{aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee}"
+    },
+    "scm": "git",
+    "is_private": true,
+    "links": {
+      "html": { "href": "https://bitbucket.org/my-org/myrepo" }
+    }
+  }
+}

--- a/applicationset/webhook/testdata/bitbucket-cloud-push.json
+++ b/applicationset/webhook/testdata/bitbucket-cloud-push.json
@@ -1,0 +1,48 @@
+{
+  "actor": {
+    "type": "user",
+    "nickname": "jsmith",
+    "uuid": "{12345678-abcd-1234-abcd-123456789012}"
+  },
+  "repository": {
+    "type": "repository",
+    "full_name": "my-org/myrepo",
+    "name": "myrepo",
+    "owner": {
+      "type": "team",
+      "nickname": "my-org",
+      "uuid": "{aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee}"
+    },
+    "scm": "git",
+    "is_private": true,
+    "links": {
+      "html": { "href": "https://bitbucket.org/my-org/myrepo" }
+    }
+  },
+  "push": {
+    "changes": [
+      {
+        "new": {
+          "type": "branch",
+          "name": "main",
+          "target": {
+            "type": "commit",
+            "hash": "abc123def456abc123def456abc123def456abc1"
+          }
+        },
+        "old": {
+          "type": "branch",
+          "name": "main",
+          "target": {
+            "type": "commit",
+            "hash": "000000000000000000000000000000000000000a"
+          }
+        },
+        "created": false,
+        "forced": false,
+        "closed": false,
+        "truncated": false
+      }
+    ]
+  }
+}

--- a/applicationset/webhook/webhook.go
+++ b/applicationset/webhook/webhook.go
@@ -657,10 +657,18 @@ func (h *WebhookHandler) shouldRefreshMergeGenerator(gen *v1alpha1.MergeGenerato
 }
 
 func bitbucketPRInfo(repo bitbucket.Repository) *prGeneratorBitbucketInfo {
-	return &prGeneratorBitbucketInfo{
-		Owner: repo.Owner.NickName,
-		Repo:  repo.Name,
+	// full_name is "workspace/repo-slug" and is always the stable API identifier.
+	// repo.Name can be a display name that differs from the slug, which would
+	// cause shouldRefreshPRGenerator to silently miss the matching ApplicationSet.
+	owner := repo.Owner.NickName
+	repoName := repo.Name
+	if repo.FullName != "" {
+		if parts := strings.SplitN(repo.FullName, "/", 2); len(parts) == 2 {
+			owner = parts[0]
+			repoName = parts[1]
+		}
 	}
+	return &prGeneratorBitbucketInfo{Owner: owner, Repo: repoName}
 }
 
 func refreshApplicationSet(c client.Client, appSet *v1alpha1.ApplicationSet) error {

--- a/applicationset/webhook/webhook.go
+++ b/applicationset/webhook/webhook.go
@@ -23,6 +23,7 @@ import (
 	"github.com/argoproj/argo-cd/v3/util/webhook"
 
 	"github.com/go-playground/webhooks/v6/azuredevops"
+	"github.com/go-playground/webhooks/v6/bitbucket"
 	"github.com/go-playground/webhooks/v6/github"
 	"github.com/go-playground/webhooks/v6/gitlab"
 	log "github.com/sirupsen/logrus"
@@ -36,12 +37,14 @@ const panicMsgAppSet = "panic while processing applicationset-controller webhook
 
 type WebhookHandler struct {
 	sync.WaitGroup // for testing
-	github         *github.Webhook
-	gitlab         *gitlab.Webhook
-	azuredevops    *azuredevops.Webhook
-	client         client.Client
-	generators     map[string]generators.Generator
-	queue          chan any
+
+	github      *github.Webhook
+	gitlab      *gitlab.Webhook
+	azuredevops *azuredevops.Webhook
+	bitbucket   *bitbucket.Webhook
+	client      client.Client
+	generators  map[string]generators.Generator
+	queue       chan any
 }
 
 type gitGeneratorInfo struct {
@@ -54,6 +57,7 @@ type prGeneratorInfo struct {
 	Azuredevops *prGeneratorAzuredevopsInfo
 	Github      *prGeneratorGithubInfo
 	Gitlab      *prGeneratorGitlabInfo
+	Bitbucket   *prGeneratorBitbucketInfo
 }
 
 type prGeneratorAzuredevopsInfo struct {
@@ -70,6 +74,11 @@ type prGeneratorGithubInfo struct {
 type prGeneratorGitlabInfo struct {
 	Project     string
 	APIHostname string
+}
+
+type prGeneratorBitbucketInfo struct {
+	Owner string
+	Repo  string
 }
 
 func NewWebhookHandler(webhookParallelism int, argocdSettingsMgr *argosettings.SettingsManager, client client.Client, generators map[string]generators.Generator) (*WebhookHandler, error) {
@@ -90,11 +99,16 @@ func NewWebhookHandler(webhookParallelism int, argocdSettingsMgr *argosettings.S
 	if err != nil {
 		return nil, fmt.Errorf("unable to init Azure DevOps webhook: %w", err)
 	}
+	bitbucketHandler, err := bitbucket.New(bitbucket.Options.UUID(argocdSettings.GetWebhookBitbucketUUID()))
+	if err != nil {
+		return nil, fmt.Errorf("unable to init Bitbucket webhook: %w", err)
+	}
 
 	webhookHandler := &WebhookHandler{
 		github:      githubHandler,
 		gitlab:      gitlabHandler,
 		azuredevops: azuredevopsHandler,
+		bitbucket:   bitbucketHandler,
 		client:      client,
 		generators:  generators,
 		queue:       make(chan any, payloadQueueSize),
@@ -169,6 +183,14 @@ func (h *WebhookHandler) Handler(w http.ResponseWriter, r *http.Request) {
 		payload, err = h.gitlab.Parse(r, gitlab.PushEvents, gitlab.TagEvents, gitlab.MergeRequestEvents, gitlab.SystemHookEvents)
 	case r.Header.Get("X-Vss-Activityid") != "":
 		payload, err = h.azuredevops.Parse(r, azuredevops.GitPushEventType, azuredevops.GitPullRequestCreatedEventType, azuredevops.GitPullRequestUpdatedEventType, azuredevops.GitPullRequestMergedEventType)
+	case r.Header.Get("X-Hook-UUID") != "":
+		payload, err = h.bitbucket.Parse(r,
+			bitbucket.RepoPushEvent,
+			bitbucket.PullRequestCreatedEvent,
+			bitbucket.PullRequestUpdatedEvent,
+			bitbucket.PullRequestMergedEvent,
+			bitbucket.PullRequestDeclinedEvent,
+		)
 	default:
 		log.Debug("Ignoring unknown webhook event")
 		http.Error(w, "Unknown webhook event", http.StatusBadRequest)
@@ -214,6 +236,14 @@ func getGitGeneratorInfo(payload any) *gitGeneratorInfo {
 		revision = webhook.ParseRevision(payload.Resource.RefUpdates[0].Name)
 		touchedHead = payload.Resource.RefUpdates[0].Name == payload.Resource.Repository.DefaultBranch
 		// unfortunately, Azure DevOps doesn't provide a list of changed files
+	case bitbucket.RepoPushPayload:
+		if len(payload.Push.Changes) == 0 || payload.Push.Changes[0].New.Name == "" {
+			return nil
+		}
+		webURL = payload.Repository.Links.HTML.Href
+		revision = payload.Push.Changes[0].New.Name
+		// Default branch is not included in the push payload; treat all pushes as potentially touching HEAD.
+		touchedHead = true
 	default:
 		return nil
 	}
@@ -279,6 +309,14 @@ func getPRGeneratorInfo(payload any) *prGeneratorInfo {
 			Repo:    repo,
 			Project: project,
 		}
+	case bitbucket.PullRequestCreatedPayload:
+		info.Bitbucket = bitbucketPRInfo(payload.Repository)
+	case bitbucket.PullRequestUpdatedPayload:
+		info.Bitbucket = bitbucketPRInfo(payload.Repository)
+	case bitbucket.PullRequestMergedPayload:
+		info.Bitbucket = bitbucketPRInfo(payload.Repository)
+	case bitbucket.PullRequestDeclinedPayload:
+		info.Bitbucket = bitbucketPRInfo(payload.Repository)
 	default:
 		return nil
 	}
@@ -405,6 +443,16 @@ func shouldRefreshPRGenerator(gen *v1alpha1.PullRequestGenerator, info *prGenera
 			return false
 		}
 		if gen.AzureDevOps.Repo != info.Azuredevops.Repo {
+			return false
+		}
+		return true
+	}
+
+	if gen.Bitbucket != nil && info.Bitbucket != nil {
+		if !strings.EqualFold(gen.Bitbucket.Owner, info.Bitbucket.Owner) {
+			return false
+		}
+		if !strings.EqualFold(gen.Bitbucket.Repo, info.Bitbucket.Repo) {
 			return false
 		}
 		return true
@@ -606,6 +654,13 @@ func (h *WebhookHandler) shouldRefreshMergeGenerator(gen *v1alpha1.MergeGenerato
 	}
 
 	return false
+}
+
+func bitbucketPRInfo(repo bitbucket.Repository) *prGeneratorBitbucketInfo {
+	return &prGeneratorBitbucketInfo{
+		Owner: repo.Owner.NickName,
+		Repo:  repo.Name,
+	}
 }
 
 func refreshApplicationSet(c client.Client, appSet *v1alpha1.ApplicationSet) error {

--- a/applicationset/webhook/webhook.go
+++ b/applicationset/webhook/webhook.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/argoproj/argo-cd/v3/applicationset/generators"
+	pullrequest "github.com/argoproj/argo-cd/v3/applicationset/services/pull_request"
 	"github.com/argoproj/argo-cd/v3/common"
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	argosettings "github.com/argoproj/argo-cd/v3/util/settings"
@@ -45,6 +46,7 @@ type WebhookHandler struct {
 	client      client.Client
 	generators  map[string]generators.Generator
 	queue       chan any
+	prHints     *pullrequest.PRHintStore
 }
 
 type gitGeneratorInfo struct {
@@ -104,6 +106,17 @@ func NewWebhookHandler(webhookParallelism int, argocdSettingsMgr *argosettings.S
 		return nil, fmt.Errorf("unable to init Bitbucket webhook: %w", err)
 	}
 
+	// Extract the shared PRHintStore from the PullRequest generator so the webhook
+	// handler can inject PR data from the payload, bypassing the eventually-consistent
+	// Bitbucket Cloud list API on webhook-triggered reconciles.
+	var prHints *pullrequest.PRHintStore
+	type prHintProvider interface {
+		GetPRHints() *pullrequest.PRHintStore
+	}
+	if p, ok := generators["PullRequest"].(prHintProvider); ok {
+		prHints = p.GetPRHints()
+	}
+
 	webhookHandler := &WebhookHandler{
 		github:      githubHandler,
 		gitlab:      gitlabHandler,
@@ -112,6 +125,7 @@ func NewWebhookHandler(webhookParallelism int, argocdSettingsMgr *argosettings.S
 		client:      client,
 		generators:  generators,
 		queue:       make(chan any, payloadQueueSize),
+		prHints:     prHints,
 	}
 
 	webhookHandler.startWorkerPool(webhookParallelism)
@@ -134,7 +148,56 @@ func (h *WebhookHandler) startWorkerPool(webhookParallelism int) {
 	}
 }
 
+// injectBitbucketPRHint seeds the PRHintStore with the PR from the webhook payload so that
+// List() can return it immediately without waiting for Bitbucket's eventually-consistent
+// list API (typically 2–6 min lag after PR creation). Only fires on created/updated events.
+func (h *WebhookHandler) injectBitbucketPRHint(payload any) {
+	if h.prHints == nil {
+		return
+	}
+	type prFields struct {
+		repo      bitbucket.Repository
+		id        int64
+		title     string
+		srcBranch string
+		dstBranch string
+		srcHash   string
+		author    string
+	}
+	var f prFields
+	switch p := payload.(type) {
+	case bitbucket.PullRequestCreatedPayload:
+		f = prFields{
+			p.Repository, p.PullRequest.ID, p.PullRequest.Title,
+			p.PullRequest.Source.Branch.Name, p.PullRequest.Destination.Branch.Name,
+			p.PullRequest.Source.Commit.Hash, p.PullRequest.Author.NickName,
+		}
+	case bitbucket.PullRequestUpdatedPayload:
+		f = prFields{
+			p.Repository, p.PullRequest.ID, p.PullRequest.Title,
+			p.PullRequest.Source.Branch.Name, p.PullRequest.Destination.Branch.Name,
+			p.PullRequest.Source.Commit.Hash, p.PullRequest.Author.NickName,
+		}
+	default:
+		return
+	}
+	info := bitbucketPRInfo(f.repo)
+	if info.Owner == "" || info.Repo == "" {
+		return
+	}
+	h.prHints.Set(info.Owner, info.Repo, []*pullrequest.PullRequest{{
+		Number:       f.id,
+		Title:        f.title,
+		Branch:       f.srcBranch,
+		TargetBranch: f.dstBranch,
+		HeadSHA:      f.srcHash,
+		Author:       f.author,
+	}})
+}
+
 func (h *WebhookHandler) HandleEvent(payload any) {
+	h.injectBitbucketPRHint(payload)
+
 	gitGenInfo := getGitGeneratorInfo(payload)
 	prGenInfo := getPRGeneratorInfo(payload)
 	if gitGenInfo == nil && prGenInfo == nil {

--- a/applicationset/webhook/webhook_test.go
+++ b/applicationset/webhook/webhook_test.go
@@ -243,6 +243,18 @@ func TestWebhookHandler(t *testing.T) {
 			expectedStatusCode: http.StatusOK,
 			expectedRefresh:    true,
 		},
+		{
+			// repository.name is a display name ("My Repo Display Name") that differs from
+			// the slug; full_name ("my-org/myrepo") must be used for matching.
+			desc:               "WebHook from a Bitbucket Cloud repository where display name differs from slug",
+			headerKey:          "X-Hook-UUID",
+			headerValue:        "{some-uuid}",
+			extraHeaders:       map[string]string{"X-Event-Key": "pullrequest:created"},
+			payloadFile:        "bitbucket-cloud-pull-request-displayname.json",
+			effectedAppSets:    []string{"pull-request-bitbucket-cloud", "plugin", "matrix-pull-request-github-plugin"},
+			expectedStatusCode: http.StatusOK,
+			expectedRefresh:    true,
+		},
 	}
 
 	namespace := "test"

--- a/applicationset/webhook/webhook_test.go
+++ b/applicationset/webhook/webhook_test.go
@@ -53,6 +53,7 @@ func TestWebhookHandler(t *testing.T) {
 		desc               string
 		headerKey          string
 		headerValue        string
+		extraHeaders       map[string]string
 		effectedAppSets    []string
 		payloadFile        string
 		expectedStatusCode int
@@ -193,6 +194,56 @@ func TestWebhookHandler(t *testing.T) {
 			expectedStatusCode: http.StatusOK,
 			expectedRefresh:    true,
 		},
+		{
+			desc:               "WebHook from a Bitbucket Cloud repository via push event",
+			headerKey:          "X-Hook-UUID",
+			headerValue:        "{some-uuid}",
+			extraHeaders:       map[string]string{"X-Event-Key": "repo:push"},
+			payloadFile:        "bitbucket-cloud-push.json",
+			effectedAppSets:    []string{"plugin", "matrix-pull-request-github-plugin"},
+			expectedStatusCode: http.StatusOK,
+			expectedRefresh:    true,
+		},
+		{
+			desc:               "WebHook from a Bitbucket Cloud repository via pull request created event",
+			headerKey:          "X-Hook-UUID",
+			headerValue:        "{some-uuid}",
+			extraHeaders:       map[string]string{"X-Event-Key": "pullrequest:created"},
+			payloadFile:        "bitbucket-cloud-pull-request-created.json",
+			effectedAppSets:    []string{"pull-request-bitbucket-cloud", "plugin", "matrix-pull-request-github-plugin"},
+			expectedStatusCode: http.StatusOK,
+			expectedRefresh:    true,
+		},
+		{
+			desc:               "WebHook from a Bitbucket Cloud repository via pull request updated event",
+			headerKey:          "X-Hook-UUID",
+			headerValue:        "{some-uuid}",
+			extraHeaders:       map[string]string{"X-Event-Key": "pullrequest:updated"},
+			payloadFile:        "bitbucket-cloud-pull-request-created.json",
+			effectedAppSets:    []string{"pull-request-bitbucket-cloud", "plugin", "matrix-pull-request-github-plugin"},
+			expectedStatusCode: http.StatusOK,
+			expectedRefresh:    true,
+		},
+		{
+			desc:               "WebHook from a Bitbucket Cloud repository via pull request merged event",
+			headerKey:          "X-Hook-UUID",
+			headerValue:        "{some-uuid}",
+			extraHeaders:       map[string]string{"X-Event-Key": "pullrequest:fulfilled"},
+			payloadFile:        "bitbucket-cloud-pull-request-created.json",
+			effectedAppSets:    []string{"pull-request-bitbucket-cloud", "plugin", "matrix-pull-request-github-plugin"},
+			expectedStatusCode: http.StatusOK,
+			expectedRefresh:    true,
+		},
+		{
+			desc:               "WebHook from a Bitbucket Cloud repository via pull request declined event",
+			headerKey:          "X-Hook-UUID",
+			headerValue:        "{some-uuid}",
+			extraHeaders:       map[string]string{"X-Event-Key": "pullrequest:rejected"},
+			payloadFile:        "bitbucket-cloud-pull-request-created.json",
+			effectedAppSets:    []string{"pull-request-bitbucket-cloud", "plugin", "matrix-pull-request-github-plugin"},
+			expectedStatusCode: http.StatusOK,
+			expectedRefresh:    true,
+		},
 	}
 
 	namespace := "test"
@@ -200,8 +251,6 @@ func TestWebhookHandler(t *testing.T) {
 	fakeClient := newFakeClient(namespace)
 	scheme := runtime.NewScheme()
 	err := v1alpha1.AddToScheme(scheme)
-	require.NoError(t, err)
-	err = v1alpha1.AddToScheme(scheme)
 	require.NoError(t, err)
 
 	for _, test := range tt {
@@ -220,6 +269,7 @@ func TestWebhookHandler(t *testing.T) {
 				fakeAppWithGithubPullRequestGenerator("pull-request-github", namespace, "CodErTOcat", "Hello-World"),
 				fakeAppWithGitlabPullRequestGenerator("pull-request-gitlab", namespace, "100500"),
 				fakeAppWithAzureDevOpsPullRequestGenerator("pull-request-azure-devops", namespace, "DefaultCollection", "Fabrikam"),
+				fakeAppWithBitbucketCloudPullRequestGenerator("pull-request-bitbucket-cloud", namespace, "my-org", "myrepo"),
 				fakeAppWithPluginGenerator("plugin", namespace),
 				fakeAppWithMatrixAndGitGenerator("matrix-git-github", namespace, "https://github.com/org/repo"),
 				fakeAppWithMatrixAndPullRequestGenerator("matrix-pull-request-github", namespace, "Codertocat", "Hello-World"),
@@ -237,6 +287,9 @@ func TestWebhookHandler(t *testing.T) {
 
 			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/webhook", http.NoBody)
 			req.Header.Set(test.headerKey, test.headerValue)
+			for k, v := range test.extraHeaders {
+				req.Header.Set(k, v)
+			}
 			eventJSON, err := os.ReadFile(filepath.Join("testdata", test.payloadFile))
 			require.NoError(t, err)
 			req.Body = io.NopCloser(bytes.NewReader(eventJSON))
@@ -465,6 +518,27 @@ func fakeAppWithAzureDevOpsPullRequestGenerator(name, namespace, project, repo s
 						AzureDevOps: &v1alpha1.PullRequestGeneratorAzureDevOps{
 							Project: project,
 							Repo:    repo,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func fakeAppWithBitbucketCloudPullRequestGenerator(name, namespace, owner, repo string) *v1alpha1.ApplicationSet {
+	return &v1alpha1.ApplicationSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.ApplicationSetSpec{
+			Generators: []v1alpha1.ApplicationSetGenerator{
+				{
+					PullRequest: &v1alpha1.PullRequestGenerator{
+						Bitbucket: &v1alpha1.PullRequestGeneratorBitbucket{
+							Owner: owner,
+							Repo:  repo,
 						},
 					},
 				},

--- a/applicationset/webhook/webhook_test.go
+++ b/applicationset/webhook/webhook_test.go
@@ -244,6 +244,18 @@ func TestWebhookHandler(t *testing.T) {
 			expectedStatusCode: http.StatusOK,
 			expectedRefresh:    true,
 		},
+		{
+			// repository.name is a display name ("My Repo Display Name") that differs from
+			// the slug; full_name ("my-org/myrepo") must be used for matching.
+			desc:               "WebHook from a Bitbucket Cloud repository where display name differs from slug",
+			headerKey:          "X-Hook-UUID",
+			headerValue:        "{some-uuid}",
+			extraHeaders:       map[string]string{"X-Event-Key": "pullrequest:created"},
+			payloadFile:        "bitbucket-cloud-pull-request-displayname.json",
+			effectedAppSets:    []string{"pull-request-bitbucket-cloud", "plugin", "matrix-pull-request-github-plugin"},
+			expectedStatusCode: http.StatusOK,
+			expectedRefresh:    true,
+		},
 	}
 
 	namespace := "test"

--- a/applicationset/webhook/webhook_test.go
+++ b/applicationset/webhook/webhook_test.go
@@ -52,6 +52,7 @@ func TestWebhookHandler(t *testing.T) {
 		desc               string
 		headerKey          string
 		headerValue        string
+		extraHeaders       map[string]string
 		effectedAppSets    []string
 		payloadFile        string
 		expectedStatusCode int
@@ -192,6 +193,56 @@ func TestWebhookHandler(t *testing.T) {
 			expectedStatusCode: http.StatusOK,
 			expectedRefresh:    true,
 		},
+		{
+			desc:               "WebHook from a Bitbucket Cloud repository via push event",
+			headerKey:          "X-Hook-UUID",
+			headerValue:        "{some-uuid}",
+			extraHeaders:       map[string]string{"X-Event-Key": "repo:push"},
+			payloadFile:        "bitbucket-cloud-push.json",
+			effectedAppSets:    []string{"plugin", "matrix-pull-request-github-plugin"},
+			expectedStatusCode: http.StatusOK,
+			expectedRefresh:    true,
+		},
+		{
+			desc:               "WebHook from a Bitbucket Cloud repository via pull request created event",
+			headerKey:          "X-Hook-UUID",
+			headerValue:        "{some-uuid}",
+			extraHeaders:       map[string]string{"X-Event-Key": "pullrequest:created"},
+			payloadFile:        "bitbucket-cloud-pull-request-created.json",
+			effectedAppSets:    []string{"pull-request-bitbucket-cloud", "plugin", "matrix-pull-request-github-plugin"},
+			expectedStatusCode: http.StatusOK,
+			expectedRefresh:    true,
+		},
+		{
+			desc:               "WebHook from a Bitbucket Cloud repository via pull request updated event",
+			headerKey:          "X-Hook-UUID",
+			headerValue:        "{some-uuid}",
+			extraHeaders:       map[string]string{"X-Event-Key": "pullrequest:updated"},
+			payloadFile:        "bitbucket-cloud-pull-request-created.json",
+			effectedAppSets:    []string{"pull-request-bitbucket-cloud", "plugin", "matrix-pull-request-github-plugin"},
+			expectedStatusCode: http.StatusOK,
+			expectedRefresh:    true,
+		},
+		{
+			desc:               "WebHook from a Bitbucket Cloud repository via pull request merged event",
+			headerKey:          "X-Hook-UUID",
+			headerValue:        "{some-uuid}",
+			extraHeaders:       map[string]string{"X-Event-Key": "pullrequest:fulfilled"},
+			payloadFile:        "bitbucket-cloud-pull-request-created.json",
+			effectedAppSets:    []string{"pull-request-bitbucket-cloud", "plugin", "matrix-pull-request-github-plugin"},
+			expectedStatusCode: http.StatusOK,
+			expectedRefresh:    true,
+		},
+		{
+			desc:               "WebHook from a Bitbucket Cloud repository via pull request declined event",
+			headerKey:          "X-Hook-UUID",
+			headerValue:        "{some-uuid}",
+			extraHeaders:       map[string]string{"X-Event-Key": "pullrequest:rejected"},
+			payloadFile:        "bitbucket-cloud-pull-request-created.json",
+			effectedAppSets:    []string{"pull-request-bitbucket-cloud", "plugin", "matrix-pull-request-github-plugin"},
+			expectedStatusCode: http.StatusOK,
+			expectedRefresh:    true,
+		},
 	}
 
 	namespace := "test"
@@ -199,8 +250,6 @@ func TestWebhookHandler(t *testing.T) {
 	fakeClient := newFakeClient(namespace)
 	scheme := runtime.NewScheme()
 	err := v1alpha1.AddToScheme(scheme)
-	require.NoError(t, err)
-	err = v1alpha1.AddToScheme(scheme)
 	require.NoError(t, err)
 
 	for _, test := range tt {
@@ -219,6 +268,7 @@ func TestWebhookHandler(t *testing.T) {
 				fakeAppWithGithubPullRequestGenerator("pull-request-github", namespace, "CodErTOcat", "Hello-World"),
 				fakeAppWithGitlabPullRequestGenerator("pull-request-gitlab", namespace, "100500"),
 				fakeAppWithAzureDevOpsPullRequestGenerator("pull-request-azure-devops", namespace, "DefaultCollection", "Fabrikam"),
+				fakeAppWithBitbucketCloudPullRequestGenerator("pull-request-bitbucket-cloud", namespace, "my-org", "myrepo"),
 				fakeAppWithPluginGenerator("plugin", namespace),
 				fakeAppWithMatrixAndGitGenerator("matrix-git-github", namespace, "https://github.com/org/repo"),
 				fakeAppWithMatrixAndPullRequestGenerator("matrix-pull-request-github", namespace, "Codertocat", "Hello-World"),
@@ -236,6 +286,9 @@ func TestWebhookHandler(t *testing.T) {
 
 			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/webhook", http.NoBody)
 			req.Header.Set(test.headerKey, test.headerValue)
+			for k, v := range test.extraHeaders {
+				req.Header.Set(k, v)
+			}
 			eventJSON, err := os.ReadFile(filepath.Join("testdata", test.payloadFile))
 			require.NoError(t, err)
 			req.Body = io.NopCloser(bytes.NewReader(eventJSON))
@@ -456,6 +509,25 @@ func fakeAppWithAzureDevOpsPullRequestGenerator(name, namespace, project, repo s
 						AzureDevOps: &v1alpha1.PullRequestGeneratorAzureDevOps{
 							Project: project,
 							Repo:    repo,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func fakeAppWithBitbucketCloudPullRequestGenerator(name, namespace, owner, repo string) *v1alpha1.ApplicationSet {
+	return &v1alpha1.ApplicationSet{
+		Name:      name,
+		Namespace: namespace,
+		Spec: v1alpha1.ApplicationSetSpec{
+			Generators: []v1alpha1.ApplicationSetGenerator{
+				{
+					PullRequest: &v1alpha1.PullRequestGenerator{
+						Bitbucket: &v1alpha1.PullRequestGeneratorBitbucket{
+							Owner: owner,
+							Repo:  repo,
 						},
 					},
 				},

--- a/docs/operator-manual/applicationset/Generators-Git.md
+++ b/docs/operator-manual/applicationset/Generators-Git.md
@@ -463,7 +463,7 @@ annotation after reconciliation.
 
 To eliminate the polling delay, the ApplicationSet webhook
 server can be configured to receive webhook events. ApplicationSet
-supports Git webhook notifications from GitHub and GitLab. The
+supports Git webhook notifications from GitHub, GitLab, and Bitbucket Cloud. The
 following explains how to configure a Git webhook for GitHub, but the
 same process should be applicable to other providers.
 
@@ -537,6 +537,9 @@ stringData:
 
   # gitlab webhook secret
   webhook.gitlab.secret: shhhh! it's a gitlab secret
+
+  # bitbucket cloud webhook UUID (from the webhook settings page)
+  webhook.bitbucket.uuid: your-webhook-uuid
 ```
 
 After saving, please restart the ApplicationSet pod for the changes to take effect.

--- a/docs/operator-manual/applicationset/Generators-Pull-Request.md
+++ b/docs/operator-manual/applicationset/Generators-Pull-Request.md
@@ -494,6 +494,39 @@ The Pull Request Generator will requeue when the next action occurs.
 
 For more information about each event, please refer to the [official documentation](https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#merge-request-events).
 
+### Bitbucket Cloud webhook configuration
+
+In your Bitbucket Cloud repository, navigate to **Repository settings > Webhooks** and add a new webhook. Set the payload URL to the `/api/webhook` endpoint of your ApplicationSet controller (e.g. `https://applicationset.example.com/api/webhook`).
+
+Under **Triggers**, select **Choose from a full list of triggers** and enable the following Pull Request events:
+
+- `Pull Request: Created`
+- `Pull Request: Updated`
+- `Pull Request: Merged`
+- `Pull Request: Declined`
+
+Bitbucket Cloud authenticates webhooks using a UUID rather than a shared secret. Copy the webhook UUID from the Bitbucket webhook settings page and add it to the `argocd-secret` Kubernetes secret:
+
+```bash
+kubectl edit secret argocd-secret -n argocd
+```
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-secret
+  namespace: argocd
+stringData:
+  # bitbucket cloud webhook UUID
+  webhook.bitbucket.uuid: your-webhook-uuid
+```
+
+After saving, restart the ApplicationSet controller pod for the change to take effect.
+
+> [!NOTE]
+> Bitbucket Cloud does not include the repository's default branch name in push payloads. The ApplicationSet controller therefore treats every push as potentially targeting HEAD. This means all ApplicationSets whose Git generator tracks the default branch will be refreshed on any push, not only pushes to the default branch.
+
 ## Lifecycle
 
 An Application will be generated when a Pull Request is discovered when the configured criteria is met - i.e. for GitHub when a Pull Request matches the specified `labels` and/or `pullRequestState`. Application will be removed when a Pull Request no longer meets the specified criteria.


### PR DESCRIPTION
Adds webhook support for the ApplicationSet controller so that PR and Git generators refresh immediately on Bitbucket Cloud events instead of waiting for the polling interval.

- Handle repo:push, pullrequest:created/updated/fulfilled/rejected events
- Validate UUID (skipped when webhook.bitbucket.uuid is unset in argocd-secret)
- shouldRefreshPRGenerator recognises BitbucketCloud PR generator config
- Docs: add Bitbucket Cloud section to Pull-Request generator docs and note HEAD over-trigger behaviour; update Git generator doc to mention Bitbucket
- Tests: cover all five event types and UUID-absent path

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
