### PR TITLE
docs: move notification timezone docs to functions page (#14670)

### DIFF
--- a/docs/operator-manual/notifications/functions.md
+++ b/docs/operator-manual/notifications/functions.md
@@ -1,6 +1,36 @@
 ### **time**
 Time related functions.
 
+#### Configuring the local timezone
+
+The `time` functions can be used in both notification templates and triggers.
+
+When converting a time value to local time using `.Local()`, Argo CD Notifications uses the local timezone configured for the `argocd-notifications-controller` container.
+
+You can configure this timezone by setting the `TZ` environment variable on the `argocd-notifications-controller` container:
+
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-notifications-controller
+spec:
+  template:
+    spec:
+      containers:
+      - name: argocd-notifications-controller
+        env:
+        - name: TZ
+          value: Asia/Tokyo
+```
+
+For example, a notification template can format an application timestamp in the configured local timezone:
+
+```
+{{ (call .time.Parse .app.status.operationState.startedAt).Local.Format "2006-01-02T15:04:05Z07:00" }}
+```
+
 <hr>
 **`time.Now() Time`**
 

--- a/docs/operator-manual/notifications/templates.md
+++ b/docs/operator-manual/notifications/templates.md
@@ -111,33 +111,6 @@ The `message` field of the template definition allows creating a basic notificat
 fields to create complex notifications. For example using service-specific you can add blocks and attachments for Slack, subject for Email or URL path, and body for Webhook.
 See corresponding service [documentation](services/overview.md) for more information.
 
-## Change the timezone
-
-You can change the timezone to show in notifications as follows.
-
-1. Call time functions.
-
-    ```
-    {{ (call .time.Parse .app.status.operationState.startedAt).Local.Format "2006-01-02T15:04:05Z07:00" }}
-    ```
-
-2. Set the `TZ` environment variable on the argocd-notifications-controller container.
-
-    ```yaml
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-      name: argocd-notifications-controller
-    spec:
-      template:
-        spec:
-          containers:
-          - name: argocd-notifications-controller
-            env:
-            - name: TZ
-              value: Asia/Tokyo
-    ```
-
 ## Functions
 
 Templates have access to the set of built-in functions such as the functions of the [Sprig](https://masterminds.github.io/sprig/) package

--- a/docs/operator-manual/notifications/templates.md
+++ b/docs/operator-manual/notifications/templates.md
@@ -111,6 +111,11 @@ The `message` field of the template definition allows creating a basic notificat
 fields to create complex notifications. For example using service-specific you can add blocks and attachments for Slack, subject for Email or URL path, and body for Webhook.
 See corresponding service [documentation](services/overview.md) for more information.
 
+## Change the timezone
+
+To change the timezone used when formatting time values in notifications, see
+[Configuring the local timezone](#configuring-the-local-timezone).
+
 ## Functions
 
 Templates have access to the set of built-in functions such as the functions of the [Sprig](https://masterminds.github.io/sprig/) package


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

This PR moves the Argo CD Notifications timezone documentation from the templates page to the functions page.

The timezone behavior is related to the `time` functions, which can be used in both notification templates and triggers. Keeping this documentation under the templates page could make it look like the behavior is template-specific.

Fixes #14670

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
