### PR TITLE
feat: Added support to 'argocd app sync' for --local manifests, and --server-side-generate (#10936)

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -31,6 +31,8 @@ import (
 	k8swatch "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/yaml"
 
+	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/retry"
+
 	"github.com/argoproj/argo-cd/v3/cmd/argocd/commands/headless"
 	"github.com/argoproj/argo-cd/v3/cmd/argocd/commands/utils"
 	cmdutil "github.com/argoproj/argo-cd/v3/cmd/util"
@@ -51,6 +53,7 @@ import (
 	"github.com/argoproj/argo-cd/v3/util/git"
 	"github.com/argoproj/argo-cd/v3/util/grpc"
 	utilio "github.com/argoproj/argo-cd/v3/util/io"
+	"github.com/argoproj/argo-cd/v3/util/manifeststream"
 	"github.com/argoproj/argo-cd/v3/util/templates"
 	"github.com/argoproj/argo-cd/v3/util/text/label"
 )
@@ -1716,6 +1719,8 @@ func NewApplicationSyncCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 		retryBackoffFactor        int64
 		local                     string
 		localRepoRoot             string
+		serverSideGenerate        bool
+		localIncludes             []string
 		infos                     []string
 		diffChanges               bool
 		diffChangesConfirm        bool
@@ -1791,6 +1796,14 @@ func NewApplicationSyncCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 				}
 			}
 
+			if err := validateLocalSyncFlags(local, serverSideApply, serverSideGenerate); err != nil {
+				log.Fatal(err.Error())
+			}
+
+			if shouldWarnDeprecatedLocalSync(local, serverSideGenerate) {
+				fmt.Fprint(os.Stderr, "Warning: local sync without --server-side-generate is deprecated and does not work with plugins.")
+			}
+
 			acdClient := headless.NewClientOrDie(clientOpts, c)
 			conn, appIf := acdClient.NewApplicationClientOrDie()
 			defer utilio.Close(conn)
@@ -1851,7 +1864,7 @@ func NewApplicationSyncCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 
 			var clusterIf clusterpkg.ClusterServiceClient
 			var projIf projectpkg.ProjectServiceClient
-			if local != "" {
+			if local != "" && !serverSideGenerate {
 				conn, c := acdClient.NewClusterClientOrDie()
 				defer utilio.Close(conn)
 				clusterIf = c
@@ -1938,13 +1951,26 @@ func NewApplicationSyncCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 						log.Fatal("Cannot use local sync when Automatic Sync Policy is enabled except with --dry-run")
 					}
 
-					cluster, err := clusterIf.Get(ctx, &clusterpkg.ClusterQuery{Name: app.Spec.Destination.Name, Server: app.Spec.Destination.Server})
-					errors.CheckError(err)
+					if serverSideGenerate {
+						client, err := appIf.GetManifestsWithFiles(ctx, grpc_retry.Disable())
+						errors.CheckError(err)
 
-					proj, err := projIf.GetDetailedProject(ctx, &projectpkg.ProjectQuery{Name: app.Spec.Project})
-					errors.CheckError(err)
+						err = manifeststream.SendApplicationManifestQueryWithFiles(ctx, client, appName, appNs, local, localIncludes)
+						errors.CheckError(err)
 
-					localObjsStrings = getLocalObjectsString(ctx, app, proj.Project, local, localRepoRoot, argoSettings, &cluster.Info)
+						targetManifests, err := client.CloseAndRecv()
+						errors.CheckError(err)
+
+						localObjsStrings = targetManifests.Manifests
+					} else {
+						cluster, err := clusterIf.Get(ctx, &clusterpkg.ClusterQuery{Name: app.Spec.Destination.Name, Server: app.Spec.Destination.Server})
+						errors.CheckError(err)
+
+						proj, err := projIf.GetDetailedProject(ctx, &projectpkg.ProjectQuery{Name: app.Spec.Project})
+						errors.CheckError(err)
+
+						localObjsStrings = getLocalObjectsString(ctx, app, proj.Project, local, localRepoRoot, argoSettings, &cluster.Info)
+					}
 				}
 
 				syncOptionsFactory := func() *application.SyncOptions {
@@ -2071,6 +2097,8 @@ func NewApplicationSyncCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 	command.Flags().BoolVar(&async, "async", false, "Do not wait for application to sync before continuing")
 	command.Flags().StringVar(&local, "local", "", "Path to a local directory. When this flag is present no git queries will be made")
 	command.Flags().StringVar(&localRepoRoot, "local-repo-root", "/", "Path to the repository root. Used together with --local allows setting the repository root")
+	command.Flags().BoolVar(&serverSideGenerate, "server-side-generate", false, "Used with --local, this will send your manifests to the server for manifest generation")
+	command.Flags().StringArrayVar(&localIncludes, "local-include", []string{"*.yaml", "*.yml", "*.json"}, "Used with --server-side-generate, specify patterns of filenames to send. Matching is based on filename and not path.")
 	command.Flags().StringArrayVar(&infos, "info", []string{}, "A list of key-value pairs during sync process. These infos will be persisted in app.")
 	command.Flags().BoolVar(&diffChangesConfirm, "assumeYes", false, "Assume yes as answer for all user queries or prompts")
 	command.Flags().BoolVar(&diffChanges, "preview-changes", false, "Preview difference against the target and live state before syncing app and wait for user confirmation")
@@ -2101,6 +2129,17 @@ func getAppNamesBySelector(ctx context.Context, appIf application.ApplicationSer
 		}
 	}
 	return appNames, nil
+}
+
+func validateLocalSyncFlags(local string, serverSideApply bool, serverSideGenerate bool) error {
+	if local != "" && serverSideApply && !serverSideGenerate {
+		return stderrors.New("--server-side with --local requires --server-side-generate")
+	}
+	return nil
+}
+
+func shouldWarnDeprecatedLocalSync(local string, serverSideGenerate bool) bool {
+	return local != "" && !serverSideGenerate
 }
 
 // ResourceState tracks the state of a resource when waiting on an application status.

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -31,8 +31,6 @@ import (
 	k8swatch "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/yaml"
 
-	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/retry"
-
 	"github.com/argoproj/argo-cd/v3/cmd/argocd/commands/headless"
 	"github.com/argoproj/argo-cd/v3/cmd/argocd/commands/utils"
 	cmdutil "github.com/argoproj/argo-cd/v3/cmd/util"
@@ -53,7 +51,6 @@ import (
 	"github.com/argoproj/argo-cd/v3/util/git"
 	"github.com/argoproj/argo-cd/v3/util/grpc"
 	utilio "github.com/argoproj/argo-cd/v3/util/io"
-	"github.com/argoproj/argo-cd/v3/util/manifeststream"
 	"github.com/argoproj/argo-cd/v3/util/templates"
 	"github.com/argoproj/argo-cd/v3/util/text/label"
 )
@@ -1200,7 +1197,7 @@ func findAndPrintDiff(
 	app *argoappv1.Application,
 	resources *application.ManagedResourcesResponse,
 	argoSettings *settings.Settings,
-	localObjsStrings []string,
+	localTargetManifests []*unstructured.Unstructured,
 	revision string,
 	revisions []string,
 	sourcePositions []int64,
@@ -1210,17 +1207,16 @@ func findAndPrintDiff(
 	appName, appNs string,
 	serverSideDiffConcurrency int,
 	serverSideDiffMaxBatchKB int,
+	excludeSecret bool,
 ) bool {
 	// Build target manifest provider based on sync type
 	var baseTargetProvider manifestProvider
-	excludeSecret := false
 	switch {
-	case len(localObjsStrings) > 0:
+	case len(localTargetManifests) > 0:
 		// Local sync: provider fetches and generates local manifests
 		baseTargetProvider = func(_ context.Context) ([]*unstructured.Unstructured, error) {
-			return manifestsToUnstructured(localObjsStrings)
+			return localTargetManifests, nil
 		}
-		excludeSecret = true
 	case len(revisions) > 0:
 		// Multi-source app with revisions
 		baseTargetProvider = newMultiSourceRevisionProvider(appIf, appName, appNs, revisions, sourcePositions, false)
@@ -1693,6 +1689,21 @@ func printTreeViewDetailed(nodeMapping map[string]argoappv1.ResourceNode, parent
 	_ = w.Flush()
 }
 
+// unstructuerdToManifests unstructured objects to manifest strings
+func unstructuredToManifests(unstructured []*unstructured.Unstructured) ([]string, error) {
+	result := make([]string, 0, len(unstructured))
+	for _, unstructured := range unstructured {
+		if unstructured != nil {
+			jsonBytes, err := json.Marshal(unstructured)
+			if err != nil {
+				return nil, fmt.Errorf("error marshaling unstructured manifest: %w", err)
+			}
+			result = append(result, string(jsonBytes))
+		}
+	}
+	return result, nil
+}
+
 // NewApplicationSyncCommand returns a new instance of an `argocd app sync` command
 func NewApplicationSyncCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 	var (
@@ -1796,14 +1807,6 @@ func NewApplicationSyncCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 				}
 			}
 
-			if err := validateLocalSyncFlags(local, serverSideApply, serverSideGenerate); err != nil {
-				log.Fatal(err.Error())
-			}
-
-			if shouldWarnDeprecatedLocalSync(local, serverSideGenerate) {
-				fmt.Fprint(os.Stderr, "Warning: local sync without --server-side-generate is deprecated and does not work with plugins.")
-			}
-
 			acdClient := headless.NewClientOrDie(clientOpts, c)
 			conn, appIf := acdClient.NewApplicationClientOrDie()
 			defer utilio.Close(conn)
@@ -1860,18 +1863,6 @@ func NewApplicationSyncCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 				s, err := settingsIf.Get(ctx, &settings.SettingsQuery{})
 				errors.CheckError(err)
 				argoSettings = s
-			}
-
-			var clusterIf clusterpkg.ClusterServiceClient
-			var projIf projectpkg.ProjectServiceClient
-			if local != "" && !serverSideGenerate {
-				conn, c := acdClient.NewClusterClientOrDie()
-				defer utilio.Close(conn)
-				clusterIf = c
-
-				conn, p := acdClient.NewProjectClientOrDie()
-				defer utilio.Close(conn)
-				projIf = p
 			}
 
 			for _, appQualifiedName := range appNames {
@@ -1945,32 +1936,43 @@ func NewApplicationSyncCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 					log.Fatalf("No matching app resources found for resource filter: %v", strings.Join(resources, ", "))
 				}
 
+				var getLocalTargetManifests manifestProvider
+				excludeSecret := false
+				var localTargetManifests []*unstructured.Unstructured
 				var localObjsStrings []string
+
+				// If the user wants to use local manifests as the target, then we provide a mechanism to render
+				// these either clientside or serverside
 				if local != "" {
 					if app.Spec.SyncPolicy != nil && app.Spec.SyncPolicy.IsAutomatedSyncEnabled() && !dryRun {
 						log.Fatal("Cannot use local sync when Automatic Sync Policy is enabled except with --dry-run")
 					}
 
 					if serverSideGenerate {
-						client, err := appIf.GetManifestsWithFiles(ctx, grpc_retry.Disable())
-						errors.CheckError(err)
-
-						err = manifeststream.SendApplicationManifestQueryWithFiles(ctx, client, appName, appNs, local, localIncludes)
-						errors.CheckError(err)
-
-						targetManifests, err := client.CloseAndRecv()
-						errors.CheckError(err)
-
-						localObjsStrings = targetManifests.Manifests
+						getLocalTargetManifests = newLocalServerSideProvider(appIf, appName, appNs, local, localIncludes)
 					} else {
-						cluster, err := clusterIf.Get(ctx, &clusterpkg.ClusterQuery{Name: app.Spec.Destination.Name, Server: app.Spec.Destination.Server})
-						errors.CheckError(err)
+						if shouldWarnDeprecatedLocalSync(local, serverSideGenerate) {
+							fmt.Fprint(os.Stderr, "Warning: local sync without --server-side-generate is deprecated and does not work with plugins.")
+						}
 
-						proj, err := projIf.GetDetailedProject(ctx, &projectpkg.ProjectQuery{Name: app.Spec.Project})
-						errors.CheckError(err)
+						conn, clusterIf := acdClient.NewClusterClientOrDie()
+						defer utilio.Close(conn)
 
-						localObjsStrings = getLocalObjectsString(ctx, app, proj.Project, local, localRepoRoot, argoSettings, &cluster.Info)
+						proj := getProject(ctx, c, clientOpts, app.Spec.Project)
+						getLocalTargetManifests = newLocalClientSideProvider(clusterIf, argoSettings, app, proj.Project, local, localRepoRoot)
+						//
+						// Local diff does not support to hide the configurable annotations in the secrets.
+						// To not have constant partial diffs, we exclude secrets from the diff.
+						excludeSecret = true
 					}
+
+					// Get target manifests
+					localTargetManifests, err = getLocalTargetManifests(ctx)
+					errors.CheckError(err)
+
+					// Since the ApplicationSyncRequest RPC works with []string, we need to convert back to that format
+					localObjsStrings, err = unstructuredToManifests(localTargetManifests)
+					errors.CheckError(err)
 				}
 
 				syncOptionsFactory := func() *application.SyncOptions {
@@ -2042,7 +2044,7 @@ func NewApplicationSyncCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 					// Check if application has ServerSideDiff annotation
 					serverSideDiff := resourceutil.HasAnnotationOption(app, argocommon.AnnotationCompareOptions, "ServerSideDiff=true")
 
-					foundDiffs = findAndPrintDiff(ctx, app, resources, argoSettings, localObjsStrings, revision, revisions, sourcePositions, ignoreNormalizerOpts, serverSideDiff, appIf, appName, appNs, serverSideDiffConcurrency, serverSideDiffMaxBatchKB)
+					foundDiffs = findAndPrintDiff(ctx, app, resources, argoSettings, localTargetManifests, revision, revisions, sourcePositions, ignoreNormalizerOpts, serverSideDiff, appIf, appName, appNs, serverSideDiffConcurrency, serverSideDiffMaxBatchKB, excludeSecret)
 					if !foundDiffs {
 						fmt.Print("====== No Differences found ======\n")
 						// if no differences found, then no need to sync
@@ -2129,13 +2131,6 @@ func getAppNamesBySelector(ctx context.Context, appIf application.ApplicationSer
 		}
 	}
 	return appNames, nil
-}
-
-func validateLocalSyncFlags(local string, serverSideApply bool, serverSideGenerate bool) error {
-	if local != "" && serverSideApply && !serverSideGenerate {
-		return stderrors.New("--server-side with --local requires --server-side-generate")
-	}
-	return nil
 }
 
 func shouldWarnDeprecatedLocalSync(local string, serverSideGenerate bool) bool {

--- a/cmd/argocd/commands/app_sync_test.go
+++ b/cmd/argocd/commands/app_sync_test.go
@@ -1,16 +1,10 @@
 package commands
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/metadata"
-
-	applicationpkg "github.com/argoproj/argo-cd/v3/pkg/apiclient/application"
-	"github.com/argoproj/argo-cd/v3/reposerver/apiclient"
 )
 
 func TestNewApplicationSyncCommand_ServerSideGenerateFlag(t *testing.T) {
@@ -18,126 +12,13 @@ func TestNewApplicationSyncCommand_ServerSideGenerateFlag(t *testing.T) {
 	flag := cmd.Flags().Lookup("server-side-generate")
 	require.NotNil(t, flag, "flag --server-side-generate should exist")
 	assert.Equal(t, "false", flag.DefValue)
+}
 
+func TestNewApplicationSyncCommand_LocalIncludeFlag(t *testing.T) {
+	cmd := NewApplicationSyncCommand(nil)
 	includeFlag := cmd.Flags().Lookup("local-include")
 	require.NotNil(t, includeFlag, "flag --local-include should exist")
 	assert.Equal(t, "[*.yaml,*.yml,*.json]", includeFlag.DefValue)
-}
-
-// fakeGetManifestsWithFilesClient is a fake implementation of
-// ApplicationService_GetManifestsWithFilesClient used to unit-test the
-// server-side-generate path in the sync command without a real gRPC connection.
-type fakeGetManifestsWithFilesClient struct {
-	sendErr    error
-	recvResult *apiclient.ManifestResponse
-	recvErr    error
-	sentMsgs   []*applicationpkg.ApplicationManifestQueryWithFilesWrapper
-}
-
-func (f *fakeGetManifestsWithFilesClient) Send(msg *applicationpkg.ApplicationManifestQueryWithFilesWrapper) error {
-	f.sentMsgs = append(f.sentMsgs, msg)
-	return f.sendErr
-}
-
-func (f *fakeGetManifestsWithFilesClient) CloseAndRecv() (*apiclient.ManifestResponse, error) {
-	return f.recvResult, f.recvErr
-}
-
-func (f *fakeGetManifestsWithFilesClient) Header() (metadata.MD, error) { return nil, nil }
-func (f *fakeGetManifestsWithFilesClient) Trailer() metadata.MD         { return nil }
-func (f *fakeGetManifestsWithFilesClient) CloseSend() error             { return nil }
-func (f *fakeGetManifestsWithFilesClient) Context() context.Context     { return context.Background() }
-func (f *fakeGetManifestsWithFilesClient) SendMsg(_ any) error          { return nil }
-func (f *fakeGetManifestsWithFilesClient) RecvMsg(_ any) error          { return nil }
-
-// fakeAppServiceClientWithManifests extends fakeAppServiceClient to allow
-// returning a custom GetManifestsWithFilesClient for server-side-generate tests.
-type fakeAppServiceClientWithManifests struct {
-	fakeAppServiceClient
-	manifestsClient applicationpkg.ApplicationService_GetManifestsWithFilesClient
-	manifestsErr    error
-}
-
-func (c *fakeAppServiceClientWithManifests) GetManifestsWithFiles(_ context.Context, _ ...grpc.CallOption) (applicationpkg.ApplicationService_GetManifestsWithFilesClient, error) {
-	return c.manifestsClient, c.manifestsErr
-}
-
-func TestNewApplicationSyncCommand_ServerSideGenerateReturnsManifests(t *testing.T) {
-	manifests := []string{
-		`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"my-cm","namespace":"default"}}`,
-	}
-	fakeClient := &fakeGetManifestsWithFilesClient{
-		recvResult: &apiclient.ManifestResponse{Manifests: manifests},
-	}
-
-	appSvcClient := &fakeAppServiceClientWithManifests{
-		manifestsClient: fakeClient,
-	}
-
-	// Verify the fake correctly satisfies the interface used by the production code
-	var _ applicationpkg.ApplicationService_GetManifestsWithFilesClient = fakeClient
-	var _ applicationpkg.ApplicationServiceClient = appSvcClient
-
-	// Verify that calling GetManifestsWithFiles and CloseAndRecv flows correctly
-	// (this mirrors the production code path in app.go)
-	stream, err := appSvcClient.GetManifestsWithFiles(context.Background())
-	require.NoError(t, err)
-
-	response, err := stream.CloseAndRecv()
-	require.NoError(t, err)
-	require.NotNil(t, response)
-	assert.Equal(t, manifests, response.Manifests)
-}
-
-func TestValidateLocalSyncFlags(t *testing.T) {
-	tests := []struct {
-		name               string
-		local              string
-		serverSideApply    bool
-		serverSideGenerate bool
-		expectErr          bool
-	}{
-		{
-			name:               "local with server-side apply requires server-side-generate",
-			local:              "/tmp/manifests",
-			serverSideApply:    true,
-			serverSideGenerate: false,
-			expectErr:          true,
-		},
-		{
-			name:               "local with server-side apply and server-side-generate is allowed",
-			local:              "/tmp/manifests",
-			serverSideApply:    true,
-			serverSideGenerate: true,
-			expectErr:          false,
-		},
-		{
-			name:               "local without server-side apply is allowed",
-			local:              "/tmp/manifests",
-			serverSideApply:    false,
-			serverSideGenerate: false,
-			expectErr:          false,
-		},
-		{
-			name:               "non-local with server-side apply is allowed",
-			local:              "",
-			serverSideApply:    true,
-			serverSideGenerate: false,
-			expectErr:          false,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			err := validateLocalSyncFlags(tc.local, tc.serverSideApply, tc.serverSideGenerate)
-			if tc.expectErr {
-				require.Error(t, err)
-				assert.Equal(t, "--server-side with --local requires --server-side-generate", err.Error())
-				return
-			}
-			require.NoError(t, err)
-		})
-	}
 }
 
 func TestShouldWarnDeprecatedLocalSync(t *testing.T) {

--- a/cmd/argocd/commands/app_sync_test.go
+++ b/cmd/argocd/commands/app_sync_test.go
@@ -1,0 +1,147 @@
+package commands
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	applicationpkg "github.com/argoproj/argo-cd/v3/pkg/apiclient/application"
+	"github.com/argoproj/argo-cd/v3/reposerver/apiclient"
+)
+
+func TestNewApplicationSyncCommand_ServerSideGenerateFlag(t *testing.T) {
+	cmd := NewApplicationSyncCommand(nil)
+	flag := cmd.Flags().Lookup("server-side-generate")
+	require.NotNil(t, flag, "flag --server-side-generate should exist")
+	assert.Equal(t, "false", flag.DefValue)
+
+	includeFlag := cmd.Flags().Lookup("local-include")
+	require.NotNil(t, includeFlag, "flag --local-include should exist")
+	assert.Equal(t, "[*.yaml,*.yml,*.json]", includeFlag.DefValue)
+}
+
+// fakeGetManifestsWithFilesClient is a fake implementation of
+// ApplicationService_GetManifestsWithFilesClient used to unit-test the
+// server-side-generate path in the sync command without a real gRPC connection.
+type fakeGetManifestsWithFilesClient struct {
+	sendErr    error
+	recvResult *apiclient.ManifestResponse
+	recvErr    error
+	sentMsgs   []*applicationpkg.ApplicationManifestQueryWithFilesWrapper
+}
+
+func (f *fakeGetManifestsWithFilesClient) Send(msg *applicationpkg.ApplicationManifestQueryWithFilesWrapper) error {
+	f.sentMsgs = append(f.sentMsgs, msg)
+	return f.sendErr
+}
+
+func (f *fakeGetManifestsWithFilesClient) CloseAndRecv() (*apiclient.ManifestResponse, error) {
+	return f.recvResult, f.recvErr
+}
+
+func (f *fakeGetManifestsWithFilesClient) Header() (metadata.MD, error) { return nil, nil }
+func (f *fakeGetManifestsWithFilesClient) Trailer() metadata.MD         { return nil }
+func (f *fakeGetManifestsWithFilesClient) CloseSend() error             { return nil }
+func (f *fakeGetManifestsWithFilesClient) Context() context.Context     { return context.Background() }
+func (f *fakeGetManifestsWithFilesClient) SendMsg(_ any) error          { return nil }
+func (f *fakeGetManifestsWithFilesClient) RecvMsg(_ any) error          { return nil }
+
+// fakeAppServiceClientWithManifests extends fakeAppServiceClient to allow
+// returning a custom GetManifestsWithFilesClient for server-side-generate tests.
+type fakeAppServiceClientWithManifests struct {
+	fakeAppServiceClient
+	manifestsClient applicationpkg.ApplicationService_GetManifestsWithFilesClient
+	manifestsErr    error
+}
+
+func (c *fakeAppServiceClientWithManifests) GetManifestsWithFiles(_ context.Context, _ ...grpc.CallOption) (applicationpkg.ApplicationService_GetManifestsWithFilesClient, error) {
+	return c.manifestsClient, c.manifestsErr
+}
+
+func TestNewApplicationSyncCommand_ServerSideGenerateReturnsManifests(t *testing.T) {
+	manifests := []string{
+		`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"my-cm","namespace":"default"}}`,
+	}
+	fakeClient := &fakeGetManifestsWithFilesClient{
+		recvResult: &apiclient.ManifestResponse{Manifests: manifests},
+	}
+
+	appSvcClient := &fakeAppServiceClientWithManifests{
+		manifestsClient: fakeClient,
+	}
+
+	// Verify the fake correctly satisfies the interface used by the production code
+	var _ applicationpkg.ApplicationService_GetManifestsWithFilesClient = fakeClient
+	var _ applicationpkg.ApplicationServiceClient = appSvcClient
+
+	// Verify that calling GetManifestsWithFiles and CloseAndRecv flows correctly
+	// (this mirrors the production code path in app.go)
+	stream, err := appSvcClient.GetManifestsWithFiles(context.Background())
+	require.NoError(t, err)
+
+	response, err := stream.CloseAndRecv()
+	require.NoError(t, err)
+	require.NotNil(t, response)
+	assert.Equal(t, manifests, response.Manifests)
+}
+
+func TestValidateLocalSyncFlags(t *testing.T) {
+	tests := []struct {
+		name               string
+		local              string
+		serverSideApply    bool
+		serverSideGenerate bool
+		expectErr          bool
+	}{
+		{
+			name:               "local with server-side apply requires server-side-generate",
+			local:              "/tmp/manifests",
+			serverSideApply:    true,
+			serverSideGenerate: false,
+			expectErr:          true,
+		},
+		{
+			name:               "local with server-side apply and server-side-generate is allowed",
+			local:              "/tmp/manifests",
+			serverSideApply:    true,
+			serverSideGenerate: true,
+			expectErr:          false,
+		},
+		{
+			name:               "local without server-side apply is allowed",
+			local:              "/tmp/manifests",
+			serverSideApply:    false,
+			serverSideGenerate: false,
+			expectErr:          false,
+		},
+		{
+			name:               "non-local with server-side apply is allowed",
+			local:              "",
+			serverSideApply:    true,
+			serverSideGenerate: false,
+			expectErr:          false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateLocalSyncFlags(tc.local, tc.serverSideApply, tc.serverSideGenerate)
+			if tc.expectErr {
+				require.Error(t, err)
+				assert.Equal(t, "--server-side with --local requires --server-side-generate", err.Error())
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestShouldWarnDeprecatedLocalSync(t *testing.T) {
+	assert.True(t, shouldWarnDeprecatedLocalSync("/tmp/manifests", false))
+	assert.False(t, shouldWarnDeprecatedLocalSync("/tmp/manifests", true))
+	assert.False(t, shouldWarnDeprecatedLocalSync("", false))
+}

--- a/docs/user-guide/commands/argocd_app_sync.md
+++ b/docs/user-guide/commands/argocd_app_sync.md
@@ -53,6 +53,7 @@ argocd app sync [APPNAME... | -l selector | --project project-name] [flags]
       --info stringArray                                  A list of key-value pairs during sync process. These infos will be persisted in app.
       --label stringArray                                 Sync only specific resources with a label. This option may be specified repeatedly.
       --local string                                      Path to a local directory. When this flag is present no git queries will be made
+      --local-include stringArray                         Used with --server-side-generate, specify patterns of filenames to send. Matching is based on filename and not path. (default [*.yaml,*.yml,*.json])
       --local-repo-root string                            Path to the repository root. Used together with --local allows setting the repository root (default "/")
   -o, --output string                                     Output format. One of: json|yaml|wide|tree|tree=detailed (default "wide")
       --preview-changes                                   Preview difference against the target and live state before syncing app and wait for user confirmation
@@ -71,6 +72,7 @@ argocd app sync [APPNAME... | -l selector | --project project-name] [flags]
       --server-side                                       Use server-side apply while syncing the application
       --server-side-diff-concurrency int                  Max concurrent batches for server-side diff. -1 = unlimited, 1 = sequential, 2+ = concurrent (0 = invalid) (default -1)
       --server-side-diff-max-batch-kb int                 Max batch size in KB for server-side diff. Smaller values are safer for proxies (default 250)
+      --server-side-generate                              Used with --local, this will send your manifests to the server for manifest generation
       --source-names stringArray                          List of source names. Default is an empty array.
       --source-positions int64Slice                       List of source positions. Default is empty array. Counting start at 1. (default [])
       --strategy string                                   Sync strategy (one of: apply|hook)

--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -1024,6 +1024,19 @@ func TestLocalManifestSync(t *testing.T) {
 		})
 }
 
+func TestLocalSyncServerSideGenerate(t *testing.T) {
+	Given(t).
+		Path(guestbookPath).
+		When().
+		CreateApp().
+		Then().
+		And(func(app *Application) {
+			localRepoRoot := fixture.LocalRepoRoot()
+			_, err := fixture.RunCli("app", "sync", app.Name, "--local", localRepoRoot, "--server-side-generate")
+			require.NoError(t, err)
+		})
+}
+
 func TestLocalSync(t *testing.T) {
 	Given(t).
 		// we've got to use Helm as this uses kubeVersion


### PR DESCRIPTION
This gives `argocd app sync` feature parity with `argocd app diff` when it comes to local manifests and server-side generation.

When `argocd app sync` is called with `--local <path>` and `--server-side-generate`, argocd will gather local manifests, upload them to the ArgoCD server, and render the manifests serverside. This is the same as what `argocd app diff` does when serverside generation is requested.

This makes it possible to use both `argocd app diff` and `argocd app sync` in workflows where the user wants to use serverside manifest rendering, and serverside diff/apply, but wants the manifests to come from the local machine instead of a hosted SCM repository. This is particularly useful in situations where there's a bit of trial-and-error involved in getting manifests right (for example when bringing up a new application).

Closes issue #10936.

Regarding codecov: This PR has code coverage comparable to the previous `argocd app sync` command, or `argocd app diff` where that was used as the reference.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
  * This is implementation of a feature request
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
  * It introduces two additional options to the `argocd app sync` command. These are documented in the docs section.
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
  - This is an extension of an existing Stable feature
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
  * nope
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).
   * nope, this is not a bug fix

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
