### PR TITLE
fix(cli): honor --kube-context when creating core-mode REST config (#12883)

### DIFF
--- a/cmd/argocd/commands/headless/headless.go
+++ b/cmd/argocd/commands/headless/headless.go
@@ -316,7 +316,7 @@ func MaybeStartLocalServer(ctx context.Context, clientOpts *apiclient.ClientOpti
 func NewClientOrDie(opts *apiclient.ClientOptions, c *cobra.Command) apiclient.Client {
 	ctx := c.Context()
 
-	ctxStr := resolveKubeContextName(opts, c)
+	ctxStr := resolveAndApplyKubeContext(opts, c)
 	// If we're in core mode, start the API server on the fly and configure the client `opts` to use it.
 	// If we're not in core mode, this function call will do nothing.
 	_, err := MaybeStartLocalServer(ctx, opts, ctxStr, nil, nil, nil)
@@ -347,9 +347,14 @@ func newClientConfig(overrides *clientcmd.ConfigOverrides) clientcmd.ClientConfi
 	)
 }
 
-// resolveKubeContextName determines the kube context name and updates the client options with the resolved context if necessary.
-func resolveKubeContextName(opts *apiclient.ClientOptions, c *cobra.Command) string {
+// resolveAndApplyKubeContext resolves the kube context name to use.
+// If the context flag was explicitly set and opts is non-nil, it applies that
+// value to opts.KubeOverrides.CurrentContext.
+func resolveAndApplyKubeContext(opts *apiclient.ClientOptions, c *cobra.Command) string {
 	ctxStr := initialize.RetrieveContextIfChanged(c.Flag("context"))
+	if opts == nil {
+		return ctxStr
+	}
 	if ctxStr != "" {
 		if opts.KubeOverrides == nil {
 			opts.KubeOverrides = &clientcmd.ConfigOverrides{}

--- a/cmd/argocd/commands/headless/headless.go
+++ b/cmd/argocd/commands/headless/headless.go
@@ -13,7 +13,6 @@ import (
 	"github.com/redis/go-redis/v9"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -178,8 +177,7 @@ func testAPI(ctx context.Context, clientOpts *apiclient.ClientOptions) error {
 // not start the local server.
 func MaybeStartLocalServer(ctx context.Context, clientOpts *apiclient.ClientOptions, ctxStr string, port *int, address *string, clientConfig clientcmd.ClientConfig) (func(), error) {
 	if clientConfig == nil {
-		flags := pflag.NewFlagSet("tmp", pflag.ContinueOnError)
-		clientConfig = cli.AddKubectlFlagsToSet(flags)
+		clientConfig = newClientConfig(clientOpts.KubeOverrides)
 	}
 	startInProcessAPI := clientOpts.Core
 	if !startInProcessAPI {
@@ -318,7 +316,7 @@ func MaybeStartLocalServer(ctx context.Context, clientOpts *apiclient.ClientOpti
 func NewClientOrDie(opts *apiclient.ClientOptions, c *cobra.Command) apiclient.Client {
 	ctx := c.Context()
 
-	ctxStr := initialize.RetrieveContextIfChanged(c.Flag("context"))
+	ctxStr := resolveKubeContextName(opts, c)
 	// If we're in core mode, start the API server on the fly and configure the client `opts` to use it.
 	// If we're not in core mode, this function call will do nothing.
 	_, err := MaybeStartLocalServer(ctx, opts, ctxStr, nil, nil, nil)
@@ -330,4 +328,39 @@ func NewClientOrDie(opts *apiclient.ClientOptions, c *cobra.Command) apiclient.C
 		log.Fatal(err)
 	}
 	return client
+}
+
+// newClientConfig creates a new clientcmd.ClientConfig based on the provided overrides.
+func newClientConfig(overrides *clientcmd.ConfigOverrides) clientcmd.ClientConfig {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
+
+	configOverrides := clientcmd.ConfigOverrides{}
+	if overrides != nil {
+		configOverrides = *overrides
+	}
+
+	return clientcmd.NewInteractiveDeferredLoadingClientConfig(
+		loadingRules,
+		&configOverrides,
+		os.Stdin,
+	)
+}
+
+// resolveKubeContextName determines the kube context name and updates the client options with the resolved context if necessary.
+func resolveKubeContextName(opts *apiclient.ClientOptions, c *cobra.Command) string {
+	ctxStr := initialize.RetrieveContextIfChanged(c.Flag("context"))
+	if ctxStr != "" {
+		if opts.KubeOverrides == nil {
+			opts.KubeOverrides = &clientcmd.ConfigOverrides{}
+		}
+		opts.KubeOverrides.CurrentContext = ctxStr
+		return ctxStr
+	}
+
+	if opts.KubeOverrides != nil {
+		return opts.KubeOverrides.CurrentContext
+	}
+
+	return ""
 }

--- a/cmd/argocd/commands/headless/headless_test.go
+++ b/cmd/argocd/commands/headless/headless_test.go
@@ -1,0 +1,99 @@
+package headless
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/argoproj/argo-cd/v3/pkg/apiclient"
+)
+
+func TestKubeContextName(t *testing.T) {
+	t.Run("returns KubeOverrides.CurrentContext", func(t *testing.T) {
+		cmd := &cobra.Command{}
+		opts := &apiclient.ClientOptions{
+			KubeOverrides: &clientcmd.ConfigOverrides{
+				CurrentContext: "target-context",
+			},
+		}
+
+		assert.Equal(t, "target-context", resolveKubeContextName(opts, cmd))
+	})
+
+	t.Run("prefers changed context flag and updates KubeOverrides", func(t *testing.T) {
+		cmd := &cobra.Command{}
+		cmd.Flags().String("context", "", "")
+		require.NoError(t, cmd.Flags().Set("context", "context-flag"))
+
+		opts := &apiclient.ClientOptions{
+			KubeOverrides: &clientcmd.ConfigOverrides{
+				CurrentContext: "kube-context",
+			},
+		}
+
+		assert.Equal(t, "context-flag", resolveKubeContextName(opts, cmd))
+		assert.Equal(t, "context-flag", opts.KubeOverrides.CurrentContext)
+	})
+}
+
+func TestNewClientConfig(t *testing.T) {
+	t.Run("applies KubeOverrides.CurrentContext to REST config", func(t *testing.T) {
+		tempDir := t.TempDir()
+		kubeconfigPath := filepath.Join(tempDir, "kubeconfig")
+		kubeconfigContent := `
+apiVersion: v1
+kind: Config
+clusters:
+- name: current-cluster
+  cluster:
+    server: https://current.example.com
+    insecure-skip-tls-verify: true
+- name: target-cluster
+  cluster:
+    server: https://target.example.com
+    insecure-skip-tls-verify: true
+contexts:
+- name: current-context
+  context:
+    cluster: current-cluster
+    user: current-user
+    namespace: current-ns
+- name: target-context
+  context:
+    cluster: target-cluster
+    user: target-user
+    namespace: target-ns
+current-context: current-context
+users:
+- name: current-user
+  user:
+    token: current-token
+- name: target-user
+  user:
+    token: target-token
+`
+		err := os.WriteFile(kubeconfigPath, []byte(kubeconfigContent), 0o600)
+		require.NoError(t, err)
+
+		t.Setenv("KUBECONFIG", kubeconfigPath)
+
+		clientConfig := newClientConfig(&clientcmd.ConfigOverrides{
+			CurrentContext: "target-context",
+		})
+		require.NotNil(t, clientConfig)
+
+		restConfig, err := clientConfig.ClientConfig()
+		require.NoError(t, err)
+		assert.Equal(t, "https://target.example.com", restConfig.Host)
+		assert.Equal(t, "target-token", restConfig.BearerToken)
+
+		namespace, _, err := clientConfig.Namespace()
+		require.NoError(t, err)
+		assert.Equal(t, "target-ns", namespace)
+	})
+}

--- a/cmd/argocd/commands/headless/headless_test.go
+++ b/cmd/argocd/commands/headless/headless_test.go
@@ -22,7 +22,7 @@ func TestKubeContextName(t *testing.T) {
 			},
 		}
 
-		assert.Equal(t, "target-context", resolveKubeContextName(opts, cmd))
+		assert.Equal(t, "target-context", resolveAndApplyKubeContext(opts, cmd))
 	})
 
 	t.Run("prefers changed context flag and updates KubeOverrides", func(t *testing.T) {
@@ -36,7 +36,7 @@ func TestKubeContextName(t *testing.T) {
 			},
 		}
 
-		assert.Equal(t, "context-flag", resolveKubeContextName(opts, cmd))
+		assert.Equal(t, "context-flag", resolveAndApplyKubeContext(opts, cmd))
 		assert.Equal(t, "context-flag", opts.KubeOverrides.CurrentContext)
 	})
 }


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->


Fixes #12883.

In core mode, `--kube-context` is stored in `clientOpts.KubeOverrides.CurrentContext`.
However, when `MaybeStartLocalServer` created a fallback Kubernetes `ClientConfig`, it did not use those overrides.
As a result, the Kubernetes REST config was created from the kubeconfig current context instead of the context specified by `--kube-context`.

This change builds the fallback `ClientConfig` from `clientOpts.KubeOverrides`, so the REST config honors `--kube-context`.

This also resolves the kube context name in `NewClientOrDie` and applies the resolved context back to `KubeOverrides` when needed.
If the kubectl-style `--context` flag is explicitly set, it continues to take precedence over `--kube-context`.
This keeps the REST config and port-forwarding behavior consistent.


Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
