### PR TITLE
fix(ui): return full source for non-hydrator apps in Parameters tab (cherry-pick #26946 for 3.4)

### DIFF
--- a/ui/src/app/applications/components/utils.test.tsx
+++ b/ui/src/app/applications/components/utils.test.tsx
@@ -13,6 +13,7 @@ import {
 import * as jsYaml from 'js-yaml';
 import {
     ComparisonStatusIcon,
+    getAppDrySource,
     getAppOperationState,
     getOperationType,
     getPodStateReason,
@@ -891,5 +892,62 @@ status:
         const {reason} = getPodStateReason(pod as State);
 
         expect(reason).toBe('SchedulingGated');
+    });
+});
+describe('getAppDrySource', () => {
+    it('returns null for undefined app', () => {
+        expect(getAppDrySource(undefined)).toBeNull();
+    });
+
+    it('returns full source for non-hydrator app', () => {
+        const app = {
+            spec: {
+                source: {
+                    repoURL: 'https://github.com/example/repo.git',
+                    path: 'helm-chart',
+                    targetRevision: 'HEAD',
+                    helm: {
+                        parameters: [{name: 'replicaCount', value: '2'}],
+                    },
+                },
+            },
+        } as Application;
+
+        const result = getAppDrySource(app);
+
+        expect(result).toEqual(app.spec.source);
+        expect(result.helm).toBeDefined();
+        expect(result.helm.parameters).toHaveLength(1);
+    });
+
+    it('returns stripped drySource for hydrator app', () => {
+        const app = {
+            spec: {
+                source: {
+                    repoURL: 'https://github.com/example/repo.git',
+                    path: 'helm-chart',
+                    targetRevision: 'HEAD',
+                    helm: {
+                        parameters: [{name: 'replicaCount', value: '2'}],
+                    },
+                },
+                sourceHydrator: {
+                    drySource: {
+                        repoURL: 'https://github.com/example/dry-repo.git',
+                        path: 'dry-path',
+                        targetRevision: 'main',
+                    },
+                },
+            },
+        } as Application;
+
+        const result = getAppDrySource(app);
+
+        expect(result).toEqual({
+            repoURL: 'https://github.com/example/dry-repo.git',
+            path: 'dry-path',
+            targetRevision: 'main',
+        });
+        expect(result).not.toHaveProperty('helm');
     });
 });

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -1474,9 +1474,11 @@ export function getAppDrySource(app?: appModels.Application): appModels.Applicat
     if (!app) {
         return null;
     }
-    const {path, targetRevision, repoURL} = app.spec.sourceHydrator?.drySource || app.spec.source;
-
-    return {repoURL, targetRevision, path};
+    if (app.spec.sourceHydrator?.drySource) {
+        const {path, targetRevision, repoURL} = app.spec.sourceHydrator.drySource;
+        return {repoURL, targetRevision, path};
+    }
+    return getAppDefaultSource(app);
 }
 
 // getAppDefaultSyncRevision gets the first app revisions from `status.sync.revisions` or, if that list is missing or empty, the `revision`


### PR DESCRIPTION
### Description of your changes

Manual cherry-pick of #26946 into `release-3.4`. The automated cherry-pick by `argo-cd-cherry-pick-bot` failed due to a context conflict in `utils.test.tsx` (the `appRBACName` describe block exists in `master` but not in `release-3.4`, which causes the patch context to mismatch).

The original fix from #26946 is preserved entirely:
- `utils.tsx`: 5 additions / 3 deletions — `getAppDrySource()` now delegates to `getAppDefaultSource()` for non-hydrator apps, returning the full source (including `helm`, `kustomize`, `directory` blocks) instead of stripping it.
- `utils.test.tsx`: 60 additions — new `describe('getAppDrySource')` block with 3 test cases covering undefined app, non-hydrator app (full source returned), and hydrator app (stripped drySource).

Conflict resolution: kept `release-3.4`'s version of `utils.test.tsx` (without the unrelated `appRBACName` describe block) and applied only the additions from #26946.

Original author of the fix: @himeshp.

Fixes #26938
Fixes #27773

I have:

- [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
- [x] I've included "Fixes [ISSUE #]" in the description to automatically close the associated issue.
- [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. N/A - cherry-pick of UI-only bug fix.
- [x] Does this PR require documentation updates? No.
- [x] I've updated documentation as required by this PR. N/A.
- [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
- [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged. (Tests from #26946 are included in this cherry-pick.)
- [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
- [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
- [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
- [x] Optional. My organization is added to USERS.md.
- [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this is the cherry-pick PR for 3.4).
