### PR TITLE
fix: add deprecation notice to SourceType field in ApplicationStatus

### DIFF
--- a/assets/swagger.json
+++ b/assets/swagger.json
@@ -8002,7 +8002,7 @@
         },
         "sourceType": {
           "type": "string",
-          "title": "SourceType specifies the type of this application"
+          "title": "SourceType specifies the type of this application. Deprecated: Use SourceTypes instead, which supports both single and multi-source applications"
         },
         "sourceTypes": {
           "type": "array",

--- a/pkg/apis/application/v1alpha1/generated.proto
+++ b/pkg/apis/application/v1alpha1/generated.proto
@@ -740,6 +740,8 @@ message ApplicationStatus {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time observedAt = 8;
 
   // SourceType specifies the type of this application
+  //
+  // Deprecated: Use SourceTypes instead, which supports both single and multi-source applications
   optional string sourceType = 9;
 
   // Summary contains a list of URLs and container images used by this application

--- a/pkg/apis/application/v1alpha1/openapi_generated.go
+++ b/pkg/apis/application/v1alpha1/openapi_generated.go
@@ -2421,7 +2421,7 @@ func schema_pkg_apis_application_v1alpha1_ApplicationStatus(ref common.Reference
 					},
 					"sourceType": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SourceType specifies the type of this application",
+							Description: "SourceType specifies the type of this application. Deprecated: Use SourceTypes instead, which supports both single and multi-source applications",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -1213,6 +1213,8 @@ type ApplicationStatus struct {
 	// Deprecated: controller no longer updates ObservedAt field
 	ObservedAt *metav1.Time `json:"observedAt,omitempty" protobuf:"bytes,8,opt,name=observedAt"`
 	// SourceType specifies the type of this application
+	//
+	// Deprecated: Use SourceTypes instead, which supports both single and multi-source applications
 	SourceType ApplicationSourceType `json:"sourceType,omitempty" protobuf:"bytes,9,opt,name=sourceType"`
 	// Summary contains a list of URLs and container images used by this application
 	Summary ApplicationSummary `json:"summary,omitempty" protobuf:"bytes,10,opt,name=summary"`


### PR DESCRIPTION
## Summary

Adds a deprecation comment to the `SourceType` field in `ApplicationStatus`, pointing users and tooling authors to use `SourceTypes` instead.

## Problem

Both `status.sourceType` (singular string) and `status.sourceTypes` (plural array) exist in the Application CRD with no guidance on which to use. This causes confusion for tooling developers — for example, argocd-image-updater breaks on multi-source apps because it reads `sourceType` (singular) and finds it empty, while `sourceTypes` (plural) contains the actual data.

Fixes #27766

## Fix

Added a deprecation comment to `SourceType` in `types.go`, consistent with how `ObservedAt` deprecation is already documented in the same struct.

## Checklist
* [x] This is a bug fix
* [x] The title of the PR states what changed and the related issues number
* [x] I've included "Fixes #27766" in the description
* [ ] I've updated both the CLI and UI to expose my feature — N/A (comment-only change)
* [ ] Does this PR require documentation updates? No
* [x] I have signed off all my commits as required by DCO
* [x] I have written unit and/or e2e tests — existing tests pass, no logic changed
* [x] I have added a brief description of why this PR is necessary