### PR TITLE
fix: remove stale git lock file and retry fetch on shallow clone (#27…

### DIFF
--- a/util/git/client.go
+++ b/util/git/client.go
@@ -565,6 +565,16 @@ func (m *nativeGitClient) fetch(ctx context.Context, revision string, depth int6
 	return m.runCredentialedCmd(ctx, args...)
 }
 
+var lockFileErrRe = regexp.MustCompile(`Unable to create '([^']+\.lock)': File exists`)
+
+func extractLockFilePath(err error) string {
+	m := lockFileErrRe.FindStringSubmatch(err.Error())
+	if len(m) < 2 {
+		return ""
+	}
+	return m[1]
+}
+
 // IsRevisionPresent checks to see if the given revision already exists locally.
 func (m *nativeGitClient) IsRevisionPresent(revision string) bool {
 	if revision == "" {
@@ -588,6 +598,14 @@ func (m *nativeGitClient) Fetch(revision string, depth int64) error {
 	ctx := context.Background()
 
 	err := m.fetch(ctx, revision, depth)
+	if err != nil {
+		if lockPath := extractLockFilePath(err); lockPath != "" {
+			log.Infof("Removing stale git lock file %s and retrying fetch for %s", lockPath, m.repoURL)
+			if removeErr := os.Remove(lockPath); removeErr == nil {
+				err = m.fetch(ctx, revision, depth)
+			}
+		}
+	}
 
 	// When we have LFS support enabled, check for large files and fetch them too.
 	if err == nil && m.IsLFSEnabled() {

--- a/util/git/client_test.go
+++ b/util/git/client_test.go
@@ -102,6 +102,34 @@ func Test_nativeGitClient_Fetch_Prune(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func Test_extractLockFilePath(t *testing.T) {
+	assert.Equal(t, "/tmp/repo/.git/shallow.lock", extractLockFilePath(errors.New("fatal: Unable to create '/tmp/repo/.git/shallow.lock': File exists.")))
+	assert.Equal(t, ".git/index.lock", extractLockFilePath(errors.New("fatal: Unable to create '.git/index.lock': File exists.")))
+	assert.Empty(t, extractLockFilePath(errors.New("fatal: repository not found")))
+	assert.Empty(t, extractLockFilePath(errors.New("fatal: File exists.")))
+}
+
+func Test_nativeGitClient_Fetch_StaleLockFile(t *testing.T) {
+	ctx := t.Context()
+	remoteDir, err := _createEmptyGitRepo(ctx)
+	require.NoError(t, err)
+
+	localDir := t.TempDir()
+	client, err := NewClientExt("file://"+remoteDir, localDir, NopCreds{}, true, false, "", "")
+	require.NoError(t, err)
+	err = client.Init()
+	require.NoError(t, err)
+
+	lockFile := filepath.Join(localDir, ".git", "shallow.lock")
+	require.NoError(t, os.WriteFile(lockFile, []byte{}, 0o600))
+
+	err = client.Fetch("", 1)
+	require.NoError(t, err)
+
+	_, err = os.Stat(lockFile)
+	assert.True(t, os.IsNotExist(err))
+}
+
 func Test_IsAnnotatedTag(t *testing.T) {
 	tempDir := t.TempDir()
 	ctx := t.Context()


### PR DESCRIPTION
…930)

**Problem**

When Argo CD uses shallow clones (depth parameter), a crashed git process leaves behind a .git/shallow.lock file. All subsequent fetch attempts fail with:


fatal: Unable to create '.git/shallow.lock': File exists.
The repo-server stays broken until the lock file is manually deleted or the pod is restarted.

**Fix**

When git fetch fails, the error message is checked against git's known lock file error format (Unable to create '...': File exists). If matched, the exact lock file path is parsed from the error, that file is removed, and the fetch is retried once. If the removal fails, the original error is returned unchanged.

**What was deliberately avoided**

Removing all *.lock files in .git/ — too broad, risks interfering with legitimate concurrent processes
Retrying without confirming the lock file was removed — would retry a fetch that will fail again
Broad string matching — the regex targets git's exact error wording to avoid false positives

Closes #27930


<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
