### PR TITLE
fix(controller): replace removed kubectl PodRequestsAndLimits

### DIFF
--- a/controller/cache/info.go
+++ b/controller/cache/info.go
@@ -14,7 +14,7 @@ import (
 	"github.com/cespare/xxhash/v2"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	resourcehelper "k8s.io/kubectl/pkg/util/resource"
+	resourcehelper "k8s.io/component-helpers/resource"
 
 	"github.com/argoproj/argo-cd/v3/common"
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
@@ -471,7 +471,7 @@ func populatePodInfo(un *unstructured.Unstructured, res *ResourceInfo) {
 		res.Info = append(res.Info, v1alpha1.InfoItem{Name: "Status Reason", Value: reason})
 	}
 
-	req, _ := resourcehelper.PodRequestsAndLimits(&pod)
+	req := resourcehelper.PodRequests(&pod, resourcehelper.PodResourcesOptions{})
 
 	res.PodInfo = &PodInfo{NodeName: pod.Spec.NodeName, ResourceRequests: req, Phase: pod.Status.Phase}
 

--- a/controller/cache/info.go
+++ b/controller/cache/info.go
@@ -471,7 +471,7 @@ func populatePodInfo(un *unstructured.Unstructured, res *ResourceInfo) {
 		res.Info = append(res.Info, v1alpha1.InfoItem{Name: "Status Reason", Value: reason})
 	}
 
-	req := resourcehelper.PodRequests(&pod, resourcehelper.PodResourcesOptions{})
+	req := resourcehelper.PodRequests(&pod, resourcehelper.PodResourcesOptions{UseStatusResources: true})
 
 	res.PodInfo = &PodInfo{NodeName: pod.Spec.NodeName, ResourceRequests: req, Phase: pod.Status.Phase}
 

--- a/go.mod
+++ b/go.mod
@@ -119,6 +119,7 @@ require (
 	k8s.io/apimachinery v0.34.0
 	k8s.io/client-go v0.34.0
 	k8s.io/code-generator v0.34.0
+	k8s.io/component-helpers v0.34.0
 	k8s.io/klog/v2 v2.140.0
 	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b
 	k8s.io/kubectl v0.34.0
@@ -310,7 +311,6 @@ require (
 	k8s.io/apiserver v0.34.0 // indirect
 	k8s.io/cli-runtime v0.34.0 // indirect
 	k8s.io/component-base v0.34.0 // indirect
-	k8s.io/component-helpers v0.34.0 // indirect
 	k8s.io/controller-manager v0.34.0 // indirect
 	k8s.io/gengo/v2 v2.0.0-20250604051438-85fd79dbfd9f // indirect
 	k8s.io/kube-aggregator v0.34.0 // indirect


### PR DESCRIPTION
## Description

`k8s.io/kubectl/pkg/util/resource.PodRequestsAndLimits` was removed in upstream kubectl (kubernetes/kubectl@ad4e7654 — the implementation moved behind a private interface inside kubectl proper and is no longer part of the public API). After the upcoming k8s.io v0.36 bump tracked in #27804 the `k8s.io/kubectl@v0.36+` module no longer exports it and `controller/cache/info.go` fails to compile with:

```
controller/cache/info.go:474:9: undefined: resourcehelper.PodRequestsAndLimits
```

This PR switches the call site to the direct successor in `k8s.io/component-helpers/resource`, which is the package the old kubectl helper was a thin wrapper around:

```go
// before
resourcehelper "k8s.io/kubectl/pkg/util/resource"
…
req, _ := resourcehelper.PodRequestsAndLimits(&pod)

// after
resourcehelper "k8s.io/component-helpers/resource"
…
req := resourcehelper.PodRequests(&pod, resourcehelper.PodResourcesOptions{UseStatusResources: true})
```

`UseStatusResources: true` preserves the behavior of the removed helper, which always consulted resource requests from container statuses when present (the in-place pod vertical scaling path). `PodRequests` only does that when the option is explicitly set — passing the zero-value options would have silently dropped that fallback. Same init-container max + sidecar-aware logic, same pod-overhead handling otherwise. The original call site at `controller/cache/info.go:474` discarded `limits` already (`req, _ :=`), so dropping the limits return is intentional.

`k8s.io/component-helpers` was already a transitive dependency on master; this change promotes it from `// indirect` to a direct require. The fix is applicable today against the current `v0.34.0` pin (component-helpers v0.34 already ships `PodRequests`) and is forward-compatible with the upcoming v0.36 bump.

## Testing

All existing `TestGetPodInfo*` subtests pass unchanged:

```
$ go test -run 'TestGetPodInfo' -v ./controller/cache/...
--- PASS: TestGetPodInfo (0.00s)
    --- PASS: TestGetPodInfo/TestGetPodInfo
    --- PASS: TestGetPodInfo/TestGetPodInfoWithSidecar
    --- PASS: TestGetPodInfo/TestGetPodInfoWithInitialContainer
    --- PASS: TestGetPodInfo/TestGetPodInfoWithRestartableInitContainer
    --- PASS: TestGetPodInfo/TestGetPodInfoWithPartiallyStartedInitContainers
    --- PASS: TestGetPodInfo/TestGetPodInfoWithStartedInitContainers
    --- PASS: TestGetPodInfo/TestGetPodInfoWithNormalInitContainer
    --- PASS: TestGetPodInfo/TestGetPodWithInitialContainerInfo
    --- PASS: TestGetPodInfo/TestGetPodWithInitialContainerInfoWithResources
    --- PASS: TestGetPodInfo/TestPodConditionSucceeded
    --- PASS: TestGetPodInfo/TestPodConditionSucceededWithResources
    --- PASS: TestGetPodInfo/TestPodConditionSucceededWithDeletion
    --- PASS: TestGetPodInfo/TestPodConditionFailed
    --- PASS: TestGetPodInfo/TestPodConditionFailedWithResources
    --- PASS: TestGetPodInfo/TestPodConditionRunningWithDeletion
    --- PASS: TestGetPodInfo/TestPodConditionPendingWithDeletion
    --- PASS: TestGetPodInfo/TestPodScheduledWithSchedulingGated
ok  	github.com/argoproj/argo-cd/v3/controller/cache	0.044s
```

Closes #27894

## Related

- #27804 — meta-tracker for the k8s 1.36 upgrade (this is blocker 3 of 3).
- #27893 / #27887 — sibling sub-blocker / PR for the HPA v2beta1/v2beta2 removal.
- #26322 — independent meta-blocker for the Events API protobuf incompatibility.

## Checklist

- [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
- [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
- [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. _(N/A — no CLI/UI surface affected.)_
- [x] Does this PR require documentation updates? _(No — internal helper substitution, no user-visible behavior change.)_
- [x] I've updated documentation as required by this PR. _(N/A.)_
- [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
- [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged. _(Existing `TestGetPodInfo*` suite exercises the affected path and continues to pass; no new test required for a behaviorally-equivalent API substitution.)_
- [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
- [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines. _(N/A — bug fix, no feature surface.)_
- [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
- [ ] Optional. My organization is added to USERS.md.
- [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).