### PR TITLE
fix(oidc_userinfo): allow userInfo URL to be customized

### DIFF
--- a/docs/operator-manual/user-management/index.md
+++ b/docs/operator-manual/user-management/index.md
@@ -397,6 +397,7 @@ Some OIDC providers don't return the group information for a user in the ID toke
 oidc.config: |
     enableUserInfoGroups: true
     userInfoPath: /userinfo
+    userInfoURL: "https://users.example.com"
     userInfoCacheExpiration: "5m"
 ```
 

--- a/util/oidc/oidc.go
+++ b/util/oidc/oidc.go
@@ -693,7 +693,8 @@ func (a *ClientApp) CheckAndRefreshToken(ctx context.Context, groupClaims jwt.Ma
 	span.SetAttributes(
 		attribute.String("iss", iss),
 		attribute.String("sub", sub),
-		attribute.String("sid", sid))
+		attribute.String("sid", sid),
+	)
 	if GetTokenExpiration(groupClaims) < refreshTokenThreshold {
 		token, err := a.GetUpdatedOidcTokenFromCache(ctx, sub, sid)
 		if err != nil {
@@ -898,7 +899,7 @@ func (a *ClientApp) SetGroupsFromUserInfo(ctx context.Context, claims jwt.Claims
 	}
 	iss := jwtutil.StringField(groupClaims, "iss")
 	if iss != sessionManagerClaimsIssuer && a.settings.UserInfoGroupsEnabled() && a.settings.UserInfoPath() != "" {
-		userInfo, unauthorized, err := a.GetUserInfo(ctx, groupClaims, a.settings.IssuerURL(), a.settings.UserInfoPath())
+		userInfo, unauthorized, err := a.GetUserInfo(ctx, groupClaims, a.settings.IssuerURL(), a.settings.UserInfoBaseURL(), a.settings.UserInfoPath())
 		if unauthorized {
 			return groupClaims, fmt.Errorf("error while quering userinfo endpoint: %w", err)
 		}
@@ -915,7 +916,7 @@ func (a *ClientApp) SetGroupsFromUserInfo(ctx context.Context, claims jwt.Claims
 }
 
 // GetUserInfo queries the IDP userinfo endpoint for claims
-func (a *ClientApp) GetUserInfo(ctx context.Context, actualClaims jwt.MapClaims, issuerURL, userInfoPath string) (jwt.MapClaims, bool, error) {
+func (a *ClientApp) GetUserInfo(ctx context.Context, actualClaims jwt.MapClaims, issuerURL, userInfoBaseURL, userInfoPath string) (jwt.MapClaims, bool, error) {
 	var span trace.Span
 	ctx, span = tracer.Start(ctx, "oidc.ClientApp.GetUserInfo")
 	defer span.End()
@@ -949,7 +950,13 @@ func (a *ClientApp) GetUserInfo(ctx context.Context, actualClaims jwt.MapClaims,
 		return claims, true, fmt.Errorf("no accessToken for %s: %w", sub, err)
 	}
 
-	url := issuerURL + userInfoPath
+	var url string
+	if userInfoBaseURL != "" {
+		url = userInfoBaseURL + userInfoPath
+	} else {
+		url = issuerURL + userInfoPath
+	}
+
 	request, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, http.NoBody)
 	if err != nil {
 		err = fmt.Errorf("failed creating new http request: %w", err)

--- a/util/oidc/oidc_test.go
+++ b/util/oidc/oidc_test.go
@@ -1017,10 +1017,11 @@ func TestGetUserInfo(t *testing.T) {
 			expectEncrypted bool
 			expectError     bool
 		}
-		idpHandler func(w http.ResponseWriter, r *http.Request)
-		idpClaims  jwt.MapClaims // as per specification sub and exp are REQUIRED fields
-		cache      cache.CacheClient
-		cacheItems []struct { // items to put in cache before execution
+		idpHandler         func(w http.ResponseWriter, r *http.Request)
+		idpHandlerUserInfo func(w http.ResponseWriter, r *http.Request) // same as idpHandler but listening on userInfoBaseURL instead of issuerURL
+		idpClaims          jwt.MapClaims                                // as per specification sub and exp are REQUIRED fields
+		cache              cache.CacheClient
+		cacheItems         []struct { // items to put in cache before execution
 			key     string
 			value   string
 			encrypt bool
@@ -1215,10 +1216,76 @@ func TestGetUserInfo(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:                  "call UserInfo on separate endpoint",
+			userInfoPath:          "/user-info",
+			expectedOutput:        jwt.MapClaims{"groups": []any{"githubOrg:developers"}}, // response from separate idpHandlerUserInfo expected
+			expectError:           false,
+			expectUnauthenticated: false,
+			expectedCacheItems: []struct {
+				key             string
+				value           string
+				expectEncrypted bool
+				expectError     bool
+			}{
+				{
+					key:             FormatUserInfoResponseCacheKey("randomUser"),
+					value:           "{\"groups\":[\"githubOrg:developers\"]}",
+					expectEncrypted: true,
+					expectError:     false,
+				},
+			},
+			idpClaims: jwt.MapClaims{"sub": "randomUser", "exp": float64(time.Now().Add(5 * time.Minute).Unix())},
+			idpHandler: func(w http.ResponseWriter, _ *http.Request) {
+				userInfoBytes := `
+				{
+					"groups":["githubOrg:engineers"]
+				}`
+				w.Header().Set("content-type", "application/json")
+				_, err := w.Write([]byte(userInfoBytes))
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+			},
+			idpHandlerUserInfo: func(w http.ResponseWriter, _ *http.Request) {
+				userInfoBytes := `
+				{
+					"groups":["githubOrg:developers"]
+				}`
+				w.Header().Set("content-type", "application/json")
+				_, err := w.Write([]byte(userInfoBytes))
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+			},
+			cache: cache.NewInMemoryCache(24 * time.Hour),
+			cacheItems: []struct {
+				key     string
+				value   string
+				encrypt bool
+			}{
+				{
+					key:     FormatAccessTokenCacheKey("randomUser"),
+					value:   "FakeAccessToken",
+					encrypt: true,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			var tsUserInfo *httptest.Server
+			if tt.idpHandlerUserInfo != nil {
+				tsUserInfo = httptest.NewServer(http.HandlerFunc(tt.idpHandlerUserInfo))
+			} else {
+				tsUserInfo = httptest.NewServer(http.HandlerFunc(tt.idpHandler))
+			}
+
 			ts := httptest.NewServer(http.HandlerFunc(tt.idpHandler))
 			defer ts.Close()
 
@@ -1243,7 +1310,7 @@ func TestGetUserInfo(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			got, unauthenticated, err := a.GetUserInfo(t.Context(), tt.idpClaims, ts.URL, tt.userInfoPath)
+			got, unauthenticated, err := a.GetUserInfo(t.Context(), tt.idpClaims, ts.URL, tsUserInfo.URL, tt.userInfoPath)
 			assert.Equal(t, tt.expectedOutput, got)
 			assert.Equal(t, tt.expectUnauthenticated, unauthenticated)
 			if tt.expectError {

--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -188,6 +188,7 @@ func (o *oidcConfig) toExported() *OIDCConfig {
 		ClientSecret:             o.ClientSecret,
 		Azure:                    o.Azure,
 		CLIClientID:              o.CLIClientID,
+		UserInfoBaseURL:          o.UserInfoBaseURL,
 		UserInfoPath:             o.UserInfoPath,
 		EnableUserInfoGroups:     o.EnableUserInfoGroups,
 		UserInfoCacheExpiration:  o.UserInfoCacheExpiration,
@@ -208,6 +209,7 @@ type OIDCConfig struct {
 	ClientSecret             string                 `json:"clientSecret,omitempty"`
 	CLIClientID              string                 `json:"cliClientID,omitempty"`
 	EnableUserInfoGroups     bool                   `json:"enableUserInfoGroups,omitempty"`
+	UserInfoBaseURL          string                 `json:"userInfoBaseURL,omitempty"` // the URL (without path) where the userinfo endpoint is located
 	UserInfoPath             string                 `json:"userInfoPath,omitempty"`
 	UserInfoCacheExpiration  string                 `json:"userInfoCacheExpiration,omitempty"`
 	RequestedScopes          []string               `json:"requestedScopes,omitempty"`
@@ -1291,7 +1293,8 @@ func (mgr *SettingsManager) RequireOverridePrivilegeForRevisionSync() (bool, err
 	}
 
 	maybeBooleanFlagValue, err2 := strconv.ParseBool(
-		argoCDCM.Data[requireOverridePrivilegeForRevisionSyncKey])
+		argoCDCM.Data[requireOverridePrivilegeForRevisionSyncKey],
+	)
 	if err2 != nil {
 		return false, fmt.Errorf("error parsing %s value: %w, expected true or false",
 			requireOverridePrivilegeForRevisionSyncKey, err2)
@@ -1556,6 +1559,9 @@ func getDownloadBinaryUrlsFromConfigMap(argoCDCM *corev1.ConfigMap) map[string]s
 func updateSettingsFromConfigMap(settings *ArgoCDSettings, argoCDCM *corev1.ConfigMap) {
 	settings.DexConfig = argoCDCM.Data[settingDexConfigKey]
 	settings.OIDCConfigRAW = argoCDCM.Data[settingsOIDCConfigKey]
+	if err := ValidateOIDCConfig(settings.OIDCConfigRAW); err != nil {
+		log.Warnf("Failed to validate OIDC config: %v", err)
+	}
 	settings.KustomizeBuildOptions = argoCDCM.Data[kustomizeBuildOptionsKey]
 	settings.StatusBadgeEnabled = argoCDCM.Data[statusBadgeEnabledKey] == "true"
 	settings.StatusBadgeRootUrl = argoCDCM.Data[statusBadgeRootURLKey]
@@ -1947,7 +1953,15 @@ func unmarshalOIDCConfig(configStr string) (oidcConfig, error) {
 }
 
 func ValidateOIDCConfig(configStr string) error {
-	_, err := unmarshalOIDCConfig(configStr)
+	settings, err := unmarshalOIDCConfig(configStr)
+	if err != nil {
+		return err
+	}
+	err = ValidateExternalURL(settings.Issuer)
+	if err != nil {
+		return err
+	}
+	err = ValidateExternalURL(settings.UserInfoBaseURL)
 	return err
 }
 
@@ -1965,6 +1979,18 @@ func (a *ArgoCDSettings) TLSConfig() *tls.Config {
 	return &tls.Config{
 		RootCAs: certPool,
 	}
+}
+
+func (a *ArgoCDSettings) UserInfoBaseURL() string {
+	if oidcConfig := a.OIDCConfig(); oidcConfig != nil {
+		if err := ValidateExternalURL(oidcConfig.UserInfoBaseURL); err == nil {
+			return oidcConfig.UserInfoBaseURL
+		}
+	}
+	if a.DexConfig != "" {
+		return a.URL + common.DexAPIEndpoint
+	}
+	return ""
 }
 
 func (a *ArgoCDSettings) IssuerURL() string {

--- a/util/settings/settings_test.go
+++ b/util/settings/settings_test.go
@@ -1082,6 +1082,48 @@ func TestGetOIDCConfig(t *testing.T) {
 				assert.Equal(t, time.Duration(0), settings.RefreshTokenThreshold())
 			},
 		},
+		{
+			name: "enableUserInfoEndpoints success",
+			configMapData: map[string]string{
+				"oidc.config": `
+enableUserInfoGroups: true
+userInfoPath: "/userinfo"
+userInfoBaseURL: "https://users.example.com"
+userInfoCacheExpiration: "5m"
+`,
+			},
+			testFunc: func(t *testing.T, settingsManager *SettingsManager) {
+				t.Helper()
+				settings, err := settingsManager.GetSettings()
+				require.NoError(t, err)
+
+				oidcConfig := settings.OIDCConfig()
+				assert.NotNil(t, oidcConfig)
+
+				assert.Equal(t, 5*time.Minute, settings.UserInfoCacheExpiration())
+				assert.Equal(t, "/userinfo", settings.UserInfoPath())
+				assert.Equal(t, "https://users.example.com", settings.UserInfoBaseURL())
+				assert.True(t, settings.UserInfoGroupsEnabled())
+			},
+		},
+		{
+			name: "userInfoBaseURL malformed url",
+			configMapData: map[string]string{
+				"oidc.config": `
+userInfoBaseURL: "://users.example.com"
+`,
+			},
+			testFunc: func(t *testing.T, settingsManager *SettingsManager) {
+				t.Helper()
+				settings, err := settingsManager.GetSettings()
+				require.NoError(t, err)
+
+				oidcConfig := settings.OIDCConfig()
+				assert.NotNil(t, oidcConfig)
+
+				assert.Empty(t, settings.UserInfoBaseURL())
+			},
+		},
 	}
 	for i := range testCases {
 		tc := testCases[i]


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

This adds a new config field to the OIDC config that allows overriding the URL used to fetch groups from the UserInfo endpoint. It's backwards compatible by falling back to the issuerURL if the userInfoURL is not specified.

This is necessary for Entra ID and possibly other providers that use a completely separate URL for the UserInfo endpoint

Follow-up of #12062

I tested locally and inside Swiss Posts env with Entra ID that it works as intended

Cherry-pick for v3.3 be awesome!

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
