### PR TITLE
fix(gitops-engine): fix nil pointer dereference error in removeWebookMutation()

### DIFF
--- a/gitops-engine/pkg/diff/diff.go
+++ b/gitops-engine/pkg/diff/diff.go
@@ -288,13 +288,13 @@ func removeWebhookMutation(predictedLive, live *unstructured.Unstructured, gvkPa
 	// Apply the predicted live state to the live state to get a diff without mutation webhook fields
 	typedPredictedLive, err = typedLive.Merge(typedPredictedLive)
 
-	// After applying the predicted live to live state, this would cause any removed fields to be restored.
-	// We need to re-remove these from predicted live.
-	typedPredictedLive = typedPredictedLive.RemoveItems(comparison.Removed)
-
 	if err != nil {
 		return nil, fmt.Errorf("error applying predicted live to live state: %w", err)
 	}
+
+	// After applying the predicted live to live state, this would cause any removed fields to be restored.
+	// We need to re-remove these from predicted live.
+	typedPredictedLive = typedPredictedLive.RemoveItems(comparison.Removed)
 
 	plu := typedPredictedLive.AsValue().Unstructured()
 	pl, ok := plu.(map[string]any)


### PR DESCRIPTION
If `typedLive.Merge(typedPredictedLive)` fails for any reason `typedPredictedLive` becomes `nil`, resulting in an `invalid memory address or nil pointer dereference` error on the next line because `err` was not checked first:

```
Recovered from panic: runtime error: invalid memory address or nil pointer dereference
goroutine 357 [running]:
runtime/debug.Stack()
	/usr/local/go/src/runtime/debug/stack.go:26 +0x5e
github.com/argoproj/argo-cd/v3/controller.(*ApplicationController).processAppRefreshQueueItem.func1()
	/go/src/github.com/argoproj/argo-cd/controller/appcontroller.go:1704 +0x94
panic({0x48ef0c0?, 0x98e27d0?})
	/usr/local/go/src/runtime/panic.go:860 +0x13a
github.com/argoproj/argo-cd/gitops-engine/pkg/diff.removeWebhookMutation(0x211d47b05130, 0x211d7ab72788, 0x211d1dabb900, {0x52b62ea, 0x11})
	/go/src/github.com/argoproj/argo-cd/gitops-engine/pkg/diff/diff.go:283 +0xd39
github.com/argoproj/argo-cd/gitops-engine/pkg/diff.serverSideDiff(0x211d7ab72778, 0x211d7ab72788, {0x211d21caabc8, 0x8, 0x8})
	/go/src/github.com/argoproj/argo-cd/gitops-engine/pkg/diff/diff.go:180 +0x2fd
github.com/argoproj/argo-cd/gitops-engine/pkg/diff.ServerSideDiff(0x211d7ab72788?, 0x211d13ba8480?, {0x211d36512bc8?, 0x10?, 0x63312a0?})
	/go/src/github.com/argoproj/argo-cd/gitops-engine/pkg/diff/diff.go:142 +0x37
github.com/argoproj/argo-cd/gitops-engine/pkg/diff.Diff(0x211d7ab726f8, 0x211d7ab72700, {0x211d36512bc8, 0x8, 0x8})
	/go/src/github.com/argoproj/argo-cd/gitops-engine/pkg/diff/diff.go:94 +0x3bf
github.com/argoproj/argo-cd/gitops-engine/pkg/diff.DiffArray({0x211d2e2c9650, 0x2, 0x211d1028be00?}, {0x211d2e2c9640, 0x2?, 0x58?}, {0x211d21caabc8, 0x8, 0x8})
	/go/src/github.com/argoproj/argo-cd/gitops-engine/pkg/diff/diff.go:856 +0x12c
github.com/argoproj/argo-cd/v3/util/argo/diff.StateDiffs({0x211d2e2c8620?, 0x211d31de2908?, 0x531149d?}, {0x211d2e2c8610?, 0x211d39fd1e30?, 0xc?}, {0x6359548, 0x211d0ce74480})
	/go/src/github.com/argoproj/argo-cd/util/argo/diff/diff.go:334 +0x7bf
github.com/argoproj/argo-cd/v3/controller.(*appStateManager).CompareAppState(0x211d0a438780, 0x211d0de88808, 0x211d388c5d48, {0x211d40052f00, 0x3, 0x4}, {0x211d1edd7800, 0x3, 0x4}, 0x0, ...)
	/go/src/github.com/argoproj/argo-cd/controller/state.go:864 +0x3b65
github.com/argoproj/argo-cd/v3/controller.(*ApplicationController).processAppRefreshQueueItem(0x211d0a242600)
	/go/src/github.com/argoproj/argo-cd/controller/appcontroller.go:1841 +0x1c25
github.com/argoproj/argo-cd/v3/controller.(*ApplicationController).Run.func3()
	/go/src/github.com/argoproj/argo-cd/controller/appcontroller.go:932 +0x25
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1({0x0?, 0x0?})
	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:233 +0x13
k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext.func1({0x631ea30?, 0x211d09aafe30?}, 0x425554?)
	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:255 +0x51
k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext({0x631ea30, 0x211d09aafe30}, 0x211d21cadf50, {0x62cc300, 0x211d12d4a180}, 0x1)
	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:256 +0xe5
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x0?, {0x62cc300?, 0x211d12d4a180?}, 0x0?, 0x0?)
	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:233 +0x46
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x211d12999780, 0x3b9aca00, 0x0, 0x1, 0x211d09aafe30)
	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:210 +0x7f
k8s.io/apimachinery/pkg/util/wait.Until(...)
	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:163
created by github.com/argoproj/argo-cd/v3/controller.(*ApplicationController).Run in goroutine 30
	/go/src/github.com/argoproj/argo-cd/controller/appcontroller.go:931 +0x906
```

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
