### PR TITLE
feat(helm): support optional: prefix on individual valueFiles entries (#27698)

### DIFF
--- a/docs/user-guide/helm.md
+++ b/docs/user-guide/helm.md
@@ -90,6 +90,53 @@ source:
     ignoreMissingValueFiles: true
 ```
 
+> [!NOTE]
+> `ignoreMissingValueFiles` only applies to local value files in the repository.
+> Remote value file URLs (e.g. `https://...`) are always fetched by Helm at
+> template time and cannot be skipped — see the warning under
+> [Marking a single file as optional](#marking-a-single-file-as-optional).
+
+### Marking a single file as optional
+
+`ignoreMissingValueFiles` makes every entry in `valueFiles` allowed-to-be-missing,
+which can hide typos or accidental renames in files that should always exist.
+To mark only specific entries as optional while keeping the rest strict, prefix
+those entries with `optional:`:
+
+```yaml
+source:
+  helm:
+    valueFiles:
+    - shared/defaults.yaml                          # required
+    - optional:shared/defaults.region-eu-west.yaml  # optional override
+    - service/defaults.yaml                         # required
+    - optional:service/defaults.production.yaml     # optional override
+```
+
+A missing required entry still produces an error; a missing `optional:` entry is
+silently skipped. Order is preserved, so an `optional:` override stays at its
+declared position relative to the file it overrides.
+
+The `optional:` prefix composes with `$ref`-source paths and glob patterns. For
+globs, `optional:` causes a zero-match to be skipped silently instead of raising
+the `ComparisonError` described under [No-match behavior](#no-match-behavior).
+
+> [!WARNING]
+> Neither `optional:` nor `ignoreMissingValueFiles` affects remote value file
+> URLs. Remote value files (e.g. `https://...`) are passed through to Helm
+> unchanged and fetched by Helm at template time, so a remote URL is always
+> effectively required — if it cannot be retrieved, rendering fails regardless
+> of these settings. The missing-file handling only applies to local files in
+> the repository (including `$ref`-source paths).
+
+> [!NOTE]
+> The literal token `optional:` is reserved at the start of `valueFiles` entries.
+> Linux filesystems do allow `:` in filenames, but it is rare in practice (it
+> conflicts with `host:path` conventions in rsync/scp and with `PATH` separators).
+> If you do have a file whose name actually starts with `optional:`, escape it by
+> prefixing the entry with `./` — anything that does not start with the literal
+> token `optional:` is treated as a path. For example: `./optional:legacy.yaml`.
+
 ## Glob Patterns in Value Files
 
 Glob patterns can be used in `valueFiles` entries to match multiple files at once. This is useful

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -78,6 +78,10 @@ const (
 	appSourceFile                  = ".argocd-source-%s.yaml"
 	ociPrefix                      = "oci://"
 	skipFileRenderingMarker        = "+argocd:skip-file-rendering"
+	// optionalValueFilePrefix marks a single valueFiles entry as allowed-to-be-missing.
+	// When present, the entry behaves as if ignoreMissingValueFiles were set, but only
+	// for that one entry. Sibling entries without the prefix remain strict.
+	optionalValueFilePrefix = "optional:"
 )
 
 var ErrExceededMaxCombinedManifestFileSize = errors.New("exceeded max combined manifest file size")
@@ -561,6 +565,7 @@ func resolveReferencedSources(hasMultipleSources bool, source *v1alpha1.Applicat
 	refCandidates := append(source.ValueFiles, refFileParams...)
 
 	for _, valueFile := range refCandidates {
+		valueFile, _ = splitOptionalPrefix(valueFile)
 		if !strings.HasPrefix(valueFile, "$") {
 			continue
 		}
@@ -832,6 +837,7 @@ func (s *Service) runManifestGenAsync(ctx context.Context, repoRoot, commitSHA, 
 
 				// Checkout every one of the referenced sources to the target revision before generating Manifests
 				for _, valueFile := range refCandidates {
+					valueFile, _ = splitOptionalPrefix(valueFile)
 					if !strings.HasPrefix(valueFile, "$") {
 						continue
 					}
@@ -1413,7 +1419,8 @@ func getResolvedValueFiles(
 	// the final position. For example, with ["*.yaml", "c.yaml"], c.yaml is excluded from
 	// the glob expansion and placed at the end where it was explicitly listed.
 	explicitPaths := make(map[pathutil.ResolvedFilePath]struct{})
-	for _, rawValueFile := range rawValueFiles {
+	for _, rawEntry := range rawValueFiles {
+		rawValueFile, _ := splitOptionalPrefix(rawEntry)
 		referencedSource := getReferencedSource(rawValueFile, refSources)
 		var resolved pathutil.ResolvedFilePath
 		var err error
@@ -1438,7 +1445,8 @@ func getResolvedValueFiles(
 			resolvedValueFiles = append(resolvedValueFiles, p)
 		}
 	}
-	for _, rawValueFile := range rawValueFiles {
+	for _, rawEntry := range rawValueFiles {
+		rawValueFile, optional := splitOptionalPrefix(rawEntry)
 		isRemote := false
 		var resolvedPath pathutil.ResolvedFilePath
 		var err error
@@ -1479,7 +1487,7 @@ func getResolvedValueFiles(
 				return nil, fmt.Errorf("error expanding glob pattern %q: %w", rawValueFile, err)
 			}
 			if len(matches) == 0 {
-				if ignoreMissingValueFiles {
+				if ignoreMissingValueFiles || optional {
 					log.Debugf(" %s values file glob matched no files", rawValueFile)
 					continue
 				}
@@ -1500,7 +1508,7 @@ func getResolvedValueFiles(
 		if !isRemote {
 			_, err = os.Stat(string(resolvedPath))
 			if os.IsNotExist(err) {
-				if ignoreMissingValueFiles {
+				if ignoreMissingValueFiles || optional {
 					log.Debugf(" %s values file does not exist", resolvedPath)
 					continue
 				}
@@ -1551,10 +1559,23 @@ func getReferencedSources(rawValueFiles []string, refSources map[string]*v1alpha
 }
 
 func getReferencedSourceName(rawValueFile string) string {
+	rawValueFile, _ = splitOptionalPrefix(rawValueFile)
 	if !strings.HasPrefix(rawValueFile, "$") {
 		return ""
 	}
 	return strings.Split(rawValueFile, "/")[0]
+}
+
+// splitOptionalPrefix strips the optional: marker from a valueFiles entry and
+// reports whether it was present. It is called at every site that interprets a
+// valueFiles string (ref-source detection, path resolution, env substitution,
+// glob expansion) so the marker composes with every existing feature without
+// further parser updates.
+func splitOptionalPrefix(raw string) (string, bool) {
+	if rest, ok := strings.CutPrefix(raw, optionalValueFilePrefix); ok {
+		return rest, true
+	}
+	return raw, false
 }
 
 func getReferencedSource(rawValueFile string, refSources map[string]*v1alpha1.RefTarget) *v1alpha1.RefTarget {
@@ -3416,6 +3437,7 @@ func (s *Service) UpdateRevisionForPaths(_ context.Context, request *apiclient.U
 	}
 
 	for _, valueFile := range refCandidates {
+		valueFile, _ = splitOptionalPrefix(valueFile)
 		if !strings.HasPrefix(valueFile, "$") {
 			continue
 		}

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -4215,6 +4215,172 @@ func Test_getResolvedValueFiles_glob(t *testing.T) {
 	})
 }
 
+func Test_splitOptionalPrefix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		raw              string
+		expectedRest     string
+		expectedOptional bool
+	}{
+		{name: "bare path", raw: "values.yaml", expectedRest: "values.yaml", expectedOptional: false},
+		{name: "optional prefix", raw: "optional:values.yaml", expectedRest: "values.yaml", expectedOptional: true},
+		{name: "optional with ref", raw: "optional:$values/foo.yaml", expectedRest: "$values/foo.yaml", expectedOptional: true},
+		{name: "optional with glob", raw: "optional:envs/*.yaml", expectedRest: "envs/*.yaml", expectedOptional: true},
+		{name: "empty after prefix", raw: "optional:", expectedRest: "", expectedOptional: true},
+		// Prefix is case-sensitive. Anything other than the literal token is treated as a plain path.
+		{name: "wrong case is not stripped", raw: "Optional:values.yaml", expectedRest: "Optional:values.yaml", expectedOptional: false},
+		{name: "extra whitespace not stripped", raw: " optional:values.yaml", expectedRest: " optional:values.yaml", expectedOptional: false},
+		// Documented escape for files actually named optional:*.yaml — prefix the entry with ./
+		// so it no longer starts with the literal token.
+		{name: "dot-slash escape preserves literal optional in filename", raw: "./optional:legacy.yaml", expectedRest: "./optional:legacy.yaml", expectedOptional: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rest, optional := splitOptionalPrefix(tc.raw)
+			assert.Equal(t, tc.expectedRest, rest)
+			assert.Equal(t, tc.expectedOptional, optional)
+		})
+	}
+}
+
+func Test_getResolvedValueFiles_optional(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	paths := utilio.NewRandomizedTempPaths(tempDir)
+	paths.Add(git.NormalizeGitURL("https://github.com/org/repo1"), path.Join(tempDir, "repo1"))
+
+	// main-repo: existing files
+	require.NoError(t, os.MkdirAll(path.Join(tempDir, "main-repo", "envs"), 0o755))
+	require.NoError(t, os.WriteFile(path.Join(tempDir, "main-repo", "values.yaml"), []byte{}, 0o644))
+	require.NoError(t, os.WriteFile(path.Join(tempDir, "main-repo", "envs", "a.yaml"), []byte{}, 0o644))
+
+	// repo1: existing file in referenced source
+	require.NoError(t, os.MkdirAll(path.Join(tempDir, "repo1"), 0o755))
+	require.NoError(t, os.WriteFile(path.Join(tempDir, "repo1", "values.yaml"), []byte{}, 0o644))
+
+	repoPath := path.Join(tempDir, "main-repo")
+	refSources := map[string]*v1alpha1.RefTarget{
+		"$ref": {Repo: v1alpha1.Repository{Repo: "https://github.com/org/repo1"}},
+	}
+
+	t.Run("optional: on missing plain path is skipped", func(t *testing.T) {
+		t.Parallel()
+		resolved, err := getResolvedValueFiles(repoPath, repoPath, &v1alpha1.Env{}, []string{},
+			[]string{"optional:missing.yaml"}, map[string]*v1alpha1.RefTarget{}, paths, false)
+		require.NoError(t, err)
+		assert.Empty(t, resolved)
+	})
+
+	t.Run("optional: on existing plain path is included", func(t *testing.T) {
+		t.Parallel()
+		resolved, err := getResolvedValueFiles(repoPath, repoPath, &v1alpha1.Env{}, []string{},
+			[]string{"optional:values.yaml"}, map[string]*v1alpha1.RefTarget{}, paths, false)
+		require.NoError(t, err)
+		require.Len(t, resolved, 1)
+		assert.Equal(t, path.Join(repoPath, "values.yaml"), string(resolved[0]))
+	})
+
+	t.Run("optional: on existing $ref source path is resolved through the ref", func(t *testing.T) {
+		t.Parallel()
+		resolved, err := getResolvedValueFiles(repoPath, repoPath, &v1alpha1.Env{}, []string{},
+			[]string{"optional:$ref/values.yaml"}, refSources, paths, false)
+		require.NoError(t, err)
+		require.Len(t, resolved, 1)
+		assert.Equal(t, path.Join(tempDir, "repo1", "values.yaml"), string(resolved[0]))
+	})
+
+	t.Run("optional: on missing $ref source path is skipped", func(t *testing.T) {
+		t.Parallel()
+		resolved, err := getResolvedValueFiles(repoPath, repoPath, &v1alpha1.Env{}, []string{},
+			[]string{"optional:$ref/missing.yaml"}, refSources, paths, false)
+		require.NoError(t, err)
+		assert.Empty(t, resolved)
+	})
+
+	t.Run("optional: on glob with matches behaves like a normal glob", func(t *testing.T) {
+		t.Parallel()
+		resolved, err := getResolvedValueFiles(repoPath, repoPath, &v1alpha1.Env{}, []string{},
+			[]string{"optional:envs/*.yaml"}, map[string]*v1alpha1.RefTarget{}, paths, false)
+		require.NoError(t, err)
+		require.Len(t, resolved, 1)
+		assert.Equal(t, path.Join(repoPath, "envs", "a.yaml"), string(resolved[0]))
+	})
+
+	t.Run("optional: on glob with zero matches is skipped without error", func(t *testing.T) {
+		t.Parallel()
+		resolved, err := getResolvedValueFiles(repoPath, repoPath, &v1alpha1.Env{}, []string{},
+			[]string{"optional:nonexistent/*.yaml"}, map[string]*v1alpha1.RefTarget{}, paths, false)
+		require.NoError(t, err)
+		assert.Empty(t, resolved)
+	})
+
+	t.Run("required sibling next to optional is still passed to helm when missing", func(t *testing.T) {
+		t.Parallel()
+		// getResolvedValueFiles itself does not stat-fail on missing non-glob entries when
+		// ignoreMissingValueFiles=false — that's helm's job to error out on later. The contract
+		// the optional: marker must preserve is: a missing required entry is *kept* in the
+		// resolved list (so helm sees it and fails), while a missing optional entry is dropped.
+		resolved, err := getResolvedValueFiles(repoPath, repoPath, &v1alpha1.Env{}, []string{},
+			[]string{
+				"optional:missing-override.yaml", // optional, missing → dropped
+				"missing-required.yaml",          // required, missing → kept (helm will error)
+			},
+			map[string]*v1alpha1.RefTarget{}, paths, false)
+		require.NoError(t, err)
+		require.Len(t, resolved, 1)
+		assert.Equal(t, path.Join(repoPath, "missing-required.yaml"), string(resolved[0]))
+	})
+
+	t.Run("required missing glob sibling next to optional missing glob still errors", func(t *testing.T) {
+		t.Parallel()
+		// For globs, zero-match *does* return GlobNoMatchError when neither flag is set.
+		// optional: on a glob suppresses that error for that entry only; the required glob
+		// next to it still raises.
+		_, err := getResolvedValueFiles(repoPath, repoPath, &v1alpha1.Env{}, []string{},
+			[]string{
+				"optional:nonexistent-optional/*.yaml", // suppressed
+				"nonexistent-required/*.yaml",          // raises GlobNoMatchError
+			},
+			map[string]*v1alpha1.RefTarget{}, paths, false)
+		require.Error(t, err)
+	})
+
+	t.Run("optional next to required-and-present preserves order", func(t *testing.T) {
+		t.Parallel()
+		resolved, err := getResolvedValueFiles(repoPath, repoPath, &v1alpha1.Env{}, []string{},
+			[]string{
+				"values.yaml",                    // required, present
+				"optional:missing-override.yaml", // optional, missing → skipped
+				"envs/a.yaml",                    // required, present
+			},
+			map[string]*v1alpha1.RefTarget{}, paths, false)
+		require.NoError(t, err)
+		require.Len(t, resolved, 2)
+		assert.Equal(t, path.Join(repoPath, "values.yaml"), string(resolved[0]))
+		assert.Equal(t, path.Join(repoPath, "envs", "a.yaml"), string(resolved[1]))
+	})
+
+	t.Run("ignoreMissingValueFiles=true does not change behavior for bare entries paired with optional", func(t *testing.T) {
+		t.Parallel()
+		// Both flags allow the missing file to be skipped; the result should be identical to
+		// using either alone for an entry that is missing.
+		resolved, err := getResolvedValueFiles(repoPath, repoPath, &v1alpha1.Env{}, []string{},
+			[]string{
+				"values.yaml",
+				"optional:missing.yaml",
+				"missing-via-global.yaml",
+			},
+			map[string]*v1alpha1.RefTarget{}, paths, true)
+		require.NoError(t, err)
+		require.Len(t, resolved, 1)
+		assert.Equal(t, path.Join(repoPath, "values.yaml"), string(resolved[0]))
+	})
+}
+
 func Test_verifyGlobMatchesWithinRoot(t *testing.T) {
 	t.Parallel()
 

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	goio "io"
 	"io/fs"
+	"net/http"
+	"net/http/httptest"
 	"net/mail"
 	"os"
 	"os/exec"
@@ -18,6 +20,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -4379,6 +4382,49 @@ func Test_getResolvedValueFiles_optional(t *testing.T) {
 		require.Len(t, resolved, 1)
 		assert.Equal(t, path.Join(repoPath, "values.yaml"), string(resolved[0]))
 	})
+
+	// Remote value file URLs are fetched by helm at render time, not read from the
+	// repository, so the missing-file handling (which is stat-based) cannot apply to
+	// them. Both ignoreMissingValueFiles and the optional: prefix are therefore no-ops
+	// for remote URLs: the URL is always passed through to helm unchanged and is
+	// effectively required. These cases lock that behavior in so neither flag silently
+	// drops a remote URL, and assert that resolution itself performs no HTTP request
+	// (proving argo-cd defers the fetch to helm rather than probing reachability).
+	//
+	// Each case points the entry at a local httptest server that 404s every request
+	// and counts hits; a non-zero count would mean resolution probed the URL.
+	remoteCases := []struct {
+		name                    string
+		optional                bool
+		ignoreMissingValueFiles bool
+	}{
+		{name: "remote URL is not skipped by ignoreMissingValueFiles", ignoreMissingValueFiles: true},
+		{name: "remote URL is not skipped by optional: prefix", optional: true},
+		{name: "remote URL is not skipped even with optional: and ignoreMissingValueFiles together", optional: true, ignoreMissingValueFiles: true},
+	}
+	for _, rc := range remoteCases {
+		t.Run(rc.name, func(t *testing.T) {
+			t.Parallel()
+			var hits atomic.Int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				hits.Add(1)
+				w.WriteHeader(http.StatusNotFound)
+			}))
+			defer srv.Close()
+
+			entry := srv.URL + "/values.yaml"
+			if rc.optional {
+				entry = "optional:" + entry
+			}
+			// httptest serves over http, so allow that scheme for this entry to be treated as remote.
+			resolved, err := getResolvedValueFiles(repoPath, repoPath, &v1alpha1.Env{}, []string{"http"},
+				[]string{entry}, map[string]*v1alpha1.RefTarget{}, paths, rc.ignoreMissingValueFiles)
+			require.NoError(t, err)
+			require.Len(t, resolved, 1)
+			assert.Equal(t, srv.URL+"/values.yaml", string(resolved[0]))
+			assert.Zero(t, hits.Load(), "argo-cd must not fetch remote value file URLs itself; helm fetches them at render time")
+		})
+	}
 }
 
 func Test_verifyGlobMatchesWithinRoot(t *testing.T) {


### PR DESCRIPTION
*Disclaimer: This PR was created and drafted together with Claude Opus 4.7*

Closes #27698.

## What this PR does

Adds an `optional:` prefix that can be applied to any single entry in
`source.helm.valueFiles`. A prefixed entry behaves as if
`ignoreMissingValueFiles` were set, but only for that one entry — sibling
entries without the prefix remain strict.

```yaml
source:
  helm:
    valueFiles:
      - shared/defaults.yaml                          # required
      - optional:shared/defaults.region-eu-west.yaml  # optional
      - service/defaults.yaml                         # required
      - optional:service/defaults.region-eu-west.yaml
      - service/defaults.production.yaml              # required
      - optional:service/defaults.production-canary.yaml
```

Behavior:

- Missing required entry: error (unchanged).
- Missing `optional:` entry: silently skipped.
- `optional:` on a glob: zero-match is silently skipped instead of raising
  `GlobNoMatchError`.
- `optional:` composes with `$ref` sources, env substitution, glob expansion,
  and remote URLs.
- `ignoreMissingValueFiles: true` keeps working unchanged. When set, bare
  entries continue to be silently skipped on miss; `optional:` entries are
  also silently skipped (`||` semantics).
- Order is preserved — Helm precedence is positional and each override stays
  in its declared position next to its base.

## Why a string prefix instead of a structured field

`valueFiles` is `[]string` today. A typed `{path, optional}` element would
better match Kubernetes API style (and matches how `configMapKeyRef.optional`
etc. are expressed) but is an API break — every consumer of `valueFiles`,
including ApplicationSet templates and the CLI, would need to handle both
forms. A reserved string prefix lands the feature with no schema change, no
CRD bump, and no `valueFiles` v2 field, while preserving the positional
ordering that a separate `optionalValueFiles` list would lose.

The literal token `optional:` becomes reserved at the start of `valueFiles`
entries. Linux filesystems do allow `:` in filenames, but it is rare in
practice (clashes with `host:path` rsync/scp conventions and `PATH`
separators). If a real file is genuinely named `optional:something.yaml`,
the entry can be escaped by prefixing with `./` — only entries that start
with the literal token are treated as markers, so `./optional:legacy.yaml`
is parsed as a path. The docs call this out explicitly.

## Why the word `optional`

Kubernetes already uses `optional: true` for the same semantic on
`configMapKeyRef`, `secretKeyRef`, `envFrom`, and `volumes.*`. Anyone reading
an ArgoCD manifest will recognize the word. Alternatives considered:

- `?` prefix — collides visually with the doublestar single-character glob.
- `-` prefix — collides with the YAML list bullet.
- `opt:` — abbreviation; no precedent.

## Implementation

Self-contained to `reposerver/repository/repository.go`:

1. New helper `splitOptionalPrefix(raw string) (string, bool)` strips the
   `optional:` token and reports whether it was present. Uses
   `strings.CutPrefix` to match the existing parsing style in the same file
   (e.g. `alias:` handling at line 1158).

2. The helper is called at every site that interprets a `valueFiles` string,
   so the marker composes with every existing feature without further parser
   updates:

   - `getReferencedSourceName` — central ref-source parser; covers
     `getReferencedSources` and `getReferencedSource` automatically.
   - The three inline `strings.HasPrefix(valueFile, "$")` ref-preflight sites
     in `resolveReferencedSources`, `runManifestGenAsync`, and
     `UpdateRevisionForPaths`.
   - The two loops inside `getResolvedValueFiles` (the pre-pass that builds
     `explicitPaths`, and the main resolution loop).

3. In `getResolvedValueFiles`, the per-entry `optional` flag is OR'd into
   the two existing skip branches:

   ```go
   // glob with zero matches
   if ignoreMissingValueFiles || optional { continue }

   // os.IsNotExist on a non-glob path
   if ignoreMissingValueFiles || optional { continue }
   ```

That is the entire functional diff. No CRD bump, no API version bump, no
ApplicationSet template changes, no CLI changes. Existing manifests behave
identically.

## Tests

In `reposerver/repository/repository_test.go`:

- `Test_splitOptionalPrefix` — unit-tests the helper across bare paths,
  prefixed paths, prefixed `$ref`, prefixed glob, empty rest, and
  case-sensitivity.
- `Test_getResolvedValueFiles_optional` — integration-level cases:
  - `optional:` on a missing plain path → skipped.
  - `optional:` on an existing plain path → included.
  - `optional:` on an existing `$ref` source → resolved through the ref.
  - `optional:` on a missing `$ref` source path → skipped.
  - `optional:` on a glob with matches → behaves like a normal glob.
  - `optional:` on a glob with zero matches → skipped without error.
  - Required missing sibling next to optional missing → required is still
    passed through to helm (helm errors later, current contract).
  - Required missing glob sibling next to optional missing glob → required
    still raises `GlobNoMatchError`.
  - Optional next to required-and-present → order preserved.
  - `ignoreMissingValueFiles=true` paired with `optional:` entries →
    behavior unchanged for bare entries; `optional:` continues to work.

All new and existing valueFile-related tests pass under `-race`.

## Documentation

`docs/user-guide/helm.md` gains a "Marking a single file as optional"
section right next to the existing `ignoreMissingValueFiles` description,
with a synthetic apps-of-apps example, a note that the marker composes with
ref sources / globs, and a callout that `optional:` is a reserved prefix.

## Backwards compatibility

- `valueFiles` remains `[]string` — no CRD, OpenAPI, or API version change.
- Manifests without `optional:` entries are unaffected.
- `ignoreMissingValueFiles` keeps current semantics.
- `argocd app set --values <path>` and ApplicationSet template-produced
  strings can carry `optional:` transparently — no CLI or template code
  changes needed.

## Feature status

Proposed as **Stable** per the [feature-status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) rubric:

- Backwards compatible by construction — bare entries behave exactly as
  before; only entries that explicitly start with `optional:` opt in.
- No CRD, API version, schema, or flag change; nothing to deprecate or
  evolve out of.
- Surface area is one reserved prefix on one field — very little that
  could change incompatibly later.
- Covered by unit tests; existing valueFile/glob tests still pass.

Happy to demote to **Beta** (with a `[BETA]` marker on the docs section)
if maintainers prefer the conservative path. **Alpha** would mean wiring
a feature flag to gate prefix recognition; I'd rather not add that
unless explicitly requested, since a silently no-op `optional:` on
default config is its own footgun.

## Related issues

- #7767 — original `ignoreMissingValueFiles` (this is the per-entry
  follow-up)
- #20789 — same gap in `helm.fileParameters`
- #18634 — same gap in `kustomize.components` / `patches`
