### PR TITLE
fix: stop hydrator retry loop after recent failed hydration (#28051)

### DIFF
--- a/controller/hydrator/hydrator.go
+++ b/controller/hydrator/hydrator.go
@@ -580,7 +580,11 @@ func (h *Hydrator) appNeedsHydration(app *appv1.Application) (needsHydration boo
 		return true, "hard hydrate requested", ""
 	case !app.Spec.SourceHydrator.DeepEquals(app.Status.SourceHydrator.CurrentOperation.SourceHydrator):
 		return true, "spec.sourceHydrator differs", ""
-	case app.Status.SourceHydrator.CurrentOperation.Phase == appv1.HydrateOperationPhaseFailed && metav1.Now().Sub(app.Status.SourceHydrator.CurrentOperation.FinishedAt.Time) > 2*time.Minute:
+	case app.Status.SourceHydrator.CurrentOperation.Phase == appv1.HydrateOperationPhaseFailed:
+		if app.Status.SourceHydrator.CurrentOperation.FinishedAt == nil ||
+			metav1.Now().Sub(app.Status.SourceHydrator.CurrentOperation.FinishedAt.Time) <= 2*time.Minute {
+			return false, "previous hydrate operation failed", ""
+		}
 		return true, "previous hydrate operation failed more than 2 minutes ago", ""
 	}
 

--- a/controller/hydrator/hydrator.go
+++ b/controller/hydrator/hydrator.go
@@ -581,11 +581,22 @@ func (h *Hydrator) appNeedsHydration(app *appv1.Application) (needsHydration boo
 	case !app.Spec.SourceHydrator.DeepEquals(app.Status.SourceHydrator.CurrentOperation.SourceHydrator):
 		return true, "spec.sourceHydrator differs", ""
 	case app.Status.SourceHydrator.CurrentOperation.Phase == appv1.HydrateOperationPhaseFailed:
-		if app.Status.SourceHydrator.CurrentOperation.FinishedAt == nil ||
-			metav1.Now().Sub(app.Status.SourceHydrator.CurrentOperation.FinishedAt.Time) <= 2*time.Minute {
+		finishedAt := app.Status.SourceHydrator.CurrentOperation.FinishedAt
+		withinCooldown := finishedAt == nil || metav1.Now().Sub(finishedAt.Time) <= 2*time.Minute
+		switch {
+		case requested:
+			// Manual/API refresh or dry-source webhook explicitly asks to hydrate;
+			// retry now (hard requests are handled by the earlier case).
+			return true, "retrying previous failed hydration", ""
+		case !withinCooldown:
+			return true, "previous hydrate operation failed more than 2 minutes ago", ""
+		case app.Status.SourceHydrator.LastComparedDryRevision == "":
+			// No baseline to diff against; revision evaluation would always report
+			// "needs hydration", causing a tight retry loop. Wait out the cooldown.
 			return false, "previous hydrate operation failed", ""
 		}
-		return true, "previous hydrate operation failed more than 2 minutes ago", ""
+		// Within cooldown with a baseline: fall through to newRevisionHasChanges so a
+		// new dry commit retries immediately while an unchanged revision stays idle.
 	}
 
 	// Check for new revision changes

--- a/controller/hydrator/hydrator_test.go
+++ b/controller/hydrator/hydrator_test.go
@@ -148,7 +148,26 @@ func Test_appNeedsHydration(t *testing.T) {
 			expectedResolvedRev:    "",
 		},
 		{
-			name: "hydrate not needed",
+			name: "hydration failed within cooldown without last compared revision",
+			app: &v1alpha1.Application{
+				Spec: v1alpha1.ApplicationSpec{SourceHydrator: &v1alpha1.SourceHydrator{}},
+				Status: v1alpha1.ApplicationStatus{SourceHydrator: v1alpha1.SourceHydratorStatus{
+					CurrentOperation: &v1alpha1.HydrateOperation{
+						DrySHA:         "abc123",
+						StartedAt:      now,
+						FinishedAt:     &now,
+						Phase:          v1alpha1.HydrateOperationPhaseFailed,
+						Message:        "Failed to hydrate: commit server unavailable",
+						SourceHydrator: v1alpha1.SourceHydrator{},
+					},
+				}},
+			},
+			expectedNeedsHydration: false,
+			expectedMessage:        "previous hydrate operation failed",
+			expectedResolvedRev:    "",
+		},
+		{
+			name: "hydration failed within cooldown",
 			app: &v1alpha1.Application{
 				Spec: v1alpha1.ApplicationSpec{SourceHydrator: &v1alpha1.SourceHydrator{}},
 				Status: v1alpha1.ApplicationStatus{SourceHydrator: v1alpha1.SourceHydratorStatus{
@@ -162,15 +181,9 @@ func Test_appNeedsHydration(t *testing.T) {
 					LastComparedDryRevision: "abc123",
 				}},
 			},
-			setupMocks: func(d *mocks.Dependencies, app *v1alpha1.Application) {
-				proj := newTestProject()
-				d.EXPECT().GetProcessableAppProj(app).Return(proj, nil)
-				drySource := app.Spec.SourceHydrator.GetDrySource()
-				d.EXPECT().EvaluateAppRevisionsChanges(mock.Anything, app, drySource, drySource.TargetRevision, proj, false).Return(false, "abc123", nil)
-			},
 			expectedNeedsHydration: false,
-			expectedMessage:        "hydration not needed",
-			expectedResolvedRev:    "abc123",
+			expectedMessage:        "previous hydrate operation failed",
+			expectedResolvedRev:    "",
 		},
 		{
 			name: "new revision detected",

--- a/controller/hydrator/hydrator_test.go
+++ b/controller/hydrator/hydrator_test.go
@@ -148,16 +148,14 @@ func Test_appNeedsHydration(t *testing.T) {
 			expectedResolvedRev:    "",
 		},
 		{
-			name: "hydration failed within cooldown without last compared revision",
+			name: "failed within cooldown, empty baseline",
 			app: &v1alpha1.Application{
 				Spec: v1alpha1.ApplicationSpec{SourceHydrator: &v1alpha1.SourceHydrator{}},
 				Status: v1alpha1.ApplicationStatus{SourceHydrator: v1alpha1.SourceHydratorStatus{
 					CurrentOperation: &v1alpha1.HydrateOperation{
-						DrySHA:         "abc123",
 						StartedAt:      now,
 						FinishedAt:     &now,
 						Phase:          v1alpha1.HydrateOperationPhaseFailed,
-						Message:        "Failed to hydrate: commit server unavailable",
 						SourceHydrator: v1alpha1.SourceHydrator{},
 					},
 				}},
@@ -167,7 +165,41 @@ func Test_appNeedsHydration(t *testing.T) {
 			expectedResolvedRev:    "",
 		},
 		{
-			name: "hydration failed within cooldown",
+			name: "failed within cooldown, nil finishedAt, empty baseline",
+			app: &v1alpha1.Application{
+				Spec: v1alpha1.ApplicationSpec{SourceHydrator: &v1alpha1.SourceHydrator{}},
+				Status: v1alpha1.ApplicationStatus{SourceHydrator: v1alpha1.SourceHydratorStatus{
+					CurrentOperation: &v1alpha1.HydrateOperation{
+						StartedAt:      now,
+						Phase:          v1alpha1.HydrateOperationPhaseFailed,
+						SourceHydrator: v1alpha1.SourceHydrator{},
+					},
+				}},
+			},
+			expectedNeedsHydration: false,
+			expectedMessage:        "previous hydrate operation failed",
+			expectedResolvedRev:    "",
+		},
+		{
+			name: "failed within cooldown, normal hydrate requested",
+			app: &v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{v1alpha1.AnnotationKeyHydrate: "normal"}},
+				Spec:       v1alpha1.ApplicationSpec{SourceHydrator: &v1alpha1.SourceHydrator{}},
+				Status: v1alpha1.ApplicationStatus{SourceHydrator: v1alpha1.SourceHydratorStatus{
+					CurrentOperation: &v1alpha1.HydrateOperation{
+						StartedAt:      now,
+						FinishedAt:     &now,
+						Phase:          v1alpha1.HydrateOperationPhaseFailed,
+						SourceHydrator: v1alpha1.SourceHydrator{},
+					},
+				}},
+			},
+			expectedNeedsHydration: true,
+			expectedMessage:        "retrying previous failed hydration",
+			expectedResolvedRev:    "",
+		},
+		{
+			name: "failed within cooldown, dry baseline, new commit",
 			app: &v1alpha1.Application{
 				Spec: v1alpha1.ApplicationSpec{SourceHydrator: &v1alpha1.SourceHydrator{}},
 				Status: v1alpha1.ApplicationStatus{SourceHydrator: v1alpha1.SourceHydratorStatus{
@@ -181,9 +213,15 @@ func Test_appNeedsHydration(t *testing.T) {
 					LastComparedDryRevision: "abc123",
 				}},
 			},
-			expectedNeedsHydration: false,
-			expectedMessage:        "previous hydrate operation failed",
-			expectedResolvedRev:    "",
+			setupMocks: func(d *mocks.Dependencies, app *v1alpha1.Application) {
+				proj := newTestProject()
+				d.EXPECT().GetProcessableAppProj(app).Return(proj, nil)
+				drySource := app.Spec.SourceHydrator.GetDrySource()
+				d.EXPECT().EvaluateAppRevisionsChanges(mock.Anything, app, drySource, drySource.TargetRevision, proj, false).Return(true, "new-sha", nil)
+			},
+			expectedNeedsHydration: true,
+			expectedMessage:        "new revision may have changes",
+			expectedResolvedRev:    "new-sha",
 		},
 		{
 			name: "new revision detected",

--- a/docs/user-guide/source-hydrator.md
+++ b/docs/user-guide/source-hydrator.md
@@ -469,6 +469,27 @@ On each run, the hydrator:
 
 This improves efficiency and reduces commit noise in your repository.
 
+## Hydration failures and retries
+
+When hydration fails, the application remains in the `Failed` phase and the error message is kept on
+`status.sourceHydrator.currentOperation` so you can diagnose the problem.
+
+> [!NOTE]
+> After a failed hydration, the controller waits about **2 minutes** before automatically retrying
+> unattended hydration. That interval matches `ARGOCD_RECONCILIATION_TIMEOUT` (the application
+> controller `--app-resync` period, default **120s**).
+>
+> You do not need to wait for that cooldown when:
+>
+> - You trigger a **manual or API refresh** (or a **dry-source webhook**), which retries hydration
+>   immediately.
+> - A **new dry commit** is detected while a dry revision baseline is already recorded in
+>   `status.sourceHydrator.lastComparedDryRevision` (for example, hydration failed at the commit step
+>   after manifests were resolved).
+>
+> If the first hydration attempt fails before any dry revision is recorded, automatic detection of a
+> new commit during the cooldown may be delayed until the cooldown expires or you refresh manually.
+
 ## Limitations
 
 ### Signature Verification

--- a/test/e2e/hydrator_test.go
+++ b/test/e2e/hydrator_test.go
@@ -13,6 +13,22 @@ import (
 	. "github.com/argoproj/argo-cd/gitops-engine/pkg/sync/common"
 )
 
+func restrictedDefaultProjectSpec() AppProjectSpec {
+	return AppProjectSpec{
+		SourceRepos:              []string{"https://example.com/not-the-repo"},
+		Destinations:             []ApplicationDestination{{Server: "*", Namespace: "*"}},
+		ClusterResourceWhitelist: []ClusterResourceRestrictionItem{{Group: "*", Kind: "*"}},
+	}
+}
+
+func permissiveDefaultProjectSpec() AppProjectSpec {
+	return AppProjectSpec{
+		SourceRepos:              []string{"*"},
+		Destinations:             []ApplicationDestination{{Server: "*", Namespace: "*"}},
+		ClusterResourceWhitelist: []ClusterResourceRestrictionItem{{Group: "*", Kind: "*"}},
+	}
+}
+
 func TestSimpleHydrator(t *testing.T) {
 	Given(t).
 		DrySourcePath("guestbook").
@@ -107,6 +123,31 @@ func TestAddingApp(t *testing.T) {
 		Delete(true).
 		Then().
 		Expect(DoesNotExist())
+}
+
+func TestHydratorNormalRefreshRecoversFailedHydration(t *testing.T) {
+	Given(t).
+		Name("test-normal-refresh-recovery").
+		DrySourcePath("guestbook").
+		DrySourceRevision("HEAD").
+		SyncSourcePath("guestbook").
+		SyncSourceBranch("env/test").
+		When().
+		CreateApp("--validate=false").
+		And(func() {
+			require.NoError(t, fixture.SetProjectSpec("default", restrictedDefaultProjectSpec()))
+		}).
+		Refresh(RefreshTypeNormal).
+		Then().
+		Expect(HydrationPhaseIs(HydrateOperationPhaseFailed)).
+		When().
+		And(func() {
+			require.NoError(t, fixture.SetProjectSpec("default", permissiveDefaultProjectSpec()))
+		}).
+		Refresh(RefreshTypeNormal).
+		Wait("--hydrated").
+		Then().
+		Expect(HydrationPhaseIs(HydrateOperationPhaseHydrated))
 }
 
 func TestKustomizeVersionOverride(t *testing.T) {


### PR DESCRIPTION
Fixes #28051

## Summary

When hydration fails before `lastComparedDryRevision` is persisted (for example, commit-server is unavailable), `appNeedsHydration` falls through to revision evaluation and immediately re-queues hydration. This replaces the failed `currentOperation` and produces a tight retry loop instead of retaining the error.

This change respects the existing 2-minute failed-operation cooldown by short-circuiting when `currentOperation.phase` is `Failed` and the failure is recent.

## Test plan

- [x] Added unit test for failed hydration within cooldown with empty `lastComparedDryRevision`
- [x] Added unit test for failed hydration within cooldown with `lastComparedDryRevision` set
- [x] `go test ./controller/hydrator/ -count=1`