### PR TITLE
feat(metrics): add parallelism limit repo server

### DIFF
--- a/docs/operator-manual/metrics.md
+++ b/docs/operator-manual/metrics.md
@@ -263,6 +263,7 @@ Scraped at the `argocd-repo-server:8084/metrics` endpoint.
 | `argocd_redis_request_duration_seconds`  | histogram  | Redis requests duration seconds.                                          |
 | `argocd_redis_request_total`             |  counter   | Number of Kubernetes requests executed during application reconciliation. |
 | `argocd_repo_pending_request_total`      |   gauge    | Number of pending requests requiring repository lock                      |
+| `argocd_repo_parallelism_wait_duration_seconds` | histogram  | Time spent waiting for the repo-server manifest generation parallelism semaphore (`--parallelismlimit`). Observed on every acquire attempt, including those that fail (e.g. context canceled). |
 | `argocd_oci_request_total`               |  counter   | Number of OCI requests performed by repo server                           |
 | `argocd_oci_request_duration_seconds`    | histogram  | Duration of OCI requests performed by the repo server.                      |
 | `argocd_oci_test_repo_fail_total`        |  counter   | Number of OCI test repo requests failures by repo server                  |

--- a/reposerver/metrics/metrics.go
+++ b/reposerver/metrics/metrics.go
@@ -17,6 +17,7 @@ type MetricsServer struct {
 	gitRequestCounter             *prometheus.CounterVec
 	gitRequestHistogram           *prometheus.HistogramVec
 	repoPendingRequestsGauge      *prometheus.GaugeVec
+	parallelismWaitHistogram      prometheus.Histogram
 	redisRequestCounter           *prometheus.CounterVec
 	redisRequestHistogram         *prometheus.HistogramVec
 	ociExtractFailCounter         *prometheus.CounterVec
@@ -87,6 +88,15 @@ func NewMetricsServer() *MetricsServer {
 		[]string{"repo"},
 	)
 	registry.MustRegister(repoPendingRequestsGauge)
+
+	parallelismWaitHistogram := prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "argocd_repo_parallelism_wait_duration_seconds",
+			Help:    "Time spent waiting for the repo-server manifest generation parallelism semaphore. Observed on every acquire attempt, including those that fail (e.g. context canceled).",
+			Buckets: []float64{0.1, 0.25, .5, 1, 2, 4, 10, 20, 60, 120},
+		},
+	)
+	registry.MustRegister(parallelismWaitHistogram)
 
 	redisRequestCounter := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -178,6 +188,7 @@ func NewMetricsServer() *MetricsServer {
 		gitRequestCounter:             gitRequestCounter,
 		gitRequestHistogram:           gitRequestHistogram,
 		repoPendingRequestsGauge:      repoPendingRequestsGauge,
+		parallelismWaitHistogram:      parallelismWaitHistogram,
 		redisRequestCounter:           redisRequestCounter,
 		redisRequestHistogram:         redisRequestHistogram,
 		ociRequestCounter:             ociRequestCounter,
@@ -218,6 +229,14 @@ func (m *MetricsServer) ObserveGitRequestDuration(repo string, requestType GitRe
 
 func (m *MetricsServer) DecPendingRepoRequest(repo string) {
 	m.repoPendingRequestsGauge.WithLabelValues(repo).Dec()
+}
+
+// ObserveParallelismWaitDuration records the time spent waiting on the
+// manifest generation parallelism semaphore. Callers should observe even when
+// Acquire fails, since starved acquires are the signal this metric exists to
+// capture.
+func (m *MetricsServer) ObserveParallelismWaitDuration(duration time.Duration) {
+	m.parallelismWaitHistogram.Observe(duration.Seconds())
 }
 
 func (m *MetricsServer) IncRedisRequest(failed bool) {

--- a/reposerver/metrics/metrics_test.go
+++ b/reposerver/metrics/metrics_test.go
@@ -1,0 +1,45 @@
+package metrics
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestObserveParallelismWaitDuration(t *testing.T) {
+	m := NewMetricsServer()
+
+	m.ObserveParallelismWaitDuration(50 * time.Millisecond)
+	m.ObserveParallelismWaitDuration(3 * time.Second)
+	m.ObserveParallelismWaitDuration(75 * time.Second)
+
+	expected := `
+# HELP argocd_repo_parallelism_wait_duration_seconds Time spent waiting for the repo-server manifest generation parallelism semaphore. Observed on every acquire attempt, including those that fail (e.g. context canceled).
+# TYPE argocd_repo_parallelism_wait_duration_seconds histogram
+argocd_repo_parallelism_wait_duration_seconds_bucket{le="0.1"} 1
+argocd_repo_parallelism_wait_duration_seconds_bucket{le="0.25"} 1
+argocd_repo_parallelism_wait_duration_seconds_bucket{le="0.5"} 1
+argocd_repo_parallelism_wait_duration_seconds_bucket{le="1"} 1
+argocd_repo_parallelism_wait_duration_seconds_bucket{le="2"} 1
+argocd_repo_parallelism_wait_duration_seconds_bucket{le="4"} 2
+argocd_repo_parallelism_wait_duration_seconds_bucket{le="10"} 2
+argocd_repo_parallelism_wait_duration_seconds_bucket{le="20"} 2
+argocd_repo_parallelism_wait_duration_seconds_bucket{le="60"} 2
+argocd_repo_parallelism_wait_duration_seconds_bucket{le="120"} 3
+argocd_repo_parallelism_wait_duration_seconds_bucket{le="+Inf"} 3
+argocd_repo_parallelism_wait_duration_seconds_sum 78.05
+argocd_repo_parallelism_wait_duration_seconds_count 3
+`
+	err := testutil.GatherAndCompare(m.PrometheusRegistry, strings.NewReader(expected), "argocd_repo_parallelism_wait_duration_seconds")
+	require.NoError(t, err)
+}
+
+func TestParallelismWaitMetricRegistered(t *testing.T) {
+	m := NewMetricsServer()
+	count := testutil.CollectAndCount(m.PrometheusRegistry, "argocd_repo_parallelism_wait_duration_seconds")
+	assert.Equal(t, 1, count)
+}

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -379,7 +379,9 @@ func (s *Service) runRepoOperation(
 	defer s.metricsServer.DecPendingRepoRequest(repo.Repo)
 
 	if settings.sem != nil {
+		acquireStart := time.Now()
 		err = settings.sem.Acquire(ctx, 1)
+		s.metricsServer.ObserveParallelismWaitDuration(time.Since(acquireStart))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

 ## Summary

  Adds a Prometheus histogram `argocd_repo_parallelism_wait_duration_seconds` to
  the repo-server, measuring time spent waiting on the manifest generation
  parallelism semaphore (`--parallelismlimit`).

  When the semaphore is saturated, manifest generation requests block until a slot
   frees up. Today there is no signal for this — it manifests downstream as
  API-server → repo-server timeouts (504s) with no way to attribute the latency to
   semaphore contention versus actual generation work.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
