### PR TITLE
feat: add health check for MedusaTask (issue #28007)

### DIFF
--- a/resource_customizations/medusa.k8ssandra.io/MedusaTask/health.lua
+++ b/resource_customizations/medusa.k8ssandra.io/MedusaTask/health.lua
@@ -1,0 +1,33 @@
+-- A bit of documentation about the fields of MedusaTask can be found here:
+-- https://docs.k8ssandra.io/reference/crd/k8ssandra-operator-crds-latest/#medusataskstatus
+local hs = {}
+
+hs.status = "Unknown"
+
+if obj.status == nil then
+	return hs
+end
+
+-- We check if we are checking the correct version of obj.status
+if obj.status.observedGeneration ~= nil and obj.status.observedGeneration ~= obj.metadata.generation then
+	return hs
+end
+
+if obj.status.finished == nil and obj.status.failed == nil then
+	hs.status = "Progressing"
+end
+
+if obj.status.finished ~= nil then
+	if obj.status.finished[0] or obj.status.finished[1] then
+		hs.status = "Healthy"
+	else
+		hs.status = "Progressing"
+	end
+end
+
+if obj.status.failed ~= nil then
+	hs.status = "Degraded"
+	hs.message = "Failed nodes exist"
+end
+
+return hs

--- a/resource_customizations/medusa.k8ssandra.io/MedusaTask/health.lua
+++ b/resource_customizations/medusa.k8ssandra.io/MedusaTask/health.lua
@@ -1,3 +1,5 @@
+-- A bit of documentation about the fields of MedusaTask can be found here:
+-- https://docs.k8ssandra.io/reference/crd/k8ssandra-operator-crds-latest/#medusataskstatus
 local hs = {}
 
 hs.status = "Unknown"

--- a/resource_customizations/medusa.k8ssandra.io/MedusaTask/health.lua
+++ b/resource_customizations/medusa.k8ssandra.io/MedusaTask/health.lua
@@ -8,6 +8,11 @@ if obj.status == nil then
 	return hs
 end
 
+-- We check if we are checking the correct version of obj.status
+if obj.status.observedGeneration ~= nil and obj.status.observedGeneration ~= obj.metadata.generation then
+	return hs
+end
+
 if obj.status.finished == nil and obj.status.failed == nil then
 	hs.status = "Progressing"
 end

--- a/resource_customizations/medusa.k8ssandra.io/MedusaTask/health.lua
+++ b/resource_customizations/medusa.k8ssandra.io/MedusaTask/health.lua
@@ -1,0 +1,26 @@
+local hs = {}
+
+hs.status = "Unknown"
+
+if obj.status == nil then
+	return hs
+end
+
+if obj.status.finished == nil and obj.status.failed == nil then
+	hs.status = "Progressing"
+end
+
+if obj.status.finished ~= nil then
+	if obj.status.finished[0] or obj.status.finished[1] then
+		hs.status = "Healthy"
+	else
+		hs.status = "Progressing"
+	end
+end
+
+if obj.status.failed ~= nil then
+	hs.status = "Degraded"
+	hs.message = "Failed nodes exist"
+end
+
+return hs

--- a/resource_customizations/medusa.k8ssandra.io/MedusaTask/health.lua
+++ b/resource_customizations/medusa.k8ssandra.io/MedusaTask/health.lua
@@ -5,16 +5,25 @@ local hs = {}
 hs.status = "Unknown"
 
 if obj.status == nil then
+	hs.message = "No status object"
+	return hs
+end
+
+if obj.status.observedGeneration == nil then
+	hs.message = "No observedGeneration"
 	return hs
 end
 
 -- We check if we are checking the correct version of obj.status
-if obj.status.observedGeneration ~= nil and obj.status.observedGeneration ~= obj.metadata.generation then
+if obj.status.observedGeneration ~= obj.metadata.generation then
+	hs.message = "observedGeneration is not equal to generation"
+	hs.status = "Progressing"
 	return hs
 end
 
 if obj.status.finished == nil and obj.status.failed == nil then
 	hs.status = "Progressing"
+	return hs
 end
 
 if obj.status.finished ~= nil then

--- a/resource_customizations/medusa.k8ssandra.io/MedusaTask/health_test.yaml
+++ b/resource_customizations/medusa.k8ssandra.io/MedusaTask/health_test.yaml
@@ -1,0 +1,17 @@
+tests:
+- healthStatus:
+    status: Healthy
+    message: ""
+  inputPath: testdata/task_ok.yaml
+- healthStatus:
+    status: Degraded
+    message: "Failed nodes exist"
+  inputPath: testdata/task_failed.yaml
+- healthStatus:
+    status: Progressing
+    message: ""
+  inputPath: testdata/task_no_finished_no_failed.yaml
+- healthStatus:
+    status: Unknown
+    message: ""
+  inputPath: testdata/task_ok_but_non_matching_generation.yaml

--- a/resource_customizations/medusa.k8ssandra.io/MedusaTask/health_test.yaml
+++ b/resource_customizations/medusa.k8ssandra.io/MedusaTask/health_test.yaml
@@ -5,7 +5,7 @@ tests:
   inputPath: testdata/task_ok.yaml
 - healthStatus:
     status: Degraded
-    message: "Failed nodes exists"
+    message: "Failed nodes exist"
   inputPath: testdata/task_failed.yaml
 - healthStatus:
     status: Progressing

--- a/resource_customizations/medusa.k8ssandra.io/MedusaTask/health_test.yaml
+++ b/resource_customizations/medusa.k8ssandra.io/MedusaTask/health_test.yaml
@@ -11,3 +11,7 @@ tests:
     status: Progressing
     message: ""
   inputPath: testdata/task_no_finished_no_failed.yaml
+- healthStatus:
+    status: Unknown
+    message: ""
+  inputPath: testdata/task_ok_but_non_matching_generation.yaml

--- a/resource_customizations/medusa.k8ssandra.io/MedusaTask/health_test.yaml
+++ b/resource_customizations/medusa.k8ssandra.io/MedusaTask/health_test.yaml
@@ -1,0 +1,13 @@
+tests:
+- healthStatus:
+    status: Healthy
+    message: ""
+  inputPath: testdata/task_ok.yaml
+- healthStatus:
+    status: Degraded
+    message: "Failed nodes exists"
+  inputPath: testdata/task_failed.yaml
+- healthStatus:
+    status: Progressing
+    message: ""
+  inputPath: testdata/task_no_finished_no_failed.yaml

--- a/resource_customizations/medusa.k8ssandra.io/MedusaTask/health_test.yaml
+++ b/resource_customizations/medusa.k8ssandra.io/MedusaTask/health_test.yaml
@@ -12,6 +12,10 @@ tests:
     message: ""
   inputPath: testdata/task_no_finished_no_failed.yaml
 - healthStatus:
-    status: Unknown
-    message: ""
+    status: Progressing
+    message: "observedGeneration is not equal to generation"
   inputPath: testdata/task_ok_but_non_matching_generation.yaml
+- healthStatus:
+    status: Unknown
+    message: "No observedGeneration"
+  inputPath: testdata/task_ok_but_no_observedgeneration.yaml

--- a/resource_customizations/medusa.k8ssandra.io/MedusaTask/testdata/task_failed.yaml
+++ b/resource_customizations/medusa.k8ssandra.io/MedusaTask/testdata/task_failed.yaml
@@ -1,0 +1,29 @@
+apiVersion: medusa.k8ssandra.io/v1alpha1
+kind: MedusaTask
+metadata:
+  creationTimestamp: '2026-04-27T14:02:33Z'
+  generation: 1
+  labels:
+    cassandra.datastax.com/cluster: test-cluster
+    cassandra.datastax.com/datacenter: stage0-test
+  name: test-purge-weekly-1777298553
+  namespace: dbaas-ac-test
+  ownerReferences:
+    - apiVersion: cassandra.datastax.com/v1beta1
+      kind: CassandraDatacenter
+      name: stage0-test
+      uid: fcd45992-002a-4294-89cd-94d15b1ac543
+  resourceVersion: '25373692'
+  uid: f07b9c4c-fb30-4ce4-b3f3-aa8aabafac57
+spec:
+  cassandraDatacenter: stage0-test
+  operation: purge
+status:
+  failed:
+    - test-cluster-stage0-test-default-sts-0
+    - test-cluster-stage0-test-default-sts-2
+    - test-cluster-stage0-test-default-sts-1
+  finishTime: '2026-04-27T15:16:33Z'
+  startTime: '2026-04-27T14:02:48Z'
+
+

--- a/resource_customizations/medusa.k8ssandra.io/MedusaTask/testdata/task_failed.yaml
+++ b/resource_customizations/medusa.k8ssandra.io/MedusaTask/testdata/task_failed.yaml
@@ -25,5 +25,6 @@ status:
     - test-cluster-stage0-test-default-sts-1
   finishTime: '2026-04-27T15:16:33Z'
   startTime: '2026-04-27T14:02:48Z'
+  observedGeneration: 1
 
 

--- a/resource_customizations/medusa.k8ssandra.io/MedusaTask/testdata/task_no_finished_no_failed.yaml
+++ b/resource_customizations/medusa.k8ssandra.io/MedusaTask/testdata/task_no_finished_no_failed.yaml
@@ -1,0 +1,24 @@
+apiVersion: medusa.k8ssandra.io/v1alpha1
+kind: MedusaTask
+metadata:
+  creationTimestamp: '2026-04-27T14:02:33Z'
+  generation: 1
+  labels:
+    cassandra.datastax.com/cluster: test-cluster
+    cassandra.datastax.com/datacenter: stage0-test
+  name: test-purge-weekly-1777298553
+  namespace: dbaas-ac-test
+  ownerReferences:
+    - apiVersion: cassandra.datastax.com/v1beta1
+      kind: CassandraDatacenter
+      name: stage0-test
+      uid: fcd45992-002a-4294-89cd-94d15b1ac543
+  resourceVersion: '25373692'
+  uid: f07b9c4c-fb30-4ce4-b3f3-aa8aabafac57
+spec:
+  cassandraDatacenter: stage0-test
+  operation: purge
+status:
+  finishTime: '2026-04-27T15:16:33Z'
+  startTime: '2026-04-27T14:02:48Z'
+

--- a/resource_customizations/medusa.k8ssandra.io/MedusaTask/testdata/task_no_finished_no_failed.yaml
+++ b/resource_customizations/medusa.k8ssandra.io/MedusaTask/testdata/task_no_finished_no_failed.yaml
@@ -21,4 +21,5 @@ spec:
 status:
   finishTime: '2026-04-27T15:16:33Z'
   startTime: '2026-04-27T14:02:48Z'
+  observedGeneration: 1
 

--- a/resource_customizations/medusa.k8ssandra.io/MedusaTask/testdata/task_ok.yaml
+++ b/resource_customizations/medusa.k8ssandra.io/MedusaTask/testdata/task_ok.yaml
@@ -1,0 +1,25 @@
+apiVersion: medusa.k8ssandra.io/v1alpha1
+kind: MedusaTask
+metadata:
+  creationTimestamp: '2026-05-03T00:00:30Z'
+  generation: 1
+  labels:
+    cassandra.datastax.com/cluster: test-cluster
+    cassandra.datastax.com/datacenter: stage0-test
+  name: test-purge-weekly-1777766400-sync
+  namespace: dbaas-ac-test
+  ownerReferences:
+    - apiVersion: cassandra.datastax.com/v1beta1
+      kind: CassandraDatacenter
+      name: stage0-test
+      uid: fcd45992-002a-4294-89cd-94d15b1ac543
+  resourceVersion: '28519097'
+  uid: 2e3163df-0b78-4daf-8a92-a296b6fa10a0
+spec:
+  cassandraDatacenter: stage0-test
+  operation: sync
+status:
+  finishTime: '2026-05-03T00:00:45Z'
+  finished:
+    - podName: test-cluster-stage0-test-default-sts-0
+  startTime: '2026-05-03T00:00:45Z'

--- a/resource_customizations/medusa.k8ssandra.io/MedusaTask/testdata/task_ok_but_no_observedgeneration.yaml
+++ b/resource_customizations/medusa.k8ssandra.io/MedusaTask/testdata/task_ok_but_no_observedgeneration.yaml
@@ -2,7 +2,7 @@ apiVersion: medusa.k8ssandra.io/v1alpha1
 kind: MedusaTask
 metadata:
   creationTimestamp: '2026-05-03T00:00:30Z'
-  generation: 1
+  generation: 3
   labels:
     cassandra.datastax.com/cluster: test-cluster
     cassandra.datastax.com/datacenter: stage0-test
@@ -23,4 +23,3 @@ status:
   finished:
     - podName: test-cluster-stage0-test-default-sts-0
   startTime: '2026-05-03T00:00:45Z'
-  observedGeneration: 1

--- a/resource_customizations/medusa.k8ssandra.io/MedusaTask/testdata/task_ok_but_non_matching_generation.yaml
+++ b/resource_customizations/medusa.k8ssandra.io/MedusaTask/testdata/task_ok_but_non_matching_generation.yaml
@@ -1,0 +1,26 @@
+apiVersion: medusa.k8ssandra.io/v1alpha1
+kind: MedusaTask
+metadata:
+  creationTimestamp: '2026-05-03T00:00:30Z'
+  generation: 3
+  labels:
+    cassandra.datastax.com/cluster: test-cluster
+    cassandra.datastax.com/datacenter: stage0-test
+  name: test-purge-weekly-1777766400-sync
+  namespace: dbaas-ac-test
+  ownerReferences:
+    - apiVersion: cassandra.datastax.com/v1beta1
+      kind: CassandraDatacenter
+      name: stage0-test
+      uid: fcd45992-002a-4294-89cd-94d15b1ac543
+  resourceVersion: '28519097'
+  uid: 2e3163df-0b78-4daf-8a92-a296b6fa10a0
+spec:
+  cassandraDatacenter: stage0-test
+  operation: sync
+status:
+  finishTime: '2026-05-03T00:00:45Z'
+  finished:
+    - podName: test-cluster-stage0-test-default-sts-0
+  startTime: '2026-05-03T00:00:45Z'
+  observedGeneration: 2


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->
This PR adds a health check for MedusaTask objects. It is taking into account the `finished` and `failed` fields of `status`.
Furthermore, it respects the `generation` field of metadata.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

Closes #28007 

This PR is based on the very sparse documentation of MedusaTask found [here](https://docs.k8ssandra.io/reference/crd/k8ssandra-operator-crds-latest/#medusataskstatus). However, dealing with MedusaTask objects has shown that looking at these fields (`finished` and `failed`) should be the right approach.

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
