### PR TITLE
fix: Improve error message when app name is missing for 'app diff' command

### DIFF
--- a/cmd/argocd/commands/app_diff.go
+++ b/cmd/argocd/commands/app_diff.go
@@ -650,6 +650,7 @@ func NewApplicationDiffCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 			ctx := c.Context()
 
 			if len(args) != 1 {
+				fmt.Fprintf(os.Stderr, "Error: Exactly one application name is required, but got %d argument(s): %v\n\n", len(args), args)
 				c.HelpFunc()(c, args)
 				os.Exit(2)
 			}


### PR DESCRIPTION
## What type of PR is this?
/kind enhancement

## What does this PR do?
Improves the user experience of the `argocd app diff` command by providing a clear error message when no application name is provided.

### Before
```bash
$ argocd app diff
# Shows help without explanation

After
```bash
$ argocd app diff
Error: Exactly one application name is required, but got 0 argument(s): []
```
# Shows help with clear error
