### PR TITLE
fix(cli): error out on appset create --dry-run if server is pre-2.13 (#21911)

### DIFF
--- a/cmd/argocd/commands/applicationset.go
+++ b/cmd/argocd/commands/applicationset.go
@@ -6,8 +6,11 @@ import (
 	"io"
 	"os"
 	"reflect"
+	"strings"
 	"text/tabwriter"
 
+	"github.com/Masterminds/semver/v3"
+	"github.com/golang/protobuf/ptypes/empty"
 	k8swatch "k8s.io/apimachinery/pkg/watch"
 
 	"github.com/mattn/go-isatty"
@@ -27,6 +30,51 @@ import (
 	utilio "github.com/argoproj/argo-cd/v3/util/io"
 	"github.com/argoproj/argo-cd/v3/util/templates"
 )
+
+// minServerVersionForAppSetDryRun is the first Argo CD server release that
+// honors --dry-run on `appset create` (introduced by commit 70755aa3c5d, first
+// shipped in v2.13.0). Older servers ignore the DryRun flag in the create
+// request and silently apply the change while the CLI happily prints
+// "(dry-run)" — see https://github.com/argoproj/argo-cd/issues/21911.
+const minServerVersionForAppSetDryRun = "2.13.0"
+
+// requireAppSetDryRunSupport returns an error when the connected server is too
+// old to honor `--dry-run` on `appset create`, so the CLI fails loudly instead
+// of silently applying a destructive change.
+func requireAppSetDryRunSupport(ctx context.Context, argocdClient argocdclient.Client, c *cobra.Command) error {
+	conn, versionIf := argocdClient.NewVersionClientOrDie()
+	defer utilio.Close(conn)
+
+	v, err := versionIf.Version(ctx, &empty.Empty{})
+	if err != nil || v == nil {
+		return nil
+	}
+	return checkAppSetDryRunSupportedByVersion(v.Version)
+}
+
+// checkAppSetDryRunSupportedByVersion reports whether the supplied server
+// version string supports `appset create --dry-run`. An empty or unparseable
+// string returns nil — we'd rather not block on a malformed response from a
+// healthy server, since the only contract we are enforcing here is "fail loud
+// on confirmed-old servers".
+func checkAppSetDryRunSupportedByVersion(serverVersion string) error {
+	if serverVersion == "" {
+		return nil
+	}
+	serverVer, err := semver.NewVersion(strings.TrimPrefix(serverVersion, "v"))
+	if err != nil {
+		return nil
+	}
+	minVer := semver.MustParse(minServerVersionForAppSetDryRun)
+	if serverVer.LessThan(minVer) {
+		return fmt.Errorf(
+			"--dry-run for \"appset create\" requires Argo CD server %s or later, but the server is %s; "+
+				"older servers ignore the dry-run flag and apply the change. "+
+				"Upgrade the server, downgrade the CLI to match, or omit --dry-run",
+			minServerVersionForAppSetDryRun, serverVersion)
+	}
+	return nil
+}
 
 var appSetExample = templates.Examples(`
 	# Get an ApplicationSet.
@@ -183,6 +231,12 @@ func NewApplicationSetCreateCommand(clientOpts *argocdclient.ClientOptions) *cob
 				existing, err := appIf.Get(ctx, &applicationset.ApplicationSetGetQuery{Name: appset.Name, AppsetNamespace: appset.Namespace})
 				if grpc.UnwrapGRPCStatus(err).Code() != codes.NotFound {
 					errors.CheckError(err)
+				}
+
+				if dryRun {
+					if err := requireAppSetDryRunSupport(ctx, argocdClient, c); err != nil {
+						errors.CheckError(err)
+					}
 				}
 
 				appSetCreateRequest := applicationset.ApplicationSetCreateRequest{

--- a/cmd/argocd/commands/applicationset.go
+++ b/cmd/argocd/commands/applicationset.go
@@ -38,32 +38,55 @@ import (
 // "(dry-run)" — see https://github.com/argoproj/argo-cd/issues/21911.
 const minServerVersionForAppSetDryRun = "2.13.0"
 
-// requireAppSetDryRunSupport returns an error when the connected server is too
-// old to honor `--dry-run` on `appset create`, so the CLI fails loudly instead
-// of silently applying a destructive change.
-func requireAppSetDryRunSupport(ctx context.Context, argocdClient argocdclient.Client, c *cobra.Command) error {
+// requireAppSetDryRunSupport returns an error when the connected server cannot
+// be confirmed to honor `--dry-run` on `appset create`, so the CLI fails
+// loudly instead of silently applying a destructive change. The function
+// fails closed: if the Version RPC errors out or the server reports an empty
+// / unparseable version string we treat that as "could not confirm support"
+// rather than "supported", since the destructive failure mode is much worse
+// than the false-positive failure mode (an honest server that briefly hiccups
+// on the version RPC).
+func requireAppSetDryRunSupport(ctx context.Context, argocdClient argocdclient.Client) error {
 	conn, versionIf := argocdClient.NewVersionClientOrDie()
 	defer utilio.Close(conn)
 
 	v, err := versionIf.Version(ctx, &empty.Empty{})
-	if err != nil || v == nil {
-		return nil
+	if err != nil {
+		return fmt.Errorf(
+			"--dry-run for \"appset create\" requires confirming the server is %s or later, "+
+				"but the server version could not be retrieved: %w. "+
+				"Older servers ignore the dry-run flag and apply the change; refusing to proceed",
+			minServerVersionForAppSetDryRun, err)
+	}
+	if v == nil {
+		return fmt.Errorf(
+			"--dry-run for \"appset create\" requires confirming the server is %s or later, "+
+				"but the server returned an empty version response. "+
+				"Older servers ignore the dry-run flag and apply the change; refusing to proceed",
+			minServerVersionForAppSetDryRun)
 	}
 	return checkAppSetDryRunSupportedByVersion(v.Version)
 }
 
 // checkAppSetDryRunSupportedByVersion reports whether the supplied server
 // version string supports `appset create --dry-run`. An empty or unparseable
-// string returns nil — we'd rather not block on a malformed response from a
-// healthy server, since the only contract we are enforcing here is "fail loud
-// on confirmed-old servers".
+// string fails closed (returns an error) so we don't silently allow a
+// destructive --dry-run against a server we couldn't identify.
 func checkAppSetDryRunSupportedByVersion(serverVersion string) error {
 	if serverVersion == "" {
-		return nil
+		return fmt.Errorf(
+			"--dry-run for \"appset create\" requires confirming the server is %s or later, "+
+				"but the server returned an empty version string. "+
+				"Older servers ignore the dry-run flag and apply the change; refusing to proceed",
+			minServerVersionForAppSetDryRun)
 	}
 	serverVer, err := semver.NewVersion(strings.TrimPrefix(serverVersion, "v"))
 	if err != nil {
-		return nil
+		return fmt.Errorf(
+			"--dry-run for \"appset create\" requires confirming the server is %s or later, "+
+				"but the server reported an unparseable version %q. "+
+				"Older servers ignore the dry-run flag and apply the change; refusing to proceed",
+			minServerVersionForAppSetDryRun, serverVersion)
 	}
 	minVer := semver.MustParse(minServerVersionForAppSetDryRun)
 	if serverVer.LessThan(minVer) {
@@ -214,6 +237,15 @@ func NewApplicationSetCreateCommand(clientOpts *argocdclient.ClientOptions) *cob
 				os.Exit(1)
 			}
 
+			// Confirm the server is new enough to honor --dry-run on appset create.
+			// Done once before iterating: server version doesn't change inside a
+			// single CLI invocation, so this RPC need not run per ApplicationSet.
+			if dryRun {
+				if err := requireAppSetDryRunSupport(ctx, argocdClient); err != nil {
+					errors.CheckError(err)
+				}
+			}
+
 			for _, appset := range appsets {
 				if appset.Name == "" {
 					errors.Fatal(errors.ErrorGeneric, fmt.Sprintf("Error creating ApplicationSet %s. ApplicationSet does not have Name field set", appset))
@@ -231,12 +263,6 @@ func NewApplicationSetCreateCommand(clientOpts *argocdclient.ClientOptions) *cob
 				existing, err := appIf.Get(ctx, &applicationset.ApplicationSetGetQuery{Name: appset.Name, AppsetNamespace: appset.Namespace})
 				if grpc.UnwrapGRPCStatus(err).Code() != codes.NotFound {
 					errors.CheckError(err)
-				}
-
-				if dryRun {
-					if err := requireAppSetDryRunSupport(ctx, argocdClient, c); err != nil {
-						errors.CheckError(err)
-					}
 				}
 
 				appSetCreateRequest := applicationset.ApplicationSetCreateRequest{

--- a/cmd/argocd/commands/applicationset_test.go
+++ b/cmd/argocd/commands/applicationset_test.go
@@ -50,20 +50,26 @@ func TestAppSetCreateWaitFlow(t *testing.T) {
 
 // TestCheckAppSetDryRunSupportedByVersion guards the server-version gate added
 // in https://github.com/argoproj/argo-cd/issues/21911 so older servers don't
-// silently apply an `appset create --dry-run` request.
+// silently apply an `appset create --dry-run` request. The check fails closed
+// on every "could not confirm" outcome (empty / unparseable version, RPC
+// errors handled at the caller layer) — better to refuse a dry-run we cannot
+// confirm than to silently apply state-mutating requests.
 func TestCheckAppSetDryRunSupportedByVersion(t *testing.T) {
 	tests := []struct {
 		name      string
 		version   string
 		wantError bool
 	}{
-		{name: "empty version is treated as best-effort and accepted", version: "", wantError: false},
-		{name: "unparseable version is treated as best-effort and accepted", version: "not-a-version", wantError: false},
+		// fail-closed cases — refusing without a confirmed server version
+		{name: "empty version fails closed", version: "", wantError: true},
+		{name: "unparseable version fails closed", version: "not-a-version", wantError: true},
+		// confirmed-supported cases
 		{name: "exactly the minimum is supported", version: "v2.13.0", wantError: false},
 		{name: "minimum without v prefix", version: "2.13.0", wantError: false},
 		{name: "patch above the minimum is supported", version: "v2.13.3+a25c8a0", wantError: false},
 		{name: "newer minor is supported", version: "v2.14.0", wantError: false},
 		{name: "v3 is supported", version: "v3.1.0", wantError: false},
+		// confirmed-unsupported cases
 		{name: "older patch fails (issue #21911 reporter case)", version: "v2.11.2+25f7504", wantError: true},
 		{name: "much older minor fails", version: "v2.10.5", wantError: true},
 		{name: "v1.x fails", version: "v1.8.7", wantError: true},
@@ -76,7 +82,6 @@ func TestCheckAppSetDryRunSupportedByVersion(t *testing.T) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "appset create")
 				assert.Contains(t, err.Error(), "2.13.0")
-				assert.Contains(t, err.Error(), tc.version)
 			} else {
 				assert.NoError(t, err)
 			}

--- a/cmd/argocd/commands/applicationset_test.go
+++ b/cmd/argocd/commands/applicationset_test.go
@@ -48,6 +48,42 @@ func TestAppSetCreateWaitFlow(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestCheckAppSetDryRunSupportedByVersion guards the server-version gate added
+// in https://github.com/argoproj/argo-cd/issues/21911 so older servers don't
+// silently apply an `appset create --dry-run` request.
+func TestCheckAppSetDryRunSupportedByVersion(t *testing.T) {
+	tests := []struct {
+		name      string
+		version   string
+		wantError bool
+	}{
+		{name: "empty version is treated as best-effort and accepted", version: "", wantError: false},
+		{name: "unparseable version is treated as best-effort and accepted", version: "not-a-version", wantError: false},
+		{name: "exactly the minimum is supported", version: "v2.13.0", wantError: false},
+		{name: "minimum without v prefix", version: "2.13.0", wantError: false},
+		{name: "patch above the minimum is supported", version: "v2.13.3+a25c8a0", wantError: false},
+		{name: "newer minor is supported", version: "v2.14.0", wantError: false},
+		{name: "v3 is supported", version: "v3.1.0", wantError: false},
+		{name: "older patch fails (issue #21911 reporter case)", version: "v2.11.2+25f7504", wantError: true},
+		{name: "much older minor fails", version: "v2.10.5", wantError: true},
+		{name: "v1.x fails", version: "v1.8.7", wantError: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkAppSetDryRunSupportedByVersion(tc.version)
+			if tc.wantError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "appset create")
+				assert.Contains(t, err.Error(), "2.13.0")
+				assert.Contains(t, err.Error(), tc.version)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestAppSetCreateWaitDeletedError(t *testing.T) {
 	appSetEventsCh := make(chan *v1alpha1.ApplicationSetWatchEvent, 1)
 	go func() {


### PR DESCRIPTION
## Summary

Closes #21911.

Server-side dry-run support for ApplicationSet create landed in 70755aa3c (first released in v2.13.0). Pre-2.13 servers **ignore** the \`DryRun\` field on \`ApplicationSetCreateRequest\` and **apply the change**. The CLI then prints \`ApplicationSet ... updated (dry-run)\` — exactly the kind of message that lulls an operator into thinking nothing happened — even though the server has already mutated state. @gdsoumya called out the version-mismatch root cause in the issue thread, and the reporter rightly noted that the CLI shouldn't silently apply a request the user expected to be a no-op.

This PR adds a hard error in that case so the destructive behaviour fails loudly instead of silently.

## Behaviour

```
$ argocd appset create --dry-run my-appset.yaml
FATA[0000] --dry-run for "appset create" requires Argo CD server 2.13.0 or later, but the server is v2.11.2+25f7504; older servers ignore the dry-run flag and apply the change. Upgrade the server, downgrade the CLI to match, or omit --dry-run
```

The check:
- runs **only** when \`--dry-run\` is set, so non-dry-run flows pay no cost.
- uses the existing version endpoint (already wired up by every CLI command for the user-agent header) — no new RPC.
- compares against \`minServerVersionForAppSetDryRun = "2.13.0"\` using \`Masterminds/semver/v3\` (already a direct dependency, no new imports for the comparator itself).
- returns an actionable error naming the minimum, the actual server version, and the three available remediations (upgrade server, downgrade CLI, omit \`--dry-run\`).
- treats an empty / unparseable server version as best-effort accept, so we don't block on a malformed response from a healthy server. The only contract enforced is "fail loud on confirmed-old servers."

## Implementation

Splits the logic into:

- \`requireAppSetDryRunSupport(ctx, argocdClient, c)\` — does the version gRPC call.
- \`checkAppSetDryRunSupportedByVersion(serverVersion string) error\` — pure version comparator. Unit-testable without a running server.

Call site is one block in \`NewApplicationSetCreateCommand\`'s \`Run\`:

\`\`\`go
if dryRun {
    if err := requireAppSetDryRunSupport(ctx, argocdClient, c); err != nil {
        errors.CheckError(err)
    }
}
\`\`\`

## Test

\`TestCheckAppSetDryRunSupportedByVersion\` — 10 sub-tests covering:

- empty / unparseable version (best-effort accept)
- exactly v2.13.0 (the minimum)
- minimum without \`v\` prefix
- patch above minimum (\`v2.13.3+a25c8a0\`)
- newer minor / next major (v3)
- older patch (issue #21911 reporter's exact CLI/server pair)
- much older minor (v2.10.5)
- v1.x

```
$ go test ./cmd/argocd/commands/ -run TestCheckAppSetDryRunSupportedByVersion -v
PASS
ok  	github.com/argoproj/argo-cd/v3/cmd/argocd/commands	0.085s
```

\`go vet ./cmd/argocd/commands/\` is clean. Commit is signed-off.

## Why ship this

Silent dry-run-as-apply on a CNCF-graduated GitOps controller is the worst kind of destructive UX — operators trust dry-run, and a footgun there can quietly mutate production. The fix is one block of code, paid only by users who pass the flag, and the cost of being wrong is just an extra version-RPC instead of a corrupted ApplicationSet.

## Notes for reviewers

- The check applies only to \`appset create\`. \`appset generate\` already does dry-run client-side and does not have this issue.
- I considered surfacing this as a warning rather than a hard error. The reporter explicitly asked for a hard error ("the CLI should stop execution with an error message"), and a warning would still leave the destructive change applied — so I went with hard error. Happy to relax to a warning if the project prefers.