### PR TITLE
fix(controller): use last synced revision as baseline

### DIFF
--- a/controller/state.go
+++ b/controller/state.go
@@ -349,13 +349,25 @@ func (m *appStateManager) evaluateRevisionChanges(
 		return revision, false, nil
 	}
 
-	// Determine the synced revision and source type for this specific source
+	// Determine the last actually-synced revision for this source. We deliberately use
+	// OperationState.SyncResult rather than Status.Sync here: Status.Sync.Revision is updated
+	// after every comparison even when the sync is blocked (e.g. by a sync window). Using it
+	// as the baseline would cause subsequent comparisons to report no new revision changes even
+	// though the cluster was never synced to the current git revision, which in turn causes
+	// alreadyAttemptedSync to skip the auto-sync. Fall back to Status.Sync when no sync has
+	// completed yet (fresh app with no operation history).
 	var syncedRevision string
-	if app.Spec.HasMultipleSources() {
-		if sourceIndex < len(app.Status.Sync.Revisions) {
+	switch {
+	case app.Spec.HasMultipleSources():
+		if app.Status.OperationState != nil && app.Status.OperationState.SyncResult != nil &&
+			sourceIndex < len(app.Status.OperationState.SyncResult.Revisions) {
+			syncedRevision = app.Status.OperationState.SyncResult.Revisions[sourceIndex]
+		} else if sourceIndex < len(app.Status.Sync.Revisions) {
 			syncedRevision = app.Status.Sync.Revisions[sourceIndex]
 		}
-	} else {
+	case app.Status.OperationState != nil && app.Status.OperationState.SyncResult != nil:
+		syncedRevision = app.Status.OperationState.SyncResult.Revision
+	default:
 		syncedRevision = app.Status.Sync.Revision
 	}
 

--- a/controller/state_test.go
+++ b/controller/state_test.go
@@ -2333,6 +2333,7 @@ func Test_evaluateRevisionChanges(t *testing.T) {
 		syncPolicy                          *v1alpha1.SyncPolicy
 		revision                            string
 		appSyncedRevision                   string
+		appLastSyncedRevision               string // overrides SyncResult.Revision when set
 		refSources                          map[string]*v1alpha1.RefTarget
 		repoDepth                           int64
 		keyManifestGenerateAnnotationExists bool
@@ -2360,12 +2361,32 @@ func Test_evaluateRevisionChanges(t *testing.T) {
 				RepoURL: "https://github.com/example/repo",
 				Path:    "manifests",
 			},
-			sourceType:         v1alpha1.ApplicationSourceTypeKustomize,
-			revision:           "abc123",
-			appSyncedRevision:  "abc123",
-			refSources:         map[string]*v1alpha1.RefTarget{},
-			expectedRevision:   "abc123",
-			expectedHasChanges: false,
+			sourceType:            v1alpha1.ApplicationSourceTypeKustomize,
+			revision:              "abc123",
+			appSyncedRevision:     "abc123",
+			appLastSyncedRevision: "abc123",
+			refSources:            map[string]*v1alpha1.RefTarget{},
+			expectedRevision:      "abc123",
+			expectedHasChanges:    false,
+		},
+		{
+			// Regression test for https://github.com/argoproj/argo-cd/issues/21692:
+			// when a sync is blocked by a sync window, Status.Sync.Revision is updated after
+			// each comparison to the new git revision even though the cluster is never synced.
+			// Subsequent comparisons must still detect changes so that auto-sync fires once the
+			// window opens.
+			name: "Sync window blocked: comparison revision matches current but last sync revision differs",
+			source: &v1alpha1.ApplicationSource{
+				RepoURL: "https://github.com/example/repo",
+				Path:    "manifests",
+			},
+			sourceType:            v1alpha1.ApplicationSourceTypeKustomize,
+			revision:              "def456",
+			appSyncedRevision:     "def456", // Status.Sync.Revision updated by comparison while sync was blocked
+			appLastSyncedRevision: "abc123", // cluster was last synced to abc123
+			refSources:            map[string]*v1alpha1.RefTarget{},
+			expectedRevision:      "def456",
+			expectedHasChanges:    true,
 		},
 		{
 			name: "Same revision with ref sources continues to evaluation",
@@ -2459,6 +2480,9 @@ func Test_evaluateRevisionChanges(t *testing.T) {
 			app.Spec.SyncPolicy = tt.syncPolicy
 			app.Status.Sync.Revision = tt.appSyncedRevision
 			app.Status.SourceType = tt.sourceType
+			if tt.appLastSyncedRevision != "" {
+				app.Status.OperationState.SyncResult.Revision = tt.appLastSyncedRevision
+			}
 			if tt.keyManifestGenerateAnnotationExists {
 				app.Annotations = map[string]string{
 					v1alpha1.AnnotationKeyManifestGeneratePaths: tt.keyManifestGenerateAnnotationVal,


### PR DESCRIPTION
*Disclaimer: I'm new to this project and did got some help from an LLM.*

When a sync is blocked by a deny sync window, Argo CD still runs the comparison and updates `Status.Sync.Revision` to the new git revision. Once the window lifts, `evaluateRevisionChanges` compares the current git revision against `Status.Sync.Revision` — they match — and returns `hasChanges = false`. This causes `alreadyAttemptedSync` to skip the revision check entirely and conclude the sync was already attempted, so auto-sync never fires. The user must push another commit or trigger a manual sync to unstick the application.

The regression was introduced in #27190 (032d9e1e80), which refactored `evaluateRevisionChanges` and added an early return when `syncedRevision == currentRevision`. The bug is that `syncedRevision` was read from `Status.Sync.Revision` (the last *compared* revision) instead of `OperationState.SyncResult.Revision` (the last *synced* revision). These two fields diverge whenever a sync is blocked.

`evaluateRevisionChanges` now reads `syncedRevision` from `OperationState.SyncResult.Revision` — the revision the cluster was last actually synced to — falling back to `Status.Sync.Revision` only for apps that have never completed a sync. With this fix, once the deny window expires and the comparison reruns, `syncedRevision (abc123) != currentRevision (def456)` so `hasChanges = true`, `alreadyAttemptedSync` correctly identifies the revision as not yet attempted, and auto-sync fires as expected.

Fixes #21692

## Wider problem

This PR only addresses the regression introduced in 032d9e1e80, which affects v3.x (master). Users on older releases such as v2.14 will not hit this specific regression because the `evaluateRevisionChanges` refactor does not exist there — but they are still affected by the original broader problem reported in #21692: when auto-sync is blocked by a deny window, the controller has no mechanism to proactively schedule a re-check for when the window opens. It relies on informer events or periodic timeouts to eventually re-queue the app. That deeper problem remains open and would warrant a separate fix (e.g. calculating the next window-open time and calling `requestAppRefresh` with that delay).


---

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. *(not applicable — no new feature)*
* [x] Does this PR require documentation updates? No — this restores existing expected behaviour, no docs change needed.
* [ ] I've updated documentation as required by this PR. *(not applicable)*
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines. *(not applicable)*
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into: the regression was introduced in the `master` branch in April 2026 (`032d9e1e80`). Older release branches (3.x, 2.x) used different code paths and are unaffected by this specific regression, though the underlying issue (#21692) was also reported against 2.13.
