### PR TITLE
fix: use OIDC refresh tokens to renew expired sessions (#27041, #12189)

### DIFF
--- a/docs/operator-manual/user-management/index.md
+++ b/docs/operator-manual/user-management/index.md
@@ -249,6 +249,11 @@ data:
           clientSecret: $dex.oidc.clientSecret
 ```
 
+> [!NOTE]
+> Argo CD's OIDC token refresh (see `refreshTokenThreshold` in [Existing OIDC Provider](#existing-oidc-provider))
+> does not apply to Dex's embedded web login flow. Once a Dex-issued ID token expires, the user
+> must log in again, regardless of `refreshTokenThreshold` being set.
+
 ### Requesting additional ID token claims
 
 By default Dex only retrieves the profile and email scopes. In order to retrieve more claims you
@@ -351,6 +356,12 @@ data:
     # Make sure the identity provider supports it and that it is activated for Argo CD OIDC client.
     # Default is false.
     enablePKCEAuthentication: true
+
+    # Optional. Argo CD uses this threshold to refresh an OIDC ID token before it expires, using the
+    # cached refresh token, so the session isn't interrupted. Must be shorter than the ID
+    # token's lifetime, or a new token will be requested on every request.
+    # Default is 0s.
+    refreshTokenThreshold: 30s
 ```
 
 > [!NOTE]

--- a/server/server.go
+++ b/server/server.go
@@ -1575,14 +1575,14 @@ func (server *ArgoCDServer) getClaims(ctx context.Context) (jwt.Claims, string, 
 		// VerifyToken returns claims without sub/sid on expiry, parse JWT directly to recover sub/sid for refresh token cache lookup
 		expiredClaims := jwt.MapClaims{}
 		if _, _, parseErr := jwt.NewParser().ParseUnverified(tokenString, expiredClaims); parseErr != nil {
-			log.Errorf("failed to parse expired token for refresh: %v", parseErr)
+			log.Warnf("failed to parse expired token for refresh: %v", parseErr)
 		} else {
 			refreshedToken, refreshErr := server.ssoClientApp.CheckAndRefreshToken(ctx, expiredClaims, server.settings.RefreshTokenThresholdWithConfig(oidcConfig))
 			if refreshErr != nil {
-				log.Errorf("failed to refresh token: %v", refreshErr)
+				log.Warnf("failed to refresh token: %v", refreshErr)
 			} else if refreshedToken != "" {
 				if refreshedClaims, _, vErr := server.sessionMgr.VerifyToken(ctx, refreshedToken); vErr != nil {
-					log.Errorf("failed to verify refreshed token: %v", vErr)
+					log.Warnf("failed to verify refreshed token: %v", vErr)
 				} else {
 					claims, newToken, err = refreshedClaims, refreshedToken, nil
 					log.Infof("refreshed token for subject: %v", jwtutil.StringField(expiredClaims, "sub"))

--- a/server/server.go
+++ b/server/server.go
@@ -1571,12 +1571,19 @@ func (server *ArgoCDServer) getClaims(ctx context.Context) (jwt.Claims, string, 
 	// OIDC tokens will be verified and reactively refreshed here if the ID token has expired.
 	claims, newToken, err := server.sessionMgr.VerifyToken(ctx, tokenString)
 	oidcConfig := server.settings.OIDCConfig()
-	if err != nil && claims != nil && (oidcConfig != nil || server.settings.IsDexConfigured()) {
+	if err != nil && claims != nil && oidcConfig != nil {
 		// VerifyToken returns claims without sub/sid on expiry, parse JWT directly to recover sub/sid for refresh token cache lookup
 		expiredClaims := jwt.MapClaims{}
-		if _, _, parseErr := jwt.NewParser().ParseUnverified(tokenString, expiredClaims); parseErr == nil {
-			if refreshedToken, refreshErr := server.ssoClientApp.CheckAndRefreshToken(ctx, expiredClaims, server.settings.RefreshTokenThresholdWithConfig(oidcConfig)); refreshErr == nil && refreshedToken != "" {
-				if refreshedClaims, _, vErr := server.sessionMgr.VerifyToken(ctx, refreshedToken); vErr == nil {
+		if _, _, parseErr := jwt.NewParser().ParseUnverified(tokenString, expiredClaims); parseErr != nil {
+			log.Errorf("failed to parse expired token for refresh: %v", parseErr)
+		} else {
+			refreshedToken, refreshErr := server.ssoClientApp.CheckAndRefreshToken(ctx, expiredClaims, server.settings.RefreshTokenThresholdWithConfig(oidcConfig))
+			if refreshErr != nil {
+				log.Errorf("failed to refresh token: %v", refreshErr)
+			} else if refreshedToken != "" {
+				if refreshedClaims, _, vErr := server.sessionMgr.VerifyToken(ctx, refreshedToken); vErr != nil {
+					log.Errorf("failed to verify refreshed token: %v", vErr)
+				} else {
 					claims, newToken, err = refreshedClaims, refreshedToken, nil
 					log.Infof("refreshed token for subject: %v", jwtutil.StringField(expiredClaims, "sub"))
 				}

--- a/server/server.go
+++ b/server/server.go
@@ -1568,15 +1568,27 @@ func (server *ArgoCDServer) getClaims(ctx context.Context) (jwt.Claims, string, 
 		return nil, "", ErrNoSession
 	}
 	// A valid argocd-issued token is automatically refreshed here prior to expiration.
-	// OIDC tokens will be verified but will not be refreshed here.
+	// OIDC tokens will be verified and reactively refreshed here if the ID token has expired.
 	claims, newToken, err := server.sessionMgr.VerifyToken(ctx, tokenString)
+	oidcConfig := server.settings.OIDCConfig()
+	if err != nil && claims != nil && (oidcConfig != nil || server.settings.IsDexConfigured()) {
+		// VerifyToken returns claims without sub/sid on expiry, parse JWT directly to recover sub/sid for refresh token cache lookup
+		expiredClaims := jwt.MapClaims{}
+		if _, _, parseErr := jwt.NewParser().ParseUnverified(tokenString, expiredClaims); parseErr == nil {
+			if refreshedToken, refreshErr := server.ssoClientApp.CheckAndRefreshToken(ctx, expiredClaims, server.settings.RefreshTokenThresholdWithConfig(oidcConfig)); refreshErr == nil && refreshedToken != "" {
+				if refreshedClaims, _, vErr := server.sessionMgr.VerifyToken(ctx, refreshedToken); vErr == nil {
+					claims, newToken, err = refreshedClaims, refreshedToken, nil
+					log.Infof("refreshed token for subject: %v", jwtutil.StringField(expiredClaims, "sub"))
+				}
+			}
+		}
+	}
 	if err != nil {
 		span.SetStatus(otel_codes.Error, err.Error())
 		return claims, "", status.Errorf(codes.Unauthenticated, "invalid session: %v", err)
 	}
 
 	finalClaims := claims
-	oidcConfig := server.settings.OIDCConfig()
 	if oidcConfig != nil || server.settings.IsDexConfigured() {
 		updatedClaims, err := server.ssoClientApp.SetGroupsFromUserInfo(ctx, claims, util_session.SessionManagerClaimsIssuer)
 		if err != nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -20,6 +20,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
 	"google.golang.org/grpc/metadata"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -894,6 +895,62 @@ func TestGetClaims(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetClaims_RefreshOnExpiredOIDCToken(t *testing.T) {
+	t.Parallel()
+
+	oidcServer := testutil.GetOIDCTestServer(t, nil)
+	t.Cleanup(oidcServer.Close)
+
+	cm := test.NewFakeConfigMap()
+	cm.Data["url"] = "https://argocd.example.com"
+	cm.Data["oidc.tls.insecure.skip.verify"] = "true"
+	cm.Data["oidc.config"] = fmt.Sprintf(`
+name: Test
+issuer: %s
+clientID: test-client-id
+clientSecret: $oidc.clientSecret`, oidcServer.URL)
+	secret := test.NewFakeSecret()
+	secret.Data["oidc.clientSecret"] = []byte("test-client-secret")
+
+	argocd := NewServer(t.Context(), ArgoCDServerOpts{
+		Namespace:     test.FakeArgoCDNamespace,
+		KubeClientset: fake.NewSimpleClientset(cm, secret),
+		AppClientset:  apps.NewSimpleClientset(),
+		RepoClientset: &mocks.Clientset{RepoServerServiceClient: &mocks.RepoServerServiceClient{}},
+	}, ApplicationSetOpts{})
+	var err error
+	argocd.ssoClientApp, err = oidc.NewClientApp(argocd.settings, "", nil, "/", cache.NewInMemoryCache(24*time.Hour))
+	require.NoError(t, err)
+
+	sub, sid := "randomUser", "1111"
+	cacheJSON, err := json.Marshal(&oidc.OidcTokenCache{Token: &oauth2.Token{RefreshToken: "not empty"}})
+	require.NoError(t, err)
+	require.NoError(t, argocd.ssoClientApp.SetValueInEncryptedCache(t.Context(),
+		fmt.Sprintf("%s_%s_%s", oidc.OidcTokenCachePrefix, sub, sid), cacheJSON, time.Minute))
+
+	expired := jwt.NewWithClaims(jwt.SigningMethodRS512, jwt.MapClaims{
+		"iss": oidcServer.URL,
+		"aud": "test-client-id",
+		"sub": sub,
+		"sid": sid,
+		"exp": jwt.NewNumericDate(time.Now().Add(-time.Minute)),
+	})
+	key, err := jwt.ParseRSAPrivateKeyFromPEM(testutil.PrivateKey)
+	require.NoError(t, err)
+	tokenString, err := expired.SignedString(key)
+	require.NoError(t, err)
+
+	ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs(apiclient.MetaDataTokenKey, tokenString))
+	gotClaims, newToken, err := argocd.getClaims(ctx)
+	require.NoError(t, err)
+	assert.NotEmpty(t, newToken)
+	assert.NotEqual(t, tokenString, newToken, "newToken should differ from the original expired token")
+
+	mapClaims, ok := gotClaims.(jwt.MapClaims)
+	require.True(t, ok)
+	assert.Equal(t, "1234567890", mapClaims["sub"], "claims should come from the refreshed token (mock returns sub=1234567890), proving reactive refresh ran")
 }
 
 func TestAuthenticate_3rd_party_JWTs(t *testing.T) {

--- a/util/oidc/oidc.go
+++ b/util/oidc/oidc.go
@@ -596,7 +596,9 @@ func (a *ClientApp) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	sid := jwtutil.StringField(claims, "sid")
-	err = a.SetValueInEncryptedCache(ctx, formatOidcTokenCacheKey(sub, sid), oidcTokenCacheJSON, GetTokenExpiration(claims))
+	// TTL = user session duration (not ID token TTL) so the refresh token
+	// outlives the ID token and is available for reactive refresh after expiry
+	err = a.SetValueInEncryptedCache(ctx, formatOidcTokenCacheKey(sub, sid), oidcTokenCacheJSON, a.settings.UserSessionDuration)
 	if err != nil {
 		claimsJSON, _ := json.Marshal(claims)
 		log.Errorf("cannot cache encrypted oidc token: %v (claims=%s)", err, claimsJSON)
@@ -693,7 +695,8 @@ func (a *ClientApp) CheckAndRefreshToken(ctx context.Context, groupClaims jwt.Ma
 	span.SetAttributes(
 		attribute.String("iss", iss),
 		attribute.String("sub", sub),
-		attribute.String("sid", sid))
+		attribute.String("sid", sid),
+	)
 	if GetTokenExpiration(groupClaims) < refreshTokenThreshold {
 		token, err := a.GetUpdatedOidcTokenFromCache(ctx, sub, sid)
 		if err != nil {
@@ -767,7 +770,7 @@ func (a *ClientApp) GetUpdatedOidcTokenFromCache(ctx context.Context, subject st
 			span.SetStatus(codes.Error, err.Error())
 			return nil, err
 		}
-		err = a.SetValueInEncryptedCache(ctx, cacheKey, oidcTokenCacheJSON, time.Until(token.Expiry))
+		err = a.SetValueInEncryptedCache(ctx, cacheKey, oidcTokenCacheJSON, a.settings.UserSessionDuration)
 		if err != nil {
 			span.SetStatus(codes.Error, err.Error())
 			return nil, err

--- a/util/oidc/oidc.go
+++ b/util/oidc/oidc.go
@@ -787,6 +787,12 @@ func (a *ClientApp) GetUpdatedOidcTokenFromCache(ctx context.Context, subject st
 			return nil, err
 		}
 		ttl := sessionRemainingTTL(oidcTokenCache.SessionStart, a.settings.UserSessionDuration)
+		if ttl <= 0 {
+			log.Info("session exceeded UserSessionDuration, forcing re-authentication")
+
+			// Return nil to force re-authentication
+			return nil, nil
+		}
 		err = a.SetValueInEncryptedCache(ctx, cacheKey, oidcTokenCacheJSON, ttl)
 		if err != nil {
 			span.SetStatus(codes.Error, err.Error())

--- a/util/oidc/oidc.go
+++ b/util/oidc/oidc.go
@@ -125,10 +125,25 @@ type OidcTokenCache struct {
 	Token *oauth2.Token `json:"token"`
 	// TokenExtraIdToken captures value of id_token
 	TokenExtraIdToken string `json:"token_extra_id_token"`
+	// SessionStart records when the OIDC session was first established
+	SessionStart time.Time `json:"session_start"`
 }
 
-// NewOidcTokenCache initializes the struct from a redirect URL and an existing token
-func NewOidcTokenCache(redirectURL string, token *oauth2.Token) *OidcTokenCache {
+// SessionDuration bounded TTL to ensure refreshed sessions
+// cannot extend beyond the originally configured session lifetime
+func sessionRemainingTTL(sessionStart time.Time, sessionDuration time.Duration) time.Duration {
+	if sessionStart.IsZero() {
+		return sessionDuration
+	}
+	remaining := time.Until(sessionStart.Add(sessionDuration))
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
+}
+
+// NewOidcTokenCache initializes the struct from a redirect URL, an existing token, and the session start time
+func NewOidcTokenCache(redirectURL string, token *oauth2.Token, sessionStart time.Time) *OidcTokenCache {
 	var idToken string
 	if token.Extra("id_token") == nil {
 		idToken = ""
@@ -139,6 +154,7 @@ func NewOidcTokenCache(redirectURL string, token *oauth2.Token) *OidcTokenCache 
 		RedirectURL:       redirectURL,
 		Token:             token,
 		TokenExtraIdToken: idToken,
+		SessionStart:      sessionStart,
 	}
 }
 
@@ -589,16 +605,15 @@ func (a *ClientApp) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Cache encrypted raw token for background refresh
-	oidcTokenCache := NewOidcTokenCache(a.getRedirectURIForRequest(r), token)
+	oidcTokenCache := NewOidcTokenCache(a.getRedirectURIForRequest(r), token, time.Now())
 	oidcTokenCacheJSON, err := json.Marshal(oidcTokenCache)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	sid := jwtutil.StringField(claims, "sid")
-	// TTL = user session duration (not ID token TTL) so the refresh token
-	// outlives the ID token and is available for reactive refresh after expiry
-	err = a.SetValueInEncryptedCache(ctx, formatOidcTokenCacheKey(sub, sid), oidcTokenCacheJSON, a.settings.UserSessionDuration)
+	ttl := sessionRemainingTTL(oidcTokenCache.SessionStart, a.settings.UserSessionDuration)
+	err = a.SetValueInEncryptedCache(ctx, formatOidcTokenCacheKey(sub, sid), oidcTokenCacheJSON, ttl)
 	if err != nil {
 		claimsJSON, _ := json.Marshal(claims)
 		log.Errorf("cannot cache encrypted oidc token: %v (claims=%s)", err, claimsJSON)
@@ -763,14 +778,16 @@ func (a *ClientApp) GetUpdatedOidcTokenFromCache(ctx context.Context, subject st
 	}
 	if token.AccessToken != oidcTokenCache.Token.AccessToken {
 		span.AddEvent("updating cache with latest token")
-		oidcTokenCache = NewOidcTokenCache(oidcTokenCache.RedirectURL, token)
+
+		oidcTokenCache = NewOidcTokenCache(oidcTokenCache.RedirectURL, token, oidcTokenCache.SessionStart)
 		oidcTokenCacheJSON, err = json.Marshal(oidcTokenCache)
 		if err != nil {
 			err = fmt.Errorf("failed to marshal oidc oidcTokenCache refresher: %w", err)
 			span.SetStatus(codes.Error, err.Error())
 			return nil, err
 		}
-		err = a.SetValueInEncryptedCache(ctx, cacheKey, oidcTokenCacheJSON, a.settings.UserSessionDuration)
+		ttl := sessionRemainingTTL(oidcTokenCache.SessionStart, a.settings.UserSessionDuration)
+		err = a.SetValueInEncryptedCache(ctx, cacheKey, oidcTokenCacheJSON, ttl)
 		if err != nil {
 			span.SetStatus(codes.Error, err.Error())
 			return nil, err

--- a/util/oidc/oidc_test.go
+++ b/util/oidc/oidc_test.go
@@ -1381,7 +1381,7 @@ func TestGetOidcTokenCacheFromJSON(t *testing.T) {
 		},
 		{
 			name:           "simple",
-			oidcTokenCache: NewOidcTokenCache("", (&oauth2.Token{}).WithExtra(map[string]any{"id_token": "simple"})),
+			oidcTokenCache: NewOidcTokenCache("", (&oauth2.Token{}).WithExtra(map[string]any{"id_token": "simple"}), time.Time{}),
 			expectIdToken:  "simple",
 		},
 	}
@@ -1424,7 +1424,7 @@ func TestClientApp_GetTokenSourceFromCache(t *testing.T) {
 		},
 		{
 			name:           "simple",
-			oidcTokenCache: NewOidcTokenCache("", (&oauth2.Token{}).WithExtra(map[string]any{"id_token": "simple"})),
+			oidcTokenCache: NewOidcTokenCache("", (&oauth2.Token{}).WithExtra(map[string]any{"id_token": "simple"}), time.Time{}),
 			provider:       &fakeProvider{},
 		},
 	}
@@ -1517,6 +1517,74 @@ requestedScopes: ["oidc"]`, oidcTestServer.URL),
 			}
 		})
 	}
+}
+
+func TestSessionRemainingTTL(t *testing.T) {
+	const dur = 10 * time.Minute
+
+	t.Run("zero session start returns original full duration", func(t *testing.T) {
+		ttl := sessionRemainingTTL(time.Time{}, dur)
+		assert.Equal(t, dur, ttl)
+	})
+
+	t.Run("active session returns remaining time", func(t *testing.T) {
+		sessionStart := time.Now().Add(-4 * time.Minute)
+		ttl := sessionRemainingTTL(sessionStart, dur)
+		// ~6 min remaining; accept ±5s of test jitter
+		assert.InDelta(t, (6 * time.Minute).Seconds(), ttl.Seconds(), 5)
+	})
+
+	t.Run("expired session returns zero", func(t *testing.T) {
+		sessionStart := time.Now().Add(-11 * time.Minute)
+		ttl := sessionRemainingTTL(sessionStart, dur)
+		assert.Equal(t, time.Duration(0), ttl)
+	})
+}
+
+func TestClientApp_GetUpdatedOidcTokenFromCache_SessionCeiling(t *testing.T) {
+	// 10 minute UserSessionDuration, 9 minutes of current session already passed
+	const sessionDuration = 10 * time.Minute
+	sessionStart := time.Now().Add(-9 * time.Minute)
+
+	oidcTestServer := test.GetOIDCTestServer(t, nil)
+	t.Cleanup(oidcTestServer.Close)
+
+	cdSettings := &settings.ArgoCDSettings{
+		URL: "https://argocd.example.com",
+		OIDCConfigRAW: fmt.Sprintf(`
+name: Test
+issuer: %s
+clientID: test-client-id
+clientSecret: test-client-secret
+requestedScopes: ["oidc"]`, oidcTestServer.URL),
+		OIDCTLSInsecureSkipVerify: true,
+		UserSessionDuration:       sessionDuration,
+	}
+	app, err := NewClientApp(cdSettings, "", nil, "/", cache.NewInMemoryCache(24*time.Hour))
+	require.NoError(t, err)
+
+	sub, sid := "alice", "s1"
+	oidcTokenCacheJSON, err := json.Marshal(&OidcTokenCache{
+		Token:        &oauth2.Token{RefreshToken: "not empty"},
+		SessionStart: sessionStart,
+	})
+	require.NoError(t, err)
+	require.NoError(t, app.SetValueInEncryptedCache(t.Context(), formatOidcTokenCacheKey(sub, sid), oidcTokenCacheJSON, sessionDuration))
+
+	_, err = app.GetUpdatedOidcTokenFromCache(t.Context(), sub, sid)
+	require.NoError(t, err)
+
+	// Retrieve the updated entry and confirm SessionStart was not reset to now.
+	updatedJSON, err := app.GetValueFromEncryptedCache(t.Context(), formatOidcTokenCacheKey(sub, sid))
+	require.NoError(t, err)
+	require.NotNil(t, updatedJSON, "cache entry should exist after refresh")
+
+	updatedCache, err := GetOidcTokenCacheFromJSON(updatedJSON)
+	require.NoError(t, err)
+
+	// TTL should be less than 1 minute after token refresh
+	assert.WithinDuration(t, sessionStart, updatedCache.SessionStart, 5*time.Second,
+		"SessionStart must be preserved across token refreshes")
 }
 
 func TestClientApp_CheckAndGetRefreshToken(t *testing.T) {

--- a/util/oidc/oidc_test.go
+++ b/util/oidc/oidc_test.go
@@ -1498,6 +1498,7 @@ clientID: test-client-id
 clientSecret: test-client-secret
 requestedScopes: ["oidc"]`, oidcTestServer.URL),
 				OIDCTLSInsecureSkipVerify: true,
+				UserSessionDuration:       24 * time.Hour,
 			}
 			app, err := NewClientApp(cdSettings, "", nil, "/", cache.NewInMemoryCache(24*time.Hour))
 			require.NoError(t, err)
@@ -1587,6 +1588,47 @@ requestedScopes: ["oidc"]`, oidcTestServer.URL),
 		"SessionStart must be preserved across token refreshes")
 }
 
+func TestClientApp_GetUpdatedOidcTokenFromCache_SessionCeilingExceeded(t *testing.T) {
+	const sessionDuration = 10 * time.Minute
+	sessionStart := time.Now().Add(-11 * time.Minute)
+
+	oidcTestServer := test.GetOIDCTestServer(t, nil)
+	t.Cleanup(oidcTestServer.Close)
+
+	cdSettings := &settings.ArgoCDSettings{
+		URL: "https://argocd.example.com",
+		OIDCConfigRAW: fmt.Sprintf(`
+name: Test
+issuer: %s
+clientID: test-client-id
+clientSecret: test-client-secret
+requestedScopes: ["oidc"]`, oidcTestServer.URL),
+		OIDCTLSInsecureSkipVerify: true,
+		UserSessionDuration:       sessionDuration,
+	}
+	app, err := NewClientApp(cdSettings, "", nil, "/", cache.NewInMemoryCache(24*time.Hour))
+	require.NoError(t, err)
+
+	sub, sid := "alice", "s1"
+	cacheKey := formatOidcTokenCacheKey(sub, sid)
+	originalJSON, err := json.Marshal(&OidcTokenCache{
+		Token:        &oauth2.Token{RefreshToken: "not empty"},
+		SessionStart: sessionStart,
+	})
+	require.NoError(t, err)
+	require.NoError(t, app.SetValueInEncryptedCache(t.Context(), cacheKey, originalJSON, time.Minute))
+
+	token, err := app.GetUpdatedOidcTokenFromCache(t.Context(), sub, sid)
+	require.NoError(t, err)
+	assert.Nil(t, token, "expired session must not yield a refreshed token")
+
+	// The refreshed token must not overwrite the cache entry with the default TTL
+	cachedValue, err := app.GetValueFromEncryptedCache(t.Context(), cacheKey)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(originalJSON), string(cachedValue),
+		"expired session must not be re-cached with the cache's default TTL")
+}
+
 func TestClientApp_CheckAndGetRefreshToken(t *testing.T) {
 	tests := []struct {
 		name                  string
@@ -1650,6 +1692,7 @@ clientSecret: test-client-secret
 refreshTokenThreshold: %s
 requestedScopes: ["oidc"]`, oidcTestServer.URL, tt.refreshTokenThreshold),
 				OIDCTLSInsecureSkipVerify: true,
+				UserSessionDuration:       24 * time.Hour,
 			}
 			// The base href (the last argument for NewClientApp) is what HandleLogin will fall back to when no explicit
 			// redirect URL is given.


### PR DESCRIPTION
### Issues Addressed
- Fixes #27041 
- Related: #12189 

### Bug Summary
Currently, the OIDC refresh flow in ArgoCD is not able to refresh sessions due to two separate bugs:
- The OAuth2 token cache TTL in `util/oidc/oidc.go` is tied to the ID token's lifetime. When the ID token has expired, the refresh token is evicted at the exact moment the refresh flow would need it. The refresh token was not being given a chance to be used. This scenario happens even if the user is active in the UI. 
- When a token has already expired, the verification flow in `server/server.go getClaims` returns `Unauthenticated` and exits before the OIDC refresh logic can run. This scenario happens when a user has successfully logged in but has not carried out any actions in the UI until after the token has expired. The session doesn't get refreshed because the refresh is on demand, i.e., whenever a user does something on the UI.

### Fix Summary
- **Extending Token Cache TTL to `UserSessionDuration`**: The OAuth2 token wrapper containing the refresh token is now cached for the `UserSessionDuration` rather than `GetTokenExpiration(claims)`/`time.Until(token.Expiry)` in `util/oidc/oidc.go`. 
- **Additional flow to attempt refresh grant on expired token**: If the token has already expired, an attempt to renew the session is made through `CheckAndRefreshToken` before returning `Unauthenticated` and exiting out early in `server/server.go`.

### Reproducing the bugs with Keycloak
1. Keycloak realm configuration in `~/keycloak-realm.json`
```json
    {
      "realm": "argocd",
      "enabled": true,
      "accessTokenLifespan": 120,
      "ssoSessionIdleTimeout": 86400,
      "ssoSessionMaxLifespan": 86400,
      "clients": [{
        "clientId": "argocd",
        "enabled": true,
        "publicClient": false,
        "secret": "argocd-client-secret",
        "redirectUris": ["http://localhost:8080/auth/callback",
  "http://localhost:4000/auth/callback"],
        "webOrigins": ["+"],
        "standardFlowEnabled": true,
        "directAccessGrantsEnabled": true,
        "protocol": "openid-connect"
      }],
      "users": [{
        "username": "test",
        "enabled": true,
        "email": "test@example.com",
        "emailVerified": true,
        "credentials": [{"type": "password", "value": "password", "temporary":
  false}]
      }]
    }
```

2. Start Keycloak with the realm configuration and additional log levels to view refresh_grant events in docker logs
```
docker run -d --name keycloak \
      -p 8090:8080 \
      -v ~/keycloak-realm.json:/opt/keycloak/data/import/realm.json \
      -e KEYCLOAK_ADMIN=admin \
      -e KEYCLOAK_ADMIN_PASSWORD=admin \
      quay.io/keycloak/keycloak:25.0 start-dev --import-realm \
      --log-level=info,org.keycloak.events:debug
```

3. Patch `argocd-cm`
```yaml
    data:
      url: http://localhost:8080
      oidc.config: |
        name: Keycloak
        issuer: http://localhost:8090/realms/argocd
        clientID: argocd
        clientSecret: argocd-client-secret
        requestedScopes: ["openid", "profile", "email"]
        refreshTokenThreshold: 30s
```

4. Run ArgoCD locally with `make start-local ARGOCD_GPG_ENABLED=false ARGOCD_E2E_DISABLE_AUTH=false`

5. Reproduce bugs
- Log in to ArgoCD via Keycloak with `test / password`
- Stay idle in the UI for 3 minutes (longer than the 2-minute access-token lifespan, so the proactive refresh window passes without an inbound request) to reproduce bug in `server/server.go`
- Keep using the UI (just switching between graph views is enough) for the duration of the access token lifetime
- In both cases, the authorization login is carried out again. Relevant logs: `api-server | {"level":"info","msg":"Performing authorization_code flow login:...` in ArgoCD and `DEBUG [org.keycloak.events] ... type="LOGIN"` in Keycloak

Once the fix has been made, refresh logs can been seen in both ArgoCD `api-server | {"level":"info","msg":"refreshed token for subject: ... ` and Keycloak `DEBUG [org.keycloak.events] ... type="REFRESH_TOKEN"`



Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x]  I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.