### PR TITLE
fix: support repeated flags in ARGOCD_OPTS (e.g. multiple --header)

### DIFF
--- a/util/config/env.go
+++ b/util/config/env.go
@@ -13,6 +13,9 @@ import (
 
 var flags map[string]string
 
+// multiFlags holds values for flags that may be repeated (e.g. --header can appear multiple times).
+var multiFlags map[string][]string
+
 func init() {
 	err := LoadFlags()
 	if err != nil {
@@ -22,6 +25,7 @@ func init() {
 
 func LoadFlags() error {
 	flags = make(map[string]string)
+	multiFlags = make(map[string][]string)
 
 	opts, err := shellquote.Split(os.Getenv("ARGOCD_OPTS"))
 	if err != nil {
@@ -34,10 +38,12 @@ func LoadFlags() error {
 		case strings.HasPrefix(opt, "--"):
 			if key != "" {
 				flags[key] = "true"
+				multiFlags[key] = append(multiFlags[key], "true")
 			}
 			key = strings.TrimPrefix(opt, "--")
 		case key != "":
 			flags[key] = opt
+			multiFlags[key] = append(multiFlags[key], opt)
 			key = ""
 		default:
 			return errors.New("ARGOCD_OPTS invalid at '" + opt + "'")
@@ -45,8 +51,9 @@ func LoadFlags() error {
 	}
 	if key != "" {
 		flags[key] = "true"
+		multiFlags[key] = append(multiFlags[key], "true")
 	}
-	// pkg shellquota doesn't recognize `=` so that the opts in format `foo=bar` could not work.
+	// pkg shellquote doesn't recognize `=` so that the opts in format `foo=bar` could not work.
 	// issue ref: https://github.com/argoproj/argo-cd/issues/6822
 	for k, v := range flags {
 		if strings.Contains(k, "=") && v == "true" {
@@ -54,6 +61,7 @@ func LoadFlags() error {
 			actualKey, actualValue := kv[0], kv[1]
 			if _, ok := flags[actualKey]; !ok {
 				flags[actualKey] = actualValue
+				multiFlags[actualKey] = append(multiFlags[actualKey], actualValue)
 			}
 		}
 	}
@@ -86,19 +94,28 @@ func GetIntFlag(key string, fallback int) int {
 }
 
 func GetStringSliceFlag(key string, fallback []string) []string {
-	val, ok := flags[key]
+	vals, ok := multiFlags[key]
 	if !ok {
 		return fallback
 	}
 
-	if val == "" {
+	// Each value may itself be a comma-separated list (legacy behaviour).
+	// Expand all values and concatenate them.
+	var result []string
+	for _, val := range vals {
+		if val == "" {
+			continue
+		}
+		stringReader := strings.NewReader(val)
+		csvReader := csv.NewReader(stringReader)
+		parts, err := csvReader.Read()
+		if err != nil {
+			log.Fatal(err)
+		}
+		result = append(result, parts...)
+	}
+	if result == nil {
 		return []string{}
 	}
-	stringReader := strings.NewReader(val)
-	csvReader := csv.NewReader(stringReader)
-	v, err := csvReader.Read()
-	if err != nil {
-		log.Fatal(err)
-	}
-	return v
+	return result
 }

--- a/util/config/env_test.go
+++ b/util/config/env_test.go
@@ -148,3 +148,22 @@ func TestFlagWithEqualSign(t *testing.T) {
 
 	assert.Equal(t, "bar", GetFlag("foo", ""))
 }
+
+func TestStringSliceFlagRepeated(t *testing.T) {
+	loadOpts(t, `--header "CF-Access-Client-Id: foo" --header "CF-Access-Client-Secret: bar"`)
+	headers := GetStringSliceFlag("header", []string{})
+
+	assert.Len(t, headers, 2)
+	assert.Equal(t, "CF-Access-Client-Id: foo", headers[0])
+	assert.Equal(t, "CF-Access-Client-Secret: bar", headers[1])
+}
+
+func TestStringSliceFlagRepeatedMixedWithCSV(t *testing.T) {
+	loadOpts(t, `--header "CF-Access-Client-Id: foo,CF-Access-Client-Secret: bar" --header "X-Custom: baz"`)
+	headers := GetStringSliceFlag("header", []string{})
+
+	assert.Len(t, headers, 3)
+	assert.Equal(t, "CF-Access-Client-Id: foo", headers[0])
+	assert.Equal(t, "CF-Access-Client-Secret: bar", headers[1])
+	assert.Equal(t, "X-Custom: baz", headers[2])
+}


### PR DESCRIPTION
## Summary of Changes

Fixes #24065

When the same flag appeared more than once in `ARGOCD_OPTS` (e.g. `--header "foo" --header "bar"`), each occurrence overwrote the previous one because `flags` is a `map[string]string`. Only the last value was kept.

**Root cause:** `LoadFlags()` in `util/config/env.go` uses a single `map[string]string` — repeated keys silently overwrite each other.

**Fix:** Introduce a parallel `multiFlags map[string][]string` that appends every occurrence of a key. `GetStringSliceFlag` now reads from `multiFlags`, expanding each entry through the existing CSV parser (preserving backwards compatibility with comma-separated headers). All other accessors (`GetFlag`, `GetBoolFlag`, `GetIntFlag`) continue to use the single-value `flags` map unchanged — no breaking changes.

## Testing

Two new test cases added to `util/config/env_test.go`:

- `TestStringSliceFlagRepeated` — verifies `--header "foo" --header "bar"` returns both values
- `TestStringSliceFlagRepeatedMixedWithCSV` — verifies repeated flags mixed with comma-separated values all expand correctly

All 25 existing tests continue to pass.

```
ok  github.com/argoproj/argo-cd/v3/util/config  0.627s
```

## Before / After

**Before:**
```bash
export ARGOCD_OPTS='--header "CF-Access-Client-Id: foo" --header "CF-Access-Client-Secret: bar"'
argocd app list
# Only one header sent — second overwrites first
```

**After:**
```bash
export ARGOCD_OPTS='--header "CF-Access-Client-Id: foo" --header "CF-Access-Client-Secret: bar"'
argocd app list
# Both headers sent — identical to passing them directly on the CLI
```

## Checklist

- [x] Fixes an existing open issue (#24065)
- [x] Unit tests added and passing
- [x] No breaking changes to existing behaviour
- [x] Semantic PR title (`fix:`)