### PR TITLE
fix: strip OIDC groups from session cookie to prevent login failures for users assigned to a large number of groups

### DIFF
--- a/util/oidc/oidc.go
+++ b/util/oidc/oidc.go
@@ -605,7 +605,13 @@ func (a *ClientApp) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if idTokenRAW != "" {
-		err = httputil.SetTokenCookie(idTokenRAW, a.baseHRef, a.secureCookie, w)
+		compactToken, err := a.createCompactSessionToken(claims)
+		if err != nil {
+			claimsJSON, _ := json.Marshal(claims)
+			http.Error(w, fmt.Sprintf("failed to create session token: claims=%s, err=%v", claimsJSON, err), http.StatusInternalServerError)
+			return
+		}
+		err = httputil.SetTokenCookie(compactToken, a.baseHRef, a.secureCookie, w)
 		if err != nil {
 			claimsJSON, _ := json.Marshal(claims)
 			http.Error(w, fmt.Sprintf("claims=%s, err=%v", claimsJSON, err), http.StatusInternalServerError)
@@ -708,6 +714,17 @@ func (a *ClientApp) CheckAndRefreshToken(ctx context.Context, groupClaims jwt.Ma
 				err = errors.New("empty id_token")
 				span.SetStatus(codes.Error, err.Error())
 				return "", err
+			}
+			// Compact OIDC sessions must stay compact after refresh so the cookie remains small.
+			if _, isCompact := groupClaims["federated_claims"]; isCompact && iss == "argocd" {
+				parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+				var newClaims jwt.MapClaims
+				if _, _, parseErr := parser.ParseUnverified(idTokenRAW, &newClaims); parseErr != nil {
+					err = fmt.Errorf("failed to parse refreshed ID token: %w", parseErr)
+					span.SetStatus(codes.Error, err.Error())
+					return "", err
+				}
+				return a.createCompactSessionToken(newClaims)
 			}
 			return idTokenRAW, nil
 		}
@@ -898,7 +915,26 @@ func (a *ClientApp) SetGroupsFromUserInfo(ctx context.Context, claims jwt.Claims
 		}
 	}
 	iss := jwtutil.StringField(groupClaims, "iss")
-	if iss != sessionManagerClaimsIssuer && a.settings.UserInfoGroupsEnabled() && a.settings.UserInfoPath() != "" {
+
+	// Compact OIDC tokens carry federated_claims and iss=="argocd". Their groups were stripped
+	// from the cookie at login time; reconstruct them here from the Redis-cached OIDC token.
+	_, isCompactOIDCToken := groupClaims["federated_claims"]
+	isCompactOIDCToken = isCompactOIDCToken && iss == sessionManagerClaimsIssuer
+
+	if isCompactOIDCToken {
+		sub := jwtutil.StringField(groupClaims, "sub")
+		sid := jwtutil.StringField(groupClaims, "sid")
+		groups, err := a.getGroupsFromCachedOIDCToken(ctx, sub, sid)
+		if err != nil {
+			log.Warnf("Failed to retrieve groups from cached OIDC token (sub=%s): %v", sub, err)
+		} else if groups != nil {
+			groupClaims["groups"] = groups
+			return groupClaims, nil
+		}
+		// Cache miss — fall through to the UserInfo endpoint if configured.
+	}
+
+	if (iss != sessionManagerClaimsIssuer || isCompactOIDCToken) && a.settings.UserInfoGroupsEnabled() && a.settings.UserInfoPath() != "" {
 		userInfo, unauthorized, err := a.GetUserInfo(ctx, groupClaims, a.settings.IssuerURL(), a.settings.UserInfoBaseURL(), a.settings.UserInfoPath())
 		if unauthorized {
 			return groupClaims, fmt.Errorf("error while quering userinfo endpoint: %w", err)
@@ -1079,4 +1115,94 @@ func formatOidcTokenCacheKey(sub string, sid string) string {
 
 func (a *ClientApp) IssuerURL() string {
 	return a.issuerURL
+}
+
+// createCompactSessionToken creates a compact ArgoCD-signed JWT from OIDC claims. Group claims are
+// stripped to keep cookie size independent of group count. Groups are reconstructed at request time
+// from the Redis-cached OIDC token via SetGroupsFromUserInfo.
+//
+// The issuer is set to "argocd" (matching SessionManagerClaimsIssuer in util/session) so the token
+// is verified locally via HMAC rather than by calling the OIDC provider on every request.
+// The presence of federated_claims distinguishes these tokens from native ArgoCD account tokens.
+func (a *ClientApp) createCompactSessionToken(oidcClaims jwt.MapClaims) (string, error) {
+	now := time.Now().UTC()
+	compact := jwt.MapClaims{
+		// "argocd" matches session.SessionManagerClaimsIssuer — verified locally via HMAC.
+		"iss": "argocd",
+		"sub": jwtutil.StringField(oidcClaims, "sub"),
+		"exp": oidcClaims["exp"],
+		"iat": jwt.NewNumericDate(now),
+		"nbf": jwt.NewNumericDate(now),
+	}
+	if email := jwtutil.StringField(oidcClaims, "email"); email != "" {
+		compact["email"] = email
+	}
+	if name := jwtutil.StringField(oidcClaims, "name"); name != "" {
+		compact["name"] = name
+	}
+	if sid := jwtutil.StringField(oidcClaims, "sid"); sid != "" {
+		compact["sid"] = sid
+	}
+
+	// Carry federated_claims through to mark OIDC origin and preserve user identity for Dex
+	// connectors (federated_claims.user_id is what GetUserIdentifier returns for Dex tokens).
+	originalIss := jwtutil.StringField(oidcClaims, "iss")
+	if fc, ok := oidcClaims["federated_claims"].(map[string]any); ok {
+		merged := make(map[string]any, len(fc)+1)
+		for k, v := range fc {
+			merged[k] = v
+		}
+		if _, hasConnectorID := merged["connector_id"]; !hasConnectorID {
+			merged["connector_id"] = originalIss
+		}
+		compact["federated_claims"] = merged
+	} else {
+		compact["federated_claims"] = map[string]any{"connector_id": originalIss}
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, compact)
+	return token.SignedString(a.settings.ServerSignature)
+}
+
+// getGroupsFromCachedOIDCToken retrieves the groups claim from the OIDC token that was cached
+// in Redis at login time. Returns nil (no error) on a cache miss so callers can fall through to
+// an alternative source (e.g. the UserInfo endpoint).
+func (a *ClientApp) getGroupsFromCachedOIDCToken(ctx context.Context, sub, sid string) ([]any, error) {
+	cacheJSON, err := a.GetValueFromEncryptedCache(ctx, formatOidcTokenCacheKey(sub, sid))
+	if err != nil {
+		return nil, fmt.Errorf("read cached OIDC token: %w", err)
+	}
+	if cacheJSON == nil {
+		return nil, nil // cache miss — caller should fall through
+	}
+
+	oidcCache, err := GetOidcTokenCacheFromJSON(cacheJSON)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal cached OIDC token: %w", err)
+	}
+	if oidcCache.TokenExtraIdToken == "" {
+		return nil, nil
+	}
+
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	var idTokenClaims jwt.MapClaims
+	if _, _, err = parser.ParseUnverified(oidcCache.TokenExtraIdToken, &idTokenClaims); err != nil {
+		return nil, fmt.Errorf("parse cached ID token: %w", err)
+	}
+
+	raw, ok := idTokenClaims["groups"]
+	if !ok {
+		return nil, nil
+	}
+	switch v := raw.(type) {
+	case []any:
+		return v, nil
+	case []string:
+		out := make([]any, len(v))
+		for i, s := range v {
+			out[i] = s
+		}
+		return out, nil
+	}
+	return nil, nil
 }

--- a/util/oidc/oidc.go
+++ b/util/oidc/oidc.go
@@ -9,6 +9,7 @@ import (
 	"html"
 	"html/template"
 	"io"
+	"maps"
 	"net"
 	"net/http"
 	"net/url"
@@ -1149,9 +1150,7 @@ func (a *ClientApp) createCompactSessionToken(oidcClaims jwt.MapClaims) (string,
 	originalIss := jwtutil.StringField(oidcClaims, "iss")
 	if fc, ok := oidcClaims["federated_claims"].(map[string]any); ok {
 		merged := make(map[string]any, len(fc)+1)
-		for k, v := range fc {
-			merged[k] = v
-		}
+		maps.Copy(merged, fc)
 		if _, hasConnectorID := merged["connector_id"]; !hasConnectorID {
 			merged["connector_id"] = originalIss
 		}

--- a/util/oidc/oidc_test.go
+++ b/util/oidc/oidc_test.go
@@ -1678,6 +1678,338 @@ requestedScopes: ["oidc"]`, oidcTestServer.URL, tt.refreshTokenThreshold),
 	}
 }
 
+func makeTestClientApp(t *testing.T, signature []byte) *ClientApp {
+	t.Helper()
+	sig := signature
+	if sig == nil {
+		var err error
+		sig, err = util.MakeSignature(32)
+		require.NoError(t, err)
+	}
+	cdSettings := &settings.ArgoCDSettings{
+		ServerSignature: sig,
+		OIDCConfigRAW: `
+issuer: http://localhost:9999
+clientID: test-client
+clientSecret: test-secret`,
+	}
+	a, err := NewClientApp(cdSettings, "", nil, "/", cache.NewInMemoryCache(24*time.Hour))
+	require.NoError(t, err)
+	return a
+}
+
+func TestCreateCompactSessionToken(t *testing.T) {
+	sig, err := util.MakeSignature(32)
+	require.NoError(t, err)
+	a := makeTestClientApp(t, sig)
+
+	t.Run("compact token contains essential claims", func(t *testing.T) {
+		oidcClaims := jwt.MapClaims{
+			"iss":   "https://idp.example.com",
+			"sub":   "user123",
+			"email": "user@example.com",
+			"name":  "Test User",
+			"sid":   "session-abc",
+			"exp":   float64(time.Now().Add(time.Hour).Unix()),
+			"groups": []string{
+				"group1", "group2", "group3",
+			},
+		}
+
+		compactToken, err := a.createCompactSessionToken(oidcClaims)
+		require.NoError(t, err)
+		assert.NotEmpty(t, compactToken)
+
+		// Parse without verification to inspect claims
+		parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+		var got jwt.MapClaims
+		_, _, err = parser.ParseUnverified(compactToken, &got)
+		require.NoError(t, err)
+
+		assert.Equal(t, "argocd", got["iss"])
+		assert.Equal(t, "user123", got["sub"])
+		assert.Equal(t, "user@example.com", got["email"])
+		assert.Equal(t, "Test User", got["name"])
+		assert.Equal(t, "session-abc", got["sid"])
+		assert.Nil(t, got["groups"], "groups must be stripped from compact token")
+
+		fc, ok := got["federated_claims"].(map[string]any)
+		require.True(t, ok, "federated_claims must be present")
+		assert.Equal(t, "https://idp.example.com", fc["connector_id"])
+	})
+
+	t.Run("compact token is smaller than original when many groups", func(t *testing.T) {
+		groups := make([]string, 200)
+		for i := range groups {
+			groups[i] = fmt.Sprintf("group-with-a-somewhat-long-name-%d", i)
+		}
+		oidcClaims := jwt.MapClaims{
+			"iss":    "https://idp.example.com",
+			"sub":    "user123",
+			"email":  "user@example.com",
+			"exp":    float64(time.Now().Add(time.Hour).Unix()),
+			"groups": groups,
+		}
+
+		// Simulate what the raw OIDC token would look like (just approximate via claims JSON)
+		rawClaimsJSON, err := json.Marshal(oidcClaims)
+		require.NoError(t, err)
+
+		compactToken, err := a.createCompactSessionToken(oidcClaims)
+		require.NoError(t, err)
+
+		assert.Less(t, len(compactToken), len(rawClaimsJSON),
+			"compact token (%d bytes) should be smaller than raw claims (%d bytes)",
+			len(compactToken), len(rawClaimsJSON))
+	})
+
+	t.Run("existing federated_claims are preserved including user_id", func(t *testing.T) {
+		oidcClaims := jwt.MapClaims{
+			"iss": "https://dex.example.com",
+			"sub": "Cgd1c2VyMTIzEgZnaXRodWI",
+			"exp": float64(time.Now().Add(time.Hour).Unix()),
+			"federated_claims": map[string]any{
+				"connector_id": "github",
+				"user_id":      "user123",
+			},
+		}
+		compactToken, err := a.createCompactSessionToken(oidcClaims)
+		require.NoError(t, err)
+
+		parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+		var got jwt.MapClaims
+		_, _, err = parser.ParseUnverified(compactToken, &got)
+		require.NoError(t, err)
+
+		fc, ok := got["federated_claims"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "github", fc["connector_id"])
+		assert.Equal(t, "user123", fc["user_id"])
+	})
+
+	t.Run("compact token is verifiable with ArgoCD server signature", func(t *testing.T) {
+		oidcClaims := jwt.MapClaims{
+			"iss": "https://idp.example.com",
+			"sub": "user123",
+			"exp": float64(time.Now().Add(time.Hour).Unix()),
+		}
+		compactToken, err := a.createCompactSessionToken(oidcClaims)
+		require.NoError(t, err)
+
+		var got jwt.MapClaims
+		parsed, err := jwt.ParseWithClaims(compactToken, &got, func(*jwt.Token) (any, error) {
+			return sig, nil
+		})
+		require.NoError(t, err)
+		assert.True(t, parsed.Valid)
+	})
+}
+
+func TestGetGroupsFromCachedOIDCToken(t *testing.T) {
+	sig, err := util.MakeSignature(32)
+	require.NoError(t, err)
+	a := makeTestClientApp(t, sig)
+
+	encKey, err := a.settings.GetServerEncryptionKey()
+	require.NoError(t, err)
+
+	cacheToken := func(sub, sid string, idTokenClaims jwt.MapClaims) {
+		t.Helper()
+		idTokenStr, err := jwt.NewWithClaims(jwt.SigningMethodHS256, idTokenClaims).SignedString(sig)
+		require.NoError(t, err)
+		oidcCache := NewOidcTokenCache("http://localhost/callback", (&oauth2.Token{}).WithExtra(map[string]any{"id_token": idTokenStr}))
+		raw, err := json.Marshal(oidcCache)
+		require.NoError(t, err)
+		enc, err := crypto.Encrypt(raw, encKey)
+		require.NoError(t, err)
+		err = a.clientCache.Set(&cache.Item{Key: formatOidcTokenCacheKey(sub, sid), Object: enc})
+		require.NoError(t, err)
+	}
+
+	t.Run("returns groups from cached OIDC token", func(t *testing.T) {
+		cacheToken("user1", "sess1", jwt.MapClaims{
+			"sub":    "user1",
+			"groups": []any{"admins", "developers"},
+			"exp":    float64(time.Now().Add(time.Hour).Unix()),
+		})
+		groups, err := a.getGroupsFromCachedOIDCToken(t.Context(), "user1", "sess1")
+		require.NoError(t, err)
+		assert.Equal(t, []any{"admins", "developers"}, groups)
+	})
+
+	t.Run("returns nil on cache miss", func(t *testing.T) {
+		groups, err := a.getGroupsFromCachedOIDCToken(t.Context(), "unknown", "unknown")
+		require.NoError(t, err)
+		assert.Nil(t, groups)
+	})
+
+	t.Run("returns nil when no groups in cached token", func(t *testing.T) {
+		cacheToken("user2", "sess2", jwt.MapClaims{
+			"sub": "user2",
+			"exp": float64(time.Now().Add(time.Hour).Unix()),
+		})
+		groups, err := a.getGroupsFromCachedOIDCToken(t.Context(), "user2", "sess2")
+		require.NoError(t, err)
+		assert.Nil(t, groups)
+	})
+}
+
+func TestSetGroupsFromUserInfo_CompactOIDCToken(t *testing.T) {
+	sig, err := util.MakeSignature(32)
+	require.NoError(t, err)
+
+	cdSettings := &settings.ArgoCDSettings{
+		ServerSignature: sig,
+		OIDCConfigRAW: `
+issuer: http://localhost:63231
+enableUserInfoGroups: true
+userInfoPath: /`,
+	}
+	a, err := NewClientApp(cdSettings, "", nil, "/", cache.NewInMemoryCache(24*time.Hour))
+	require.NoError(t, err)
+
+	encKey, err := cdSettings.GetServerEncryptionKey()
+	require.NoError(t, err)
+
+	// Cache the full OIDC token (with groups) to simulate what HandleCallback stores
+	cacheOIDCToken := func(sub, sid string, groups []any) {
+		t.Helper()
+		idTokenClaims := jwt.MapClaims{
+			"sub":    sub,
+			"groups": groups,
+			"exp":    float64(time.Now().Add(time.Hour).Unix()),
+		}
+		idTokenStr, err := jwt.NewWithClaims(jwt.SigningMethodHS256, idTokenClaims).SignedString(sig)
+		require.NoError(t, err)
+		oidcCache := NewOidcTokenCache("http://localhost/cb", (&oauth2.Token{}).WithExtra(map[string]any{"id_token": idTokenStr}))
+		raw, err := json.Marshal(oidcCache)
+		require.NoError(t, err)
+		enc, err := crypto.Encrypt(raw, encKey)
+		require.NoError(t, err)
+		err = a.clientCache.Set(&cache.Item{Key: formatOidcTokenCacheKey(sub, sid), Object: enc})
+		require.NoError(t, err)
+	}
+
+	t.Run("groups reconstructed from Redis cache for compact OIDC token", func(t *testing.T) {
+		cacheOIDCToken("user1", "sess1", []any{"eng", "admin"})
+
+		// Simulate what Parse() returns for a compact token
+		compactClaims := jwt.MapClaims{
+			"iss": "argocd",
+			"sub": "user1",
+			"sid": "sess1",
+			"federated_claims": map[string]any{
+				"connector_id": "https://idp.example.com",
+			},
+		}
+		got, err := a.SetGroupsFromUserInfo(t.Context(), compactClaims, "argocd")
+		require.NoError(t, err)
+		assert.Equal(t, []any{"eng", "admin"}, got["groups"])
+	})
+
+	t.Run("regular ArgoCD local-account token is not affected", func(t *testing.T) {
+		// Local account token has no federated_claims
+		localClaims := jwt.MapClaims{
+			"iss": "argocd",
+			"sub": "admin",
+		}
+		got, err := a.SetGroupsFromUserInfo(t.Context(), localClaims, "argocd")
+		require.NoError(t, err)
+		assert.Nil(t, got["groups"], "local account tokens must not have groups injected")
+	})
+
+	t.Run("cache miss falls through to UserInfo endpoint error", func(t *testing.T) {
+		compactClaims := jwt.MapClaims{
+			"iss": "argocd",
+			"sub": "missing-user",
+			"sid": "missing-sess",
+			"federated_claims": map[string]any{
+				"connector_id": "https://idp.example.com",
+			},
+		}
+		// No access token cached, so GetUserInfo will fail
+		_, err := a.SetGroupsFromUserInfo(t.Context(), compactClaims, "argocd")
+		// Expect an error from the UserInfo endpoint since we have no access token
+		require.Error(t, err)
+	})
+}
+
+func TestHandleCallback_CompactTokenInCookie(t *testing.T) {
+	// Build a large group list that would bust the 4 KB single-cookie limit if stored raw.
+	largeGroups := make([]string, 150)
+	for i := range largeGroups {
+		largeGroups[i] = fmt.Sprintf("team-%03d-engineering-department", i)
+	}
+
+	oidcTestServer := test.GetOIDCTestServerWithGroups(t, largeGroups)
+	t.Cleanup(oidcTestServer.Close)
+
+	sig, err := util.MakeSignature(32)
+	require.NoError(t, err)
+	cdSettings := &settings.ArgoCDSettings{
+		URL:             "https://argocd.example.com",
+		ServerSignature: sig,
+		OIDCConfigRAW: fmt.Sprintf(`
+name: Test
+issuer: %s
+clientID: test-client-id
+clientSecret: test-client-secret
+requestedScopes: ["oidc"]`, oidcTestServer.URL),
+		OIDCTLSInsecureSkipVerify: true,
+	}
+	app, err := NewClientApp(cdSettings, "", nil, "/", cache.NewInMemoryCache(24*time.Hour))
+	require.NoError(t, err)
+
+	// Drive the login → callback flow
+	w := httptest.NewRecorder()
+	loginReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://argocd.example.com/auth/login", http.NoBody)
+	app.HandleLogin(w, loginReq)
+
+	redirectURL, err := w.Result().Location()
+	require.NoError(t, err)
+	state := redirectURL.Query().Get("state")
+
+	callbackReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet,
+		fmt.Sprintf("https://argocd.example.com/auth/callback?state=%s&code=abc", state), http.NoBody)
+	for _, c := range w.Result().Cookies() {
+		callbackReq.AddCookie(c)
+	}
+
+	w = httptest.NewRecorder()
+	app.HandleCallback(w, callbackReq)
+	require.Equal(t, http.StatusSeeOther, w.Code, "callback must redirect: %s", w.Body.String())
+
+	// Find the argocd.token cookie
+	var tokenCookie string
+	for _, c := range w.Result().Cookies() {
+		if strings.HasPrefix(c.Name, common.AuthCookieName) {
+			tokenCookie = c.Value
+			break
+		}
+	}
+	require.NotEmpty(t, tokenCookie, "argocd.token cookie must be set")
+
+	// The cookie value should be a single cookie (no chunking prefix) or at most a few chunks —
+	// the key assertion is that it's an ArgoCD-signed token, not the raw OIDC ID token.
+	// We strip the chunk-count prefix if present.
+	rawToken := tokenCookie
+	if idx := strings.Index(tokenCookie, ":"); idx != -1 {
+		if _, convErr := fmt.Sscanf(tokenCookie[:idx], "%d", new(int)); convErr == nil {
+			rawToken = tokenCookie[idx+1:]
+		}
+	}
+
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	var claims jwt.MapClaims
+	_, _, err = parser.ParseUnverified(rawToken, &claims)
+	require.NoError(t, err)
+
+	assert.Equal(t, "argocd", claims["iss"], "compact token must be ArgoCD-signed")
+	assert.Nil(t, claims["groups"], "groups must not appear in the cookie token")
+	_, hasFC := claims["federated_claims"]
+	assert.True(t, hasFC, "federated_claims must be present to mark OIDC origin")
+}
+
 func TestClientApp_getRedirectURIForRequest(t *testing.T) {
 	tests := []struct {
 		name               string

--- a/util/oidc/oidc_test.go
+++ b/util/oidc/oidc_test.go
@@ -1993,9 +1993,9 @@ requestedScopes: ["oidc"]`, oidcTestServer.URL),
 	// the key assertion is that it's an ArgoCD-signed token, not the raw OIDC ID token.
 	// We strip the chunk-count prefix if present.
 	rawToken := tokenCookie
-	if idx := strings.Index(tokenCookie, ":"); idx != -1 {
-		if _, convErr := fmt.Sscanf(tokenCookie[:idx], "%d", new(int)); convErr == nil {
-			rawToken = tokenCookie[idx+1:]
+	if before, after, ok := strings.Cut(tokenCookie, ":"); ok {
+		if _, convErr := fmt.Sscanf(before, "%d", new(int)); convErr == nil {
+			rawToken = after
 		}
 	}
 

--- a/util/session/sessionmanager.go
+++ b/util/session/sessionmanager.go
@@ -250,6 +250,12 @@ func (mgr *SessionManager) Parse(tokenString string) (jwt.Claims, string, error)
 		return nil, "", err
 	}
 
+	// Compact OIDC tokens carry federated_claims and are signed by ArgoCD but belong to an
+	// external user identity. Skip the ArgoCD account checks that apply only to local accounts.
+	if _, hasFC := claims["federated_claims"]; hasFC {
+		return token.Claims, "", nil
+	}
+
 	issuedAt, err := jwtutil.IssuedAtTime(claims)
 	if err != nil {
 		return nil, "", err
@@ -655,6 +661,13 @@ func Username(ctx context.Context) string {
 	}
 	switch jwtutil.StringField(mapClaims, "iss") {
 	case SessionManagerClaimsIssuer:
+		// Compact OIDC tokens have federated_claims; use email-first to match the existing
+		// OIDC token behaviour so RBAC rules based on email continue to work unchanged.
+		if _, hasFC := mapClaims["federated_claims"]; hasFC {
+			if e := jwtutil.StringField(mapClaims, "email"); e != "" {
+				return e
+			}
+		}
 		return jwtutil.GetUserIdentifier(mapClaims)
 	default:
 		e := jwtutil.StringField(mapClaims, "email")

--- a/util/session/sessionmanager_test.go
+++ b/util/session/sessionmanager_test.go
@@ -520,6 +520,102 @@ func TestGetUserIdentifier(t *testing.T) {
 	assert.Equal(t, "foo", GetUserIdentifier(loggedInContextFederated))
 }
 
+// signCompactOIDCToken creates an ArgoCD-signed compact OIDC token for use in tests.
+func signCompactOIDCToken(t *testing.T, sig []byte, claims jwt.MapClaims) string {
+	t.Helper()
+	token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString(sig)
+	require.NoError(t, err)
+	return token
+}
+
+func TestParse_CompactOIDCToken(t *testing.T) {
+	const password = "password"
+	settingsMgr := settings.NewSettingsManager(t.Context(), getKubeClient(t, password, true), "argocd")
+	mgr := newSessionManager(settingsMgr, getProjLister(), NewUserStateStorage(nil))
+
+	argoSettings, err := settingsMgr.GetSettings()
+	require.NoError(t, err)
+	sig := argoSettings.ServerSignature
+
+	t.Run("compact OIDC token passes Parse without account lookup", func(t *testing.T) {
+		// The sub here is an opaque OIDC subject — not an ArgoCD account name.
+		// Without the federated_claims early-return, GetAccount would fail.
+		token := signCompactOIDCToken(t, sig, jwt.MapClaims{
+			"iss":   SessionManagerClaimsIssuer,
+			"sub":   "oidc-opaque-subject-12345",
+			"email": "alice@example.com",
+			"exp":   float64(time.Now().Add(time.Hour).Unix()),
+			"iat":   float64(time.Now().Unix()),
+			"federated_claims": map[string]any{
+				"connector_id": "https://idp.example.com",
+			},
+		})
+
+		claims, newToken, err := mgr.Parse(token)
+		require.NoError(t, err, "Parse must succeed for compact OIDC tokens")
+		assert.Empty(t, newToken)
+
+		mapClaims, err := jwtutil.MapClaims(claims)
+		require.NoError(t, err)
+		assert.Equal(t, "oidc-opaque-subject-12345", mapClaims["sub"])
+		assert.Equal(t, "alice@example.com", mapClaims["email"])
+	})
+
+	t.Run("local account token still enforces account checks", func(t *testing.T) {
+		// A local account token without federated_claims must still go through account validation.
+		token := signCompactOIDCToken(t, sig, jwt.MapClaims{
+			"iss": SessionManagerClaimsIssuer,
+			"sub": "nonexistent-local-account:login",
+			"exp": float64(time.Now().Add(time.Hour).Unix()),
+			"iat": float64(time.Now().Unix()),
+			"jti": "some-unique-id",
+		})
+
+		_, _, err := mgr.Parse(token)
+		require.Error(t, err, "Parse must fail for unknown local accounts")
+	})
+}
+
+func TestUsername_CompactOIDCToken(t *testing.T) {
+	//nolint:staticcheck
+	compactOIDCCtx := context.WithValue(context.Background(), "claims", &jwt.MapClaims{
+		"iss":   SessionManagerClaimsIssuer,
+		"sub":   "oidc-opaque-subject",
+		"email": "alice@example.com",
+		"federated_claims": map[string]any{
+			"connector_id": "https://idp.example.com",
+		},
+	})
+
+	//nolint:staticcheck
+	compactOIDCCtxDex := context.WithValue(context.Background(), "claims", &jwt.MapClaims{
+		"iss":   SessionManagerClaimsIssuer,
+		"sub":   "Cgd1c2VyMTIzEgZnaXRodWI",
+		"email": "dexuser@example.com",
+		"federated_claims": map[string]any{
+			"connector_id": "github",
+			"user_id":      "user123",
+		},
+	})
+
+	t.Run("email used as username for compact OIDC token", func(t *testing.T) {
+		assert.Equal(t, "alice@example.com", Username(compactOIDCCtx))
+	})
+
+	t.Run("email used as username for compact Dex token", func(t *testing.T) {
+		assert.Equal(t, "dexuser@example.com", Username(compactOIDCCtxDex))
+	})
+
+	t.Run("local account token unaffected (no federated_claims)", func(t *testing.T) {
+		//nolint:staticcheck
+		localCtx := context.WithValue(context.Background(), "claims", &jwt.MapClaims{
+			"iss": SessionManagerClaimsIssuer,
+			"sub": "admin",
+		})
+		assert.Equal(t, "admin", Username(localCtx))
+	})
+}
+
 func TestGroups(t *testing.T) {
 	assert.Empty(t, Groups(loggedOutContext, []string{"groups"}))
 	assert.Equal(t, []string{"baz"}, Groups(loggedInContext, []string{"groups"}))

--- a/util/test/testutil.go
+++ b/util/test/testutil.go
@@ -251,6 +251,78 @@ func GetAzureOIDCTestServer(t *testing.T, tokenRequestPreHandler func(r *http.Re
 	return ts
 }
 
+// GetOIDCTestServerWithGroups returns an OIDC test server whose /token endpoint issues ID tokens
+// that include the provided groups claim. Use this to simulate a user belonging to many groups.
+func GetOIDCTestServerWithGroups(t *testing.T, groups []string) *httptest.Server {
+	t.Helper()
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+	ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.RequestURI {
+		case "/.well-known/openid-configuration":
+			_, err := fmt.Fprintf(w, `
+{
+  "issuer": "%[1]s",
+  "authorization_endpoint": "%[1]s/auth",
+  "token_endpoint": "%[1]s/token",
+  "jwks_uri": "%[1]s/keys",
+  "userinfo_endpoint": "%[1]s/userinfo",
+  "grant_types_supported": ["authorization_code"],
+  "response_types_supported": ["code"],
+  "subject_types_supported": ["public"],
+  "id_token_signing_alg_values_supported": ["RS512"],
+  "scopes_supported": ["openid"],
+  "token_endpoint_auth_methods_supported": ["client_secret_basic", "client_secret_post"],
+  "claims_supported": ["sub", "aud", "exp", "groups"]
+}`, ts.URL)
+			require.NoError(t, err)
+		case "/token":
+			token, err := generateJWTTokenWithGroups(ts.URL, groups)
+			require.NoError(t, err)
+			response := TokenResponse{
+				AccessToken:  token,
+				TokenType:    "Bearer",
+				ExpiresIn:    3600,
+				IDToken:      token,
+				RefreshToken: token,
+			}
+			out, err := json.Marshal(response)
+			require.NoError(t, err)
+			_, err = w.Write(out)
+			require.NoError(t, err)
+		case "/keys":
+			pubKey, err := jwt.ParseRSAPublicKeyFromPEM(Cert)
+			require.NoError(t, err)
+			jwks := jose.JSONWebKeySet{Keys: []jose.JSONWebKey{{Key: pubKey}}}
+			out, err := json.Marshal(jwks)
+			require.NoError(t, err)
+			_, err = w.Write(out)
+			require.NoError(t, err)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	return ts
+}
+
+func generateJWTTokenWithGroups(issuer string, groups []string) (string, error) {
+	token := jwt.NewWithClaims(jwt.SigningMethodRS512, jwt.MapClaims{
+		"sub":    "1234567890",
+		"aud":    "test-client-id",
+		"name":   "John Doe",
+		"email":  "john.doe@example.com",
+		"iat":    time.Now().Unix(),
+		"iss":    issuer,
+		"exp":    time.Now().Add(time.Hour).Unix(),
+		"groups": groups,
+	})
+	key, err := jwt.ParseRSAPrivateKeyFromPEM(PrivateKey)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse RSA private key: %w", err)
+	}
+	return token.SignedString(key)
+}
+
 type TokenResponse struct {
 	AccessToken  string `json:"access_token"`
 	TokenType    string `json:"token_type"`


### PR DESCRIPTION
ArgoCD stores the session token in a browser cookie, which browsers limit to 4 KB. Users belonging to many OIDC/SAML groups can exceed this limit, causing login to fail silently.

Instead of storing the raw IDP-issued JWT (which includes all group claims), create a compact ArgoCD-signed token (HMAC-SHA256) at callback time that omits the groups claim. Group membership is reconstructed on each request from the encrypted OIDC token already cached in Redis under the session's (sub, sid) key.

Fixes #25414 

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
