### PR TITLE
fix(controller): aggregate Missing for resources with registered health checks

### DIFF
--- a/controller/health.go
+++ b/controller/health.go
@@ -8,6 +8,7 @@ import (
 	"github.com/argoproj/argo-cd/gitops-engine/pkg/sync/ignore"
 	kubeutil "github.com/argoproj/argo-cd/gitops-engine/pkg/utils/kube"
 	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/argoproj/argo-cd/v3/common"
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application"
@@ -72,8 +73,12 @@ func setApplicationHealth(resources []managedResource, statuses []appv1.Resource
 			statuses[i].Health = nil
 		}
 
-		// Missing resources should not affect parent app health - the OutOfSync status already indicates resources are missing
-		if res.Live == nil && healthStatus.Status == health.HealthStatusMissing {
+		// Missing resources without a registered health check should not affect parent
+		// app health — the OutOfSync status already indicates that. Resources whose
+		// kind has an override or built-in health check MUST aggregate as Missing so
+		// parent app-of-apps wave gates correctly wait for them. See #27917.
+		gvk := schema.GroupVersionKind{Group: res.Group, Version: res.Version, Kind: res.Kind}
+		if _, hasOverride := healthOverrides[lua.GetConfigMapKey(gvk)]; healthStatus.Status == health.HealthStatusMissing && !hasOverride && health.GetHealthCheckFunc(gvk) == nil {
 			continue
 		}
 

--- a/controller/health_test.go
+++ b/controller/health_test.go
@@ -127,6 +127,9 @@ func TestSetApplicationHealth_OnlyHooks(t *testing.T) {
 	assert.Equal(t, health.HealthStatusHealthy, healthStatus)
 }
 
+// Pod kind has a built-in health check, so a Live==nil Pod must aggregate as
+// Missing (so parent app-of-apps wave gates hold). Originally asserted Healthy
+// when introduced with #25962; flipped to Missing as part of the #27917 fix.
 func TestSetApplicationHealth_MissingResource(t *testing.T) {
 	pod := resourceFromFile("./testdata/pod-running-restart-always.yaml")
 	pod2 := pod.DeepCopy()
@@ -140,9 +143,12 @@ func TestSetApplicationHealth_MissingResource(t *testing.T) {
 
 	healthStatus, err := setApplicationHealth(resources, resourceStatuses, lua.ResourceHealthOverrides{}, app, true)
 	require.NoError(t, err)
-	assert.Equal(t, health.HealthStatusHealthy, healthStatus)
+	assert.Equal(t, health.HealthStatusMissing, healthStatus)
 }
 
+// Same as above but the Live!=nil sibling carries the ignore-healthcheck
+// annotation. The Live==nil Pod still aggregates as Missing because Pod has a
+// built-in health check; the annotation only suppresses the Live!=nil resource.
 func TestSetApplicationHealth_MissingResource_WithIgnoreHealthcheck(t *testing.T) {
 	pod := resourceFromFile("./testdata/pod-running-restart-always.yaml")
 	pod2 := pod.DeepCopy()
@@ -157,9 +163,12 @@ func TestSetApplicationHealth_MissingResource_WithIgnoreHealthcheck(t *testing.T
 
 	healthStatus, err := setApplicationHealth(resources, resourceStatuses, lua.ResourceHealthOverrides{}, app, true)
 	require.NoError(t, err)
-	assert.Equal(t, health.HealthStatusHealthy, healthStatus)
+	assert.Equal(t, health.HealthStatusMissing, healthStatus)
 }
 
+// A Live!=nil child Application with no registered override falls through
+// (GetResourceHealth returns nil and the loop continues), so the Live==nil
+// Pod sibling drives the aggregate to Missing (Pod has built-in health).
 func TestSetApplicationHealth_MissingResource_WithChildApp(t *testing.T) {
 	childApp := newAppLiveObj(health.HealthStatusUnknown)
 	pod := resourceFromFile("./testdata/pod-running-restart-always.yaml")
@@ -171,7 +180,32 @@ func TestSetApplicationHealth_MissingResource_WithChildApp(t *testing.T) {
 
 	healthStatus, err := setApplicationHealth(resources, resourceStatuses, lua.ResourceHealthOverrides{}, app, true)
 	require.NoError(t, err)
-	assert.Equal(t, health.HealthStatusHealthy, healthStatus)
+	assert.Equal(t, health.HealthStatusMissing, healthStatus)
+}
+
+// Regression test for #27917. A child Application with a mix of applied
+// resources (Live!=nil) and resources whose apply failed (Live==nil) must
+// aggregate as Missing — not Healthy — when the failed resource's kind has
+// a registered health check (override or built-in). Otherwise parent
+// app-of-apps wave gates release prematurely.
+func TestSetApplicationHealth_MissingResource_WithRegisteredHealthCheck(t *testing.T) {
+	runningPod := resourceFromFile("./testdata/pod-running-restart-always.yaml")
+
+	overrides := lua.ResourceHealthOverrides{
+		lua.GetConfigMapKey(schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Widget"}): appv1.ResourceOverride{
+			HealthLua: `hs = {} hs.status = "Healthy" return hs`,
+		},
+	}
+
+	resources := []managedResource{
+		{Group: "", Version: "v1", Kind: "Pod", Live: &runningPod},
+		{Group: "example.com", Version: "v1", Kind: "Widget"},
+	}
+	resourceStatuses := initStatuses(resources)
+
+	healthStatus, err := setApplicationHealth(resources, resourceStatuses, overrides, app, true)
+	require.NoError(t, err)
+	assert.Equal(t, health.HealthStatusMissing, healthStatus)
 }
 
 func TestSetApplicationHealth_AllMissingResources(t *testing.T) {


### PR DESCRIPTION
Restores the v3.3.9 three-condition predicate in setApplicationHealth: skip Live==nil + Missing only when the kind has neither a registered override nor a built-in health check. PR #25962 / 82597111a silently skipped ALL Live==nil resources, causing child Applications with sync-failed resources to misreport Healthy and parent app-of-apps wave gates to release prematurely.

The post-loop "all resources missing" fallback added by #25962 is preserved for the all-missing case.

Updated three existing tests whose assertions encoded the buggy behavior (TestSetApplicationHealth_MissingResource and its WithIgnoreHealthcheck/WithChildApp variants), and added a new regression test TestSetApplicationHealth_MissingResource_WithRegisteredHealthCheck that captures the wave-gating scenario from the issue.

Fixes #27917