### PR TITLE
docs: Clarify sharded controller metrics

### DIFF
--- a/docs/operator-manual/metrics.md
+++ b/docs/operator-manual/metrics.md
@@ -6,6 +6,10 @@ Argo CD exposes different sets of Prometheus metrics per server.
 
 Metrics about applications. Scraped at the `argocd-metrics:8082/metrics` endpoint.
 
+Single-replica `application-controller` installs can continue scraping `argocd-metrics:8082/metrics`.
+
+For sharded or multi-replica `application-controller` deployments, scrape every controller pod or endpoint. Scraping the `argocd-metrics` ClusterIP or service DNS name from a static config may hit only one backend and miss metrics from other shards. See [High Availability](./high_availability.md#argocd-application-controller) for controller sharding configuration.
+
 | Metric                                            |   Type    | Description                                                                                                                                 |
 | ------------------------------------------------- | :-------: | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `argocd_app_info`                                 |   gauge   | Information about Applications. It contains labels such as `sync_status` and `health_status` that reflect the application state in Argo CD. |
@@ -290,6 +294,7 @@ Scraped at the `argocd-commit-server:8087/metrics` endpoint.
 
 If using Prometheus Operator, the following ServiceMonitor example manifests can be used.
 Add a namespace where Argo CD is installed and change `metadata.labels.release` to the name of label selected by your Prometheus.
+`ServiceMonitor` endpoint discovery scrapes all matching Service endpoints, so the `argocd-metrics` example collects metrics from every `application-controller` pod when the Service selector targets all controller replicas. For non-Operator scrapers (e.g. Telegraf, Grafana Agent), use Kubernetes pod or endpoint discovery rather than a ClusterIP target.
 
 ```yaml
 apiVersion: monitoring.coreos.com/v1


### PR DESCRIPTION
Closes #27901

Sharded `application-controller` replicas expose shard-local metrics. Scraping `argocd-metrics:8082/metrics` via ClusterIP/DNS from a static config gets kube-proxy load-balanced to one backend per scrape, so the scraper silently sees only one shard. No error, just incomplete metrics.

The existing `ServiceMonitor` example already handles this for Prometheus Operator users because endpoint discovery scrapes all matching pods. This adds the missing guidance for static scrape configs and non-Operator scrapers (Telegraf, Grafana Agent).

Two paragraphs added to `docs/operator-manual/metrics.md`:

* Under the `argocd-metrics:8082/metrics` endpoint description — calls out the single-replica vs sharded behaviour, links to the High Availability page for sharding config.
* Under the `ServiceMonitor` example — clarifies endpoint discovery covers all pods when the Service selector matches, and points non-Operator scrapers at pod/endpoint discovery instead of a ClusterIP target.

Checklist:

* [x] (c) this does not need to be in the release notes
* [x] The title of the PR states what changed and the related issue number
* [x] The title of the PR conforms to the Title of the PR
* [x] I've included "Closes [ISSUE #]" in the description
* [ ] N/A — no CLI/UI changes (docs only)
* [x] I've updated documentation as required
* [x] DCO sign-off
* [ ] N/A — no unit/e2e tests required (docs only)
* [x] My build is green (`make build-docs-local`)
* [ ] N/A — no new feature
* [x] Brief description of why this PR is necessary included above
* [ ] Optional. My organization is added to USERS.md.
* [ ] N/A — not a bug fix, no cherry-picks needed

Test plan:

* `make build-docs-local`