### PR TITLE
fix(ui): ApplicationSet detail view for non-default namespace (#27928)

### DIFF
--- a/ui/src/app/shared/services/applications-service.namespace.test.ts
+++ b/ui/src/app/shared/services/applications-service.namespace.test.ts
@@ -1,0 +1,22 @@
+import {namespaceQuery, namespaceQueryKey} from './applications-service.namespace';
+
+describe('ApplicationSet namespace query params', () => {
+    it('uses appNamespace for applications', () => {
+        expect(namespaceQueryKey('application')).toBe('appNamespace');
+        expect(namespaceQuery('application', 'team-platform')).toEqual({appNamespace: 'team-platform'});
+    });
+
+    it('uses appsetNamespace for ApplicationSet GET/resource-tree', () => {
+        expect(namespaceQueryKey('applicationset')).toBe('appsetNamespace');
+        expect(namespaceQuery('applicationset', 'team-platform')).toEqual({appsetNamespace: 'team-platform'});
+    });
+
+    it('uses appSetNamespace for ApplicationSet watch stream', () => {
+        expect(namespaceQueryKey('applicationset', true)).toBe('appSetNamespace');
+        expect(namespaceQuery('applicationset', 'team-platform', true)).toEqual({appSetNamespace: 'team-platform'});
+    });
+
+    it('returns empty object when namespace is empty', () => {
+        expect(namespaceQuery('applicationset', '')).toEqual({});
+    });
+});

--- a/ui/src/app/shared/services/applications-service.namespace.ts
+++ b/ui/src/app/shared/services/applications-service.namespace.ts
@@ -1,0 +1,11 @@
+/** Application API uses appNamespace; ApplicationSet API uses appsetNamespace (appSetNamespace for watch stream). */
+export function namespaceQueryKey(objectListKind: string, forWatch = false): string {
+    return objectListKind === 'application' ? 'appNamespace' : forWatch ? 'appSetNamespace' : 'appsetNamespace';
+}
+
+export function namespaceQuery(objectListKind: string, namespace: string, forWatch = false): {[key: string]: string} {
+    if (!namespace) {
+        return {};
+    }
+    return {[namespaceQueryKey(objectListKind, forWatch)]: namespace};
+}

--- a/ui/src/app/shared/services/applications-service.ts
+++ b/ui/src/app/shared/services/applications-service.ts
@@ -6,6 +6,7 @@ import * as models from '../models';
 import {isValidURL} from '../utils';
 import requests from './requests';
 import {getRootPathByApp, isApp} from '../../applications/components/utils';
+import {namespaceQuery, namespaceQueryKey} from './applications-service.namespace';
 
 interface QueryOptions {
     fields: string[];
@@ -59,14 +60,11 @@ export class ApplicationsService {
     }
 
     public get(name: string, appNamespace: string, objectListKind: string, refresh?: 'normal' | 'hard'): Promise<models.AbstractApplication> {
-        const query: {[key: string]: string} = {};
+        const query: {[key: string]: string} = {...namespaceQuery(objectListKind, appNamespace)};
         const isApplication = objectListKind === 'application';
         const endpoint = isApplication ? '/applications' : '/applicationsets';
         if (refresh) {
             query.refresh = refresh;
-        }
-        if (appNamespace) {
-            query.appNamespace = appNamespace;
         }
         return requests
             .get(`${endpoint}/${name}`)
@@ -119,7 +117,7 @@ export class ApplicationsService {
         const endpoint = isApplication ? '/applications' : '/applicationsets';
         return requests
             .get(`${endpoint}/${name}/resource-tree`)
-            .query({appNamespace})
+            .query(namespaceQuery(objectListKind, appNamespace))
             .then(res => res.body as models.AbstractApplicationTree);
     }
 
@@ -247,14 +245,16 @@ export class ApplicationsService {
                 search.set('resourceVersion', query.resourceVersion);
             }
             if (query.appNamespace) {
-                search.set('appNamespace', query.appNamespace);
+                search.set(namespaceQueryKey(objectListKind, true), query.appNamespace);
             }
         }
         if (options) {
             const searchOptions = optionsToSearch(options);
             search.set('fields', searchOptions.fields);
             search.set('selector', searchOptions.selector);
-            search.set('appNamespace', searchOptions.appNamespace);
+            if (searchOptions.appNamespace) {
+                search.set(namespaceQueryKey(objectListKind, true), searchOptions.appNamespace);
+            }
             if (isApplication) {
                 query?.projects?.forEach(project => search.append('projects', project));
             }


### PR DESCRIPTION
## Summary

- ApplicationSet detail pages under `/applicationsets/<namespace>/<name>` failed to load when the AppSet was not in the Argo CD control-plane namespace.
- The UI sent `appNamespace` on GET/watch/resource-tree requests; the ApplicationSet API expects `appsetNamespace` (and `appSetNamespace` for the watch stream per swagger).

## Root cause

`ApplicationsService.get()`, `resourceTree()`, and `watch()` always used the Application query parameter `appNamespace`, which the ApplicationSet server ignores.

## Fix

- Map namespace to the correct query key per resource type (`applications-service.namespace.ts`).
- Add unit tests for the mapping.

## Test plan

- [x] `pnpm test` in `ui/` — all suites pass (including 4 new namespace tests)
- [x] `eslint` on changed files
- [ ] Manual: open namespaced AppSet URL (e.g. `cd.apps.argoproj.io/applicationsets/team-platform/services`) after build

Fixes #27928