### PR TITLE
fix: clean up orphaned temp packfiles left by an interrupted git fetch (#18831)

### DIFF
--- a/util/git/client.go
+++ b/util/git/client.go
@@ -293,6 +293,14 @@ func NewClientExt(rawRepoURL string, root string, creds Creds, insecure bool, en
 
 var gitClientTimeout = env.ParseDurationFromEnv("ARGOCD_GIT_REQUEST_TIMEOUT", 15*time.Second, 0, math.MaxInt64)
 
+// gitCleanupGracePeriod is the minimum age a temporary pack file must reach
+// before cleanupOrphanedTempPackfiles will remove it. A fetch is killed at
+// ARGOCD_EXEC_TIMEOUT (plus the fatal-timeout grace), so twice that comfortably
+// exceeds the longest a fetch can be in flight; anything older cannot belong to
+// a live fetch (for example a concurrent fetch from another repo-server replica
+// sharing an RWX cache volume).
+var gitCleanupGracePeriod = 2 * env.ParseDurationFromEnv("ARGOCD_EXEC_TIMEOUT", 90*time.Second, 0, math.MaxInt64)
+
 // Returns a HTTP client object suitable for go-git to use using the following
 // pattern:
 //   - If insecure is true, always returns a client with certificate verification
@@ -579,6 +587,79 @@ func (m *nativeGitClient) IsRevisionPresent(revision string) bool {
 	return false
 }
 
+// cleanupOrphanedTempPackfiles removes leftover objects/pack/tmp_{pack,idx,rev,mtimes}_* files
+// produced by a git fetch/index-pack that was killed (for example by the exec
+// timeout) before it could finalize the pack. Git treats these as garbage and
+// never prunes them itself, so without this cleanup they accumulate on every
+// failed fetch into the reused cache directory and can grow the repo-server
+// volume without bound. This is best-effort: failures are logged, not returned.
+//
+// Within a single repo-server the per-repository lock (reposerver/repository/
+// lock.go) already serializes fetch/checkout per cache directory, so no
+// in-process fetch is writing these files when we get here. To stay safe across
+// processes too (for example several repo-server replicas sharing an RWX cache
+// volume), only files older than a grace window are removed, so a temp file that
+// a concurrent fetch is still writing is never deleted.
+func (m *nativeGitClient) cleanupOrphanedTempPackfiles() {
+	// git's index-pack streams these temp files into objects/pack/ during a fetch
+	// and renames them to pack-<hash>.* on finalize; a killed fetch strands them.
+	// This is a best-effort superset across git versions (tmp_rev_/tmp_mtimes_
+	// are newer). The receive-pack quarantine dir (tmp_objdir-*) is a directory
+	// and is skipped below, so it is intentionally not listed here.
+	tempPrefixes := []string{"tmp_pack_", "tmp_idx_", "tmp_rev_", "tmp_mtimes_"}
+	packDir := filepath.Join(m.root, ".git", "objects", "pack")
+	entries, err := os.ReadDir(packDir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Warnf("git cleanup: cannot read pack dir %s: %v", packDir, err)
+		}
+		return
+	}
+
+	var removed int
+	var reclaimed int64
+	for _, entry := range entries {
+		// Only remove git's interrupted-fetch temp files (the tempPrefixes
+		// above); finalized pack-*.{pack,idx,rev} files and any subdirectories
+		// must be left untouched.
+		name := entry.Name()
+		if entry.IsDir() {
+			continue
+		}
+		isTempPack := false
+		for _, prefix := range tempPrefixes {
+			if strings.HasPrefix(name, prefix) {
+				isTempPack = true
+				break
+			}
+		}
+		if !isTempPack {
+			continue
+		}
+		info, infoErr := entry.Info()
+		if infoErr != nil {
+			// Can't determine the age, so don't risk deleting a live temp file.
+			continue
+		}
+		if time.Since(info.ModTime()) < gitCleanupGracePeriod {
+			// Still within the grace window: a concurrent fetch may be writing
+			// it. Leave it; a later sweep reclaims it once it is stale.
+			continue
+		}
+		path := filepath.Join(packDir, name)
+		if rerr := os.Remove(path); rerr != nil {
+			log.Warnf("git cleanup: failed to remove orphaned temp pack %s: %v", path, rerr)
+			continue
+		}
+		removed++
+		reclaimed += info.Size()
+	}
+
+	if removed > 0 {
+		log.Infof("git cleanup: removed %d orphaned temp pack file(s) (%d bytes) for %s", removed, reclaimed, m.repoURL)
+	}
+}
+
 // Fetch fetches latest updates from origin
 func (m *nativeGitClient) Fetch(revision string, depth int64) error {
 	if m.OnFetch != nil {
@@ -588,9 +669,13 @@ func (m *nativeGitClient) Fetch(revision string, depth int64) error {
 	ctx := context.Background()
 
 	err := m.fetch(ctx, revision, depth)
+	if err != nil {
+		m.cleanupOrphanedTempPackfiles()
+		return err
+	}
 
 	// When we have LFS support enabled, check for large files and fetch them too.
-	if err == nil && m.IsLFSEnabled() {
+	if m.IsLFSEnabled() {
 		largeFiles, err := m.LsLargeFiles()
 		if err == nil && len(largeFiles) > 0 {
 			err = m.runCredentialedCmd(ctx, "lfs", "fetch", "--all")

--- a/util/git/client_test.go
+++ b/util/git/client_test.go
@@ -62,6 +62,94 @@ func _createEmptyGitRepo(ctx context.Context) (string, error) {
 	return tempDir, err
 }
 
+func Test_nativeGitClient_cleanupOrphanedTempPackfiles(t *testing.T) {
+	root := t.TempDir()
+	packDir := filepath.Join(root, ".git", "objects", "pack")
+	require.NoError(t, os.MkdirAll(packDir, 0o755))
+	// gitCleanupGracePeriod defaults to 2 * 90s = 3m, so an hour-old file is
+	// safely stale and a just-written one is safely fresh.
+	old := time.Now().Add(-time.Hour)
+
+	// Stale temp files git's index-pack can strand when a fetch is killed before
+	// it finalizes the pack. All must be removed once past the grace window.
+	stale := []string{"tmp_pack_deadbeef", "tmp_idx_deadbeef", "tmp_rev_deadbeef", "tmp_mtimes_deadbeef"}
+	for _, name := range stale {
+		p := filepath.Join(packDir, name)
+		require.NoError(t, os.WriteFile(p, []byte("partial data"), 0o644))
+		require.NoError(t, os.Chtimes(p, old, old))
+	}
+
+	// A temp file still within the grace window may belong to a concurrent fetch
+	// (for example another replica) and must be preserved.
+	fresh := filepath.Join(packDir, "tmp_pack_inflight")
+	require.NoError(t, os.WriteFile(fresh, []byte("in-progress"), 0o644))
+
+	// Finalized pack files (even when old) and a push-path quarantine directory
+	// must be kept.
+	keep := []string{
+		"pack-0123456789abcdef0123456789abcdef01234567.pack",
+		"pack-0123456789abcdef0123456789abcdef01234567.idx",
+		"pack-0123456789abcdef0123456789abcdef01234567.rev",
+	}
+	for _, name := range keep {
+		p := filepath.Join(packDir, name)
+		require.NoError(t, os.WriteFile(p, []byte("real data"), 0o644))
+		require.NoError(t, os.Chtimes(p, old, old))
+	}
+	quarantine := filepath.Join(packDir, "tmp_objdir-incoming")
+	require.NoError(t, os.MkdirAll(quarantine, 0o755))
+	require.NoError(t, os.Chtimes(quarantine, old, old))
+
+	client := &nativeGitClient{root: root, repoURL: "https://example.com/repo.git"}
+	client.cleanupOrphanedTempPackfiles()
+
+	for _, name := range stale {
+		assert.NoFileExists(t, filepath.Join(packDir, name), "stale temp file %s should be removed", name)
+	}
+	assert.FileExists(t, fresh, "temp file within the grace window must be preserved")
+	for _, name := range keep {
+		assert.FileExists(t, filepath.Join(packDir, name), "finalized file %s must be preserved", name)
+	}
+	assert.DirExists(t, quarantine, "push-path quarantine directory must not be touched")
+}
+
+func Test_nativeGitClient_cleanupOrphanedTempPackfiles_noPackDir(t *testing.T) {
+	// A repository whose pack directory does not exist yet must not panic or error.
+	client := &nativeGitClient{root: t.TempDir(), repoURL: "https://example.com/repo.git"}
+	assert.NotPanics(t, client.cleanupOrphanedTempPackfiles)
+}
+
+func Test_nativeGitClient_Fetch_cleansOrphanedTempPacksOnError(t *testing.T) {
+	ctx := t.Context()
+	root := t.TempDir()
+
+	require.NoError(t, runCmd(ctx, root, "git", "init"))
+	// Point origin at a non-existent path so the fetch fails deterministically.
+	badRemote := filepath.Join(root, "does-not-exist")
+	require.NoError(t, runCmd(ctx, root, "git", "remote", "add", "origin", "file://"+badRemote))
+
+	// A real index-pack killed mid-stream cannot be reproduced deterministically
+	// in a unit test, so stand in for the stranded files with synthetic temp
+	// pack/index files, aged past the grace window, and assert the failed fetch
+	// removes them.
+	packDir := filepath.Join(root, ".git", "objects", "pack")
+	require.NoError(t, os.MkdirAll(packDir, 0o755))
+	old := time.Now().Add(-time.Hour)
+	orphanPack := filepath.Join(packDir, "tmp_pack_orphan")
+	orphanIdx := filepath.Join(packDir, "tmp_idx_orphan")
+	for _, p := range []string{orphanPack, orphanIdx} {
+		require.NoError(t, os.WriteFile(p, []byte("partial data"), 0o644))
+		require.NoError(t, os.Chtimes(p, old, old))
+	}
+
+	client := &nativeGitClient{root: root, repoURL: "file://" + badRemote, creds: NopCreds{}}
+
+	err := client.Fetch("", 0)
+	require.Error(t, err, "fetch against a missing remote must fail")
+	assert.NoFileExists(t, orphanPack, "orphaned temp pack should be cleaned up after a failed fetch")
+	assert.NoFileExists(t, orphanIdx, "orphaned temp index should be cleaned up after a failed fetch")
+}
+
 func Test_nativeGitClient_Fetch(t *testing.T) {
 	tempDir, err := _createEmptyGitRepo(t.Context())
 	require.NoError(t, err)


### PR DESCRIPTION
## What

A `git fetch` in `argocd-repo-server` that is killed by the exec timeout (`ARGOCD_EXEC_TIMEOUT`) before `index-pack` finalizes the pack leaves partially written temporary files in `objects/pack/` (`tmp_pack_`, `tmp_idx_`, `tmp_rev_`, `tmp_mtimes_`). Git treats these as garbage and never prunes them, so on every refresh they accumulate in the reused per-repository cache directory and grow the repo-server volume without bound. In one reproduction a single 164 MB upstream repo grew one clone to 27 GB (423 orphaned temp packs, 0 finalized objects), filling the node filesystem and triggering node-level `DiskPressure` that evicted unrelated pods. A full `git count-objects` breakdown is in #18831.

This removes those orphaned temp files when a fetch returns an error.

## How

- After `m.fetch(...)` fails, `Fetch` runs a best-effort cleanup of `objects/pack/tmp_{pack,idx,rev,mtimes}_*` in the repository cache directory.
- Only files older than a grace window (`2 × ARGOCD_EXEC_TIMEOUT`) are removed. A fetch is killed at `ARGOCD_EXEC_TIMEOUT`, so anything older cannot belong to a live fetch — this keeps cleanup safe across processes too (for example several repo-server replicas sharing an RWX cache volume), on top of the existing per-repository lock.
- Finalized `pack-*.{pack,idx,rev}` files and the push-path quarantine directory (`tmp_objdir-*`) are left untouched.

Cleanup is scoped to the fetch error path because that is the only operation writing packs into `objects/pack/` (LFS objects land under `.git/lfs/`).

## Relation to existing work, and why a rewrite

This reworks the idea behind the stalled enhancement #23501 and its PR #23493 into a smaller, bug-fix-shaped change. I chose to rewrite rather than build on #23493 because:

- #23493 is gated behind an opt-in env var (`ARGOCD_GIT_CLEANUP_ENABLED`, default off), so the leak persists for everyone by default. This is a bug, not a feature, so cleanup here is default-on with no new configuration.
- Its grace period was a multi-constant heuristic; here it is a single window of `2 × ARGOCD_EXEC_TIMEOUT`, tied directly to the kill deadline.
- It only handled `tmp_pack_`; this also covers the `tmp_idx_`/`tmp_rev_`/`tmp_mtimes_` files a killed `index-pack` can strand.
- It has been stale and in merge conflict for months.

## A note on AGENTS.md

I'm aware this repo's AGENTS.md asks for a pre-approved issue and discourages duplicating open PRs. This PR is a deliberate decision on my part as a human maintainer, not an automated submission. The underlying bug is real and reproducible (#18831, open since 2024) and both the issue and the related PR have stalled. As a maintainer of a CNCF project myself, I'd rather bring a finished, tested fix than leave a live, node-evicting resource leak waiting on a stale thread. I'm happy to adapt the approach to whatever the maintainers prefer.

Closes #18831

---

Checklist:

* [x] Either (a) I've created an enhancement proposal, (b) **this is a bug fix**, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issue number.
* [x] The title of the PR conforms to the Title of the PR guide.
* [x] I've included "Closes [ISSUE #]" to automatically close the associated issue.
* [ ] I've updated both the CLI and UI — N/A: internal repo-server behavior, no CLI/UI surface.
* [ ] Does this PR require documentation updates? — No: no new configuration or user-facing API; the cleanup is automatic.
* [x] I have signed off all my commits as required by DCO.
* [x] I have written unit tests for my change.
* [x] My build is green.
* [x] I have added a brief description of why this PR is necessary.
* [ ] Optional. For bug fixes: low-risk, no-API-change, a reasonable cherry-pick candidate for active release branches.
