### PR TITLE
fix: auto-sync directory apps with manifest paths

### DIFF
--- a/controller/state.go
+++ b/controller/state.go
@@ -422,11 +422,13 @@ func (m *appStateManager) evaluateRevisionChanges(ctx context.Context, app *v1al
 	// Determine the synced revision and source type for comparison
 	syncedRevision := app.Status.Sync.Revision
 	sourceType := app.Status.SourceType
+	sourceHydratorDrySource := false
 	if app.Spec.SourceHydrator != nil {
 		if drySource := app.Spec.SourceHydrator.GetDrySource(); source.Equals(&drySource) {
 			// Always resolve the revision even if UpdateRevisionForPaths is not called so we can
 			// correctly compare it with the syncedRevision
 			alwaysResolveRevision = true
+			sourceHydratorDrySource = true
 			sourceIndex = -1 // Special case allowing GetSourcePtrByIndex() to return the dry source
 			// Use LastComparedDryRevision as the synced revision for cache lookups
 			syncedRevision = app.Status.SourceHydrator.LastComparedDryRevision
@@ -492,7 +494,7 @@ func (m *appStateManager) evaluateRevisionChanges(ctx context.Context, app *v1al
 		// resolved revision from comparison even though no sync attempted it yet.
 		// Keep UpdateRevisionForPaths for cache updates, but let auto-sync compare
 		// the resolved revision against the last actual sync result.
-		if sourceType == v1alpha1.ApplicationSourceTypeDirectory {
+		if sourceType == v1alpha1.ApplicationSourceTypeDirectory && !sourceHydratorDrySource {
 			return resolvedRevision, true, nil
 		}
 		return resolvedRevision, updateRevisionResult.Changes, nil

--- a/controller/state.go
+++ b/controller/state.go
@@ -421,6 +421,7 @@ func (m *appStateManager) evaluateRevisionChanges(ctx context.Context, app *v1al
 
 	// Determine the synced revision and source type for comparison
 	syncedRevision := app.Status.Sync.Revision
+	sourceType := app.Status.SourceType
 	if app.Spec.SourceHydrator != nil {
 		if drySource := app.Spec.SourceHydrator.GetDrySource(); source.Equals(&drySource) {
 			// Always resolve the revision even if UpdateRevisionForPaths is not called so we can
@@ -435,6 +436,9 @@ func (m *appStateManager) evaluateRevisionChanges(ctx context.Context, app *v1al
 			syncedRevision = app.Status.Sync.Revisions[sourceIndex]
 		} else {
 			syncedRevision = ""
+		}
+		if sourceIndex >= 0 && sourceIndex < len(app.Status.SourceTypes) {
+			sourceType = app.Status.SourceTypes[sourceIndex]
 		}
 	}
 
@@ -484,6 +488,13 @@ func (m *appStateManager) evaluateRevisionChanges(ctx context.Context, app *v1al
 			resolvedRevision = updateRevisionResult.Revision
 		}
 
+		// For Directory sources, Status.Sync.Revision may already contain the
+		// resolved revision from comparison even though no sync attempted it yet.
+		// Keep UpdateRevisionForPaths for cache updates, but let auto-sync compare
+		// the resolved revision against the last actual sync result.
+		if sourceType == v1alpha1.ApplicationSourceTypeDirectory {
+			return resolvedRevision, true, nil
+		}
 		return resolvedRevision, updateRevisionResult.Changes, nil
 	} else if alwaysResolveRevision {
 		resp, err := repoClient.ResolveRevision(ctx, &apiclient.ResolveRevisionRequest{

--- a/controller/state_test.go
+++ b/controller/state_test.go
@@ -2283,6 +2283,32 @@ func Test_EvaluateAppRevisionsChanges(t *testing.T) {
 			expectedResolvedRevisions: []string{"def456"},
 		},
 		{
+			name: "directory source with annotation reports possible changes after resolving revision",
+			app: func() *v1alpha1.Application {
+				app := newFakeApp()
+				app.Annotations = map[string]string{
+					v1alpha1.AnnotationKeyManifestGeneratePaths: ".",
+				}
+				app.Status.SourceType = v1alpha1.ApplicationSourceTypeDirectory
+				app.Status.Sync.Revision = "resolved-head-sha"
+				return app
+			}(),
+			sources: func() []v1alpha1.ApplicationSource {
+				app := newFakeApp()
+				return []v1alpha1.ApplicationSource{app.Spec.GetSource()}
+			}(),
+			revisions: []string{"HEAD"},
+			data: fakeData{
+				updateRevisionForPathsResponse: &apiclient.UpdateRevisionForPathsResponse{
+					Revision: "resolved-head-sha",
+					Changes:  false,
+				},
+			},
+			sendRuntimeState:          false,
+			expectedHasChanges:        true,
+			expectedResolvedRevisions: []string{"resolved-head-sha"},
+		},
+		{
 			name: "with send runtime state",
 			app: func() *v1alpha1.Application {
 				app := newFakeApp()

--- a/controller/state_test.go
+++ b/controller/state_test.go
@@ -2530,6 +2530,7 @@ func Test_EvaluateAppRevisionsChanges(t *testing.T) {
 				app.Annotations = map[string]string{
 					v1alpha1.AnnotationKeyManifestGeneratePaths: ".",
 				}
+				app.Status.SourceType = v1alpha1.ApplicationSourceTypeDirectory
 				app.Spec.SourceHydrator = &v1alpha1.SourceHydrator{
 					DrySource: v1alpha1.DrySource{
 						RepoURL:        app.Spec.Source.RepoURL,


### PR DESCRIPTION

  Fixes #27875

  ## Summary


  `UpdateRevisionForPaths` is still called so the repo-server can update the manifest cache and return the resolved
  revision. For Directory sources, its `Changes=false` result is no longer used to suppress revision comparison in auto-

  ## Testing

  - `go test -v ./controller -run Test_EvaluateAppRevisionsChanges/
  directory_source_with_annotation_reports_possible_changes_after_resolving_revision -count=1`
  - `go test ./controller -run "Test_EvaluateAppRevisionsChanges|TestAlreadyAttemptSync|TestAutoSync" -count=1`
  - `go test ./controller -count=1`
  https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/
