### PR TITLE
fix: GRPCRoute health check ignores stale observedGeneration conditions (#28086)

### DIFF
--- a/resource_customizations/gateway.networking.k8s.io/GRPCRoute/health.lua
+++ b/resource_customizations/gateway.networking.k8s.io/GRPCRoute/health.lua
@@ -9,10 +9,39 @@ function checkConditions(conditions, conditionType)
   return true
 end
 
+-- isParentGenerationObserved checks if a parent's conditions match the current resource generation
+-- For GRPCRoute, observedGeneration is stored in each condition within a parent
+function isParentGenerationObserved(obj, parent)
+  if obj.metadata.generation == nil then
+    -- If no generation is set, accept all conditions
+    return true
+  end
+
+  if parent.conditions == nil or #parent.conditions == 0 then
+    return false
+  end
+
+  -- Check if all conditions have observedGeneration matching current generation
+  for _, condition in ipairs(parent.conditions) do
+    if condition.observedGeneration ~= nil then
+      if condition.observedGeneration ~= obj.metadata.generation then
+        return false
+      end
+    end
+  end
+
+  return true
+end
+
 if obj.status ~= nil then
   if obj.status.parents ~= nil then
     for _, parent in ipairs(obj.status.parents) do
       if parent.conditions ~= nil then
+        -- Skip this parent if it's not from the current generation
+        if not isParentGenerationObserved(obj, parent) then
+          goto continue
+        end
+
         local resolvedRefsFalse, resolvedRefsMsg = checkConditions(parent.conditions, "ResolvedRefs")
         local acceptedFalse, acceptedMsg = checkConditions(parent.conditions, "Accepted")
 
@@ -44,15 +73,20 @@ if obj.status ~= nil then
           hs.message = "Parent " .. (parent.parentRef.name or "") .. ": " .. progressingMsg
           return hs
         end
+
+        ::continue::
       end
     end
 
     if #obj.status.parents > 0 then
       for _, parent in ipairs(obj.status.parents) do
         if parent.conditions ~= nil and #parent.conditions > 0 then
-          hs.status = "Healthy"
-          hs.message = "GRPCRoute is healthy"
-          return hs
+          -- Only mark as healthy if we found a parent from the current generation
+          if isParentGenerationObserved(obj, parent) then
+            hs.status = "Healthy"
+            hs.message = "GRPCRoute is healthy"
+            return hs
+          end
         end
       end
     end

--- a/resource_customizations/gateway.networking.k8s.io/GRPCRoute/health_test.yaml
+++ b/resource_customizations/gateway.networking.k8s.io/GRPCRoute/health_test.yaml
@@ -27,3 +27,7 @@ tests:
     status: Healthy
     message: GRPCRoute is healthy
   inputPath: testdata/healthy_multiple_generations.yaml
+- healthStatus:
+    status: Progressing
+    message: Waiting for GRPCRoute status
+  inputPath: testdata/progressing_all_stale.yaml

--- a/resource_customizations/gateway.networking.k8s.io/GRPCRoute/health_test.yaml
+++ b/resource_customizations/gateway.networking.k8s.io/GRPCRoute/health_test.yaml
@@ -23,3 +23,7 @@ tests:
     status: Degraded
     message: "Parent : BackendRef service-does-not-exist not found"
   inputPath: testdata/degraded_no_parent_name.yaml
+- healthStatus:
+    status: Healthy
+    message: GRPCRoute is healthy
+  inputPath: testdata/healthy_multiple_generations.yaml

--- a/resource_customizations/gateway.networking.k8s.io/GRPCRoute/testdata/healthy_multiple_generations.yaml
+++ b/resource_customizations/gateway.networking.k8s.io/GRPCRoute/testdata/healthy_multiple_generations.yaml
@@ -1,0 +1,59 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: example-grpcroute
+  generation: 2
+spec:
+  parentRefs:
+    - kind: Gateway
+      name: eg
+      namespace: envoy-gateway-system
+      sectionName: foo-nonexistent
+  hostnames:
+    - "example-grpcroute.example.com"
+  rules:
+    - backendRefs:
+        - name: example-service
+          port: 8080
+status:
+  parents:
+    - conditions:
+        - lastTransitionTime: "2025-10-14T11:19:41Z"
+          message: No listeners match this parent ref
+          observedGeneration: 1
+          reason: NoMatchingParent
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: "2025-10-14T11:19:41Z"
+          message: Resolved all the Object references for the Route
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      controllerName: example.io/gateway-controller
+      parentRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: eg
+        namespace: envoy-gateway-system
+        sectionName: foo-nonexistent
+    - conditions:
+        - lastTransitionTime: "2025-10-14T11:25:18Z"
+          message: Route is accepted
+          observedGeneration: 2
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-10-14T11:25:18Z"
+          message: Resolved all the Object references for the Route
+          observedGeneration: 2
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      controllerName: example.io/gateway-controller
+      parentRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: eg
+        namespace: envoy-gateway-system
+        sectionName: https-net

--- a/resource_customizations/gateway.networking.k8s.io/GRPCRoute/testdata/progressing_all_stale.yaml
+++ b/resource_customizations/gateway.networking.k8s.io/GRPCRoute/testdata/progressing_all_stale.yaml
@@ -1,0 +1,59 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: example-grpcroute
+  generation: 2
+spec:
+  parentRefs:
+    - kind: Gateway
+      name: eg
+      namespace: envoy-gateway-system
+      sectionName: foo-nonexistent
+  hostnames:
+    - "example-grpcroute.example.com"
+  rules:
+    - backendRefs:
+        - name: example-service
+          port: 8080
+status:
+  parents:
+    - conditions:
+        - lastTransitionTime: "2025-10-14T11:19:41Z"
+          message: No listeners match this parent ref
+          observedGeneration: 1
+          reason: NoMatchingParent
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: "2025-10-14T11:19:41Z"
+          message: Resolved all the Object references for the Route
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      controllerName: example.io/gateway-controller
+      parentRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: eg
+        namespace: envoy-gateway-system
+        sectionName: foo-nonexistent
+    - conditions:
+        - lastTransitionTime: "2025-10-14T11:19:41Z"
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-10-14T11:19:41Z"
+          message: Resolved all the Object references for the Route
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      controllerName: example.io/gateway-controller
+      parentRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: eg
+        namespace: envoy-gateway-system
+        sectionName: https-net


### PR DESCRIPTION
## What does this PR do?

The GRPCRoute health check in `resource_customizations/gateway.networking.k8s.io/GRPCRoute/health.lua` did not filter parent status conditions by `observedGeneration`. When a GRPCRoute's status contained conditions from a previous generation (e.g. immediately after a spec change, before the controller reconciled), those stale conditions were still evaluated, which could yield an incorrect `Degraded` status (from an already-resolved failure) or a premature `Healthy` status (before the new generation was observed).

This is the same bug that was fixed for HTTPRoute in #24958. GRPCRoute has the identical `RouteStatus` shape (`status.parents[].conditions[].observedGeneration`) but never received the equivalent fix.

This PR ports the `isParentGenerationObserved` helper from `HTTPRoute/health.lua` to GRPCRoute:
- Parents whose conditions do not match `metadata.generation` are skipped.
- `Healthy` is only reported for a parent observed at the current generation.

A new `healthy_multiple_generations.yaml` test fixture covers a route with both a stale (gen 1, `Accepted=False`) and a current (gen 2, accepted) parent — asserting `Healthy`. Without the fix this case reports `Degraded`.

Closes #28086

## Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

> [!NOTE]
> This is a health-check-only change (Lua + test data); no API structs, CLI, UI, or documentation are affected. Behavior is now consistent with the HTTPRoute fix from #24958.
