### PR TITLE
feat(ui): show event reporting component as tooltip on resource events (#25684)

### DIFF
--- a/ui/src/app/shared/components/events-list/events-list.test.tsx
+++ b/ui/src/app/shared/components/events-list/events-list.test.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import * as renderer from 'react-test-renderer';
+
+jest.mock('argo-ui', () => ({
+    Tooltip: ({content, children}: {content: React.ReactNode; children: React.ReactNode}) => (
+        <span data-test-tooltip={typeof content === 'string' ? content : ''}>{children}</span>
+    )
+}));
+
+import {EventsList} from './events-list';
+import * as models from '../../models';
+
+function makeEvent(overrides: Partial<models.Event> = {}): models.Event {
+    return {
+        metadata: {uid: 'uid-1', name: 'evt', namespace: 'default'} as models.ObjectMeta,
+        involvedObject: {kind: 'Pod', namespace: 'default', name: 'p', uid: 'p-uid', apiVersion: 'v1', resourceVersion: '1', fieldPath: ''},
+        reason: 'FailedScheduling',
+        message: 'no nodes available',
+        source: {component: '', host: ''},
+        firstTimestamp: '2025-01-01T00:00:00Z',
+        lastTimestamp: '2025-01-01T00:01:00Z',
+        count: 1,
+        type: 'Warning',
+        eventTime: '2025-01-01T00:00:00Z',
+        series: {count: 0, lastObservedTime: '', state: ''},
+        action: '',
+        related: {kind: '', namespace: '', name: '', uid: '', apiVersion: '', resourceVersion: '', fieldPath: ''},
+        reportingComponent: '',
+        reportingInstance: '',
+        ...overrides
+    };
+}
+
+function tooltipContents(inst: renderer.ReactTestInstance): string[] {
+    return inst.findAll(node => node.type === 'span' && node.props && typeof node.props['data-test-tooltip'] === 'string' && node.props['data-test-tooltip'] !== '').map(n => n.props['data-test-tooltip']);
+}
+
+describe('EventsList', () => {
+    it('renders a no-events message when given an empty list', () => {
+        const inst = renderer.create(<EventsList events={[]} />).root;
+        expect(inst.findAllByType('p').length).toBe(1);
+    });
+
+    it('renders reportingComponent in a tooltip on the reason cell', () => {
+        const event = makeEvent({reportingComponent: 'cert-manager'});
+        const inst = renderer.create(<EventsList events={[event]} />).root;
+        expect(tooltipContents(inst)).toEqual(['Reported by: cert-manager']);
+    });
+
+    it('falls back to source.component when reportingComponent is empty', () => {
+        const event = makeEvent({reportingComponent: '', source: {component: 'kubelet', host: 'node-1'}});
+        const inst = renderer.create(<EventsList events={[event]} />).root;
+        expect(tooltipContents(inst)).toEqual(['Reported by: kubelet']);
+    });
+
+    it('omits the tooltip when both reportingComponent and source.component are empty', () => {
+        const event = makeEvent({reportingComponent: '', source: {component: '', host: ''}});
+        const inst = renderer.create(<EventsList events={[event]} />).root;
+        expect(tooltipContents(inst)).toEqual([]);
+    });
+
+    it('prefers reportingComponent over source.component', () => {
+        const event = makeEvent({reportingComponent: 'gateway-controller', source: {component: 'kubelet', host: 'node-1'}});
+        const inst = renderer.create(<EventsList events={[event]} />).root;
+        expect(tooltipContents(inst)).toEqual(['Reported by: gateway-controller']);
+    });
+});

--- a/ui/src/app/shared/components/events-list/events-list.tsx
+++ b/ui/src/app/shared/components/events-list/events-list.tsx
@@ -1,3 +1,4 @@
+import {Tooltip} from 'argo-ui';
 import * as moment from 'moment';
 import * as React from 'react';
 import {ago} from 'argo-ui/v2';
@@ -5,6 +6,10 @@ import {ago} from 'argo-ui/v2';
 import * as models from '../../models';
 
 require('./events-list.scss');
+
+function getEventIssuer(event: models.Event): string {
+    return event.reportingComponent || (event.source && event.source.component) || '';
+}
 
 function timestampSort(first: models.Event, second: models.Event): number {
     if (first.lastTimestamp && !second.lastTimestamp) {
@@ -44,19 +49,31 @@ export const EventsList = (props: {events: models.Event[]}) => {
                             <div className='columns small-2 xxlarge-2'>LAST OCCURRED</div>
                         </div>
                     </div>
-                    {events.map(event => (
-                        <div className={`argo-table-list__row events-list__event events-list__event--${event.type}`} key={event.metadata.uid}>
-                            <div className='row'>
-                                <div className='columns small-2 xxlarge-2'>{event.reason}</div>
-                                <div className='columns small-4 xxlarge-5' style={{whiteSpace: 'normal', lineHeight: 'normal'}}>
-                                    {event.message}
+                    {events.map(event => {
+                        const issuer = getEventIssuer(event);
+                        const reasonCell = issuer ? (
+                            <Tooltip content={`Reported by: ${issuer}`}>
+                                <span>{event.reason}</span>
+                            </Tooltip>
+                        ) : (
+                            <span>{event.reason}</span>
+                        );
+                        return (
+                            <div className={`argo-table-list__row events-list__event events-list__event--${event.type}`} key={event.metadata.uid}>
+                                <div className='row'>
+                                    <div className='columns small-2 xxlarge-2'>{reasonCell}</div>
+                                    <div className='columns small-4 xxlarge-5' style={{whiteSpace: 'normal', lineHeight: 'normal'}}>
+                                        {event.message}
+                                    </div>
+                                    <div className='columns small-2 xxlarge-1'>{event.count}</div>
+                                    <div className='columns small-2 xxlarge-2'>
+                                        {event.firstTimestamp ? getTimeElements(event.firstTimestamp) : getTimeElements(event.eventTime)}
+                                    </div>
+                                    <div className='columns small-2 xxlarge-2'>{event.lastTimestamp ? getTimeElements(event.lastTimestamp) : getTimeElements(event.eventTime)}</div>
                                 </div>
-                                <div className='columns small-2 xxlarge-1'>{event.count}</div>
-                                <div className='columns small-2 xxlarge-2'>{event.firstTimestamp ? getTimeElements(event.firstTimestamp) : getTimeElements(event.eventTime)}</div>
-                                <div className='columns small-2 xxlarge-2'>{event.lastTimestamp ? getTimeElements(event.lastTimestamp) : getTimeElements(event.eventTime)}</div>
                             </div>
-                        </div>
-                    ))}
+                        );
+                    })}
                 </div>
             )}
         </div>

--- a/ui/src/app/shared/models.ts
+++ b/ui/src/app/shared/models.ts
@@ -830,7 +830,7 @@ export interface Event {
     series: EventSeries;
     action: string;
     related: ObjectReference;
-    reportingController: string;
+    reportingComponent: string;
     reportingInstance: string;
 }
 


### PR DESCRIPTION
Surfaces the Kubernetes `reportingComponent` field (with fallback to `source.component`) on the resource events tab as a tooltip on the event reason cell, so operators can tell at a glance which controller emitted a given event (cert-manager, kubelet, a gateway controller, etc.). The previous UI only showed the reason text, leaving no clue about provenance. Closes #25684.

### Before

The reason cell on the resource events tab is plain text; there is no way to tell whether a `FailedScheduling` or `SyncError` event came from kubelet, cert-manager, a gateway controller, or some other component.

### After

Hovering the reason cell shows a tooltip `Reported by: <component>` populated from `event.reportingComponent`, falling back to `event.source.component` when `reportingComponent` is empty (older events). When both are empty the tooltip is omitted entirely.

![events-tab tooltip showing "Reported by: kubelet" on an Unhealthy event](https://raw.githubusercontent.com/sashetov/argo-cd/pr-27797-assets/screenshot.png)

This also fixes a latent bug in `ui/src/app/shared/models.ts` where the `Event` interface declared `reportingController: string`. The Kubernetes core/v1 Event JSON wire field is `reportingComponent` (the Go struct field is `ReportingController` but its json tag is `reportingComponent`), so the old name never carried a value. The field was unused elsewhere in the UI, so renaming it has no other impact.

### Files changed

- `ui/src/app/shared/components/events-list/events-list.tsx` — wrap the reason cell in an `argo-ui` `Tooltip` when an issuer is present.
- `ui/src/app/shared/components/events-list/events-list.test.tsx` — new Jest tests covering the four cases (reportingComponent set, source.component fallback, both empty, both set).
- `ui/src/app/shared/models.ts` — rename `reportingController` to `reportingComponent` on `Event` to match the JSON wire format.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.