### PR TITLE
feat(server): drop objects from non-allowed namespaces before they enter the cache.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -62,6 +62,7 @@ import (
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
@@ -128,6 +129,7 @@ import (
 	settings_notif "github.com/argoproj/argo-cd/v3/util/notification/settings"
 	"github.com/argoproj/argo-cd/v3/util/oidc"
 	"github.com/argoproj/argo-cd/v3/util/rbac"
+	"github.com/argoproj/argo-cd/v3/util/security"
 	util_session "github.com/argoproj/argo-cd/v3/util/session"
 	settings_util "github.com/argoproj/argo-cd/v3/util/settings"
 	"github.com/argoproj/argo-cd/v3/util/swagger"
@@ -330,6 +332,17 @@ func NewServer(ctx context.Context, opts ArgoCDServerOpts, appsetOpts Applicatio
 
 	appsetInformer := appFactory.Argoproj().V1alpha1().ApplicationSets().Informer()
 	appsetLister := appFactory.Argoproj().V1alpha1().ApplicationSets().Lister()
+
+	// When watching cluster-wide (i.e. application.namespaces is configured),
+	// drop objects from namespaces that are not in the allowed list before
+	// they enter the informer cache. This avoids caching Applications and
+	// ApplicationSets that the server is not configured to manage, which
+	// reduces memory usage in multi-tenant clusters.
+	if len(opts.ApplicationNamespaces) > 0 {
+		filter := newNamespaceFilterTransform(opts.Namespace, opts.ApplicationNamespaces)
+		errorsutil.CheckError(appInformer.SetTransform(filter))
+		errorsutil.CheckError(appsetInformer.SetTransform(filter))
+	}
 
 	userStateStorage := util_session.NewUserStateStorage(opts.RedisClient)
 	sessionMgr := util_session.NewSessionManager(settingsMgr, projLister, opts.DexServerAddr, opts.DexTLSConfig, userStateStorage)
@@ -1737,4 +1750,33 @@ func (server *ArgoCDServer) allowedApplicationNamespacesAsString() string {
 		ns += strings.Join(server.ApplicationNamespaces, ", ")
 	}
 	return ns
+}
+
+// newNamespaceFilterTransform returns a cache.TransformFunc that drops objects
+// whose namespace is neither the control-plane namespace nor matches one of
+// the configured application namespace patterns. Dropped objects are returned
+// as a nil object so they are not stored in the informer cache, which reduces
+// memory usage when watching cluster-wide. The serverNamespace is always
+// allowed regardless of the contents of applicationNamespaces.
+//
+// Returning (nil, nil) is a deliberate use of client-go's TransformFunc: the
+// delta processor still computes the cache key from the pre-transform object,
+// then attempts to store the transformed (nil) value. The indexer rejects the
+// nil object via its key function, so it never enters the cache, and the
+// resulting per-item error is swallowed by the shared informer's process
+// loop without re-queueing. The behavior is exercised end-to-end by
+// TestInformerFilterDoesNotCacheDisallowedNamespaces.
+func newNamespaceFilterTransform(serverNamespace string, applicationNamespaces []string) cache.TransformFunc {
+	return func(obj any) (any, error) {
+		accessor, err := meta.Accessor(obj)
+		if err != nil {
+			// Not a Kubernetes object (e.g. a tombstone with no metadata).
+			// Pass through so we don't accidentally drop deletion events.
+			return obj, nil
+		}
+		if !security.IsNamespaceEnabled(accessor.GetNamespace(), serverNamespace, applicationNamespaces) {
+			return nil, nil
+		}
+		return obj, nil
+	}
 }

--- a/server/server_namespace_filter_informer_test.go
+++ b/server/server_namespace_filter_informer_test.go
@@ -1,0 +1,57 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	apps "github.com/argoproj/argo-cd/v3/pkg/client/clientset/versioned/fake"
+	appinformer "github.com/argoproj/argo-cd/v3/pkg/client/informers/externalversions"
+)
+
+// TestInformerFilterDoesNotCacheDisallowedNamespaces drives the full
+// SharedIndexInformer pipeline (list -> transform -> indexer) and asserts
+// that objects from disallowed namespaces never reach the cache, while
+// allowed and control-plane namespace objects do. This guards against
+// regressions where the transform stops dropping (or starts polluting the
+// cache with nil entries).
+func TestInformerFilterDoesNotCacheDisallowedNamespaces(t *testing.T) {
+	kept := &v1alpha1.Application{ObjectMeta: metav1.ObjectMeta{Name: "kept", Namespace: "team-a"}}
+	control := &v1alpha1.Application{ObjectMeta: metav1.ObjectMeta{Name: "ctrl", Namespace: "argocd"}}
+	dropped := &v1alpha1.Application{ObjectMeta: metav1.ObjectMeta{Name: "dropped", Namespace: "team-b"}}
+
+	client := apps.NewSimpleClientset(kept, control, dropped)
+	factory := appinformer.NewSharedInformerFactoryWithOptions(client, 0)
+
+	appInformer := factory.Argoproj().V1alpha1().Applications().Informer()
+	require.NoError(t, appInformer.SetTransform(newNamespaceFilterTransform("argocd", []string{"team-a"})))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go appInformer.Run(ctx.Done())
+
+	require.Eventually(t, appInformer.HasSynced, 2*time.Second, 10*time.Millisecond)
+
+	// Wait for the informer to process the list through the FIFO into the
+	// indexer. We expect exactly two objects (control-plane + team-a).
+	require.NoError(t, wait.PollUntilContextTimeout(ctx, 10*time.Millisecond, 2*time.Second, true, func(_ context.Context) (bool, error) {
+		return len(appInformer.GetIndexer().List()) >= 2, nil
+	}))
+
+	listed := appInformer.GetIndexer().List()
+	gotNS := map[string]bool{}
+	for _, obj := range listed {
+		app, ok := obj.(*v1alpha1.Application)
+		require.True(t, ok, "indexer must only hold non-nil Applications, got %T", obj)
+		gotNS[app.Namespace] = true
+	}
+	assert.True(t, gotNS["argocd"], "control-plane namespace should be cached")
+	assert.True(t, gotNS["team-a"], "allowed namespace should be cached")
+	assert.False(t, gotNS["team-b"], "disallowed namespace must not be cached")
+}

--- a/server/server_namespace_filter_test.go
+++ b/server/server_namespace_filter_test.go
@@ -1,0 +1,91 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+)
+
+func Test_newNamespaceFilterTransform(t *testing.T) {
+	const serverNS = "argocd"
+
+	app := func(ns string) *v1alpha1.Application {
+		return &v1alpha1.Application{ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: ns}}
+	}
+	appSet := func(ns string) *v1alpha1.ApplicationSet {
+		return &v1alpha1.ApplicationSet{ObjectMeta: metav1.ObjectMeta{Name: "appset", Namespace: ns}}
+	}
+
+	tests := []struct {
+		name            string
+		allowed         []string
+		obj             any
+		wantKept        bool
+		wantPassthrough bool // for non-meta objects we expect the original obj returned unchanged
+	}{
+		{
+			name:     "control-plane namespace is always kept",
+			allowed:  []string{"team-*"},
+			obj:      app(serverNS),
+			wantKept: true,
+		},
+		{
+			name:     "namespace matching an allowed glob pattern is kept",
+			allowed:  []string{"team-*"},
+			obj:      app("team-alpha"),
+			wantKept: true,
+		},
+		{
+			name:     "namespace not matching any pattern is dropped",
+			allowed:  []string{"team-*"},
+			obj:      app("other"),
+			wantKept: false,
+		},
+		{
+			name:     "exact namespace match is kept",
+			allowed:  []string{"foo", "bar"},
+			obj:      app("bar"),
+			wantKept: true,
+		},
+		{
+			name:     "applicationset in disallowed namespace is dropped",
+			allowed:  []string{"team-a"},
+			obj:      appSet("team-b"),
+			wantKept: false,
+		},
+		{
+			name:     "applicationset in allowed namespace is kept",
+			allowed:  []string{"team-a"},
+			obj:      appSet("team-a"),
+			wantKept: true,
+		},
+		{
+			name:            "tombstone-like non-meta object is passed through",
+			allowed:         []string{"foo"},
+			obj:             cache.DeletedFinalStateUnknown{Key: "ns/name", Obj: nil},
+			wantKept:        true,
+			wantPassthrough: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			transform := newNamespaceFilterTransform(serverNS, tc.allowed)
+			got, err := transform(tc.obj)
+			require.NoError(t, err)
+			if tc.wantKept {
+				assert.NotNil(t, got, "object should be kept")
+				if !tc.wantPassthrough {
+					assert.Same(t, tc.obj, got, "kept object should be returned unchanged")
+				}
+			} else {
+				assert.Nil(t, got, "object should be dropped")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #27915 


This PR installs a SetTransform on the app and appset informers that drops objects from disallowed namespaces before they enter the cache. 

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
