### PR TITLE
feat(ui): add regex search toggle to application(sets) list (#27857)

### DIFF
--- a/ui/src/app/applications/components/applications-list/application-sets-list.tsx
+++ b/ui/src/app/applications/components/applications-list/application-sets-list.tsx
@@ -85,7 +85,7 @@ function loadApplicationSets(projects: string[]): Observable<models.ApplicationS
     );
 }
 
-const ViewPref = ({children}: {children: (pref: AppsListPreferences & {page: number; search: string; searchRegex: boolean}) => React.ReactNode}) => {
+const ViewPref = ({children}: {children: (pref: AppsListPreferences & {page: number; search: string}) => React.ReactNode}) => {
     const observableQuery$ = useObservableQuery();
 
     return (
@@ -117,8 +117,7 @@ const ViewPref = ({children}: {children: (pref: AppsListPreferences & {page: num
                         return {
                             ...viewPref,
                             page: parseInt(params.get('page') || '0', 10),
-                            search: params.get('search') || '',
-                            searchRegex: params.get('searchRegex') === 'true'
+                            search: params.get('search') || ''
                         };
                     })
                 )
@@ -152,10 +151,7 @@ const ApplicationSetsSearchBar = (props: {content: string; searchRegex: boolean;
             value={content || ''}
             onChange={value => ctx.navigation.goto('.', {search: value}, {replace: true})}
             placeholder={searchRegex ? 'Regex search (e.g. ^foo-.*-prod$)' : 'Search application sets...'}
-            regex={{
-                enabled: searchRegex,
-                onToggle: () => ctx.navigation.goto('.', {searchRegex: !searchRegex || null}, {replace: true})
-            }}
+            regexEnabled={searchRegex}
             autocomplete={{
                 items: appSets.map(appSet => AppUtils.appQualifiedName(appSet, useAuthSettingsCtx?.appsInAnyNamespaceEnabled)),
                 filterSuggestions: true,
@@ -180,13 +176,46 @@ const ApplicationSetsSearchBar = (props: {content: string; searchRegex: boolean;
 
 const ApplicationSetsToolbar = (props: {
     appSets: models.ApplicationSet[];
-    pref: AppsListPreferences & {page: number; search: string; searchRegex: boolean};
+    pref: AppsListPreferences & {page: number; search: string};
     ctx: ContextApis;
     healthBarPrefs: HealthStatusBarPreferences;
 }) => {
+    const regexInvalid = React.useMemo(() => {
+        if (!props.pref.searchRegex || !props.pref.search) {
+            return false;
+        }
+        try {
+            new RegExp(props.pref.search);
+            return false;
+        } catch {
+            return true;
+        }
+    }, [props.pref.searchRegex, props.pref.search]);
+
+    const regexToggleClass = `applications-list__regex-toggle argo-button argo-button--base${props.pref.searchRegex ? '' : '-o'}${
+        regexInvalid ? ' applications-list__regex-toggle--invalid' : ''
+    }`;
+
     return (
         <React.Fragment key='appset-list-tools'>
             <ApplicationSetsSearchBar content={props.pref.search} searchRegex={props.pref.searchRegex} appSets={props.appSets} ctx={props.ctx} />
+            <Tooltip
+                content={
+                    props.pref.searchRegex ? (regexInvalid ? 'Invalid regex pattern' : 'Regex search enabled, click to switch to plain text') : 'Click to enable regex search'
+                }>
+                <button
+                    type='button'
+                    aria-label='Toggle regex search'
+                    aria-pressed={props.pref.searchRegex}
+                    className={regexToggleClass}
+                    onClick={() => {
+                        services.viewPreferences.updatePreferences({
+                            appList: {...props.pref, searchRegex: !props.pref.searchRegex}
+                        });
+                    }}>
+                    .*
+                </button>
+            </Tooltip>
             <Tooltip content='Toggle Health Status Bar'>
                 <button
                     className={`applications-list__accordion argo-button argo-button--base${props.healthBarPrefs.showHealthStatusBar ? '-o' : ''}`}
@@ -400,7 +429,8 @@ export const ApplicationSetsList = (props: RouteComponentProps<any>) => {
                                             view: pref.view,
                                             hideFilters: pref.hideFilters,
                                             statusBarView: pref.statusBarView,
-                                            annotationsFilter: pref.annotationsFilter
+                                            annotationsFilter: pref.annotationsFilter,
+                                            searchRegex: pref.searchRegex
                                         };
                                         const {filteredApps, filterResults} = filterApplicationSets(appSets, appSetPref, pref.search, pref.searchRegex);
 

--- a/ui/src/app/applications/components/applications-list/application-sets-list.tsx
+++ b/ui/src/app/applications/components/applications-list/application-sets-list.tsx
@@ -11,6 +11,7 @@ import * as models from '../../../shared/models';
 import {AppsListPreferences, AppsListViewKey, AppsListViewType, AppSetsListPreferences, HealthStatusBarPreferences, services, ViewPreferences} from '../../../shared/services';
 import {useSidebarTarget} from '../../../sidebar/sidebar';
 import {useObservableQuery} from '../../../shared/hooks/query';
+import {isInvalidRegex} from '../../../shared/utils';
 import * as AppUtils from '../utils';
 import {AppSetsFilter, ApplicationSetFilteredApp, getAppSetFilterResults} from './applications-filter';
 import {createMatcher} from './applications-list-search';
@@ -180,24 +181,14 @@ const ApplicationSetsToolbar = (props: {
     ctx: ContextApis;
     healthBarPrefs: HealthStatusBarPreferences;
 }) => {
-    const regexInvalid = React.useMemo(() => {
-        if (!props.pref.searchRegex || !props.pref.search) {
-            return false;
-        }
-        try {
-            new RegExp(props.pref.search);
-            return false;
-        } catch {
-            return true;
-        }
-    }, [props.pref.searchRegex, props.pref.search]);
+    const regexInvalid = props.pref.searchRegex && isInvalidRegex(props.pref.search);
 
     const regexToggleClass = `applications-list__regex-toggle argo-button argo-button--base${props.pref.searchRegex ? '' : '-o'}${
         regexInvalid ? ' applications-list__regex-toggle--invalid' : ''
     }`;
 
     return (
-        <React.Fragment key='appset-list-tools'>
+        <div className='applications-list__toolbar-controls' key='appset-list-tools'>
             <ApplicationSetsSearchBar content={props.pref.search} searchRegex={props.pref.searchRegex} appSets={props.appSets} ctx={props.ctx} />
             <Tooltip
                 content={
@@ -231,7 +222,7 @@ const ApplicationSetsToolbar = (props: {
                     <i className='fas fa-ruler-horizontal' />
                 </button>
             </Tooltip>
-        </React.Fragment>
+        </div>
     );
 };
 

--- a/ui/src/app/applications/components/applications-list/application-sets-list.tsx
+++ b/ui/src/app/applications/components/applications-list/application-sets-list.tsx
@@ -10,9 +10,10 @@ import {AuthSettingsCtx, Consumer, Context, ContextApis} from '../../../shared/c
 import * as models from '../../../shared/models';
 import {AppsListPreferences, AppsListViewKey, AppsListViewType, AppSetsListPreferences, HealthStatusBarPreferences, services, ViewPreferences} from '../../../shared/services';
 import {useSidebarTarget} from '../../../sidebar/sidebar';
-import {useObservableQuery, useQuery} from '../../../shared/hooks/query';
+import {useObservableQuery} from '../../../shared/hooks/query';
 import * as AppUtils from '../utils';
 import {AppSetsFilter, ApplicationSetFilteredApp, getAppSetFilterResults} from './applications-filter';
+import {createMatcher} from './applications-list-search';
 import {AppSetsStatusBar} from './applications-status-bar';
 import {AppSetTile} from './appset-tile';
 import {AppSetTableRow} from './appset-table-row';
@@ -84,7 +85,7 @@ function loadApplicationSets(projects: string[]): Observable<models.ApplicationS
     );
 }
 
-const ViewPref = ({children}: {children: (pref: AppsListPreferences & {page: number; search: string}) => React.ReactNode}) => {
+const ViewPref = ({children}: {children: (pref: AppsListPreferences & {page: number; search: string; searchRegex: boolean}) => React.ReactNode}) => {
     const observableQuery$ = useObservableQuery();
 
     return (
@@ -113,7 +114,12 @@ const ViewPref = ({children}: {children: (pref: AppsListPreferences & {page: num
                                 .map(decodeURIComponent)
                                 .filter(item => !!item);
                         }
-                        return {...viewPref, page: parseInt(params.get('page') || '0', 10), search: params.get('search') || ''};
+                        return {
+                            ...viewPref,
+                            page: parseInt(params.get('page') || '0', 10),
+                            search: params.get('search') || '',
+                            searchRegex: params.get('searchRegex') === 'true'
+                        };
                     })
                 )
             }>
@@ -125,36 +131,41 @@ const ViewPref = ({children}: {children: (pref: AppsListPreferences & {page: num
 function filterApplicationSets(
     appSets: models.ApplicationSet[],
     pref: AppSetsListPreferences,
-    search: string
+    search: string,
+    searchRegex: boolean
 ): {filteredApps: models.ApplicationSet[]; filterResults: ApplicationSetFilteredApp[]} {
     const filterResults = getAppSetFilterResults(appSets, pref);
+    const matchesSearch = createMatcher(search, searchRegex);
 
     return {
         filterResults,
-        filteredApps: filterResults.filter(
-            app => (search === '' || app.metadata.name.includes(search) || app.metadata.namespace.includes(search)) && Object.values(app.filterResult).every(val => val)
-        )
+        filteredApps: filterResults.filter(app => matchesSearch(app.metadata.name, app.metadata.namespace) && Object.values(app.filterResult).every(val => val))
     };
 }
 
-const ApplicationSetsSearchBar = (props: {content: string; ctx: ContextApis; appSets: models.ApplicationSet[]}) => {
+const ApplicationSetsSearchBar = (props: {content: string; searchRegex: boolean; ctx: ContextApis; appSets: models.ApplicationSet[]}) => {
+    const {content, searchRegex, ctx, appSets} = props;
     const useAuthSettingsCtx = React.useContext(AuthSettingsCtx);
 
     return (
         <SearchBar
-            value={props.content || ''}
-            onChange={value => props.ctx.navigation.goto('.', {search: value}, {replace: true})}
-            placeholder='Search application sets...'
+            value={content || ''}
+            onChange={value => ctx.navigation.goto('.', {search: value}, {replace: true})}
+            placeholder={searchRegex ? 'Regex search (e.g. ^foo-.*-prod$)' : 'Search application sets...'}
+            regex={{
+                enabled: searchRegex,
+                onToggle: () => ctx.navigation.goto('.', {searchRegex: !searchRegex || null}, {replace: true})
+            }}
             autocomplete={{
-                items: props.appSets.map(appSet => AppUtils.appQualifiedName(appSet, useAuthSettingsCtx?.appsInAnyNamespaceEnabled)),
+                items: appSets.map(appSet => AppUtils.appQualifiedName(appSet, useAuthSettingsCtx?.appsInAnyNamespaceEnabled)),
                 filterSuggestions: true,
                 onSelect: val => {
-                    const selectedAppSet = props.appSets?.find(appSet => {
+                    const selectedAppSet = appSets?.find(appSet => {
                         const qualifiedName = AppUtils.appQualifiedName(appSet, useAuthSettingsCtx?.appsInAnyNamespaceEnabled);
                         return qualifiedName === val;
                     });
                     if (selectedAppSet) {
-                        props.ctx.navigation.goto(`/${AppUtils.getAppUrl(selectedAppSet)}`);
+                        ctx.navigation.goto(`/${AppUtils.getAppUrl(selectedAppSet)}`);
                     }
                 },
                 renderItem: item => (
@@ -169,15 +180,13 @@ const ApplicationSetsSearchBar = (props: {content: string; ctx: ContextApis; app
 
 const ApplicationSetsToolbar = (props: {
     appSets: models.ApplicationSet[];
-    pref: AppsListPreferences & {page: number; search: string};
+    pref: AppsListPreferences & {page: number; search: string; searchRegex: boolean};
     ctx: ContextApis;
     healthBarPrefs: HealthStatusBarPreferences;
 }) => {
-    const query = useQuery();
-
     return (
         <React.Fragment key='appset-list-tools'>
-            <ApplicationSetsSearchBar content={query.get('search')} appSets={props.appSets} ctx={props.ctx} />
+            <ApplicationSetsSearchBar content={props.pref.search} searchRegex={props.pref.searchRegex} appSets={props.appSets} ctx={props.ctx} />
             <Tooltip content='Toggle Health Status Bar'>
                 <button
                     className={`applications-list__accordion argo-button argo-button--base${props.healthBarPrefs.showHealthStatusBar ? '-o' : ''}`}
@@ -393,7 +402,7 @@ export const ApplicationSetsList = (props: RouteComponentProps<any>) => {
                                             statusBarView: pref.statusBarView,
                                             annotationsFilter: pref.annotationsFilter
                                         };
-                                        const {filteredApps, filterResults} = filterApplicationSets(appSets, appSetPref, pref.search);
+                                        const {filteredApps, filterResults} = filterApplicationSets(appSets, appSetPref, pref.search, pref.searchRegex);
 
                                         return (
                                             <React.Fragment>

--- a/ui/src/app/applications/components/applications-list/applications-list-search.test.ts
+++ b/ui/src/app/applications/components/applications-list/applications-list-search.test.ts
@@ -1,0 +1,66 @@
+import {createMatcher} from './applications-list-search';
+
+describe('createMatcher', () => {
+    describe('empty search', () => {
+        test('returns a matcher that always matches, regardless of regex flag', () => {
+            expect(createMatcher('', false)('app-prod-frontend', 'default')).toBe(true);
+            expect(createMatcher('', true)('app-prod-frontend', 'default')).toBe(true);
+        });
+    });
+
+    describe('plain substring search', () => {
+        test('matches substring in name', () => {
+            expect(createMatcher('prod', false)('app-prod-frontend', 'default')).toBe(true);
+        });
+
+        test('matches substring in namespace', () => {
+            expect(createMatcher('platform', false)('guestbook', 'team-platform')).toBe(true);
+        });
+
+        test('returns false when neither name nor namespace contains the term', () => {
+            expect(createMatcher('staging', false)('app-prod-frontend', 'default')).toBe(false);
+        });
+
+        test('is case-sensitive', () => {
+            expect(createMatcher('PROD', false)('app-prod-frontend', 'default')).toBe(false);
+        });
+
+        test('treats regex metacharacters as literals', () => {
+            expect(createMatcher('^app', false)('app-prod-frontend', 'default')).toBe(false);
+        });
+    });
+
+    describe('regex search', () => {
+        test('matches anchored pattern on name', () => {
+            const matcher = createMatcher('^app-prod-', true);
+            expect(matcher('app-prod-frontend', 'default')).toBe(true);
+            expect(matcher('guestbook-prod', 'default')).toBe(false);
+        });
+
+        test('matches anchored pattern on namespace', () => {
+            expect(createMatcher('frontend$', true)('guestbook', 'team-frontend')).toBe(true);
+        });
+
+        test('matches alternation', () => {
+            const matcher = createMatcher('^(app-prod|guestbook)', true);
+            expect(matcher('guestbook-prod', 'default')).toBe(true);
+            expect(matcher('app-staging-frontend', 'default')).toBe(false);
+        });
+
+        test('returns false for invalid regex', () => {
+            expect(createMatcher('[abc', true)('app-prod-frontend', 'default')).toBe(false);
+            expect(createMatcher('*', true)('app-prod-frontend', 'default')).toBe(false);
+        });
+
+        test('is case-sensitive (no implicit "i" flag)', () => {
+            expect(createMatcher('^APP-', true)('app-prod-frontend', 'default')).toBe(false);
+        });
+
+        test('compiles the regex once and reuses it across calls', () => {
+            const matcher = createMatcher('^app-', true);
+            expect(matcher('app-one', 'default')).toBe(true);
+            expect(matcher('app-two', 'default')).toBe(true);
+            expect(matcher('guestbook', 'default')).toBe(false);
+        });
+    });
+});

--- a/ui/src/app/applications/components/applications-list/applications-list-search.ts
+++ b/ui/src/app/applications/components/applications-list/applications-list-search.ts
@@ -1,0 +1,16 @@
+// Invalid regex returns a never-match so the empty state surfaces the broken pattern to the user.
+export function createMatcher(search: string, useRegex: boolean): (name: string, namespace: string) => boolean {
+    if (search === '') {
+        return () => true;
+    }
+    if (useRegex) {
+        let re: RegExp;
+        try {
+            re = new RegExp(search);
+        } catch {
+            return () => false;
+        }
+        return (name, namespace) => re.test(name) || re.test(namespace);
+    }
+    return (name, namespace) => name.includes(search) || namespace.includes(search);
+}

--- a/ui/src/app/applications/components/applications-list/applications-list.scss
+++ b/ui/src/app/applications/components/applications-list/applications-list.scss
@@ -90,6 +90,22 @@
         }
     }
 
+    // Groups the SearchBar with adjacent toggle buttons so they shrink together
+    // instead of the search bar taking a full row and orphaning the buttons.
+    &__toolbar-controls {
+        display: flex;
+        align-items: center;
+        flex-grow: 1;
+        min-width: 0;
+        .search-bar__wrapper {
+            flex-shrink: 1;
+            min-width: 0;
+            @include breakpoint(medium down) {
+                flex-basis: auto;
+            }
+        }
+    }
+
     &__view-type {
         white-space: nowrap;
         i {

--- a/ui/src/app/applications/components/applications-list/applications-list.scss
+++ b/ui/src/app/applications/components/applications-list/applications-list.scss
@@ -79,6 +79,17 @@
         margin-left: 10px;
     }
 
+    &__regex-toggle {
+        margin-left: 10px;
+        font-family: monospace;
+        font-weight: 600;
+        &--invalid {
+            background-color: $argo-failed-color !important;
+            border-color: $argo-failed-color !important;
+            color: white !important;
+        }
+    }
+
     &__view-type {
         white-space: nowrap;
         i {

--- a/ui/src/app/applications/components/applications-list/applications-list.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-list.tsx
@@ -24,6 +24,7 @@ import {FlexTopBar} from '../../../shared/components';
 import {ViewTypeSwitcher} from './view-type-switcher';
 import {useSidebarTarget} from '../../../sidebar/sidebar';
 import {useQuery, useObservableQuery} from '../../../shared/hooks/query';
+import {isInvalidRegex} from '../../../shared/utils';
 
 import './applications-list.scss';
 
@@ -272,24 +273,14 @@ interface ApplicationsToolbarProps {
 }
 
 const ApplicationsToolbar: React.FC<ApplicationsToolbarProps> = ({applications, pref, ctx, healthBarPrefs}) => {
-    const regexInvalid = React.useMemo(() => {
-        if (!pref.searchRegex || !pref.search) {
-            return false;
-        }
-        try {
-            new RegExp(pref.search);
-            return false;
-        } catch {
-            return true;
-        }
-    }, [pref.searchRegex, pref.search]);
+    const regexInvalid = pref.searchRegex && isInvalidRegex(pref.search);
 
     const regexToggleClass = `applications-list__regex-toggle argo-button argo-button--base${pref.searchRegex ? '' : '-o'}${
         regexInvalid ? ' applications-list__regex-toggle--invalid' : ''
     }`;
 
     return (
-        <React.Fragment key='app-list-tools'>
+        <div className='applications-list__toolbar-controls' key='app-list-tools'>
             <ApplicationsListSearchBar content={pref.search} searchRegex={pref.searchRegex} apps={applications} ctx={ctx} />
             <Tooltip content={pref.searchRegex ? (regexInvalid ? 'Invalid regex pattern' : 'Regex search enabled, click to switch to plain text') : 'Click to enable regex search'}>
                 <button
@@ -324,7 +315,7 @@ const ApplicationsToolbar: React.FC<ApplicationsToolbarProps> = ({applications, 
                     <i className='fas fa-ruler-horizontal' />
                 </button>
             </Tooltip>
-        </React.Fragment>
+        </div>
     );
 };
 

--- a/ui/src/app/applications/components/applications-list/applications-list.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-list.tsx
@@ -99,7 +99,7 @@ function loadApplications(projects: string[], appNamespace: string): Observable<
     );
 }
 
-const ViewPref = ({children}: {children: (pref: AppsListPreferences & {page: number; search: string; searchRegex: boolean}) => React.ReactNode}) => {
+const ViewPref = ({children}: {children: (pref: AppsListPreferences & {page: number; search: string}) => React.ReactNode}) => {
     const observableQuery$ = useObservableQuery();
 
     return (
@@ -188,8 +188,7 @@ const ViewPref = ({children}: {children: (pref: AppsListPreferences & {page: num
                         return {
                             ...viewPref,
                             page: parseInt(params.get('page') || '0', 10),
-                            search: params.get('search') || '',
-                            searchRegex: params.get('searchRegex') === 'true'
+                            search: params.get('search') || ''
                         };
                     })
                 )
@@ -242,10 +241,7 @@ const ApplicationsListSearchBar = (props: {content: string; searchRegex: boolean
             onChange={value => ctx.navigation.goto('.', {search: value}, {replace: true})}
             placeholder={searchRegex ? 'Regex search (e.g. ^foo-.*-prod$)' : 'Search applications...'}
             disableKeyboardShortcuts={!!appInput}
-            regex={{
-                enabled: searchRegex,
-                onToggle: () => ctx.navigation.goto('.', {searchRegex: !searchRegex || null}, {replace: true})
-            }}
+            regexEnabled={searchRegex}
             autocomplete={{
                 items: apps.map(app => AppUtils.appQualifiedName(app, useAuthSettingsCtx?.appsInAnyNamespaceEnabled)),
                 filterSuggestions: true,
@@ -270,15 +266,45 @@ const ApplicationsListSearchBar = (props: {content: string; searchRegex: boolean
 
 interface ApplicationsToolbarProps {
     applications: models.Application[];
-    pref: AppsListPreferences & {page: number; search: string; searchRegex: boolean};
+    pref: AppsListPreferences & {page: number; search: string};
     ctx: ContextApis;
     healthBarPrefs: HealthStatusBarPreferences;
 }
 
 const ApplicationsToolbar: React.FC<ApplicationsToolbarProps> = ({applications, pref, ctx, healthBarPrefs}) => {
+    const regexInvalid = React.useMemo(() => {
+        if (!pref.searchRegex || !pref.search) {
+            return false;
+        }
+        try {
+            new RegExp(pref.search);
+            return false;
+        } catch {
+            return true;
+        }
+    }, [pref.searchRegex, pref.search]);
+
+    const regexToggleClass = `applications-list__regex-toggle argo-button argo-button--base${pref.searchRegex ? '' : '-o'}${
+        regexInvalid ? ' applications-list__regex-toggle--invalid' : ''
+    }`;
+
     return (
         <React.Fragment key='app-list-tools'>
             <ApplicationsListSearchBar content={pref.search} searchRegex={pref.searchRegex} apps={applications} ctx={ctx} />
+            <Tooltip content={pref.searchRegex ? (regexInvalid ? 'Invalid regex pattern' : 'Regex search enabled, click to switch to plain text') : 'Click to enable regex search'}>
+                <button
+                    type='button'
+                    aria-label='Toggle regex search'
+                    aria-pressed={pref.searchRegex}
+                    className={regexToggleClass}
+                    onClick={() => {
+                        services.viewPreferences.updatePreferences({
+                            appList: {...pref, searchRegex: !pref.searchRegex}
+                        });
+                    }}>
+                    .*
+                </button>
+            </Tooltip>
             <Tooltip content='Toggle Health Status Bar'>
                 <button
                     className={`applications-list__accordion argo-button argo-button--base${healthBarPrefs.showHealthStatusBar ? '-o' : ''}`}

--- a/ui/src/app/applications/components/applications-list/applications-list.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-list.tsx
@@ -14,6 +14,7 @@ import {ApplicationSyncPanel} from '../application-sync-panel/application-sync-p
 import {ApplicationsSyncPanel} from '../applications-sync-panel/applications-sync-panel';
 import * as AppUtils from '../utils';
 import {ApplicationsFilter, FilteredApp, getAppFilterResults} from './applications-filter';
+import {createMatcher} from './applications-list-search';
 import {AppsStatusBar} from './applications-status-bar';
 import {ApplicationsSummary} from './applications-summary';
 import {ApplicationsTable} from './applications-table';
@@ -98,7 +99,7 @@ function loadApplications(projects: string[], appNamespace: string): Observable<
     );
 }
 
-const ViewPref = ({children}: {children: (pref: AppsListPreferences & {page: number; search: string}) => React.ReactNode}) => {
+const ViewPref = ({children}: {children: (pref: AppsListPreferences & {page: number; search: string; searchRegex: boolean}) => React.ReactNode}) => {
     const observableQuery$ = useObservableQuery();
 
     return (
@@ -184,7 +185,12 @@ const ViewPref = ({children}: {children: (pref: AppsListPreferences & {page: num
                                 .map(decodeURIComponent)
                                 .filter(item => !!item);
                         }
-                        return {...viewPref, page: parseInt(params.get('page') || '0', 10), search: params.get('search') || ''};
+                        return {
+                            ...viewPref,
+                            page: parseInt(params.get('page') || '0', 10),
+                            search: params.get('search') || '',
+                            searchRegex: params.get('searchRegex') === 'true'
+                        };
                     })
                 )
             }>
@@ -193,7 +199,12 @@ const ViewPref = ({children}: {children: (pref: AppsListPreferences & {page: num
     );
 };
 
-function filterApplications(applications: models.Application[], pref: AppsListPreferences, search: string): {filteredApps: models.Application[]; filterResults: FilteredApp[]} {
+function filterApplications(
+    applications: models.Application[],
+    pref: AppsListPreferences,
+    search: string,
+    searchRegex: boolean
+): {filteredApps: models.Application[]; filterResults: FilteredApp[]} {
     const processedApps = applications.map(app => {
         let isAppOfAppsPattern = false;
         if (app.status.summary?.isAppOfApps === true) {
@@ -202,12 +213,11 @@ function filterApplications(applications: models.Application[], pref: AppsListPr
         return {...app, isAppOfAppsPattern};
     });
     const filterResults = getAppFilterResults(processedApps, pref);
+    const matchesSearch = createMatcher(search, searchRegex);
 
     return {
         filterResults,
-        filteredApps: filterResults.filter(
-            app => (search === '' || app.metadata.name.includes(search) || app.metadata.namespace.includes(search)) && Object.values(app.filterResult).every(val => val)
-        )
+        filteredApps: filterResults.filter(app => matchesSearch(app.metadata.name, app.metadata.namespace) && Object.values(app.filterResult).every(val => val))
     };
 }
 
@@ -219,8 +229,8 @@ function tryJsonParse(input: string) {
     }
 }
 
-const ApplicationsListSearchBar = (props: {content: string; ctx: ContextApis; apps: models.Application[]}) => {
-    const {content, ctx, apps} = {...props};
+const ApplicationsListSearchBar = (props: {content: string; searchRegex: boolean; ctx: ContextApis; apps: models.Application[]}) => {
+    const {content, searchRegex, ctx, apps} = props;
     const useAuthSettingsCtx = React.useContext(AuthSettingsCtx);
 
     const query = new URLSearchParams(window.location.search);
@@ -230,8 +240,12 @@ const ApplicationsListSearchBar = (props: {content: string; ctx: ContextApis; ap
         <SearchBar
             value={content || ''}
             onChange={value => ctx.navigation.goto('.', {search: value}, {replace: true})}
-            placeholder='Search applications...'
+            placeholder={searchRegex ? 'Regex search (e.g. ^foo-.*-prod$)' : 'Search applications...'}
             disableKeyboardShortcuts={!!appInput}
+            regex={{
+                enabled: searchRegex,
+                onToggle: () => ctx.navigation.goto('.', {searchRegex: !searchRegex || null}, {replace: true})
+            }}
             autocomplete={{
                 items: apps.map(app => AppUtils.appQualifiedName(app, useAuthSettingsCtx?.appsInAnyNamespaceEnabled)),
                 filterSuggestions: true,
@@ -256,17 +270,15 @@ const ApplicationsListSearchBar = (props: {content: string; ctx: ContextApis; ap
 
 interface ApplicationsToolbarProps {
     applications: models.Application[];
-    pref: AppsListPreferences & {page: number; search: string};
+    pref: AppsListPreferences & {page: number; search: string; searchRegex: boolean};
     ctx: ContextApis;
     healthBarPrefs: HealthStatusBarPreferences;
 }
 
 const ApplicationsToolbar: React.FC<ApplicationsToolbarProps> = ({applications, pref, ctx, healthBarPrefs}) => {
-    const query = useQuery();
-
     return (
         <React.Fragment key='app-list-tools'>
-            <ApplicationsListSearchBar content={query.get('search')} apps={applications} ctx={ctx} />
+            <ApplicationsListSearchBar content={pref.search} searchRegex={pref.searchRegex} apps={applications} ctx={ctx} />
             <Tooltip content='Toggle Health Status Bar'>
                 <button
                     className={`applications-list__accordion argo-button argo-button--base${healthBarPrefs.showHealthStatusBar ? '-o' : ''}`}
@@ -399,7 +411,7 @@ export const ApplicationsList = (props: RouteComponentProps<any>) => {
                                             };
 
                                             const apps = applications as models.Application[];
-                                            const {filteredApps, filterResults} = filterApplications(apps, pref, pref.search);
+                                            const {filteredApps, filterResults} = filterApplications(apps, pref, pref.search, pref.searchRegex);
 
                                             return (
                                                 <React.Fragment>

--- a/ui/src/app/shared/components/flex-top-bar/flex-top-bar.tsx
+++ b/ui/src/app/shared/components/flex-top-bar/flex-top-bar.tsx
@@ -1,7 +1,6 @@
 import {Toolbar, Tooltip} from 'argo-ui';
 import * as React from 'react';
-import {Observable} from 'rxjs';
-import {AuthOption, DataLoader} from '../';
+import {AuthOption} from '../';
 
 import './flex-top-bar.scss';
 
@@ -12,14 +11,14 @@ export interface ToolbarWithOptions extends Toolbar {
 }
 
 interface FlexTopBarProps {
-    toolbar: ToolbarWithOptions | Observable<ToolbarWithOptions>;
+    toolbar: ToolbarWithOptions;
 }
 
 export const FlexTopBar = (props: FlexTopBarProps) => {
     return (
         <React.Fragment>
             <div className='top-bar row flex-top-bar' key='tool-bar'>
-                <DataLoader load={() => Promise.resolve(props.toolbar)}>{(toolbar: ToolbarWithOptions) => <FlexTopBarContent toolbar={toolbar} />}</DataLoader>
+                <FlexTopBarContent toolbar={props.toolbar} />
             </div>
             <div className='flex-top-bar__padder' />
         </React.Fragment>

--- a/ui/src/app/shared/components/search-bar/search-bar.scss
+++ b/ui/src/app/shared/components/search-bar/search-bar.scss
@@ -91,5 +91,52 @@
                 color: $argo-color-gray-6;
             }
         }
+        &--regex {
+            border-color: $argo-color-teal-5 !important;
+        }
+        &--regex-invalid {
+            border-color: $argo-failed-color !important;
+        }
+    }
+
+    &__regex-toggle {
+        background: transparent;
+        border: 1px solid $argo-color-gray-5;
+        color: $argo-color-gray-7;
+        border-radius: 3px;
+        padding: 0 6px;
+        margin-left: 6px;
+        font-family: monospace;
+        font-size: 12px;
+        font-weight: 600;
+        line-height: 18px;
+        flex-shrink: 0;
+        cursor: pointer;
+        user-select: none;
+        &:hover {
+            border-color: $argo-color-teal-5;
+            color: $argo-color-teal-5;
+        }
+        &:focus-visible {
+            outline: 2px solid $argo-color-teal-5;
+            outline-offset: 1px;
+        }
+        &--active {
+            background-color: $argo-color-teal-5;
+            border-color: $argo-color-teal-5;
+            color: white;
+            &:hover {
+                color: white;
+            }
+        }
+        &--invalid {
+            background-color: $argo-failed-color;
+            border-color: $argo-failed-color;
+            color: white;
+            &:hover {
+                border-color: $argo-failed-color;
+                color: white;
+            }
+        }
     }
 }

--- a/ui/src/app/shared/components/search-bar/search-bar.scss
+++ b/ui/src/app/shared/components/search-bar/search-bar.scss
@@ -98,45 +98,4 @@
             border-color: $argo-failed-color !important;
         }
     }
-
-    &__regex-toggle {
-        background: transparent;
-        border: 1px solid $argo-color-gray-5;
-        color: $argo-color-gray-7;
-        border-radius: 3px;
-        padding: 0 6px;
-        margin-left: 6px;
-        font-family: monospace;
-        font-size: 12px;
-        font-weight: 600;
-        line-height: 18px;
-        flex-shrink: 0;
-        cursor: pointer;
-        user-select: none;
-        &:hover {
-            border-color: $argo-color-teal-5;
-            color: $argo-color-teal-5;
-        }
-        &:focus-visible {
-            outline: 2px solid $argo-color-teal-5;
-            outline-offset: 1px;
-        }
-        &--active {
-            background-color: $argo-color-teal-5;
-            border-color: $argo-color-teal-5;
-            color: white;
-            &:hover {
-                color: white;
-            }
-        }
-        &--invalid {
-            background-color: $argo-failed-color;
-            border-color: $argo-failed-color;
-            color: white;
-            &:hover {
-                border-color: $argo-failed-color;
-                color: white;
-            }
-        }
-    }
 }

--- a/ui/src/app/shared/components/search-bar/search-bar.tsx
+++ b/ui/src/app/shared/components/search-bar/search-bar.tsx
@@ -3,6 +3,7 @@ import {Autocomplete} from 'argo-ui';
 import classNames from 'classnames';
 import {Key, KeybindingContext} from 'argo-ui/v2';
 
+import {isInvalidRegex} from '../../utils';
 import './search-bar.scss';
 
 interface SearchBarProps {
@@ -40,17 +41,7 @@ export const SearchBar: React.FC<SearchBarProps> = ({value, onChange, placeholde
         onChange(newValue);
     };
 
-    const regexInvalid = React.useMemo(() => {
-        if (!regexEnabled || !value) {
-            return false;
-        }
-        try {
-            new RegExp(value);
-            return false;
-        } catch {
-            return true;
-        }
-    }, [regexEnabled, value]);
+    const regexInvalid = regexEnabled && isInvalidRegex(value);
 
     const inputClassName = classNames('search-bar__input', {
         'search-bar__input--regex': regexEnabled && !regexInvalid,
@@ -103,9 +94,25 @@ export const SearchBar: React.FC<SearchBarProps> = ({value, onChange, placeholde
         // Normalize items to {value, label} format
         const normalizedItems = autocomplete.items.map(item => (typeof item === 'string' ? {value: item, label: item} : item));
 
+        // In regex mode, Autocomplete's built-in substring filter would hide valid regex matches,
+        // so we pre-filter with the pattern ourselves and disable its filter.
+        let effectiveItems = normalizedItems;
+        let effectiveFilter = autocomplete.filterSuggestions ?? true;
+        if (regexEnabled) {
+            effectiveFilter = false;
+            if (value) {
+                if (regexInvalid) {
+                    effectiveItems = [];
+                } else {
+                    const re = new RegExp(value);
+                    effectiveItems = normalizedItems.filter(item => re.test(item.value));
+                }
+            }
+        }
+
         return (
             <Autocomplete
-                filterSuggestions={autocomplete.filterSuggestions ?? true}
+                filterSuggestions={effectiveFilter}
                 renderInput={inputProps => (
                     <div className={inputClassName} ref={searchBarRef}>
                         <i className='fa fa-search' style={{marginRight: '9px', cursor: 'pointer'}} onClick={focusInput} />
@@ -137,7 +144,7 @@ export const SearchBar: React.FC<SearchBarProps> = ({value, onChange, placeholde
                 onSelect={val => autocomplete.onSelect(val)}
                 onChange={e => handleChange(e.target.value)}
                 value={value}
-                items={normalizedItems}
+                items={effectiveItems}
             />
         );
     }

--- a/ui/src/app/shared/components/search-bar/search-bar.tsx
+++ b/ui/src/app/shared/components/search-bar/search-bar.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import {Autocomplete} from 'argo-ui';
+import {Autocomplete, Tooltip} from 'argo-ui';
+import classNames from 'classnames';
 import {Key, KeybindingContext} from 'argo-ui/v2';
 
 import './search-bar.scss';
@@ -10,6 +11,12 @@ interface SearchBarProps {
     placeholder?: string;
     /** Disable keyboard shortcuts (useful when parent has custom handling) */
     disableKeyboardShortcuts?: boolean;
+    /** Optional regex toggle. When provided, a `.*` button is rendered next to the input
+     *  and the input's border switches to a teal/red active/invalid state based on the value. */
+    regex?: {
+        enabled: boolean;
+        onToggle: () => void;
+    };
     /** Optional autocomplete configuration */
     autocomplete?: {
         items: Array<string | {value: string; label: string}>;
@@ -19,7 +26,7 @@ interface SearchBarProps {
     };
 }
 
-export const SearchBar: React.FC<SearchBarProps> = ({value, onChange, placeholder = 'Search...', disableKeyboardShortcuts = false, autocomplete}) => {
+export const SearchBar: React.FC<SearchBarProps> = ({value, onChange, placeholder = 'Search...', disableKeyboardShortcuts = false, regex, autocomplete}) => {
     const inputRef = React.useRef<HTMLInputElement>(null);
     const searchBarRef = React.useRef<HTMLDivElement>(null);
     const {useKeybinding} = React.useContext(KeybindingContext);
@@ -35,6 +42,39 @@ export const SearchBar: React.FC<SearchBarProps> = ({value, onChange, placeholde
         setLocalValue(newValue);
         onChange(newValue);
     };
+
+    const regexInvalid = React.useMemo(() => {
+        if (!regex?.enabled || !value) {
+            return false;
+        }
+        try {
+            new RegExp(value);
+            return false;
+        } catch {
+            return true;
+        }
+    }, [regex?.enabled, value]);
+
+    const inputClassName = classNames('search-bar__input', {
+        'search-bar__input--regex': regex?.enabled && !regexInvalid,
+        'search-bar__input--regex-invalid': regexInvalid
+    });
+
+    const regexToggle = regex && (
+        <Tooltip content={regex.enabled ? (regexInvalid ? 'Invalid regex pattern' : 'Regex search enabled, click to switch to plain text') : 'Click to enable regex search'}>
+            <button
+                type='button'
+                aria-label='Toggle regex search'
+                aria-pressed={regex.enabled}
+                className={classNames('search-bar__regex-toggle', {
+                    'search-bar__regex-toggle--active': regex.enabled && !regexInvalid,
+                    'search-bar__regex-toggle--invalid': regexInvalid
+                })}
+                onClick={regex.onToggle}>
+                .*
+            </button>
+        </Tooltip>
+    );
 
     const focusInput = () => {
         if (autocomplete && searchBarRef.current) {
@@ -86,7 +126,7 @@ export const SearchBar: React.FC<SearchBarProps> = ({value, onChange, placeholde
             <Autocomplete
                 filterSuggestions={autocomplete.filterSuggestions ?? true}
                 renderInput={inputProps => (
-                    <div className='search-bar__input' ref={searchBarRef}>
+                    <div className={inputClassName} ref={searchBarRef}>
                         <i className='fa fa-search' style={{marginRight: '9px', cursor: 'pointer'}} onClick={focusInput} />
                         <input
                             {...inputProps}
@@ -107,6 +147,7 @@ export const SearchBar: React.FC<SearchBarProps> = ({value, onChange, placeholde
                             className='argo-field'
                             placeholder={placeholder}
                         />
+                        {regexToggle}
                         <div className='keyboard-hint'>/</div>
                         {value && <i className='fa fa-times' onClick={() => handleChange('')} style={{cursor: 'pointer', marginLeft: '5px'}} />}
                     </div>
@@ -124,7 +165,7 @@ export const SearchBar: React.FC<SearchBarProps> = ({value, onChange, placeholde
     // Default simple search bar without autocomplete
     return (
         <div className='search-bar__wrapper'>
-            <div className='search-bar__input'>
+            <div className={inputClassName}>
                 <i className='fa fa-search' style={{marginRight: '9px', cursor: 'pointer'}} onClick={focusInput} />
                 <input
                     ref={inputRef}
@@ -146,6 +187,7 @@ export const SearchBar: React.FC<SearchBarProps> = ({value, onChange, placeholde
                     }}
                     style={{fontSize: '14px', flex: 1, minWidth: 0}}
                 />
+                {regexToggle}
                 <div className='keyboard-hint'>/</div>
                 {localValue && <i className='fa fa-times' onClick={() => handleChange('')} style={{cursor: 'pointer', marginLeft: '5px'}} />}
             </div>

--- a/ui/src/app/shared/components/search-bar/search-bar.tsx
+++ b/ui/src/app/shared/components/search-bar/search-bar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {Autocomplete, Tooltip} from 'argo-ui';
+import {Autocomplete} from 'argo-ui';
 import classNames from 'classnames';
 import {Key, KeybindingContext} from 'argo-ui/v2';
 
@@ -11,12 +11,9 @@ interface SearchBarProps {
     placeholder?: string;
     /** Disable keyboard shortcuts (useful when parent has custom handling) */
     disableKeyboardShortcuts?: boolean;
-    /** Optional regex toggle. When provided, a `.*` button is rendered next to the input
-     *  and the input's border switches to a teal/red active/invalid state based on the value. */
-    regex?: {
-        enabled: boolean;
-        onToggle: () => void;
-    };
+    /** When true, the input's border switches to a teal/red active/invalid state based on
+     *  whether `value` parses as a valid RegExp. The toggle button lives outside the SearchBar. */
+    regexEnabled?: boolean;
     /** Optional autocomplete configuration */
     autocomplete?: {
         items: Array<string | {value: string; label: string}>;
@@ -26,7 +23,7 @@ interface SearchBarProps {
     };
 }
 
-export const SearchBar: React.FC<SearchBarProps> = ({value, onChange, placeholder = 'Search...', disableKeyboardShortcuts = false, regex, autocomplete}) => {
+export const SearchBar: React.FC<SearchBarProps> = ({value, onChange, placeholder = 'Search...', disableKeyboardShortcuts = false, regexEnabled, autocomplete}) => {
     const inputRef = React.useRef<HTMLInputElement>(null);
     const searchBarRef = React.useRef<HTMLDivElement>(null);
     const {useKeybinding} = React.useContext(KeybindingContext);
@@ -44,7 +41,7 @@ export const SearchBar: React.FC<SearchBarProps> = ({value, onChange, placeholde
     };
 
     const regexInvalid = React.useMemo(() => {
-        if (!regex?.enabled || !value) {
+        if (!regexEnabled || !value) {
             return false;
         }
         try {
@@ -53,28 +50,12 @@ export const SearchBar: React.FC<SearchBarProps> = ({value, onChange, placeholde
         } catch {
             return true;
         }
-    }, [regex?.enabled, value]);
+    }, [regexEnabled, value]);
 
     const inputClassName = classNames('search-bar__input', {
-        'search-bar__input--regex': regex?.enabled && !regexInvalid,
+        'search-bar__input--regex': regexEnabled && !regexInvalid,
         'search-bar__input--regex-invalid': regexInvalid
     });
-
-    const regexToggle = regex && (
-        <Tooltip content={regex.enabled ? (regexInvalid ? 'Invalid regex pattern' : 'Regex search enabled, click to switch to plain text') : 'Click to enable regex search'}>
-            <button
-                type='button'
-                aria-label='Toggle regex search'
-                aria-pressed={regex.enabled}
-                className={classNames('search-bar__regex-toggle', {
-                    'search-bar__regex-toggle--active': regex.enabled && !regexInvalid,
-                    'search-bar__regex-toggle--invalid': regexInvalid
-                })}
-                onClick={regex.onToggle}>
-                .*
-            </button>
-        </Tooltip>
-    );
 
     const focusInput = () => {
         if (autocomplete && searchBarRef.current) {
@@ -147,7 +128,6 @@ export const SearchBar: React.FC<SearchBarProps> = ({value, onChange, placeholde
                             className='argo-field'
                             placeholder={placeholder}
                         />
-                        {regexToggle}
                         <div className='keyboard-hint'>/</div>
                         {value && <i className='fa fa-times' onClick={() => handleChange('')} style={{cursor: 'pointer', marginLeft: '5px'}} />}
                     </div>
@@ -187,7 +167,6 @@ export const SearchBar: React.FC<SearchBarProps> = ({value, onChange, placeholde
                     }}
                     style={{fontSize: '14px', flex: 1, minWidth: 0}}
                 />
-                {regexToggle}
                 <div className='keyboard-hint'>/</div>
                 {localValue && <i className='fa fa-times' onClick={() => handleChange('')} style={{cursor: 'pointer', marginLeft: '5px'}} />}
             </div>

--- a/ui/src/app/shared/services/view-preferences-service.ts
+++ b/ui/src/app/shared/services/view-preferences-service.ts
@@ -84,6 +84,7 @@ export class AbstractAppsListPreferences {
     public statusBarView: HealthStatusBarPreferences;
     public showFavorites: boolean;
     public favoritesAppList: string[];
+    public searchRegex: boolean;
 }
 
 export class AppsListPreferences extends AbstractAppsListPreferences {
@@ -175,6 +176,7 @@ const DEFAULT_PREFERENCES: ViewPreferences = {
         hideFilters: false,
         showFavorites: false,
         favoritesAppList: new Array<string>(),
+        searchRegex: false,
         statusBarView: {
             showHealthStatusBar: true
         }

--- a/ui/src/app/shared/utils.ts
+++ b/ui/src/app/shared/utils.ts
@@ -146,6 +146,18 @@ export const formatClusterQueryParam = (cluster: Cluster) => {
     return `${cluster.name} (${cluster.server})`;
 };
 
+export const isInvalidRegex = (pattern: string): boolean => {
+    if (!pattern) {
+        return false;
+    }
+    try {
+        new RegExp(pattern);
+        return false;
+    } catch {
+        return true;
+    }
+};
+
 /**
  * Checks if SSO is configured for authentication usage.
  * @param userInfo - User information from the session


### PR DESCRIPTION
Opening this PR to add an optional regex toggle to the Applications and Applicationsets list search bar. Default behaviour does not change: plain substring search stays on unless you click the `.*` pill to turn regex on.

Personally, I'm pretty excited about this one. We run Argo CD with literally thousands of Applications, and the substring filter starts to creak at that scale. You know roughly what you're looking for, but you can't quite spell it out as one contiguous string, so you end up scrolling. For me, it was the kind of friction you stop noticing because you've adapted around it.

With this toggle on, the search bar finally speaks the language we already use for naming things:

  - `payments.prod` to use wildcards
  - `qa|staging` slices the non-prod world in one keystroke
  - `team-alpha-` shows everything a single team owns
  
The active state is obvious at a glance (teal border, lit `.*` pill), an invalid pattern lights up red instead of silently returning nothing useful.

A small toggle, but for platform teams, SREs, and anyone managing more than a screenful of apps. For me, this changes how you navigate Argo CD.


https://github.com/user-attachments/assets/3b573007-0167-440e-92dd-0527e9f63251


Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [n/a] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [n/a] Does this PR require documentation updates?
* [n/a] I've updated documentation as required by this PR.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [X] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [n/a] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [X] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [n/a] Optional. My organization is added to USERS.md.
* [n/a] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

Fixes: #27857 
