### PR TITLE
fix: prevent nil-pointer panic for unknown repo types

### DIFF
--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -3063,8 +3063,11 @@ func (s *Service) TestRepository(ctx context.Context, q *apiclient.TestRepositor
 			return err
 		},
 	}
-	check := checks[repo.Type]
 	apiResp := &apiclient.TestRepositoryResponse{VerifiedRepository: false}
+	check, ok := checks[repo.Type]
+	if !ok {
+		return apiResp, fmt.Errorf("unsupported repository type %q", repo.Type)
+	}
 	err := check()
 	if err != nil {
 		return apiResp, fmt.Errorf("error testing repository connectivity: %w", err)

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -3052,6 +3052,17 @@ func TestTestRepoHelmOCI(t *testing.T) {
 	assert.ErrorContains(t, err, "OCI Helm repository URL should include hostname and port only")
 }
 
+func TestTestRepositoryUnsupportedType(t *testing.T) {
+	service := newService(t, ".")
+	_, err := service.TestRepository(t.Context(), &apiclient.TestRepositoryRequest{
+		Repo: &v1alpha1.Repository{
+			Repo: "https://example.com/repo",
+			Type: "bogus",
+		},
+	})
+	assert.ErrorContains(t, err, `unsupported repository type "bogus"`)
+}
+
 func Test_getHelmDependencyRepos(t *testing.T) {
 	repo1 := "https://charts.bitnami.com/bitnami"
 	repo2 := "https://eventstore.github.io/EventStore.Charts"

--- a/server/repository/repository.go
+++ b/server/repository/repository.go
@@ -212,7 +212,7 @@ func (s *Server) ListWriteRepositories(ctx context.Context, q *repositorypkg.Rep
 	return &v1alpha1.RepositoryList{Items: items}, nil
 }
 
-// ListRepositoriesByAppProject returns a list of all configured repositories and the state of their connections. It
+// prepareRepoList returns a list of all configured repositories and the state of their connections. It
 // normalizes, sanitizes, and filters out repositories that the user does not have access to in the specified project.
 // It also sorts the repositories by project and repo name.
 func (s *Server) prepareRepoList(ctx context.Context, resourceType string, repos []*v1alpha1.Repository, forceRefresh bool) (v1alpha1.Repositories, error) {


### PR DESCRIPTION
Today Argo CD looks up the repository connectivity by a [check function](https://github.com/argoproj/argo-cd/blob/master/reposerver/repository/repository.go#L3068) from a map keyed by `repo.Type` where the repo type could either be `git`/`helm`/`oci`. For an empty type, the default is `git`.  Any other value apart from it maybe because of a typo, unsupported provider returns a nil function from the map lookup and the subsequent `check()` call will panic with a nil-pointer dereference. This PR fixes this by simply returning an error for a unknown repo type.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
