### PR TITLE
feat(ui): support spec.sourceHydrator.drySource.repoURL

### DIFF
--- a/ui/src/app/applications/components/application-create-panel/hydrator-source-panel.tsx
+++ b/ui/src/app/applications/components/application-create-panel/hydrator-source-panel.tsx
@@ -47,6 +47,7 @@ const subsectionBodyStyle: React.CSSProperties = {
 export const HydratorSourcePanel = (props: HydratorSourcePanelProps) => {
     const app = props.formApi.getFormState().values as models.Application;
     const drySourceRepoURL = app.spec.sourceHydrator?.drySource?.repoURL || '';
+    const syncSourceRepoURL = app.spec.sourceHydrator?.syncSource?.repoURL || drySourceRepoURL;
 
     return (
         <div style={{display: 'flex', flexDirection: 'column', gap: '1rem'}}>
@@ -84,9 +85,23 @@ export const HydratorSourcePanel = (props: HydratorSourcePanelProps) => {
             <div style={{display: 'flex', flexDirection: 'column'}}>
                 <p style={{marginBottom: 0, fontWeight: 600}}>SYNC SOURCE</p>
                 <div style={subsectionBodyStyle}>
+                    <div style={{display: 'flex', width: '100%'}}>
+                        <div style={{flex: 1, minWidth: 0}}>
+                            <FormField
+                                formApi={props.formApi}
+                                label='Repository URL (optional)'
+                                field='spec.sourceHydrator.syncSource.repoURL'
+                                component={AutocompleteField}
+                                componentProps={{
+                                    items: props.repos,
+                                    filterSuggestions: true
+                                }}
+                            />
+                        </div>
+                    </div>
                     <LabeledRevisionField
                         formApi={props.formApi}
-                        repoURL={drySourceRepoURL}
+                        repoURL={syncSourceRepoURL}
                         repoType='git'
                         fieldValue='spec.sourceHydrator.syncSource.targetBranch'
                         revisionType='Branches'
@@ -103,7 +118,7 @@ export const HydratorSourcePanel = (props: HydratorSourcePanelProps) => {
                 <div style={subsectionBodyStyle}>
                     <LabeledRevisionField
                         formApi={props.formApi}
-                        repoURL={drySourceRepoURL}
+                        repoURL={syncSourceRepoURL}
                         repoType='git'
                         fieldValue='spec.sourceHydrator.hydrateTo.targetBranch'
                         revisionType='Branches'

--- a/ui/src/app/applications/components/application-hydrate-operation-state/application-hydrate-operation-state.tsx
+++ b/ui/src/app/applications/components/application-hydrate-operation-state/application-hydrate-operation-state.tsx
@@ -6,6 +6,8 @@ import * as React from 'react';
 import {Revision, Timestamp} from '../../../shared/components';
 import * as models from '../../../shared/models';
 
+import {getHydratorSyncSourceRepoURL} from '../utils';
+
 import './application-hydrate-operation-state.scss';
 
 interface Props {
@@ -52,7 +54,7 @@ export const ApplicationHydrateOperationState: React.FunctionComponent<Props> = 
             title: 'HYDRATED REVISION',
             value: (
                 <div>
-                    <Revision repoUrl={hydrateOperationState.sourceHydrator.drySource.repoURL} revision={hydrateOperationState.hydratedSHA} />
+                    <Revision repoUrl={getHydratorSyncSourceRepoURL(hydrateOperationState.sourceHydrator)} revision={hydrateOperationState.hydratedSHA} />
                 </div>
             )
         });

--- a/ui/src/app/applications/components/application-summary/application-summary.tsx
+++ b/ui/src/app/applications/components/application-summary/application-summary.tsx
@@ -24,7 +24,17 @@ import {isValidURL} from '../../../shared/utils';
 
 import {ApplicationSyncOptionsField} from '../application-sync-options/application-sync-options';
 import {RevisionFormField} from '../revision-form-field/revision-form-field';
-import {ComparisonStatusIcon, HealthStatusIcon, syncStatusMessage, urlPattern, formatCreationTimestamp, getAppDefaultSource, getAppSpecDefaultSource, appRBACName} from '../utils';
+import {
+    ComparisonStatusIcon,
+    HealthStatusIcon,
+    syncStatusMessage,
+    urlPattern,
+    formatCreationTimestamp,
+    getAppDefaultSource,
+    getAppSpecDefaultSource,
+    getHydratorSyncSourceRepoURL,
+    appRBACName
+} from '../utils';
 import {ApplicationRetryOptions} from '../application-retry-options/application-retry-options';
 import {ApplicationRetryView} from '../application-retry-view/application-retry-view';
 import {Link} from 'react-router-dom';
@@ -457,27 +467,36 @@ export const ApplicationSummary = (props: ApplicationSummaryProps) => {
 
     const syncSourceItems: EditablePanelItem[] = [
         {
+            title: 'REPO URL (OPTIONAL)',
+            hint: 'Git repo for hydrated manifests. Defaults to the dry source repo when unset.',
+            view: <Repo url={getHydratorSyncSourceRepoURL(app.spec.sourceHydrator)} />,
+            edit: (formApi: FormApi) => <FormField formApi={formApi} field='spec.sourceHydrator.syncSource.repoURL' component={Text} />
+        },
+        {
             title: 'TARGET BRANCH',
             hint: 'Branch where hydrated manifests are written and synced from.',
-            view: <Revision repoUrl={app.spec.sourceHydrator?.drySource?.repoURL} revision={app.spec.sourceHydrator?.syncSource?.targetBranch || 'HEAD'} />,
-            edit: (formApi: FormApi) => (
-                <RevisionFormField
-                    helpIconTop={'0'}
-                    hideLabel={true}
-                    formApi={formApi}
-                    fieldValue='spec.sourceHydrator.syncSource.targetBranch'
-                    repoURL={source.repoURL}
-                    repoType='git'
-                    revisionType='Branches'
-                />
-            )
+            view: <Revision repoUrl={getHydratorSyncSourceRepoURL(app.spec.sourceHydrator)} revision={app.spec.sourceHydrator?.syncSource?.targetBranch || 'HEAD'} />,
+            edit: (formApi: FormApi) => {
+                const spec = formApi.getFormState().values.spec as models.ApplicationSpec;
+                return (
+                    <RevisionFormField
+                        helpIconTop={'0'}
+                        hideLabel={true}
+                        formApi={formApi}
+                        fieldValue='spec.sourceHydrator.syncSource.targetBranch'
+                        repoURL={getHydratorSyncSourceRepoURL(spec.sourceHydrator)}
+                        repoType='git'
+                        revisionType='Branches'
+                    />
+                );
+            }
         },
         {
             title: 'PATH',
             hint: 'Output directory for hydrated manifests; must be a non-root path.',
             view: (
                 <Revision
-                    repoUrl={app.spec.sourceHydrator?.drySource?.repoURL}
+                    repoUrl={getHydratorSyncSourceRepoURL(app.spec.sourceHydrator)}
                     revision={app.spec.sourceHydrator?.syncSource?.targetBranch || 'HEAD'}
                     path={app.spec.sourceHydrator?.syncSource?.path}
                     isForPath={true}>
@@ -494,24 +513,27 @@ export const ApplicationSummary = (props: ApplicationSummaryProps) => {
             hint: 'Optional staging branch to write hydrated output before syncing.',
             view: (
                 <Revision
-                    repoUrl={app.spec.sourceHydrator?.drySource?.repoURL}
+                    repoUrl={getHydratorSyncSourceRepoURL(app.spec.sourceHydrator)}
                     revision={
                         app.spec.sourceHydrator?.hydrateTo?.targetBranch ||
                         (app.spec.sourceHydrator?.syncSource?.targetBranch ? `${app.spec.sourceHydrator.syncSource.targetBranch}-next` : 'HEAD')
                     }
                 />
             ),
-            edit: (formApi: FormApi) => (
-                <RevisionFormField
-                    helpIconTop={'0'}
-                    hideLabel={true}
-                    formApi={formApi}
-                    fieldValue='spec.sourceHydrator.hydrateTo.targetBranch'
-                    repoURL={source.repoURL}
-                    repoType='git'
-                    revisionType='Branches'
-                />
-            )
+            edit: (formApi: FormApi) => {
+                const spec = formApi.getFormState().values.spec as models.ApplicationSpec;
+                return (
+                    <RevisionFormField
+                        helpIconTop={'0'}
+                        hideLabel={true}
+                        formApi={formApi}
+                        fieldValue='spec.sourceHydrator.hydrateTo.targetBranch'
+                        repoURL={getHydratorSyncSourceRepoURL(spec.sourceHydrator)}
+                        repoType='git'
+                        revisionType='Branches'
+                    />
+                );
+            }
         }
     ];
 

--- a/ui/src/app/applications/components/utils.test.tsx
+++ b/ui/src/app/applications/components/utils.test.tsx
@@ -15,7 +15,10 @@ import {
     appRBACName,
     ComparisonStatusIcon,
     getAppDrySource,
+    getAppHydratorSyncSource,
     getAppOperationState,
+    getAppSpecDefaultSource,
+    getHydratorSyncSourceRepoURL,
     getOperationType,
     getPodStateReason,
     HealthStatusIcon,
@@ -1001,5 +1004,57 @@ describe('getAppDrySource', () => {
             targetRevision: 'main',
         });
         expect(result).not.toHaveProperty('helm');
+    });
+});
+
+describe('getHydratorSyncSourceRepoURL', () => {
+    it('uses syncSource repoURL when set', () => {
+        expect(
+            getHydratorSyncSourceRepoURL({
+                drySource: {repoURL: 'https://github.com/example/dry.git', targetRevision: 'main'},
+                syncSource: {repoURL: 'https://github.com/example/hydrated.git', targetBranch: 'env/test', path: 'out'}
+            })
+        ).toBe('https://github.com/example/hydrated.git');
+    });
+
+    it('falls back to drySource repoURL when syncSource repoURL is unset', () => {
+        expect(
+            getHydratorSyncSourceRepoURL({
+                drySource: {repoURL: 'https://github.com/example/dry.git', targetRevision: 'main'},
+                syncSource: {targetBranch: 'env/test', path: 'out'}
+            })
+        ).toBe('https://github.com/example/dry.git');
+    });
+});
+
+describe('getAppHydratorSyncSource', () => {
+    it('returns the sync source with resolved repo URL', () => {
+        expect(
+            getAppHydratorSyncSource({
+                drySource: {repoURL: 'https://github.com/example/dry.git', targetRevision: 'main', path: 'in'},
+                syncSource: {repoURL: 'https://github.com/example/hydrated.git', targetBranch: 'env/test', path: 'out'}
+            })
+        ).toEqual({
+            repoURL: 'https://github.com/example/hydrated.git',
+            targetRevision: 'env/test',
+            path: 'out'
+        });
+    });
+});
+
+describe('getAppSpecDefaultSource', () => {
+    it('returns sync source for hydrator apps', () => {
+        expect(
+            getAppSpecDefaultSource({
+                sourceHydrator: {
+                    drySource: {repoURL: 'https://github.com/example/dry.git', targetRevision: 'main', path: 'in'},
+                    syncSource: {repoURL: 'https://github.com/example/hydrated.git', targetBranch: 'env/test', path: 'out'}
+                }
+            })
+        ).toEqual({
+            repoURL: 'https://github.com/example/hydrated.git',
+            targetRevision: 'env/test',
+            path: 'out'
+        });
     });
 });

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -14,7 +14,6 @@ import {ResourceTreeNode} from './application-resource-tree/application-resource
 import {CheckboxField, COLORS, ErrorNotification, Revision} from '../../shared/components';
 import * as appModels from '../../shared/models';
 import {services} from '../../shared/services';
-import {ApplicationSource} from '../../shared/models';
 
 require('./utils.scss');
 
@@ -994,14 +993,10 @@ export function syncStatusMessage(app: appModels.Application) {
 }
 
 export function hydrationStatusMessage(app: appModels.Application) {
-    const drySource = app.status.sourceHydrator.currentOperation.sourceHydrator.drySource;
+    const sourceHydrator = app.status.sourceHydrator.currentOperation.sourceHydrator;
+    const drySource = sourceHydrator.drySource;
     const dryCommit = app.status.sourceHydrator.currentOperation.drySHA;
-    const syncSource: ApplicationSource = {
-        repoURL: drySource.repoURL,
-        targetRevision:
-            app.status.sourceHydrator.currentOperation.sourceHydrator.hydrateTo?.targetBranch || app.status.sourceHydrator.currentOperation.sourceHydrator.syncSource.targetBranch,
-        path: app.status.sourceHydrator.currentOperation.sourceHydrator.syncSource.path
-    };
+    const syncSource = getAppHydratorSyncSource(sourceHydrator);
     const hydratedCommit = app.status.sourceHydrator.currentOperation.hydratedSHA || '';
 
     switch (app.status.sourceHydrator.currentOperation.phase) {
@@ -1509,6 +1504,18 @@ export function getAppDrySource(app?: appModels.Application): appModels.Applicat
     return getAppDefaultSource(app);
 }
 
+export function getHydratorSyncSourceRepoURL(sourceHydrator: appModels.SourceHydrator): string {
+    return sourceHydrator.syncSource?.repoURL || sourceHydrator.drySource?.repoURL || '';
+}
+
+export function getAppHydratorSyncSource(sourceHydrator: appModels.SourceHydrator): appModels.ApplicationSource {
+    return {
+        repoURL: getHydratorSyncSourceRepoURL(sourceHydrator),
+        targetRevision: sourceHydrator.syncSource.targetBranch,
+        path: sourceHydrator.syncSource.path
+    };
+}
+
 // getAppAllSources gets all app sources as an array. For single source apps, returns [source].
 // For multi-source apps, returns the sources array. For sourceHydrator apps, returns a single synthesized source.
 export function getAppAllSources(app?: appModels.Application): appModels.ApplicationSource[] {
@@ -1517,13 +1524,7 @@ export function getAppAllSources(app?: appModels.Application): appModels.Applica
     }
 
     if (app.spec.sourceHydrator) {
-        return [
-            {
-                repoURL: app.spec.sourceHydrator.drySource.repoURL,
-                targetRevision: app.spec.sourceHydrator.syncSource.targetBranch,
-                path: app.spec.sourceHydrator.syncSource.path
-            } as appModels.ApplicationSource
-        ];
+        return [getAppHydratorSyncSource(app.spec.sourceHydrator)];
     }
 
     if (app.spec.sources && app.spec.sources.length > 0) {
@@ -1594,11 +1595,7 @@ export function getAppDefaultOperationSyncRevisionExtra(app?: appModels.Applicat
 
 export function getAppSpecDefaultSource(spec: appModels.ApplicationSpec) {
     if (spec.sourceHydrator) {
-        return {
-            repoURL: spec.sourceHydrator.drySource.repoURL,
-            targetRevision: spec.sourceHydrator.syncSource.targetBranch,
-            path: spec.sourceHydrator.syncSource.path
-        };
+        return getAppHydratorSyncSource(spec.sourceHydrator);
     }
     return spec.sources && spec.sources.length > 0 ? spec.sources[0] : spec.source;
 }

--- a/ui/src/app/shared/models.ts
+++ b/ui/src/app/shared/models.ts
@@ -272,6 +272,7 @@ export interface DrySource {
 export interface SyncSource {
     targetBranch: string;
     path: string;
+    repoURL?: string;
 }
 
 export interface HydrateTo {


### PR DESCRIPTION
Following up on https://github.com/argoproj/argo-cd/pull/27011 to add UI support for the new field.


https://github.com/user-attachments/assets/b6f02830-4815-40ae-a4a7-e1377eeeadc5


You'll notice an error pop on on loading the app page. That's a backend bug, I'll work on it in another PR.