### PR TITLE
docs: remove --request-timeout from auto-generated CLI docs

### DIFF
--- a/docs/operator-manual/server-commands/argocd-application-controller.md
+++ b/docs/operator-manual/server-commands/argocd-application-controller.md
@@ -69,7 +69,6 @@ argocd-application-controller [flags]
       --repo-server-plaintext                                     Disable TLS on connections to repo server
       --repo-server-strict-tls                                    Whether to use strict validation of the TLS cert presented by the repo server
       --repo-server-timeout-seconds int                           Repo server RPC call timeout seconds. (default 60)
-      --request-timeout string                                    The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --self-heal-backoff-cap-seconds int                         Specifies max timeout of exponential backoff between application self heal attempts (default 300)
       --self-heal-backoff-factor int                              Specifies factor of exponential timeout between application self heal attempts (default 3)
       --self-heal-backoff-timeout-seconds int                     Specifies initial timeout of exponential backoff between self heal attempts (default 2)

--- a/docs/operator-manual/server-commands/argocd-applicationset-controller.md
+++ b/docs/operator-manual/server-commands/argocd-applicationset-controller.md
@@ -52,7 +52,6 @@ argocd-applicationset-controller [flags]
       --repo-server-plaintext                   Disable TLS on connections to repo server
       --repo-server-strict-tls                  Whether to use strict validation of the TLS cert presented by the repo server
       --repo-server-timeout-seconds int         Repo server RPC call timeout seconds. (default 60)
-      --request-timeout string                  The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --scm-no-proxy string                     Comma-separated list of hosts that should bypass the --scm-proxy-url proxy.
       --scm-proxy-url string                    HTTP/HTTPS proxy URL for outbound SCM provider API requests (GitHub, GitLab, etc.). Does NOT affect Kubernetes API server connectivity — use --proxy-url (kubectl flag) for that.
       --scm-root-ca-path string                 Provide Root CA Path for self-signed TLS Certificates

--- a/docs/operator-manual/server-commands/argocd-dex_gendexcfg.md
+++ b/docs/operator-manual/server-commands/argocd-dex_gendexcfg.md
@@ -30,7 +30,6 @@ argocd-dex gendexcfg [flags]
   -o, --out string                     Output to the specified file instead of stdout
       --password string                Password for basic authentication to the API server
       --proxy-url string               If provided, this URL will be used to connect via proxy
-      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                  The address and port of the Kubernetes API server
       --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server

--- a/docs/operator-manual/server-commands/argocd-dex_rundex.md
+++ b/docs/operator-manual/server-commands/argocd-dex_rundex.md
@@ -29,7 +29,6 @@ argocd-dex rundex [flags]
   -n, --namespace string               If present, the namespace scope for this CLI request
       --password string                Password for basic authentication to the API server
       --proxy-url string               If provided, this URL will be used to connect via proxy
-      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                  The address and port of the Kubernetes API server
       --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server

--- a/docs/operator-manual/server-commands/argocd-server.md
+++ b/docs/operator-manual/server-commands/argocd-server.md
@@ -99,7 +99,6 @@ argocd-server [flags]
       --repo-server-sentinelmaster string               Redis sentinel master group name. (default "master")
       --repo-server-strict-tls                          Perform strict validation of TLS certificates when connecting to repo server
       --repo-server-timeout-seconds int                 Repo server RPC call timeout seconds. (default 60)
-      --request-timeout string                          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --revision-cache-expiration duration              Cache expiration for cached revision (default 3m0s)
       --revision-cache-lock-timeout duration            Cache TTL for locks to prevent duplicate requests on revisions, set to 0 to disable (default 10s)
       --rootpath string                                 Used if Argo CD is running behind reverse proxy under subpath different from /

--- a/docs/operator-manual/server-commands/argocd-server_version.md
+++ b/docs/operator-manual/server-commands/argocd-server_version.md
@@ -32,7 +32,6 @@ argocd-server version [flags]
   -n, --namespace string               If present, the namespace scope for this CLI request
       --password string                Password for basic authentication to the API server
       --proxy-url string               If provided, this URL will be used to connect via proxy
-      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                  The address and port of the Kubernetes API server
       --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server

--- a/docs/user-guide/commands/argocd_account.md
+++ b/docs/user-guide/commands/argocd_account.md
@@ -35,7 +35,6 @@ argocd account [flags]
   -n, --namespace string           If present, the namespace scope for this CLI request
       --password string            Password for basic authentication to the API server
       --proxy-url string           If provided, this URL will be used to connect via proxy
-      --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --token string               Bearer token for authentication to the API server
       --user string                The name of the kubeconfig user to use
       --username string            Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_app_get-reconcile-results.md
+++ b/docs/user-guide/commands/argocd_admin_app_get-reconcile-results.md
@@ -31,7 +31,6 @@ argocd admin app get-reconcile-results PATH [flags]
       --proxy-url string                                  If provided, this URL will be used to connect via proxy
       --refresh                                           If set to true then recalculates apps reconciliation
       --repo-server string                                Repo server address.
-      --request-timeout string                            The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                                     The address and port of the Kubernetes API server
       --server-side-diff                                  If set to "true" will use server-side diff while comparing resources. Default ("false")
       --tls-server-name string                            If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.

--- a/docs/user-guide/commands/argocd_admin_cluster_kubeconfig.md
+++ b/docs/user-guide/commands/argocd_admin_cluster_kubeconfig.md
@@ -43,7 +43,6 @@ argocd admin cluster kubeconfig https://cluster-api-url:6443 /path/to/output/kub
   -n, --namespace string               If present, the namespace scope for this CLI request
       --password string                Password for basic authentication to the API server
       --proxy-url string               If provided, this URL will be used to connect via proxy
-      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                  The address and port of the Kubernetes API server
       --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_cluster_namespaces.md
+++ b/docs/user-guide/commands/argocd_admin_cluster_namespaces.md
@@ -26,7 +26,6 @@ argocd admin cluster namespaces [flags]
   -n, --namespace string               If present, the namespace scope for this CLI request
       --password string                Password for basic authentication to the API server
       --proxy-url string               If provided, this URL will be used to connect via proxy
-      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                  The address and port of the Kubernetes API server
       --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_cluster_namespaces_disable-namespaced-mode.md
+++ b/docs/user-guide/commands/argocd_admin_cluster_namespaces_disable-namespaced-mode.md
@@ -27,7 +27,6 @@ argocd admin cluster namespaces disable-namespaced-mode PATTERN [flags]
   -n, --namespace string               If present, the namespace scope for this CLI request
       --password string                Password for basic authentication to the API server
       --proxy-url string               If provided, this URL will be used to connect via proxy
-      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                  The address and port of the Kubernetes API server
       --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_cluster_namespaces_enable-namespaced-mode.md
+++ b/docs/user-guide/commands/argocd_admin_cluster_namespaces_enable-namespaced-mode.md
@@ -29,7 +29,6 @@ argocd admin cluster namespaces enable-namespaced-mode PATTERN [flags]
   -n, --namespace string               If present, the namespace scope for this CLI request
       --password string                Password for basic authentication to the API server
       --proxy-url string               If provided, this URL will be used to connect via proxy
-      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                  The address and port of the Kubernetes API server
       --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_cluster_shards.md
+++ b/docs/user-guide/commands/argocd_admin_cluster_shards.md
@@ -38,7 +38,6 @@ argocd admin cluster shards [flags]
       --redis-use-tls                         Use TLS when connecting to Redis. 
       --redisdb int                           Redis database.
       --replicas int                          Application controller replicas count. Inferred from number of running controller pods if not specified
-      --request-timeout string                The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --sentinel stringArray                  Redis sentinel hostname and port (e.g. argocd-redis-ha-announce-0:6379). 
       --sentinelmaster string                 Redis sentinel master group name. (default "master")
       --server string                         The address and port of the Kubernetes API server

--- a/docs/user-guide/commands/argocd_admin_cluster_stats.md
+++ b/docs/user-guide/commands/argocd_admin_cluster_stats.md
@@ -52,7 +52,6 @@ argocd admin cluster stats target-cluster
       --redis-use-tls                         Use TLS when connecting to Redis. 
       --redisdb int                           Redis database.
       --replicas int                          Application controller replicas count. Inferred from number of running controller pods if not specified
-      --request-timeout string                The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --sentinel stringArray                  Redis sentinel hostname and port (e.g. argocd-redis-ha-announce-0:6379). 
       --sentinelmaster string                 Redis sentinel master group name. (default "master")
       --server string                         The address and port of the Kubernetes API server

--- a/docs/user-guide/commands/argocd_admin_dashboard.md
+++ b/docs/user-guide/commands/argocd_admin_dashboard.md
@@ -42,7 +42,6 @@ $ argocd admin dashboard --redis-compress gzip
       --password string                Password for basic authentication to the API server
       --port int                       Listen on given port (default 8080)
       --proxy-url string               If provided, this URL will be used to connect via proxy
-      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                  The address and port of the Kubernetes API server
       --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_export.md
+++ b/docs/user-guide/commands/argocd_admin_export.md
@@ -29,7 +29,6 @@ argocd admin export [flags]
   -o, --out string                          Output to the specified file instead of stdout (default "-")
       --password string                     Password for basic authentication to the API server
       --proxy-url string                    If provided, this URL will be used to connect via proxy
-      --request-timeout string              The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                       The address and port of the Kubernetes API server
       --tls-server-name string              If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                        Bearer token for authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_import.md
+++ b/docs/user-guide/commands/argocd_admin_import.md
@@ -33,7 +33,6 @@ argocd admin import SOURCE [flags]
       --prompts-enabled                     Force optional interactive prompts to be enabled or disabled, overriding local configuration. If not specified, the local configuration value will be used, which is false by default.
       --proxy-url string                    If provided, this URL will be used to connect via proxy
       --prune                               Prune secrets, applications and projects which do not appear in the backup
-      --request-timeout string              The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                       The address and port of the Kubernetes API server
       --skip-resources-with-label string    Skip importing resources based on the label e.g. '--skip-resources-with-label my-label/example.io=true'
       --stop-operation                      Stop any existing operations

--- a/docs/user-guide/commands/argocd_admin_initial-password.md
+++ b/docs/user-guide/commands/argocd_admin_initial-password.md
@@ -26,7 +26,6 @@ argocd admin initial-password [flags]
   -n, --namespace string               If present, the namespace scope for this CLI request
       --password string                Password for basic authentication to the API server
       --proxy-url string               If provided, this URL will be used to connect via proxy
-      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                  The address and port of the Kubernetes API server
       --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_proj_generate-allow-list.md
+++ b/docs/user-guide/commands/argocd_admin_proj_generate-allow-list.md
@@ -34,7 +34,6 @@ argocd admin proj generate-allow-list /path/to/clusterrole.yaml my-project
   -o, --out string                     Output to the specified file instead of stdout (default "-")
       --password string                Password for basic authentication to the API server
       --proxy-url string               If provided, this URL will be used to connect via proxy
-      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                  The address and port of the Kubernetes API server
       --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_proj_update-role-policy.md
+++ b/docs/user-guide/commands/argocd_admin_proj_update-role-policy.md
@@ -39,7 +39,6 @@ argocd admin proj update-role-policy PROJECT_GLOB MODIFICATION ACTION [flags]
       --password string                Password for basic authentication to the API server
       --permission string              Action permission
       --proxy-url string               If provided, this URL will be used to connect via proxy
-      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --resource string                Resource e.g. 'applications'
       --role string                    Role name pattern e.g. '*deployer*' (default "*")
       --scope string                   Resource scope e.g. '*'

--- a/docs/user-guide/commands/argocd_admin_redis-initial-password.md
+++ b/docs/user-guide/commands/argocd_admin_redis-initial-password.md
@@ -26,7 +26,6 @@ argocd admin redis-initial-password [flags]
   -n, --namespace string               If present, the namespace scope for this CLI request
       --password string                Password for basic authentication to the API server
       --proxy-url string               If provided, this URL will be used to connect via proxy
-      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                  The address and port of the Kubernetes API server
       --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_settings.md
+++ b/docs/user-guide/commands/argocd_admin_settings.md
@@ -29,7 +29,6 @@ argocd admin settings [flags]
   -n, --namespace string               If present, the namespace scope for this CLI request
       --password string                Password for basic authentication to the API server
       --proxy-url string               If provided, this URL will be used to connect via proxy
-      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                  The address and port of the Kubernetes API server
       --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_settings_rbac.md
+++ b/docs/user-guide/commands/argocd_admin_settings_rbac.md
@@ -57,7 +57,6 @@ argocd admin settings rbac [flags]
       --redis-haproxy-name string       Name of the Redis HA Proxy; set this or the ARGOCD_REDIS_HAPROXY_NAME environment variable when the HA Proxy's name label differs from the default, for example when installing via the Helm chart (default "argocd-redis-ha-haproxy")
       --redis-name string               Name of the Redis deployment; set this or the ARGOCD_REDIS_NAME environment variable when the Redis's name label differs from the default, for example when installing via the Helm chart (default "argocd-redis")
       --repo-server-name string         Name of the Argo CD Repo server; set this or the ARGOCD_REPO_SERVER_NAME environment variable when the server's name label differs from the default, for example when installing via the Helm chart (default "argocd-repo-server")
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                   The address and port of the Kubernetes API server
       --server-crt string               Server certificate file
       --server-name string              Name of the Argo CD API server; set this or the ARGOCD_SERVER_NAME environment variable when the server's name label differs from the default, for example when installing via the Helm chart (default "argocd-server")

--- a/docs/user-guide/commands/argocd_admin_settings_rbac_can.md
+++ b/docs/user-guide/commands/argocd_admin_settings_rbac_can.md
@@ -59,7 +59,6 @@ argocd admin settings rbac can someuser create application 'default/app' --defau
       --policy-file string             path to the policy file to use
       --proxy-url string               If provided, this URL will be used to connect via proxy
   -q, --quiet                          quiet mode - do not print results to stdout
-      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                  The address and port of the Kubernetes API server
       --strict                         whether to perform strict check on action and resource names (default true)
       --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.

--- a/docs/user-guide/commands/argocd_admin_settings_rbac_validate.md
+++ b/docs/user-guide/commands/argocd_admin_settings_rbac_validate.md
@@ -53,7 +53,6 @@ argocd admin settings rbac validate --namespace argocd
       --password string                Password for basic authentication to the API server
       --policy-file string             path to the policy file to use
       --proxy-url string               If provided, this URL will be used to connect via proxy
-      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                  The address and port of the Kubernetes API server
       --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server

--- a/docs/user-guide/commands/argocd_admin_settings_resource-overrides.md
+++ b/docs/user-guide/commands/argocd_admin_settings_resource-overrides.md
@@ -57,7 +57,6 @@ argocd admin settings resource-overrides [flags]
       --redis-haproxy-name string       Name of the Redis HA Proxy; set this or the ARGOCD_REDIS_HAPROXY_NAME environment variable when the HA Proxy's name label differs from the default, for example when installing via the Helm chart (default "argocd-redis-ha-haproxy")
       --redis-name string               Name of the Redis deployment; set this or the ARGOCD_REDIS_NAME environment variable when the Redis's name label differs from the default, for example when installing via the Helm chart (default "argocd-redis")
       --repo-server-name string         Name of the Argo CD Repo server; set this or the ARGOCD_REPO_SERVER_NAME environment variable when the server's name label differs from the default, for example when installing via the Helm chart (default "argocd-repo-server")
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                   The address and port of the Kubernetes API server
       --server-crt string               Server certificate file
       --server-name string              Name of the Argo CD API server; set this or the ARGOCD_SERVER_NAME environment variable when the server's name label differs from the default, for example when installing via the Helm chart (default "argocd-server")

--- a/docs/user-guide/commands/argocd_admin_settings_resource-overrides_health.md
+++ b/docs/user-guide/commands/argocd_admin_settings_resource-overrides_health.md
@@ -68,7 +68,6 @@ argocd admin settings resource-overrides health ./deploy.yaml --argocd-cm-path .
       --redis-haproxy-name string       Name of the Redis HA Proxy; set this or the ARGOCD_REDIS_HAPROXY_NAME environment variable when the HA Proxy's name label differs from the default, for example when installing via the Helm chart (default "argocd-redis-ha-haproxy")
       --redis-name string               Name of the Redis deployment; set this or the ARGOCD_REDIS_NAME environment variable when the Redis's name label differs from the default, for example when installing via the Helm chart (default "argocd-redis")
       --repo-server-name string         Name of the Argo CD Repo server; set this or the ARGOCD_REPO_SERVER_NAME environment variable when the server's name label differs from the default, for example when installing via the Helm chart (default "argocd-repo-server")
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                   The address and port of the Kubernetes API server
       --server-crt string               Server certificate file
       --server-name string              Name of the Argo CD API server; set this or the ARGOCD_SERVER_NAME environment variable when the server's name label differs from the default, for example when installing via the Helm chart (default "argocd-server")

--- a/docs/user-guide/commands/argocd_admin_settings_resource-overrides_ignore-differences.md
+++ b/docs/user-guide/commands/argocd_admin_settings_resource-overrides_ignore-differences.md
@@ -68,7 +68,6 @@ argocd admin settings resource-overrides ignore-differences ./deploy.yaml --argo
       --redis-haproxy-name string       Name of the Redis HA Proxy; set this or the ARGOCD_REDIS_HAPROXY_NAME environment variable when the HA Proxy's name label differs from the default, for example when installing via the Helm chart (default "argocd-redis-ha-haproxy")
       --redis-name string               Name of the Redis deployment; set this or the ARGOCD_REDIS_NAME environment variable when the Redis's name label differs from the default, for example when installing via the Helm chart (default "argocd-redis")
       --repo-server-name string         Name of the Argo CD Repo server; set this or the ARGOCD_REPO_SERVER_NAME environment variable when the server's name label differs from the default, for example when installing via the Helm chart (default "argocd-repo-server")
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                   The address and port of the Kubernetes API server
       --server-crt string               Server certificate file
       --server-name string              Name of the Argo CD API server; set this or the ARGOCD_SERVER_NAME environment variable when the server's name label differs from the default, for example when installing via the Helm chart (default "argocd-server")

--- a/docs/user-guide/commands/argocd_admin_settings_resource-overrides_ignore-resource-updates.md
+++ b/docs/user-guide/commands/argocd_admin_settings_resource-overrides_ignore-resource-updates.md
@@ -69,7 +69,6 @@ argocd admin settings resource-overrides ignore-resource-updates ./deploy.yaml -
       --redis-haproxy-name string       Name of the Redis HA Proxy; set this or the ARGOCD_REDIS_HAPROXY_NAME environment variable when the HA Proxy's name label differs from the default, for example when installing via the Helm chart (default "argocd-redis-ha-haproxy")
       --redis-name string               Name of the Redis deployment; set this or the ARGOCD_REDIS_NAME environment variable when the Redis's name label differs from the default, for example when installing via the Helm chart (default "argocd-redis")
       --repo-server-name string         Name of the Argo CD Repo server; set this or the ARGOCD_REPO_SERVER_NAME environment variable when the server's name label differs from the default, for example when installing via the Helm chart (default "argocd-repo-server")
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                   The address and port of the Kubernetes API server
       --server-crt string               Server certificate file
       --server-name string              Name of the Argo CD API server; set this or the ARGOCD_SERVER_NAME environment variable when the server's name label differs from the default, for example when installing via the Helm chart (default "argocd-server")

--- a/docs/user-guide/commands/argocd_admin_settings_resource-overrides_list-actions.md
+++ b/docs/user-guide/commands/argocd_admin_settings_resource-overrides_list-actions.md
@@ -68,7 +68,6 @@ argocd admin settings resource-overrides action list /tmp/deploy.yaml --argocd-c
       --redis-haproxy-name string       Name of the Redis HA Proxy; set this or the ARGOCD_REDIS_HAPROXY_NAME environment variable when the HA Proxy's name label differs from the default, for example when installing via the Helm chart (default "argocd-redis-ha-haproxy")
       --redis-name string               Name of the Redis deployment; set this or the ARGOCD_REDIS_NAME environment variable when the Redis's name label differs from the default, for example when installing via the Helm chart (default "argocd-redis")
       --repo-server-name string         Name of the Argo CD Repo server; set this or the ARGOCD_REPO_SERVER_NAME environment variable when the server's name label differs from the default, for example when installing via the Helm chart (default "argocd-repo-server")
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                   The address and port of the Kubernetes API server
       --server-crt string               Server certificate file
       --server-name string              Name of the Argo CD API server; set this or the ARGOCD_SERVER_NAME environment variable when the server's name label differs from the default, for example when installing via the Helm chart (default "argocd-server")

--- a/docs/user-guide/commands/argocd_admin_settings_resource-overrides_run-action.md
+++ b/docs/user-guide/commands/argocd_admin_settings_resource-overrides_run-action.md
@@ -69,7 +69,6 @@ argocd admin settings resource-overrides action /tmp/deploy.yaml restart --argoc
       --redis-haproxy-name string       Name of the Redis HA Proxy; set this or the ARGOCD_REDIS_HAPROXY_NAME environment variable when the HA Proxy's name label differs from the default, for example when installing via the Helm chart (default "argocd-redis-ha-haproxy")
       --redis-name string               Name of the Redis deployment; set this or the ARGOCD_REDIS_NAME environment variable when the Redis's name label differs from the default, for example when installing via the Helm chart (default "argocd-redis")
       --repo-server-name string         Name of the Argo CD Repo server; set this or the ARGOCD_REPO_SERVER_NAME environment variable when the server's name label differs from the default, for example when installing via the Helm chart (default "argocd-repo-server")
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                   The address and port of the Kubernetes API server
       --server-crt string               Server certificate file
       --server-name string              Name of the Argo CD API server; set this or the ARGOCD_SERVER_NAME environment variable when the server's name label differs from the default, for example when installing via the Helm chart (default "argocd-server")

--- a/docs/user-guide/commands/argocd_admin_settings_validate.md
+++ b/docs/user-guide/commands/argocd_admin_settings_validate.md
@@ -73,7 +73,6 @@ argocd admin settings validate --group accounts --group plugins --load-cluster-s
       --redis-haproxy-name string       Name of the Redis HA Proxy; set this or the ARGOCD_REDIS_HAPROXY_NAME environment variable when the HA Proxy's name label differs from the default, for example when installing via the Helm chart (default "argocd-redis-ha-haproxy")
       --redis-name string               Name of the Redis deployment; set this or the ARGOCD_REDIS_NAME environment variable when the Redis's name label differs from the default, for example when installing via the Helm chart (default "argocd-redis")
       --repo-server-name string         Name of the Argo CD Repo server; set this or the ARGOCD_REPO_SERVER_NAME environment variable when the server's name label differs from the default, for example when installing via the Helm chart (default "argocd-repo-server")
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                   The address and port of the Kubernetes API server
       --server-crt string               Server certificate file
       --server-name string              Name of the Argo CD API server; set this or the ARGOCD_SERVER_NAME environment variable when the server's name label differs from the default, for example when installing via the Helm chart (default "argocd-server")

--- a/docs/user-guide/commands/argocd_app.md
+++ b/docs/user-guide/commands/argocd_app.md
@@ -32,7 +32,6 @@ argocd app [flags]
   -n, --namespace string           If present, the namespace scope for this CLI request
       --password string            Password for basic authentication to the API server
       --proxy-url string           If provided, this URL will be used to connect via proxy
-      --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --token string               Bearer token for authentication to the API server
       --user string                The name of the kubeconfig user to use
       --username string            Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_appset.md
+++ b/docs/user-guide/commands/argocd_appset.md
@@ -39,7 +39,6 @@ argocd appset [flags]
   -n, --namespace string           If present, the namespace scope for this CLI request
       --password string            Password for basic authentication to the API server
       --proxy-url string           If provided, this URL will be used to connect via proxy
-      --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --token string               Bearer token for authentication to the API server
       --user string                The name of the kubeconfig user to use
       --username string            Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_cert.md
+++ b/docs/user-guide/commands/argocd_cert.md
@@ -42,7 +42,6 @@ argocd cert [flags]
   -n, --namespace string           If present, the namespace scope for this CLI request
       --password string            Password for basic authentication to the API server
       --proxy-url string           If provided, this URL will be used to connect via proxy
-      --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --token string               Bearer token for authentication to the API server
       --user string                The name of the kubeconfig user to use
       --username string            Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_cluster.md
+++ b/docs/user-guide/commands/argocd_cluster.md
@@ -39,7 +39,6 @@ argocd cluster [flags]
   -n, --namespace string           If present, the namespace scope for this CLI request
       --password string            Password for basic authentication to the API server
       --proxy-url string           If provided, this URL will be used to connect via proxy
-      --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --token string               Bearer token for authentication to the API server
       --user string                The name of the kubeconfig user to use
       --username string            Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_configure.md
+++ b/docs/user-guide/commands/argocd_configure.md
@@ -31,7 +31,6 @@ argocd configure --prompts-enabled=false
       --password string            Password for basic authentication to the API server
       --prompts-enabled            Enable (or disable) optional interactive prompts
       --proxy-url string           If provided, this URL will be used to connect via proxy
-      --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --token string               Bearer token for authentication to the API server
       --user string                The name of the kubeconfig user to use
       --username string            Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_gpg.md
+++ b/docs/user-guide/commands/argocd_gpg.md
@@ -19,7 +19,6 @@ argocd gpg [flags]
   -n, --namespace string           If present, the namespace scope for this CLI request
       --password string            Password for basic authentication to the API server
       --proxy-url string           If provided, this URL will be used to connect via proxy
-      --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --token string               Bearer token for authentication to the API server
       --user string                The name of the kubeconfig user to use
       --username string            Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_proj.md
+++ b/docs/user-guide/commands/argocd_proj.md
@@ -35,7 +35,6 @@ argocd proj [flags]
   -n, --namespace string           If present, the namespace scope for this CLI request
       --password string            Password for basic authentication to the API server
       --proxy-url string           If provided, this URL will be used to connect via proxy
-      --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --token string               Bearer token for authentication to the API server
       --user string                The name of the kubeconfig user to use
       --username string            Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_repo.md
+++ b/docs/user-guide/commands/argocd_repo.md
@@ -37,7 +37,6 @@ argocd repo rm https://github.com/yourusername/your-repo.git
   -n, --namespace string           If present, the namespace scope for this CLI request
       --password string            Password for basic authentication to the API server
       --proxy-url string           If provided, this URL will be used to connect via proxy
-      --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --token string               Bearer token for authentication to the API server
       --user string                The name of the kubeconfig user to use
       --username string            Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_repocreds.md
+++ b/docs/user-guide/commands/argocd_repocreds.md
@@ -32,7 +32,6 @@ argocd repocreds [flags]
   -n, --namespace string           If present, the namespace scope for this CLI request
       --password string            Password for basic authentication to the API server
       --proxy-url string           If provided, this URL will be used to connect via proxy
-      --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --token string               Bearer token for authentication to the API server
       --user string                The name of the kubeconfig user to use
       --username string            Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_version.md
+++ b/docs/user-guide/commands/argocd_version.md
@@ -38,7 +38,6 @@ argocd version [flags]
   -o, --output string              Output format. One of: json|yaml|wide|short (default "wide")
       --password string            Password for basic authentication to the API server
       --proxy-url string           If provided, this URL will be used to connect via proxy
-      --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --short                      print just the version number
       --token string               Bearer token for authentication to the API server
       --user string                The name of the kubeconfig user to use

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,28 +79,28 @@ nav:
     - operator-manual/notifications/troubleshooting-errors.md
     - operator-manual/notifications/examples.md
     - Notification Services:
-      - operator-manual/notifications/services/alertmanager.md
-      - operator-manual/notifications/services/awssqs.md
-      - operator-manual/notifications/services/email.md
-      - operator-manual/notifications/services/gcppubsub.md
-      - operator-manual/notifications/services/github.md
-      - operator-manual/notifications/services/googlechat.md
-      - operator-manual/notifications/services/grafana.md
-      - operator-manual/notifications/services/mattermost.md
-      - operator-manual/notifications/services/nats.md
-      - operator-manual/notifications/services/newrelic.md
-      - operator-manual/notifications/services/opsgenie.md
-      - operator-manual/notifications/services/overview.md
-      - operator-manual/notifications/services/pagerduty.md
-      - operator-manual/notifications/services/pagerduty_v2.md
-      - operator-manual/notifications/services/pushover.md
-      - operator-manual/notifications/services/rocketchat.md
-      - operator-manual/notifications/services/slack.md
-      - operator-manual/notifications/services/teams-workflows.md
-      - operator-manual/notifications/services/teams.md
-      - operator-manual/notifications/services/telegram.md
-      - operator-manual/notifications/services/webex.md
-      - operator-manual/notifications/services/webhook.md
+      - docs\operator-manual\notifications\services\alertmanager.md
+      - docs\operator-manual\notifications\services\awssqs.md
+      - docs\operator-manual\notifications\services\email.md
+      - docs\operator-manual\notifications\services\gcppubsub.md
+      - docs\operator-manual\notifications\services\github.md
+      - docs\operator-manual\notifications\services\googlechat.md
+      - docs\operator-manual\notifications\services\grafana.md
+      - docs\operator-manual\notifications\services\mattermost.md
+      - docs\operator-manual\notifications\services\nats.md
+      - docs\operator-manual\notifications\services\newrelic.md
+      - docs\operator-manual\notifications\services\opsgenie.md
+      - docs\operator-manual\notifications\services\overview.md
+      - docs\operator-manual\notifications\services\pagerduty.md
+      - docs\operator-manual\notifications\services\pagerduty_v2.md
+      - docs\operator-manual\notifications\services\pushover.md
+      - docs\operator-manual\notifications\services\rocketchat.md
+      - docs\operator-manual\notifications\services\slack.md
+      - docs\operator-manual\notifications\services\teams-workflows.md
+      - docs\operator-manual\notifications\services\teams.md
+      - docs\operator-manual\notifications\services\telegram.md
+      - docs\operator-manual\notifications\services\webex.md
+      - docs\operator-manual\notifications\services\webhook.md
   - operator-manual/troubleshooting.md
   - ApplicationSet:
     - Introduction: operator-manual/applicationset/index.md

--- a/util/cli/cli.go
+++ b/util/cli/cli.go
@@ -78,6 +78,7 @@ func AddKubectlFlagsToSet(flags *pflag.FlagSet) clientcmd.ClientConfig {
 	kflags := clientcmd.RecommendedConfigOverrideFlags("")
 	flags.StringVar(&loadingRules.ExplicitPath, "kubeconfig", "", "Path to a kube config. Only required if out-of-cluster")
 	clientcmd.BindOverrideFlags(&overrides, flags, kflags)
+	_ = flags.MarkHidden("request-timeout")
 	return clientcmd.NewInteractiveDeferredLoadingClientConfig(loadingRules, &overrides, os.Stdin)
 }
 


### PR DESCRIPTION
Fixes #18198.

The \--request-timeout\ flag is injected by \cli-runtime\ but is not intended to configure the server timeout (and causes confusion in the docs since it's an inherited flag). This hides the flag from \rgocd\ commands so it is no longer auto-generated into the CLI documentation.