### PR TITLE
chore: add UI approver scope

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,3 +18,7 @@
 /cmd/main.go @argoproj/argocd-approvers @argoproj/argocd-approvers-cli
 # Also include @argoproj/argocd-approvers-docs to avoid requiring CLI approvers for docs-only PRs.
 /docs/operator-manual/ @argoproj/argocd-approvers @argoproj/argocd-approvers-docs @argoproj/argocd-approvers-cli
+
+# UI
+/ui/**      @argoproj/argocd-approvers @argoproj/argocd-approvers-ui
+/ui-test/** @argoproj/argocd-approvers @argoproj/argocd-approvers-ui


### PR DESCRIPTION
There are [a lot](https://github.com/crenshaw-dev/scoped-approvers/blob/main/report.md) of PRs that touch only the `ui` directory. @jwinters01 has been accepted as an Approver(ui), we just need to define the scope of the role.