### PR TITLE
fix(ui): reflect missing Application health in ApplicationSet list

### DIFF
--- a/ui/src/app/applications/components/utils.test.tsx
+++ b/ui/src/app/applications/components/utils.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as renderer from 'react-test-renderer';
 import {
     Application,
+    ApplicationSet,
     HealthStatus,
     HealthStatuses,
     OperationPhases,
@@ -13,6 +14,7 @@ import {
 import * as jsYaml from 'js-yaml';
 import {
     ComparisonStatusIcon,
+    getAppSetHealthStatus,
     getAppOperationState,
     getOperationType,
     getPodStateReason,
@@ -74,6 +76,50 @@ test('getOperationType.Unknown', () => {
     const state = getOperationType({metadata: {}, status: {}} as Application);
 
     expect(state).toBe('Unknown');
+});
+
+describe('getAppSetHealthStatus', () => {
+    it('returns Missing when a generated application is missing', () => {
+        const healthStatus = getAppSetHealthStatus({
+            status: {
+                conditions: [{type: 'ResourcesUpToDate', status: 'True', message: 'all applications are up to date'}],
+                resources: [
+                    {
+                        group: 'argoproj.io',
+                        version: 'v1alpha1',
+                        kind: 'Application',
+                        namespace: 'argocd',
+                        name: 'guestbook',
+                        status: 'OutOfSync',
+                        health: {status: 'Missing', message: ''}
+                    }
+                ]
+            }
+        } as ApplicationSet);
+
+        expect(healthStatus).toBe('Missing');
+    });
+
+    it('keeps ApplicationSet errors higher priority than generated application health', () => {
+        const healthStatus = getAppSetHealthStatus({
+            status: {
+                conditions: [{type: 'ErrorOccurred', status: 'True', message: 'generator failed'}],
+                resources: [
+                    {
+                        group: 'argoproj.io',
+                        version: 'v1alpha1',
+                        kind: 'Application',
+                        namespace: 'argocd',
+                        name: 'guestbook',
+                        status: 'Synced',
+                        health: {status: 'Healthy', message: ''}
+                    }
+                ]
+            }
+        } as ApplicationSet);
+
+        expect(healthStatus).toBe('Degraded');
+    });
 });
 
 test('OperationState.undefined', () => {

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -1784,24 +1784,37 @@ export function getRootPathByApp(abstractApp: appModels.AbstractApplication) {
     return isApp(abstractApp) ? '/applications' : '/applicationsets';
 }
 
-// Get ApplicationSet health status from its conditions
-// Priority: ErrorOccurred=True → Degraded, RolloutProgressing=True → Progressing, ResourcesUpToDate=True → Healthy, else Unknown
+function getAppSetResourcesHealthStatus(appSet: appModels.ApplicationSet): appModels.HealthStatusCode | undefined {
+    return appSet.status?.resources
+        ?.map(resource => resource.health?.status as appModels.HealthStatusCode | undefined)
+        .filter((status): status is appModels.HealthStatusCode => !!status && status !== 'Healthy' && appModels.HealthPriority[status] !== undefined)
+        .sort((left, right) => appModels.HealthPriority[left] - appModels.HealthPriority[right])[0];
+}
+
+// Get ApplicationSet health status from its conditions and generated Applications.
+// Priority: ErrorOccurred=True → Degraded, RolloutProgressing=True → Progressing, generated Application health, ResourcesUpToDate=True → Healthy, else Unknown
 export function getAppSetHealthStatus(appSet: appModels.ApplicationSet): appModels.HealthStatusCode {
     const conditions = appSet.status?.conditions;
-    if (!conditions || conditions.length === 0) {
-        return 'Unknown';
-    }
 
     // Check for errors first (indicates degraded state)
-    const errorCondition = conditions.find(c => c.type === 'ErrorOccurred' && c.status === 'True');
+    const errorCondition = conditions?.find(c => c.type === 'ErrorOccurred' && c.status === 'True');
     if (errorCondition) {
         return 'Degraded';
+    }
+
+    if (!conditions || conditions.length === 0) {
+        return getAppSetResourcesHealthStatus(appSet) || 'Unknown';
     }
 
     // Check if rollout is progressing
     const progressingCondition = conditions.find(c => c.type === 'RolloutProgressing' && c.status === 'True');
     if (progressingCondition) {
         return 'Progressing';
+    }
+
+    const resourcesHealthStatus = getAppSetResourcesHealthStatus(appSet);
+    if (resourcesHealthStatus) {
+        return resourcesHealthStatus;
     }
 
     // Check if resources are up to date (healthy state)


### PR DESCRIPTION
## Summary

Fixes #27878.

This updates the ApplicationSet UI health helper to consider non-healthy generated Application health from status.resources. When an ApplicationSet has generated Applications that are Missing or otherwise unhealthy while the ApplicationSet condition reports ResourcesUpToDate=True, the ApplicationSet list now reflects the child Application health instead of showing the ApplicationSet as healthy.

The ApplicationSet ErrorOccurred=True and RolloutProgressing=True conditions remain higher priority than generated Application resource health.

## Testing

- git diff --check
- npx eslint src/app/applications/components/utils.tsx

Attempted but blocked by existing local setup/issues:

- npm test -- --runTestsByPath src/app/applications/components/utils.test.tsx fails before running tests because Jest does not transform the pnpm-installed argo-ui/src/index.ts dependency.
- npm run lint -- --quiet src/app/applications/components/utils.tsx src/app/applications/components/utils.test.tsx runs the full UI tsc first and fails on existing application-resource-tree type errors unrelated to this change.