### PR TITLE
fix: GetRefSources populates refSources for multi source app with a single source

### DIFF
--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -542,8 +542,9 @@ func GetSyncedRefSources(refSources argoappv1.RefTargetRevisionMapping, sources 
 // once (which would lead to ambiguous references).
 func GetRefSources(ctx context.Context, sources argoappv1.ApplicationSources, project string, getRepository func(ctx context.Context, url string, project string) (*argoappv1.Repository, error), revisions []string) (argoappv1.RefTargetRevisionMapping, error) {
 	refSources := make(argoappv1.RefTargetRevisionMapping)
-	if len(sources) > 1 {
-		// Validate first to avoid unnecessary DB calls.
+	if len(sources) > 0 {
+		// Validate first to avoid unnecessary DB calls. Use len(sources) > 0 (not > 1) so a sole source with ref:
+		// is populated; otherwise GetSyncedRefSources panics when spec.sources has one element (see #27759).
 		refKeys := make(map[string]bool)
 		for _, source := range sources {
 			if source.Ref == "" {

--- a/util/argo/argo_test.go
+++ b/util/argo/argo_test.go
@@ -1675,6 +1675,25 @@ func Test_GetRefSources(t *testing.T) {
 		require.Error(t, err)
 		assert.Empty(t, refSources)
 	})
+
+	t.Run("single source with ref populates refSources", func(t *testing.T) {
+		argoSpec := getMultiSourceAppSpec(argoappv1.ApplicationSources{
+			{RepoURL: "file://" + repoPath, TargetRevision: "HEAD", Ref: "gitops"},
+		})
+
+		refSources, err := GetRefSources(t.Context(), argoSpec.Sources, argoSpec.Project, func(_ context.Context, _ string, _ string) (*argoappv1.Repository, error) {
+			return repo, nil
+		}, []string{})
+
+		require.NoError(t, err)
+		expected := argoappv1.RefTargetRevisionMapping{
+			"$gitops": &argoappv1.RefTarget{
+				Repo:           *repo,
+				TargetRevision: "HEAD",
+			},
+		}
+		assert.Equal(t, expected, refSources)
+	})
 }
 
 func TestValidatePermissionsMultipleSources(t *testing.T) {
@@ -2303,4 +2322,32 @@ func Test_GetSyncedRefSources(t *testing.T) {
 			assert.Equal(t, tt.result, syncedRefSources)
 		})
 	}
+}
+
+// Covers https://github.com/argoproj/argo-cd/issues/27759:
+// spec.sources with one element still sets HasMultipleSources(); GetRefSources must populate refSources so
+// GetSyncedRefSources does not dereference a missing map entry.
+func Test_GetRefSourcesAndSyncedRefSources_SingleSourceWithRef(t *testing.T) {
+	repoPath, err := filepath.Abs("./../..")
+	require.NoError(t, err)
+	repo := &argoappv1.Repository{Repo: "file://" + repoPath}
+	sources := argoappv1.ApplicationSources{
+		{RepoURL: "file://" + repoPath, TargetRevision: "HEAD", Ref: "gitops"},
+	}
+
+	refSources, err := GetRefSources(t.Context(), sources, "", func(_ context.Context, _ string, _ string) (*argoappv1.Repository, error) {
+		return repo, nil
+	}, []string{})
+	require.NoError(t, err)
+
+	syncedRevisions := []string{"rev"}
+	synced := GetSyncedRefSources(refSources, sources, syncedRevisions)
+
+	expected := argoappv1.RefTargetRevisionMapping{
+		"$gitops": &argoappv1.RefTarget{
+			Repo:           *repo,
+			TargetRevision: "rev",
+		},
+	}
+	assert.Equal(t, expected, synced)
 }


### PR DESCRIPTION
Closes #27759
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
