### PR TITLE
chore(deps): bump redoc/dompurify to v3.4.0 in /ui for fixing CVE-2026-41240(cherry-pick 3.3)

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -61,6 +61,7 @@
     "@types/react": "^16.9.3",
     "@types/react-dom": "^16.8.2",
     "normalize-url": "4.5.1",
+    "redoc/dompurify": "^3.4.0",
     "rxjs": "6.6.7"
   },
   "devDependencies": {

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -3678,10 +3678,10 @@ domhandler@^4.0.0, domhandler@^4.2.0:
   dependencies:
     domelementtype "^2.2.0"
 
-dompurify@^3.0.6:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.2.4.tgz#af5a5a11407524431456cf18836c55d13441cd8e"
-  integrity sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==
+dompurify@^3.0.6, dompurify@^3.4.0:
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.5.tgz#bedc7d30a6007ae9a8937b952be6adb76a28e871"
+  integrity sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 


### PR DESCRIPTION
cherry-pick of #27751 for release 3.3