### PR TITLE
feat: make manifest hydration queue concurrency configurable (#27926)

### DIFF
--- a/cmd/argocd-application-controller/commands/argocd_application_controller.go
+++ b/cmd/argocd-application-controller/commands/argocd_application_controller.go
@@ -70,6 +70,7 @@ func NewCommand() *cobra.Command {
 		syncTimeout                      int
 		statusProcessors                 int
 		operationProcessors              int
+		hydrationProcessors              int
 		glogLevel                        int
 		metricsPort                      int
 		metricsCacheExpiration           time.Duration
@@ -243,7 +244,7 @@ func NewCommand() *cobra.Command {
 				cancel()
 			}()
 
-			go appController.Run(ctx, statusProcessors, operationProcessors)
+			go appController.Run(ctx, statusProcessors, operationProcessors, hydrationProcessors)
 
 			<-ctx.Done()
 
@@ -263,6 +264,7 @@ func NewCommand() *cobra.Command {
 	command.Flags().StringVar(&commitServerAddress, "commit-server", env.StringFromEnv("ARGOCD_APPLICATION_CONTROLLER_COMMIT_SERVER", common.DefaultCommitServerAddr), "Commit server address.")
 	command.Flags().IntVar(&statusProcessors, "status-processors", env.ParseNumFromEnv("ARGOCD_APPLICATION_CONTROLLER_STATUS_PROCESSORS", 20, 0, math.MaxInt32), "Number of application status processors")
 	command.Flags().IntVar(&operationProcessors, "operation-processors", env.ParseNumFromEnv("ARGOCD_APPLICATION_CONTROLLER_OPERATION_PROCESSORS", 10, 0, math.MaxInt32), "Number of application operation processors")
+	command.Flags().IntVar(&hydrationProcessors, "hydration-processors", env.ParseNumFromEnv("ARGOCD_APPLICATION_CONTROLLER_HYDRATION_PROCESSORS", 5, 1, math.MaxInt32), "Number of manifest hydration processors (only relevant when the Source Hydrator is enabled)")
 	command.Flags().StringVar(&cmdutil.LogFormat, "logformat", env.StringFromEnv("ARGOCD_APPLICATION_CONTROLLER_LOGFORMAT", "json"), "Set the logging format. One of: json|text")
 	command.Flags().StringVar(&cmdutil.LogLevel, "loglevel", env.StringFromEnv("ARGOCD_APPLICATION_CONTROLLER_LOGLEVEL", "info"), "Set the logging level. One of: debug|info|warn|error")
 	command.Flags().IntVar(&glogLevel, "gloglevel", 0, "Set the glog logging level")

--- a/cmd/argocd-application-controller/commands/argocd_application_controller_test.go
+++ b/cmd/argocd-application-controller/commands/argocd_application_controller_test.go
@@ -1,0 +1,20 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewCommand_HydrationProcessorsFlag pins down the contract for the manifest hydration concurrency
+// knob added for https://github.com/argoproj/argo-cd/issues/27926: the flag exists and defaults to a value
+// greater than 1 (so the default deployment exercises hydration concurrency and tests are more likely to
+// catch races, per the maintainer's guidance on the issue).
+func TestNewCommand_HydrationProcessorsFlag(t *testing.T) {
+	cmd := NewCommand()
+
+	f := cmd.Flags().Lookup("hydration-processors")
+	require.NotNil(t, f, "expected --hydration-processors flag to be registered")
+	assert.Equal(t, "5", f.DefValue, "default hydration processors should be greater than 1")
+}

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -888,7 +888,20 @@ func (ctrl *ApplicationController) hideSecretData(destCluster *appv1.Cluster, ap
 }
 
 // Run starts the Application CRD controller.
-func (ctrl *ApplicationController) Run(ctx context.Context, statusProcessors int, operationProcessors int) {
+// normalizeHydrationProcessors clamps the configured number of manifest hydration workers to a safe
+// minimum. The --hydration-processors flag / ARGOCD_APPLICATION_CONTROLLER_HYDRATION_PROCESSORS env var
+// can be set to 0 or a negative value on the command line (the env default is clamped, but an explicit
+// flag value is not). Starting zero workers would silently stall hydration, so fall back to a single
+// worker and warn. See https://github.com/argoproj/argo-cd/issues/27926.
+func normalizeHydrationProcessors(hydrationProcessors int) int {
+	if hydrationProcessors < 1 {
+		log.Warnf("hydration-processors was set to %d; hydration requires at least one worker, using 1 instead", hydrationProcessors)
+		return 1
+	}
+	return hydrationProcessors
+}
+
+func (ctrl *ApplicationController) Run(ctx context.Context, statusProcessors int, operationProcessors int, hydrationProcessors int) {
 	defer runtime.HandleCrash()
 	defer ctrl.appRefreshQueue.ShutDown()
 	defer ctrl.appComparisonTypeRefreshQueue.ShutDown()
@@ -956,15 +969,26 @@ func (ctrl *ApplicationController) Run(ctx context.Context, statusProcessors int
 	}, time.Second, ctx.Done())
 
 	if ctrl.hydrator != nil {
+		// The app hydrate queue is intentionally drained by a single worker. It is keyed per
+		// application and only marks each app's hydration phase before enqueuing the (deduped)
+		// hydration key, so it is cheap and ordering-sensitive; parallelizing it would widen the
+		// race window described in hydrator.ProcessHydrationQueueItem without any throughput benefit.
 		go wait.Until(func() {
 			for ctrl.processAppHydrateQueueItem() {
 			}
 		}, time.Second, ctx.Done())
 
-		go wait.Until(func() {
-			for ctrl.processHydrationQueueItem() {
-			}
-		}, time.Second, ctx.Done())
+		// The hydration queue does the heavy lifting (generating manifests and committing to the
+		// hydrated branch) and is keyed by {SourceRepoURL, SourceTargetRevision, DestinationBranch}.
+		// Because it is a rate-limiting workqueue, the same key is never processed by two workers at
+		// once, so additional workers only parallelize hydration across *distinct* keys. This is the
+		// concurrency knob requested in https://github.com/argoproj/argo-cd/issues/27926.
+		for range normalizeHydrationProcessors(hydrationProcessors) {
+			go wait.Until(func() {
+				for ctrl.processHydrationQueueItem() {
+				}
+			}, time.Second, ctx.Done())
+		}
 	}
 
 	<-ctx.Done()

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -969,20 +969,23 @@ func (ctrl *ApplicationController) Run(ctx context.Context, statusProcessors int
 	}, time.Second, ctx.Done())
 
 	if ctrl.hydrator != nil {
-		// The app hydrate queue is intentionally drained by a single worker. It is keyed per
-		// application and only marks each app's hydration phase before enqueuing the (deduped)
-		// hydration key, so it is cheap and ordering-sensitive; parallelizing it would widen the
-		// race window described in hydrator.ProcessHydrationQueueItem without any throughput benefit.
+		// The app hydrate queue is keyed per application. Its only job is to decide whether the
+		// app needs hydration and, if so, enqueue the (deduped) hydration key. The Hydrating
+		// status mark and all subsequent per-app status writes live on the hydration queue side,
+		// so this worker is just an enqueuer and a single goroutine is sufficient
+		// (https://github.com/argoproj/argo-cd/issues/27926).
 		go wait.Until(func() {
 			for ctrl.processAppHydrateQueueItem() {
 			}
 		}, time.Second, ctx.Done())
 
-		// The hydration queue does the heavy lifting (generating manifests and committing to the
-		// hydrated branch) and is keyed by {SourceRepoURL, SourceTargetRevision, DestinationBranch}.
-		// Because it is a rate-limiting workqueue, the same key is never processed by two workers at
-		// once, so additional workers only parallelize hydration across *distinct* keys. This is the
-		// concurrency knob requested in https://github.com/argoproj/argo-cd/issues/27926.
+		// The hydration queue does the heavy lifting (marking apps Hydrating, generating
+		// manifests, committing to the hydrated branch, and writing the per-app statuses) and is
+		// keyed by {SourceRepoURL, SourceTargetRevision, DestinationBranch}. Because it is a
+		// rate-limiting workqueue, the same key is never processed by two workers at once, so
+		// additional workers only parallelize hydration across *distinct* keys. The per-key dedup
+		// is also what makes the status writes safe to do inside this worker rather than ahead of
+		// time on the app hydrate queue. This is the concurrency knob requested in #27926.
 		for range normalizeHydrationProcessors(hydrationProcessors) {
 			go wait.Until(func() {
 				for ctrl.processHydrationQueueItem() {

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -1161,14 +1161,14 @@ func TestFinalizeAppDeletion(t *testing.T) {
 			}}, nil)
 
 			fakeAppCs := ctrl.applicationClientset.(*appclientset.Clientset)
-			// fakeAppCs.Fake's RWMutex protects ReactionChain. Wrap the swap so it does not race
-			// with informer-driven Patches reading the chain via Fake.Invokes: this subtest's
-			// invalid Destination (name + server) makes the namespace indexer in
+			// The embedded testing.Fake's RWMutex protects ReactionChain. Wrap the swap so it
+			// does not race with informer-driven Patches reading the chain via Invokes: this
+			// subtest's invalid Destination (name + server) makes the namespace indexer in
 			// newApplicationInformerAndLister invoke setAppCondition → Patch concurrently.
-			fakeAppCs.Fake.Lock()
+			fakeAppCs.Lock()
 			defaultReactor := fakeAppCs.ReactionChain[0]
 			fakeAppCs.ReactionChain = nil
-			fakeAppCs.Fake.Unlock()
+			fakeAppCs.Unlock()
 			fakeAppCs.AddReactor("get", "*", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
 				return defaultReactor.React(action)
 			})

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -1161,8 +1161,14 @@ func TestFinalizeAppDeletion(t *testing.T) {
 			}}, nil)
 
 			fakeAppCs := ctrl.applicationClientset.(*appclientset.Clientset)
+			// fakeAppCs.Fake's RWMutex protects ReactionChain. Wrap the swap so it does not race
+			// with informer-driven Patches reading the chain via Fake.Invokes: this subtest's
+			// invalid Destination (name + server) makes the namespace indexer in
+			// newApplicationInformerAndLister invoke setAppCondition → Patch concurrently.
+			fakeAppCs.Fake.Lock()
 			defaultReactor := fakeAppCs.ReactionChain[0]
 			fakeAppCs.ReactionChain = nil
+			fakeAppCs.Fake.Unlock()
 			fakeAppCs.AddReactor("get", "*", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
 				return defaultReactor.React(action)
 			})

--- a/controller/hydration_concurrency_test.go
+++ b/controller/hydration_concurrency_test.go
@@ -1,0 +1,178 @@
+package controller
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/util/workqueue"
+
+	hydratortypes "github.com/argoproj/argo-cd/v3/controller/hydrator/types"
+	"github.com/argoproj/argo-cd/v3/pkg/ratelimiter"
+)
+
+// TestNormalizeHydrationProcessors verifies that the hydration worker count is clamped to a safe minimum.
+// The --hydration-processors CLI flag can be set to 0 or a negative value (the env default is clamped, but
+// an explicit flag value is not), which would otherwise start zero workers and silently stall hydration.
+// See https://github.com/argoproj/argo-cd/issues/27926.
+func TestNormalizeHydrationProcessors(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		configured int
+		want       int
+	}{
+		{"zero clamps to one", 0, 1},
+		{"negative clamps to one", -3, 1},
+		{"one stays one", 1, 1},
+		{"default preserved", 5, 5},
+		{"large value preserved", 50, 50},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, normalizeHydrationProcessors(tc.configured))
+		})
+	}
+}
+
+func newTestHydrationQueue() workqueue.TypedRateLimitingInterface[hydratortypes.HydrationQueueKey] {
+	return workqueue.NewTypedRateLimitingQueue(
+		ratelimiter.NewCustomAppControllerRateLimiter[hydratortypes.HydrationQueueKey](ratelimiter.GetDefaultAppRateLimiterConfig()),
+	)
+}
+
+// TestHydrationQueue_DistinctKeysProcessConcurrently asserts the core feature claim of #27926: when the
+// hydration queue is drained by multiple workers, distinct hydration keys are processed concurrently, while
+// no single key is ever processed by two workers at the same time. The worker loop mirrors the one started
+// in ApplicationController.Run.
+func TestHydrationQueue_DistinctKeysProcessConcurrently(t *testing.T) {
+	t.Parallel()
+
+	queue := newTestHydrationQueue()
+	t.Cleanup(queue.ShutDown)
+
+	const numKeys = 12
+	const numWorkers = 4
+	for i := range numKeys {
+		queue.Add(hydratortypes.HydrationQueueKey{SourceRepoURL: fmt.Sprintf("https://example.com/repo-%d", i)})
+	}
+
+	var (
+		mu             sync.Mutex
+		inFlight       int
+		maxConcurrent  int
+		processed      int
+		perKeyActive   = map[hydratortypes.HydrationQueueKey]bool{}
+		sameKeyOverlap bool
+	)
+
+	processNext := func() bool {
+		key, shutdown := queue.Get()
+		if shutdown {
+			return false
+		}
+		defer queue.Done(key)
+
+		mu.Lock()
+		if perKeyActive[key] {
+			sameKeyOverlap = true
+		}
+		perKeyActive[key] = true
+		inFlight++
+		if inFlight > maxConcurrent {
+			maxConcurrent = inFlight
+		}
+		mu.Unlock()
+
+		// Hold the key briefly so that concurrent processing of distinct keys is observable.
+		time.Sleep(20 * time.Millisecond)
+
+		mu.Lock()
+		inFlight--
+		perKeyActive[key] = false
+		processed++
+		allDone := processed == numKeys
+		mu.Unlock()
+
+		if allDone {
+			queue.ShutDown()
+		}
+		return true
+	}
+
+	var wg sync.WaitGroup
+	for range numWorkers {
+		wg.Go(func() {
+			for processNext() {
+			}
+		})
+	}
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, numKeys, processed, "every distinct key should be processed exactly once")
+	assert.False(t, sameKeyOverlap, "the same hydration key must never be processed by two workers at once")
+	assert.GreaterOrEqual(t, maxConcurrent, 2, "distinct hydration keys should be processed concurrently with multiple workers")
+}
+
+// TestHydrationQueue_SameKeyNotProcessedConcurrently asserts the dedup guarantee the feature relies on: a
+// hydration key that is re-enqueued while it is still in-flight is withheld until the in-flight processing
+// calls Done, so the same key is never handed to two workers simultaneously. See #27926.
+func TestHydrationQueue_SameKeyNotProcessedConcurrently(t *testing.T) {
+	t.Parallel()
+
+	queue := newTestHydrationQueue()
+	t.Cleanup(queue.ShutDown)
+
+	key := hydratortypes.HydrationQueueKey{SourceRepoURL: "https://example.com/repo", DestinationBranch: "env/dev"}
+	queue.Add(key)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	secondPickup := make(chan hydratortypes.HydrationQueueKey, 1)
+
+	// Worker 1 takes the key and holds it (does not call Done) until released.
+	go func() {
+		k, shutdown := queue.Get()
+		if shutdown {
+			return
+		}
+		close(started)
+		<-release
+		queue.Done(k)
+	}()
+
+	<-started
+	// Re-enqueue the same key while it is still in-flight. The workqueue must not hand it to another
+	// worker until the first one calls Done.
+	queue.Add(key)
+
+	// Worker 2 attempts to take work; it must block while the key is in-flight.
+	go func() {
+		k, shutdown := queue.Get()
+		if !shutdown {
+			secondPickup <- k
+		}
+	}()
+
+	select {
+	case <-secondPickup:
+		t.Fatal("the same hydration key was delivered to a second worker while still in-flight")
+	case <-time.After(150 * time.Millisecond):
+		// Expected: the re-added key is withheld until the first worker calls Done.
+	}
+
+	// Release the first worker; the re-added key should now become available to worker 2.
+	close(release)
+	select {
+	case got := <-secondPickup:
+		assert.Equal(t, key, got)
+		queue.Done(got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("re-added key was not delivered after the first worker finished")
+	}
+}

--- a/controller/hydrator/hydrator.go
+++ b/controller/hydrator/hydrator.go
@@ -108,12 +108,19 @@ func NewHydrator(dependencies Dependencies, statusRefreshTimeout time.Duration, 
 	}
 }
 
-// ProcessAppHydrateQueueItem processes an application hydrate queue item. It checks if the application needs hydration
-// and if so, it updates the application's status to indicate that hydration is in progress. It then adds the
-// hydration queue item to the queue for further processing.
+// ProcessAppHydrateQueueItem processes an application hydrate queue item. It checks whether the
+// application needs hydration and, if so, enqueues the deduped hydration key.
 //
-// It's likely that multiple applications will trigger hydration at the same time. The hydration queue key is meant to
-// dedupe these requests.
+// The per-app status update that marks the application as Hydrating is deliberately NOT done here.
+// It is performed by ProcessHydrationQueueItem, which gathers every application sharing the
+// hydration key and updates them together. Because the hydration workqueue dedups by key and never
+// hands the same key to two workers concurrently, ProcessHydrationQueueItem holds exclusive
+// ownership of the entire app group when it runs — there is no possibility of a worker observing a
+// partial view of the group, so the status update is safe under parallel hydration workers
+// (https://github.com/argoproj/argo-cd/issues/27926).
+//
+// It's likely that multiple applications will trigger hydration at the same time. The hydration
+// queue key is meant to dedupe these requests.
 func (h *Hydrator) ProcessAppHydrateQueueItem(origApp *appv1.Application) {
 	app := origApp.DeepCopy()
 	if app.Spec.SourceHydrator == nil {
@@ -130,19 +137,17 @@ func (h *Hydrator) ProcessAppHydrateQueueItem(origApp *appv1.Application) {
 		app.Status.SourceHydrator.LastComparedDryRevision = resolvedDryRevision
 		logCtx.WithField("lastComparedDryRevision", resolvedDryRevision).Debug("Updated last compared dry revision")
 	}
-	if needsHydration {
-		app.Status.SourceHydrator.CurrentOperation = &appv1.HydrateOperation{
-			StartedAt:      metav1.Now(),
-			FinishedAt:     nil,
-			Phase:          appv1.HydrateOperationPhaseHydrating,
-			SourceHydrator: *app.Spec.SourceHydrator,
-		}
-	}
 
 	// Always persist to consume the hydrate annotation, even if hydration is not needed.
 	h.dependencies.PersistHydrationStatus(origApp, &app.Status.SourceHydrator)
 
-	needsRefresh := app.Status.SourceHydrator.CurrentOperation.Phase == appv1.HydrateOperationPhaseHydrating && metav1.Now().Sub(app.Status.SourceHydrator.CurrentOperation.StartedAt.Time) > h.statusRefreshTimeout
+	// needsRefresh re-enqueues the hydration key for an app that was marked Hydrating on an earlier
+	// pass but whose StartedAt has aged past statusRefreshTimeout (typically because the hydration
+	// worker crashed or fell behind). CurrentOperation can be nil here for an app that has never
+	// been hydrated, so the nil guard is required now that we no longer set CurrentOperation above.
+	needsRefresh := app.Status.SourceHydrator.CurrentOperation != nil &&
+		app.Status.SourceHydrator.CurrentOperation.Phase == appv1.HydrateOperationPhaseHydrating &&
+		metav1.Now().Sub(app.Status.SourceHydrator.CurrentOperation.StartedAt.Time) > h.statusRefreshTimeout
 	if needsHydration || needsRefresh {
 		logCtx.WithField("reason", reason).Info("Hydrating app")
 		h.dependencies.AddHydrationQueueItem(getHydrationQueueKey(app))
@@ -165,9 +170,17 @@ func getHydrationQueueKey(app *appv1.Application) types.HydrationQueueKey {
 }
 
 // ProcessHydrationQueueItem processes a hydration queue item. It retrieves the relevant applications for the given
-// hydration key, hydrates their latest commit, and updates their status accordingly. If the hydration fails, it marks
-// the operation as failed and logs the error. If successful, it updates the operation to indicate that hydration was
-// successful and requests a refresh of the applications to pick up the new hydrated commit.
+// hydration key, marks every app in the group as Hydrating, generates and commits their manifests, and updates each
+// app's status accordingly. If the hydration fails, it marks the operation as failed and logs the error. If successful,
+// it updates the operation to indicate that hydration was successful and requests a refresh of the applications to pick
+// up the new hydrated commit.
+//
+// The hydration workqueue is a rate-limiting queue keyed by hydration key, which guarantees the same key is never
+// handed to two workers at once. So at the start of this function we hold exclusive ownership over the entire app
+// group sharing this key. That ownership is what makes the per-app status updates safe even when multiple hydration
+// workers are running in parallel (https://github.com/argoproj/argo-cd/issues/27926): there is no possibility of a
+// worker observing a partial view of the group, so we can mark every app Hydrating up front and keep their statuses in
+// lockstep with the single commit produced by hydrate().
 func (h *Hydrator) ProcessHydrationQueueItem(hydrationKey types.HydrationQueueKey) {
 	logCtx := log.WithFields(log.Fields{
 		"sourceRepoURL":        hydrationKey.SourceRepoURL,
@@ -187,28 +200,11 @@ func (h *Hydrator) ProcessHydrationQueueItem(hydrationKey types.HydrationQueueKe
 	}
 	logCtx.WithField("appCount", len(apps))
 
-	// Concurrency handling (https://github.com/argoproj/argo-cd/issues/27926): with more than one
-	// hydration worker, a hydration queue item for this key can be picked up before
-	// ProcessAppHydrateQueueItem has marked every app in the group as Hydrating, so some apps below may
-	// still have a nil or stale CurrentOperation.
-	//
-	// We deliberately still hydrate the COMPLETE set of apps for the key, not just the ones already
-	// marked Hydrating. The commit server records a git note per dry SHA and short-circuits any later
-	// commit for the same dry SHA before writing manifests (see commitserver/commit/commit.go,
-	// IsHydrated). If we committed only a subset now, a later commit for the remaining apps would be
-	// skipped by that note and those apps would be marked hydrated without their manifests ever being
-	// written. Committing the full path set in a single pass keeps the note's "already hydrated"
-	// guarantee accurate and avoids partial hydration.
-	//
-	// What we guard is the per-app STATUS update further below: an app that is not in the Hydrating phase
-	// is skipped, because its CurrentOperation may be nil (dereferencing it would panic) or stale (we
-	// must not overwrite it). Its manifests are still committed above, so no data is lost; only its
-	// status lags. That status reconciles on a later hydration pass via the existing refresh/resync path
-	// rather than immediately: an app left in the Hydrating phase is not re-hydrated by
-	// ProcessAppHydrateQueueItem (appNeedsHydration reports "already in progress") until its operation is
-	// older than statusRefreshTimeout (or the app is otherwise re-queued, e.g. on spec change or resync).
-	// On that later pass the commit server hits the dry-SHA note and returns the existing hydrated SHA
-	// without re-committing, and the status is finalized.
+	// Atomically mark every app in this group as Hydrating before doing any work. The workqueue's
+	// per-key dedup means no other worker can be touching this group concurrently, so it is safe to
+	// do the status writes here rather than in ProcessAppHydrateQueueItem
+	// (https://github.com/argoproj/argo-cd/issues/27926).
+	h.markAppsHydrating(apps)
 
 	// validate all the applications to make sure they are all correctly configured.
 	// All applications sharing the same hydration key must succeed for the hydration to be processed.
@@ -246,12 +242,8 @@ func (h *Hydrator) ProcessHydrationQueueItem(hydrationKey types.HydrationQueueKe
 		genericError := genericHydrationError(appErrors)
 		for _, app := range apps {
 			if drySHA != "" {
-				// If we have a drySHA, we can set it on the app status. Guard the CurrentOperation
-				// deref: under concurrent hydration (#27926) an app in this group may not be in the
-				// Hydrating phase yet and can have a nil CurrentOperation.
-				if app.Status.SourceHydrator.CurrentOperation != nil {
-					app.Status.SourceHydrator.CurrentOperation.DrySHA = drySHA
-				}
+				// markAppsHydrating ran before hydrate(), so CurrentOperation is always populated here.
+				app.Status.SourceHydrator.CurrentOperation.DrySHA = drySHA
 				app.Status.SourceHydrator.LastComparedDryRevision = drySHA
 			}
 			if err, ok := appErrors[app.QualifiedName()]; ok {
@@ -268,17 +260,6 @@ func (h *Hydrator) ProcessHydrationQueueItem(hydrationKey types.HydrationQueueKe
 	logCtx.Debug("Successfully hydrated apps")
 	finishedAt := metav1.Now()
 	for _, app := range apps {
-		// The manifests for every app in this group were just committed (the complete path set), but we
-		// only update the status of apps the controller has actually marked Hydrating. Under concurrent
-		// hydration (#27926) an app in this group may not be Hydrating yet: its CurrentOperation may be
-		// nil (dereferencing it below would panic) or stale (we must not overwrite it). Such an app keeps
-		// its current status; it is finalized on a later hydration pass via the existing refresh/resync
-		// path (see the note at the top of this method), which hits the dry-SHA note and returns the
-		// already-hydrated SHA without re-committing.
-		if app.Status.SourceHydrator.CurrentOperation == nil || app.Status.SourceHydrator.CurrentOperation.Phase != appv1.HydrateOperationPhaseHydrating {
-			logCtx.WithFields(applog.GetAppLogFields(app)).Debug("skipping hydration status update for app not in the Hydrating phase; it will be reconciled on a later pass")
-			continue
-		}
 		origApp := app.DeepCopy()
 		operation := &appv1.HydrateOperation{
 			StartedAt:      app.Status.SourceHydrator.CurrentOperation.StartedAt,
@@ -306,15 +287,39 @@ func (h *Hydrator) ProcessHydrationQueueItem(hydrationKey types.HydrationQueueKe
 	}
 }
 
-// setAppHydratorError updates the CurrentOperation with the error information.
-func (h *Hydrator) setAppHydratorError(app *appv1.Application, err error) {
-	// if there is no in-progress operation, we do not update the status. Under concurrent hydration
-	// (#27926) the app may not be in the Hydrating phase yet and CurrentOperation can be nil, so the
-	// nil check also guards against a panic.
-	if app.Status.SourceHydrator.CurrentOperation == nil || app.Status.SourceHydrator.CurrentOperation.Phase != appv1.HydrateOperationPhaseHydrating {
-		return
+// markAppsHydrating stamps every app in the group with a Hydrating CurrentOperation and persists
+// the change. It is called from ProcessHydrationQueueItem, where the hydration workqueue's per-key
+// dedup gives the caller exclusive ownership of the app group — there is no possibility of another
+// worker mutating these apps' hydration phase concurrently
+// (https://github.com/argoproj/argo-cd/issues/27926).
+//
+// Apps already in the Hydrating phase are left alone. That happens on a needsRefresh re-entry
+// (statusRefreshTimeout elapsed while the previous attempt was in-flight) and also on the very
+// first re-entry for a brand-new run where ProcessAppHydrateQueueItem fires twice before the
+// hydration worker picks the key up. Preserving the original StartedAt keeps the operation's
+// elapsed time meaningful for observers, and avoids needlessly thrashing the persisted status.
+func (h *Hydrator) markAppsHydrating(apps []*appv1.Application) {
+	now := metav1.Now()
+	for _, app := range apps {
+		if app.Status.SourceHydrator.CurrentOperation != nil &&
+			app.Status.SourceHydrator.CurrentOperation.Phase == appv1.HydrateOperationPhaseHydrating {
+			continue
+		}
+		origApp := app.DeepCopy()
+		app.Status.SourceHydrator.CurrentOperation = &appv1.HydrateOperation{
+			StartedAt:      now,
+			FinishedAt:     nil,
+			Phase:          appv1.HydrateOperationPhaseHydrating,
+			SourceHydrator: *app.Spec.SourceHydrator,
+		}
+		h.dependencies.PersistHydrationStatus(origApp, &app.Status.SourceHydrator)
 	}
+}
 
+// setAppHydratorError updates the CurrentOperation with the error information. It is only called
+// from ProcessHydrationQueueItem after markAppsHydrating has ensured every app has a Hydrating
+// CurrentOperation, so no nil guard is needed here.
+func (h *Hydrator) setAppHydratorError(app *appv1.Application, err error) {
 	origApp := app.DeepCopy()
 	app.Status.SourceHydrator.CurrentOperation.Phase = appv1.HydrateOperationPhaseFailed
 	failedAt := metav1.Now()

--- a/controller/hydrator/hydrator.go
+++ b/controller/hydrator/hydrator.go
@@ -187,20 +187,28 @@ func (h *Hydrator) ProcessHydrationQueueItem(hydrationKey types.HydrationQueueKe
 	}
 	logCtx.WithField("appCount", len(apps))
 
-	// FIXME: we might end up in a race condition here where an HydrationQueueItem is processed
-	// before all applications had their CurrentOperation set by ProcessAppHydrateQueueItem.
-	// This would cause this method to update "old" CurrentOperation.
-	// It should only start hydration if all apps are in the HydrateOperationPhaseHydrating phase.
-	raceDetected := false
-	for _, app := range apps {
-		if app.Status.SourceHydrator.CurrentOperation == nil || app.Status.SourceHydrator.CurrentOperation.Phase != appv1.HydrateOperationPhaseHydrating {
-			raceDetected = true
-			break
-		}
-	}
-	if raceDetected {
-		logCtx.Warn("race condition detected: not all apps are in HydrateOperationPhaseHydrating phase")
-	}
+	// Concurrency handling (https://github.com/argoproj/argo-cd/issues/27926): with more than one
+	// hydration worker, a hydration queue item for this key can be picked up before
+	// ProcessAppHydrateQueueItem has marked every app in the group as Hydrating, so some apps below may
+	// still have a nil or stale CurrentOperation.
+	//
+	// We deliberately still hydrate the COMPLETE set of apps for the key, not just the ones already
+	// marked Hydrating. The commit server records a git note per dry SHA and short-circuits any later
+	// commit for the same dry SHA before writing manifests (see commitserver/commit/commit.go,
+	// IsHydrated). If we committed only a subset now, a later commit for the remaining apps would be
+	// skipped by that note and those apps would be marked hydrated without their manifests ever being
+	// written. Committing the full path set in a single pass keeps the note's "already hydrated"
+	// guarantee accurate and avoids partial hydration.
+	//
+	// What we guard is the per-app STATUS update further below: an app that is not in the Hydrating phase
+	// is skipped, because its CurrentOperation may be nil (dereferencing it would panic) or stale (we
+	// must not overwrite it). Its manifests are still committed above, so no data is lost; only its
+	// status lags. That status reconciles on a later hydration pass via the existing refresh/resync path
+	// rather than immediately: an app left in the Hydrating phase is not re-hydrated by
+	// ProcessAppHydrateQueueItem (appNeedsHydration reports "already in progress") until its operation is
+	// older than statusRefreshTimeout (or the app is otherwise re-queued, e.g. on spec change or resync).
+	// On that later pass the commit server hits the dry-SHA note and returns the existing hydrated SHA
+	// without re-committing, and the status is finalized.
 
 	// validate all the applications to make sure they are all correctly configured.
 	// All applications sharing the same hydration key must succeed for the hydration to be processed.
@@ -238,8 +246,12 @@ func (h *Hydrator) ProcessHydrationQueueItem(hydrationKey types.HydrationQueueKe
 		genericError := genericHydrationError(appErrors)
 		for _, app := range apps {
 			if drySHA != "" {
-				// If we have a drySHA, we can set it on the app status
-				app.Status.SourceHydrator.CurrentOperation.DrySHA = drySHA
+				// If we have a drySHA, we can set it on the app status. Guard the CurrentOperation
+				// deref: under concurrent hydration (#27926) an app in this group may not be in the
+				// Hydrating phase yet and can have a nil CurrentOperation.
+				if app.Status.SourceHydrator.CurrentOperation != nil {
+					app.Status.SourceHydrator.CurrentOperation.DrySHA = drySHA
+				}
 				app.Status.SourceHydrator.LastComparedDryRevision = drySHA
 			}
 			if err, ok := appErrors[app.QualifiedName()]; ok {
@@ -256,6 +268,17 @@ func (h *Hydrator) ProcessHydrationQueueItem(hydrationKey types.HydrationQueueKe
 	logCtx.Debug("Successfully hydrated apps")
 	finishedAt := metav1.Now()
 	for _, app := range apps {
+		// The manifests for every app in this group were just committed (the complete path set), but we
+		// only update the status of apps the controller has actually marked Hydrating. Under concurrent
+		// hydration (#27926) an app in this group may not be Hydrating yet: its CurrentOperation may be
+		// nil (dereferencing it below would panic) or stale (we must not overwrite it). Such an app keeps
+		// its current status; it is finalized on a later hydration pass via the existing refresh/resync
+		// path (see the note at the top of this method), which hits the dry-SHA note and returns the
+		// already-hydrated SHA without re-committing.
+		if app.Status.SourceHydrator.CurrentOperation == nil || app.Status.SourceHydrator.CurrentOperation.Phase != appv1.HydrateOperationPhaseHydrating {
+			logCtx.WithFields(applog.GetAppLogFields(app)).Debug("skipping hydration status update for app not in the Hydrating phase; it will be reconciled on a later pass")
+			continue
+		}
 		origApp := app.DeepCopy()
 		operation := &appv1.HydrateOperation{
 			StartedAt:      app.Status.SourceHydrator.CurrentOperation.StartedAt,
@@ -285,8 +308,10 @@ func (h *Hydrator) ProcessHydrationQueueItem(hydrationKey types.HydrationQueueKe
 
 // setAppHydratorError updates the CurrentOperation with the error information.
 func (h *Hydrator) setAppHydratorError(app *appv1.Application, err error) {
-	// if the operation is not in progress, we do not update the status
-	if app.Status.SourceHydrator.CurrentOperation.Phase != appv1.HydrateOperationPhaseHydrating {
+	// if there is no in-progress operation, we do not update the status. Under concurrent hydration
+	// (#27926) the app may not be in the Hydrating phase yet and CurrentOperation can be nil, so the
+	// nil check also guards against a panic.
+	if app.Status.SourceHydrator.CurrentOperation == nil || app.Status.SourceHydrator.CurrentOperation.Phase != appv1.HydrateOperationPhaseHydrating {
 		return
 	}
 
@@ -418,7 +443,10 @@ func (h *Hydrator) hydrate(logCtx *log.Entry, apps []*appv1.Application, project
 
 	for _, app := range apps[1:] {
 		eg.Go(func() error {
-			_, pathDetails, err = h.getManifests(ctx, app, targetRevision, projects[app.Spec.Project])
+			// Use goroutine-local variables here. Assigning to the function-scoped pathDetails/err
+			// from multiple errgroup goroutines is a data race (and can append the wrong path under
+			// the mutex). See https://github.com/argoproj/argo-cd/issues/27926.
+			_, pathDetails, err := h.getManifests(ctx, app, targetRevision, projects[app.Spec.Project])
 			mu.Lock()
 			defer mu.Unlock()
 			if err != nil {

--- a/controller/hydrator/hydrator_test.go
+++ b/controller/hydrator/hydrator_test.go
@@ -3,6 +3,7 @@ package hydrator
 import (
 	"context"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -1671,4 +1672,221 @@ func Test_newRevisionHasChanges(t *testing.T) {
 			}
 		})
 	}
+}
+
+// --- Concurrency tests for the manifest hydration queue (https://github.com/argoproj/argo-cd/issues/27926) ---
+//
+// Once the hydration queue is drained by more than one processor, a hydration queue item can be picked up
+// before ProcessAppHydrateQueueItem has marked every app for that key as Hydrating. The tests below pin down
+// the resulting behavior: apps that are not in the Hydrating phase (and may have a nil CurrentOperation) must
+// be skipped rather than panicked on or overwritten with stale state.
+
+// expectSuccessfulHydratePipeline wires up the happy-path mocks for hydrate() so the tests can focus on how
+// ProcessHydrationQueueItem updates (or skips) application status. getRepoObjsCalls is the number of apps
+// whose manifests are generated (one GetRepoObjs call per app, regardless of hydration phase).
+func expectSuccessfulHydratePipeline(d *mocks.Dependencies, r *mocks.RepoGetter, rc *reposervermocks.RepoServerServiceClient, cc *commitservermocks.CommitServiceClient, getRepoObjsCalls int) {
+	d.EXPECT().GetProcessableAppProj(mock.Anything).Return(newTestProject(), nil)
+	d.EXPECT().GetRepoObjs(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, &repoclient.ManifestResponse{Revision: "abc123"}, nil).Times(getRepoObjsCalls)
+	r.EXPECT().GetRepository(mock.Anything, "https://example.com/repo", "test-project").Return(nil, nil).Once()
+	rc.EXPECT().GetRevisionMetadata(mock.Anything, mock.Anything).Return(nil, nil).Once()
+	d.EXPECT().GetWriteCredentials(mock.Anything, "https://example.com/repo", "test-project").Return(nil, nil).Once()
+	d.EXPECT().GetHydratorCommitMessageTemplate().Return("commit message", nil).Once()
+	d.EXPECT().GetCommitAuthorName().Return("", nil).Once()
+	d.EXPECT().GetCommitAuthorEmail().Return("", nil).Once()
+	cc.EXPECT().CommitHydratedManifests(mock.Anything, mock.Anything).
+		Return(&commitclient.CommitHydratedManifestsResponse{HydratedSha: "def456"}, nil).Once()
+}
+
+// TestProcessHydrationQueueItem_RaceConditionAppNotHydrating verifies that when a hydration queue item is
+// processed before the app has been marked Hydrating (CurrentOperation is nil) - the race window once the
+// queue is drained by multiple workers - hydration still runs (manifests are generated and committed for
+// the complete set), but the app's status is NOT updated and the nil CurrentOperation does not cause a
+// panic. The app's status reconciles on a later pass once it is marked Hydrating. See #27926.
+func TestProcessHydrationQueueItem_RaceConditionAppNotHydrating(t *testing.T) {
+	t.Parallel()
+	d := mocks.NewDependencies(t)
+	r := mocks.NewRepoGetter(t)
+	rc := reposervermocks.NewRepoServerServiceClient(t)
+	cc := commitservermocks.NewCommitServiceClient(t)
+
+	app := newTestApp("racey-app")
+	require.Nil(t, app.Status.SourceHydrator.CurrentOperation, "precondition: app must not yet be marked Hydrating")
+	hydrationKey := getHydrationQueueKey(app)
+	d.EXPECT().GetProcessableApps().Return(&v1alpha1.ApplicationList{Items: []v1alpha1.Application{*app}}, nil)
+	expectSuccessfulHydratePipeline(d, r, rc, cc, 1)
+
+	h := &Hydrator{dependencies: d, repoGetter: r, commitClientset: &commitservermocks.Clientset{CommitServiceClient: cc}, repoClientset: &reposervermocks.Clientset{RepoServerServiceClient: rc}}
+
+	require.NotPanics(t, func() {
+		h.ProcessHydrationQueueItem(hydrationKey)
+	})
+	// The app's manifests are committed, but because it is not in the Hydrating phase its status must
+	// not be written (which would overwrite a nil/stale CurrentOperation) and it is not refreshed.
+	d.AssertNotCalled(t, "PersistHydrationStatus", mock.Anything, mock.Anything)
+	d.AssertNotCalled(t, "RequestAppRefresh", mock.Anything, mock.Anything)
+}
+
+// TestProcessHydrationQueueItem_MixedPhases_OnlyHydratingAppsPersisted runs many applications that share a
+// single hydration key where only some have been marked Hydrating - the steady state once the hydration
+// queue is processed with multiple workers. Only the Hydrating apps should have their status persisted; the
+// rest must be left untouched, with no panics. See #27926.
+func TestProcessHydrationQueueItem_MixedPhases_OnlyHydratingAppsPersisted(t *testing.T) {
+	t.Parallel()
+
+	const hydratingCount = 12
+	const notReadyCount = 8
+	const totalApps = hydratingCount + notReadyCount
+
+	d := mocks.NewDependencies(t)
+	r := mocks.NewRepoGetter(t)
+	rc := reposervermocks.NewRepoServerServiceClient(t)
+	cc := commitservermocks.NewCommitServiceClient(t)
+
+	items := make([]v1alpha1.Application, 0, totalApps)
+	hydratingNames := make(map[string]bool, hydratingCount)
+	for i := range totalApps {
+		app := newTestApp(fmt.Sprintf("app-%d", i))
+		// Distinct destination paths so validateApplications does not flag duplicates.
+		app.Spec.SourceHydrator.SyncSource.Path = fmt.Sprintf("app-%d", i)
+		if i < hydratingCount {
+			app = setTestAppPhase(app, v1alpha1.HydrateOperationPhaseHydrating)
+			hydratingNames[app.Name] = true
+		}
+		items = append(items, *app)
+	}
+
+	hydrationKey := getHydrationQueueKey(&items[0])
+	d.EXPECT().GetProcessableApps().Return(&v1alpha1.ApplicationList{Items: items}, nil)
+	// The COMPLETE set is hydrated (one GetRepoObjs call per app) so the dry-SHA commit contains every
+	// app's manifests and the commit-server note stays accurate; only the status updates are limited to
+	// the apps that are actually in the Hydrating phase.
+	expectSuccessfulHydratePipeline(d, r, rc, cc, totalApps)
+
+	persisted := map[string]bool{}
+	d.EXPECT().PersistHydrationStatus(mock.Anything, mock.Anything).Run(func(orig *v1alpha1.Application, _ *v1alpha1.SourceHydratorStatus) {
+		persisted[orig.Name] = true
+	}).Return().Times(hydratingCount)
+	d.EXPECT().RequestAppRefresh(mock.Anything, mock.Anything).Return(nil).Times(hydratingCount)
+
+	h := &Hydrator{dependencies: d, repoGetter: r, commitClientset: &commitservermocks.Clientset{CommitServiceClient: cc}, repoClientset: &reposervermocks.Clientset{RepoServerServiceClient: rc}}
+
+	require.NotPanics(t, func() {
+		h.ProcessHydrationQueueItem(hydrationKey)
+	})
+
+	require.Len(t, persisted, hydratingCount)
+	for name := range persisted {
+		require.True(t, hydratingNames[name], "status was persisted for app %q which was not in the Hydrating phase", name)
+	}
+}
+
+// TestSetAppHydratorError_NilCurrentOperation verifies setAppHydratorError is a no-op (and does not panic)
+// when the app has no in-progress operation, which can happen under concurrent hydration. See #27926.
+func TestSetAppHydratorError_NilCurrentOperation(t *testing.T) {
+	t.Parallel()
+	d := mocks.NewDependencies(t)
+	app := newTestApp("no-op-app")
+	require.Nil(t, app.Status.SourceHydrator.CurrentOperation)
+	h := &Hydrator{dependencies: d}
+
+	require.NotPanics(t, func() {
+		h.setAppHydratorError(app, errors.New("boom"))
+	})
+	// No status should be persisted when there is no in-progress operation.
+	d.AssertNotCalled(t, "PersistHydrationStatus", mock.Anything, mock.Anything)
+}
+
+// TestProcessHydrationQueueItem_CommitsCompletePathSet is the regression test for the partial-hydration
+// hazard: when a hydration key has apps in mixed phases, the single commit for the dry SHA must contain
+// the manifests for the COMPLETE set of apps, not just the ones already marked Hydrating. The commit
+// server records a git note per dry SHA and short-circuits any later commit for the same dry SHA before
+// writing manifests (commitserver/commit/commit.go, IsHydrated). If the first commit were partial, a
+// not-yet-ready app would later be skipped by that note and marked hydrated without its manifests ever
+// being written. See https://github.com/argoproj/argo-cd/issues/27926.
+func TestProcessHydrationQueueItem_CommitsCompletePathSet(t *testing.T) {
+	t.Parallel()
+	d := mocks.NewDependencies(t)
+	r := mocks.NewRepoGetter(t)
+	rc := reposervermocks.NewRepoServerServiceClient(t)
+	cc := commitservermocks.NewCommitServiceClient(t)
+
+	ready := setTestAppPhase(newTestApp("ready-app"), v1alpha1.HydrateOperationPhaseHydrating)
+	ready.Spec.SourceHydrator.SyncSource.Path = "ready"
+	// notReady has not been marked Hydrating yet (nil CurrentOperation) - the race window.
+	notReady := newTestApp("not-ready-app")
+	notReady.Spec.SourceHydrator.SyncSource.Path = "not-ready"
+	require.Nil(t, notReady.Status.SourceHydrator.CurrentOperation)
+
+	hydrationKey := getHydrationQueueKey(ready)
+	require.Equal(t, hydrationKey, getHydrationQueueKey(notReady), "both apps must share the hydration key")
+
+	d.EXPECT().GetProcessableApps().Return(&v1alpha1.ApplicationList{Items: []v1alpha1.Application{*ready, *notReady}}, nil)
+	d.EXPECT().GetProcessableAppProj(mock.Anything).Return(newTestProject(), nil)
+	d.EXPECT().GetRepoObjs(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, &repoclient.ManifestResponse{Revision: "abc123"}, nil).Times(2)
+	r.EXPECT().GetRepository(mock.Anything, "https://example.com/repo", "test-project").Return(nil, nil).Once()
+	rc.EXPECT().GetRevisionMetadata(mock.Anything, mock.Anything).Return(nil, nil).Once()
+	d.EXPECT().GetWriteCredentials(mock.Anything, "https://example.com/repo", "test-project").Return(nil, nil).Once()
+	d.EXPECT().GetHydratorCommitMessageTemplate().Return("commit message", nil).Once()
+	d.EXPECT().GetCommitAuthorName().Return("", nil).Once()
+	d.EXPECT().GetCommitAuthorEmail().Return("", nil).Once()
+
+	var committedPaths []string
+	cc.EXPECT().CommitHydratedManifests(mock.Anything, mock.Anything).
+		Run(func(_ context.Context, in *commitclient.CommitHydratedManifestsRequest, _ ...grpc.CallOption) {
+			for _, p := range in.Paths {
+				committedPaths = append(committedPaths, p.Path)
+			}
+		}).Return(&commitclient.CommitHydratedManifestsResponse{HydratedSha: "def456"}, nil).Once()
+
+	// Only the ready app's status is updated; the not-ready app is reconciled on a later pass.
+	d.EXPECT().PersistHydrationStatus(mock.Anything, mock.Anything).Return().Once()
+	d.EXPECT().RequestAppRefresh(ready.Name, ready.Namespace).Return(nil).Once()
+
+	h := &Hydrator{dependencies: d, repoGetter: r, commitClientset: &commitservermocks.Clientset{CommitServiceClient: cc}, repoClientset: &reposervermocks.Clientset{RepoServerServiceClient: rc}}
+
+	h.ProcessHydrationQueueItem(hydrationKey)
+
+	// The single dry-SHA commit must contain BOTH apps' paths even though only one was Hydrating, so the
+	// commit-server note does not later short-circuit the not-ready app's manifests.
+	assert.ElementsMatch(t, []string{"ready", "not-ready"}, committedPaths)
+}
+
+// TestProcessHydrationQueueItem_SkippedAppFinalizesOnLaterPass locks the reconcile behavior documented in
+// ProcessHydrationQueueItem: an app whose status update was skipped on an earlier pass (it was not yet
+// observed as Hydrating) finalizes its status on a later pass once it is Hydrating. Its manifests were
+// already committed on the earlier complete-set pass, so on this pass the commit server short-circuits via
+// the dry-SHA note and returns the already-hydrated SHA without re-committing, and the status transitions
+// to Hydrated. See https://github.com/argoproj/argo-cd/issues/27926.
+func TestProcessHydrationQueueItem_SkippedAppFinalizesOnLaterPass(t *testing.T) {
+	t.Parallel()
+	d := mocks.NewDependencies(t)
+	r := mocks.NewRepoGetter(t)
+	rc := reposervermocks.NewRepoServerServiceClient(t)
+	cc := commitservermocks.NewCommitServiceClient(t)
+
+	// The app is now Hydrating; its manifests were committed on the earlier complete-set pass.
+	app := setTestAppPhase(newTestApp("late-app"), v1alpha1.HydrateOperationPhaseHydrating)
+	hydrationKey := getHydrationQueueKey(app)
+	d.EXPECT().GetProcessableApps().Return(&v1alpha1.ApplicationList{Items: []v1alpha1.Application{*app}}, nil)
+	// expectSuccessfulHydratePipeline models the commit server returning the existing hydrated SHA
+	// ("def456") - the same result the dry-SHA note short-circuit produces.
+	expectSuccessfulHydratePipeline(d, r, rc, cc, 1)
+
+	var persisted *v1alpha1.SourceHydratorStatus
+	d.EXPECT().PersistHydrationStatus(mock.Anything, mock.Anything).Run(func(_ *v1alpha1.Application, s *v1alpha1.SourceHydratorStatus) {
+		persisted = s
+	}).Return().Once()
+	d.EXPECT().RequestAppRefresh(app.Name, app.Namespace).Return(nil).Once()
+
+	h := &Hydrator{dependencies: d, repoGetter: r, commitClientset: &commitservermocks.Clientset{CommitServiceClient: cc}, repoClientset: &reposervermocks.Clientset{RepoServerServiceClient: rc}}
+	h.ProcessHydrationQueueItem(hydrationKey)
+
+	require.NotNil(t, persisted)
+	require.NotNil(t, persisted.CurrentOperation)
+	assert.Equal(t, v1alpha1.HydrateOperationPhaseHydrated, persisted.CurrentOperation.Phase)
+	assert.Equal(t, "def456", persisted.CurrentOperation.HydratedSHA)
+	require.NotNil(t, persisted.LastSuccessfulOperation)
+	assert.Equal(t, "def456", persisted.LastSuccessfulOperation.HydratedSHA)
 }

--- a/controller/hydrator/hydrator_test.go
+++ b/controller/hydrator/hydrator_test.go
@@ -600,11 +600,11 @@ func TestProcessAppHydrateQueueItem_HydrationNeeded_NoCurrentOperation(t *testin
 	d.AssertCalled(t, "AddHydrationQueueItem", mock.Anything)
 
 	require.NotNil(t, persistedStatus)
-	assert.NotNil(t, persistedStatus.CurrentOperation.StartedAt)
-	assert.Nil(t, persistedStatus.CurrentOperation.FinishedAt)
-	assert.Equal(t, v1alpha1.HydrateOperationPhaseHydrating, persistedStatus.CurrentOperation.Phase)
-	assert.Equal(t, *app.Spec.SourceHydrator, persistedStatus.CurrentOperation.SourceHydrator)
-	// LastComparedDryRevision is not set because we returned early
+	// ProcessAppHydrateQueueItem no longer marks the app Hydrating — that work moved to
+	// ProcessHydrationQueueItem so it can happen atomically across the whole app group
+	// (https://github.com/argoproj/argo-cd/issues/27926). All we persist here is the consumed
+	// hydrate annotation; CurrentOperation stays nil until the hydration worker picks the key up.
+	assert.Nil(t, persistedStatus.CurrentOperation)
 	assert.Empty(t, persistedStatus.LastComparedDryRevision)
 }
 
@@ -712,10 +712,13 @@ func TestProcessAppHydrateQueueItem_HydrationNeeded_RevisionChanges(t *testing.T
 	d.AssertCalled(t, "AddHydrationQueueItem", mock.Anything)
 
 	require.NotNil(t, persistedStatus)
-	assert.NotNil(t, persistedStatus.CurrentOperation.StartedAt)
-	assert.Nil(t, persistedStatus.CurrentOperation.FinishedAt)
-	assert.Equal(t, v1alpha1.HydrateOperationPhaseHydrating, persistedStatus.CurrentOperation.Phase)
-	assert.Equal(t, *app.Spec.SourceHydrator, persistedStatus.CurrentOperation.SourceHydrator)
+	// ProcessAppHydrateQueueItem no longer overwrites CurrentOperation with a Hydrating stamp;
+	// that move lives on ProcessHydrationQueueItem now (#27926). We persist the freshly resolved
+	// LastComparedDryRevision and leave the prior Hydrated CurrentOperation intact until the
+	// hydration worker takes the key.
+	require.NotNil(t, persistedStatus.CurrentOperation)
+	assert.Equal(t, v1alpha1.HydrateOperationPhaseHydrated, persistedStatus.CurrentOperation.Phase)
+	assert.Equal(t, "old-sha", persistedStatus.CurrentOperation.DrySHA)
 	assert.Equal(t, "new-sha", persistedStatus.LastComparedDryRevision)
 }
 
@@ -1676,14 +1679,14 @@ func Test_newRevisionHasChanges(t *testing.T) {
 
 // --- Concurrency tests for the manifest hydration queue (https://github.com/argoproj/argo-cd/issues/27926) ---
 //
-// Once the hydration queue is drained by more than one processor, a hydration queue item can be picked up
-// before ProcessAppHydrateQueueItem has marked every app for that key as Hydrating. The tests below pin down
-// the resulting behavior: apps that are not in the Hydrating phase (and may have a nil CurrentOperation) must
-// be skipped rather than panicked on or overwritten with stale state.
+// ProcessHydrationQueueItem owns the per-app status updates for the entire app group sharing a hydration
+// key. The hydration workqueue dedups on the key, so no two workers ever process the same group at once.
+// The tests below pin down that contract: every app in the group must be marked Hydrating before any work
+// runs, then marked Hydrated (or Failed) as a single batch by the same worker.
 
-// expectSuccessfulHydratePipeline wires up the happy-path mocks for hydrate() so the tests can focus on how
-// ProcessHydrationQueueItem updates (or skips) application status. getRepoObjsCalls is the number of apps
-// whose manifests are generated (one GetRepoObjs call per app, regardless of hydration phase).
+// expectSuccessfulHydratePipeline wires up the happy-path mocks for hydrate() so the tests can focus on
+// how ProcessHydrationQueueItem stamps Hydrating/Hydrated status on each app. getRepoObjsCalls is the
+// number of apps whose manifests are generated (one GetRepoObjs call per app).
 func expectSuccessfulHydratePipeline(d *mocks.Dependencies, r *mocks.RepoGetter, rc *reposervermocks.RepoServerServiceClient, cc *commitservermocks.CommitServiceClient, getRepoObjsCalls int) {
 	d.EXPECT().GetProcessableAppProj(mock.Anything).Return(newTestProject(), nil)
 	d.EXPECT().GetRepoObjs(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -1692,82 +1695,50 @@ func expectSuccessfulHydratePipeline(d *mocks.Dependencies, r *mocks.RepoGetter,
 	rc.EXPECT().GetRevisionMetadata(mock.Anything, mock.Anything).Return(nil, nil).Once()
 	d.EXPECT().GetWriteCredentials(mock.Anything, "https://example.com/repo", "test-project").Return(nil, nil).Once()
 	d.EXPECT().GetHydratorCommitMessageTemplate().Return("commit message", nil).Once()
+	d.EXPECT().GetHydratorReadmeMessageTemplate().Return("readme message", nil).Once()
 	d.EXPECT().GetCommitAuthorName().Return("", nil).Once()
 	d.EXPECT().GetCommitAuthorEmail().Return("", nil).Once()
 	cc.EXPECT().CommitHydratedManifests(mock.Anything, mock.Anything).
 		Return(&commitclient.CommitHydratedManifestsResponse{HydratedSha: "def456"}, nil).Once()
 }
 
-// TestProcessHydrationQueueItem_RaceConditionAppNotHydrating verifies that when a hydration queue item is
-// processed before the app has been marked Hydrating (CurrentOperation is nil) - the race window once the
-// queue is drained by multiple workers - hydration still runs (manifests are generated and committed for
-// the complete set), but the app's status is NOT updated and the nil CurrentOperation does not cause a
-// panic. The app's status reconciles on a later pass once it is marked Hydrating. See #27926.
-func TestProcessHydrationQueueItem_RaceConditionAppNotHydrating(t *testing.T) {
+// TestProcessHydrationQueueItem_MarksAllAppsHydratingThenHydrated verifies the core contract of the new
+// design (https://github.com/argoproj/argo-cd/issues/27926): when ProcessHydrationQueueItem picks up a key
+// it marks every app in the group Hydrating up front, runs the single commit, then marks every app
+// Hydrated. Apps without a prior CurrentOperation - the case that used to be the parallel-worker race
+// window - get the same treatment as apps already Hydrating.
+func TestProcessHydrationQueueItem_MarksAllAppsHydratingThenHydrated(t *testing.T) {
 	t.Parallel()
 	d := mocks.NewDependencies(t)
 	r := mocks.NewRepoGetter(t)
 	rc := reposervermocks.NewRepoServerServiceClient(t)
 	cc := commitservermocks.NewCommitServiceClient(t)
 
-	app := newTestApp("racey-app")
-	require.Nil(t, app.Status.SourceHydrator.CurrentOperation, "precondition: app must not yet be marked Hydrating")
-	hydrationKey := getHydrationQueueKey(app)
-	d.EXPECT().GetProcessableApps().Return(&v1alpha1.ApplicationList{Items: []v1alpha1.Application{*app}}, nil)
-	expectSuccessfulHydratePipeline(d, r, rc, cc, 1)
+	// One app already Hydrating from a prior pass; one app brand-new with nil CurrentOperation.
+	hydrating := setTestAppPhase(newTestApp("hydrating-app"), v1alpha1.HydrateOperationPhaseHydrating)
+	hydrating.Spec.SourceHydrator.SyncSource.Path = "hydrating"
+	fresh := newTestApp("fresh-app")
+	fresh.Spec.SourceHydrator.SyncSource.Path = "fresh"
+	require.Nil(t, fresh.Status.SourceHydrator.CurrentOperation, "precondition: fresh app starts with nil CurrentOperation")
 
-	h := &Hydrator{dependencies: d, repoGetter: r, commitClientset: &commitservermocks.Clientset{CommitServiceClient: cc}, repoClientset: &reposervermocks.Clientset{RepoServerServiceClient: rc}}
+	hydrationKey := getHydrationQueueKey(hydrating)
+	require.Equal(t, hydrationKey, getHydrationQueueKey(fresh), "both apps must share the hydration key")
 
-	require.NotPanics(t, func() {
-		h.ProcessHydrationQueueItem(hydrationKey)
-	})
-	// The app's manifests are committed, but because it is not in the Hydrating phase its status must
-	// not be written (which would overwrite a nil/stale CurrentOperation) and it is not refreshed.
-	d.AssertNotCalled(t, "PersistHydrationStatus", mock.Anything, mock.Anything)
-	d.AssertNotCalled(t, "RequestAppRefresh", mock.Anything, mock.Anything)
-}
+	d.EXPECT().GetProcessableApps().Return(&v1alpha1.ApplicationList{Items: []v1alpha1.Application{*hydrating, *fresh}}, nil)
+	expectSuccessfulHydratePipeline(d, r, rc, cc, 2)
 
-// TestProcessHydrationQueueItem_MixedPhases_OnlyHydratingAppsPersisted runs many applications that share a
-// single hydration key where only some have been marked Hydrating - the steady state once the hydration
-// queue is processed with multiple workers. Only the Hydrating apps should have their status persisted; the
-// rest must be left untouched, with no panics. See #27926.
-func TestProcessHydrationQueueItem_MixedPhases_OnlyHydratingAppsPersisted(t *testing.T) {
-	t.Parallel()
-
-	const hydratingCount = 12
-	const notReadyCount = 8
-	const totalApps = hydratingCount + notReadyCount
-
-	d := mocks.NewDependencies(t)
-	r := mocks.NewRepoGetter(t)
-	rc := reposervermocks.NewRepoServerServiceClient(t)
-	cc := commitservermocks.NewCommitServiceClient(t)
-
-	items := make([]v1alpha1.Application, 0, totalApps)
-	hydratingNames := make(map[string]bool, hydratingCount)
-	for i := range totalApps {
-		app := newTestApp(fmt.Sprintf("app-%d", i))
-		// Distinct destination paths so validateApplications does not flag duplicates.
-		app.Spec.SourceHydrator.SyncSource.Path = fmt.Sprintf("app-%d", i)
-		if i < hydratingCount {
-			app = setTestAppPhase(app, v1alpha1.HydrateOperationPhaseHydrating)
-			hydratingNames[app.Name] = true
+	// Capture every persisted status update in order so we can verify the markAppsHydrating → Hydrated
+	// sequence per app. We encode (name, phase) as "name:phase" so the linter can see the values are
+	// actually consumed by the equality assertions below.
+	var events []string
+	d.EXPECT().PersistHydrationStatus(mock.Anything, mock.Anything).Run(func(orig *v1alpha1.Application, s *v1alpha1.SourceHydratorStatus) {
+		phase := v1alpha1.HydrateOperationPhase("nil")
+		if s.CurrentOperation != nil {
+			phase = s.CurrentOperation.Phase
 		}
-		items = append(items, *app)
-	}
-
-	hydrationKey := getHydrationQueueKey(&items[0])
-	d.EXPECT().GetProcessableApps().Return(&v1alpha1.ApplicationList{Items: items}, nil)
-	// The COMPLETE set is hydrated (one GetRepoObjs call per app) so the dry-SHA commit contains every
-	// app's manifests and the commit-server note stays accurate; only the status updates are limited to
-	// the apps that are actually in the Hydrating phase.
-	expectSuccessfulHydratePipeline(d, r, rc, cc, totalApps)
-
-	persisted := map[string]bool{}
-	d.EXPECT().PersistHydrationStatus(mock.Anything, mock.Anything).Run(func(orig *v1alpha1.Application, _ *v1alpha1.SourceHydratorStatus) {
-		persisted[orig.Name] = true
-	}).Return().Times(hydratingCount)
-	d.EXPECT().RequestAppRefresh(mock.Anything, mock.Anything).Return(nil).Times(hydratingCount)
+		events = append(events, fmt.Sprintf("%s:%s", orig.Name, phase))
+	}).Return()
+	d.EXPECT().RequestAppRefresh(mock.Anything, mock.Anything).Return(nil).Times(2)
 
 	h := &Hydrator{dependencies: d, repoGetter: r, commitClientset: &commitservermocks.Clientset{CommitServiceClient: cc}, repoClientset: &reposervermocks.Clientset{RepoServerServiceClient: rc}}
 
@@ -1775,35 +1746,55 @@ func TestProcessHydrationQueueItem_MixedPhases_OnlyHydratingAppsPersisted(t *tes
 		h.ProcessHydrationQueueItem(hydrationKey)
 	})
 
-	require.Len(t, persisted, hydratingCount)
-	for name := range persisted {
-		require.True(t, hydratingNames[name], "status was persisted for app %q which was not in the Hydrating phase", name)
-	}
+	// The hydrating-app was already Hydrating, so markAppsHydrating must skip it (no first event); only
+	// the final Hydrated stamp lands. The fresh-app gets two persists: Hydrating up front, then Hydrated.
+	require.Len(t, events, 3, "expected fresh-app to be persisted Hydrating then Hydrated, plus hydrating-app's Hydrated stamp")
+	assert.Equal(t, "fresh-app:Hydrating", events[0])
+	assert.ElementsMatch(t,
+		[]string{"hydrating-app:Hydrated", "fresh-app:Hydrated"},
+		events[1:],
+	)
 }
 
-// TestSetAppHydratorError_NilCurrentOperation verifies setAppHydratorError is a no-op (and does not panic)
-// when the app has no in-progress operation, which can happen under concurrent hydration. See #27926.
-func TestSetAppHydratorError_NilCurrentOperation(t *testing.T) {
+// TestProcessHydrationQueueItem_MarksHydratingBeforeValidation locks the ordering: markAppsHydrating runs
+// before validation, so even when validation fails for every app the persisted Hydrating stamp is still
+// observable (followed immediately by the Failed stamp). This is the contract that lets us stop guarding
+// CurrentOperation deref in the failure paths.
+func TestProcessHydrationQueueItem_MarksHydratingBeforeValidation(t *testing.T) {
 	t.Parallel()
 	d := mocks.NewDependencies(t)
-	app := newTestApp("no-op-app")
-	require.Nil(t, app.Status.SourceHydrator.CurrentOperation)
-	h := &Hydrator{dependencies: d}
 
+	app := newTestApp("fresh-app")
+	require.Nil(t, app.Status.SourceHydrator.CurrentOperation)
+	hydrationKey := getHydrationQueueKey(app)
+
+	d.EXPECT().GetProcessableApps().Return(&v1alpha1.ApplicationList{Items: []v1alpha1.Application{*app}}, nil)
+	// Validation fails for every app in the group, so hydrate() is never called - but markAppsHydrating
+	// has already persisted the Hydrating stamp before validateApplications runs.
+	d.EXPECT().GetProcessableAppProj(mock.Anything).Return(nil, errors.New("project-not-found")).Once()
+
+	var phases []v1alpha1.HydrateOperationPhase
+	d.EXPECT().PersistHydrationStatus(mock.Anything, mock.Anything).Run(func(_ *v1alpha1.Application, s *v1alpha1.SourceHydratorStatus) {
+		require.NotNil(t, s.CurrentOperation, "every persist after markAppsHydrating must have a populated CurrentOperation")
+		phases = append(phases, s.CurrentOperation.Phase)
+	}).Return().Times(2)
+
+	h := &Hydrator{dependencies: d}
 	require.NotPanics(t, func() {
-		h.setAppHydratorError(app, errors.New("boom"))
+		h.ProcessHydrationQueueItem(hydrationKey)
 	})
-	// No status should be persisted when there is no in-progress operation.
-	d.AssertNotCalled(t, "PersistHydrationStatus", mock.Anything, mock.Anything)
+
+	require.Equal(t,
+		[]v1alpha1.HydrateOperationPhase{v1alpha1.HydrateOperationPhaseHydrating, v1alpha1.HydrateOperationPhaseFailed},
+		phases,
+		"expected the Hydrating stamp to land before the Failed stamp",
+	)
 }
 
-// TestProcessHydrationQueueItem_CommitsCompletePathSet is the regression test for the partial-hydration
-// hazard: when a hydration key has apps in mixed phases, the single commit for the dry SHA must contain
-// the manifests for the COMPLETE set of apps, not just the ones already marked Hydrating. The commit
-// server records a git note per dry SHA and short-circuits any later commit for the same dry SHA before
-// writing manifests (commitserver/commit/commit.go, IsHydrated). If the first commit were partial, a
-// not-yet-ready app would later be skipped by that note and marked hydrated without its manifests ever
-// being written. See https://github.com/argoproj/argo-cd/issues/27926.
+// TestProcessHydrationQueueItem_CommitsCompletePathSet keeps the regression guard for partial hydration:
+// the single dry-SHA commit must contain every app's path. The commit server records a git note per dry
+// SHA and short-circuits later commits for the same dry SHA before writing manifests
+// (commitserver/commit/commit.go, IsHydrated), so a partial first commit would silently lose paths.
 func TestProcessHydrationQueueItem_CommitsCompletePathSet(t *testing.T) {
 	t.Parallel()
 	d := mocks.NewDependencies(t)
@@ -1813,15 +1804,13 @@ func TestProcessHydrationQueueItem_CommitsCompletePathSet(t *testing.T) {
 
 	ready := setTestAppPhase(newTestApp("ready-app"), v1alpha1.HydrateOperationPhaseHydrating)
 	ready.Spec.SourceHydrator.SyncSource.Path = "ready"
-	// notReady has not been marked Hydrating yet (nil CurrentOperation) - the race window.
-	notReady := newTestApp("not-ready-app")
-	notReady.Spec.SourceHydrator.SyncSource.Path = "not-ready"
-	require.Nil(t, notReady.Status.SourceHydrator.CurrentOperation)
+	fresh := newTestApp("fresh-app")
+	fresh.Spec.SourceHydrator.SyncSource.Path = "fresh"
 
 	hydrationKey := getHydrationQueueKey(ready)
-	require.Equal(t, hydrationKey, getHydrationQueueKey(notReady), "both apps must share the hydration key")
+	require.Equal(t, hydrationKey, getHydrationQueueKey(fresh), "both apps must share the hydration key")
 
-	d.EXPECT().GetProcessableApps().Return(&v1alpha1.ApplicationList{Items: []v1alpha1.Application{*ready, *notReady}}, nil)
+	d.EXPECT().GetProcessableApps().Return(&v1alpha1.ApplicationList{Items: []v1alpha1.Application{*ready, *fresh}}, nil)
 	d.EXPECT().GetProcessableAppProj(mock.Anything).Return(newTestProject(), nil)
 	d.EXPECT().GetRepoObjs(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, &repoclient.ManifestResponse{Revision: "abc123"}, nil).Times(2)
@@ -1829,6 +1818,7 @@ func TestProcessHydrationQueueItem_CommitsCompletePathSet(t *testing.T) {
 	rc.EXPECT().GetRevisionMetadata(mock.Anything, mock.Anything).Return(nil, nil).Once()
 	d.EXPECT().GetWriteCredentials(mock.Anything, "https://example.com/repo", "test-project").Return(nil, nil).Once()
 	d.EXPECT().GetHydratorCommitMessageTemplate().Return("commit message", nil).Once()
+	d.EXPECT().GetHydratorReadmeMessageTemplate().Return("readme message", nil).Once()
 	d.EXPECT().GetCommitAuthorName().Return("", nil).Once()
 	d.EXPECT().GetCommitAuthorEmail().Return("", nil).Once()
 
@@ -1840,53 +1830,63 @@ func TestProcessHydrationQueueItem_CommitsCompletePathSet(t *testing.T) {
 			}
 		}).Return(&commitclient.CommitHydratedManifestsResponse{HydratedSha: "def456"}, nil).Once()
 
-	// Only the ready app's status is updated; the not-ready app is reconciled on a later pass.
-	d.EXPECT().PersistHydrationStatus(mock.Anything, mock.Anything).Return().Once()
-	d.EXPECT().RequestAppRefresh(ready.Name, ready.Namespace).Return(nil).Once()
+	// fresh-app: Hydrating then Hydrated (2). ready-app: only the final Hydrated stamp (1).
+	d.EXPECT().PersistHydrationStatus(mock.Anything, mock.Anything).Return().Times(3)
+	d.EXPECT().RequestAppRefresh(mock.Anything, mock.Anything).Return(nil).Times(2)
 
 	h := &Hydrator{dependencies: d, repoGetter: r, commitClientset: &commitservermocks.Clientset{CommitServiceClient: cc}, repoClientset: &reposervermocks.Clientset{RepoServerServiceClient: rc}}
 
 	h.ProcessHydrationQueueItem(hydrationKey)
 
-	// The single dry-SHA commit must contain BOTH apps' paths even though only one was Hydrating, so the
-	// commit-server note does not later short-circuit the not-ready app's manifests.
-	assert.ElementsMatch(t, []string{"ready", "not-ready"}, committedPaths)
+	assert.ElementsMatch(t, []string{"ready", "fresh"}, committedPaths)
 }
 
-// TestProcessHydrationQueueItem_SkippedAppFinalizesOnLaterPass locks the reconcile behavior documented in
-// ProcessHydrationQueueItem: an app whose status update was skipped on an earlier pass (it was not yet
-// observed as Hydrating) finalizes its status on a later pass once it is Hydrating. Its manifests were
-// already committed on the earlier complete-set pass, so on this pass the commit server short-circuits via
-// the dry-SHA note and returns the already-hydrated SHA without re-committing, and the status transitions
-// to Hydrated. See https://github.com/argoproj/argo-cd/issues/27926.
-func TestProcessHydrationQueueItem_SkippedAppFinalizesOnLaterPass(t *testing.T) {
+// TestProcessHydrationQueueItem_LargeGroupAllAppsPersisted exercises the new design at scale: many apps
+// sharing a single key, an arbitrary mix of pre-existing phases (Hydrating, Hydrated, nil). Every app
+// must end up persisted as Hydrated and every app must request a refresh. See #27926.
+func TestProcessHydrationQueueItem_LargeGroupAllAppsPersisted(t *testing.T) {
 	t.Parallel()
+
+	const totalApps = 20
+
 	d := mocks.NewDependencies(t)
 	r := mocks.NewRepoGetter(t)
 	rc := reposervermocks.NewRepoServerServiceClient(t)
 	cc := commitservermocks.NewCommitServiceClient(t)
 
-	// The app is now Hydrating; its manifests were committed on the earlier complete-set pass.
-	app := setTestAppPhase(newTestApp("late-app"), v1alpha1.HydrateOperationPhaseHydrating)
-	hydrationKey := getHydrationQueueKey(app)
-	d.EXPECT().GetProcessableApps().Return(&v1alpha1.ApplicationList{Items: []v1alpha1.Application{*app}}, nil)
-	// expectSuccessfulHydratePipeline models the commit server returning the existing hydrated SHA
-	// ("def456") - the same result the dry-SHA note short-circuit produces.
-	expectSuccessfulHydratePipeline(d, r, rc, cc, 1)
+	items := make([]v1alpha1.Application, 0, totalApps)
+	for i := range totalApps {
+		app := newTestApp(fmt.Sprintf("app-%d", i))
+		// Distinct destination paths so validateApplications does not flag duplicates.
+		app.Spec.SourceHydrator.SyncSource.Path = fmt.Sprintf("app-%d", i)
+		switch i % 3 {
+		case 0:
+			// Leave CurrentOperation nil - first-time hydration.
+		case 1:
+			app = setTestAppPhase(app, v1alpha1.HydrateOperationPhaseHydrating)
+		case 2:
+			app = setTestAppPhase(app, v1alpha1.HydrateOperationPhaseHydrated)
+		}
+		items = append(items, *app)
+	}
 
-	var persisted *v1alpha1.SourceHydratorStatus
-	d.EXPECT().PersistHydrationStatus(mock.Anything, mock.Anything).Run(func(_ *v1alpha1.Application, s *v1alpha1.SourceHydratorStatus) {
-		persisted = s
-	}).Return().Once()
-	d.EXPECT().RequestAppRefresh(app.Name, app.Namespace).Return(nil).Once()
+	hydrationKey := getHydrationQueueKey(&items[0])
+	d.EXPECT().GetProcessableApps().Return(&v1alpha1.ApplicationList{Items: items}, nil)
+	expectSuccessfulHydratePipeline(d, r, rc, cc, totalApps)
+
+	hydrated := map[string]bool{}
+	d.EXPECT().PersistHydrationStatus(mock.Anything, mock.Anything).Run(func(orig *v1alpha1.Application, s *v1alpha1.SourceHydratorStatus) {
+		if s.CurrentOperation != nil && s.CurrentOperation.Phase == v1alpha1.HydrateOperationPhaseHydrated {
+			hydrated[orig.Name] = true
+		}
+	}).Return()
+	d.EXPECT().RequestAppRefresh(mock.Anything, mock.Anything).Return(nil).Times(totalApps)
 
 	h := &Hydrator{dependencies: d, repoGetter: r, commitClientset: &commitservermocks.Clientset{CommitServiceClient: cc}, repoClientset: &reposervermocks.Clientset{RepoServerServiceClient: rc}}
-	h.ProcessHydrationQueueItem(hydrationKey)
 
-	require.NotNil(t, persisted)
-	require.NotNil(t, persisted.CurrentOperation)
-	assert.Equal(t, v1alpha1.HydrateOperationPhaseHydrated, persisted.CurrentOperation.Phase)
-	assert.Equal(t, "def456", persisted.CurrentOperation.HydratedSHA)
-	require.NotNil(t, persisted.LastSuccessfulOperation)
-	assert.Equal(t, "def456", persisted.LastSuccessfulOperation.HydratedSHA)
+	require.NotPanics(t, func() {
+		h.ProcessHydrationQueueItem(hydrationKey)
+	})
+
+	require.Len(t, hydrated, totalApps, "every app in the group must end up persisted as Hydrated")
 }

--- a/docs/operator-manual/argocd-cmd-params-cm.yaml
+++ b/docs/operator-manual/argocd-cmd-params-cm.yaml
@@ -54,6 +54,8 @@ data:
   controller.status.processors: "20"
   # Number of application operation processors (default 10)
   controller.operation.processors: "10"
+  # Number of manifest hydration processors (default 5). Only relevant when the Source Hydrator is enabled.
+  controller.hydration.processors: "5"
   # Set the logging format. One of: json|text (default "json")
   controller.log.format: "json"
   # Set the logging level. One of: debug|info|warn|error (default "info")

--- a/docs/operator-manual/high_availability.md
+++ b/docs/operator-manual/high_availability.md
@@ -85,6 +85,12 @@ get the actual cluster state.
   processors if your Argo CD instance manages too many applications.
   For 1000 applications, we use 50 for `--status-processors` and 25 for `--operation-processors`
 
+* when the [Source Hydrator](../user-guide/source-hydrator.md) is enabled, the controller hydrates manifests using a
+  separate queue whose concurrency is controlled by the `--hydration-processors` flag (5 by default). The hydration
+  queue is keyed by source repo, target revision, and destination branch, so the same key is never hydrated by more
+  than one processor at a time; increasing the count only parallelizes hydration across distinct keys. Increase it if a
+  single controller hydrates many independent repositories or branches and hydration becomes a bottleneck.
+
 * The manifest generation typically takes the most time during reconciliation. The duration of manifest generation is
   limited to make sure the controller refresh queue does not overflow.
   The app reconciliation fails with `Context deadline exceeded` error if the manifest generation is taking too much

--- a/docs/operator-manual/server-commands/argocd-application-controller.md
+++ b/docs/operator-manual/server-commands/argocd-application-controller.md
@@ -35,6 +35,7 @@ argocd-application-controller [flags]
       --enable-k8s-event none                                     Enable ArgoCD to use k8s event. For disabling all events, set the value as none. (e.g --enable-k8s-event=none), For enabling specific events, set the value as `event reason`. (e.g --enable-k8s-event=StatusRefreshed,ResourceCreated) (default [all])
       --gloglevel int                                             Set the glog logging level
   -h, --help                                                      help for argocd-application-controller
+      --hydration-processors int                                  Number of manifest hydration processors (only relevant when the Source Hydrator is enabled) (default 5)
       --hydrator-enabled                                          Feature flag to enable Hydrator. Default ("false")
       --ignore-normalizer-jq-execution-timeout-seconds duration   Set ignore normalizer JQ execution timeout
       --insecure-skip-tls-verify                                  If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure

--- a/manifests/base/application-controller-deployment/argocd-application-controller-deployment.yaml
+++ b/manifests/base/application-controller-deployment/argocd-application-controller-deployment.yaml
@@ -79,6 +79,12 @@ spec:
               name: argocd-cmd-params-cm
               key: controller.operation.processors
               optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_HYDRATION_PROCESSORS
+          valueFrom:
+            configMapKeyRef:
+              name: argocd-cmd-params-cm
+              key: controller.hydration.processors
+              optional: true
         - name: ARGOCD_APPLICATION_CONTROLLER_LOGFORMAT
           valueFrom:
             configMapKeyRef:

--- a/manifests/base/application-controller/argocd-application-controller-statefulset.yaml
+++ b/manifests/base/application-controller/argocd-application-controller-statefulset.yaml
@@ -82,6 +82,12 @@ spec:
               name: argocd-cmd-params-cm
               key: controller.operation.processors
               optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_HYDRATION_PROCESSORS
+          valueFrom:
+            configMapKeyRef:
+              name: argocd-cmd-params-cm
+              key: controller.hydration.processors
+              optional: true
         - name: ARGOCD_APPLICATION_CONTROLLER_LOGFORMAT
           valueFrom:
             configMapKeyRef:

--- a/manifests/core-install-with-hydrator.yaml
+++ b/manifests/core-install-with-hydrator.yaml
@@ -32263,6 +32263,12 @@ spec:
               key: controller.operation.processors
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_HYDRATION_PROCESSORS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.hydration.processors
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_APPLICATION_CONTROLLER_LOGFORMAT
           valueFrom:
             configMapKeyRef:

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -32091,6 +32091,12 @@ spec:
               key: controller.operation.processors
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_HYDRATION_PROCESSORS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.hydration.processors
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_APPLICATION_CONTROLLER_LOGFORMAT
           valueFrom:
             configMapKeyRef:

--- a/manifests/ha/install-with-hydrator.yaml
+++ b/manifests/ha/install-with-hydrator.yaml
@@ -34435,6 +34435,12 @@ spec:
               key: controller.operation.processors
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_HYDRATION_PROCESSORS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.hydration.processors
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_APPLICATION_CONTROLLER_LOGFORMAT
           valueFrom:
             configMapKeyRef:

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -34265,6 +34265,12 @@ spec:
               key: controller.operation.processors
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_HYDRATION_PROCESSORS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.hydration.processors
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_APPLICATION_CONTROLLER_LOGFORMAT
           valueFrom:
             configMapKeyRef:

--- a/manifests/ha/namespace-install-with-hydrator.yaml
+++ b/manifests/ha/namespace-install-with-hydrator.yaml
@@ -3537,6 +3537,12 @@ spec:
               key: controller.operation.processors
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_HYDRATION_PROCESSORS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.hydration.processors
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_APPLICATION_CONTROLLER_LOGFORMAT
           valueFrom:
             configMapKeyRef:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -3367,6 +3367,12 @@ spec:
               key: controller.operation.processors
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_HYDRATION_PROCESSORS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.hydration.processors
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_APPLICATION_CONTROLLER_LOGFORMAT
           valueFrom:
             configMapKeyRef:

--- a/manifests/install-with-hydrator.yaml
+++ b/manifests/install-with-hydrator.yaml
@@ -33403,6 +33403,12 @@ spec:
               key: controller.operation.processors
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_HYDRATION_PROCESSORS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.hydration.processors
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_APPLICATION_CONTROLLER_LOGFORMAT
           valueFrom:
             configMapKeyRef:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -33231,6 +33231,12 @@ spec:
               key: controller.operation.processors
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_HYDRATION_PROCESSORS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.hydration.processors
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_APPLICATION_CONTROLLER_LOGFORMAT
           valueFrom:
             configMapKeyRef:

--- a/manifests/namespace-install-with-hydrator.yaml
+++ b/manifests/namespace-install-with-hydrator.yaml
@@ -2505,6 +2505,12 @@ spec:
               key: controller.operation.processors
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_HYDRATION_PROCESSORS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.hydration.processors
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_APPLICATION_CONTROLLER_LOGFORMAT
           valueFrom:
             configMapKeyRef:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -2333,6 +2333,12 @@ spec:
               key: controller.operation.processors
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_HYDRATION_PROCESSORS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.hydration.processors
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_APPLICATION_CONTROLLER_LOGFORMAT
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
## What / why

Closes #27926.

The manifest hydration queue used by the Source Hydrator is currently drained by a single goroutine, so source repos are hydrated one at a time. In hub-spoke topologies where a single Argo CD instance hydrates many repos, this serial processing becomes the bottleneck for how quickly changes become deployable.

This PR makes the hydration queue concurrency tunable, mirroring the existing `--status-processors` / `--operation-processors` pattern:

- Adds `--hydration-processors` (env `ARGOCD_APPLICATION_CONTROLLER_HYDRATION_PROCESSORS`), default `5`, minimum `1`.
- The `hydrationQueue` is drained by N workers; `appHydrateQueue` stays single-worker. The queue is keyed by `{SourceRepoURL, SourceTargetRevision, DestinationBranch}` and is rate-limiting, so the same key is never processed by two workers at once — additional workers only parallelize across distinct keys.
- Threaded through `Run(...)`, the application-controller manifests, `argocd-cmd-params-cm`, and the HA/operator docs.

**Additional correctness fix (required to enable concurrency safely):** running multiple workers makes a pre-existing race likely — a hydration item can be processed before all apps for a key are marked `Hydrating` (nil `CurrentOperation`), which previously panicked and could overwrite status. To handle this safely the hydrator now always commits the **complete** app set for a key in a single pass (the commit server records a git note per dry SHA and short-circuits later commits, so a partial commit would leave some apps marked hydrated without their manifests), and only the per-app status writes are guarded (apps not yet `Hydrating` are skipped and finalize on a later refresh/resync pass). The worker count is clamped to a minimum of 1 so a `0`/negative flag value cannot silently stall hydration.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. <!-- N/A: this is an application-controller flag, like --status-processors/--operation-processors; there is no CLI command or UI surface for it. -->
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).
