### PR TITLE
feat(ui): ApplicationSet Preview Apps tab in UI

### DIFF
--- a/ui/src/app/applications/components/application-details/application-details.tsx
+++ b/ui/src/app/applications/components/application-details/application-details.tsx
@@ -909,6 +909,11 @@ Are you sure you want to disable auto-sync and rollback application '${props.mat
                                                               title: 'AppSet Details',
                                                               iconClassName: 'fa fa-info-circle',
                                                               action: () => selectNode(appFullName)
+                                                          },
+                                                          {
+                                                              title: 'Preview Apps',
+                                                              iconClassName: 'fa fa-eye',
+                                                              action: () => selectNode(appFullName, 0, 'preview')
                                                           }
                                                       ]
                                             },
@@ -1192,7 +1197,7 @@ Are you sure you want to disable auto-sync and rollback application '${props.mat
                                         )}
                                         {!isApplication && (
                                             <SlidingPanel isShown={isAppSelected} onClose={() => selectNode('')}>
-                                                <AppSetResourceDetails appSet={application as appModels.ApplicationSet} />
+                                                {isAppSelected && <AppSetResourceDetails appSet={application as appModels.ApplicationSet} />}
                                             </SlidingPanel>
                                         )}
                                         {isApplication && (

--- a/ui/src/app/applications/components/resource-details/appset-generated-apps-diff.tsx
+++ b/ui/src/app/applications/components/resource-details/appset-generated-apps-diff.tsx
@@ -1,0 +1,254 @@
+import {Tabs} from 'argo-ui';
+import * as jsYaml from 'js-yaml';
+import * as React from 'react';
+import {useEffect, useState} from 'react';
+
+import {MonacoEditor} from '../../../shared/components';
+import * as models from '../../../shared/models';
+import {services} from '../../../shared/services';
+import {ApplicationResourcesDiff} from '../application-resources-diff/application-resources-diff';
+import './resource-details.scss';
+
+export interface AppSetGeneratedAppsDiffProps {
+    currentAppSet: models.ApplicationSet;
+    proposedAppSet: models.ApplicationSet;
+    trigger: number;
+    rbacProject?: string;
+}
+
+function extractErrorMessage(err: any): string {
+    if (err?.response?.body?.message) {
+        return err.response.body.message;
+    }
+    if (err?.response?.body?.error) {
+        return err.response.body.error;
+    }
+    if (err?.message) {
+        return err.message;
+    }
+    return 'Preview failed';
+}
+
+function isPermissionDeniedError(err: any): boolean {
+    if (err?.response?.status === 403) {
+        return true;
+    }
+    const msg = extractErrorMessage(err).toLowerCase();
+    return msg.includes('permission denied') || msg.includes('permissiondenied');
+}
+
+const AppManifestCard = ({app}: {app: models.Application}) => {
+    const yaml = React.useMemo(() => jsYaml.dump(app.spec || {}), [app]);
+    const name = app.metadata?.name || '(unnamed)';
+    const namespace = app.metadata?.namespace || '';
+    return (
+        <div className='white-box' style={{marginTop: '10px'}}>
+            <div className='white-box__details'>
+                <div style={{marginBottom: '8px'}}>
+                    <strong>{namespace ? `${namespace}/${name}` : name}</strong>
+                </div>
+                <MonacoEditor
+                    vScrollBar={false}
+                    editor={{
+                        input: {text: yaml, language: 'yaml'},
+                        options: {readOnly: true, minimap: {enabled: false}, wordWrap: 'on', scrollBeyondLastLine: false}
+                    }}
+                />
+            </div>
+        </div>
+    );
+};
+
+export const AppSetGeneratedAppsDiff = (props: AppSetGeneratedAppsDiffProps) => {
+    const {currentAppSet, proposedAppSet, trigger, rbacProject} = props;
+    const [running, setRunning] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [permissionDenied, setPermissionDenied] = useState(false);
+    const [generated, setGenerated] = useState<models.Application[] | null>(null);
+    const [currentApps, setCurrentApps] = useState<models.Application[]>([]);
+    const [diffStates, setDiffStates] = useState<models.ResourceDiff[] | null>(null);
+    const [diffWarning, setDiffWarning] = useState<string | null>(null);
+    const [resultTab, setResultTab] = useState<string>('diff');
+
+    useEffect(() => {
+        if (trigger === 0) {
+            return;
+        }
+        let cancelled = false;
+        const run = async () => {
+            setError(null);
+            setPermissionDenied(false);
+            setDiffWarning(null);
+            setRunning(true);
+            try {
+                const [proposedApps, currentAppsResult] = await Promise.all([
+                    services.applications.appSetGenerate(proposedAppSet),
+                    services.applications.appSetGenerate(currentAppSet).catch(e => {
+                        if (!cancelled) {
+                            setDiffWarning(`Could not generate current appset output for diff: ${extractErrorMessage(e)}`);
+                        }
+                        return [] as models.Application[];
+                    })
+                ]);
+                if (cancelled) return;
+
+                const currentAppsList = currentAppsResult as models.Application[];
+                setGenerated(proposedApps);
+                setCurrentApps(currentAppsList);
+
+                const defaultNs = currentAppSet.metadata?.namespace || proposedAppSet.metadata?.namespace || '';
+                const keyOf = (app: models.Application) => `${app.metadata?.namespace || defaultNs}/${app.metadata?.name}`;
+                const currentByKey = new Map<string, models.Application>();
+                for (const app of currentAppsList) {
+                    currentByKey.set(keyOf(app), app);
+                }
+                const proposedByKey = new Map<string, models.Application>();
+                for (const app of proposedApps) {
+                    proposedByKey.set(keyOf(app), app);
+                }
+                const allKeys: string[] = [];
+                const seen = new Set<string>();
+                for (const k of [...Array.from(proposedByKey.keys()), ...Array.from(currentByKey.keys())]) {
+                    if (!seen.has(k)) {
+                        seen.add(k);
+                        allKeys.push(k);
+                    }
+                }
+                const states: models.ResourceDiff[] = allKeys.map(key => {
+                    const current = currentByKey.get(key) || null;
+                    const proposed = proposedByKey.get(key) || null;
+                    const sep = key.indexOf('/');
+                    const ns = key.slice(0, sep);
+                    const name = key.slice(sep + 1);
+                    return {
+                        group: 'argoproj.io',
+                        kind: 'Application',
+                        namespace: ns,
+                        name,
+                        hook: false,
+                        normalizedLiveState: current,
+                        predictedLiveState: proposed,
+                        liveState: current,
+                        targetState: proposed
+                    } as models.ResourceDiff;
+                });
+                setDiffStates(states);
+            } catch (e: any) {
+                if (cancelled) return;
+                if (isPermissionDeniedError(e)) {
+                    setPermissionDenied(true);
+                }
+                setError(extractErrorMessage(e));
+                setGenerated(null);
+                setDiffStates(null);
+                setCurrentApps([]);
+            } finally {
+                if (!cancelled) setRunning(false);
+            }
+        };
+        run();
+        return () => {
+            cancelled = true;
+        };
+    }, [trigger, currentAppSet, proposedAppSet]);
+
+    if (running) {
+        return (
+            <div className='white-box' style={{marginTop: '15px'}}>
+                <div className='white-box__details'>
+                    <i className='fa fa-circle-notch fa-spin' style={{marginRight: '6px'}} />
+                    Previewing...
+                </div>
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div className='white-box' style={{marginTop: '15px'}}>
+                <div className='white-box__details'>
+                    {permissionDenied ? (
+                        <>
+                            <p>PERMISSION DENIED</p>
+                            <div>
+                                You need <code>applicationsets, create</code> permission on project <code>{rbacProject || 'unknown'}</code> to preview generated Applications.
+                            </div>
+                        </>
+                    ) : (
+                        <>
+                            <p>PREVIEW FAILED</p>
+                            <pre style={{whiteSpace: 'pre-wrap', wordBreak: 'break-word', maxHeight: '400px', overflow: 'auto'}}>{error}</pre>
+                        </>
+                    )}
+                </div>
+            </div>
+        );
+    }
+
+    if (!generated) {
+        return null;
+    }
+
+    return (
+        <div style={{marginTop: '15px'}}>
+            {diffWarning && (
+                <div className='white-box' style={{marginBottom: '15px'}}>
+                    <div className='white-box__details'>{diffWarning}</div>
+                </div>
+            )}
+            <div className='appset-generated-apps-diff__manifest'>
+                <Tabs
+                    key={resultTab}
+                    selectedTabKey={resultTab}
+                    onTabSelected={setResultTab}
+                    tabs={[
+                        {
+                            title: 'LIVE APPS',
+                            key: 'current',
+                            content:
+                                currentApps.length === 0 ? (
+                                    <div className='white-box'>
+                                        <div className='white-box__details'>No Applications are currently generated by this ApplicationSet.</div>
+                                    </div>
+                                ) : (
+                                    <div>
+                                        {currentApps.map(app => (
+                                            <AppManifestCard key={`${app.metadata?.namespace}/${app.metadata?.name}`} app={app} />
+                                        ))}
+                                    </div>
+                                )
+                        },
+                        {
+                            title: 'DIFF',
+                            key: 'diff',
+                            content:
+                                diffStates && diffStates.length > 0 ? (
+                                    <ApplicationResourcesDiff states={diffStates} />
+                                ) : (
+                                    <div className='white-box'>
+                                        <div className='white-box__details'>No changes — proposed output matches current output.</div>
+                                    </div>
+                                )
+                        },
+                        {
+                            title: 'DESIRED APPS',
+                            key: 'preview',
+                            content:
+                                generated.length === 0 ? (
+                                    <div className='white-box'>
+                                        <div className='white-box__details'>No Applications would be generated by this ApplicationSet.</div>
+                                    </div>
+                                ) : (
+                                    <div>
+                                        {generated.map(app => (
+                                            <AppManifestCard key={`${app.metadata?.namespace}/${app.metadata?.name}`} app={app} />
+                                        ))}
+                                    </div>
+                                )
+                        }
+                    ]}
+                />
+            </div>
+        </div>
+    );
+};

--- a/ui/src/app/applications/components/resource-details/appset-preview-tab.tsx
+++ b/ui/src/app/applications/components/resource-details/appset-preview-tab.tsx
@@ -1,3 +1,4 @@
+import {Tabs} from 'argo-ui';
 import * as jsYaml from 'js-yaml';
 import * as monacoEditor from 'monaco-editor';
 import * as React from 'react';
@@ -6,36 +7,10 @@ import {useEffect, useRef, useState} from 'react';
 import {MonacoEditor} from '../../../shared/components';
 import * as models from '../../../shared/models';
 import {services} from '../../../shared/services';
+import {ApplicationResourcesDiff} from '../application-resources-diff/application-resources-diff';
 
 interface AppSetPreviewTabProps {
     appSet: models.ApplicationSet;
-}
-
-const VOLATILE_METADATA_FIELDS = ['managedFields', 'uid', 'resourceVersion', 'generation', 'creationTimestamp', 'selfLink'];
-const NOISY_ANNOTATIONS = ['kubectl.kubernetes.io/last-applied-configuration'];
-
-function cleanManifest(obj: any): any {
-    const copy: any = JSON.parse(JSON.stringify(obj));
-    if (copy?.metadata) {
-        for (const field of VOLATILE_METADATA_FIELDS) {
-            delete copy.metadata[field];
-        }
-        if (copy.metadata.annotations) {
-            for (const ann of NOISY_ANNOTATIONS) {
-                delete copy.metadata.annotations[ann];
-            }
-            if (Object.keys(copy.metadata.annotations).length === 0) {
-                delete copy.metadata.annotations;
-            }
-        }
-    }
-    delete copy.status;
-    return {
-        apiVersion: copy.apiVersion,
-        kind: copy.kind,
-        metadata: copy.metadata,
-        spec: copy.spec
-    };
 }
 
 function extractErrorMessage(err: any): string {
@@ -59,32 +34,23 @@ function isPermissionDeniedError(err: any): boolean {
     return msg.includes('permission denied') || msg.includes('permissiondenied');
 }
 
-const GeneratedAppCard = ({app}: {app: models.Application}) => {
-    const [expanded, setExpanded] = useState(false);
-    const yaml = React.useMemo(() => jsYaml.dump(cleanManifest(app)), [app]);
+const AppManifestCard = ({app}: {app: models.Application}) => {
+    const yaml = React.useMemo(() => jsYaml.dump(app.spec || {}), [app]);
     const name = app.metadata?.name || '(unnamed)';
     const namespace = app.metadata?.namespace || '';
-
     return (
         <div className='white-box' style={{marginTop: '10px'}}>
             <div className='white-box__details'>
-                <div style={{display: 'flex', alignItems: 'center', justifyContent: 'space-between'}}>
+                <div style={{marginBottom: '8px'}}>
                     <strong>{namespace ? `${namespace}/${name}` : name}</strong>
-                    <button className='argo-button argo-button--base-o' onClick={() => setExpanded(e => !e)}>
-                        {expanded ? 'Hide YAML' : 'Show YAML'}
-                    </button>
                 </div>
-                {expanded && (
-                    <div style={{marginTop: '10px'}}>
-                        <MonacoEditor
-                            vScrollBar={false}
-                            editor={{
-                                input: {text: yaml, language: 'yaml'},
-                                options: {readOnly: true, minimap: {enabled: false}, wordWrap: 'on'}
-                            }}
-                        />
-                    </div>
-                )}
+                <MonacoEditor
+                    vScrollBar={false}
+                    editor={{
+                        input: {text: yaml, language: 'yaml'},
+                        options: {readOnly: true, minimap: {enabled: false}, wordWrap: 'on', scrollBeyondLastLine: false}
+                    }}
+                />
             </div>
         </div>
     );
@@ -92,7 +58,7 @@ const GeneratedAppCard = ({app}: {app: models.Application}) => {
 
 export const AppSetPreviewTab = (props: AppSetPreviewTabProps) => {
     const {appSet} = props;
-    const initialYaml = React.useMemo(() => jsYaml.dump(cleanManifest(appSet)), [appSet]);
+    const initialYaml = React.useMemo(() => jsYaml.dump(appSet.spec || {}), [appSet]);
     const modelRef = useRef<monacoEditor.editor.ITextModel | null>(null);
     const resultRef = useRef<HTMLDivElement | null>(null);
     const [editing, setEditing] = useState(false);
@@ -100,7 +66,11 @@ export const AppSetPreviewTab = (props: AppSetPreviewTabProps) => {
     const [error, setError] = useState<string | null>(null);
     const [permissionDenied, setPermissionDenied] = useState(false);
     const [generated, setGenerated] = useState<models.Application[] | null>(null);
+    const [currentApps, setCurrentApps] = useState<models.Application[]>([]);
+    const [diffStates, setDiffStates] = useState<models.ResourceDiff[] | null>(null);
+    const [diffWarning, setDiffWarning] = useState<string | null>(null);
     const [editorKey, setEditorKey] = useState(0);
+    const [resultTab, setResultTab] = useState<string>('diff');
 
     useEffect(() => {
         if ((generated || error) && resultRef.current) {
@@ -118,27 +88,77 @@ export const AppSetPreviewTab = (props: AppSetPreviewTabProps) => {
     const onPreview = async () => {
         setError(null);
         setPermissionDenied(false);
-        let parsed: models.ApplicationSet;
+        setDiffWarning(null);
+        let parsedSpec: any;
         try {
-            parsed = jsYaml.load(readEditorYaml()) as models.ApplicationSet;
+            parsedSpec = jsYaml.load(readEditorYaml());
         } catch (e: any) {
             setError(`Invalid YAML: ${e.message || e}`);
             return;
         }
-        if (!parsed || !parsed.metadata) {
-            setError('Invalid YAML: missing ApplicationSet metadata');
+        if (!parsedSpec || typeof parsedSpec !== 'object') {
+            setError('Invalid YAML: spec must be an object');
             return;
         }
+        const parsed: models.ApplicationSet = {...appSet, spec: parsedSpec};
         setPreviewing(true);
         try {
-            const apps = await services.applications.appSetGenerate(parsed);
-            setGenerated(apps);
+            const [proposedApps, currentAppsResult] = await Promise.all([
+                services.applications.appSetGenerate(parsed),
+                services.applications.appSetGenerate(appSet).catch(e => {
+                    setDiffWarning(`Could not generate current appset output for diff: ${extractErrorMessage(e)}`);
+                    return [] as models.Application[];
+                })
+            ]);
+            setGenerated(proposedApps);
+
+            const currentAppsList = currentAppsResult as models.Application[];
+            setCurrentApps(currentAppsList);
+            const defaultNs = appSet.metadata?.namespace || '';
+            const keyOf = (app: models.Application) => `${app.metadata?.namespace || defaultNs}/${app.metadata?.name}`;
+            const currentByKey = new Map<string, models.Application>();
+            for (const app of currentAppsList) {
+                currentByKey.set(keyOf(app), app);
+            }
+            const proposedByKey = new Map<string, models.Application>();
+            for (const app of proposedApps) {
+                proposedByKey.set(keyOf(app), app);
+            }
+            const allKeys: string[] = [];
+            const seen = new Set<string>();
+            for (const k of [...Array.from(proposedByKey.keys()), ...Array.from(currentByKey.keys())]) {
+                if (!seen.has(k)) {
+                    seen.add(k);
+                    allKeys.push(k);
+                }
+            }
+            const states: models.ResourceDiff[] = allKeys.map(key => {
+                const current = currentByKey.get(key) || null;
+                const proposed = proposedByKey.get(key) || null;
+                const sep = key.indexOf('/');
+                const ns = key.slice(0, sep);
+                const name = key.slice(sep + 1);
+                return {
+                    group: 'argoproj.io',
+                    kind: 'Application',
+                    namespace: ns,
+                    name,
+                    hook: false,
+                    normalizedLiveState: current,
+                    predictedLiveState: proposed,
+                    liveState: current,
+                    targetState: proposed
+                } as models.ResourceDiff;
+            });
+            setDiffStates(states);
         } catch (e: any) {
             if (isPermissionDeniedError(e)) {
                 setPermissionDenied(true);
             }
             setError(extractErrorMessage(e));
             setGenerated(null);
+            setDiffStates(null);
+            setCurrentApps([]);
         } finally {
             setPreviewing(false);
         }
@@ -158,6 +178,10 @@ export const AppSetPreviewTab = (props: AppSetPreviewTabProps) => {
 
     return (
         <div className='applicationset-preview' style={{padding: '15px'}}>
+            <div style={{marginBottom: '15px', fontSize: '13px', color: '#6d7f8b'}}>
+                <i className='fa fa-info-circle' style={{marginRight: '6px'}} />
+                Preview what Applications your ApplicationSet will generate. The diff compares your proposed ApplicationSet's output to the current ApplicationSet's output.
+            </div>
             <div className='white-box'>
                 <div className='white-box__details'>
                     <div style={{display: 'flex', alignItems: 'center', justifyContent: 'space-between'}}>
@@ -230,13 +254,65 @@ export const AppSetPreviewTab = (props: AppSetPreviewTabProps) => {
                             </div>
                         </div>
                     </div>
-                    {generated.length === 0 ? (
+                    {diffWarning && (
                         <div className='white-box' style={{marginTop: '15px'}}>
-                            <div className='white-box__details'>No Applications would be generated by this ApplicationSet.</div>
+                            <div className='white-box__details'>{diffWarning}</div>
                         </div>
-                    ) : (
-                        generated.map(app => <GeneratedAppCard key={`${app.metadata?.namespace}/${app.metadata?.name}`} app={app} />)
                     )}
+                    <div style={{marginTop: '15px'}}>
+                        <Tabs
+                            key={resultTab}
+                            navTransparent={true}
+                            selectedTabKey={resultTab}
+                            onTabSelected={setResultTab}
+                            tabs={[
+                                {
+                                    title: 'CURRENT',
+                                    key: 'current',
+                                    content:
+                                        currentApps.length === 0 ? (
+                                            <div className='white-box'>
+                                                <div className='white-box__details'>No Applications are currently generated by this ApplicationSet.</div>
+                                            </div>
+                                        ) : (
+                                            <div>
+                                                {currentApps.map(app => (
+                                                    <AppManifestCard key={`${app.metadata?.namespace}/${app.metadata?.name}`} app={app} />
+                                                ))}
+                                            </div>
+                                        )
+                                },
+                                {
+                                    title: 'DIFF',
+                                    key: 'diff',
+                                    content:
+                                        diffStates && diffStates.length > 0 ? (
+                                            <ApplicationResourcesDiff states={diffStates} />
+                                        ) : (
+                                            <div className='white-box'>
+                                                <div className='white-box__details'>No changes — proposed output matches current output.</div>
+                                            </div>
+                                        )
+                                },
+                                {
+                                    title: 'PREVIEW',
+                                    key: 'preview',
+                                    content:
+                                        generated.length === 0 ? (
+                                            <div className='white-box'>
+                                                <div className='white-box__details'>No Applications would be generated by this ApplicationSet.</div>
+                                            </div>
+                                        ) : (
+                                            <div>
+                                                {generated.map(app => (
+                                                    <AppManifestCard key={`${app.metadata?.namespace}/${app.metadata?.name}`} app={app} />
+                                                ))}
+                                            </div>
+                                        )
+                                }
+                            ]}
+                        />
+                    </div>
                 </div>
             )}
         </div>

--- a/ui/src/app/applications/components/resource-details/appset-preview-tab.tsx
+++ b/ui/src/app/applications/components/resource-details/appset-preview-tab.tsx
@@ -1,4 +1,3 @@
-import {Tabs} from 'argo-ui';
 import * as jsYaml from 'js-yaml';
 import * as monacoEditor from 'monaco-editor';
 import * as React from 'react';
@@ -6,55 +5,11 @@ import {useEffect, useRef, useState} from 'react';
 
 import {MonacoEditor} from '../../../shared/components';
 import * as models from '../../../shared/models';
-import {services} from '../../../shared/services';
-import {ApplicationResourcesDiff} from '../application-resources-diff/application-resources-diff';
+import {AppSetGeneratedAppsDiff} from './appset-generated-apps-diff';
 
 interface AppSetPreviewTabProps {
     appSet: models.ApplicationSet;
 }
-
-function extractErrorMessage(err: any): string {
-    if (err?.response?.body?.message) {
-        return err.response.body.message;
-    }
-    if (err?.response?.body?.error) {
-        return err.response.body.error;
-    }
-    if (err?.message) {
-        return err.message;
-    }
-    return 'Preview failed';
-}
-
-function isPermissionDeniedError(err: any): boolean {
-    if (err?.response?.status === 403) {
-        return true;
-    }
-    const msg = extractErrorMessage(err).toLowerCase();
-    return msg.includes('permission denied') || msg.includes('permissiondenied');
-}
-
-const AppManifestCard = ({app}: {app: models.Application}) => {
-    const yaml = React.useMemo(() => jsYaml.dump(app.spec || {}), [app]);
-    const name = app.metadata?.name || '(unnamed)';
-    const namespace = app.metadata?.namespace || '';
-    return (
-        <div className='white-box' style={{marginTop: '10px'}}>
-            <div className='white-box__details'>
-                <div style={{marginBottom: '8px'}}>
-                    <strong>{namespace ? `${namespace}/${name}` : name}</strong>
-                </div>
-                <MonacoEditor
-                    vScrollBar={false}
-                    editor={{
-                        input: {text: yaml, language: 'yaml'},
-                        options: {readOnly: true, minimap: {enabled: false}, wordWrap: 'on', scrollBeyondLastLine: false}
-                    }}
-                />
-            </div>
-        </div>
-    );
-};
 
 export const AppSetPreviewTab = (props: AppSetPreviewTabProps) => {
     const {appSet} = props;
@@ -62,21 +17,16 @@ export const AppSetPreviewTab = (props: AppSetPreviewTabProps) => {
     const modelRef = useRef<monacoEditor.editor.ITextModel | null>(null);
     const resultRef = useRef<HTMLDivElement | null>(null);
     const [editing, setEditing] = useState(false);
-    const [previewing, setPreviewing] = useState(false);
-    const [error, setError] = useState<string | null>(null);
-    const [permissionDenied, setPermissionDenied] = useState(false);
-    const [generated, setGenerated] = useState<models.Application[] | null>(null);
-    const [currentApps, setCurrentApps] = useState<models.Application[]>([]);
-    const [diffStates, setDiffStates] = useState<models.ResourceDiff[] | null>(null);
-    const [diffWarning, setDiffWarning] = useState<string | null>(null);
+    const [parseError, setParseError] = useState<string | null>(null);
     const [editorKey, setEditorKey] = useState(0);
-    const [resultTab, setResultTab] = useState<string>('diff');
+    const [proposedAppSet, setProposedAppSet] = useState<models.ApplicationSet | null>(null);
+    const [trigger, setTrigger] = useState(0);
 
     useEffect(() => {
-        if ((generated || error) && resultRef.current) {
+        if ((proposedAppSet || parseError) && resultRef.current) {
             resultRef.current.scrollIntoView({behavior: 'smooth', block: 'start'});
         }
-    }, [generated, error]);
+    }, [proposedAppSet, parseError]);
 
     const readEditorYaml = (): string => {
         if (modelRef.current) {
@@ -85,83 +35,23 @@ export const AppSetPreviewTab = (props: AppSetPreviewTabProps) => {
         return initialYaml;
     };
 
-    const onPreview = async () => {
-        setError(null);
-        setPermissionDenied(false);
-        setDiffWarning(null);
+    const onPreview = () => {
+        setParseError(null);
         let parsedSpec: any;
         try {
             parsedSpec = jsYaml.load(readEditorYaml());
         } catch (e: any) {
-            setError(`Invalid YAML: ${e.message || e}`);
+            setParseError(`Invalid YAML: ${e.message || e}`);
+            setProposedAppSet(null);
             return;
         }
         if (!parsedSpec || typeof parsedSpec !== 'object') {
-            setError('Invalid YAML: spec must be an object');
+            setParseError('Invalid YAML: spec must be an object');
+            setProposedAppSet(null);
             return;
         }
-        const parsed: models.ApplicationSet = {...appSet, spec: parsedSpec};
-        setPreviewing(true);
-        try {
-            const [proposedApps, currentAppsResult] = await Promise.all([
-                services.applications.appSetGenerate(parsed),
-                services.applications.appSetGenerate(appSet).catch(e => {
-                    setDiffWarning(`Could not generate current appset output for diff: ${extractErrorMessage(e)}`);
-                    return [] as models.Application[];
-                })
-            ]);
-            setGenerated(proposedApps);
-
-            const currentAppsList = currentAppsResult as models.Application[];
-            setCurrentApps(currentAppsList);
-            const defaultNs = appSet.metadata?.namespace || '';
-            const keyOf = (app: models.Application) => `${app.metadata?.namespace || defaultNs}/${app.metadata?.name}`;
-            const currentByKey = new Map<string, models.Application>();
-            for (const app of currentAppsList) {
-                currentByKey.set(keyOf(app), app);
-            }
-            const proposedByKey = new Map<string, models.Application>();
-            for (const app of proposedApps) {
-                proposedByKey.set(keyOf(app), app);
-            }
-            const allKeys: string[] = [];
-            const seen = new Set<string>();
-            for (const k of [...Array.from(proposedByKey.keys()), ...Array.from(currentByKey.keys())]) {
-                if (!seen.has(k)) {
-                    seen.add(k);
-                    allKeys.push(k);
-                }
-            }
-            const states: models.ResourceDiff[] = allKeys.map(key => {
-                const current = currentByKey.get(key) || null;
-                const proposed = proposedByKey.get(key) || null;
-                const sep = key.indexOf('/');
-                const ns = key.slice(0, sep);
-                const name = key.slice(sep + 1);
-                return {
-                    group: 'argoproj.io',
-                    kind: 'Application',
-                    namespace: ns,
-                    name,
-                    hook: false,
-                    normalizedLiveState: current,
-                    predictedLiveState: proposed,
-                    liveState: current,
-                    targetState: proposed
-                } as models.ResourceDiff;
-            });
-            setDiffStates(states);
-        } catch (e: any) {
-            if (isPermissionDeniedError(e)) {
-                setPermissionDenied(true);
-            }
-            setError(extractErrorMessage(e));
-            setGenerated(null);
-            setDiffStates(null);
-            setCurrentApps([]);
-        } finally {
-            setPreviewing(false);
-        }
+        setProposedAppSet({...appSet, spec: parsedSpec});
+        setTrigger(t => t + 1);
     };
 
     const onEdit = () => {
@@ -189,17 +79,17 @@ export const AppSetPreviewTab = (props: AppSetPreviewTabProps) => {
                         <div>
                             {editing ? (
                                 <>
-                                    <button className='argo-button argo-button--base' onClick={onPreview} disabled={previewing}>
-                                        {previewing ? 'Previewing...' : 'Preview'}
+                                    <button className='argo-button argo-button--base' onClick={onPreview}>
+                                        Preview
                                     </button>{' '}
-                                    <button className='argo-button argo-button--base-o' onClick={onCancelEdit} disabled={previewing}>
+                                    <button className='argo-button argo-button--base-o' onClick={onCancelEdit}>
                                         Cancel
                                     </button>
                                 </>
                             ) : (
                                 <>
-                                    <button className='argo-button argo-button--base' onClick={onPreview} disabled={previewing}>
-                                        {previewing ? 'Previewing...' : 'Preview'}
+                                    <button className='argo-button argo-button--base' onClick={onPreview}>
+                                        Preview
                                     </button>{' '}
                                     <button className='argo-button argo-button--base-o' onClick={onEdit}>
                                         Edit
@@ -224,95 +114,18 @@ export const AppSetPreviewTab = (props: AppSetPreviewTabProps) => {
                 </div>
             </div>
 
-            {error && (
+            {parseError && (
                 <div ref={resultRef} className='white-box' style={{marginTop: '15px'}}>
                     <div className='white-box__details'>
-                        {permissionDenied ? (
-                            <>
-                                <p>PERMISSION DENIED</p>
-                                <div>
-                                    You need <code>applicationsets, create</code> permission on project <code>{project}</code> to preview generated Applications.
-                                </div>
-                            </>
-                        ) : (
-                            <>
-                                <p>PREVIEW FAILED</p>
-                                <pre style={{whiteSpace: 'pre-wrap', wordBreak: 'break-word', maxHeight: '400px', overflow: 'auto'}}>{error}</pre>
-                            </>
-                        )}
+                        <p>PREVIEW FAILED</p>
+                        <pre style={{whiteSpace: 'pre-wrap', wordBreak: 'break-word', maxHeight: '400px', overflow: 'auto'}}>{parseError}</pre>
                     </div>
                 </div>
             )}
 
-            {generated && !error && (
-                <div ref={resultRef} style={{marginTop: '15px'}}>
-                    <div className='white-box'>
-                        <div className='white-box__details'>
-                            <p>GENERATED APPLICATIONS</p>
-                            <div>
-                                {generated.length} application{generated.length === 1 ? '' : 's'} would be generated by this ApplicationSet.
-                            </div>
-                        </div>
-                    </div>
-                    {diffWarning && (
-                        <div className='white-box' style={{marginTop: '15px'}}>
-                            <div className='white-box__details'>{diffWarning}</div>
-                        </div>
-                    )}
-                    <div style={{marginTop: '15px'}}>
-                        <Tabs
-                            key={resultTab}
-                            navTransparent={true}
-                            selectedTabKey={resultTab}
-                            onTabSelected={setResultTab}
-                            tabs={[
-                                {
-                                    title: 'CURRENT',
-                                    key: 'current',
-                                    content:
-                                        currentApps.length === 0 ? (
-                                            <div className='white-box'>
-                                                <div className='white-box__details'>No Applications are currently generated by this ApplicationSet.</div>
-                                            </div>
-                                        ) : (
-                                            <div>
-                                                {currentApps.map(app => (
-                                                    <AppManifestCard key={`${app.metadata?.namespace}/${app.metadata?.name}`} app={app} />
-                                                ))}
-                                            </div>
-                                        )
-                                },
-                                {
-                                    title: 'DIFF',
-                                    key: 'diff',
-                                    content:
-                                        diffStates && diffStates.length > 0 ? (
-                                            <ApplicationResourcesDiff states={diffStates} />
-                                        ) : (
-                                            <div className='white-box'>
-                                                <div className='white-box__details'>No changes — proposed output matches current output.</div>
-                                            </div>
-                                        )
-                                },
-                                {
-                                    title: 'PREVIEW',
-                                    key: 'preview',
-                                    content:
-                                        generated.length === 0 ? (
-                                            <div className='white-box'>
-                                                <div className='white-box__details'>No Applications would be generated by this ApplicationSet.</div>
-                                            </div>
-                                        ) : (
-                                            <div>
-                                                {generated.map(app => (
-                                                    <AppManifestCard key={`${app.metadata?.namespace}/${app.metadata?.name}`} app={app} />
-                                                ))}
-                                            </div>
-                                        )
-                                }
-                            ]}
-                        />
-                    </div>
+            {proposedAppSet && !parseError && (
+                <div ref={resultRef}>
+                    <AppSetGeneratedAppsDiff currentAppSet={appSet} proposedAppSet={proposedAppSet} trigger={trigger} rbacProject={project} />
                 </div>
             )}
         </div>

--- a/ui/src/app/applications/components/resource-details/appset-preview-tab.tsx
+++ b/ui/src/app/applications/components/resource-details/appset-preview-tab.tsx
@@ -1,0 +1,244 @@
+import * as jsYaml from 'js-yaml';
+import * as monacoEditor from 'monaco-editor';
+import * as React from 'react';
+import {useEffect, useRef, useState} from 'react';
+
+import {MonacoEditor} from '../../../shared/components';
+import * as models from '../../../shared/models';
+import {services} from '../../../shared/services';
+
+interface AppSetPreviewTabProps {
+    appSet: models.ApplicationSet;
+}
+
+const VOLATILE_METADATA_FIELDS = ['managedFields', 'uid', 'resourceVersion', 'generation', 'creationTimestamp', 'selfLink'];
+const NOISY_ANNOTATIONS = ['kubectl.kubernetes.io/last-applied-configuration'];
+
+function cleanManifest(obj: any): any {
+    const copy: any = JSON.parse(JSON.stringify(obj));
+    if (copy?.metadata) {
+        for (const field of VOLATILE_METADATA_FIELDS) {
+            delete copy.metadata[field];
+        }
+        if (copy.metadata.annotations) {
+            for (const ann of NOISY_ANNOTATIONS) {
+                delete copy.metadata.annotations[ann];
+            }
+            if (Object.keys(copy.metadata.annotations).length === 0) {
+                delete copy.metadata.annotations;
+            }
+        }
+    }
+    delete copy.status;
+    return {
+        apiVersion: copy.apiVersion,
+        kind: copy.kind,
+        metadata: copy.metadata,
+        spec: copy.spec
+    };
+}
+
+function extractErrorMessage(err: any): string {
+    if (err?.response?.body?.message) {
+        return err.response.body.message;
+    }
+    if (err?.response?.body?.error) {
+        return err.response.body.error;
+    }
+    if (err?.message) {
+        return err.message;
+    }
+    return 'Preview failed';
+}
+
+function isPermissionDeniedError(err: any): boolean {
+    if (err?.response?.status === 403) {
+        return true;
+    }
+    const msg = extractErrorMessage(err).toLowerCase();
+    return msg.includes('permission denied') || msg.includes('permissiondenied');
+}
+
+const GeneratedAppCard = ({app}: {app: models.Application}) => {
+    const [expanded, setExpanded] = useState(false);
+    const yaml = React.useMemo(() => jsYaml.dump(cleanManifest(app)), [app]);
+    const name = app.metadata?.name || '(unnamed)';
+    const namespace = app.metadata?.namespace || '';
+
+    return (
+        <div className='white-box' style={{marginTop: '10px'}}>
+            <div className='white-box__details'>
+                <div style={{display: 'flex', alignItems: 'center', justifyContent: 'space-between'}}>
+                    <strong>{namespace ? `${namespace}/${name}` : name}</strong>
+                    <button className='argo-button argo-button--base-o' onClick={() => setExpanded(e => !e)}>
+                        {expanded ? 'Hide YAML' : 'Show YAML'}
+                    </button>
+                </div>
+                {expanded && (
+                    <div style={{marginTop: '10px'}}>
+                        <MonacoEditor
+                            vScrollBar={false}
+                            editor={{
+                                input: {text: yaml, language: 'yaml'},
+                                options: {readOnly: true, minimap: {enabled: false}, wordWrap: 'on'}
+                            }}
+                        />
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export const AppSetPreviewTab = (props: AppSetPreviewTabProps) => {
+    const {appSet} = props;
+    const initialYaml = React.useMemo(() => jsYaml.dump(cleanManifest(appSet)), [appSet]);
+    const modelRef = useRef<monacoEditor.editor.ITextModel | null>(null);
+    const resultRef = useRef<HTMLDivElement | null>(null);
+    const [editing, setEditing] = useState(false);
+    const [previewing, setPreviewing] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [permissionDenied, setPermissionDenied] = useState(false);
+    const [generated, setGenerated] = useState<models.Application[] | null>(null);
+    const [editorKey, setEditorKey] = useState(0);
+
+    useEffect(() => {
+        if ((generated || error) && resultRef.current) {
+            resultRef.current.scrollIntoView({behavior: 'smooth', block: 'start'});
+        }
+    }, [generated, error]);
+
+    const readEditorYaml = (): string => {
+        if (modelRef.current) {
+            return modelRef.current.getLinesContent().join('\n');
+        }
+        return initialYaml;
+    };
+
+    const onPreview = async () => {
+        setError(null);
+        setPermissionDenied(false);
+        let parsed: models.ApplicationSet;
+        try {
+            parsed = jsYaml.load(readEditorYaml()) as models.ApplicationSet;
+        } catch (e: any) {
+            setError(`Invalid YAML: ${e.message || e}`);
+            return;
+        }
+        if (!parsed || !parsed.metadata) {
+            setError('Invalid YAML: missing ApplicationSet metadata');
+            return;
+        }
+        setPreviewing(true);
+        try {
+            const apps = await services.applications.appSetGenerate(parsed);
+            setGenerated(apps);
+        } catch (e: any) {
+            if (isPermissionDeniedError(e)) {
+                setPermissionDenied(true);
+            }
+            setError(extractErrorMessage(e));
+            setGenerated(null);
+        } finally {
+            setPreviewing(false);
+        }
+    };
+
+    const onEdit = () => {
+        setEditing(true);
+    };
+
+    const onCancelEdit = () => {
+        setEditing(false);
+        setEditorKey(k => k + 1);
+    };
+
+    const spec = appSet.spec as any;
+    const project = spec?.template?.spec?.project || 'unknown';
+
+    return (
+        <div className='applicationset-preview' style={{padding: '15px'}}>
+            <div className='white-box'>
+                <div className='white-box__details'>
+                    <div style={{display: 'flex', alignItems: 'center', justifyContent: 'space-between'}}>
+                        <p style={{margin: 0}}>APPLICATIONSET MANIFEST{editing && ' (edits are not saved)'}</p>
+                        <div>
+                            {editing ? (
+                                <>
+                                    <button className='argo-button argo-button--base' onClick={onPreview} disabled={previewing}>
+                                        {previewing ? 'Previewing...' : 'Preview'}
+                                    </button>{' '}
+                                    <button className='argo-button argo-button--base-o' onClick={onCancelEdit} disabled={previewing}>
+                                        Cancel
+                                    </button>
+                                </>
+                            ) : (
+                                <>
+                                    <button className='argo-button argo-button--base' onClick={onPreview} disabled={previewing}>
+                                        {previewing ? 'Previewing...' : 'Preview'}
+                                    </button>{' '}
+                                    <button className='argo-button argo-button--base-o' onClick={onEdit}>
+                                        Edit
+                                    </button>
+                                </>
+                            )}
+                        </div>
+                    </div>
+                    <div style={{marginTop: '10px'}}>
+                        <MonacoEditor
+                            key={editorKey}
+                            vScrollBar={false}
+                            editor={{
+                                input: {text: initialYaml, language: 'yaml'},
+                                options: {readOnly: !editing, minimap: {enabled: false}, wordWrap: 'on'},
+                                getApi: api => {
+                                    modelRef.current = api.getModel() as monacoEditor.editor.ITextModel;
+                                }
+                            }}
+                        />
+                    </div>
+                </div>
+            </div>
+
+            {error && (
+                <div ref={resultRef} className='white-box' style={{marginTop: '15px'}}>
+                    <div className='white-box__details'>
+                        {permissionDenied ? (
+                            <>
+                                <p>PERMISSION DENIED</p>
+                                <div>
+                                    You need <code>applicationsets, create</code> permission on project <code>{project}</code> to preview generated Applications.
+                                </div>
+                            </>
+                        ) : (
+                            <>
+                                <p>PREVIEW FAILED</p>
+                                <pre style={{whiteSpace: 'pre-wrap', wordBreak: 'break-word', maxHeight: '400px', overflow: 'auto'}}>{error}</pre>
+                            </>
+                        )}
+                    </div>
+                </div>
+            )}
+
+            {generated && !error && (
+                <div ref={resultRef} style={{marginTop: '15px'}}>
+                    <div className='white-box'>
+                        <div className='white-box__details'>
+                            <p>GENERATED APPLICATIONS</p>
+                            <div>
+                                {generated.length} application{generated.length === 1 ? '' : 's'} would be generated by this ApplicationSet.
+                            </div>
+                        </div>
+                    </div>
+                    {generated.length === 0 ? (
+                        <div className='white-box' style={{marginTop: '15px'}}>
+                            <div className='white-box__details'>No Applications would be generated by this ApplicationSet.</div>
+                        </div>
+                    ) : (
+                        generated.map(app => <GeneratedAppCard key={`${app.metadata?.namespace}/${app.metadata?.name}`} app={app} />)
+                    )}
+                </div>
+            )}
+        </div>
+    );
+};

--- a/ui/src/app/applications/components/resource-details/appset-resource-details.tsx
+++ b/ui/src/app/applications/components/resource-details/appset-resource-details.tsx
@@ -141,7 +141,13 @@ export const AppSetResourceDetails = (props: AppSetResourceDetailsProps) => {
                 <h1>{appSet.metadata.name}</h1>
                 <HealthStatusIcon state={{status: healthStatus, message: ''}} />
             </div>
-            <Tabs navTransparent={true} tabs={getTabs()} selectedTabKey={tab} onTabSelected={selected => appContext.navigation.goto('.', {tab: selected}, {replace: true})} />
+            <Tabs
+                key={tab || 'default'}
+                navTransparent={true}
+                tabs={getTabs()}
+                selectedTabKey={tab}
+                onTabSelected={selected => appContext.navigation.goto('.', {tab: selected}, {replace: true})}
+            />
         </div>
     );
 };

--- a/ui/src/app/applications/components/resource-details/appset-resource-details.tsx
+++ b/ui/src/app/applications/components/resource-details/appset-resource-details.tsx
@@ -8,6 +8,7 @@ import {Context} from '../../../shared/context';
 import {ResourceIcon} from '../resource-icon';
 import {ResourceLabel} from '../resource-label';
 import {HealthStatusIcon, getAppSetHealthStatus, getAppSetConditionCategory} from '../utils';
+import {AppSetPreviewTab} from './appset-preview-tab';
 import './resource-details.scss';
 
 interface AppSetResourceDetailsProps {
@@ -112,6 +113,11 @@ export const AppSetResourceDetails = (props: AppSetResourceDetailsProps) => {
                         </DataLoader>
                     </div>
                 )
+            },
+            {
+                title: 'PREVIEW',
+                key: 'preview',
+                content: <AppSetPreviewTab appSet={appSet} />
             }
         ];
 

--- a/ui/src/app/applications/components/resource-details/appset-resource-node-preview.tsx
+++ b/ui/src/app/applications/components/resource-details/appset-resource-node-preview.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react';
+
+import * as models from '../../../shared/models';
+import {AppSetGeneratedAppsDiff} from './appset-generated-apps-diff';
+import './resource-details.scss';
+
+interface AppSetResourceNodePreviewProps {
+    liveAppSet: any;
+    targetAppSet: any;
+    syncStatus: models.SyncStatusCode;
+}
+
+function toAppSet(raw: any, fallbackMeta?: {name?: string; namespace?: string}): models.ApplicationSet {
+    if (raw && typeof raw === 'object' && raw.metadata && raw.spec) {
+        return raw as models.ApplicationSet;
+    }
+    return {
+        apiVersion: 'argoproj.io/v1alpha1',
+        kind: 'ApplicationSet',
+        metadata: {
+            name: fallbackMeta?.name || '',
+            namespace: fallbackMeta?.namespace || ''
+        },
+        spec: {}
+    } as unknown as models.ApplicationSet;
+}
+
+export const AppSetResourceNodePreview = (props: AppSetResourceNodePreviewProps) => {
+    const {liveAppSet, targetAppSet, syncStatus} = props;
+
+    if (syncStatus === models.SyncStatuses.Synced) {
+        return (
+            <div className='applicationset-preview' style={{padding: '15px'}}>
+                <div className='white-box'>
+                    <div className='white-box__details'>
+                        <i className='fa fa-check-circle appset-resource-node-preview__synced-icon' />
+                        ApplicationSet is in sync — no preview available.
+                    </div>
+                </div>
+            </div>
+        );
+    }
+
+    if (!targetAppSet) {
+        return (
+            <div className='applicationset-preview' style={{padding: '15px'}}>
+                <div className='white-box'>
+                    <div className='white-box__details'>No target ApplicationSet manifest available to preview.</div>
+                </div>
+            </div>
+        );
+    }
+
+    const fallbackMeta = {
+        name: targetAppSet?.metadata?.name,
+        namespace: targetAppSet?.metadata?.namespace
+    };
+    const currentAppSet = toAppSet(liveAppSet, fallbackMeta);
+    const proposedAppSet = toAppSet(targetAppSet, fallbackMeta);
+    const project = (proposedAppSet.spec as any)?.template?.spec?.project || 'unknown';
+
+    return (
+        <div className='applicationset-preview' style={{padding: '15px'}}>
+            <div style={{marginBottom: '15px', fontSize: '13px', color: '#6d7f8b'}}>
+                <i className='fa fa-info-circle' style={{marginRight: '6px'}} />
+                Preview shows what child Applications will change when this app-of-appset syncs.
+            </div>
+            <AppSetGeneratedAppsDiff currentAppSet={currentAppSet} proposedAppSet={proposedAppSet} trigger={1} rbacProject={project} />
+        </div>
+    );
+};

--- a/ui/src/app/applications/components/resource-details/resource-details.scss
+++ b/ui/src/app/applications/components/resource-details/resource-details.scss
@@ -18,3 +18,28 @@
         }
     }
 }
+
+.appset-resource-node-preview__synced-icon {
+    margin-right: 6px;
+    color: $argo-success-color;
+}
+
+.appset-generated-apps-diff__manifest {
+    overflow-x: auto;
+    .tabs__content {
+        background-color: white;
+        @include themify($themes) {
+            background-color: themed('background-2');
+        }
+    }
+    .application-resources-diff__checkboxes.white-box {
+        padding: 6px 12px;
+    }
+    .custom-diff-hunk {
+        border-bottom: none;
+    }
+}
+
+.tabs .fa-stack[data-count='!']:after {
+    background: $argo-status-warning-color;
+}

--- a/ui/src/app/applications/components/resource-details/resource-details.tsx
+++ b/ui/src/app/applications/components/resource-details/resource-details.tsx
@@ -15,6 +15,7 @@ import {ApplicationResourceEvents} from '../application-resource-events/applicat
 import {ResourceTreeNode} from '../application-resource-tree/application-resource-tree';
 import {ApplicationResourcesDiff} from '../application-resources-diff/application-resources-diff';
 import {ApplicationSummary} from '../application-summary/application-summary';
+import {AppSetResourceNodePreview} from './appset-resource-node-preview';
 import {PodsLogsViewer} from '../pod-logs-viewer/pod-logs-viewer';
 import {PodTerminalViewer} from '../pod-terminal-viewer/pod-terminal-viewer';
 import {ResourceIcon} from '../resource-icon';
@@ -62,7 +63,8 @@ export const ResourceDetails = (props: ResourceDetailsProps) => {
         tabs: Tab[],
         execEnabled: boolean,
         execAllowed: boolean,
-        logsAllowed: boolean
+        logsAllowed: boolean,
+        controlledState: {summary: models.ResourceStatus; state: models.ResourceDiff} | null
     ) => {
         if (!node || node === undefined) {
             return [];
@@ -148,6 +150,15 @@ export const ResourceDetails = (props: ResourceDetailsProps) => {
                     }
                 ]);
             }
+        }
+        if (node?.kind === 'ApplicationSet' && node?.group === 'argoproj.io') {
+            const appSetSyncStatus = controlledState?.summary?.status || SyncStatuses.Unknown;
+            tabs.push({
+                title: 'PREVIEW',
+                key: 'preview',
+                badge: appSetSyncStatus === SyncStatuses.OutOfSync ? '!' : null,
+                content: <AppSetResourceNodePreview liveAppSet={state} targetAppSet={controlledState?.state?.targetState} syncStatus={appSetSyncStatus} />
+            });
         }
         if (state) {
             extensionTabs.forEach((tabExtensions, i) => {
@@ -356,7 +367,8 @@ export const ResourceDetails = (props: ResourceDetailsProps) => {
                                     ],
                                     data.execEnabled,
                                     data.execAllowed,
-                                    data.logsAllowed
+                                    data.logsAllowed,
+                                    data.controlledState
                                 )}
                                 selectedTabKey={tab}
                                 onTabSelected={selected => appContext.navigation.goto('.', {tab: selected}, {replace: true})}

--- a/ui/src/app/shared/services/applications-service.ts
+++ b/ui/src/app/shared/services/applications-service.ts
@@ -653,9 +653,11 @@ export class ApplicationsService {
     }
 
     public appSetGenerate(appSet: models.ApplicationSet): Promise<models.Application[]> {
+        const {status, ...rest} = appSet as models.ApplicationSet & {status?: unknown};
+        void status;
         return requests
             .post(`/applicationsets/generate`)
-            .send({applicationSet: appSet})
+            .send({applicationSet: rest})
             .then(res => (res.body as {applications?: models.Application[]}).applications || []);
     }
 }

--- a/ui/src/app/shared/services/applications-service.ts
+++ b/ui/src/app/shared/services/applications-service.ts
@@ -651,4 +651,11 @@ export class ApplicationsService {
             .query({appsetNamespace: appNamespace})
             .then(res => (res.body as models.EventList).items || []);
     }
+
+    public appSetGenerate(appSet: models.ApplicationSet): Promise<models.Application[]> {
+        return requests
+            .post(`/applicationsets/generate`)
+            .send({applicationSet: appSet})
+            .then(res => (res.body as {applications?: models.Application[]}).applications || []);
+    }
 }


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->
closes https://github.com/argoproj/argo-cd/issues/27800
Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->

## Summary

This PR adds a 'Preview' tab to the ApplicationSet UI. As right now this is a CLI only feature and I think many would like to have this in the UI as well. This is based on the `POST /api/v1/applicationsets/generate` command allowing us to see what applications will be generated from an ApplicationSet. Users will be able to edit the YAML of the applicationSet in an editor and hit preview to render the applicationSet and view a diff comparing:

1. Current state (What applications will my AppSet currently generate?)
2. Diff (What changed between current and proposed Appset apps?)
3. Preview (What applications will my AppSet generate after i made changes to the YAML?)


https://github.com/user-attachments/assets/fc8a7fef-2c28-42b5-92d7-0ef3e993c2b0

Second part of the feature is in the Application page where we have an App of Appset 
or resource details preview feature:
1. "Current" = generate against the live cluster appset.
2. "Preview" = generate against desired state AppSet (Git).
show CURRENT / DIFF / PREVIEW based on Git changes
This is a safety net before clicking Sync on an app-of-appset whose autoSync is disabled.

This will generate the preview when clicking on the tab. No YAML editor. 
If appSet is Synced, no preview /diff will be available.

https://github.com/user-attachments/assets/40338d89-e0ca-413b-8458-e0071d5d7b7d

