### PR TITLE
test: add t.Parallel() to util collections, io, rand, security tests (#27423)

### DIFF
--- a/util/collections/maps_test.go
+++ b/util/collections/maps_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestMergeStringMaps(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		args []map[string]string
@@ -59,6 +60,7 @@ func TestMergeStringMaps(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			assert.Equalf(t, tt.want, Merge(tt.args...), "Merge[string, string](%v)", tt.args)
 		})
 	}

--- a/util/io/bytereadseeker_test.go
+++ b/util/io/bytereadseeker_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestByteReadSeeker_Read(t *testing.T) {
+	t.Parallel()
 	inString := "hello world"
 	reader := NewByteReadSeeker([]byte(inString))
 	bytes := make([]byte, 11)
@@ -21,6 +22,7 @@ func TestByteReadSeeker_Read(t *testing.T) {
 }
 
 func TestByteReadSeeker_Seek_Start(t *testing.T) {
+	t.Parallel()
 	inString := "hello world"
 	reader := NewByteReadSeeker([]byte(inString))
 	offset, err := reader.Seek(6, io.SeekStart)
@@ -34,6 +36,7 @@ func TestByteReadSeeker_Seek_Start(t *testing.T) {
 }
 
 func TestByteReadSeeker_Seek_Current(t *testing.T) {
+	t.Parallel()
 	inString := "hello world"
 	reader := NewByteReadSeeker([]byte(inString))
 	offset, err := reader.Seek(3, io.SeekCurrent)
@@ -50,6 +53,7 @@ func TestByteReadSeeker_Seek_Current(t *testing.T) {
 }
 
 func TestByteReadSeeker_Seek_End(t *testing.T) {
+	t.Parallel()
 	inString := "hello world"
 	reader := NewByteReadSeeker([]byte(inString))
 	offset, err := reader.Seek(-5, io.SeekEnd)
@@ -63,6 +67,7 @@ func TestByteReadSeeker_Seek_End(t *testing.T) {
 }
 
 func TestByteReadSeeker_Seek_OutOfBounds(t *testing.T) {
+	t.Parallel()
 	inString := "hello world"
 	reader := NewByteReadSeeker([]byte(inString))
 	_, err := reader.Seek(12, io.SeekStart)

--- a/util/io/path/resolved_test.go
+++ b/util/io/path/resolved_test.go
@@ -10,31 +10,37 @@ import (
 )
 
 func Test_resolveSymlinkRecursive(t *testing.T) {
+	t.Parallel()
 	testsDir, err := filepath.Abs("./testdata")
 	if err != nil {
 		panic(err)
 	}
 	t.Run("Resolve non-symlink", func(t *testing.T) {
+		t.Parallel()
 		r, err := resolveSymbolicLinkRecursive(testsDir+"/foo", 2)
 		require.NoError(t, err)
 		assert.Equal(t, testsDir+"/foo", r)
 	})
 	t.Run("Successfully resolve symlink", func(t *testing.T) {
+		t.Parallel()
 		r, err := resolveSymbolicLinkRecursive(testsDir+"/bar", 2)
 		require.NoError(t, err)
 		assert.Equal(t, testsDir+"/foo", r)
 	})
 	t.Run("Do not allow symlink at all", func(t *testing.T) {
+		t.Parallel()
 		r, err := resolveSymbolicLinkRecursive(testsDir+"/bar", 0)
 		require.Error(t, err)
 		assert.Empty(t, r)
 	})
 	t.Run("Error because too nested symlink", func(t *testing.T) {
+		t.Parallel()
 		r, err := resolveSymbolicLinkRecursive(testsDir+"/bam", 2)
 		require.Error(t, err)
 		assert.Empty(t, r)
 	})
 	t.Run("No such file or directory", func(t *testing.T) {
+		t.Parallel()
 		r, err := resolveSymbolicLinkRecursive(testsDir+"/foobar", 2)
 		require.NoError(t, err)
 		assert.Equal(t, testsDir+"/foobar", r)
@@ -42,6 +48,7 @@ func Test_resolveSymlinkRecursive(t *testing.T) {
 }
 
 func Test_isURLSchemeAllowed(t *testing.T) {
+	t.Parallel()
 	type testdata struct {
 		name     string
 		scheme   string
@@ -88,6 +95,7 @@ func Test_isURLSchemeAllowed(t *testing.T) {
 	}
 	for _, tt := range tts {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			r := isURLSchemeAllowed(tt.scheme, tt.allowed)
 			assert.Equal(t, tt.expected, r)
 		})
@@ -97,25 +105,30 @@ func Test_isURLSchemeAllowed(t *testing.T) {
 var allowedRemoteProtocols = []string{"http", "https"}
 
 func Test_resolveFilePath(t *testing.T) {
+	t.Parallel()
 	t.Run("Resolve normal relative path into absolute path", func(t *testing.T) {
+		t.Parallel()
 		p, remote, err := ResolveValueFilePathOrUrl("/foo/bar", "/foo", "baz/bim.yaml", allowedRemoteProtocols)
 		require.NoError(t, err)
 		assert.False(t, remote)
 		assert.Equal(t, "/foo/bar/baz/bim.yaml", string(p))
 	})
 	t.Run("Resolve normal relative path into absolute path", func(t *testing.T) {
+		t.Parallel()
 		p, remote, err := ResolveValueFilePathOrUrl("/foo/bar", "/foo", "baz/../../bim.yaml", allowedRemoteProtocols)
 		require.NoError(t, err)
 		assert.False(t, remote)
 		assert.Equal(t, "/foo/bim.yaml", string(p))
 	})
 	t.Run("Error on path resolving outside repository root", func(t *testing.T) {
+		t.Parallel()
 		p, remote, err := ResolveValueFilePathOrUrl("/foo/bar", "/foo", "baz/../../../bim.yaml", allowedRemoteProtocols)
 		require.ErrorContains(t, err, "outside repository root")
 		assert.False(t, remote)
 		assert.Empty(t, string(p))
 	})
 	t.Run("Return verbatim URL", func(t *testing.T) {
+		t.Parallel()
 		url := "https://some.where/foo,yaml"
 		p, remote, err := ResolveValueFilePathOrUrl("/foo/bar", "/foo", url, allowedRemoteProtocols)
 		require.NoError(t, err)
@@ -123,6 +136,7 @@ func Test_resolveFilePath(t *testing.T) {
 		assert.Equal(t, url, string(p))
 	})
 	t.Run("URL scheme not allowed", func(t *testing.T) {
+		t.Parallel()
 		url := "file:///some.where/foo,yaml"
 		p, remote, err := ResolveValueFilePathOrUrl("/foo/bar", "/foo", url, allowedRemoteProtocols)
 		require.Error(t, err)
@@ -130,18 +144,21 @@ func Test_resolveFilePath(t *testing.T) {
 		assert.Empty(t, string(p))
 	})
 	t.Run("Implicit URL by absolute path", func(t *testing.T) {
+		t.Parallel()
 		p, remote, err := ResolveValueFilePathOrUrl("/foo/bar", "/foo", "/baz.yaml", allowedRemoteProtocols)
 		require.NoError(t, err)
 		assert.False(t, remote)
 		assert.Equal(t, "/foo/baz.yaml", string(p))
 	})
 	t.Run("Relative app path", func(t *testing.T) {
+		t.Parallel()
 		p, remote, err := ResolveValueFilePathOrUrl(".", "/foo", "/baz.yaml", allowedRemoteProtocols)
 		require.NoError(t, err)
 		assert.False(t, remote)
 		assert.Equal(t, "/foo/baz.yaml", string(p))
 	})
 	t.Run("Relative repo path", func(t *testing.T) {
+		t.Parallel()
 		c, err := os.Getwd()
 		require.NoError(t, err)
 		p, remote, err := ResolveValueFilePathOrUrl(".", ".", "baz.yaml", allowedRemoteProtocols)
@@ -150,30 +167,35 @@ func Test_resolveFilePath(t *testing.T) {
 		assert.Equal(t, c+"/baz.yaml", string(p))
 	})
 	t.Run("Overlapping root prefix without trailing slash", func(t *testing.T) {
+		t.Parallel()
 		p, remote, err := ResolveValueFilePathOrUrl(".", "/foo", "../foo2/baz.yaml", allowedRemoteProtocols)
 		require.ErrorContains(t, err, "outside repository root")
 		assert.False(t, remote)
 		assert.Empty(t, string(p))
 	})
 	t.Run("Overlapping root prefix with trailing slash", func(t *testing.T) {
+		t.Parallel()
 		p, remote, err := ResolveValueFilePathOrUrl(".", "/foo/", "../foo2/baz.yaml", allowedRemoteProtocols)
 		require.ErrorContains(t, err, "outside repository root")
 		assert.False(t, remote)
 		assert.Empty(t, string(p))
 	})
 	t.Run("Garbage input as values file", func(t *testing.T) {
+		t.Parallel()
 		p, remote, err := ResolveValueFilePathOrUrl(".", "/foo/", "kfdj\\ks&&&321209.,---e32908923%$§!\"", allowedRemoteProtocols)
 		require.ErrorContains(t, err, "outside repository root")
 		assert.False(t, remote)
 		assert.Empty(t, string(p))
 	})
 	t.Run("NUL-byte path input as values file", func(t *testing.T) {
+		t.Parallel()
 		p, remote, err := ResolveValueFilePathOrUrl(".", "/foo/", "\000", allowedRemoteProtocols)
 		require.ErrorContains(t, err, "outside repository root")
 		assert.False(t, remote)
 		assert.Empty(t, string(p))
 	})
 	t.Run("Resolve root path into absolute path - jsonnet library path", func(t *testing.T) {
+		t.Parallel()
 		p, err := ResolveFileOrDirectoryPath("/foo", "/foo", "./")
 		require.NoError(t, err)
 		assert.Equal(t, "/foo", string(p))

--- a/util/io/paths_test.go
+++ b/util/io/paths_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestGetPath_SameURLs(t *testing.T) {
+	t.Parallel()
 	paths := NewRandomizedTempPaths(os.TempDir())
 	res1, err := paths.GetPath("https://localhost/test.txt")
 	require.NoError(t, err)
@@ -18,6 +19,7 @@ func TestGetPath_SameURLs(t *testing.T) {
 }
 
 func TestGetPath_DifferentURLs(t *testing.T) {
+	t.Parallel()
 	paths := NewRandomizedTempPaths(os.TempDir())
 	res1, err := paths.GetPath("https://localhost/test1.txt")
 	require.NoError(t, err)
@@ -27,6 +29,7 @@ func TestGetPath_DifferentURLs(t *testing.T) {
 }
 
 func TestGetPath_SameURLsDifferentInstances(t *testing.T) {
+	t.Parallel()
 	paths1 := NewRandomizedTempPaths(os.TempDir())
 	res1, err := paths1.GetPath("https://localhost/test.txt")
 	require.NoError(t, err)
@@ -36,6 +39,9 @@ func TestGetPath_SameURLsDifferentInstances(t *testing.T) {
 	assert.NotEqual(t, res1, res2)
 }
 
+// TestGetPathIfExists is intentionally NOT parallel: its subtests share the
+// same RandomizedTempPaths instance and depend on call order ("does not exist"
+// must run before "does exist" populates the path).
 func TestGetPathIfExists(t *testing.T) {
 	paths := NewRandomizedTempPaths(os.TempDir())
 	t.Run("does not exist", func(t *testing.T) {
@@ -50,6 +56,12 @@ func TestGetPathIfExists(t *testing.T) {
 	})
 }
 
+// TestGetPaths_no_race is intentionally NOT parallel: it fires goroutines
+// that call require/assert on t without waiting, which is only safe while
+// the parent test is still running. Adding t.Parallel() would let the runner
+// mark the test complete before those goroutines execute, violating the
+// testing.T contract (Fatal/FailNow must run on the test goroutine). The
+// test exists to be inspected by `go test -race`; parallelism adds no value.
 func TestGetPaths_no_race(t *testing.T) {
 	paths := NewRandomizedTempPaths(os.TempDir())
 	go func() {

--- a/util/rand/rand_test.go
+++ b/util/rand/rand_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestRandString(t *testing.T) {
+	t.Parallel()
 	ss, err := StringFromCharset(10, "A")
 	require.NoError(t, err)
 	assert.Equal(t, "AAAAAAAAAA", ss)
@@ -18,6 +19,7 @@ func TestRandString(t *testing.T) {
 }
 
 func TestRandHex(t *testing.T) {
+	t.Parallel()
 	ss, err := RandHex(10)
 	require.NoError(t, err)
 	assert.Len(t, ss, 10)

--- a/util/security/path_traversal_test.go
+++ b/util/security/path_traversal_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestEnforceToCurrentRoot(t *testing.T) {
+	t.Parallel()
 	cleanDir, err := EnforceToCurrentRoot("/home/argo/helmapp/", "/home/argo/helmapp/values.yaml")
 	require.NoError(t, err)
 	assert.Equal(t, "/home/argo/helmapp/values.yaml", cleanDir)


### PR DESCRIPTION
…(#27423)


## Description

Refs #27423.

Adds `t.Parallel()` to a small batch of utility unit tests where the tests are isolated and safe to run in parallel.

This updates tests under:

- `util/collections`
- `util/io`
- `util/io/path`
- `util/rand`
- `util/security`

`TestGetPathIfExists` is intentionally left sequential because its subtests share the same `RandomizedTempPaths` instance and depend on execution order. The `"does not exist"` case must run before the `"does exist"` case populates the path.

`TestGetPaths_no_race` is also intentionally left sequential because it is a race smoke test that starts goroutines using `testing.T`.

For timing, I compared the touched package set against `upstream/master` with `go test ... -count=50`. This small utility batch does not show a meaningful standalone speedup; timings were noise-level equivalent. This PR is intended as a small, low-risk slice of #27423.

## Testing

```bash
go vet ./util/...
make lint-local
make TEST_MODULE="./util/collections ./util/io ./util/io/path ./util/rand ./util/security" test-local
make TEST_MODULE="./util/collections ./util/io ./util/io/path ./util/rand ./util/security" test-race-local
make build-local
go test ./util/collections ./util/io ./util/io/path ./util/rand ./util/security -shuffle=on -count=10
```

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
