### PR TITLE
fix(appset): pass inherited params to nested matrix generators(#16578)

### DIFF
--- a/applicationset/generators/matrix.go
+++ b/applicationset/generators/matrix.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"dario.cat/mergo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/argoproj/argo-cd/v3/applicationset/utils"
@@ -33,6 +35,10 @@ func NewMatrixGenerator(supportedGenerators map[string]Generator) Generator {
 }
 
 func (m *MatrixGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator, appSet *argoprojiov1alpha1.ApplicationSet, client client.Client) ([]map[string]any, error) {
+	return m.generateParams(appSetGenerator, appSet, nil, client)
+}
+
+func (m *MatrixGenerator) generateParams(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator, appSet *argoprojiov1alpha1.ApplicationSet, inheritedParams map[string]any, client client.Client) ([]map[string]any, error) {
 	if appSetGenerator.Matrix == nil {
 		return nil, ErrEmptyAppSetGenerator
 	}
@@ -47,66 +53,102 @@ func (m *MatrixGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.App
 
 	res := []map[string]any{}
 
-	g0, err := m.getParams(appSetGenerator.Matrix.Generators[0], appSet, nil, client)
+	g0, err := m.getParams(appSetGenerator.Matrix.Generators[0], appSet, inheritedParams, client)
 	if err != nil {
 		return nil, fmt.Errorf("error failed to get params for first generator in matrix generator: %w", err)
 	}
+
 	for _, a := range g0 {
-		g1, err := m.getParams(appSetGenerator.Matrix.Generators[1], appSet, a, client)
+		paramsForSecondGenerator, err := combineMatrixParams(a, inheritedParams, appSet.Spec.GoTemplate)
+		if err != nil {
+			return nil, fmt.Errorf("failed to combine params from the first generator in the matrix generator with inherited params: %w", err)
+		}
+
+		g1, err := m.getParams(appSetGenerator.Matrix.Generators[1], appSet, paramsForSecondGenerator, client)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get params for second generator in the matrix generator: %w", err)
 		}
+
 		for _, b := range g1 {
-			if appSet.Spec.GoTemplate {
-				tmp := map[string]any{}
-				if err := mergo.Merge(&tmp, b, mergo.WithOverride); err != nil {
-					return nil, fmt.Errorf("failed to merge params from the second generator in the matrix generator with temp map: %w", err)
-				}
-				if err := mergo.Merge(&tmp, a, mergo.WithOverride); err != nil {
-					return nil, fmt.Errorf("failed to merge params from the second generator in the matrix generator with the first: %w", err)
-				}
-				res = append(res, tmp)
-			} else {
-				val, err := utils.CombineStringMaps(a, b)
-				if err != nil {
-					return nil, fmt.Errorf("failed to combine string maps with merging params for the matrix generator: %w", err)
-				}
-				res = append(res, val)
+			val, err := combineMatrixParams(a, b, appSet.Spec.GoTemplate)
+			if err != nil {
+				return nil, fmt.Errorf("failed to combine params for the matrix generator: %w", err)
 			}
+			res = append(res, val)
 		}
 	}
 
 	return res, nil
 }
 
+// combineMatrixParams combines two matrix parameter sets.
+//
+// In GoTemplate mode, preferred takes precedence when both maps contain the same
+// key. This keeps the existing matrix precedence rule: params from the first
+// child generator win over params from the second child generator.
+//
+// In non-GoTemplate mode, duplicate keys with different string values are an
+// error, matching utils.CombineStringMaps.
+func combineMatrixParams(preferred, fallback map[string]any, useGoTemplate bool) (map[string]any, error) {
+	if useGoTemplate {
+		tmp := map[string]any{}
+
+		if len(fallback) > 0 {
+			if err := mergo.Merge(&tmp, fallback, mergo.WithOverride); err != nil {
+				return nil, err
+			}
+		}
+
+		if len(preferred) > 0 {
+			if err := mergo.Merge(&tmp, preferred, mergo.WithOverride); err != nil {
+				return nil, err
+			}
+		}
+
+		return tmp, nil
+	}
+
+	return utils.CombineStringMaps(preferred, fallback)
+}
+
 func (m *MatrixGenerator) getParams(appSetBaseGenerator argoprojiov1alpha1.ApplicationSetNestedGenerator, appSet *argoprojiov1alpha1.ApplicationSet, params map[string]any, client client.Client) ([]map[string]any, error) {
-	matrixGen, err := getMatrixGenerator(appSetBaseGenerator)
+	childGenerator, err := nestedGeneratorToApplicationSetGenerator(appSetBaseGenerator)
 	if err != nil {
 		return nil, err
 	}
-	mergeGen, err := getMergeGenerator(appSetBaseGenerator)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving merge generator: %w", err)
+
+	relevantGenerators := GetRelevantGenerators(childGenerator, m.supportedGenerators)
+	if len(relevantGenerators) > 1 {
+		return nil, ErrMoreThenOneInnerGenerators
+	}
+
+	// Do not call Transform for a nested matrix here. Transform interpolates the
+	// whole generator before GenerateParams, but a nested matrix must interpolate
+	// each child sequentially so the second child can see params from the first child.
+	if childGenerator.Matrix != nil {
+		matrixParams, err := m.generateParams(
+			&argoprojiov1alpha1.ApplicationSetGenerator{
+				Matrix: childGenerator.Matrix,
+			},
+			appSet,
+			params,
+			client,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("child matrix generator returned an error on parameter generation: %w", err)
+		}
+
+		return filterParamsBySelector(matrixParams, appSetBaseGenerator.Selector)
 	}
 
 	t, err := Transform(
-		argoprojiov1alpha1.ApplicationSetGenerator{
-			List:                    appSetBaseGenerator.List,
-			Clusters:                appSetBaseGenerator.Clusters,
-			Git:                     appSetBaseGenerator.Git,
-			SCMProvider:             appSetBaseGenerator.SCMProvider,
-			ClusterDecisionResource: appSetBaseGenerator.ClusterDecisionResource,
-			PullRequest:             appSetBaseGenerator.PullRequest,
-			Plugin:                  appSetBaseGenerator.Plugin,
-			Matrix:                  matrixGen,
-			Merge:                   mergeGen,
-			Selector:                appSetBaseGenerator.Selector,
-		},
+		*childGenerator,
 		m.supportedGenerators,
 		argoprojiov1alpha1.ApplicationSetTemplate{},
 		appSet,
 		params,
-		client)
+		client,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("child generator returned an error on parameter generation: %w", err)
 	}
@@ -120,6 +162,61 @@ func (m *MatrixGenerator) getParams(appSetBaseGenerator argoprojiov1alpha1.Appli
 	}
 
 	return t[0].Params, nil
+}
+
+// nestedGeneratorToApplicationSetGenerator converts an ApplicationSetNestedGenerator
+// into an ApplicationSetGenerator so it can be processed by Transform or by MatrixGenerator recursively.
+func nestedGeneratorToApplicationSetGenerator(appSetBaseGenerator argoprojiov1alpha1.ApplicationSetNestedGenerator) (*argoprojiov1alpha1.ApplicationSetGenerator, error) {
+	matrixGen, err := getMatrixGenerator(appSetBaseGenerator)
+	if err != nil {
+		return nil, err
+	}
+
+	mergeGen, err := getMergeGenerator(appSetBaseGenerator)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving merge generator: %w", err)
+	}
+
+	return &argoprojiov1alpha1.ApplicationSetGenerator{
+		List:                    appSetBaseGenerator.List,
+		Clusters:                appSetBaseGenerator.Clusters,
+		Git:                     appSetBaseGenerator.Git,
+		SCMProvider:             appSetBaseGenerator.SCMProvider,
+		ClusterDecisionResource: appSetBaseGenerator.ClusterDecisionResource,
+		PullRequest:             appSetBaseGenerator.PullRequest,
+		Plugin:                  appSetBaseGenerator.Plugin,
+		Matrix:                  matrixGen,
+		Merge:                   mergeGen,
+		Selector:                appSetBaseGenerator.Selector,
+	}, nil
+}
+
+// filterParamsBySelector filters the given params by the given selector.
+func filterParamsBySelector(params []map[string]any, selector *metav1.LabelSelector) ([]map[string]any, error) {
+	if selector == nil {
+		return params, nil
+	}
+
+	parsedSelector, err := utils.LabelSelectorAsSelector(selector)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing label selector: %w", err)
+	}
+
+	filteredParams := make([]map[string]any, 0, len(params))
+	for _, param := range params {
+		flatParam, err := flattenParameters(param)
+		if err != nil {
+			return nil, fmt.Errorf("error flattening parameters: %w", err)
+		}
+
+		if !parsedSelector.Matches(labels.Set(flatParam)) {
+			continue
+		}
+
+		filteredParams = append(filteredParams, param)
+	}
+
+	return filteredParams, nil
 }
 
 const maxDuration time.Duration = 1<<63 - 1

--- a/applicationset/generators/matrix_test.go
+++ b/applicationset/generators/matrix_test.go
@@ -1,6 +1,7 @@
 package generators
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -1181,4 +1182,343 @@ func TestGitGenerator_GenerateParams_list_x_git_matrix_generator_go_templates_va
 			"foo": "some",
 		},
 	}}, params)
+}
+
+func TestMatrixGenerateNestedMatrixElementsYamlUsesInnerGeneratorParamsGoTemplate(t *testing.T) {
+	appSet := &v1alpha1.ApplicationSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "set",
+		},
+		Spec: v1alpha1.ApplicationSetSpec{
+			GoTemplate:        true,
+			GoTemplateOptions: []string{"missingkey=error"},
+		},
+	}
+
+	nestedMatrix := mustJSON(t, v1alpha1.NestedMatrixGenerator{
+		Generators: v1alpha1.ApplicationSetTerminalGenerators{
+			{
+				List: &v1alpha1.ListGenerator{
+					Elements: []apiextensionsv1.JSON{
+						mustJSON(t, map[string]any{
+							"app": map[string]any{
+								"name": "guestbook",
+								"charts": []any{
+									map[string]any{
+										"releaseName": "component1",
+										"chart":       "chart1",
+									},
+									map[string]any{
+										"releaseName": "component2",
+										"chart":       "chart2",
+									},
+								},
+							},
+							"revision": "{{ .head_sha }}",
+						}),
+					},
+				},
+			},
+			{
+				List: &v1alpha1.ListGenerator{
+					Elements:     []apiextensionsv1.JSON{},
+					ElementsYaml: "{{ .app.charts | toJson }}",
+				},
+			},
+		},
+	})
+
+	matrixGenerator := NewMatrixGenerator(map[string]Generator{
+		"List": &ListGenerator{},
+	})
+
+	got, err := matrixGenerator.GenerateParams(
+		&v1alpha1.ApplicationSetGenerator{
+			Matrix: &v1alpha1.MatrixGenerator{
+				Generators: []v1alpha1.ApplicationSetNestedGenerator{
+					{
+						List: &v1alpha1.ListGenerator{
+							Elements: []apiextensionsv1.JSON{
+								mustJSON(t, map[string]any{
+									"branch":   "feature/foo",
+									"head_sha": "abc123",
+								}),
+							},
+						},
+					},
+					{
+						Matrix: &nestedMatrix,
+					},
+				},
+			},
+		},
+		appSet,
+		nil,
+	)
+
+	require.NoError(t, err)
+
+	expectedApp := map[string]any{
+		"name": "guestbook",
+		"charts": []any{
+			map[string]any{
+				"releaseName": "component1",
+				"chart":       "chart1",
+			},
+			map[string]any{
+				"releaseName": "component2",
+				"chart":       "chart2",
+			},
+		},
+	}
+
+	assert.Equal(t, []map[string]any{
+		{
+			"branch":      "feature/foo",
+			"head_sha":    "abc123",
+			"revision":    "abc123",
+			"app":         expectedApp,
+			"releaseName": "component1",
+			"chart":       "chart1",
+		},
+		{
+			"branch":      "feature/foo",
+			"head_sha":    "abc123",
+			"revision":    "abc123",
+			"app":         expectedApp,
+			"releaseName": "component2",
+			"chart":       "chart2",
+		},
+	}, got)
+}
+
+func TestMatrixGenerateNestedMatrixUsesInheritedParamsWhenKeysConflictGoTemplate(t *testing.T) {
+	appSet := &v1alpha1.ApplicationSet{
+		Spec: v1alpha1.ApplicationSetSpec{
+			GoTemplate: true,
+		},
+	}
+
+	nestedMatrix := mustJSON(t, v1alpha1.NestedMatrixGenerator{
+		Generators: v1alpha1.ApplicationSetTerminalGenerators{
+			{
+				List: &v1alpha1.ListGenerator{
+					Elements: []apiextensionsv1.JSON{
+						mustJSON(t, map[string]any{
+							"env": "staging",
+							"app": map[string]any{
+								"charts": []any{
+									map[string]any{
+										"releaseName": "component1",
+									},
+								},
+							},
+						}),
+					},
+				},
+			},
+			{
+				List: &v1alpha1.ListGenerator{
+					Elements: []apiextensionsv1.JSON{},
+					ElementsYaml: `[
+						{
+							"releaseName": "component1",
+							"observedEnv": "{{ .env }}"
+						}
+					]`,
+				},
+			},
+		},
+	})
+
+	matrixGenerator := NewMatrixGenerator(map[string]Generator{
+		"List": &ListGenerator{},
+	})
+
+	got, err := matrixGenerator.GenerateParams(
+		&v1alpha1.ApplicationSetGenerator{
+			Matrix: &v1alpha1.MatrixGenerator{
+				Generators: []v1alpha1.ApplicationSetNestedGenerator{
+					{
+						List: &v1alpha1.ListGenerator{
+							Elements: []apiextensionsv1.JSON{
+								mustJSON(t, map[string]any{
+									"env": "prod",
+								}),
+							},
+						},
+					},
+					{
+						Matrix: &nestedMatrix,
+					},
+				},
+			},
+		},
+		appSet,
+		nil,
+	)
+
+	require.NoError(t, err)
+
+	assert.Equal(t, []map[string]any{
+		{
+			"env":         "prod",
+			"observedEnv": "staging",
+			"releaseName": "component1",
+			"app": map[string]any{
+				"charts": []any{
+					map[string]any{
+						"releaseName": "component1",
+					},
+				},
+			},
+		},
+	}, got)
+}
+
+func TestMatrixGenerateNestedMatrixSecondChildCanUseOuterAndInnerParamsGoTemplate(t *testing.T) {
+	appSet := &v1alpha1.ApplicationSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "set",
+		},
+		Spec: v1alpha1.ApplicationSetSpec{
+			GoTemplate:        true,
+			GoTemplateOptions: []string{"missingkey=error"},
+		},
+	}
+
+	nestedMatrix := mustJSON(t, v1alpha1.NestedMatrixGenerator{
+		Generators: v1alpha1.ApplicationSetTerminalGenerators{
+			{
+				List: &v1alpha1.ListGenerator{
+					Elements: []apiextensionsv1.JSON{
+						mustJSON(t, map[string]any{
+							"key2": "value2",
+						}),
+					},
+				},
+			},
+			{
+				List: &v1alpha1.ListGenerator{
+					Elements: []apiextensionsv1.JSON{
+						mustJSON(t, map[string]any{
+							"substitute1": "{{ .key1 }}",
+							"substitute2": "{{ .key2 }}",
+						}),
+					},
+				},
+			},
+		},
+	})
+
+	matrixGenerator := NewMatrixGenerator(map[string]Generator{
+		"List": &ListGenerator{},
+	})
+
+	got, err := matrixGenerator.GenerateParams(
+		&v1alpha1.ApplicationSetGenerator{
+			Matrix: &v1alpha1.MatrixGenerator{
+				Generators: []v1alpha1.ApplicationSetNestedGenerator{
+					{
+						List: &v1alpha1.ListGenerator{
+							Elements: []apiextensionsv1.JSON{
+								mustJSON(t, map[string]any{
+									"key1": "value1",
+								}),
+							},
+						},
+					},
+					{
+						Matrix: &nestedMatrix,
+					},
+				},
+			},
+		},
+		appSet,
+		nil,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, []map[string]any{
+		{
+			"key1":        "value1",
+			"key2":        "value2",
+			"substitute1": "value1",
+			"substitute2": "value2",
+		},
+	}, got)
+}
+
+func TestMatrixGenerateAppliesSelectorOnNestedMatrix(t *testing.T) {
+	appSet := &v1alpha1.ApplicationSet{
+		Spec: v1alpha1.ApplicationSetSpec{GoTemplate: true},
+	}
+
+	nestedMatrix := mustJSON(t, v1alpha1.NestedMatrixGenerator{
+		Generators: v1alpha1.ApplicationSetTerminalGenerators{
+			{
+				List: &v1alpha1.ListGenerator{
+					Elements: []apiextensionsv1.JSON{
+						mustJSON(t, map[string]any{"component": "api"}),
+						mustJSON(t, map[string]any{"component": "worker"}),
+					},
+				},
+			},
+			{
+				List: &v1alpha1.ListGenerator{
+					Elements: []apiextensionsv1.JSON{
+						mustJSON(t, map[string]any{"cluster": "prod"}),
+					},
+				},
+			},
+		},
+	})
+
+	matrixGenerator := NewMatrixGenerator(map[string]Generator{
+		"List": &ListGenerator{},
+	})
+
+	got, err := matrixGenerator.GenerateParams(
+		&v1alpha1.ApplicationSetGenerator{
+			Matrix: &v1alpha1.MatrixGenerator{
+				Generators: []v1alpha1.ApplicationSetNestedGenerator{
+					{
+						List: &v1alpha1.ListGenerator{
+							Elements: []apiextensionsv1.JSON{
+								mustJSON(t, map[string]any{"env": "prod"}),
+							},
+						},
+					},
+					{
+						Matrix: &nestedMatrix,
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"component": "api",
+							},
+						},
+					},
+				},
+			},
+		},
+		appSet,
+		nil,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, []map[string]any{
+		{
+			"env":       "prod",
+			"component": "api",
+			"cluster":   "prod",
+		},
+	}, got)
+}
+
+func mustJSON(t *testing.T, v any) apiextensionsv1.JSON {
+	t.Helper()
+
+	raw, err := json.Marshal(v)
+	require.NoError(t, err)
+
+	return apiextensionsv1.JSON{Raw: raw}
 }


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

## Summary

This PR fixes parameter generation for nested matrix generators.

Previously, when a matrix generator contained another matrix generator as its second child, parameters produced by the outer matrix's first child were not available while evaluating the nested matrix. As a result, a nested list generator using `elementsYaml` could not reference parameters generated by a previous generator.

For example, the following pattern failed because `.app.charts` was not available when rendering `elementsYaml`:

```yaml
generators:
  - matrix:
      generators:
        - pullRequest: ...
        - matrix:
            generators:
              - git:
                  files:
                    - path: configs/config.yaml
              - list:
                  elementsYaml: "{{ .app.charts | toJson }}"
```

This PR passes inherited params into nested matrix generators so that child generators can use params generated by earlier matrix children.

Fixes #16578

## Precedence note

This PR currently preserves the existing matrix merge behavior where params from the first child generator take precedence over params from the second child generator.

- Ref: https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Generators-Matrix/#overriding-parameters-from-one-child-generator-in-another-child-generator

For nested matrix generators, inherited params from the outer matrix are also passed into the nested matrix evaluation context. In cases where inherited params and params generated inside the nested matrix use the same key, the current implementation lets the nested matrix's first child params take precedence while rendering the nested matrix's second child.

This means there is a subtle precedence question for conflict cases:

- Should inherited params from the outer matrix always take precedence inside nested matrix evaluation?
- Or should params generated by the nested matrix's own first child take precedence while rendering its second child?

I kept the current behavior explicit in tests so that we can discuss and confirm the intended semantics in this PR.

## Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
