### PR TITLE
ci: upload unit and e2e coverage separately with Codecov flags

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,6 +9,11 @@ ignore:
 - "vendor/.*"
 - "test/.*"
 - "**/mocks/*"
+flags:
+  unit-tests:
+    carryforward: true
+  e2e:
+    carryforward: true
 coverage:
   status:
     # we've found this not to be useful

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -434,12 +434,11 @@ jobs:
           name: test-results
           path: test-results
       - name: Generate unit test coverage profile
-        # Main and gitops-engine use different counter modes (set vs atomic),
-        # so they must be converted separately and then concatenated.
+        # -pcombine allows merging coverage from different binaries whose counter
+        # modes differ (main uses set, gitops-engine uses atomic due to -race).
         run: |
-          go tool covdata textfmt -i=test-results -o test-results/unit-coverage.out
-          go tool covdata textfmt -i=test-results/gitops-engine -o test-results/unit-coverage-engine.out
-          tail -n +2 test-results/unit-coverage-engine.out >> test-results/unit-coverage.out
+          go tool covdata merge -pcombine -i=test-results,test-results/gitops-engine -o test-results/merged
+          go tool covdata textfmt -i=test-results/merged -o test-results/unit-coverage.out
       - name: Generate e2e test coverage profile
         # We generate coverage reports for all Argo CD components, but only the applicationset-controller,
         # app-controller, repo-server, and commit-server report contain coverage data. The other components currently

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -437,6 +437,7 @@ jobs:
         # -pcombine allows merging coverage from different binaries whose counter
         # modes differ (main uses set, gitops-engine uses atomic due to -race).
         run: |
+          mkdir -p test-results/merged
           go tool covdata merge -pcombine -i=test-results,test-results/gitops-engine -o test-results/merged
           go tool covdata textfmt -i=test-results/merged -o test-results/unit-coverage.out
       - name: Generate e2e test coverage profile

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -454,6 +454,7 @@ jobs:
           version: v11.2.8 # https://github.com/getsentry/prevent-cli/releases/tag/v11.2.8
           files: test-results/unit-coverage.out
           flags: unit-tests
+          disable_search: true
           fail_ci_if_error: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -464,6 +465,7 @@ jobs:
           version: v11.2.8 # https://github.com/getsentry/prevent-cli/releases/tag/v11.2.8
           files: test-results/e2e-coverage.out
           flags: e2e
+          disable_search: true
           fail_ci_if_error: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -433,20 +433,37 @@ jobs:
         with:
           name: test-results
           path: test-results
-      - name: combine-go-coverage
+      - name: Generate unit test coverage profile
+        # Main and gitops-engine use different counter modes (set vs atomic),
+        # so they must be converted separately and then concatenated.
+        run: |
+          go tool covdata textfmt -i=test-results -o test-results/unit-coverage.out
+          go tool covdata textfmt -i=test-results/gitops-engine -o test-results/unit-coverage-engine.out
+          tail -n +2 test-results/unit-coverage-engine.out >> test-results/unit-coverage.out
+      - name: Generate e2e test coverage profile
         # We generate coverage reports for all Argo CD components, but only the applicationset-controller,
         # app-controller, repo-server, and commit-server report contain coverage data. The other components currently
         # don't shut down gracefully, so no coverage data is produced. Once those components are fixed, we can add
         # references to their coverage output directories.
         run: |
-          go tool covdata percent -i=test-results,e2e-code-coverage/applicationset-controller,e2e-code-coverage/repo-server,e2e-code-coverage/app-controller,e2e-code-coverage/commit-server -o test-results/full-coverage.out
-      - name: Upload code coverage information to codecov.io
-        # Only run when the workflow is for upstream (PR target or push is in argoproj/argo-cd).
+          go tool covdata textfmt -i=e2e-code-coverage/applicationset-controller,e2e-code-coverage/repo-server,e2e-code-coverage/app-controller,e2e-code-coverage/commit-server -o test-results/e2e-coverage.out
+      - name: Upload unit test coverage to codecov.io
         if: github.repository == 'argoproj/argo-cd'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           version: v11.2.8 # https://github.com/getsentry/prevent-cli/releases/tag/v11.2.8
-          files: test-results/full-coverage.out
+          files: test-results/unit-coverage.out
+          flags: unit-tests
+          fail_ci_if_error: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload e2e test coverage to codecov.io
+        if: github.repository == 'argoproj/argo-cd'
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          version: v11.2.8 # https://github.com/getsentry/prevent-cli/releases/tag/v11.2.8
+          files: test-results/e2e-coverage.out
+          flags: e2e
           fail_ci_if_error: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -458,8 +458,8 @@ endif
 test-gitops-engine:
 # run if TEST_MODULE is empty or points to gitops-engine tests
 ifneq ($(if $(TEST_MODULE),,ALL)$(filter github.com/argoproj/argo-cd/gitops-engine% ./gitops-engine%,$(TEST_MODULE)),)
-	mkdir -p $(PWD)/test-results
-	cd gitops-engine && go test -race -cover ./... -args -test.gocoverdir="$(PWD)/test-results"
+	mkdir -p $(PWD)/test-results/gitops-engine
+	cd gitops-engine && go test -race -cover ./... -args -test.gocoverdir="$(PWD)/test-results/gitops-engine"
 endif
 
 .PHONY: test-race


### PR DESCRIPTION
## Summary

- Split the single combined coverage upload into two separate uploads with Codecov flags (`unit-tests` and `e2e`)
- Add flag definitions to `.codecov.yml` with `carryforward: true`
- Unit test and e2e coverage profiles are now generated separately using `go tool covdata textfmt` instead of combining them with `go tool covdata percent`

This enables flag-filtered coverage views on Codecov, allowing teams to track unit test and e2e coverage independently.

## Changes

### `.github/workflows/ci-build.yaml`
- Replace combined `go tool covdata percent` step with two separate `go tool covdata textfmt` steps (one for unit tests, one for e2e)
- Upload unit test coverage with `flags: unit-tests`
- Upload e2e coverage with `flags: e2e`
- Codecov automatically merges both uploads for the overall project coverage view

### `.codecov.yml`
- Add `flags:` section defining `unit-tests` and `e2e` flags
- Both flags exclude `test/` directory and enable `carryforward`

## Test plan
- [ ] Verify CI pipeline passes with the split coverage uploads
- [ ] Confirm both `unit-tests` and `e2e` flags appear on Codecov
- [ ] Verify overall project coverage remains unchanged (Codecov merges flagged uploads)