### PR TITLE
fix(appset): check repo size when receiving a 404 for the default branch from github

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -367,6 +367,7 @@ Currently, the following organizations are **officially** using Argo CD:
 1. [Spendesk](https://spendesk.com/)
 1. [Splunk](https://splunk.com/)
 1. [Spores Labs](https://spores.app)
+1. [stafftastic](https://stafftastic.com)
 1. [Statsig](https://statsig.com)
 1. [SternumIOT](https://sternumiot.com)
 1. [Stone Payments](https://www.stone.com.br/)

--- a/applicationset/services/scm_provider/github.go
+++ b/applicationset/services/scm_provider/github.go
@@ -16,6 +16,7 @@ type GithubProvider struct {
 	organization         string
 	allBranches          bool
 	excludeArchivedRepos bool
+	repoSizes            map[string]int
 }
 
 var _ SCMProviderService = &GithubProvider{}
@@ -46,7 +47,13 @@ func NewGithubProvider(organization string, token string, url string, allBranche
 			return nil, err
 		}
 	}
-	return &GithubProvider{client: client, organization: organization, allBranches: allBranches, excludeArchivedRepos: excludeArchivedRepos}, nil
+	return &GithubProvider{
+		client:               client,
+		organization:         organization,
+		allBranches:          allBranches,
+		excludeArchivedRepos: excludeArchivedRepos,
+		repoSizes:            make(map[string]int),
+	}, nil
 }
 
 func (g *GithubProvider) GetBranches(ctx context.Context, repo *Repository) ([]*Repository, error) {
@@ -104,6 +111,7 @@ func (g *GithubProvider) ListRepos(ctx context.Context, cloneProtocol string) ([
 				Labels:       githubRepo.Topics,
 				RepositoryId: githubRepo.ID,
 			})
+			g.repoSizes[githubRepo.GetName()] = githubRepo.GetSize()
 		}
 		if resp.NextPage == 0 {
 			break
@@ -132,7 +140,7 @@ func (g *GithubProvider) listBranches(ctx context.Context, repo *Repository) ([]
 	if !g.allBranches {
 		defaultBranch, resp, err := g.client.Repositories.GetBranch(ctx, repo.Organization, repo.Repository, repo.Branch, 0)
 		if err != nil {
-			if resp.StatusCode == http.StatusNotFound {
+			if resp != nil && resp.StatusCode == http.StatusNotFound && g.repoSizes[repo.Repository] == 0 {
 				// Default branch doesn't exist, so the repo is empty.
 				return []github.Branch{}, nil
 			}

--- a/applicationset/services/scm_provider/github_test.go
+++ b/applicationset/services/scm_provider/github_test.go
@@ -743,6 +743,16 @@ func TestGithubGetBranches(t *testing.T) {
 	_, err = host.GetBranches(t.Context(), repo2)
 	require.NoError(t, err)
 
+	// Repo has contents but default branch is reported to not exist
+	repo3 := &Repository{
+		Organization: "argoproj",
+		Repository:   "argo-cd",
+		Branch:       "does-not-exist",
+	}
+	host.repoSizes["argo-cd"] = 108
+	_, err = host.GetBranches(t.Context(), repo3)
+	require.Error(t, err)
+
 	// Get all branches
 	host.allBranches = true
 	repos, err = host.GetBranches(t.Context(), repo)


### PR DESCRIPTION
This addresses a very unusual edge-case, but something I experienced today leading to the issue described in #14318. I don't think this is the only thing that could case this to happen, so I won't say this fixes it, but at least it should fix one of the reasons it might happen.

What I saw was that requests to the GitHub API sporadically returned 404 responses. The logs I saw specifically said it was happening when trying to list repos, but looking at the code that should never lead to the ApplicationSet deleting its apps. Some requests went through and some applications generated 1 application, others 0 (these are ApplicationSets with the scmProvider (GitHub) filtered to match one repository with allBranches=false, so these should always generate exactly 1 application each unless the repos are deleted).

Inspecting logs I noticed many other instances of GitHub returning error responses, 502s, 401s, 429s, etc. But this never lead to generating 0 applications, since listBranches would correctly return an error if it received such a response.

When GitHub sporadically returns 404s this leads to an edge-case where if the ListByOrg call succeeds but the GetBranch call receives a 404 response, the ApplicationSet controller believes that the repository is empty and rightfully generates no applications.

This attempts to safeguard against that by storing the size returned by ListByOrg in the Repository struct and checking that the size of the repository is in fact 0 before concluding that the repo is empty instead of relying fully on the response.

I realize that this struct is probably used by the other SCM providers, so this change might touch a lot of unrelated code, but I'm not sure if this is a problem. At least the other tests in `github.com/argoproj/argo-cd/v3/applicationset/...` are passing, while the GitHub ones needed adjustment since the mock API responses contain a non-zero size.

For anyone who might end up here after running into the same issue today, I experienced this from 2026-05-28 13:01:45 until 2026-05-28 13:23:08 (UTC).

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
