### PR TITLE
fix: Disabling git submodules leads into a mess in reposerver repos when…

### DIFF
--- a/util/git/client.go
+++ b/util/git/client.go
@@ -694,14 +694,16 @@ func (m *nativeGitClient) Checkout(revision string, submoduleEnabled bool, clean
 			}
 		}
 	}
+	hasGitmodules := false
 	if _, err := os.Stat(m.root + "/.gitmodules"); !os.IsNotExist(err) {
+		hasGitmodules = true
 		if submoduleEnabled {
 			if err := m.Submodule(); err != nil {
 				return "", fmt.Errorf("failed to update submodules: %w", err)
 			}
 		}
 	}
-	if cleanState || submoduleEnabled {
+	if cleanState || submoduleEnabled || hasGitmodules {
 		// NOTE
 		// The double “f” in the arguments is not a typo: the first “f” tells
 		// `git clean` to delete untracked files and directories, and the second “f”

--- a/util/git/client_test.go
+++ b/util/git/client_test.go
@@ -448,6 +448,45 @@ func Test_nativeGitClient_Submodule(t *testing.T) {
 	assert.Equal(t, bar+"baz\n", string(result))
 }
 
+func Test_nativeGitClient_Checkout_SubmoduleDisabledStillCleansState(t *testing.T) {
+	ctx := t.Context()
+	tempDir := t.TempDir()
+
+	foo := filepath.Join(tempDir, "foo")
+	require.NoError(t, os.Mkdir(foo, 0o755))
+	require.NoError(t, runCmd(ctx, foo, "git", "init"))
+	require.NoError(t, runCmd(ctx, foo, "git", "commit", "-m", "Initial commit", "--allow-empty"))
+
+	bar := filepath.Join(tempDir, "bar")
+	require.NoError(t, os.Mkdir(bar, 0o755))
+	require.NoError(t, runCmd(ctx, bar, "git", "init"))
+	require.NoError(t, runCmd(ctx, bar, "git", "commit", "-m", "Initial commit", "--allow-empty"))
+
+	t.Setenv("GIT_ALLOW_PROTOCOL", "file")
+	require.NoError(t, runCmd(ctx, foo, "git", "submodule", "add", bar))
+	require.NoError(t, runCmd(ctx, foo, "git", "commit", "-m", "Add submodule"))
+
+	client, err := NewClient("file://"+foo, NopCreds{}, true, false, "", "")
+	require.NoError(t, err)
+	require.NoError(t, client.Init())
+	require.NoError(t, client.Fetch("", 0))
+
+	commitSHA, err := client.LsRemote("HEAD")
+	require.NoError(t, err)
+
+	_, err = client.Checkout(commitSHA, false, true)
+	require.NoError(t, err)
+
+	untrackedFile := filepath.Join(client.Root(), "stale.txt")
+	require.NoError(t, os.WriteFile(untrackedFile, []byte("stale"), 0o644))
+
+	_, err = client.Checkout(commitSHA, false, false)
+	require.NoError(t, err)
+
+	_, err = os.Stat(untrackedFile)
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
 func TestNewClient_invalidSSHURL(t *testing.T) {
 	client, err := NewClient("ssh://bitbucket.org:org/repo", NopCreds{}, false, false, "", "")
 	assert.Nil(t, client)


### PR DESCRIPTION
## Summary

## Root cause

Before the fix, the second checkout did not run `git clean -ffdx` when `submoduleEnabled=false` and `cleanState=false`. The untracked `stale.txt` remained in the repo working tree, demonstrating state leakage between operations. In real reposerver usage, this stale state can pollute later render operations and cause inconsistent or unknown application status outcomes.

## Steps to reproduce

1. From the repository root, run `go test ./util/git -run Test_nativeGitClient_Checkout_SubmoduleDisabledStillCleansState -count=1`.
2. The test creates a repository with a `.gitmodules` file, checks out a revision with submodules disabled, writes an untracked `stale.txt`, and checks out the same revision again with `cleanState=false`.
3. This mirrors reposerver reuse of a local clone across multiple revision operations when submodules are disabled.

## Fix

Files changed (2):

- `util/git/client.go`
- `util/git/client_test.go`

## Verification

Test file changed: `util/git/client_test.go`.

Fixes #27872
