### PR TITLE
chore: prevent local dev toolchain conflicts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 COPY hack/install.sh hack/tool-versions.sh ./
 COPY hack/installers installers
 
-RUN ./install.sh helm && \
-    INSTALL_PATH=/usr/local/bin ./install.sh kustomize && \
-    ./install.sh git-lfs
+RUN BIN=/usr/local/bin ./install.sh helm && \
+    BIN=/usr/local/bin ./install.sh kustomize && \
+    BIN=/usr/local/bin ./install.sh git-lfs
 
 ####################################################################################################
 # Argo CD Base - used as the base for both the release and dev argocd images

--- a/Dockerfile.tilt
+++ b/Dockerfile.tilt
@@ -26,9 +26,9 @@ RUN go install github.com/go-delve/delve/cmd/dlv@latest
 COPY hack/install.sh hack/tool-versions.sh ./
 COPY hack/installers installers
 
-RUN ./install.sh helm && \
-    INSTALL_PATH=/usr/local/bin ./install.sh kustomize && \
-    ./install.sh git-lfs
+RUN BIN=/usr/local/bin ./install.sh helm && \
+    BIN=/usr/local/bin ./install.sh kustomize && \
+    BIN=/usr/local/bin ./install.sh git-lfs
 
 COPY hack/gpg-wrapper.sh \
     hack/git-verify-wrapper.sh \

--- a/Makefile
+++ b/Makefile
@@ -409,7 +409,9 @@ lint: test-tools-image
 
 # Run linter on the code (local version)
 .PHONY: lint-local
+lint-local: export PATH := $(PWD)/dist:$(PATH)
 lint-local:
+	which golangci-lint
 	golangci-lint --version
 	golangci-lint run --fix --verbose
 
@@ -641,6 +643,7 @@ install-tools-local: install-test-tools-local install-codegen-tools-local instal
 # Installs all tools required for running unit & end-to-end tests (Linux packages)
 .PHONY: install-test-tools-local
 install-test-tools-local:
+	./hack/install.sh test-go-tools
 	./hack/install.sh kustomize
 	./hack/install.sh helm
 	./hack/install.sh gotestsum

--- a/docs/developer-guide/toolchain-guide.md
+++ b/docs/developer-guide/toolchain-guide.md
@@ -1,13 +1,14 @@
 # Development Toolchain
 
 ## Prerequisites
+
 [Development Environment](development-environment.md)
 
 ## Local vs Virtualized toolchain
 
 Argo CD provides a fully virtualized development and testing toolchain using Docker images. Those images provide the same runtime environment as the final product, and it is much easier to keep up-to-date with changes to the toolchain and dependencies. The virtualized toolchain runs the build and programs inside a Docker container using the test tools image. That makes everything repeatable. The dynamic nature of requirements is another reason to choose this toolchain. This setup may also require configuring the default K8s API URL that comes with installing a local K8s cluster.
 
-The local toolchain results in a faster development and testing cycle. Particularly on macOS where Docker and the Linux kernel run inside a VM, you may want to try developing fully locally. Local toolchain also requires installing additional tools on your machine. This toolchain is a good choice for working with an IDE debugger. 
+The local toolchain results in a faster development and testing cycle. Particularly on macOS where Docker and the Linux kernel run inside a VM, you may want to try developing fully locally. Local toolchain also requires installing additional tools on your machine. This toolchain is a good choice for working with an IDE debugger.
 
 Most relevant targets for the build & test cycles in the `Makefile` provide two variants, one of them suffixed with `-local`. For example, `make test` will run unit tests in the Docker container (virtualized toolchain), `make test-local` (local toolchain) will run it natively on your local system.
 
@@ -15,16 +16,17 @@ Most relevant targets for the build & test cycles in the `Makefile` provide two 
 
 If you are going to use the virtualized toolchain, please bear in mind the following things:
 
-* Your Kubernetes API server must listen on the interface of your local machine or VM, and not on `127.0.0.1` or  `localhost` only.
-* Your Kubernetes client configuration (`~/.kube/config`) must not use an API URL that points to `localhost`, `127.0.0.1` or `0.0.0.0`
+- Your Kubernetes API server must listen on the interface of your local machine or VM, and not on `127.0.0.1` or `localhost` only.
+- Your Kubernetes client configuration (`~/.kube/config`) must not use an API URL that points to `localhost`, `127.0.0.1` or `0.0.0.0`
 
 The Docker container for the virtualized toolchain will use the following local mounts from your workstation, and possibly modify its contents:
 
-* `~/go/src` - Your Go workspace's source directory (modifications expected)
-* `~/.cache/go-build` - Your Go build cache (modifications expected)
-* `~/.kube` - Your Kubernetes client configuration (no modifications)
+- `~/go/src` - Your Go workspace's source directory (modifications expected)
+- `~/.cache/go-build` - Your Go build cache (modifications expected)
+- `~/.kube` - Your Kubernetes client configuration (no modifications)
 
 #### Known issues on macOS
+
 [Known issues](mac-users.md)
 
 #### Docker privileges
@@ -38,16 +40,19 @@ SUDO=sudo make sometarget
 ```
 
 Or you can opt to export this permanently to your environment, for example
+
 ```
 export SUDO=sudo
 ```
 
 #### Using Podman
+
 In order to use podman for running and testing Argo CD locally, set the `DOCKER` environment variable to `podman` before you run `make`, e.g:
 
 ```
 DOCKER=podman make start
 ```
+
 If you have podman installed, you can leverage its rootless mode.
 
 #### Build the required Docker image
@@ -57,41 +62,41 @@ Build the required Docker image by running `make test-tools-image`. This image o
 The `Dockerfile` used to build these images can be found at `test/container/Dockerfile`.
 
 #### Configure your K8s cluster for connection from the build container
+
 ##### K3d
+
 K3d is a minimal Kubernetes distribution, in docker. Because it's running in a docker container, you're dealing with docker's internal networking rules when using k3d. A typical Kubernetes cluster running on your local machine is part of the same network that you're on, so you can access it using **kubectl**. However, a Kubernetes cluster running within a docker container (in this case, the one launched by make) cannot access 0.0.0.0 from inside the container itself, when 0.0.0.0 is a network resource outside the container itself (and/or the container's network). This is the cost of a fully self-contained, disposable Kubernetes cluster.
 
 The configuration you will need for Argo CD virtualized toolchain:
 
 1. For most users, the following command works to find the host IP address.
+   - If you have perl
 
-    * If you have perl
+     ```pl
+     perl -e '
+     use strict;
+     use Socket;
 
-       ```pl
-       perl -e '
-       use strict;
-       use Socket;
+     my $target = sockaddr_in(53, inet_aton("8.8.8.8"));
+     socket(my $s, AF_INET, SOCK_DGRAM, getprotobyname("udp")) or die $!;
+     connect($s, $target) or die $!;
+     my $local_addr = getsockname($s) or die $!;
+     my (undef, $ip) = sockaddr_in($local_addr);
+     print "IP: ", inet_ntoa($ip), "\n";
+     '
+     ```
 
-       my $target = sockaddr_in(53, inet_aton("8.8.8.8"));
-       socket(my $s, AF_INET, SOCK_DGRAM, getprotobyname("udp")) or die $!;
-       connect($s, $target) or die $!;
-       my $local_addr = getsockname($s) or die $!;
-       my (undef, $ip) = sockaddr_in($local_addr);
-       print "IP: ", inet_ntoa($ip), "\n";
-       '
-       ```
+   - If you don't
+     - Try `ip route get 8.8.8.8` on Linux
+     - Try `ifconfig`/`ipconfig` (and pick the ip address that feels right -- look for `192.168.x.x` or `10.x.x.x` addresses)
 
-    * If you don't
+   Note that `8.8.8.8` is Google's Public DNS server, in most places it's likely to be accessible and thus is a good proxy for "which outbound address would my computer use", but you can replace it with a different IP address if necessary.
 
-      * Try `ip route get 8.8.8.8` on Linux
-      * Try `ifconfig`/`ipconfig` (and pick the ip address that feels right -- look for `192.168.x.x` or `10.x.x.x` addresses)
-
-    Note that `8.8.8.8` is Google's Public DNS server, in most places it's likely to be accessible and thus is a good proxy for "which outbound address would my computer use", but you can replace it with a different IP address if necessary.
-
-    Keep in mind that this IP is dynamically assigned by the router so if your router restarts for any reason, your IP might change.
+   Keep in mind that this IP is dynamically assigned by the router so if your router restarts for any reason, your IP might change.
 
 2. Edit your ~/.kube/config and replace 0.0.0.0 with the above IP address, delete the cluster cert and add `insecure-skip-tls-verify: true`
 
-3. Execute a `kubectl version` to make sure you can still connect to the Kubernetes API server via this new IP. 
+3. Execute a `kubectl version` to make sure you can still connect to the Kubernetes API server via this new IP.
 
 ##### Minikube
 
@@ -100,7 +105,6 @@ By default, minikube will create Kubernetes client configuration that uses authe
 #### Test connection from the build container to your K8s cluster
 
 You can test whether the virtualized toolchain has access to your Kubernetes cluster by running `make verify-kube-connect` which will run `kubectl version` inside the Docker container used for running all tests.
-
 
 If you receive an error similar to the following:
 
@@ -129,18 +133,18 @@ Goreman is used to start all needed processes to get a working Argo CD developme
 
 #### Install required dependencies and build-tools
 
-> [!NOTE]
-> The installation instructions are valid for Linux hosts only. Mac instructions will follow shortly.
+For installing the tools required to build and test Argo CD on your local system, we provide convenient installer scripts. By default, they will install binaries to the local `dist/` directory in the project root, which does not require `root` privileges.
 
-For installing the tools required to build and test Argo CD on your local system, we provide convenient installer scripts. By default, they will install binaries to `/usr/local/bin` on your system, which might require `root` privileges.
-
-You can change the target location by setting the `BIN` environment before running the installer scripts. For example, you can install the binaries into `~/go/bin` (which should then be the first component in your `PATH` environment, i.e. `export PATH=~/go/bin:$PATH`):
+You can change the target location by setting the `BIN` environment before running the installer scripts. For example, you can install the binaries into `/usr/local/bin` (system-wide) or `~/go/bin`:
 
 ```shell
+# Install to /usr/local/bin (requires sudo)
+BIN=/usr/local/bin make install-tools-local
+
+# Install to ~/go/bin (add to PATH: export PATH=~/go/bin:$PATH)
 BIN=~/go/bin make install-tools-local
 ```
 
 Additionally, you have to install at least the following tools via your OS's package manager (this list might not be always up-to-date):
 
-* Git LFS plugin
-* GnuPG version 2
+- GnuPG version 2

--- a/hack/Dockerfile.dev-tools
+++ b/hack/Dockerfile.dev-tools
@@ -1,8 +1,8 @@
 FROM argocd-test-tools:latest as base
 
-RUN ./install.sh codegen-tools
-RUN ./install.sh codegen-go-tools
-RUN ./install.sh lint-tools
+RUN BIN=/usr/local/bin ./install.sh codegen-tools
+RUN BIN=/usr/local/bin ./install.sh codegen-go-tools
+RUN BIN=/usr/local/bin ./install.sh lint-tools
 
 RUN mkdir -p /home/user && chmod 777 /home/user
 

--- a/hack/generate-mock.sh
+++ b/hack/generate-mock.sh
@@ -13,6 +13,7 @@ PROJECT_ROOT=$(
 PATH="${PROJECT_ROOT}/dist:${PATH}"
 
 # output tool versions
+which mockery
 mockery version
 
 mockery --config "${PROJECT_ROOT}"/.mockery.yaml

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -2,7 +2,6 @@
 set -eux -o pipefail
 
 export DOWNLOADS=/tmp/dl
-export BIN=${BIN:-/usr/local/bin}
 
 mkdir -p $DOWNLOADS
 

--- a/hack/installers/install-codegen-go-tools.sh
+++ b/hack/installers/install-codegen-go-tools.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eux -o pipefail
 
-SRCROOT="$( CDPATH='' cd -- "$(dirname "$0")/../.." && pwd -P )"
+PROJECT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)
 
 # This script installs all our golang-based codegen utility CLIs necessary for codegen.
 # Some dependencies are vendored in go.mod (ones which are actually imported in our codebase).
@@ -18,7 +18,7 @@ go_mod_install() {
 }
 
 # All binaries are compiled into the argo-cd/dist directory, which is added to the PATH during codegen
-export GOBIN="${SRCROOT}/dist"
+export GOBIN="${PROJECT_ROOT}/dist"
 mkdir -p "$GOBIN"
 
 # protoc-gen-go* is used to generate <service>.pb.go from .proto files

--- a/hack/installers/install-git-lfs.sh
+++ b/hack/installers/install-git-lfs.sh
@@ -5,6 +5,7 @@ set -eux -o pipefail
 
 PROJECT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)
 INSTALL_PATH="${BIN:-$PROJECT_ROOT/dist}"
+[ -d "$INSTALL_PATH" ] || mkdir -p "$INSTALL_PATH"
 
 export TARGET_FILE=git-lfs-${INSTALL_OS}-${ARCHITECTURE}-v${git_lfs_version}.tar.gz
 

--- a/hack/installers/install-git-lfs.sh
+++ b/hack/installers/install-git-lfs.sh
@@ -3,10 +3,17 @@ set -eux -o pipefail
 
 . "$(dirname "$0")"/../tool-versions.sh
 
+PROJECT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)
+INSTALL_PATH="${BIN:-$PROJECT_ROOT/dist}"
+
 export TARGET_FILE=git-lfs-${INSTALL_OS}-${ARCHITECTURE}-v${git_lfs_version}.tar.gz
 
 [ -e "$DOWNLOADS/${TARGET_FILE}" ] || curl -sLf --retry 3 -o "$DOWNLOADS/${TARGET_FILE}" "https://github.com/git-lfs/git-lfs/releases/download/v${git_lfs_version}/${TARGET_FILE}"
 "$(dirname "$0")"/compare-chksum.sh
 mkdir -p /tmp/git-lfs && tar -C /tmp/git-lfs --strip-components=1 -xzf "$DOWNLOADS/${TARGET_FILE}"
-sudo install -m 0755 "/tmp/git-lfs/git-lfs" "$BIN/git-lfs"
+if [ -w "$INSTALL_PATH" ]; then
+  install -m 0755 "/tmp/git-lfs/git-lfs" "$INSTALL_PATH/git-lfs"
+else
+  sudo install -m 0755 "/tmp/git-lfs/git-lfs" "$INSTALL_PATH/git-lfs"
+fi
 git-lfs version

--- a/hack/installers/install-gotestsum.sh
+++ b/hack/installers/install-gotestsum.sh
@@ -4,8 +4,7 @@ set -eux -o pipefail
 # Code from: https://github.com/argoproj/argo-rollouts/blob/f650a1fd0ba7beb2125e1598410515edd572776f/hack/installers/install-dev-tools.sh
 
 PROJECT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")"/../..; pwd)
-INSTALL_PATH="${BIN:-$INSTALL_PATH}"
-INSTALL_PATH="${INSTALL_PATH:-$PROJECT_ROOT/dist}"
+INSTALL_PATH="${BIN:-$PROJECT_ROOT/dist}"
 PATH="${INSTALL_PATH}:${PATH}"
 [ -d "$INSTALL_PATH" ] || mkdir -p "$INSTALL_PATH"
 
@@ -22,6 +21,11 @@ url="https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_
 
 mkdir -p /tmp/gotestsum-${GOTESTSUM_VERSION}
 tar -xvzf "${temp_path}" -C /tmp/gotestsum-${GOTESTSUM_VERSION}
-sudo cp /tmp/gotestsum-${GOTESTSUM_VERSION}/gotestsum "${INSTALL_PATH}/gotestsum"
-sudo chmod +x "${INSTALL_PATH}/gotestsum"
+if [ -w "$INSTALL_PATH" ]; then
+  cp /tmp/gotestsum-${GOTESTSUM_VERSION}/gotestsum "${INSTALL_PATH}/gotestsum"
+  chmod +x "${INSTALL_PATH}/gotestsum"
+else
+  sudo cp /tmp/gotestsum-${GOTESTSUM_VERSION}/gotestsum "${INSTALL_PATH}/gotestsum"
+  sudo chmod +x "${INSTALL_PATH}/gotestsum"
+fi
 gotestsum --version

--- a/hack/installers/install-helm.sh
+++ b/hack/installers/install-helm.sh
@@ -3,10 +3,17 @@ set -eux -o pipefail
 
 . "$(dirname "$0")"/../tool-versions.sh
 
+PROJECT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)
+INSTALL_PATH="${BIN:-$PROJECT_ROOT/dist}"
+
 export TARGET_FILE=helm-v${helm3_version}-${INSTALL_OS}-${ARCHITECTURE}.tar.gz
 
 [ -e "$DOWNLOADS/${TARGET_FILE}" ] || curl -sLf --retry 3 -o "$DOWNLOADS/${TARGET_FILE}" "https://get.helm.sh/helm-v${helm3_version}-$INSTALL_OS-$ARCHITECTURE.tar.gz"
 "$(dirname "$0")"/compare-chksum.sh
 mkdir -p /tmp/helm && tar -C /tmp/helm -xf "$DOWNLOADS/${TARGET_FILE}"
-sudo install -m 0755 "/tmp/helm/$INSTALL_OS-$ARCHITECTURE/helm" "$BIN/helm"
+if [ -w "$INSTALL_PATH" ]; then
+  install -m 0755 "/tmp/helm/$INSTALL_OS-$ARCHITECTURE/helm" "$INSTALL_PATH/helm"
+else
+  sudo install -m 0755 "/tmp/helm/$INSTALL_OS-$ARCHITECTURE/helm" "$INSTALL_PATH/helm"
+fi
 helm version

--- a/hack/installers/install-helm.sh
+++ b/hack/installers/install-helm.sh
@@ -5,6 +5,7 @@ set -eux -o pipefail
 
 PROJECT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)
 INSTALL_PATH="${BIN:-$PROJECT_ROOT/dist}"
+[ -d "$INSTALL_PATH" ] || mkdir -p "$INSTALL_PATH"
 
 export TARGET_FILE=helm-v${helm3_version}-${INSTALL_OS}-${ARCHITECTURE}.tar.gz
 

--- a/hack/installers/install-kustomize.sh
+++ b/hack/installers/install-kustomize.sh
@@ -6,8 +6,7 @@ INSTALLERS=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)
 
 . "$INSTALLERS/../tool-versions.sh"
 
-INSTALL_PATH="${BIN:-$INSTALL_PATH}"
-INSTALL_PATH="${INSTALL_PATH:-$PROJECT_ROOT/dist}"
+INSTALL_PATH="${BIN:-$PROJECT_ROOT/dist}"
 PATH="${INSTALL_PATH}:${PATH}"
 [ -d "$INSTALL_PATH" ] || mkdir -p "$INSTALL_PATH"
 
@@ -32,7 +31,11 @@ case $ARCHITECTURE in
       [ -e "${DOWNLOADS}/${TARGET_FILE}" ] || curl -sLf --retry 3 -o "${DOWNLOADS}/${TARGET_FILE}" "$URL"
       "$INSTALLERS/compare-chksum.sh"
       tar -C /tmp -xf "${DOWNLOADS}/${TARGET_FILE}"
-      sudo install -m 0755 /tmp/kustomize "$INSTALL_PATH/$BINNAME"
+      if [ -w "$INSTALL_PATH" ]; then
+        install -m 0755 /tmp/kustomize "$INSTALL_PATH/$BINNAME"
+      else
+        sudo install -m 0755 /tmp/kustomize "$INSTALL_PATH/$BINNAME"
+      fi
       ;;
   *)
     case $KUSTOMIZE_VERSION in
@@ -42,7 +45,11 @@ case $ARCHITECTURE in
         BINNAME=kustomize2
         [ -e "${DOWNLOADS}/${TARGET_FILE}" ] || curl -sLf --retry 3 -o "${DOWNLOADS}/${TARGET_FILE}" "$URL"
         "$INSTALLERS/compare-chksum.sh"
-        sudo install -m 0755 "${DOWNLOADS}/${TARGET_FILE}" "$INSTALL_PATH/$BINNAME"
+        if [ -w "$INSTALL_PATH" ]; then
+          install -m 0755 "${DOWNLOADS}/${TARGET_FILE}" "$INSTALL_PATH/$BINNAME"
+        else
+          sudo install -m 0755 "${DOWNLOADS}/${TARGET_FILE}" "$INSTALL_PATH/$BINNAME"
+        fi
         ;;
       *)
         export TARGET_FILE=kustomize_${KUSTOMIZE_VERSION}_${INSTALL_OS}_${ARCHITECTURE}.tar.gz
@@ -51,7 +58,11 @@ case $ARCHITECTURE in
         [ -e "${DOWNLOADS}/${TARGET_FILE}" ] || curl -sLf --retry 3 -o "${DOWNLOADS}/${TARGET_FILE}" "$URL"
         "$INSTALLERS/compare-chksum.sh"
         tar -C /tmp -xf "${DOWNLOADS}/${TARGET_FILE}"
-        sudo install -m 0755 /tmp/kustomize "$INSTALL_PATH/$BINNAME"
+        if [ -w "$INSTALL_PATH" ]; then
+          install -m 0755 /tmp/kustomize "$INSTALL_PATH/$BINNAME"
+        else
+          sudo install -m 0755 /tmp/kustomize "$INSTALL_PATH/$BINNAME"
+        fi
         ;;
     esac
     ;;

--- a/hack/installers/install-lint-tools.sh
+++ b/hack/installers/install-lint-tools.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -eux -o pipefail
 
+PROJECT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)
+
+# All binaries are compiled into the argo-cd/dist directory, which is added to the PATH during codegen
+export GOBIN="${PROJECT_ROOT}/dist"
+mkdir -p "$GOBIN"
+
 # renovate: datasource=go packageName=github.com/golangci/golangci-lint/v2
 GOLANGCI_LINT_VERSION=2.11.4
 

--- a/hack/installers/install-oras.sh
+++ b/hack/installers/install-oras.sh
@@ -3,10 +3,8 @@ set -eux -o pipefail
 
 . "$(dirname "$0")"/../tool-versions.sh
 
-# shellcheck disable=SC2046
-# shellcheck disable=SC2128
-PROJECT_ROOT=$(cd $(dirname "${BASH_SOURCE}")/../..; pwd)
-INSTALL_PATH="${INSTALL_PATH:-$PROJECT_ROOT/dist}"
+PROJECT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)
+INSTALL_PATH="${BIN:-$PROJECT_ROOT/dist}"
 PATH="${INSTALL_PATH}:${PATH}"
 [ -d "$INSTALL_PATH" ] || mkdir -p "$INSTALL_PATH"
 
@@ -17,4 +15,8 @@ export TARGET_FILE=oras_${oras_version}_${INSTALL_OS}_${ARCHITECTURE}.tar.gz
 "$(dirname "$0")"/compare-chksum.sh
 
 tar -C /tmp -xf "${DOWNLOADS}"/"${TARGET_FILE}"
-sudo install -m 0755 /tmp/oras "$INSTALL_PATH"/oras
+if [ -w "$INSTALL_PATH" ]; then
+  install -m 0755 /tmp/oras "$INSTALL_PATH"/oras
+else
+  sudo install -m 0755 /tmp/oras "$INSTALL_PATH"/oras
+fi

--- a/hack/installers/install-protoc.sh
+++ b/hack/installers/install-protoc.sh
@@ -41,7 +41,7 @@ url="https://github.com/protocolbuffers/protobuf/releases/download/v${protoc_ver
 mkdir -p "/tmp/protoc-${protoc_version}"
 unzip -o "$DOWNLOADS/${TARGET_FILE}" -d "/tmp/protoc-${protoc_version}"
 mkdir -p "${DIST_PATH}/protoc-include"
-sudo install -m 0755 "/tmp/protoc-${protoc_version}/bin/protoc" "${DIST_PATH}/protoc"
+install -m 0755 "/tmp/protoc-${protoc_version}/bin/protoc" "${DIST_PATH}/protoc"
 (
     cd "/tmp/protoc-${protoc_version}/include/"
     find -- * -type d -exec install -m 0755 -d "${DIST_PATH}/protoc-include/{}" \;

--- a/hack/installers/install-protoc.sh
+++ b/hack/installers/install-protoc.sh
@@ -4,6 +4,7 @@ set -eux -o pipefail
 PROJECT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")"/../..; pwd)
 DIST_PATH="${PROJECT_ROOT}/dist"
 PATH="${DIST_PATH}:${PATH}"
+[ -d "$DIST_PATH" ] || mkdir -p "$DIST_PATH"
 
 . "$(dirname "$0")"/../tool-versions.sh
 

--- a/hack/installers/install-test-go-tools.sh
+++ b/hack/installers/install-test-go-tools.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -eux -o pipefail
+
+PROJECT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)
+
+
+# All binaries are compiled into the argo-cd/dist directory
+export GOBIN="${PROJECT_ROOT}/dist"
+mkdir -p "$GOBIN"
+
+# renovate: datasource=go packageName=github.com/jstemmer/go-junit-report/v2
+JUNIT_REPORT_VERSION=2.1.0
+go install github.com/jstemmer/go-junit-report/v2@v${JUNIT_REPORT_VERSION}

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -1,15 +1,11 @@
 #!/bin/bash
 set -eux -o pipefail
 
-# check for local installation of go-junit-report otherwise install locally
-which go-junit-report || go install github.com/jstemmer/go-junit-report@latest
-
-# check for local installation of gotestsum otherwise install locally
-which gotestsum || go install gotest.tools/gotestsum@latest
+PROJECT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)
 
 TEST_RESULTS=${TEST_RESULTS:-test-results}
 TEST_FLAGS=${TEST_FLAGS:-}
-DIST_DIR=${DIST_DIR:-dist}
+DIST_DIR=${DIST_DIR:-$PROJECT_ROOT/dist}
 
 # Add DIST_DIR to PATH so binaries installed for argo are found first
 export PATH="${DIST_DIR}:${PATH}"

--- a/hack/update-manifests.sh
+++ b/hack/update-manifests.sh
@@ -4,13 +4,13 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-SRCROOT="$( CDPATH='' cd -- "$(dirname "$0")/.." && pwd -P )"
+PROJECT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)
 AUTOGENMSG="# This is an auto-generated file. DO NOT EDIT"
 
-KUSTOMIZE=kustomize
-[ -f "$SRCROOT/dist/kustomize" ] && KUSTOMIZE="$SRCROOT/dist/kustomize"
+# Add DIST_DIR to PATH so binaries installed for argo are found first
+export PATH="${PROJECT_ROOT}/dist:${PATH}"
 
-cd "${SRCROOT}/manifests/ha/base/redis-ha" && ./generate.sh
+cd "${PROJECT_ROOT}/manifests/ha/base/redis-ha" && ./generate.sh
 
 # Empty defaults - to avoid errors for unset env. variables
 IMAGE_REGISTRY="${IMAGE_REGISTRY:-}"
@@ -56,7 +56,7 @@ detect_current_image() {
 }
 
 # Determine source image (what to replace)
-DETECTED_IMAGE=$(detect_current_image "${SRCROOT}/manifests/base/kustomization.yaml")
+DETECTED_IMAGE=$(detect_current_image "${PROJECT_ROOT}/manifests/base/kustomization.yaml")
 if [ -n "$DETECTED_IMAGE" ] && [ "$DETECTED_IMAGE" != "quay.io/argoproj/argocd" ]; then
   # Found a custom image in manifests (subsequent release scenario)
   SOURCE_IMAGE_NAME="$DETECTED_IMAGE"
@@ -76,7 +76,7 @@ if [ "$IMAGE_TAG" = "" ]; then
   fi
   if [[ $branch = release-* ]]; then
     pwd
-    IMAGE_TAG=v$(cat "$SRCROOT/VERSION")
+    IMAGE_TAG=v$(cat "$PROJECT_ROOT/VERSION")
   fi
 fi
 # otherwise, use latest
@@ -84,8 +84,9 @@ if [ "$IMAGE_TAG" = "" ]; then
   IMAGE_TAG=latest
 fi
 
+KUSTOMIZE="kustomize"
 $KUSTOMIZE version
-which "$KUSTOMIZE"
+which $KUSTOMIZE
 
 echo "=== Manifest Generation Configuration ==="
 echo "Source image (to replace): ${SOURCE_IMAGE_NAME}"
@@ -97,43 +98,43 @@ else
 fi
 echo "========================================"
 
-cd "${SRCROOT}/manifests/base" && $KUSTOMIZE edit set image "${SOURCE_IMAGE_NAME}=${FULL_IMAGE_NAME}:${IMAGE_TAG}"
-cd "${SRCROOT}/manifests/ha/base" && $KUSTOMIZE edit set image "${SOURCE_IMAGE_NAME}=${FULL_IMAGE_NAME}:${IMAGE_TAG}"
-cd "${SRCROOT}/manifests/core-install" && $KUSTOMIZE edit set image "${SOURCE_IMAGE_NAME}=${FULL_IMAGE_NAME}:${IMAGE_TAG}"
+cd "${PROJECT_ROOT}/manifests/base" && $KUSTOMIZE edit set image "${SOURCE_IMAGE_NAME}=${FULL_IMAGE_NAME}:${IMAGE_TAG}"
+cd "${PROJECT_ROOT}/manifests/ha/base" && $KUSTOMIZE edit set image "${SOURCE_IMAGE_NAME}=${FULL_IMAGE_NAME}:${IMAGE_TAG}"
+cd "${PROJECT_ROOT}/manifests/core-install" && $KUSTOMIZE edit set image "${SOURCE_IMAGE_NAME}=${FULL_IMAGE_NAME}:${IMAGE_TAG}"
 
 # Because commit-server is added as a resource outside the base, we have to explicitly set the image override here.
 # If/when commit-server is added to the base, this can be removed.
-cd "${SRCROOT}/manifests/base/commit-server" && $KUSTOMIZE edit set image "${SOURCE_IMAGE_NAME}=${FULL_IMAGE_NAME}:${IMAGE_TAG}"
+cd "${PROJECT_ROOT}/manifests/base/commit-server" && $KUSTOMIZE edit set image "${SOURCE_IMAGE_NAME}=${FULL_IMAGE_NAME}:${IMAGE_TAG}"
 
-echo "${AUTOGENMSG}" > "${SRCROOT}/manifests/install.yaml"
-$KUSTOMIZE build "${SRCROOT}/manifests/cluster-install" >> "${SRCROOT}/manifests/install.yaml"
+echo "${AUTOGENMSG}" > "${PROJECT_ROOT}/manifests/install.yaml"
+$KUSTOMIZE build "${PROJECT_ROOT}/manifests/cluster-install" >> "${PROJECT_ROOT}/manifests/install.yaml"
 
-echo "${AUTOGENMSG}" > "${SRCROOT}/manifests/namespace-install.yaml"
-$KUSTOMIZE build "${SRCROOT}/manifests/namespace-install" >> "${SRCROOT}/manifests/namespace-install.yaml"
+echo "${AUTOGENMSG}" > "${PROJECT_ROOT}/manifests/namespace-install.yaml"
+$KUSTOMIZE build "${PROJECT_ROOT}/manifests/namespace-install" >> "${PROJECT_ROOT}/manifests/namespace-install.yaml"
 
-echo "${AUTOGENMSG}" > "${SRCROOT}/manifests/ha/install.yaml"
-$KUSTOMIZE build "${SRCROOT}/manifests/ha/cluster-install" >> "${SRCROOT}/manifests/ha/install.yaml"
+echo "${AUTOGENMSG}" > "${PROJECT_ROOT}/manifests/ha/install.yaml"
+$KUSTOMIZE build "${PROJECT_ROOT}/manifests/ha/cluster-install" >> "${PROJECT_ROOT}/manifests/ha/install.yaml"
 
-echo "${AUTOGENMSG}" > "${SRCROOT}/manifests/ha/namespace-install.yaml"
-$KUSTOMIZE build "${SRCROOT}/manifests/ha/namespace-install" >> "${SRCROOT}/manifests/ha/namespace-install.yaml"
+echo "${AUTOGENMSG}" > "${PROJECT_ROOT}/manifests/ha/namespace-install.yaml"
+$KUSTOMIZE build "${PROJECT_ROOT}/manifests/ha/namespace-install" >> "${PROJECT_ROOT}/manifests/ha/namespace-install.yaml"
 
-echo "${AUTOGENMSG}" > "${SRCROOT}/manifests/core-install.yaml"
-$KUSTOMIZE build "${SRCROOT}/manifests/core-install" >> "${SRCROOT}/manifests/core-install.yaml"
+echo "${AUTOGENMSG}" > "${PROJECT_ROOT}/manifests/core-install.yaml"
+$KUSTOMIZE build "${PROJECT_ROOT}/manifests/core-install" >> "${PROJECT_ROOT}/manifests/core-install.yaml"
 
 # Copies enabling manifest hydrator. These can be removed once the manifest hydrator is either removed or enabled by
 # default.
 
-echo "${AUTOGENMSG}" > "${SRCROOT}/manifests/install-with-hydrator.yaml"
-$KUSTOMIZE build "${SRCROOT}/manifests/cluster-install-with-hydrator" >> "${SRCROOT}/manifests/install-with-hydrator.yaml"
+echo "${AUTOGENMSG}" > "${PROJECT_ROOT}/manifests/install-with-hydrator.yaml"
+$KUSTOMIZE build "${PROJECT_ROOT}/manifests/cluster-install-with-hydrator" >> "${PROJECT_ROOT}/manifests/install-with-hydrator.yaml"
 
-echo "${AUTOGENMSG}" > "${SRCROOT}/manifests/namespace-install-with-hydrator.yaml"
-$KUSTOMIZE build "${SRCROOT}/manifests/namespace-install-with-hydrator" >> "${SRCROOT}/manifests/namespace-install-with-hydrator.yaml"
+echo "${AUTOGENMSG}" > "${PROJECT_ROOT}/manifests/namespace-install-with-hydrator.yaml"
+$KUSTOMIZE build "${PROJECT_ROOT}/manifests/namespace-install-with-hydrator" >> "${PROJECT_ROOT}/manifests/namespace-install-with-hydrator.yaml"
 
-echo "${AUTOGENMSG}" > "${SRCROOT}/manifests/ha/install-with-hydrator.yaml"
-$KUSTOMIZE build "${SRCROOT}/manifests/ha/cluster-install-with-hydrator" >> "${SRCROOT}/manifests/ha/install-with-hydrator.yaml"
+echo "${AUTOGENMSG}" > "${PROJECT_ROOT}/manifests/ha/install-with-hydrator.yaml"
+$KUSTOMIZE build "${PROJECT_ROOT}/manifests/ha/cluster-install-with-hydrator" >> "${PROJECT_ROOT}/manifests/ha/install-with-hydrator.yaml"
 
-echo "${AUTOGENMSG}" > "${SRCROOT}/manifests/ha/namespace-install-with-hydrator.yaml"
-$KUSTOMIZE build "${SRCROOT}/manifests/ha/namespace-install-with-hydrator" >> "${SRCROOT}/manifests/ha/namespace-install-with-hydrator.yaml"
+echo "${AUTOGENMSG}" > "${PROJECT_ROOT}/manifests/ha/namespace-install-with-hydrator.yaml"
+$KUSTOMIZE build "${PROJECT_ROOT}/manifests/ha/namespace-install-with-hydrator" >> "${PROJECT_ROOT}/manifests/ha/namespace-install-with-hydrator.yaml"
 
-echo "${AUTOGENMSG}" > "${SRCROOT}/manifests/core-install-with-hydrator.yaml"
-$KUSTOMIZE build "${SRCROOT}/manifests/core-install-with-hydrator" >> "${SRCROOT}/manifests/core-install-with-hydrator.yaml"
+echo "${AUTOGENMSG}" > "${PROJECT_ROOT}/manifests/core-install-with-hydrator.yaml"
+$KUSTOMIZE build "${PROJECT_ROOT}/manifests/core-install-with-hydrator" >> "${PROJECT_ROOT}/manifests/core-install-with-hydrator.yaml"

--- a/test/container/Dockerfile
+++ b/test/container/Dockerfile
@@ -40,7 +40,7 @@ RUN  apt-get update && apt-get install --fix-missing --no-install-recommends -y 
     unzip \
     zip && \
     if [ "$(uname -m)" = "aarch64" ]; then \
-       apt-get install --fix-missing -y binutils-gold; \
+    apt-get install --fix-missing -y binutils-gold; \
     fi && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -64,16 +64,16 @@ COPY hack/install.sh hack/tool-versions.sh go.* ./
 COPY hack/installers installers
 COPY gitops-engine/go.* ./gitops-engine/
 
-RUN ./install.sh helm && \
-    ./install.sh kustomize && \
-    ./install.sh codegen-tools && \
-    ./install.sh codegen-go-tools && \
-    ./install.sh lint-tools && \
-    ./install.sh gotestsum && \
-    ./install.sh git-lfs && \
+RUN BIN=/usr/local/bin ./install.sh helm && \
+    BIN=/usr/local/bin ./install.sh kustomize && \
+    BIN=/usr/local/bin ./install.sh codegen-tools && \
+    BIN=/usr/local/bin ./install.sh codegen-go-tools && \
+    BIN=/usr/local/bin ./install.sh lint-tools && \
+    BIN=/usr/local/bin ./install.sh test-go-tools && \
+    BIN=/usr/local/bin ./install.sh gotestsum && \
+    BIN=/usr/local/bin ./install.sh git-lfs && \
     go install github.com/mattn/goreman@latest && \
     go install github.com/kisielk/godepgraph@latest && \
-    go install github.com/jstemmer/go-junit-report@latest && \
     rm -rf /tmp/dl && \
     rm -rf /tmp/helm && \
     rm -rf /tmp/ks_*


### PR DESCRIPTION
Make sure all tools are installed in the dist/ folder on dev environment so it does not conflict with the user bin folder. 
Explicitly specify bin for container installation
Make sudo unnecessary for local env setup (since we install everything in dist and it doesnt require sudo)

