### PR TITLE
chore: wrap errors in util/rbac to improve observability (#10592)

### DIFF
--- a/util/rbac/rbac.go
+++ b/util/rbac/rbac.go
@@ -194,7 +194,7 @@ func (e *Enforcer) tryGetCasbinEnforcer(project string, policy string) (CasbinEn
 		enforcer, err = newEnforcerSafe(matchFunc, e.model, e.adapter)
 	}
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error creating casbin enforcer: %w", err)
 	}
 
 	enforcer.AddFunction("globOrRegexMatch", matchFunc)
@@ -254,20 +254,23 @@ func (e *Enforcer) EnableEnforce(s bool) {
 // LoadPolicy executes casbin.Enforcer functionality and will invalidate cache if required.
 func (e *Enforcer) LoadPolicy() error {
 	_, err := e.tryGetCasbinEnforcer("", "")
-	return err
+	if err != nil {
+		return fmt.Errorf("error loading RBAC policy: %w", err)
+	}
+	return nil
 }
 
 // CheckUserDefinedRoleReferentialIntegrity iterates over roles and policies to validate the existence of a matching policy subject for every defined role
 func CheckUserDefinedRoleReferentialIntegrity(e CasbinEnforcer) error {
 	allRoles, err := e.GetAllRoles()
 	if err != nil {
-		return err
+		return fmt.Errorf("error getting all RBAC roles: %w", err)
 	}
 	notFound := make([]string, 0)
 	for _, roleName := range allRoles {
 		permissions, err := e.GetImplicitPermissionsForUser(roleName)
 		if err != nil {
-			return err
+			return fmt.Errorf("error getting permissions for role %q: %w", roleName, err)
 		}
 		if len(permissions) == 0 {
 			notFound = append(notFound, roleName)
@@ -437,12 +440,12 @@ func (e *Enforcer) RunPolicyLoader(ctx context.Context, onUpdated func(cm *corev
 	cm, err := e.clientset.CoreV1().ConfigMaps(e.namespace).Get(ctx, e.configmap, metav1.GetOptions{})
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
-			return err
+			return fmt.Errorf("error getting RBAC configmap %q: %w", e.configmap, err)
 		}
 	} else {
 		err = e.syncUpdate(cm, onUpdated)
 		if err != nil {
-			return err
+			return fmt.Errorf("error syncing RBAC policy update: %w", err)
 		}
 	}
 	e.runInformer(ctx, onUpdated)
@@ -523,7 +526,7 @@ func (e *Enforcer) syncUpdate(cm *corev1.ConfigMap, onUpdated func(cm *corev1.Co
 	e.SetMatchMode(cm.Data[ConfigMapMatchModeKey])
 	policyCSV := PolicyCSV(cm.Data)
 	if err := onUpdated(cm); err != nil {
-		return err
+		return fmt.Errorf("error running policy update callback: %w", err)
 	}
 	return e.SetUserPolicy(policyCSV)
 }
@@ -572,7 +575,7 @@ func (a *argocdAdapter) LoadPolicy(model model.Model) error {
 	for _, policyStr := range []string{a.builtinPolicy, a.userDefinedPolicy, a.runtimePolicy} {
 		for line := range strings.SplitSeq(policyStr, "\n") {
 			if err := loadPolicyLine(strings.TrimSpace(line), model); err != nil {
-				return err
+				return fmt.Errorf("error loading policy line: %w", err)
 			}
 		}
 	}
@@ -590,7 +593,7 @@ func loadPolicyLine(line string, model model.Model) error {
 	reader.TrimLeadingSpace = true
 	tokens, err := reader.Read()
 	if err != nil {
-		return err
+		return fmt.Errorf("error parsing policy line %q: %w", line, err)
 	}
 
 	tokenLen := len(tokens)


### PR DESCRIPTION
Closes #10592

## Summary

Wraps bare `return err` sites in `util/rbac/rbac.go` with `fmt.Errorf` and `%w`, so that when errors surface to callers they carry actionable context (e.g. `"error getting RBAC configmap \"argocd-rbac-cm\": ..."`) while preserving the full error chain for `errors.Is`/`errors.As` inspection.

8 sites wrapped:
- `tryGetCasbinEnforcer` — enforcer construction failure
- `LoadPolicy` — top-level policy load
- `CheckUserDefinedRoleReferentialIntegrity` × 2 — role/permission lookups
- `RunPolicyLoader` × 2 — configmap fetch and sync
- `syncUpdate` — policy update callback
- `argocdAdapter.LoadPolicy` — policy line load
- `loadPolicyLine` — CSV parse failure (includes the offending line in the message)

No behavioural changes; error types and wrapping with `%w` are fully backwards-compatible.

---

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. *(N/A — internal error wrapping only)*
* [x] Does this PR require documentation updates? No — no user-facing behaviour changes.
* [ ] I've updated documentation as required by this PR. *(N/A)*
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. All existing unit tests pass; no new tests required as error wrapping does not change observable behaviour.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines. *(N/A)*
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.