### PR TITLE
feat(ui): add inline diff slider to application tiles

### DIFF
--- a/ui/src/app/applications/components/applications-list/application-tile.tsx
+++ b/ui/src/app/applications/components/applications-list/application-tile.tsx
@@ -21,9 +21,10 @@ export interface ApplicationTileProps {
     syncApplication: (appName: string, appNamespace: string) => void;
     refreshApplication: (appName: string, appNamespace: string) => void;
     deleteApplication: (appName: string, appNamespace: string) => void;
+    showDiff: (app: models.Application) => void;
 }
 
-export const ApplicationTile = ({app, selected, pref, ctx, tileRef, syncApplication, refreshApplication, deleteApplication}: ApplicationTileProps) => {
+export const ApplicationTile = ({app, selected, pref, ctx, tileRef, syncApplication, refreshApplication, deleteApplication, showDiff}: ApplicationTileProps) => {
     const useAuthSettingsCtx = React.useContext(AuthSettingsCtx);
     const favList = pref.appList.favoritesAppList || [];
 
@@ -267,6 +268,16 @@ export const ApplicationTile = ({app, selected, pref, ctx, tileRef, syncApplicat
                     <i className='fa fa-sync' /> Sync
                 </button>
                 &nbsp;
+                {app.status.sync.status !== models.SyncStatuses.Synced && (
+                    <>
+                        <Tooltip className='custom-tooltip' content={'Diff'}>
+                            <button type='button' className='argo-button argo-button--base' qe-id='applications-tiles-button-diff' onClick={() => showDiff(app)}>
+                                <i className='fa fa-file-medical' /> <span className='show-for-xxlarge'>Diff</span>
+                            </button>
+                        </Tooltip>
+                        &nbsp;
+                    </>
+                )}
                 <Tooltip className='custom-tooltip' content={'Refresh'}>
                     {/* Spreading refreshLinkAttrs (= {disabled: isAppRefreshing(app)}) onto a real
                         <button> would actively block clicks while a refresh is in flight, leaving

--- a/ui/src/app/applications/components/applications-list/applications-tiles.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-tiles.tsx
@@ -1,4 +1,4 @@
-import {DataLoader} from 'argo-ui';
+import {DataLoader, SlidingPanel} from 'argo-ui';
 import * as React from 'react';
 import {Key, KeybindingContext, NumKey, NumKeyToNumber, NumPadKey, useNav} from 'argo-ui/v2';
 import {Consumer, Context} from '../../../shared/context';
@@ -6,6 +6,7 @@ import * as models from '../../../shared/models';
 import * as AppUtils from '../utils';
 import {isApp} from '../utils';
 import {services} from '../../../shared/services';
+import {ApplicationResourcesDiff} from '../application-resources-diff/application-resources-diff';
 import {ApplicationTile} from './application-tile';
 import {AppSetTile} from './appset-tile';
 
@@ -47,6 +48,7 @@ const useItemsPerContainer = (itemRef: any, containerRef: any): number => {
 
 export const ApplicationTiles = ({applications, syncApplication, refreshApplication, deleteApplication}: ApplicationTilesProps) => {
     const [selectedApp, navApp, reset] = useNav(applications.length);
+    const [diffApp, setDiffApp] = React.useState<models.Application | null>(null);
 
     const ctxh = React.useContext(Context);
     const firstTileRef = React.useRef<HTMLDivElement>(null);
@@ -102,32 +104,51 @@ export const ApplicationTiles = ({applications, syncApplication, refreshApplicat
             {ctx => (
                 <DataLoader load={() => services.viewPreferences.getPreferences()}>
                     {pref => (
-                        <div className='applications-tiles argo-table-list argo-table-list--clickable' ref={appContainerRef}>
-                            {applications.map((app, i) =>
-                                isApp(app) ? (
-                                    <ApplicationTile
-                                        key={AppUtils.appInstanceName(app)}
-                                        app={app as models.Application}
-                                        selected={selectedApp === i}
-                                        pref={pref}
-                                        ctx={ctx}
-                                        tileRef={i === 0 ? firstTileRef : undefined}
-                                        syncApplication={syncApplication}
-                                        refreshApplication={refreshApplication}
-                                        deleteApplication={deleteApplication}
-                                    />
-                                ) : (
-                                    <AppSetTile
-                                        key={AppUtils.appInstanceName(app)}
-                                        appSet={app as models.ApplicationSet}
-                                        selected={selectedApp === i}
-                                        pref={pref}
-                                        ctx={ctx}
-                                        tileRef={i === 0 ? firstTileRef : undefined}
-                                    />
-                                )
-                            )}
-                        </div>
+                        <>
+                            <div className='applications-tiles argo-table-list argo-table-list--clickable' ref={appContainerRef}>
+                                {applications.map((app, i) =>
+                                    isApp(app) ? (
+                                        <ApplicationTile
+                                            key={AppUtils.appInstanceName(app)}
+                                            app={app as models.Application}
+                                            selected={selectedApp === i}
+                                            pref={pref}
+                                            ctx={ctx}
+                                            tileRef={i === 0 ? firstTileRef : undefined}
+                                            syncApplication={syncApplication}
+                                            refreshApplication={refreshApplication}
+                                            deleteApplication={deleteApplication}
+                                            showDiff={setDiffApp}
+                                        />
+                                    ) : (
+                                        <AppSetTile
+                                            key={AppUtils.appInstanceName(app)}
+                                            appSet={app as models.ApplicationSet}
+                                            selected={selectedApp === i}
+                                            pref={pref}
+                                            ctx={ctx}
+                                            tileRef={i === 0 ? firstTileRef : undefined}
+                                        />
+                                    )
+                                )}
+                            </div>
+                            <SlidingPanel
+                                isShown={diffApp !== null}
+                                onClose={() => setDiffApp(null)}
+                                header={<h4>{diffApp && AppUtils.appQualifiedName(diffApp, false)} — Diff</h4>}>
+                                {diffApp && (
+                                    <DataLoader
+                                        key={AppUtils.appInstanceName(diffApp)}
+                                        load={() =>
+                                            services.applications.managedResources(diffApp.metadata.name, diffApp.metadata.namespace, {
+                                                fields: ['items.normalizedLiveState', 'items.predictedLiveState', 'items.group', 'items.kind', 'items.namespace', 'items.name']
+                                            })
+                                        }>
+                                        {managedResources => <ApplicationResourcesDiff states={managedResources} />}
+                                    </DataLoader>
+                                )}
+                            </SlidingPanel>
+                        </>
                     )}
                 </DataLoader>
             )}


### PR DESCRIPTION
Fixes #20696

## Summary

Adds a **Diff** shortcut button to application cards on the home screen that opens an **inline `SlidingPanel`** rather than navigating away — consistent with the existing UX pattern where Sync, Refresh, and Delete all stay on the page.

This directly addresses the reviewer feedback on #26325:

> could the DIFF button open a slider in the applications tiles page instead of navigating away? It would be more consistent with the current UX, where shortcut buttons don't leave the page.

## Changes

**`application-tile.tsx`**
- Add `showDiff: (app: models.Application) => void` to `ApplicationTileProps`
- Render a Diff button (using `fa-file-medical`, consistent with the DIFF tab in app-details) between Sync and Refresh, only when `app.status.sync.status !== SyncStatuses.Synced`

**`applications-tiles.tsx`**
- Add `diffApp` state to track which application's diff panel is open
- Pass `setDiffApp` as the `showDiff` callback to each `ApplicationTile`
- Render a `SlidingPanel` that loads `managedResources` on demand and displays `ApplicationResourcesDiff` inline

## Behaviour

- Button only appears on OutOfSync apps (same condition as the DIFF tab in app-details)
- Clicking Diff opens a panel over the current page — no navigation
- Panel header shows the application name
- Panel content lazy-loads the same resource diff data used everywhere else
- Closing the panel returns focus to the tiles view