### PR TITLE
feat: add support for parameters when running actions from the CLI (#28000)

### DIFF
--- a/cmd/argocd/commands/admin/settings.go
+++ b/cmd/argocd/commands/admin/settings.go
@@ -24,8 +24,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/yaml"
 
+	cmdutil "github.com/argoproj/argo-cd/v3/cmd/util"
 	"github.com/argoproj/argo-cd/v3/common"
-	applicationpkg "github.com/argoproj/argo-cd/v3/pkg/apiclient/application"
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v3/util/argo/normalizers"
 	"github.com/argoproj/argo-cd/v3/util/cli"
@@ -582,21 +582,8 @@ argocd admin settings resource-overrides action /tmp/deploy.yaml restart --argoc
 			action := args[1]
 
 			// Parse resource action parameters
-			parsedParams := make([]*applicationpkg.ResourceActionParameters, 0)
-			if len(resourceActionParameters) > 0 {
-				for _, param := range resourceActionParameters {
-					parts := strings.SplitN(param, "=", 2)
-					if len(parts) != 2 {
-						log.Fatalf("Invalid parameter format: %s", param)
-					}
-					name := parts[0]
-					value := parts[1]
-					parsedParams = append(parsedParams, &applicationpkg.ResourceActionParameters{
-						Name:  &name,
-						Value: &value,
-					})
-				}
-			}
+			parsedParams, err := cmdutil.ParseActionParameters(resourceActionParameters)
+			errors.CheckError(err)
 
 			executeResourceOverrideCommand(ctx, cmdCtx, args, func(res unstructured.Unstructured, override v1alpha1.ResourceOverride, overrides map[string]v1alpha1.ResourceOverride) {
 				gvk := res.GroupVersionKind()

--- a/cmd/argocd/commands/admin/settings.go
+++ b/cmd/argocd/commands/admin/settings.go
@@ -584,6 +584,9 @@ argocd admin settings resource-overrides action /tmp/deploy.yaml restart --argoc
 			// Parse resource action parameters
 			parsedParams, err := cmdutil.ParseActionParameters(resourceActionParameters)
 			errors.CheckError(err)
+			if dupes := cmdutil.DuplicateActionParameterNames(parsedParams); len(dupes) > 0 {
+				log.Warnf("Duplicate parameter names provided (%s): the last value for each parameter will be used", strings.Join(dupes, ", "))
+			}
 
 			executeResourceOverrideCommand(ctx, cmdCtx, args, func(res unstructured.Unstructured, override v1alpha1.ResourceOverride, overrides map[string]v1alpha1.ResourceOverride) {
 				gvk := res.GroupVersionKind()

--- a/cmd/argocd/commands/app_actions.go
+++ b/cmd/argocd/commands/app_actions.go
@@ -150,6 +150,7 @@ func NewApplicationResourceActionsRunCommand(clientOpts *argocdclient.ClientOpti
 	var kind string
 	var group string
 	var all bool
+	var params []string
 	command := &cobra.Command{
 		Use:   "run APPNAME ACTION",
 		Short: "Runs an available action on resource(s) matching the specified filters.",
@@ -167,6 +168,7 @@ func NewApplicationResourceActionsRunCommand(clientOpts *argocdclient.ClientOpti
 	command.Flags().StringVar(&group, "group", "", "Group of the resource on which the action should be run")
 	errors.CheckError(command.MarkFlagRequired("kind"))
 	command.Flags().BoolVar(&all, "all", false, "Indicates whether to run the action on multiple matching resources")
+	command.Flags().StringArrayVar(&params, "param", []string{}, "Action parameter in key=value format (e.g. replicas=2). This flag may be repeated")
 
 	command.Run = func(c *cobra.Command, args []string) {
 		ctx := c.Context()
@@ -191,20 +193,23 @@ func NewApplicationResourceActionsRunCommand(clientOpts *argocdclient.ClientOpti
 			}
 		}
 
+		parsedParams, err := util.ParseActionParameters(params)
+		errors.CheckError(err)
+
 		for i := range filteredObjects {
 			obj := filteredObjects[i]
 			gvk := obj.GroupVersionKind()
 			objResourceName := obj.GetName()
 			_, err := appIf.RunResourceActionV2(ctx, &applicationpkg.ResourceActionRunRequestV2{
-				Name:         &appName,
-				AppNamespace: &appNs,
-				Namespace:    new(obj.GetNamespace()),
-				ResourceName: new(objResourceName),
-				Group:        new(gvk.Group),
-				Kind:         new(gvk.Kind),
-				Version:      new(gvk.GroupVersion().Version),
-				Action:       new(actionName),
-				// TODO: add support for parameters
+				Name:                     &appName,
+				AppNamespace:             &appNs,
+				Namespace:                new(obj.GetNamespace()),
+				ResourceName:             new(objResourceName),
+				Group:                    new(gvk.Group),
+				Kind:                     new(gvk.Kind),
+				Version:                  new(gvk.GroupVersion().Version),
+				Action:                   new(actionName),
+				ResourceActionParameters: parsedParams,
 			})
 			if err == nil {
 				continue
@@ -213,6 +218,9 @@ func NewApplicationResourceActionsRunCommand(clientOpts *argocdclient.ClientOpti
 				errors.CheckError(err)
 			}
 			fmt.Println("RunResourceActionV2 is not supported by the server, falling back to RunResourceAction.")
+			if len(parsedParams) > 0 {
+				fmt.Fprintln(os.Stderr, "Warning: --param flags are not supported by this server version and will be ignored.")
+			}
 			//nolint:staticcheck // RunResourceAction is deprecated, but we still need to support it for backward compatibility.
 			_, err = appIf.RunResourceAction(ctx, &applicationpkg.ResourceActionRunRequest{
 				Name:         &appName,

--- a/cmd/argocd/commands/app_actions.go
+++ b/cmd/argocd/commands/app_actions.go
@@ -218,9 +218,6 @@ func NewApplicationResourceActionsRunCommand(clientOpts *argocdclient.ClientOpti
 				errors.CheckError(err)
 			}
 			fmt.Println("RunResourceActionV2 is not supported by the server, falling back to RunResourceAction.")
-			if len(parsedParams) > 0 {
-				fmt.Fprintln(os.Stderr, "Warning: --param flags are not supported by this server version and will be ignored.")
-			}
 			//nolint:staticcheck // RunResourceAction is deprecated, but we still need to support it for backward compatibility.
 			_, err = appIf.RunResourceAction(ctx, &applicationpkg.ResourceActionRunRequest{
 				Name:         &appName,

--- a/cmd/argocd/commands/app_actions.go
+++ b/cmd/argocd/commands/app_actions.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"text/tabwriter"
 
 	log "github.com/sirupsen/logrus"
@@ -195,6 +196,9 @@ func NewApplicationResourceActionsRunCommand(clientOpts *argocdclient.ClientOpti
 
 		parsedParams, err := util.ParseActionParameters(params)
 		errors.CheckError(err)
+		if dupes := util.DuplicateActionParameterNames(parsedParams); len(dupes) > 0 {
+			log.Warnf("Duplicate parameter names provided (%s): the last value for each parameter will be used", strings.Join(dupes, ", "))
+		}
 
 		for i := range filteredObjects {
 			obj := filteredObjects[i]

--- a/cmd/util/actions.go
+++ b/cmd/util/actions.go
@@ -17,6 +17,9 @@ func ParseActionParameters(params []string) ([]*applicationpkg.ResourceActionPar
 		}
 		name := parts[0]
 		value := parts[1]
+		if name == "" {
+				return nil, fmt.Errorf("invalid parameter format %q: parameter name cannot be empty", param)
+		}
 		parsedParams = append(parsedParams, &applicationpkg.ResourceActionParameters{
 			Name:  &name,
 			Value: &value,

--- a/cmd/util/actions.go
+++ b/cmd/util/actions.go
@@ -9,6 +9,7 @@ import (
 
 // ParseActionParameters parses a slice of "name=value" strings into ResourceActionParameters.
 func ParseActionParameters(params []string) ([]*applicationpkg.ResourceActionParameters, error) {
+	seen := make(map[string]bool, len(params))
 	parsedParams := make([]*applicationpkg.ResourceActionParameters, 0, len(params))
 	for _, param := range params {
 		parts := strings.SplitN(param, "=", 2)
@@ -20,6 +21,10 @@ func ParseActionParameters(params []string) ([]*applicationpkg.ResourceActionPar
 		if name == "" {
 			return nil, fmt.Errorf("invalid parameter format %q: parameter name cannot be empty", param)
 		}
+		if seen[name] {
+			return nil, fmt.Errorf("parameter %q is specified more than once", name)
+		}
+		seen[name] = true
 		parsedParams = append(parsedParams, &applicationpkg.ResourceActionParameters{
 			Name:  &name,
 			Value: &value,

--- a/cmd/util/actions.go
+++ b/cmd/util/actions.go
@@ -27,3 +27,19 @@ func ParseActionParameters(params []string) ([]*applicationpkg.ResourceActionPar
 	}
 	return parsedParams, nil
 }
+
+// DuplicateActionParameterNames returns the names of any parameters specified more than once.
+func DuplicateActionParameterNames(params []*applicationpkg.ResourceActionParameters) []string {
+	seen := make(map[string]int, len(params))
+	var duplicates []string
+	for _, p := range params {
+		if p == nil || p.Name == nil {
+			continue
+		}
+		seen[*p.Name]++
+		if seen[*p.Name] == 2 {
+			duplicates = append(duplicates, *p.Name)
+		}
+	}
+	return duplicates
+}

--- a/cmd/util/actions.go
+++ b/cmd/util/actions.go
@@ -18,7 +18,7 @@ func ParseActionParameters(params []string) ([]*applicationpkg.ResourceActionPar
 		name := parts[0]
 		value := parts[1]
 		if name == "" {
-				return nil, fmt.Errorf("invalid parameter format %q: parameter name cannot be empty", param)
+			return nil, fmt.Errorf("invalid parameter format %q: parameter name cannot be empty", param)
 		}
 		parsedParams = append(parsedParams, &applicationpkg.ResourceActionParameters{
 			Name:  &name,

--- a/cmd/util/actions.go
+++ b/cmd/util/actions.go
@@ -9,7 +9,6 @@ import (
 
 // ParseActionParameters parses a slice of "name=value" strings into ResourceActionParameters.
 func ParseActionParameters(params []string) ([]*applicationpkg.ResourceActionParameters, error) {
-	seen := make(map[string]bool, len(params))
 	parsedParams := make([]*applicationpkg.ResourceActionParameters, 0, len(params))
 	for _, param := range params {
 		parts := strings.SplitN(param, "=", 2)
@@ -21,10 +20,6 @@ func ParseActionParameters(params []string) ([]*applicationpkg.ResourceActionPar
 		if name == "" {
 			return nil, fmt.Errorf("invalid parameter format %q: parameter name cannot be empty", param)
 		}
-		if seen[name] {
-			return nil, fmt.Errorf("parameter %q is specified more than once", name)
-		}
-		seen[name] = true
 		parsedParams = append(parsedParams, &applicationpkg.ResourceActionParameters{
 			Name:  &name,
 			Value: &value,

--- a/cmd/util/actions.go
+++ b/cmd/util/actions.go
@@ -1,0 +1,26 @@
+package util
+
+import (
+	"fmt"
+	"strings"
+
+	applicationpkg "github.com/argoproj/argo-cd/v3/pkg/apiclient/application"
+)
+
+// ParseActionParameters parses a slice of "name=value" strings into ResourceActionParameters.
+func ParseActionParameters(params []string) ([]*applicationpkg.ResourceActionParameters, error) {
+	parsedParams := make([]*applicationpkg.ResourceActionParameters, 0, len(params))
+	for _, param := range params {
+		parts := strings.SplitN(param, "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid parameter format %q: expected name=value", param)
+		}
+		name := parts[0]
+		value := parts[1]
+		parsedParams = append(parsedParams, &applicationpkg.ResourceActionParameters{
+			Name:  &name,
+			Value: &value,
+		})
+	}
+	return parsedParams, nil
+}

--- a/cmd/util/actions_test.go
+++ b/cmd/util/actions_test.go
@@ -62,11 +62,6 @@ func TestParseActionParameters(t *testing.T) {
 			params:      []string{"replicas"},
 			expectError: true,
 		},
-		{
-			name:        "duplicate keys",
-			params:      []string{"replicas=2", "replicas=3"},
-			expectError: true,
-		},
 	}
 
 	for _, tc := range testCases {

--- a/cmd/util/actions_test.go
+++ b/cmd/util/actions_test.go
@@ -46,6 +46,11 @@ func TestParseActionParameters(t *testing.T) {
 			},
 		},
 		{
+			name:        "empty key",
+			params:      []string{"=value"},
+			expectError: true,
+		},
+		{
 			name:   "empty value",
 			params: []string{"key="},
 			expectedParams: []*applicationpkg.ResourceActionParameters{

--- a/cmd/util/actions_test.go
+++ b/cmd/util/actions_test.go
@@ -62,6 +62,11 @@ func TestParseActionParameters(t *testing.T) {
 			params:      []string{"replicas"},
 			expectError: true,
 		},
+		{
+			name:        "duplicate keys",
+			params:      []string{"replicas=2", "replicas=3"},
+			expectError: true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/cmd/util/actions_test.go
+++ b/cmd/util/actions_test.go
@@ -9,9 +9,9 @@ import (
 	applicationpkg "github.com/argoproj/argo-cd/v3/pkg/apiclient/application"
 )
 
-func TestParseActionParameters(t *testing.T) {
-	strPtr := func(s string) *string { return &s }
+func strPtr(s string) *string { return &s }
 
+func TestParseActionParameters(t *testing.T) {
 	testCases := []struct {
 		name           string
 		params         []string
@@ -62,6 +62,14 @@ func TestParseActionParameters(t *testing.T) {
 			params:      []string{"replicas"},
 			expectError: true,
 		},
+		{
+			name:   "duplicate keys",
+			params: []string{"replicas=2", "replicas=3"},
+			expectedParams: []*applicationpkg.ResourceActionParameters{
+				{Name: strPtr("replicas"), Value: strPtr("2")},
+				{Name: strPtr("replicas"), Value: strPtr("3")},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -77,6 +85,77 @@ func TestParseActionParameters(t *testing.T) {
 				assert.Equal(t, *tc.expectedParams[i].Name, *p.Name)
 				assert.Equal(t, *tc.expectedParams[i].Value, *p.Value)
 			}
+		})
+	}
+}
+
+func TestDuplicateActionParameterNames(t *testing.T) {
+	testCases := []struct {
+		name          string
+		params        []*applicationpkg.ResourceActionParameters
+		expectedDupes []string
+	}{
+		{
+			name:          "empty",
+			params:        []*applicationpkg.ResourceActionParameters{},
+			expectedDupes: nil,
+		},
+		{
+			name: "no duplicates",
+			params: []*applicationpkg.ResourceActionParameters{
+				{Name: strPtr("replicas"), Value: strPtr("2")},
+			},
+			expectedDupes: nil,
+		},
+		{
+			name: "single duplicate",
+			params: []*applicationpkg.ResourceActionParameters{
+				{Name: strPtr("replicas"), Value: strPtr("2")},
+				{Name: strPtr("replicas"), Value: strPtr("3")},
+			},
+			expectedDupes: []string{"replicas"},
+		},
+		{
+			name: "multiple duplicates",
+			params: []*applicationpkg.ResourceActionParameters{
+				{Name: strPtr("replicas"), Value: strPtr("2")},
+				{Name: strPtr("replicas"), Value: strPtr("3")},
+				{Name: strPtr("replicas"), Value: strPtr("4")},
+			},
+			expectedDupes: []string{"replicas"},
+		},
+		{
+			name: "multiple distinct duplicates",
+			params: []*applicationpkg.ResourceActionParameters{
+				{Name: strPtr("replicas"), Value: strPtr("2")},
+				{Name: strPtr("replicas"), Value: strPtr("3")},
+				{Name: strPtr("replicas"), Value: strPtr("4")},
+				{Name: strPtr("image"), Value: strPtr("foo")},
+				{Name: strPtr("image"), Value: strPtr("bar")},
+				{Name: strPtr("image"), Value: strPtr("baz")},
+			},
+			expectedDupes: []string{"replicas", "image"},
+		},
+		{
+			name: "nil element in slice",
+			params: []*applicationpkg.ResourceActionParameters{
+				nil,
+			},
+			expectedDupes: nil,
+		},
+		{
+			name: "nil name field",
+			params: []*applicationpkg.ResourceActionParameters{
+				{Name: nil, Value: nil},
+			},
+			expectedDupes: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := DuplicateActionParameterNames(tc.params)
+			assert.ElementsMatch(t, tc.expectedDupes, result)
 		})
 	}
 }

--- a/cmd/util/actions_test.go
+++ b/cmd/util/actions_test.go
@@ -1,0 +1,77 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	applicationpkg "github.com/argoproj/argo-cd/v3/pkg/apiclient/application"
+)
+
+func TestParseActionParameters(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
+
+	testCases := []struct {
+		name           string
+		params         []string
+		expectedParams []*applicationpkg.ResourceActionParameters
+		expectError    bool
+	}{
+		{
+			name:           "empty",
+			params:         []string{},
+			expectedParams: []*applicationpkg.ResourceActionParameters{},
+		},
+		{
+			name:   "single parameter",
+			params: []string{"replicas=2"},
+			expectedParams: []*applicationpkg.ResourceActionParameters{
+				{Name: strPtr("replicas"), Value: strPtr("2")},
+			},
+		},
+		{
+			name:   "multiple parameters",
+			params: []string{"replicas=2", "image=foo"},
+			expectedParams: []*applicationpkg.ResourceActionParameters{
+				{Name: strPtr("replicas"), Value: strPtr("2")},
+				{Name: strPtr("image"), Value: strPtr("foo")},
+			},
+		},
+		{
+			name:   "value containing equals sign",
+			params: []string{"url=http://example.com?foo=bar"},
+			expectedParams: []*applicationpkg.ResourceActionParameters{
+				{Name: strPtr("url"), Value: strPtr("http://example.com?foo=bar")},
+			},
+		},
+		{
+			name:   "empty value",
+			params: []string{"key="},
+			expectedParams: []*applicationpkg.ResourceActionParameters{
+				{Name: strPtr("key"), Value: strPtr("")},
+			},
+		},
+		{
+			name:        "missing equals sign",
+			params:      []string{"replicas"},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := ParseActionParameters(tc.params)
+			if tc.expectError {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Len(t, result, len(tc.expectedParams))
+			for i, p := range result {
+				assert.Equal(t, *tc.expectedParams[i].Name, *p.Name)
+				assert.Equal(t, *tc.expectedParams[i].Value, *p.Value)
+			}
+		})
+	}
+}

--- a/docs/operator-manual/resource_actions.md
+++ b/docs/operator-manual/resource_actions.md
@@ -236,6 +236,15 @@ See the [Deployment actions discovery script](https://github.com/argoproj/argo-c
 
 The [resource scale actions](../user-guide/scale_application_resources.md) documentation shows how this function behaves in the UI.
 
+Action parameters can also be passed from the CLI using the `--param` flag in `key=value` format. The flag may be repeated to pass multiple parameters:
+
+```bash
+argocd app actions run APPNAME ACTION --kind KIND --resource-name RESOURCE --param key1=value1 --param key2=value2
+```
+
+> [!NOTE]
+> If the same parameter is specified more than once, the last provided value for that parameter will be used.
+
 ## Contributing a Custom Resource Action
 
 A resource action can be bundled into Argo CD. Custom resource action scripts are located in the `resource_customizations` directory of [https://github.com/argoproj/argo-cd](https://github.com/argoproj/argo-cd). Each contributed custom action needs to have a Lua script for discovery and a Lua script for the actual action logic. It also needs to have testdata and expected K8s resource manifests, which represent the outcome of performing the action.

--- a/docs/operator-manual/troubleshooting.md
+++ b/docs/operator-manual/troubleshooting.md
@@ -52,6 +52,15 @@ The following `argocd admin` command lists actions available for a given resourc
 argocd admin settings resource-overrides list-actions /tmp/deploy.yaml --argocd-cm-path /private/tmp/argocd-cm.yaml
 ```
 
+Actions that require parameters can be tested with the `--param` flag in `key=value` format. The flag may be repeated to pass multiple parameters:
+
+```bash
+argocd admin settings resource-overrides run-action /tmp/deploy.yaml scale --argocd-cm-path /private/tmp/argocd-cm.yaml --param replicas=3
+```
+
+> [!NOTE]
+> If the same parameter is specified more than once, the last provided value for that parameter will be used.
+
 ## Cluster credentials
 
 The `argocd admin cluster kubeconfig` is useful if you manually created Secret with cluster credentials and trying need to

--- a/docs/operator-manual/upgrading/3.4-3.5.md
+++ b/docs/operator-manual/upgrading/3.4-3.5.md
@@ -107,6 +107,10 @@ Legacy configurations will continue to function temporarily (issuing a warning) 
 
 No action is required for users that do not use GnuPG signature verification.
 
+### Stricter error handling for scale resource actions
+
+The scale resource actions for Deployment and StatefulSet have been updated with stricter error handling. Invalid values for the replicas parameter are now caught by the resource action instead of being passed to the Kubernetes API server. As a consequence, the error messages that the actions return when invalid parameters are provided have changed.
+
 ## API Changes
 
 ## Security Changes

--- a/docs/user-guide/commands/argocd_app_actions_run.md
+++ b/docs/user-guide/commands/argocd_app_actions_run.md
@@ -28,6 +28,7 @@ argocd app actions run APPNAME ACTION [flags]
   -h, --help                   help for run
       --kind string            Kind of the resource on which the action should be run
       --namespace string       Namespace of the resource on which the action should be run
+      --param stringArray      Action parameter in key=value format (e.g. replicas=2). This flag may be repeated
       --resource-name string   Name of resource on which the action should be run
 ```
 

--- a/docs/user-guide/scale_application_resources.md
+++ b/docs/user-guide/scale_application_resources.md
@@ -18,3 +18,12 @@ This enables users to scale resources directly from the Argo CD UI. Users will b
 > [!NOTE]
 > If you use HPA (Horizontal Pod Autoscaling) or enabled Argo CD auto-sync, changing the replica count in scale actions would be overwritten.
 > Ensure that invalid values (e.g., `non-numeric` characters, `negative` numbers, or values beyond the `max integer limit`) cannot be entered.
+
+## CLI Usage
+
+You can also scale resources from the CLI using the `--param` flag:
+
+```bash
+argocd app actions run APPNAME scale --kind Deployment --resource-name RESOURCE_NAME --param replicas=2
+argocd app actions run APPNAME scale --kind StatefulSet --resource-name RESOURCE_NAME --param replicas=3
+```

--- a/docs/user-guide/scale_application_resources.md
+++ b/docs/user-guide/scale_application_resources.md
@@ -27,3 +27,6 @@ You can also scale resources from the CLI using the `--param` flag:
 argocd app actions run APPNAME scale --kind Deployment --resource-name RESOURCE_NAME --param replicas=2
 argocd app actions run APPNAME scale --kind StatefulSet --resource-name RESOURCE_NAME --param replicas=3
 ```
+
+> [!NOTE]
+> If the same parameter is specified more than once, the last provided value for that parameter will be used.

--- a/resource_customizations/apps/Deployment/actions/action_test.yaml
+++ b/resource_customizations/apps/Deployment/actions/action_test.yaml
@@ -125,7 +125,10 @@ actionTests:
 
   - action: scale
     inputPath: testdata/deployment.yaml
-    expectedErrorMessage: "invalid number: not_a_number"
+    expectedErrorMessage: "replicas parameter is required"
+
+  - action: scale
+    inputPath: testdata/deployment.yaml
+    expectedErrorMessage: "invalid number: not_a_number (must be >= 0)"
     parameters:
       replicas: "not_a_number"
-

--- a/resource_customizations/apps/Deployment/actions/action_test.yaml
+++ b/resource_customizations/apps/Deployment/actions/action_test.yaml
@@ -129,6 +129,12 @@ actionTests:
 
   - action: scale
     inputPath: testdata/deployment.yaml
+    expectedErrorMessage: 'invalid number: -1 (must be >= 0)'
+    parameters:
+        replicas: '-1'
+
+  - action: scale
+    inputPath: testdata/deployment.yaml
     expectedErrorMessage: "invalid number: not_a_number (must be >= 0)"
     parameters:
       replicas: "not_a_number"

--- a/resource_customizations/apps/Deployment/actions/action_test.yaml
+++ b/resource_customizations/apps/Deployment/actions/action_test.yaml
@@ -129,12 +129,18 @@ actionTests:
 
   - action: scale
     inputPath: testdata/deployment.yaml
-    expectedErrorMessage: 'invalid number: -1 (must be >= 0)'
+    expectedErrorMessage: 'invalid number: -1 (must be a non-negative integer)'
     parameters:
         replicas: '-1'
 
   - action: scale
     inputPath: testdata/deployment.yaml
-    expectedErrorMessage: "invalid number: not_a_number (must be >= 0)"
+    expectedErrorMessage: 'invalid number: 1.5 (must be a non-negative integer)'
+    parameters:
+        replicas: '1.5'
+
+  - action: scale
+    inputPath: testdata/deployment.yaml
+    expectedErrorMessage: "invalid number: not_a_number (must be a non-negative integer)"
     parameters:
       replicas: "not_a_number"

--- a/resource_customizations/apps/Deployment/actions/scale/action.lua
+++ b/resource_customizations/apps/Deployment/actions/scale/action.lua
@@ -1,9 +1,14 @@
 local os = require("os")
 
-local replicas = tonumber(actionParams["replicas"])
+local replicas = actionParams["replicas"]
 if not replicas then
-    error("invalid number: " .. actionParams["replicas"], 0)
+    error("replicas parameter is required", 0)
 end
 
-obj.spec.replicas = replicas
+local replicasNum = tonumber(replicas)
+if not replicasNum or replicasNum < 0 then
+    error("invalid number: " .. replicas .. " (must be >= 0)", 0)
+end
+
+obj.spec.replicas = replicasNum
 return obj

--- a/resource_customizations/apps/Deployment/actions/scale/action.lua
+++ b/resource_customizations/apps/Deployment/actions/scale/action.lua
@@ -6,8 +6,8 @@ if not replicas then
 end
 
 local replicasNum = tonumber(replicas)
-if not replicasNum or replicasNum < 0 then
-    error("invalid number: " .. replicas .. " (must be >= 0)", 0)
+if not replicasNum or replicasNum < 0 or replicasNum %1 ~=0 then
+    error("invalid number: " .. replicas .. " (must be a non-negative integer)", 0)
 end
 
 obj.spec.replicas = replicasNum

--- a/resource_customizations/apps/StatefulSet/actions/action_test.yaml
+++ b/resource_customizations/apps/StatefulSet/actions/action_test.yaml
@@ -9,6 +9,9 @@ actionTests:
       replicas: '6'
   - action: scale
     inputPath: testdata/statefulset.yaml
-    expectedErrorMessage: 'invalid number: not_a_number'
+    expectedErrorMessage: 'replicas parameter is required'
+  - action: scale
+    inputPath: testdata/statefulset.yaml
+    expectedErrorMessage: 'invalid number: not_a_number (must be >= 0)'
     parameters:
       replicas: 'not_a_number'

--- a/resource_customizations/apps/StatefulSet/actions/action_test.yaml
+++ b/resource_customizations/apps/StatefulSet/actions/action_test.yaml
@@ -12,6 +12,16 @@ actionTests:
     expectedErrorMessage: 'replicas parameter is required'
   - action: scale
     inputPath: testdata/statefulset.yaml
-    expectedErrorMessage: 'invalid number: not_a_number (must be >= 0)'
+    expectedErrorMessage: 'invalid number: -1 (must be a non-negative integer)'
+    parameters:
+        replicas: '-1'
+  - action: scale
+    inputPath: testdata/statefulset.yaml
+    expectedErrorMessage: 'invalid number: 1.5 (must be a non-negative integer)'
+    parameters:
+        replicas: '1.5'
+  - action: scale
+    inputPath: testdata/statefulset.yaml
+    expectedErrorMessage: 'invalid number: not_a_number (must be a non-negative integer)'
     parameters:
       replicas: 'not_a_number'

--- a/resource_customizations/apps/StatefulSet/actions/scale/action.lua
+++ b/resource_customizations/apps/StatefulSet/actions/scale/action.lua
@@ -1,9 +1,14 @@
 local os = require("os")
 
-local replicas = tonumber(actionParams["replicas"])
+local replicas = actionParams["replicas"]
 if not replicas then
-    error("invalid number: " .. actionParams["replicas"], 0)
+    error("replicas parameter is required", 0)
 end
 
-obj.spec.replicas = replicas
+local replicasNum = tonumber(replicas)
+if not replicasNum or replicasNum < 0 then
+    error("invalid number: " .. replicas .. " (must be >= 0)", 0)
+end
+
+obj.spec.replicas = replicasNum
 return obj

--- a/resource_customizations/apps/StatefulSet/actions/scale/action.lua
+++ b/resource_customizations/apps/StatefulSet/actions/scale/action.lua
@@ -6,8 +6,8 @@ if not replicas then
 end
 
 local replicasNum = tonumber(replicas)
-if not replicasNum or replicasNum < 0 then
-    error("invalid number: " .. replicas .. " (must be >= 0)", 0)
+if not replicasNum or replicasNum < 0 or replicasNum %1 ~=0 then
+    error("invalid number: " .. replicas .. " (must be a non-negative integer)", 0)
 end
 
 obj.spec.replicas = replicasNum

--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -896,6 +896,43 @@ func TestNewStyleResourceActionMixedOk(t *testing.T) {
 		})
 }
 
+func TestScaleDeploymentActionWithParam(t *testing.T) {
+	Given(t).
+		Path(guestbookPath).
+		When().
+		CreateApp().
+		Sync().
+		Then().
+		And(func(app *Application) {
+			// Scale to 2 replicas using the --param flag
+			_, err := fixture.RunCli("app", "actions", "run", app.Name, "scale",
+				"--kind", "Deployment", "--param", "replicas=2")
+			require.NoError(t, err)
+
+			deployment, err := fixture.KubeClientset.AppsV1().Deployments(app.Spec.Destination.Namespace).Get(t.Context(), "guestbook-ui", metav1.GetOptions{})
+			require.NoError(t, err)
+			assert.EqualValues(t, 2, *deployment.Spec.Replicas)
+		}).
+		And(func(app *Application) {
+			// Missing --param flag should fail
+			_, err := fixture.RunCli("app", "actions", "run", app.Name, "scale",
+				"--kind", "Deployment")
+			assert.ErrorContains(t, err, "replicas parameter is required")
+		}).
+		And(func(app *Application) {
+			// Non-numeric values should fail
+			_, err := fixture.RunCli("app", "actions", "run", app.Name, "scale",
+				"--kind", "Deployment", "--param", "replicas=notanumber")
+			assert.ErrorContains(t, err, "invalid number")
+		}).
+		And(func(app *Application) {
+			// Malformed param (no = separator) should fail
+			_, err := fixture.RunCli("app", "actions", "run", app.Name, "scale",
+				"--kind", "Deployment", "--param", "replicas")
+			assert.ErrorContains(t, err, "invalid parameter format")
+		})
+}
+
 func TestSyncResourceByLabel(t *testing.T) {
 	Given(t).
 		Path(guestbookPath).


### PR DESCRIPTION
Fixes #28000

Adds a `--param key=value` flag to `argocd app actions run`. The parameter parsing logic that already existed in `argocd admin settings` is moved into a shared ParseActionParameters helper in cmd/util and reused by both commands.

Also fixes the Lua scale actions to separately handle both the "missing parameter" and "invalid value" cases, using the same logic as the [existing scale action for keda.sh/ScaledObject](https://github.com/argoproj/argo-cd/blob/95e0696d50d890218e72a55ec335d628054c52f5/resource_customizations/keda.sh/ScaledObject/actions/paused-replicas/action.lua)

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
  - Not a new feature, but adds missing CLI support for an existing feature 
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
  - Only the CLI needs updating in this case. Action parameters are already supported in the UI
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
  - See issue #28000
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
