### PR TITLE
feat: add KubeConfigExecProvider for dynamic cluster credentials

### DIFF
--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -588,6 +588,14 @@ func (c *liveStateCache) getCluster(cluster *appv1.Cluster) (clustercache.Cluste
 		clustercache.SetEventProcessingInterval(clusterCacheEventsProcessingInterval),
 	}
 
+	if cluster.Config.KubeConfigExecProvider != nil {
+		clusterCacheOpts = append(clusterCacheOpts,
+			clustercache.SetConfigProvider(func() (*rest.Config, error) {
+				return cluster.RESTConfig()
+			}),
+		)
+	}
+
 	clusterCache = clustercache.NewClusterCache(clusterCacheConfig, clusterCacheOpts...)
 
 	_ = clusterCache.OnResourceUpdated(func(newRes *clustercache.Resource, oldRes *clustercache.Resource, namespaceResources map[kube.ResourceKey]*clustercache.Resource) {

--- a/gitops-engine/pkg/cache/cluster.go
+++ b/gitops-engine/pkg/cache/cluster.go
@@ -208,10 +208,10 @@ func NewClusterCache(config *rest.Config, opts ...UpdateSettingsFunc) *clusterCa
 		eventHandlers:           map[uint64]OnEventHandler{},
 		processEventsHandlers:   map[uint64]OnProcessEventsHandler{},
 		log:                     log,
-		listRetryLimit:      1,
-		listRetryUseBackoff: false,
-		listRetryFunc:       ListRetryFuncNever,
-		parentUIDToChildren: make(map[types.UID][]kube.ResourceKey),
+		listRetryLimit:          1,
+		listRetryUseBackoff:     false,
+		listRetryFunc:           ListRetryFuncNever,
+		parentUIDToChildren:     make(map[types.UID][]kube.ResourceKey),
 	}
 	for i := range opts {
 		opts[i](cache)
@@ -256,6 +256,7 @@ type clusterCache struct {
 	kubectl          kube.Kubectl
 	log              logr.Logger
 	config           *rest.Config
+	configProvider   func() (*rest.Config, error)
 	namespaces       []string
 	clusterResources bool
 	settings         Settings
@@ -520,7 +521,6 @@ func (c *clusterCache) rebuildParentToChildrenIndex() {
 		}
 	}
 }
-
 
 // addToParentUIDToChildren adds a child to the parent-to-children index
 func (c *clusterCache) addToParentUIDToChildren(parentUID types.UID, childKey kube.ResourceKey) {
@@ -1006,6 +1006,13 @@ func (c *clusterCache) sync() error {
 	c.resources = make(map[kube.ResourceKey]*Resource)
 	c.namespacedResources = make(map[schema.GroupKind]bool)
 	c.parentUIDToChildren = make(map[types.UID][]kube.ResourceKey)
+	if c.configProvider != nil {
+		freshConfig, err := c.configProvider()
+		if err != nil {
+			return fmt.Errorf("failed to refresh cluster config: %w", err)
+		}
+		c.config = freshConfig
+	}
 	config := c.config
 	version, err := c.kubectl.GetServerVersion(config)
 	if err != nil {

--- a/gitops-engine/pkg/cache/settings.go
+++ b/gitops-engine/pkg/cache/settings.go
@@ -80,6 +80,16 @@ func SetConfig(config *rest.Config) UpdateSettingsFunc {
 	}
 }
 
+// SetConfigProvider sets a callback that produces a fresh rest.Config on every cache sync.
+// This is used when cluster credentials are fetched dynamically (e.g. via KubeConfigExecProvider),
+// ensuring that reconnections pick up rotated CA certificates and credentials.
+// If not set, the static config passed to NewClusterCache is used.
+func SetConfigProvider(provider func() (*rest.Config, error)) UpdateSettingsFunc {
+	return func(cache *clusterCache) {
+		cache.configProvider = provider
+	}
+}
+
 // SetListPageSize sets the page size for list pager.
 func SetListPageSize(listPageSize int64) UpdateSettingsFunc {
 	return func(cache *clusterCache) {

--- a/gitops-engine/pkg/cache/settings_test.go
+++ b/gitops-engine/pkg/cache/settings_test.go
@@ -72,3 +72,25 @@ func TestSetEventsProcessingInterval(t *testing.T) {
 	cache.Invalidate(SetEventProcessingInterval(interval))
 	assert.Equal(t, interval, cache.eventProcessingInterval)
 }
+
+func TestSetConfigProvider(t *testing.T) {
+	cache := NewClusterCache(&rest.Config{Host: "https://original"}, SetKubectl(&kubetest.MockKubectlCmd{}))
+	assert.Nil(t, cache.configProvider)
+
+	provider := func() (*rest.Config, error) {
+		return &rest.Config{Host: "https://refreshed"}, nil
+	}
+	cache.Invalidate(SetConfigProvider(provider))
+
+	assert.NotNil(t, cache.configProvider)
+	refreshedConfig, err := cache.configProvider()
+	assert.NoError(t, err)
+	assert.Equal(t, "https://refreshed", refreshedConfig.Host)
+}
+
+func TestSetConfigProvider_NilByDefault(t *testing.T) {
+	cache := NewClusterCache(&rest.Config{Host: "https://original"}, SetKubectl(&kubetest.MockKubectlCmd{}))
+	assert.Nil(t, cache.configProvider)
+	// Config should remain unchanged when no provider is set
+	assert.Equal(t, "https://original", cache.config.Host)
+}

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"regexp"
@@ -2413,6 +2414,29 @@ type ExecProviderConfig struct {
 	InstallHint string `json:"installHint,omitempty" protobuf:"bytes,5,opt,name=installHint"`
 }
 
+// KubeConfigExecProvider is config used to call an external command to produce a full kubeconfig file.
+// Unlike ExecProviderConfig which only produces credentials, this command produces an entire
+// kubeconfig (server, CA, auth) which ArgoCD reads to build a REST config. ArgoCD creates a
+// temp file and passes its path as the last argument to the command. The command must write a
+// valid kubeconfig to that file.
+type KubeConfigExecProvider struct {
+	// Command to execute
+	Command string `json:"command" protobuf:"bytes,1,opt,name=command"`
+
+	// Arguments to pass to the command when executing it.
+	// The temp file path is appended as the last argument automatically.
+	Args []string `json:"args,omitempty" protobuf:"bytes,2,rep,name=args"`
+
+	// Env defines additional environment variables to expose to the process
+	Env map[string]string `json:"env,omitempty" protobuf:"bytes,3,opt,name=env"`
+
+	// APIVersion is the preferred api version of the kubeconfig output
+	APIVersion string `json:"apiVersion,omitempty" protobuf:"bytes,4,opt,name=apiVersion"`
+
+	// InstallHint is shown to the user when the executable doesn't seem to be present
+	InstallHint string `json:"installHint,omitempty" protobuf:"bytes,5,opt,name=installHint"`
+}
+
 // ClusterConfig is the configuration attributes. This structure is subset of the go-client
 // rest.Config with annotations added for marshalling.
 type ClusterConfig struct {
@@ -2439,6 +2463,14 @@ type ClusterConfig struct {
 
 	// ProxyURL is the URL to the proxy to be used for all requests send to the server
 	ProxyUrl string `json:"proxyUrl,omitempty" protobuf:"bytes,8,opt,name=proxyUrl"` //nolint:revive //FIXME(var-naming)
+
+	// KubeConfigExecProvider contains configuration for an external command that produces a full kubeconfig file.
+	// When set, this takes precedence over all other authentication methods.
+	KubeConfigExecProvider *KubeConfigExecProvider `json:"kubeConfigExecProvider,omitempty" protobuf:"bytes,9,opt,name=kubeConfigExecProvider"`
+
+	// KubeConfigContext specifies the context name to use from the kubeconfig produced by KubeConfigExec.
+	// If empty, the default context from the kubeconfig is used.
+	KubeConfigContext string `json:"kubeConfigContext,omitempty" protobuf:"bytes,10,opt,name=kubeConfigContext"`
 }
 
 // TLSClientConfig contains settings to enable transport layer security
@@ -3700,6 +3732,62 @@ func ParseProxyUrl(proxyUrl string) (*url.URL, error) { //nolint:revive //FIXME(
 	return u, nil
 }
 
+// runKubeConfigExecProvider executes an external command that produces a full kubeconfig file.
+// It creates a temp file, appends its path as the last argument to the command, runs the command,
+// and loads the resulting kubeconfig to build a rest.Config. The server URL is overridden with
+// the provided serverURL to preserve ArgoCD's cluster identity model.
+func runKubeConfigExecProvider(provider *KubeConfigExecProvider, kubeConfigContext string, serverURL string) (*rest.Config, error) {
+	tmpFile, err := os.CreateTemp("", "argocd-kubeconfig-*")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp file for kubeconfig: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
+	defer os.Remove(tmpPath)
+
+	args := make([]string, len(provider.Args)+1)
+	copy(args, provider.Args)
+	args[len(provider.Args)] = tmpPath
+
+	cmd := exec.Command(provider.Command, args...)
+	cmd.Env = os.Environ()
+	for k, v := range provider.Env {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		errMsg := fmt.Sprintf("kubeconfig exec provider command %q failed: %v", provider.Command, err)
+		if stderr.Len() > 0 {
+			errMsg += fmt.Sprintf(", stderr: %s", stderr.String())
+		}
+		if provider.InstallHint != "" {
+			errMsg += fmt.Sprintf(" (install hint: %s)", provider.InstallHint)
+		}
+		return nil, fmt.Errorf("%s", errMsg)
+	}
+
+	loadingRules := &clientcmd.ClientConfigLoadingRules{
+		ExplicitPath: tmpPath,
+	}
+	overrides := &clientcmd.ConfigOverrides{}
+	if kubeConfigContext != "" {
+		overrides.CurrentContext = kubeConfigContext
+	}
+
+	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides)
+	config, err := clientConfig.ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load kubeconfig from exec provider output: %w", err)
+	}
+
+	config.Host = serverURL
+
+	return config, nil
+}
+
 // RawRestConfig returns a go-client REST config from cluster that might be serialized into the file using kube.WriteKubeConfig method.
 func (c *Cluster) RawRestConfig() (*rest.Config, error) {
 	var config *rest.Config
@@ -3737,6 +3825,8 @@ func (c *Cluster) RawRestConfig() (*rest.Config, error) {
 			CAData:     c.Config.CAData,
 		}
 		switch {
+		case c.Config.KubeConfigExecProvider != nil:
+			config, err = runKubeConfigExecProvider(c.Config.KubeConfigExecProvider, c.Config.KubeConfigContext, c.Server)
 		case c.Config.AWSAuthConfig != nil:
 			args := []string{"aws", "--cluster-name", c.Config.AWSAuthConfig.ClusterName}
 			if c.Config.AWSAuthConfig.RoleARN != "" {

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -18,6 +19,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 func TestAppProject_IsSourcePermitted(t *testing.T) {
@@ -240,9 +243,209 @@ func TestAppProject_IsDestinationPermitted(t *testing.T) {
 			permitted, _ := proj.IsDestinationPermitted(destCluster, data.appDest.Namespace, func(_ string) ([]*Cluster, error) {
 				return []*Cluster{}, nil
 			})
-			assert.Equal(t, data.isPermitted, permitted)
+			assert.Equal(t, testCopy.expected, testCopy.a.Equals(testCopy.b))
 		})
 	}
+}
+
+func writeTestKubeconfig(t *testing.T, config clientcmdapi.Config) string {
+	t.Helper()
+	tmpFile := filepath.Join(t.TempDir(), "kubeconfig")
+	err := clientcmd.WriteToFile(config, tmpFile)
+	require.NoError(t, err)
+	return tmpFile
+}
+
+func TestRawRestConfig_KubeConfigExecProvider_HappyPath(t *testing.T) {
+	kubeconfig := clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"test-cluster": {
+				Server:                   "https://kubeconfig-server:6443",
+				CertificateAuthorityData: []byte("test-ca-data"),
+			},
+		},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"test-user": {
+				Token: "test-bearer-token",
+			},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			"test-context": {
+				Cluster:  "test-cluster",
+				AuthInfo: "test-user",
+			},
+		},
+		CurrentContext: "test-context",
+	}
+	kubeconfigPath := writeTestKubeconfig(t, kubeconfig)
+
+	cluster := Cluster{
+		Server: "https://argocd-server:6443",
+		Config: ClusterConfig{
+			KubeConfigExecProvider: &KubeConfigExecProvider{
+				Command: "cp",
+				Args:    []string{kubeconfigPath},
+			},
+		},
+	}
+
+	config, err := cluster.RawRestConfig()
+	require.NoError(t, err)
+
+	assert.Equal(t, "https://argocd-server:6443", config.Host)
+	assert.Equal(t, "test-bearer-token", config.BearerToken)
+	assert.Equal(t, []byte("test-ca-data"), config.TLSClientConfig.CAData)
+}
+
+func TestRawRestConfig_KubeConfigExecProvider_ContextSelection(t *testing.T) {
+	kubeconfig := clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"cluster-a": {Server: "https://cluster-a:6443"},
+			"cluster-b": {Server: "https://cluster-b:6443"},
+		},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"user-a": {Token: "token-a"},
+			"user-b": {Token: "token-b"},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			"context-a": {Cluster: "cluster-a", AuthInfo: "user-a"},
+			"context-b": {Cluster: "cluster-b", AuthInfo: "user-b"},
+		},
+		CurrentContext: "context-a",
+	}
+	kubeconfigPath := writeTestKubeconfig(t, kubeconfig)
+
+	cluster := Cluster{
+		Server: "https://argocd-server:6443",
+		Config: ClusterConfig{
+			KubeConfigExecProvider: &KubeConfigExecProvider{
+				Command: "cp",
+				Args:    []string{kubeconfigPath},
+			},
+			KubeConfigContext: "context-b",
+		},
+	}
+
+	config, err := cluster.RawRestConfig()
+	require.NoError(t, err)
+
+	assert.Equal(t, "https://argocd-server:6443", config.Host)
+	assert.Equal(t, "token-b", config.BearerToken)
+}
+
+func TestRawRestConfig_KubeConfigExecProvider_CommandFailure(t *testing.T) {
+	cluster := Cluster{
+		Server: "https://argocd-server:6443",
+		Config: ClusterConfig{
+			KubeConfigExecProvider: &KubeConfigExecProvider{
+				Command: "sh",
+				Args:    []string{"-c", "echo 'something went wrong' >&2; exit 1; #"},
+			},
+		},
+	}
+
+	config, err := cluster.RawRestConfig()
+	assert.Nil(t, config)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "something went wrong")
+}
+
+func TestRawRestConfig_KubeConfigExecProvider_CommandNotFound(t *testing.T) {
+	cluster := Cluster{
+		Server: "https://argocd-server:6443",
+		Config: ClusterConfig{
+			KubeConfigExecProvider: &KubeConfigExecProvider{
+				Command:     "nonexistent-kubeconfig-fetcher-binary",
+				InstallHint: "Install it from https://example.com",
+			},
+		},
+	}
+
+	config, err := cluster.RawRestConfig()
+	assert.Nil(t, config)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nonexistent-kubeconfig-fetcher-binary")
+	assert.Contains(t, err.Error(), "Install it from https://example.com")
+}
+
+func TestRawRestConfig_KubeConfigExecProvider_WithEnvVars(t *testing.T) {
+	scriptContent := `#!/bin/sh
+cat > "$1" <<EOF
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://env-test:6443
+  name: env-cluster
+contexts:
+- context:
+    cluster: env-cluster
+    user: env-user
+  name: env-context
+current-context: env-context
+users:
+- name: env-user
+  user:
+    token: ${MY_TEST_TOKEN}
+EOF
+`
+	scriptDir := t.TempDir()
+	scriptPath := filepath.Join(scriptDir, "gen-kubeconfig.sh")
+	err := os.WriteFile(scriptPath, []byte(scriptContent), 0o755)
+	require.NoError(t, err)
+
+	cluster := Cluster{
+		Server: "https://argocd-server:6443",
+		Config: ClusterConfig{
+			KubeConfigExecProvider: &KubeConfigExecProvider{
+				Command: scriptPath,
+				Env:     map[string]string{"MY_TEST_TOKEN": "env-token-value"},
+			},
+		},
+	}
+
+	config, err := cluster.RawRestConfig()
+	require.NoError(t, err)
+
+	assert.Equal(t, "https://argocd-server:6443", config.Host)
+	assert.Equal(t, "env-token-value", config.BearerToken)
+}
+
+func TestRawRestConfig_KubeConfigExecProvider_PrecedenceOverExecProvider(t *testing.T) {
+	kubeconfig := clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"test-cluster": {Server: "https://kubeconfig-server:6443"},
+		},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"test-user": {Token: "kubeconfig-token"},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			"test-context": {Cluster: "test-cluster", AuthInfo: "test-user"},
+		},
+		CurrentContext: "test-context",
+	}
+	kubeconfigPath := writeTestKubeconfig(t, kubeconfig)
+
+	cluster := Cluster{
+		Server: "https://argocd-server:6443",
+		Config: ClusterConfig{
+			KubeConfigExecProvider: &KubeConfigExecProvider{
+				Command: "cp",
+				Args:    []string{kubeconfigPath},
+			},
+			ExecProviderConfig: &ExecProviderConfig{
+				Command: "some-other-exec",
+				Args:    []string{"get-token"},
+			},
+		},
+	}
+
+	config, err := cluster.RawRestConfig()
+	require.NoError(t, err)
+
+	assert.Equal(t, "https://argocd-server:6443", config.Host)
+	assert.Equal(t, "kubeconfig-token", config.BearerToken)
+	assert.Nil(t, config.ExecProvider)
 }
 
 func TestAppProject_IsNegatedDestinationPermitted(t *testing.T) {


### PR DESCRIPTION
Add support for a new cluster authentication method that executes an external command to produce a full kubeconfig file dynamically. Unlike ExecProviderConfig which only produces credentials, this provider generates an entire kubeconfig (server, CA, auth) that ArgoCD reads to build a REST config.

Key changes:
- New KubeConfigExecProvider type in ClusterConfig
- SetConfigProvider option in gitops-engine cluster cache for dynamic config refresh on each sync cycle
- Unit tests for new functionality

Closes #26729

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
