### PR TITLE
fix: filter ApplicationSets by cluster selector when handling cluster secret events

### DIFF
--- a/applicationset/controllers/clustereventhandler.go
+++ b/applicationset/controllers/clustereventhandler.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -32,19 +33,19 @@ type clusterSecretEventHandler struct {
 }
 
 func (h *clusterSecretEventHandler) Create(ctx context.Context, e event.CreateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	h.queueRelatedAppGenerators(ctx, q, e.Object)
+	h.queueRelatedAppGenerators(ctx, q, e.Object, nil)
 }
 
 func (h *clusterSecretEventHandler) Update(ctx context.Context, e event.UpdateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	h.queueRelatedAppGenerators(ctx, q, e.ObjectNew)
+	h.queueRelatedAppGenerators(ctx, q, e.ObjectNew, e.ObjectOld)
 }
 
 func (h *clusterSecretEventHandler) Delete(ctx context.Context, e event.DeleteEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	h.queueRelatedAppGenerators(ctx, q, e.Object)
+	h.queueRelatedAppGenerators(ctx, q, e.Object, nil)
 }
 
 func (h *clusterSecretEventHandler) Generic(ctx context.Context, e event.GenericEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	h.queueRelatedAppGenerators(ctx, q, e.Object)
+	h.queueRelatedAppGenerators(ctx, q, e.Object, nil)
 }
 
 // addRateLimitingInterface defines the Add method of workqueue.RateLimitingInterface, allow us to easily mock
@@ -53,17 +54,27 @@ type addRateLimitingInterface[T comparable] interface {
 	Add(item T)
 }
 
-func (h *clusterSecretEventHandler) queueRelatedAppGenerators(ctx context.Context, q addRateLimitingInterface[reconcile.Request], object client.Object) {
+func (h *clusterSecretEventHandler) queueRelatedAppGenerators(ctx context.Context, q addRateLimitingInterface[reconcile.Request], objectNew client.Object, objectOld client.Object) {
+	candidateLabels := make([]labels.Labels, 0, 2)
+
 	// Check for label, lookup all ApplicationSets that might match the cluster, queue them all
-	if object.GetLabels()[common.LabelKeySecretType] != common.LabelValueSecretTypeCluster {
+	if objectNew.GetLabels()[common.LabelKeySecretType] == common.LabelValueSecretTypeCluster {
+		newLabels := labels.Set(objectNew.GetLabels())
+		candidateLabels = append(candidateLabels, newLabels)
+	}
+
+	if objectOld != nil && objectOld.GetLabels()[common.LabelKeySecretType] == common.LabelValueSecretTypeCluster {
+		oldLabels := labels.Set(objectOld.GetLabels())
+		candidateLabels = append(candidateLabels, oldLabels)
+	}
+
+	if len(candidateLabels) == 0 {
 		return
 	}
 
-	secretLabels := labels.Set(object.GetLabels())
-
 	h.Log.WithFields(log.Fields{
-		"namespace": object.GetNamespace(),
-		"name":      object.GetName(),
+		"namespace": objectNew.GetNamespace(),
+		"name":      objectNew.GetName(),
 	}).Info("processing event for cluster secret")
 
 	appSetList := &argoprojiov1alpha1.ApplicationSetList{}
@@ -82,7 +93,7 @@ func (h *clusterSecretEventHandler) queueRelatedAppGenerators(ctx context.Contex
 		foundClusterGenerator := false
 		for _, generator := range appSet.Spec.Generators {
 			if generator.Clusters != nil {
-				ok, err := clusterGeneratorMatches(generator.Clusters, secretLabels)
+				ok, err := clusterGeneratorMatches(generator.Clusters, candidateLabels)
 				if err != nil {
 					h.Log.
 						WithFields(log.Fields{
@@ -99,7 +110,7 @@ func (h *clusterSecretEventHandler) queueRelatedAppGenerators(ctx context.Contex
 			}
 
 			if generator.Matrix != nil {
-				ok, err := nestedGeneratorsHaveClusterGenerator(generator.Matrix.Generators, secretLabels)
+				ok, err := nestedGeneratorsHaveClusterGenerator(generator.Matrix.Generators, candidateLabels)
 				if err != nil {
 					h.Log.
 						WithFields(log.Fields{
@@ -116,7 +127,7 @@ func (h *clusterSecretEventHandler) queueRelatedAppGenerators(ctx context.Contex
 			}
 
 			if generator.Merge != nil {
-				ok, err := nestedGeneratorsHaveClusterGenerator(generator.Merge.Generators, secretLabels)
+				ok, err := nestedGeneratorsHaveClusterGenerator(generator.Merge.Generators, candidateLabels)
 				if err != nil {
 					h.Log.
 						WithFields(log.Fields{
@@ -140,9 +151,9 @@ func (h *clusterSecretEventHandler) queueRelatedAppGenerators(ctx context.Contex
 }
 
 // nestedGeneratorsHaveClusterGenerator iterate over provided nested generators to check if they have a cluster generator.
-func nestedGeneratorsHaveClusterGenerator(generators []argoprojiov1alpha1.ApplicationSetNestedGenerator, secretLabels labels.Labels) (bool, error) {
+func nestedGeneratorsHaveClusterGenerator(generators []argoprojiov1alpha1.ApplicationSetNestedGenerator, labelSets []labels.Labels) (bool, error) {
 	for _, generator := range generators {
-		if ok, err := nestedGeneratorHasClusterGenerator(generator, secretLabels); ok || err != nil {
+		if ok, err := nestedGeneratorHasClusterGenerator(generator, labelSets); ok || err != nil {
 			return ok, err
 		}
 	}
@@ -150,9 +161,9 @@ func nestedGeneratorsHaveClusterGenerator(generators []argoprojiov1alpha1.Applic
 }
 
 // nestedGeneratorHasClusterGenerator checks if the provided generator has a cluster generator.
-func nestedGeneratorHasClusterGenerator(nested argoprojiov1alpha1.ApplicationSetNestedGenerator, secretLabels labels.Labels) (bool, error) {
+func nestedGeneratorHasClusterGenerator(nested argoprojiov1alpha1.ApplicationSetNestedGenerator, labelSets []labels.Labels) (bool, error) {
 	if nested.Clusters != nil {
-		return clusterGeneratorMatches(nested.Clusters, secretLabels)
+		return clusterGeneratorMatches(nested.Clusters, labelSets)
 	}
 
 	if nested.Matrix != nil {
@@ -161,7 +172,7 @@ func nestedGeneratorHasClusterGenerator(nested argoprojiov1alpha1.ApplicationSet
 			return false, fmt.Errorf("unable to get nested matrix generator: %w", err)
 		}
 		if nestedMatrix != nil {
-			hasClusterGenerator, err := nestedGeneratorsHaveClusterGenerator(nestedMatrix.ToMatrixGenerator().Generators, secretLabels)
+			hasClusterGenerator, err := nestedGeneratorsHaveClusterGenerator(nestedMatrix.ToMatrixGenerator().Generators, labelSets)
 			if err != nil {
 				return false, fmt.Errorf("error evaluating nested matrix generator: %w", err)
 			}
@@ -175,7 +186,7 @@ func nestedGeneratorHasClusterGenerator(nested argoprojiov1alpha1.ApplicationSet
 			return false, fmt.Errorf("unable to get nested merge generator: %w", err)
 		}
 		if nestedMerge != nil {
-			hasClusterGenerator, err := nestedGeneratorsHaveClusterGenerator(nestedMerge.ToMergeGenerator().Generators, secretLabels)
+			hasClusterGenerator, err := nestedGeneratorsHaveClusterGenerator(nestedMerge.ToMergeGenerator().Generators, labelSets)
 			if err != nil {
 				return false, fmt.Errorf("error evaluating nested merge generator: %w", err)
 			}
@@ -187,7 +198,7 @@ func nestedGeneratorHasClusterGenerator(nested argoprojiov1alpha1.ApplicationSet
 }
 
 // clusterGeneratorMatches checks if a given cluster generator matches the provided secret labels.
-func clusterGeneratorMatches(cluster *argoprojiov1alpha1.ClusterGenerator, secretLabels labels.Labels) (bool, error) {
+func clusterGeneratorMatches(cluster *argoprojiov1alpha1.ClusterGenerator, labelSets []labels.Labels) (bool, error) {
 	if cluster == nil {
 		return false, nil
 	}
@@ -195,5 +206,10 @@ func clusterGeneratorMatches(cluster *argoprojiov1alpha1.ClusterGenerator, secre
 	if err != nil {
 		return false, fmt.Errorf("invalid label selector in cluster generator: %w", err)
 	}
-	return selector.Matches(secretLabels), nil
+
+	if slices.ContainsFunc(labelSets, selector.Matches) {
+		return true, nil
+	}
+
+	return false, nil
 }

--- a/applicationset/controllers/clustereventhandler.go
+++ b/applicationset/controllers/clustereventhandler.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	log "github.com/sirupsen/logrus"
@@ -56,6 +59,8 @@ func (h *clusterSecretEventHandler) queueRelatedAppGenerators(ctx context.Contex
 		return
 	}
 
+	secretLabels := labels.Set(object.GetLabels())
+
 	h.Log.WithFields(log.Fields{
 		"namespace": object.GetNamespace(),
 		"name":      object.GetName(),
@@ -77,12 +82,24 @@ func (h *clusterSecretEventHandler) queueRelatedAppGenerators(ctx context.Contex
 		foundClusterGenerator := false
 		for _, generator := range appSet.Spec.Generators {
 			if generator.Clusters != nil {
-				foundClusterGenerator = true
-				break
+				ok, err := clusterGeneratorMatches(generator.Clusters, secretLabels)
+				if err != nil {
+					h.Log.
+						WithFields(log.Fields{
+							"namespace": appSet.GetNamespace(),
+							"name":      appSet.GetName(),
+						}).
+						WithError(err).
+						Error("Unable to check if ApplicationSet cluster generator matches cluster labels")
+				}
+				if ok {
+					foundClusterGenerator = true
+					break
+				}
 			}
 
 			if generator.Matrix != nil {
-				ok, err := nestedGeneratorsHaveClusterGenerator(generator.Matrix.Generators)
+				ok, err := nestedGeneratorsHaveClusterGenerator(generator.Matrix.Generators, secretLabels)
 				if err != nil {
 					h.Log.
 						WithFields(log.Fields{
@@ -99,7 +116,7 @@ func (h *clusterSecretEventHandler) queueRelatedAppGenerators(ctx context.Contex
 			}
 
 			if generator.Merge != nil {
-				ok, err := nestedGeneratorsHaveClusterGenerator(generator.Merge.Generators)
+				ok, err := nestedGeneratorsHaveClusterGenerator(generator.Merge.Generators, secretLabels)
 				if err != nil {
 					h.Log.
 						WithFields(log.Fields{
@@ -116,7 +133,6 @@ func (h *clusterSecretEventHandler) queueRelatedAppGenerators(ctx context.Contex
 			}
 		}
 		if foundClusterGenerator {
-			// TODO: only queue the AppGenerator if the labels match this cluster
 			req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: appSet.Namespace, Name: appSet.Name}}
 			q.Add(req)
 		}
@@ -124,9 +140,9 @@ func (h *clusterSecretEventHandler) queueRelatedAppGenerators(ctx context.Contex
 }
 
 // nestedGeneratorsHaveClusterGenerator iterate over provided nested generators to check if they have a cluster generator.
-func nestedGeneratorsHaveClusterGenerator(generators []argoprojiov1alpha1.ApplicationSetNestedGenerator) (bool, error) {
+func nestedGeneratorsHaveClusterGenerator(generators []argoprojiov1alpha1.ApplicationSetNestedGenerator, secretLabels labels.Labels) (bool, error) {
 	for _, generator := range generators {
-		if ok, err := nestedGeneratorHasClusterGenerator(generator); ok || err != nil {
+		if ok, err := nestedGeneratorHasClusterGenerator(generator, secretLabels); ok || err != nil {
 			return ok, err
 		}
 	}
@@ -134,9 +150,9 @@ func nestedGeneratorsHaveClusterGenerator(generators []argoprojiov1alpha1.Applic
 }
 
 // nestedGeneratorHasClusterGenerator checks if the provided generator has a cluster generator.
-func nestedGeneratorHasClusterGenerator(nested argoprojiov1alpha1.ApplicationSetNestedGenerator) (bool, error) {
+func nestedGeneratorHasClusterGenerator(nested argoprojiov1alpha1.ApplicationSetNestedGenerator, secretLabels labels.Labels) (bool, error) {
 	if nested.Clusters != nil {
-		return true, nil
+		return clusterGeneratorMatches(nested.Clusters, secretLabels)
 	}
 
 	if nested.Matrix != nil {
@@ -145,7 +161,7 @@ func nestedGeneratorHasClusterGenerator(nested argoprojiov1alpha1.ApplicationSet
 			return false, fmt.Errorf("unable to get nested matrix generator: %w", err)
 		}
 		if nestedMatrix != nil {
-			hasClusterGenerator, err := nestedGeneratorsHaveClusterGenerator(nestedMatrix.ToMatrixGenerator().Generators)
+			hasClusterGenerator, err := nestedGeneratorsHaveClusterGenerator(nestedMatrix.ToMatrixGenerator().Generators, secretLabels)
 			if err != nil {
 				return false, fmt.Errorf("error evaluating nested matrix generator: %w", err)
 			}
@@ -159,7 +175,7 @@ func nestedGeneratorHasClusterGenerator(nested argoprojiov1alpha1.ApplicationSet
 			return false, fmt.Errorf("unable to get nested merge generator: %w", err)
 		}
 		if nestedMerge != nil {
-			hasClusterGenerator, err := nestedGeneratorsHaveClusterGenerator(nestedMerge.ToMergeGenerator().Generators)
+			hasClusterGenerator, err := nestedGeneratorsHaveClusterGenerator(nestedMerge.ToMergeGenerator().Generators, secretLabels)
 			if err != nil {
 				return false, fmt.Errorf("error evaluating nested merge generator: %w", err)
 			}
@@ -168,4 +184,16 @@ func nestedGeneratorHasClusterGenerator(nested argoprojiov1alpha1.ApplicationSet
 	}
 
 	return false, nil
+}
+
+// clusterGeneratorMatches checks if a given cluster generator matches the provided secret labels.
+func clusterGeneratorMatches(cluster *argoprojiov1alpha1.ClusterGenerator, secretLabels labels.Labels) (bool, error) {
+	if cluster == nil {
+		return false, nil
+	}
+	selector, err := metav1.LabelSelectorAsSelector(&cluster.Selector)
+	if err != nil {
+		return false, fmt.Errorf("invalid label selector in cluster generator: %w", err)
+	}
+	return selector.Matches(secretLabels), nil
 }

--- a/applicationset/controllers/clustereventhandler.go
+++ b/applicationset/controllers/clustereventhandler.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -31,19 +32,19 @@ type clusterSecretEventHandler struct {
 }
 
 func (h *clusterSecretEventHandler) Create(ctx context.Context, e event.CreateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	h.queueRelatedAppGenerators(ctx, q, e.Object)
+	h.queueRelatedAppGenerators(ctx, q, e.Object, nil)
 }
 
 func (h *clusterSecretEventHandler) Update(ctx context.Context, e event.UpdateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	h.queueRelatedAppGenerators(ctx, q, e.ObjectNew)
+	h.queueRelatedAppGenerators(ctx, q, e.ObjectNew, e.ObjectOld)
 }
 
 func (h *clusterSecretEventHandler) Delete(ctx context.Context, e event.DeleteEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	h.queueRelatedAppGenerators(ctx, q, e.Object)
+	h.queueRelatedAppGenerators(ctx, q, e.Object, nil)
 }
 
 func (h *clusterSecretEventHandler) Generic(ctx context.Context, e event.GenericEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	h.queueRelatedAppGenerators(ctx, q, e.Object)
+	h.queueRelatedAppGenerators(ctx, q, e.Object, nil)
 }
 
 // addRateLimitingInterface defines the Add method of workqueue.RateLimitingInterface, allow us to easily mock
@@ -52,17 +53,27 @@ type addRateLimitingInterface[T comparable] interface {
 	Add(item T)
 }
 
-func (h *clusterSecretEventHandler) queueRelatedAppGenerators(ctx context.Context, q addRateLimitingInterface[reconcile.Request], object client.Object) {
+func (h *clusterSecretEventHandler) queueRelatedAppGenerators(ctx context.Context, q addRateLimitingInterface[reconcile.Request], objectNew client.Object, objectOld client.Object) {
+	candidateLabels := make([]labels.Labels, 0, 2)
+
 	// Check for label, lookup all ApplicationSets that might match the cluster, queue them all
-	if object.GetLabels()[common.LabelKeySecretType] != common.LabelValueSecretTypeCluster {
+	if objectNew.GetLabels()[common.LabelKeySecretType] == common.LabelValueSecretTypeCluster {
+		newLabels := labels.Set(objectNew.GetLabels())
+		candidateLabels = append(candidateLabels, newLabels)
+	}
+
+	if objectOld != nil && objectOld.GetLabels()[common.LabelKeySecretType] == common.LabelValueSecretTypeCluster {
+		oldLabels := labels.Set(objectOld.GetLabels())
+		candidateLabels = append(candidateLabels, oldLabels)
+	}
+
+	if len(candidateLabels) == 0 {
 		return
 	}
 
-	secretLabels := labels.Set(object.GetLabels())
-
 	h.Log.WithFields(log.Fields{
-		"namespace": object.GetNamespace(),
-		"name":      object.GetName(),
+		"namespace": objectNew.GetNamespace(),
+		"name":      objectNew.GetName(),
 	}).Info("processing event for cluster secret")
 
 	appSetList := &argoprojiov1alpha1.ApplicationSetList{}
@@ -81,7 +92,7 @@ func (h *clusterSecretEventHandler) queueRelatedAppGenerators(ctx context.Contex
 		foundClusterGenerator := false
 		for _, generator := range appSet.Spec.Generators {
 			if generator.Clusters != nil {
-				ok, err := clusterGeneratorMatches(generator.Clusters, secretLabels)
+				ok, err := clusterGeneratorMatches(generator.Clusters, candidateLabels)
 				if err != nil {
 					h.Log.
 						WithFields(log.Fields{
@@ -98,7 +109,7 @@ func (h *clusterSecretEventHandler) queueRelatedAppGenerators(ctx context.Contex
 			}
 
 			if generator.Matrix != nil {
-				ok, err := nestedGeneratorsHaveClusterGenerator(generator.Matrix.Generators, secretLabels)
+				ok, err := nestedGeneratorsHaveClusterGenerator(generator.Matrix.Generators, candidateLabels)
 				if err != nil {
 					h.Log.
 						WithFields(log.Fields{
@@ -115,7 +126,7 @@ func (h *clusterSecretEventHandler) queueRelatedAppGenerators(ctx context.Contex
 			}
 
 			if generator.Merge != nil {
-				ok, err := nestedGeneratorsHaveClusterGenerator(generator.Merge.Generators, secretLabels)
+				ok, err := nestedGeneratorsHaveClusterGenerator(generator.Merge.Generators, candidateLabels)
 				if err != nil {
 					h.Log.
 						WithFields(log.Fields{
@@ -139,9 +150,9 @@ func (h *clusterSecretEventHandler) queueRelatedAppGenerators(ctx context.Contex
 }
 
 // nestedGeneratorsHaveClusterGenerator iterate over provided nested generators to check if they have a cluster generator.
-func nestedGeneratorsHaveClusterGenerator(generators []argoprojiov1alpha1.ApplicationSetNestedGenerator, secretLabels labels.Labels) (bool, error) {
+func nestedGeneratorsHaveClusterGenerator(generators []argoprojiov1alpha1.ApplicationSetNestedGenerator, labelSets []labels.Labels) (bool, error) {
 	for _, generator := range generators {
-		if ok, err := nestedGeneratorHasClusterGenerator(generator, secretLabels); ok || err != nil {
+		if ok, err := nestedGeneratorHasClusterGenerator(generator, labelSets); ok || err != nil {
 			return ok, err
 		}
 	}
@@ -149,9 +160,9 @@ func nestedGeneratorsHaveClusterGenerator(generators []argoprojiov1alpha1.Applic
 }
 
 // nestedGeneratorHasClusterGenerator checks if the provided generator has a cluster generator.
-func nestedGeneratorHasClusterGenerator(nested argoprojiov1alpha1.ApplicationSetNestedGenerator, secretLabels labels.Labels) (bool, error) {
+func nestedGeneratorHasClusterGenerator(nested argoprojiov1alpha1.ApplicationSetNestedGenerator, labelSets []labels.Labels) (bool, error) {
 	if nested.Clusters != nil {
-		return clusterGeneratorMatches(nested.Clusters, secretLabels)
+		return clusterGeneratorMatches(nested.Clusters, labelSets)
 	}
 
 	if nested.Matrix != nil {
@@ -160,7 +171,7 @@ func nestedGeneratorHasClusterGenerator(nested argoprojiov1alpha1.ApplicationSet
 			return false, fmt.Errorf("unable to get nested matrix generator: %w", err)
 		}
 		if nestedMatrix != nil {
-			hasClusterGenerator, err := nestedGeneratorsHaveClusterGenerator(nestedMatrix.ToMatrixGenerator().Generators, secretLabels)
+			hasClusterGenerator, err := nestedGeneratorsHaveClusterGenerator(nestedMatrix.ToMatrixGenerator().Generators, labelSets)
 			if err != nil {
 				return false, fmt.Errorf("error evaluating nested matrix generator: %w", err)
 			}
@@ -174,7 +185,7 @@ func nestedGeneratorHasClusterGenerator(nested argoprojiov1alpha1.ApplicationSet
 			return false, fmt.Errorf("unable to get nested merge generator: %w", err)
 		}
 		if nestedMerge != nil {
-			hasClusterGenerator, err := nestedGeneratorsHaveClusterGenerator(nestedMerge.ToMergeGenerator().Generators, secretLabels)
+			hasClusterGenerator, err := nestedGeneratorsHaveClusterGenerator(nestedMerge.ToMergeGenerator().Generators, labelSets)
 			if err != nil {
 				return false, fmt.Errorf("error evaluating nested merge generator: %w", err)
 			}
@@ -186,7 +197,7 @@ func nestedGeneratorHasClusterGenerator(nested argoprojiov1alpha1.ApplicationSet
 }
 
 // clusterGeneratorMatches checks if a given cluster generator matches the provided secret labels.
-func clusterGeneratorMatches(cluster *argoprojiov1alpha1.ClusterGenerator, secretLabels labels.Labels) (bool, error) {
+func clusterGeneratorMatches(cluster *argoprojiov1alpha1.ClusterGenerator, labelSets []labels.Labels) (bool, error) {
 	if cluster == nil {
 		return false, nil
 	}
@@ -194,5 +205,10 @@ func clusterGeneratorMatches(cluster *argoprojiov1alpha1.ClusterGenerator, secre
 	if err != nil {
 		return false, fmt.Errorf("invalid label selector in cluster generator: %w", err)
 	}
-	return selector.Matches(secretLabels), nil
+
+	if slices.ContainsFunc(labelSets, selector.Matches) {
+		return true, nil
+	}
+
+	return false, nil
 }

--- a/applicationset/controllers/clustereventhandler.go
+++ b/applicationset/controllers/clustereventhandler.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	log "github.com/sirupsen/logrus"
@@ -55,6 +58,8 @@ func (h *clusterSecretEventHandler) queueRelatedAppGenerators(ctx context.Contex
 		return
 	}
 
+	secretLabels := labels.Set(object.GetLabels())
+
 	h.Log.WithFields(log.Fields{
 		"namespace": object.GetNamespace(),
 		"name":      object.GetName(),
@@ -76,12 +81,24 @@ func (h *clusterSecretEventHandler) queueRelatedAppGenerators(ctx context.Contex
 		foundClusterGenerator := false
 		for _, generator := range appSet.Spec.Generators {
 			if generator.Clusters != nil {
-				foundClusterGenerator = true
-				break
+				ok, err := clusterGeneratorMatches(generator.Clusters, secretLabels)
+				if err != nil {
+					h.Log.
+						WithFields(log.Fields{
+							"namespace": appSet.GetNamespace(),
+							"name":      appSet.GetName(),
+						}).
+						WithError(err).
+						Error("Unable to check if ApplicationSet cluster generator matches cluster labels")
+				}
+				if ok {
+					foundClusterGenerator = true
+					break
+				}
 			}
 
 			if generator.Matrix != nil {
-				ok, err := nestedGeneratorsHaveClusterGenerator(generator.Matrix.Generators)
+				ok, err := nestedGeneratorsHaveClusterGenerator(generator.Matrix.Generators, secretLabels)
 				if err != nil {
 					h.Log.
 						WithFields(log.Fields{
@@ -98,7 +115,7 @@ func (h *clusterSecretEventHandler) queueRelatedAppGenerators(ctx context.Contex
 			}
 
 			if generator.Merge != nil {
-				ok, err := nestedGeneratorsHaveClusterGenerator(generator.Merge.Generators)
+				ok, err := nestedGeneratorsHaveClusterGenerator(generator.Merge.Generators, secretLabels)
 				if err != nil {
 					h.Log.
 						WithFields(log.Fields{
@@ -115,7 +132,6 @@ func (h *clusterSecretEventHandler) queueRelatedAppGenerators(ctx context.Contex
 			}
 		}
 		if foundClusterGenerator {
-			// TODO: only queue the AppGenerator if the labels match this cluster
 			req := ctrl.Request{Namespace: appSet.Namespace, Name: appSet.Name}
 			q.Add(req)
 		}
@@ -123,9 +139,9 @@ func (h *clusterSecretEventHandler) queueRelatedAppGenerators(ctx context.Contex
 }
 
 // nestedGeneratorsHaveClusterGenerator iterate over provided nested generators to check if they have a cluster generator.
-func nestedGeneratorsHaveClusterGenerator(generators []argoprojiov1alpha1.ApplicationSetNestedGenerator) (bool, error) {
+func nestedGeneratorsHaveClusterGenerator(generators []argoprojiov1alpha1.ApplicationSetNestedGenerator, secretLabels labels.Labels) (bool, error) {
 	for _, generator := range generators {
-		if ok, err := nestedGeneratorHasClusterGenerator(generator); ok || err != nil {
+		if ok, err := nestedGeneratorHasClusterGenerator(generator, secretLabels); ok || err != nil {
 			return ok, err
 		}
 	}
@@ -133,9 +149,9 @@ func nestedGeneratorsHaveClusterGenerator(generators []argoprojiov1alpha1.Applic
 }
 
 // nestedGeneratorHasClusterGenerator checks if the provided generator has a cluster generator.
-func nestedGeneratorHasClusterGenerator(nested argoprojiov1alpha1.ApplicationSetNestedGenerator) (bool, error) {
+func nestedGeneratorHasClusterGenerator(nested argoprojiov1alpha1.ApplicationSetNestedGenerator, secretLabels labels.Labels) (bool, error) {
 	if nested.Clusters != nil {
-		return true, nil
+		return clusterGeneratorMatches(nested.Clusters, secretLabels)
 	}
 
 	if nested.Matrix != nil {
@@ -144,7 +160,7 @@ func nestedGeneratorHasClusterGenerator(nested argoprojiov1alpha1.ApplicationSet
 			return false, fmt.Errorf("unable to get nested matrix generator: %w", err)
 		}
 		if nestedMatrix != nil {
-			hasClusterGenerator, err := nestedGeneratorsHaveClusterGenerator(nestedMatrix.ToMatrixGenerator().Generators)
+			hasClusterGenerator, err := nestedGeneratorsHaveClusterGenerator(nestedMatrix.ToMatrixGenerator().Generators, secretLabels)
 			if err != nil {
 				return false, fmt.Errorf("error evaluating nested matrix generator: %w", err)
 			}
@@ -158,7 +174,7 @@ func nestedGeneratorHasClusterGenerator(nested argoprojiov1alpha1.ApplicationSet
 			return false, fmt.Errorf("unable to get nested merge generator: %w", err)
 		}
 		if nestedMerge != nil {
-			hasClusterGenerator, err := nestedGeneratorsHaveClusterGenerator(nestedMerge.ToMergeGenerator().Generators)
+			hasClusterGenerator, err := nestedGeneratorsHaveClusterGenerator(nestedMerge.ToMergeGenerator().Generators, secretLabels)
 			if err != nil {
 				return false, fmt.Errorf("error evaluating nested merge generator: %w", err)
 			}
@@ -167,4 +183,16 @@ func nestedGeneratorHasClusterGenerator(nested argoprojiov1alpha1.ApplicationSet
 	}
 
 	return false, nil
+}
+
+// clusterGeneratorMatches checks if a given cluster generator matches the provided secret labels.
+func clusterGeneratorMatches(cluster *argoprojiov1alpha1.ClusterGenerator, secretLabels labels.Labels) (bool, error) {
+	if cluster == nil {
+		return false, nil
+	}
+	selector, err := metav1.LabelSelectorAsSelector(&cluster.Selector)
+	if err != nil {
+		return false, fmt.Errorf("invalid label selector in cluster generator: %w", err)
+	}
+	return selector.Matches(secretLabels), nil
 }

--- a/applicationset/controllers/clustereventhandler_test.go
+++ b/applicationset/controllers/clustereventhandler_test.go
@@ -3,6 +3,8 @@ package controllers
 import (
 	"testing"
 
+	"k8s.io/apimachinery/pkg/labels"
+
 	argocommon "github.com/argoproj/argo-cd/v3/common"
 
 	log "github.com/sirupsen/logrus"
@@ -223,6 +225,80 @@ func TestClusterEventHandler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "argocd",
 					Name:      "my-non-argocd-secret",
+				},
+			},
+			expectedRequests: []reconcile.Request{},
+		},
+		{
+			name: "a cluster generator with matching labels should produce a request",
+			items: []argov1alpha1.ApplicationSet{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-app-set",
+						Namespace: "argocd",
+					},
+					Spec: argov1alpha1.ApplicationSetSpec{
+						Generators: []argov1alpha1.ApplicationSetGenerator{
+							{
+								Clusters: &argov1alpha1.ClusterGenerator{
+									Selector: metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"env":    "prod",
+											"region": "us-east-1",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			secret: corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "argocd",
+					Name:      "my-secret",
+					Labels: map[string]string{
+						argocommon.LabelKeySecretType: argocommon.LabelValueSecretTypeCluster,
+						"env":                         "prod",
+						"region":                      "us-east-1",
+					},
+				},
+			},
+			expectedRequests: []reconcile.Request{
+				{NamespacedName: types.NamespacedName{Namespace: "argocd", Name: "my-app-set"}},
+			},
+		},
+		{
+			name: "a cluster generator with non matching labels should not produce a request",
+			items: []argov1alpha1.ApplicationSet{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-app-set",
+						Namespace: "argocd",
+					},
+					Spec: argov1alpha1.ApplicationSetSpec{
+						Generators: []argov1alpha1.ApplicationSetGenerator{
+							{
+								Clusters: &argov1alpha1.ClusterGenerator{
+									Selector: metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"env": "prod",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			secret: corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "argocd",
+					Name:      "my-secret",
+					Labels: map[string]string{
+						argocommon.LabelKeySecretType: argocommon.LabelValueSecretTypeCluster,
+						"env":                         "dev",
+					},
 				},
 			},
 			expectedRequests: []reconcile.Request{},
@@ -599,7 +675,8 @@ func TestNestedGeneratorHasClusterGenerator_NestedClusterGenerator(t *testing.T)
 		Clusters: &argov1alpha1.ClusterGenerator{},
 	}
 
-	hasClusterGenerator, err := nestedGeneratorHasClusterGenerator(nested)
+	emptyLabels := labels.Set{}
+	hasClusterGenerator, err := nestedGeneratorHasClusterGenerator(nested, emptyLabels)
 
 	require.NoError(t, err)
 	assert.True(t, hasClusterGenerator)
@@ -626,7 +703,8 @@ func TestNestedGeneratorHasClusterGenerator_NestedMergeGenerator(t *testing.T) {
 		},
 	}
 
-	hasClusterGenerator, err := nestedGeneratorHasClusterGenerator(nested)
+	matchingLabels := labels.Set{"argocd.argoproj.io/secret-type": "cluster"}
+	hasClusterGenerator, err := nestedGeneratorHasClusterGenerator(nested, matchingLabels)
 
 	require.NoError(t, err)
 	assert.True(t, hasClusterGenerator)
@@ -653,8 +731,72 @@ func TestNestedGeneratorHasClusterGenerator_NestedMergeGeneratorWithInvalidJSON(
 		},
 	}
 
-	hasClusterGenerator, err := nestedGeneratorHasClusterGenerator(nested)
+	emptyLabels := labels.Set{}
+	hasClusterGenerator, err := nestedGeneratorHasClusterGenerator(nested, emptyLabels)
 
 	require.Error(t, err)
+	assert.False(t, hasClusterGenerator)
+}
+
+func TestNestedGeneratorHasClusterGenerator_NestedMergeGeneratorNonMatchingLabels(t *testing.T) {
+	nested := argov1alpha1.ApplicationSetNestedGenerator{
+		Merge: &apiextensionsv1.JSON{
+			Raw: []byte(
+				`{
+					"generators": [
+					  {
+						"clusters": {
+						  "selector": {
+							"matchLabels": {
+							  "env": "prod"
+							}
+						  }
+						}
+					  }
+					]
+				  }`,
+			),
+		},
+	}
+
+	nonMatchingLabels := labels.Set{"env": "dev"}
+	hasClusterGenerator, err := nestedGeneratorHasClusterGenerator(nested, nonMatchingLabels)
+
+	require.NoError(t, err)
+	assert.False(t, hasClusterGenerator)
+}
+
+func TestNestedGeneratorHasClusterGenerator_NestedMatrixGeneratorPartialLabels(t *testing.T) {
+	nested := argov1alpha1.ApplicationSetNestedGenerator{
+		Matrix: &apiextensionsv1.JSON{
+			Raw: []byte(
+				`{
+					"generators": [
+					  {
+						"clusters": {
+						  "selector": {
+							"matchLabels": {
+							  "env": "prod",
+							  "region": "us-east-1"
+							}
+						  }
+						},
+						"list": {
+						  "elements": [
+							  "a",
+							  "b"
+						  ]
+						}
+					  }
+					]
+				  }`,
+			),
+		},
+	}
+
+	nonMatchingLabels := labels.Set{"env": "prod"}
+	hasClusterGenerator, err := nestedGeneratorHasClusterGenerator(nested, nonMatchingLabels)
+
+	require.NoError(t, err)
 	assert.False(t, hasClusterGenerator)
 }

--- a/applicationset/controllers/clustereventhandler_test.go
+++ b/applicationset/controllers/clustereventhandler_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -43,6 +44,7 @@ func TestClusterEventHandler(t *testing.T) {
 		name             string
 		items            []argov1alpha1.ApplicationSet
 		secret           corev1.Secret
+		secretOld        *corev1.Secret
 		expectedRequests []ctrl.Request
 	}{
 		{
@@ -645,6 +647,80 @@ func TestClusterEventHandler(t *testing.T) {
 			},
 			expectedRequests: []reconcile.Request{},
 		},
+		{
+			name: "when a cluster secret label changes from stage to prod, both stage and prod appsets should reconcile but not dev",
+			items: []argov1alpha1.ApplicationSet{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "dev-appset",
+						Namespace: "argocd",
+					},
+					Spec: argov1alpha1.ApplicationSetSpec{
+						Generators: []argov1alpha1.ApplicationSetGenerator{{
+							Clusters: &argov1alpha1.ClusterGenerator{
+								Selector: metav1.LabelSelector{
+									MatchLabels: map[string]string{"env": "dev"},
+								},
+							},
+						}},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "stage-appset",
+						Namespace: "argocd",
+					},
+					Spec: argov1alpha1.ApplicationSetSpec{
+						Generators: []argov1alpha1.ApplicationSetGenerator{{
+							Clusters: &argov1alpha1.ClusterGenerator{
+								Selector: metav1.LabelSelector{
+									MatchLabels: map[string]string{"env": "stage"},
+								},
+							},
+						}},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "prod-appset",
+						Namespace: "argocd",
+					},
+					Spec: argov1alpha1.ApplicationSetSpec{
+						Generators: []argov1alpha1.ApplicationSetGenerator{{
+							Clusters: &argov1alpha1.ClusterGenerator{
+								Selector: metav1.LabelSelector{
+									MatchLabels: map[string]string{"env": "prod"},
+								},
+							},
+						}},
+					},
+				},
+			},
+			secret: corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "argocd",
+					Name:      "my-secret",
+					Labels: map[string]string{
+						argocommon.LabelKeySecretType: argocommon.LabelValueSecretTypeCluster,
+						"env":                         "prod",
+					},
+				},
+			},
+			secretOld: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "argocd",
+					Name:      "my-secret",
+					Labels: map[string]string{
+						argocommon.LabelKeySecretType: argocommon.LabelValueSecretTypeCluster,
+						"env":                         "stage",
+					},
+				},
+			},
+			expectedRequests: []reconcile.Request{
+				{NamespacedName: types.NamespacedName{Namespace: "argocd", Name: "prod-appset"}},
+				{NamespacedName: types.NamespacedName{Namespace: "argocd", Name: "stage-appset"}},
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -663,7 +739,11 @@ func TestClusterEventHandler(t *testing.T) {
 
 			mockAddRateLimitingInterface := mockAddRateLimitingInterface{}
 
-			handler.queueRelatedAppGenerators(t.Context(), &mockAddRateLimitingInterface, &test.secret)
+			var secretOld client.Object
+			if test.secretOld != nil {
+				secretOld = test.secretOld
+			}
+			handler.queueRelatedAppGenerators(t.Context(), &mockAddRateLimitingInterface, &test.secret, secretOld)
 
 			assert.ElementsMatch(t, mockAddRateLimitingInterface.addedItems, test.expectedRequests)
 		})
@@ -676,7 +756,7 @@ func TestNestedGeneratorHasClusterGenerator_NestedClusterGenerator(t *testing.T)
 	}
 
 	emptyLabels := labels.Set{}
-	hasClusterGenerator, err := nestedGeneratorHasClusterGenerator(nested, emptyLabels)
+	hasClusterGenerator, err := nestedGeneratorHasClusterGenerator(nested, []labels.Labels{emptyLabels})
 
 	require.NoError(t, err)
 	assert.True(t, hasClusterGenerator)
@@ -704,7 +784,7 @@ func TestNestedGeneratorHasClusterGenerator_NestedMergeGenerator(t *testing.T) {
 	}
 
 	matchingLabels := labels.Set{"argocd.argoproj.io/secret-type": "cluster"}
-	hasClusterGenerator, err := nestedGeneratorHasClusterGenerator(nested, matchingLabels)
+	hasClusterGenerator, err := nestedGeneratorHasClusterGenerator(nested, []labels.Labels{matchingLabels})
 
 	require.NoError(t, err)
 	assert.True(t, hasClusterGenerator)
@@ -732,7 +812,7 @@ func TestNestedGeneratorHasClusterGenerator_NestedMergeGeneratorWithInvalidJSON(
 	}
 
 	emptyLabels := labels.Set{}
-	hasClusterGenerator, err := nestedGeneratorHasClusterGenerator(nested, emptyLabels)
+	hasClusterGenerator, err := nestedGeneratorHasClusterGenerator(nested, []labels.Labels{emptyLabels})
 
 	require.Error(t, err)
 	assert.False(t, hasClusterGenerator)
@@ -760,7 +840,7 @@ func TestNestedGeneratorHasClusterGenerator_NestedMergeGeneratorNonMatchingLabel
 	}
 
 	nonMatchingLabels := labels.Set{"env": "dev"}
-	hasClusterGenerator, err := nestedGeneratorHasClusterGenerator(nested, nonMatchingLabels)
+	hasClusterGenerator, err := nestedGeneratorHasClusterGenerator(nested, []labels.Labels{nonMatchingLabels})
 
 	require.NoError(t, err)
 	assert.False(t, hasClusterGenerator)
@@ -795,7 +875,7 @@ func TestNestedGeneratorHasClusterGenerator_NestedMatrixGeneratorPartialLabels(t
 	}
 
 	nonMatchingLabels := labels.Set{"env": "prod"}
-	hasClusterGenerator, err := nestedGeneratorHasClusterGenerator(nested, nonMatchingLabels)
+	hasClusterGenerator, err := nestedGeneratorHasClusterGenerator(nested, []labels.Labels{nonMatchingLabels})
 
 	require.NoError(t, err)
 	assert.False(t, hasClusterGenerator)

--- a/applicationset/controllers/clustereventhandler_test.go
+++ b/applicationset/controllers/clustereventhandler_test.go
@@ -880,3 +880,24 @@ func TestNestedGeneratorHasClusterGenerator_NestedMatrixGeneratorPartialLabels(t
 	require.NoError(t, err)
 	assert.False(t, hasClusterGenerator)
 }
+
+func TestClusterGenerator_InvalidSelector(t *testing.T) {
+	clusterGenerator := argov1alpha1.ClusterGenerator{
+		Selector: metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{
+					Key:      "env",
+					Operator: metav1.LabelSelectorOperator("InvalidOperator"),
+					Values:   []string{"prod", "dev"},
+				},
+			},
+		},
+	}
+
+	emptyLabels := labels.Set{}
+	hasClusterGenerator, err := clusterGeneratorMatches(&clusterGenerator, []labels.Labels{emptyLabels})
+
+	require.Error(t, err)
+	assert.False(t, hasClusterGenerator)
+	assert.ErrorContains(t, err, "invalid label selector in cluster generator")
+}

--- a/applicationset/controllers/clustereventhandler_test.go
+++ b/applicationset/controllers/clustereventhandler_test.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -43,6 +44,7 @@ func TestClusterEventHandler(t *testing.T) {
 		name             string
 		items            []argov1alpha1.ApplicationSet
 		secret           corev1.Secret
+		secretOld        *corev1.Secret
 		expectedRequests []ctrl.Request
 	}{
 		{
@@ -615,6 +617,80 @@ func TestClusterEventHandler(t *testing.T) {
 			},
 			expectedRequests: []reconcile.Request{},
 		},
+		{
+			name: "when a cluster secret label changes from stage to prod, both stage and prod appsets should reconcile but not dev",
+			items: []argov1alpha1.ApplicationSet{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "dev-appset",
+						Namespace: "argocd",
+					},
+					Spec: argov1alpha1.ApplicationSetSpec{
+						Generators: []argov1alpha1.ApplicationSetGenerator{{
+							Clusters: &argov1alpha1.ClusterGenerator{
+								Selector: metav1.LabelSelector{
+									MatchLabels: map[string]string{"env": "dev"},
+								},
+							},
+						}},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "stage-appset",
+						Namespace: "argocd",
+					},
+					Spec: argov1alpha1.ApplicationSetSpec{
+						Generators: []argov1alpha1.ApplicationSetGenerator{{
+							Clusters: &argov1alpha1.ClusterGenerator{
+								Selector: metav1.LabelSelector{
+									MatchLabels: map[string]string{"env": "stage"},
+								},
+							},
+						}},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "prod-appset",
+						Namespace: "argocd",
+					},
+					Spec: argov1alpha1.ApplicationSetSpec{
+						Generators: []argov1alpha1.ApplicationSetGenerator{{
+							Clusters: &argov1alpha1.ClusterGenerator{
+								Selector: metav1.LabelSelector{
+									MatchLabels: map[string]string{"env": "prod"},
+								},
+							},
+						}},
+					},
+				},
+			},
+			secret: corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "argocd",
+					Name:      "my-secret",
+					Labels: map[string]string{
+						argocommon.LabelKeySecretType: argocommon.LabelValueSecretTypeCluster,
+						"env":                         "prod",
+					},
+				},
+			},
+			secretOld: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "argocd",
+					Name:      "my-secret",
+					Labels: map[string]string{
+						argocommon.LabelKeySecretType: argocommon.LabelValueSecretTypeCluster,
+						"env":                         "stage",
+					},
+				},
+			},
+			expectedRequests: []reconcile.Request{
+				{NamespacedName: types.NamespacedName{Namespace: "argocd", Name: "prod-appset"}},
+				{NamespacedName: types.NamespacedName{Namespace: "argocd", Name: "stage-appset"}},
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -634,7 +710,11 @@ func TestClusterEventHandler(t *testing.T) {
 
 			mockAddRateLimitingInterface := mockAddRateLimitingInterface{}
 
-			handler.queueRelatedAppGenerators(t.Context(), &mockAddRateLimitingInterface, &test.secret)
+			var secretOld client.Object
+			if test.secretOld != nil {
+				secretOld = test.secretOld
+			}
+			handler.queueRelatedAppGenerators(t.Context(), &mockAddRateLimitingInterface, &test.secret, secretOld)
 
 			assert.ElementsMatch(t, mockAddRateLimitingInterface.addedItems, test.expectedRequests)
 		})
@@ -648,7 +728,7 @@ func TestNestedGeneratorHasClusterGenerator_NestedClusterGenerator(t *testing.T)
 	}
 
 	emptyLabels := labels.Set{}
-	hasClusterGenerator, err := nestedGeneratorHasClusterGenerator(nested, emptyLabels)
+	hasClusterGenerator, err := nestedGeneratorHasClusterGenerator(nested, []labels.Labels{emptyLabels})
 
 	require.NoError(t, err)
 	assert.True(t, hasClusterGenerator)
@@ -677,7 +757,7 @@ func TestNestedGeneratorHasClusterGenerator_NestedMergeGenerator(t *testing.T) {
 	}
 
 	matchingLabels := labels.Set{"argocd.argoproj.io/secret-type": "cluster"}
-	hasClusterGenerator, err := nestedGeneratorHasClusterGenerator(nested, matchingLabels)
+	hasClusterGenerator, err := nestedGeneratorHasClusterGenerator(nested, []labels.Labels{matchingLabels})
 
 	require.NoError(t, err)
 	assert.True(t, hasClusterGenerator)
@@ -706,7 +786,7 @@ func TestNestedGeneratorHasClusterGenerator_NestedMergeGeneratorWithInvalidJSON(
 	}
 
 	emptyLabels := labels.Set{}
-	hasClusterGenerator, err := nestedGeneratorHasClusterGenerator(nested, emptyLabels)
+	hasClusterGenerator, err := nestedGeneratorHasClusterGenerator(nested, []labels.Labels{emptyLabels})
 
 	require.Error(t, err)
 	assert.False(t, hasClusterGenerator)
@@ -734,7 +814,7 @@ func TestNestedGeneratorHasClusterGenerator_NestedMergeGeneratorNonMatchingLabel
 	}
 
 	nonMatchingLabels := labels.Set{"env": "dev"}
-	hasClusterGenerator, err := nestedGeneratorHasClusterGenerator(nested, nonMatchingLabels)
+	hasClusterGenerator, err := nestedGeneratorHasClusterGenerator(nested, []labels.Labels{nonMatchingLabels})
 
 	require.NoError(t, err)
 	assert.False(t, hasClusterGenerator)
@@ -769,7 +849,7 @@ func TestNestedGeneratorHasClusterGenerator_NestedMatrixGeneratorPartialLabels(t
 	}
 
 	nonMatchingLabels := labels.Set{"env": "prod"}
-	hasClusterGenerator, err := nestedGeneratorHasClusterGenerator(nested, nonMatchingLabels)
+	hasClusterGenerator, err := nestedGeneratorHasClusterGenerator(nested, []labels.Labels{nonMatchingLabels})
 
 	require.NoError(t, err)
 	assert.False(t, hasClusterGenerator)

--- a/applicationset/controllers/clustereventhandler_test.go
+++ b/applicationset/controllers/clustereventhandler_test.go
@@ -854,3 +854,24 @@ func TestNestedGeneratorHasClusterGenerator_NestedMatrixGeneratorPartialLabels(t
 	require.NoError(t, err)
 	assert.False(t, hasClusterGenerator)
 }
+
+func TestClusterGenerator_InvalidSelector(t *testing.T) {
+	clusterGenerator := argov1alpha1.ClusterGenerator{
+		Selector: metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{
+					Key:      "env",
+					Operator: metav1.LabelSelectorOperator("InvalidOperator"),
+					Values:   []string{"prod", "dev"},
+				},
+			},
+		},
+	}
+
+	emptyLabels := labels.Set{}
+	hasClusterGenerator, err := clusterGeneratorMatches(&clusterGenerator, []labels.Labels{emptyLabels})
+
+	require.Error(t, err)
+	assert.False(t, hasClusterGenerator)
+	assert.ErrorContains(t, err, "invalid label selector in cluster generator")
+}

--- a/applicationset/controllers/clustereventhandler_test.go
+++ b/applicationset/controllers/clustereventhandler_test.go
@@ -687,8 +687,8 @@ func TestClusterEventHandler(t *testing.T) {
 				},
 			},
 			expectedRequests: []reconcile.Request{
-				{NamespacedName: types.NamespacedName{Namespace: "argocd", Name: "prod-appset"}},
-				{NamespacedName: types.NamespacedName{Namespace: "argocd", Name: "stage-appset"}},
+				{Namespace: "argocd", Name: "prod-appset"},
+				{Namespace: "argocd", Name: "stage-appset"},
 			},
 		},
 	}

--- a/applicationset/controllers/clustereventhandler_test.go
+++ b/applicationset/controllers/clustereventhandler_test.go
@@ -3,6 +3,8 @@ package controllers
 import (
 	"testing"
 
+	"k8s.io/apimachinery/pkg/labels"
+
 	argocommon "github.com/argoproj/argo-cd/v3/common"
 
 	log "github.com/sirupsen/logrus"
@@ -209,6 +211,80 @@ func TestClusterEventHandler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "argocd",
 					Name:      "my-non-argocd-secret",
+				},
+			},
+			expectedRequests: []reconcile.Request{},
+		},
+		{
+			name: "a cluster generator with matching labels should produce a request",
+			items: []argov1alpha1.ApplicationSet{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-app-set",
+						Namespace: "argocd",
+					},
+					Spec: argov1alpha1.ApplicationSetSpec{
+						Generators: []argov1alpha1.ApplicationSetGenerator{
+							{
+								Clusters: &argov1alpha1.ClusterGenerator{
+									Selector: metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"env":    "prod",
+											"region": "us-east-1",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			secret: corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "argocd",
+					Name:      "my-secret",
+					Labels: map[string]string{
+						argocommon.LabelKeySecretType: argocommon.LabelValueSecretTypeCluster,
+						"env":                         "prod",
+						"region":                      "us-east-1",
+					},
+				},
+			},
+			expectedRequests: []reconcile.Request{
+				{Namespace: "argocd", Name: "my-app-set"},
+			},
+		},
+		{
+			name: "a cluster generator with non matching labels should not produce a request",
+			items: []argov1alpha1.ApplicationSet{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-app-set",
+						Namespace: "argocd",
+					},
+					Spec: argov1alpha1.ApplicationSetSpec{
+						Generators: []argov1alpha1.ApplicationSetGenerator{
+							{
+								Clusters: &argov1alpha1.ClusterGenerator{
+									Selector: metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"env": "prod",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			secret: corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "argocd",
+					Name:      "my-secret",
+					Labels: map[string]string{
+						argocommon.LabelKeySecretType: argocommon.LabelValueSecretTypeCluster,
+						"env":                         "dev",
+					},
 				},
 			},
 			expectedRequests: []reconcile.Request{},
@@ -571,7 +647,8 @@ func TestNestedGeneratorHasClusterGenerator_NestedClusterGenerator(t *testing.T)
 		Clusters: &argov1alpha1.ClusterGenerator{},
 	}
 
-	hasClusterGenerator, err := nestedGeneratorHasClusterGenerator(nested)
+	emptyLabels := labels.Set{}
+	hasClusterGenerator, err := nestedGeneratorHasClusterGenerator(nested, emptyLabels)
 
 	require.NoError(t, err)
 	assert.True(t, hasClusterGenerator)
@@ -599,7 +676,8 @@ func TestNestedGeneratorHasClusterGenerator_NestedMergeGenerator(t *testing.T) {
 		},
 	}
 
-	hasClusterGenerator, err := nestedGeneratorHasClusterGenerator(nested)
+	matchingLabels := labels.Set{"argocd.argoproj.io/secret-type": "cluster"}
+	hasClusterGenerator, err := nestedGeneratorHasClusterGenerator(nested, matchingLabels)
 
 	require.NoError(t, err)
 	assert.True(t, hasClusterGenerator)
@@ -627,8 +705,72 @@ func TestNestedGeneratorHasClusterGenerator_NestedMergeGeneratorWithInvalidJSON(
 		},
 	}
 
-	hasClusterGenerator, err := nestedGeneratorHasClusterGenerator(nested)
+	emptyLabels := labels.Set{}
+	hasClusterGenerator, err := nestedGeneratorHasClusterGenerator(nested, emptyLabels)
 
 	require.Error(t, err)
+	assert.False(t, hasClusterGenerator)
+}
+
+func TestNestedGeneratorHasClusterGenerator_NestedMergeGeneratorNonMatchingLabels(t *testing.T) {
+	nested := argov1alpha1.ApplicationSetNestedGenerator{
+		Merge: &apiextensionsv1.JSON{
+			Raw: []byte(
+				`{
+					"generators": [
+					  {
+						"clusters": {
+						  "selector": {
+							"matchLabels": {
+							  "env": "prod"
+							}
+						  }
+						}
+					  }
+					]
+				  }`,
+			),
+		},
+	}
+
+	nonMatchingLabels := labels.Set{"env": "dev"}
+	hasClusterGenerator, err := nestedGeneratorHasClusterGenerator(nested, nonMatchingLabels)
+
+	require.NoError(t, err)
+	assert.False(t, hasClusterGenerator)
+}
+
+func TestNestedGeneratorHasClusterGenerator_NestedMatrixGeneratorPartialLabels(t *testing.T) {
+	nested := argov1alpha1.ApplicationSetNestedGenerator{
+		Matrix: &apiextensionsv1.JSON{
+			Raw: []byte(
+				`{
+					"generators": [
+					  {
+						"clusters": {
+						  "selector": {
+							"matchLabels": {
+							  "env": "prod",
+							  "region": "us-east-1"
+							}
+						  }
+						},
+						"list": {
+						  "elements": [
+							  "a",
+							  "b"
+						  ]
+						}
+					  }
+					]
+				  }`,
+			),
+		},
+	}
+
+	nonMatchingLabels := labels.Set{"env": "prod"}
+	hasClusterGenerator, err := nestedGeneratorHasClusterGenerator(nested, nonMatchingLabels)
+
+	require.NoError(t, err)
 	assert.False(t, hasClusterGenerator)
 }

--- a/applicationset/controllers/clustereventhandler_test.go
+++ b/applicationset/controllers/clustereventhandler_test.go
@@ -221,10 +221,8 @@ func TestClusterEventHandler(t *testing.T) {
 			name: "a cluster generator with matching labels should produce a request",
 			items: []argov1alpha1.ApplicationSet{
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "my-app-set",
-						Namespace: "argocd",
-					},
+					Name:      "my-app-set",
+					Namespace: "argocd",
 					Spec: argov1alpha1.ApplicationSetSpec{
 						Generators: []argov1alpha1.ApplicationSetGenerator{
 							{
@@ -260,10 +258,8 @@ func TestClusterEventHandler(t *testing.T) {
 			name: "a cluster generator with non matching labels should not produce a request",
 			items: []argov1alpha1.ApplicationSet{
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "my-app-set",
-						Namespace: "argocd",
-					},
+					Name:      "my-app-set",
+					Namespace: "argocd",
 					Spec: argov1alpha1.ApplicationSetSpec{
 						Generators: []argov1alpha1.ApplicationSetGenerator{
 							{
@@ -621,10 +617,8 @@ func TestClusterEventHandler(t *testing.T) {
 			name: "when a cluster secret label changes from stage to prod, both stage and prod appsets should reconcile but not dev",
 			items: []argov1alpha1.ApplicationSet{
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "dev-appset",
-						Namespace: "argocd",
-					},
+					Name:      "dev-appset",
+					Namespace: "argocd",
 					Spec: argov1alpha1.ApplicationSetSpec{
 						Generators: []argov1alpha1.ApplicationSetGenerator{{
 							Clusters: &argov1alpha1.ClusterGenerator{
@@ -636,10 +630,8 @@ func TestClusterEventHandler(t *testing.T) {
 					},
 				},
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "stage-appset",
-						Namespace: "argocd",
-					},
+					Name:      "stage-appset",
+					Namespace: "argocd",
 					Spec: argov1alpha1.ApplicationSetSpec{
 						Generators: []argov1alpha1.ApplicationSetGenerator{{
 							Clusters: &argov1alpha1.ClusterGenerator{
@@ -651,10 +643,8 @@ func TestClusterEventHandler(t *testing.T) {
 					},
 				},
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "prod-appset",
-						Namespace: "argocd",
-					},
+					Name:      "prod-appset",
+					Namespace: "argocd",
 					Spec: argov1alpha1.ApplicationSetSpec{
 						Generators: []argov1alpha1.ApplicationSetGenerator{{
 							Clusters: &argov1alpha1.ClusterGenerator{
@@ -677,13 +667,11 @@ func TestClusterEventHandler(t *testing.T) {
 				},
 			},
 			secretOld: &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "argocd",
-					Name:      "my-secret",
-					Labels: map[string]string{
-						argocommon.LabelKeySecretType: argocommon.LabelValueSecretTypeCluster,
-						"env":                         "stage",
-					},
+				Namespace: "argocd",
+				Name:      "my-secret",
+				Labels: map[string]string{
+					argocommon.LabelKeySecretType: argocommon.LabelValueSecretTypeCluster,
+					"env":                         "stage",
 				},
 			},
 			expectedRequests: []reconcile.Request{


### PR DESCRIPTION

### What does this PR do?

Fixes a inline `TODO` in `clusterSecretEventHandler` (see [inline TODO here](https://github.com/argoproj/argo-cd/blob/9a0c75c1e7d1fae8f7b0dd705ca1fe2618f61f35/applicationset/controllers/clustereventhandler.go#L119)) where all ApplicationSets containing a cluster generator were requeued on any cluster secret event, regardless of whether the secret's labels matched the generator's selector.

This PR evaluates the cluster secret's labels against the `LabelSelector` defined in each Cluster Generator before enqueuing a reconciliation request.

**Changes:**
- Top-level cluster generators: skipped if the secret labels don't match the selector
- Nested Matrix/Merge generators: recursively evaluated with the same label matching logic
- No selector defined: preserves existing behavior (matches all clusters)
- Update a cluster secret (changing labels, annotations, etc):  requeue any ApplicationSet matching either `ObjectOld` or `ObjectNew` cluster secret labels 

### Why

The existing behavior was incorrect — ApplicationSets were being reconciled for cluster secrets they were never configured to care about. When a cluster secret event occurred (create, update, delete, generic), it triggered a requeue for all ApplicationSets with a cluster generator, causing unnecessary reconciliation cycles.  

### Testing

Added tests covering: label match, label mismatch, empty selector, nested Matrix/Merge generator scenarios and cluster secret label change.


Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).