### PR TITLE
fix(oidc): include offline_access scope in Dex web login flow (#27829)

### DIFF
--- a/util/oidc/oidc.go
+++ b/util/oidc/oidc.go
@@ -1052,6 +1052,16 @@ func (a *ClientApp) getScopes() []string {
 	} else if a.settings.IsDexConfigured() {
 		scopes = append(GetScopesOrDefault(nil), common.DexFederatedScope)
 	}
+	// Ensure offline_access is requested when the provider supports it, so that
+	// Dex issues a refresh token. Without this, the web login flow never receives
+	// a refresh token and OIDC session refresh does not work (see issue #27829).
+	if a.provider != nil {
+		if oidcConf, err := a.provider.ParseConfig(); err == nil && oidcConf != nil {
+			if OfflineAccess(oidcConf.ScopesSupported) {
+				scopes = append(scopes, gooidc.ScopeOfflineAccess)
+			}
+		}
+	}
 	return scopes
 }
 

--- a/util/oidc/oidc_bug27829_test.go
+++ b/util/oidc/oidc_bug27829_test.go
@@ -1,0 +1,120 @@
+package oidc
+
+import (
+	"testing"
+
+	gooidc "github.com/coreos/go-oidc/v3/oidc"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/argoproj/argo-cd/v3/util/settings"
+)
+
+// mockProviderWithScopes returns a Provider whose ParseConfig() reports
+// specific scopes_supported, letting us control what OfflineAccess() sees.
+type mockProviderWithScopes struct {
+	fakeProvider
+	scopesSupported []string
+}
+
+func (m *mockProviderWithScopes) ParseConfig() (*OIDCConfiguration, error) {
+	return &OIDCConfiguration{
+		ScopesSupported: m.scopesSupported,
+	}, nil
+}
+
+// TestBug27829_Fix_DexWebFlow_IncludesOfflineAccess verifies the fix:
+// getScopes() now calls OfflineAccess() and appends offline_access when
+// the provider supports it, matching the CLI path's behavior.
+func TestBug27829_Fix_DexWebFlow_IncludesOfflineAccess(t *testing.T) {
+	t.Run("Dex configured, provider supports offline_access", func(t *testing.T) {
+		cdSettings := &settings.ArgoCDSettings{
+			URL: "https://argocd.example.com",
+			DexConfig: `connectors:
+- type: github
+  name: GitHub
+  config:
+    clientID: aabbccddeeff00112233
+    clientSecret: aabbccddeeff00112233`,
+		}
+		provider := &mockProviderWithScopes{
+			scopesSupported: []string{
+				"openid", "profile", "email", "groups",
+				"offline_access", "federated:id",
+			},
+		}
+		app := &ClientApp{
+			settings: cdSettings,
+			provider: provider,
+		}
+
+		scopes := app.getScopes()
+
+		// FIX VERIFIED: offline_access is now included
+		assert.Contains(t, scopes, gooidc.ScopeOfflineAccess,
+			"After fix: getScopes() includes offline_access when provider supports it")
+		assert.Contains(t, scopes, "openid")
+		assert.Contains(t, scopes, "federated:id")
+	})
+
+	t.Run("Dex configured, provider does NOT support offline_access", func(t *testing.T) {
+		cdSettings := &settings.ArgoCDSettings{
+			URL: "https://argocd.example.com",
+			DexConfig: `connectors:
+- type: github
+  name: GitHub
+  config:
+    clientID: aabbccddeeff00112233
+    clientSecret: aabbccddeeff00112233`,
+		}
+		provider := &mockProviderWithScopes{
+			scopesSupported: []string{"openid", "profile", "email"},
+		}
+		app := &ClientApp{
+			settings: cdSettings,
+			provider: provider,
+		}
+
+		scopes := app.getScopes()
+
+		// Should NOT include offline_access when provider doesn't support it
+		assert.NotContains(t, scopes, gooidc.ScopeOfflineAccess,
+			"offline_access NOT added when provider doesn't support it")
+	})
+
+	t.Run("OIDC config with explicit requestedScopes", func(t *testing.T) {
+		cdSettings := &settings.ArgoCDSettings{
+			OIDCConfigRAW: `
+name: Test
+issuer: https://example.com
+clientID: test-client
+clientSecret: test-secret
+requestedScopes:
+- openid
+- profile
+`,
+		}
+		provider := &mockProviderWithScopes{
+			scopesSupported: []string{"openid", "offline_access"},
+		}
+		app := &ClientApp{
+			settings: cdSettings,
+			provider: provider,
+		}
+
+		scopes := app.getScopes()
+
+		// User's explicit scopes are preserved, offline_access is appended
+		assert.Contains(t, scopes, "openid")
+		assert.Contains(t, scopes, "profile")
+		assert.Contains(t, scopes, gooidc.ScopeOfflineAccess,
+			"offline_access appended to user's explicit scopes")
+	})
+}
+
+// TestBug27829_OfflineAccess_DetectsCorrectly proves the building blocks work.
+func TestBug27829_OfflineAccess_DetectsCorrectly(t *testing.T) {
+	assert.True(t, OfflineAccess([]string{"openid", "offline_access"}))
+	assert.False(t, OfflineAccess([]string{"openid", "profile"}))
+	assert.True(t, OfflineAccess(nil))
+	assert.True(t, OfflineAccess([]string{}))
+}


### PR DESCRIPTION
<!--
Note on DCO:

All commits must be signed off. Argo CD uses a DCO bot to enforce this.
-->

**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:

The web login flow's `getScopes()` in `util/oidc/oidc.go` never requests the `offline_access` scope from Dex, even when the provider explicitly advertises it in `scopes_supported`. Without this scope, Dex never issues a refresh token, so OIDC session refresh (implemented in #23727) is completely bypassed for web users — they get kicked back to the login page on every token expiry.

The CLI login path (`pkg/apiclient/apiclient.go:349-350`) already handles this correctly by calling `OfflineAccess()` and appending `ScopeOfflineAccess`. This fix brings the web flow to parity.

**Which issue(s) this PR fixes**:

Fixes #27829

**Special notes for your reviewer**:

The fix adds a 7-line block to `getScopes()` that:
1. Checks the provider's `scopes_supported` via `ParseConfig()`
2. Calls the existing `OfflineAccess()` helper (same as CLI path)
3. Appends `gooidc.ScopeOfflineAccess` when supported

Three nil-safety guards: `provider != nil`, `err == nil`, `oidcConf != nil`. If any fails, we silently skip (offline_access is nice-to-have, should not block login).

Tests added in `util/oidc/oidc_bug27829_test.go`:
- Dex configured + provider supports offline_access → scope includes it
- Dex configured + provider does NOT support it → scope does NOT include it
- OIDC config with explicit requestedScopes → user's scopes preserved + offline_access appended

**Checklist**:

- [x] Title of the PR uses [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Either this is a trivial change, or I have added tests that prove my fix is effective
- [x] I have verified the fix works by running the full test suite
