### PR TITLE
fix(server): allow server-side diff for resource not yet synced (#27679)

### DIFF
--- a/server/application/application.go
+++ b/server/application/application.go
@@ -1210,6 +1210,7 @@ func (s *Server) Delete(ctx context.Context, q *application.ApplicationDeleteReq
 	}
 	s.logAppEvent(ctx, a, argo.EventReasonResourceDeleted, "deleted application")
 	return &application.ApplicationResponse{}, nil
+
 }
 
 func (s *Server) isApplicationPermitted(selector labels.Selector, minVersion int, claims any, appName, appNs string, projects map[string]bool, a v1alpha1.Application) bool {
@@ -3109,15 +3110,22 @@ func (s *Server) ServerSideDiff(ctx context.Context, q *application.ApplicationS
 				i, len(q.GetLiveResources()), len(targetObjs))
 		}
 
-		found := false
-		for _, item := range managedResources {
-			if item.Kind == kind && item.Group == group && item.Namespace == namespace && item.Name == name {
-				found = true
-				break
+		// Skip managed-resources check for new resources in server‑side diff
+		isNewResource := i >= len(q.GetLiveResources()) ||
+			q.GetLiveResources()[i].LiveState == "" ||
+			q.GetLiveResources()[i].LiveState == "null"
+
+		if !isNewResource {
+			found := false
+			for _, item := range managedResources {
+				if item.Kind == kind && item.Group == group && item.Namespace == namespace && item.Name == name {
+					found = true
+					break
+				}
 			}
-		}
-		if !found {
-			return nil, status.Errorf(codes.PermissionDenied, "%s %s %s not found as part of application %s", kind, group, name, a.Name)
+			if !found {
+				return nil, status.Errorf(codes.PermissionDenied, "%s %s %s not found as part of application %s", kind, group, name, a.Name)
+			}
 		}
 
 		// Create ResourceDiff with StateDiffs results


### PR DESCRIPTION
Closes #27679

**Why this PR is necessary**
Server‑side diff (`argocd app diff --server-side-diff`) rejects new resources
(never synced to the cluster) with `PermissionDenied: <resource> not found as
part of application`. The API endpoint was checking every resource against
`managedResources` (the cached *live* state), but a new resource only present in
the target manifests can’t be found there.

**What this PR does**
In `server/application/application.go`, before checking the managed resources,
identify resources that have no live state (`LiveState` is `""` or `"null"`, or
the index is beyond the live resources slice). For these new resources the
managed‑resource check is skipped entirely, allowing the diff to proceed.

**Checklist**

- [x] this is a bug fix
- [x] Title conforms to [the style guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
- [x] Closes #27679
- [x] The build is green (existing tests pass)
- [x] No CLI / UI changes required
- [x] Documentation update not needed (bug fix)
- [x] I have signed off all commits (DCO)