### PR TITLE
feat(util/cache): support Microsoft Entra ID workload identity for Redis

### DIFF
--- a/docs/operator-manual/argocd-cmd-params-cm.yaml
+++ b/docs/operator-manual/argocd-cmd-params-cm.yaml
@@ -23,9 +23,10 @@ data:
   # "azure" (Microsoft Entra ID workload identity for Azure Cache for Redis).
   # When set, redis.password / REDIS_PASSWORD are ignored.
   redis.credentials.provider: ""
-  # Optional override for the Microsoft Entra ID application/client ID used to acquire
-  # Redis access tokens. Defaults to the AZURE_CLIENT_ID env var injected by the
-  # workload-identity admission webhook. Only honoured when redis.credentials.provider=azure.
+  # Microsoft Entra ID application/client ID used to acquire Redis access tokens.
+  # When unset, falls back to azidentity.DefaultAzureCredential (which honours the
+  # AZURE_CLIENT_ID env var injected by the workload-identity admission webhook).
+  # Only honoured when redis.credentials.provider=azure.
   redis.azure.client.id: ""
   # OAuth scope to request when acquiring Microsoft Entra ID tokens for Redis.
   # Override only when targeting a non-public Azure cloud (e.g. Azure Government).

--- a/docs/operator-manual/argocd-cmd-params-cm.yaml
+++ b/docs/operator-manual/argocd-cmd-params-cm.yaml
@@ -18,6 +18,19 @@ data:
   redis.compression: gzip
   # Redis database
   redis.db:
+  # Use a registered RedisCredentialsProvider for dynamic Redis authentication
+  # (e.g. cloud-provider workload identity). Currently supported values:
+  # "azure" (Microsoft Entra ID workload identity for Azure Cache for Redis).
+  # When set, redis.password / REDIS_PASSWORD are ignored.
+  redis.credentials.provider: ""
+  # Optional override for the Microsoft Entra ID application/client ID used to acquire
+  # Redis access tokens. Defaults to the AZURE_CLIENT_ID env var injected by the
+  # workload-identity admission webhook. Only honoured when redis.credentials.provider=azure.
+  redis.azure.client.id: ""
+  # OAuth scope to request when acquiring Microsoft Entra ID tokens for Redis.
+  # Override only when targeting a non-public Azure cloud (e.g. Azure Government).
+  # Only honoured when redis.credentials.provider=azure.
+  redis.azure.scope: "https://redis.azure.com/.default"
 
   # Enables the alpha "manifest hydrator" feature. (default "false")
   hydrator.enabled: "false"

--- a/docs/operator-manual/server-commands/argocd-application-controller.md
+++ b/docs/operator-manual/server-commands/argocd-application-controller.md
@@ -57,7 +57,7 @@ argocd-application-controller [flags]
       --persist-resource-health                                   Enables storing the managed resources health in the Application CRD
       --proxy-url string                                          If provided, this URL will be used to connect via proxy
       --redis string                                              Redis server hostname and port (e.g. argocd-redis:6379). 
-      --redis-azure-client-id string                              Optional override for the Microsoft Entra ID application/client ID used to acquire Redis access tokens. Defaults to the AZURE_CLIENT_ID injected by the workload-identity webhook. Only honoured when --redis-credentials-provider=azure.
+      --redis-azure-client-id string                              Microsoft Entra ID application/client ID used to acquire Redis access tokens. When unset, falls back to azidentity.DefaultAzureCredential (which honours the AZURE_CLIENT_ID env var injected by the workload-identity admission webhook). Only honoured when --redis-credentials-provider=azure.
       --redis-azure-scope string                                  OAuth scope to request when acquiring Microsoft Entra ID tokens for Redis. Override only when targeting a non-public Azure cloud (e.g. Azure Government). Only honoured when --redis-credentials-provider=azure. (default "https://redis.azure.com/.default")
       --redis-ca-certificate string                               Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
       --redis-client-certificate string                           Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).

--- a/docs/operator-manual/server-commands/argocd-application-controller.md
+++ b/docs/operator-manual/server-commands/argocd-application-controller.md
@@ -57,10 +57,13 @@ argocd-application-controller [flags]
       --persist-resource-health                                   Enables storing the managed resources health in the Application CRD
       --proxy-url string                                          If provided, this URL will be used to connect via proxy
       --redis string                                              Redis server hostname and port (e.g. argocd-redis:6379). 
+      --redis-azure-client-id string                              Optional override for the Microsoft Entra ID application/client ID used to acquire Redis access tokens. Defaults to the AZURE_CLIENT_ID injected by the workload-identity webhook. Only honoured when --redis-credentials-provider=azure.
+      --redis-azure-scope string                                  OAuth scope to request when acquiring Microsoft Entra ID tokens for Redis. Override only when targeting a non-public Azure cloud (e.g. Azure Government). Only honoured when --redis-credentials-provider=azure. (default "https://redis.azure.com/.default")
       --redis-ca-certificate string                               Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
       --redis-client-certificate string                           Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
       --redis-client-key string                                   Path to Redis client key (e.g. /etc/certs/redis/client.crt).
       --redis-compress string                                     Enable compression for data sent to Redis with the required compression algorithm. (possible values: gzip, none) (default "gzip")
+      --redis-credentials-provider string                         Use a registered credentials provider to authenticate to Redis dynamically (e.g. cloud-provider workload identity). Registered providers: [azure]. When set, --redis-password / REDIS_PASSWORD are ignored.
       --redis-insecure-skip-tls-verify                            Skip Redis server certificate validation.
       --redis-use-tls                                             Use TLS when connecting to Redis. 
       --redisdb int                                               Redis database.

--- a/docs/operator-manual/server-commands/argocd-repo-server.md
+++ b/docs/operator-manual/server-commands/argocd-repo-server.md
@@ -42,7 +42,7 @@ argocd-repo-server [flags]
       --plugin-use-manifest-generate-paths             Pass the resources described in argocd.argoproj.io/manifest-generate-paths value to the cmpserver to generate the application manifests.
       --port int                                       Listen on given port for incoming connections (default 8081)
       --redis string                                   Redis server hostname and port (e.g. argocd-redis:6379). 
-      --redis-azure-client-id string                   Optional override for the Microsoft Entra ID application/client ID used to acquire Redis access tokens. Defaults to the AZURE_CLIENT_ID injected by the workload-identity webhook. Only honoured when --redis-credentials-provider=azure.
+      --redis-azure-client-id string                   Microsoft Entra ID application/client ID used to acquire Redis access tokens. When unset, falls back to azidentity.DefaultAzureCredential (which honours the AZURE_CLIENT_ID env var injected by the workload-identity admission webhook). Only honoured when --redis-credentials-provider=azure.
       --redis-azure-scope string                       OAuth scope to request when acquiring Microsoft Entra ID tokens for Redis. Override only when targeting a non-public Azure cloud (e.g. Azure Government). Only honoured when --redis-credentials-provider=azure. (default "https://redis.azure.com/.default")
       --redis-ca-certificate string                    Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
       --redis-client-certificate string                Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).

--- a/docs/operator-manual/server-commands/argocd-repo-server.md
+++ b/docs/operator-manual/server-commands/argocd-repo-server.md
@@ -42,10 +42,13 @@ argocd-repo-server [flags]
       --plugin-use-manifest-generate-paths             Pass the resources described in argocd.argoproj.io/manifest-generate-paths value to the cmpserver to generate the application manifests.
       --port int                                       Listen on given port for incoming connections (default 8081)
       --redis string                                   Redis server hostname and port (e.g. argocd-redis:6379). 
+      --redis-azure-client-id string                   Optional override for the Microsoft Entra ID application/client ID used to acquire Redis access tokens. Defaults to the AZURE_CLIENT_ID injected by the workload-identity webhook. Only honoured when --redis-credentials-provider=azure.
+      --redis-azure-scope string                       OAuth scope to request when acquiring Microsoft Entra ID tokens for Redis. Override only when targeting a non-public Azure cloud (e.g. Azure Government). Only honoured when --redis-credentials-provider=azure. (default "https://redis.azure.com/.default")
       --redis-ca-certificate string                    Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
       --redis-client-certificate string                Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
       --redis-client-key string                        Path to Redis client key (e.g. /etc/certs/redis/client.crt).
       --redis-compress string                          Enable compression for data sent to Redis with the required compression algorithm. (possible values: gzip, none) (default "gzip")
+      --redis-credentials-provider string              Use a registered credentials provider to authenticate to Redis dynamically (e.g. cloud-provider workload identity). Registered providers: [azure]. When set, --redis-password / REDIS_PASSWORD are ignored.
       --redis-insecure-skip-tls-verify                 Skip Redis server certificate validation.
       --redis-use-tls                                  Use TLS when connecting to Redis. 
       --redisdb int                                    Redis database.

--- a/docs/operator-manual/server-commands/argocd-server.md
+++ b/docs/operator-manual/server-commands/argocd-server.md
@@ -76,7 +76,7 @@ argocd-server [flags]
       --port int                                        Listen on given port (default 8080)
       --proxy-url string                                If provided, this URL will be used to connect via proxy
       --redis string                                    Redis server hostname and port (e.g. argocd-redis:6379). 
-      --redis-azure-client-id string                    Optional override for the Microsoft Entra ID application/client ID used to acquire Redis access tokens. Defaults to the AZURE_CLIENT_ID injected by the workload-identity webhook. Only honoured when --redis-credentials-provider=azure.
+      --redis-azure-client-id string                    Microsoft Entra ID application/client ID used to acquire Redis access tokens. When unset, falls back to azidentity.DefaultAzureCredential (which honours the AZURE_CLIENT_ID env var injected by the workload-identity admission webhook). Only honoured when --redis-credentials-provider=azure.
       --redis-azure-scope string                        OAuth scope to request when acquiring Microsoft Entra ID tokens for Redis. Override only when targeting a non-public Azure cloud (e.g. Azure Government). Only honoured when --redis-credentials-provider=azure. (default "https://redis.azure.com/.default")
       --redis-ca-certificate string                     Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
       --redis-client-certificate string                 Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
@@ -91,7 +91,7 @@ argocd-server [flags]
       --repo-server-default-cache-expiration duration   Cache expiration default (default 24h0m0s)
       --repo-server-plaintext                           Use a plaintext client (non-TLS) to connect to repository server
       --repo-server-redis string                        Redis server hostname and port (e.g. argocd-redis:6379). 
-      --repo-server-redis-azure-client-id string        Optional override for the Microsoft Entra ID application/client ID used to acquire Redis access tokens. Defaults to the AZURE_CLIENT_ID injected by the workload-identity webhook. Only honoured when --redis-credentials-provider=azure.
+      --repo-server-redis-azure-client-id string        Microsoft Entra ID application/client ID used to acquire Redis access tokens. When unset, falls back to azidentity.DefaultAzureCredential (which honours the AZURE_CLIENT_ID env var injected by the workload-identity admission webhook). Only honoured when --redis-credentials-provider=azure.
       --repo-server-redis-azure-scope string            OAuth scope to request when acquiring Microsoft Entra ID tokens for Redis. Override only when targeting a non-public Azure cloud (e.g. Azure Government). Only honoured when --redis-credentials-provider=azure. (default "https://redis.azure.com/.default")
       --repo-server-redis-ca-certificate string         Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
       --repo-server-redis-client-certificate string     Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).

--- a/docs/operator-manual/server-commands/argocd-server.md
+++ b/docs/operator-manual/server-commands/argocd-server.md
@@ -76,10 +76,13 @@ argocd-server [flags]
       --port int                                        Listen on given port (default 8080)
       --proxy-url string                                If provided, this URL will be used to connect via proxy
       --redis string                                    Redis server hostname and port (e.g. argocd-redis:6379). 
+      --redis-azure-client-id string                    Optional override for the Microsoft Entra ID application/client ID used to acquire Redis access tokens. Defaults to the AZURE_CLIENT_ID injected by the workload-identity webhook. Only honoured when --redis-credentials-provider=azure.
+      --redis-azure-scope string                        OAuth scope to request when acquiring Microsoft Entra ID tokens for Redis. Override only when targeting a non-public Azure cloud (e.g. Azure Government). Only honoured when --redis-credentials-provider=azure. (default "https://redis.azure.com/.default")
       --redis-ca-certificate string                     Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
       --redis-client-certificate string                 Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
       --redis-client-key string                         Path to Redis client key (e.g. /etc/certs/redis/client.crt).
       --redis-compress string                           Enable compression for data sent to Redis with the required compression algorithm. (possible values: gzip, none) (default "gzip")
+      --redis-credentials-provider string               Use a registered credentials provider to authenticate to Redis dynamically (e.g. cloud-provider workload identity). Registered providers: [azure]. When set, --redis-password / REDIS_PASSWORD are ignored.
       --redis-insecure-skip-tls-verify                  Skip Redis server certificate validation.
       --redis-use-tls                                   Use TLS when connecting to Redis. 
       --redisdb int                                     Redis database.
@@ -88,10 +91,13 @@ argocd-server [flags]
       --repo-server-default-cache-expiration duration   Cache expiration default (default 24h0m0s)
       --repo-server-plaintext                           Use a plaintext client (non-TLS) to connect to repository server
       --repo-server-redis string                        Redis server hostname and port (e.g. argocd-redis:6379). 
+      --repo-server-redis-azure-client-id string        Optional override for the Microsoft Entra ID application/client ID used to acquire Redis access tokens. Defaults to the AZURE_CLIENT_ID injected by the workload-identity webhook. Only honoured when --redis-credentials-provider=azure.
+      --repo-server-redis-azure-scope string            OAuth scope to request when acquiring Microsoft Entra ID tokens for Redis. Override only when targeting a non-public Azure cloud (e.g. Azure Government). Only honoured when --redis-credentials-provider=azure. (default "https://redis.azure.com/.default")
       --repo-server-redis-ca-certificate string         Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
       --repo-server-redis-client-certificate string     Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
       --repo-server-redis-client-key string             Path to Redis client key (e.g. /etc/certs/redis/client.crt).
       --repo-server-redis-compress string               Enable compression for data sent to Redis with the required compression algorithm. (possible values: gzip, none) (default "gzip")
+      --repo-server-redis-credentials-provider string   Use a registered credentials provider to authenticate to Redis dynamically (e.g. cloud-provider workload identity). Registered providers: [azure]. When set, --redis-password / REDIS_PASSWORD are ignored.
       --repo-server-redis-insecure-skip-tls-verify      Skip Redis server certificate validation.
       --repo-server-redis-use-tls                       Use TLS when connecting to Redis. 
       --repo-server-redisdb int                         Redis database.

--- a/docs/operator-manual/upgrading/3.4-3.5.md
+++ b/docs/operator-manual/upgrading/3.4-3.5.md
@@ -134,6 +134,25 @@ Consume structured result from `sourceIntegrityResult` field instead.
 
 ## Other Changes
 
+### Pluggable Redis credentials provider — Microsoft Entra ID workload identity (opt-in)
+
+Argo CD 3.5 adds a pluggable `RedisCredentialsProviderFactory` registry that lets the cache layer pick up credentials from a dynamic source (e.g. cloud-provider workload identity) instead of a static password. The first registered backend is **Microsoft Entra ID** for Azure Cache for Redis; other clouds (GCP Memorystore IAM, AWS ElastiCache IAM) can be added by registering an additional factory.
+
+The feature is fully opt-in. Existing deployments are unaffected. To enable the Azure backend, set the following on the `argocd-cmd-params-cm` ConfigMap (or pass the equivalent CLI flags / env vars):
+
+```yaml
+data:
+  redis.credentials.provider: "azure"
+  # Optional: override the AZURE_CLIENT_ID env var injected by the workload-identity webhook.
+  # redis.azure.client.id: "<application-or-managed-identity-client-id>"
+  # Optional: override only when targeting non-public Azure clouds.
+  # redis.azure.scope: "https://redis.azure.us/.default"
+```
+
+When a credentials provider is selected, `redis.password` / `REDIS_PASSWORD` is intentionally ignored: cloud-issued tokens are short-lived and the static value would only be honoured until the first reconnect. For the `azure` backend the AUTH username is derived from the principal's object ID (the `oid` JWT claim) and the password is a freshly issued access token that go-redis re-acquires automatically on each (re)connect.
+
+The Argo CD workload identity (or managed identity) needs the **Data Owner** access policy on the target cache. See [Use Microsoft Entra ID for cache authentication](https://learn.microsoft.com/azure/azure-cache-for-redis/cache-azure-active-directory-for-authentication) for the Azure-side setup.
+
 ### Release `sbom.tar.gz` contents
 
 For normal GitHub releases, **`sbom.tar.gz`** still includes **`bom-go-mod.spdx`** (Go dependencies, tag-value SPDX from `spdx-sbom-generator`) and **`bom-docker-image.spdx`** (the published release image, tag-value SPDX from `sigs.k8s.io/bom`). The UI dependency list is now **`bom-ui-pnpm.spdx.json`**: **SPDX 2.3 JSON** from **`pnpm sbom`**, replacing the old tag-value **`./ui`** output from `spdx-sbom-generator`.

--- a/docs/proposals/redis-azure-workload-identity.md
+++ b/docs/proposals/redis-azure-workload-identity.md
@@ -1,0 +1,318 @@
+---
+title: Pluggable Redis credentials provider (with Microsoft Entra ID as first implementation)
+authors:
+  - "@tarapratap"
+sponsors:
+  - TBD
+reviewers:
+  - TBD
+approvers:
+  - TBD
+
+creation-date: 2026-06-02
+last-updated: 2026-06-04
+---
+
+# Pluggable Redis credentials provider (with Microsoft Entra ID as first implementation)
+
+## Summary
+
+Introduce a small `RedisCredentialsProviderFactory` extension point in
+`util/cache/` that lets Argo CD acquire short-lived, automatically rotated
+Redis credentials from a registered backend (typically a cloud provider's
+workload identity), instead of a static password.
+
+A single new flag — `--redis-credentials-provider` — selects which backend is
+active. The first registered backend in this proposal is **Microsoft Entra ID
+workload identity** for Azure Cache for Redis (`--redis-credentials-provider=azure`).
+The same registry trivially accommodates GCP Memorystore IAM and AWS
+ElastiCache IAM as future contributions, but those are explicitly out of
+scope for this PR.
+
+When a provider is selected, the Redis client uses
+`redis.Options.CredentialsProviderContext` to resolve credentials on every
+(re)connect, and any value coming from `--redis-password` / `REDIS_PASSWORD`
+is discarded. For the `azure` backend the AUTH username is the principal's
+object ID (the `oid` JWT claim), and two companion flags
+(`--redis-azure-client-id`, `--redis-azure-scope`) handle multi-identity and
+sovereign-cloud deployments.
+
+The change is fully opt-in; the flag defaults to empty (= unchanged static
+password flow).
+
+## Motivation
+
+Azure Cache for Redis has supported [Microsoft Entra ID
+authentication](https://learn.microsoft.com/azure/azure-cache-for-redis/cache-azure-active-directory-for-authentication)
+as the recommended auth mode since 2024. Operators on Azure Kubernetes Service
+(AKS) typically run every other workload (Cosmos DB, Service Bus, Storage,
+Key Vault, …) under [workload identity](https://azure.github.io/azure-workload-identity/docs/),
+so secrets never enter cluster state. Argo CD is currently the odd one out: it
+requires a long-lived Redis access key plumbed through a Kubernetes `Secret`,
+which forces operators to either:
+
+1. Persist the key to source control / Terraform state, or
+2. Stand up a side-channel (Key Vault + CSI driver / External Secrets Operator)
+   purely to keep that one key out of state.
+
+Both options add operational complexity without delivering security on par with
+the workload-identity flow used by the rest of the platform. Several upstream
+issues track this gap, e.g.
+[argo-cd#19133](https://github.com/argoproj/argo-cd/issues/19133) and
+[argo-cd#19136](https://github.com/argoproj/argo-cd/issues/19136). Internally,
+the Minecraft Services franchise team — whose adoption motivated this proposal
+— hit it during their migration to a shared-Redis topology and worked around
+it with a static key, but the wider community has been requesting a first-class
+solution.
+
+### Goals
+
+* Let Argo CD authenticate to Azure Cache for Redis without any static
+  password, using the same workload identity mechanism that every other Azure
+  client SDK in Argo CD already supports (Argo CD already imports
+  `github.com/Azure/azure-sdk-for-go/sdk/azidentity`).
+* Be fully opt-in; existing deployments are unaffected.
+* Reuse the existing `--redis-*` flag surface so the change is uniform across
+  `argocd-server`, `argocd-application-controller`, `argocd-repo-server`,
+  `argocd-applicationset-controller` and `argocd-notifications-controller`
+  (they all share `util/cache.AddCacheFlagsToCmd`).
+* Refresh tokens automatically. Entra ID tokens expire roughly every hour; a
+  per-`(re)connect` callback fits go-redis' connection lifecycle and avoids
+  any custom refresh goroutine.
+
+### Non-Goals
+
+* AWS ElastiCache IAM auth, GCP Memorystore IAM auth, or any other cloud's
+  managed-identity-style flow. The same `CredentialsProviderContext` hook
+  could host them, but each cloud has its own SDK, scope and identity
+  conventions; they belong in follow-up proposals.
+* Rotating the `argocd-redis` ConfigMap or any other resource shape change.
+* Changing the default authentication path or deprecating
+  `--redis-password` / `REDIS_PASSWORD`.
+* Workload identity for the bundled in-cluster Redis chart. This proposal
+  targets external Redis instances (where AAD auth is meaningful); the
+  in-cluster Redis is unauthenticated by default and out of scope.
+
+## Proposal
+
+Introduce a small extension point in `util/cache/`:
+
+```go
+type RedisCredentialsProvider = func(ctx context.Context) (username, password string, err error)
+
+type RedisCredentialsProviderFactory interface {
+    Name() string                                                  // "azure", "gcp", "aws"
+    AddFlags(cmd *cobra.Command, flagPrefix, envPrefix string)     // backend-specific flags
+    Build(loadedUsername string) (RedisCredentialsProvider, error) // wired into go-redis
+}
+
+func RegisterRedisCredentialsProvider(f RedisCredentialsProviderFactory)
+```
+
+Implementations register themselves via `init()`; `AddCacheFlagsToCmd` walks
+the registry and exposes both the global selector flag and each backend's
+flags. At `Build` time the closure looks up the selected factory by name.
+
+### Flags
+
+| Flag | Env var | Default | Description |
+|------|---------|---------|-------------|
+| `--redis-credentials-provider` | `REDIS_CREDENTIALS_PROVIDER` | `""` | Use a registered credentials provider for Redis authentication. Currently supported: `azure`. When set, `--redis-password` / `REDIS_PASSWORD` are ignored. |
+| `--redis-azure-client-id` | `REDIS_AZURE_CLIENT_ID` | `""` | Optional Entra ID application/client ID override. Defaults to the `AZURE_CLIENT_ID` env var injected by the workload-identity admission webhook. Only honoured when `--redis-credentials-provider=azure`. |
+| `--redis-azure-scope` | `REDIS_AZURE_SCOPE` | `https://redis.azure.com/.default` | Override only when targeting non-public Azure clouds (e.g. Azure Government). Only honoured when `--redis-credentials-provider=azure`. |
+
+When `--redis-credentials-provider=azure`, the Azure factory constructs an
+`azidentity.NewWorkloadIdentityCredential` (or `NewDefaultAzureCredential`
+when no client-id override is provided) and wraps it in a closure that
+implements the [`go-redis`](https://github.com/redis/go-redis)
+`CredentialsProviderContext` signature. That hook is invoked on every new
+connection and on every reconnect, so when the AAD token rotates (every ~60
+minutes by default) Argo CD picks up the new token transparently on the next
+reconnect — no daemon, no restart, no shared-cache eviction.
+
+The username surfaced to Redis is the principal's **object ID**, decoded from
+the `oid` claim of the issued JWT (falling back to `sub` for principals that
+do not carry an `oid`). Azure Cache for Redis expects the username in this
+form when AAD auth is enabled — neither the application/client ID nor a
+human-readable name will work. This decoding is intentionally signature-less:
+the caller already trusts the token issuer (azidentity just produced it) and
+only needs the payload to recover the AUTH username.
+
+### Use cases
+
+#### Use case 1: External Azure Cache for Redis with workload identity (primary)
+
+A platform team is migrating Argo CD off the bundled in-cluster Redis to a
+shared, regionally-replicated Azure Cache for Redis Enterprise instance. They
+want every client (including Argo CD) to authenticate the same way as the
+rest of their platform: workload-identity-federated AAD tokens, with
+`Data Owner` granted to the Argo CD KSA via an `azurerm_role_assignment`.
+
+Setting `--redis-credentials-provider=azure` (or
+`REDIS_CREDENTIALS_PROVIDER=azure`) on every Argo CD pod is sufficient. The
+existing `azurerm_redis_cache.id` becomes the only thing referenced from
+Terraform; no `azurerm_key_vault_secret` and no `data.azurerm_redis_cache`
+data source pulling the access key.
+
+#### Use case 2: Azure Government / sovereign cloud
+
+The same operator is running in `usgovvirginia`. They flip
+`--redis-azure-scope=https://redis.azure.us/.default` and the default
+azidentity Authority probe transparently routes through Azure Government's
+identity endpoint.
+
+#### Future use case: GCP Memorystore / AWS ElastiCache
+
+Both [GCP Memorystore for Redis](https://cloud.google.com/memorystore/docs/cluster/auth-using-iam)
+and [AWS ElastiCache](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/auth-iam.html)
+support IAM-based authentication that fits the same shape: acquire a
+short-lived credential from the cloud SDK, surface it via
+`CredentialsProviderContext`. With the registry in place, these become
+single-file additions (`util/cache/gcp.go`, `util/cache/aws.go`) that don't
+touch `cache.go`. They are intentionally out of scope for this PR — better
+to validate the abstraction with one concrete implementation first and let
+each cloud's contributors own their own backend.
+
+### Implementation Details
+
+The whole patch lives under `util/cache/`:
+
+* New file **`util/cache/credentials.go`** (~110 lines) containing:
+  * `RedisCredentialsProvider` (exported type alias matching go-redis's
+    `CredentialsProviderContext` signature).
+  * `RedisCredentialsProviderFactory` interface.
+  * `RegisterRedisCredentialsProvider` and a private registry guarded by a
+    `sync.RWMutex`.
+* New file **`util/cache/credentials_test.go`** (~140 lines) covering registry
+  registration, duplicate-panic, unknown-name lookup, and `AddFlags`
+  delegation.
+* New file **`util/cache/azure.go`** (~140 lines) containing:
+  * `AzureRedisCredentialsProviderName` and `DefaultAzureCacheForRedisScope`
+    (exported constants).
+  * `azureCredentialsProviderFactory` struct registered via `init()`, with
+    `Name()`, `AddFlags()`, and `Build()` implementing the factory.
+  * `newAzureCredential(clientID string) (azcore.TokenCredential, error)` —
+    a package-level `var` so tests can substitute a stub.
+  * `azureCredentialsProvider(cred, staticUsername, scope) func(ctx) (string, string, error)`.
+  * `extractPrincipalID(token) (string, error)` — JWT payload decode that
+    prefers `oid` and falls back to `sub`.
+* New file **`util/cache/azure_test.go`** (~165 lines) with 13 cases covering
+  oid/sub precedence, malformed-token handling, static-username precedence,
+  custom-scope plumbing, error propagation, and the per-call refresh
+  invariant.
+* Modified **`util/cache/cache.go`**:
+  * Both `buildRedisClient` and `buildFailoverRedisClient` accept an optional
+    `redisCredentialsProvider` parameter and set
+    `opts.CredentialsProviderContext` when non-nil. The recursive hook used
+    for command-level retries threads the same provider through.
+  * `AddCacheFlagsToCmd` registers the new selector flag, calls
+    `addRedisCredentialsProviderFlags` to register every backend's flags, and
+    inside the existing closure looks the chosen factory up by name and
+    invokes its `Build()`.
+
+Argo CD already imports `github.com/Azure/azure-sdk-for-go/sdk/azidentity`
+v1.13.x and `github.com/redis/go-redis/v9` v9.18+, so no new module is added.
+
+The flag surface is registered in exactly one place
+(`util/cache.AddCacheFlagsToCmd`) and inherited by every binary that uses
+the shared cache client; no per-component wiring is required.
+
+### Detailed examples
+
+```yaml
+# argocd-cmd-params-cm
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cmd-params-cm
+data:
+  redis.server: my-cache.redis.cache.windows.net:6380
+  redis.use.tls: "true"
+  redis.credentials.provider: "azure"
+  # redis.azure.client.id: "" — defaults to AZURE_CLIENT_ID
+  # redis.azure.scope: "" — defaults to https://redis.azure.com/.default
+```
+
+The companion `azurerm_role_assignment` and federated identity credential
+shape live outside Argo CD; the Argo CD-side change is just the flags.
+
+### Security Considerations
+
+* **Token lifetime is ~1h.** Even if a token is captured (TLS-protected
+  network, in-pod memory access by another container in the same pod), it
+  expires fast. Compare to the existing static-key flow where the key is
+  long-lived and lives in a Kubernetes `Secret`.
+* **No new secret material on disk.** Workload identity tokens live only in
+  the projected service-account-token volume that the Kubernetes API server
+  refreshes; Argo CD never persists them.
+* **JWT decode is signature-less by design.** The decode is purely to read
+  the `oid` claim that we just got from azidentity in a TLS-protected call.
+  We are not validating identity claims from an untrusted source.
+* **Static `--redis-password` is intentionally discarded** when the flag is
+  set, so an operator cannot accidentally leave a stale password configured.
+  This is documented in the flag help text.
+* **Dependency surface.** `azidentity` is already vendored. No new
+  third-party crypto code is introduced.
+
+### Risks and Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Operators select the provider but forget to grant the workload identity `Data Owner` on the cache | First connection fails fast with an Azure-side `WRONGPASS` and a clear log line containing the principal's `oid`; runbook in the operator manual. |
+| `oid` claim is missing for unusual principals (e.g. some service principals) | Fallback to `sub`; `errNoUsername` documents the `--redis-username` escape hatch. |
+| `azidentity` cannot acquire a token (no AZURE_FEDERATED_TOKEN_FILE) | The error is surfaced at first connect; fallback is to clear `--redis-credentials-provider`. |
+| HA Redis with the bundled `redis-ha` haproxy chart | This proposal targets external Redis instances; the in-cluster `redis-ha` haproxy is untouched. |
+| Registry abstraction over-engineers a single-cloud need | The interface is deliberately tiny (3 methods). It costs ~110 lines of code to gain a clean extension story for GCP/AWS contributors. |
+
+### Upgrade / Downgrade Strategy
+
+* **Upgrade.** Existing deployments are unaffected: the new flag defaults to
+  empty. Operators opt in by setting one ConfigMap key.
+* **Downgrade.** Clearing `--redis-credentials-provider` (or rolling back the
+  Argo CD image) immediately reverts to static-password auth. The same Redis
+  instance can keep AAD enabled in parallel — Azure Cache for Redis allows
+  both auth modes simultaneously while in transition.
+
+## Drawbacks
+
+* Adds Azure-specific code to a generic cache package. We argue this is
+  acceptable because (a) `azidentity` is already a dependency, (b) it sits
+  behind an opt-in flag, (c) it is isolated to `util/cache/azure.go`, and
+  (d) the registry interface in `credentials.go` makes it easy to keep the
+  Azure code self-contained and add other clouds the same way.
+* The registry abstraction has only one implementation today. We accept this
+  as a one-time cost: the alternative (refactor on the second cloud) is
+  noisier and tends to leak the first implementation's assumptions into the
+  abstraction.
+
+## Alternatives
+
+1. **Sidecar Redis-AAD proxy (e.g. open-source `azure-redis-aad-proxy`).** Adds
+   an extra hop, an extra container per Argo CD pod, and operator
+   responsibility for the proxy's own lifecycle. Doesn't deliver workload
+   identity to Argo CD itself.
+2. **Out-of-tree fork.** Keeps maintenance burden on individual operators;
+   does not benefit the wider community; has to be re-rebased on every Argo
+   CD release.
+3. **Keep the static-key flow and document a CSI / External Secrets
+   pattern.** Works but is the status quo; doesn't move Argo CD onto the
+   workload-identity story the rest of the platform has adopted.
+4. **Hard-code Azure in `cache.go` (no registry).** Smaller diff but blocks
+   GCP/AWS contributors from adding their own backends without churning the
+   exact same code. We adopted the registry to keep the door open.
+
+## Open Questions
+
+1. Should the Azure backend live under `util/cache/azure.go` (current
+   proposal) or a subpackage `util/cache/providers/azure/`? Subpackage gives
+   stricter isolation per cloud; co-location keeps the diff smaller and
+   matches the size of the implementation. Happy to move on reviewer
+   preference.
+2. Should we also accept the principal's object ID via a new
+   `--redis-azure-username` flag for environments where the JWT decode is
+   undesirable? `--redis-username` already serves this; calling it out
+   explicitly may be clearer.
+3. Naming: `--redis-credentials-provider=azure` vs
+   `--redis-credentials-provider=entra` vs
+   `--redis-credentials-provider=aad`. We picked `azure` because that
+   matches `azidentity` and `azurerm`; happy to bikeshed.

--- a/docs/user-guide/commands/argocd_admin_cluster_shards.md
+++ b/docs/user-guide/commands/argocd_admin_cluster_shards.md
@@ -30,10 +30,13 @@ argocd admin cluster shards [flags]
       --port-forward-redis                    Automatically port-forward ha proxy redis from current namespace? (default true)
       --proxy-url string                      If provided, this URL will be used to connect via proxy
       --redis string                          Redis server hostname and port (e.g. argocd-redis:6379). 
+      --redis-azure-client-id string          Microsoft Entra ID application/client ID used to acquire Redis access tokens. When unset, falls back to azidentity.DefaultAzureCredential (which honours the AZURE_CLIENT_ID env var injected by the workload-identity admission webhook). Only honoured when --redis-credentials-provider=azure.
+      --redis-azure-scope string              OAuth scope to request when acquiring Microsoft Entra ID tokens for Redis. Override only when targeting a non-public Azure cloud (e.g. Azure Government). Only honoured when --redis-credentials-provider=azure. (default "https://redis.azure.com/.default")
       --redis-ca-certificate string           Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
       --redis-client-certificate string       Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
       --redis-client-key string               Path to Redis client key (e.g. /etc/certs/redis/client.crt).
       --redis-compress string                 Enable compression for data sent to Redis with the required compression algorithm. (possible values: gzip, none) (default "gzip")
+      --redis-credentials-provider string     Use a registered credentials provider to authenticate to Redis dynamically (e.g. cloud-provider workload identity). Registered providers: [azure]. When set, --redis-password / REDIS_PASSWORD are ignored.
       --redis-insecure-skip-tls-verify        Skip Redis server certificate validation.
       --redis-use-tls                         Use TLS when connecting to Redis. 
       --redisdb int                           Redis database.

--- a/docs/user-guide/commands/argocd_admin_cluster_stats.md
+++ b/docs/user-guide/commands/argocd_admin_cluster_stats.md
@@ -44,10 +44,13 @@ argocd admin cluster stats target-cluster
       --port-forward-redis                    Automatically port-forward ha proxy redis from current namespace? (default true)
       --proxy-url string                      If provided, this URL will be used to connect via proxy
       --redis string                          Redis server hostname and port (e.g. argocd-redis:6379). 
+      --redis-azure-client-id string          Microsoft Entra ID application/client ID used to acquire Redis access tokens. When unset, falls back to azidentity.DefaultAzureCredential (which honours the AZURE_CLIENT_ID env var injected by the workload-identity admission webhook). Only honoured when --redis-credentials-provider=azure.
+      --redis-azure-scope string              OAuth scope to request when acquiring Microsoft Entra ID tokens for Redis. Override only when targeting a non-public Azure cloud (e.g. Azure Government). Only honoured when --redis-credentials-provider=azure. (default "https://redis.azure.com/.default")
       --redis-ca-certificate string           Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
       --redis-client-certificate string       Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
       --redis-client-key string               Path to Redis client key (e.g. /etc/certs/redis/client.crt).
       --redis-compress string                 Enable compression for data sent to Redis with the required compression algorithm. (possible values: gzip, none) (default "gzip")
+      --redis-credentials-provider string     Use a registered credentials provider to authenticate to Redis dynamically (e.g. cloud-provider workload identity). Registered providers: [azure]. When set, --redis-password / REDIS_PASSWORD are ignored.
       --redis-insecure-skip-tls-verify        Skip Redis server certificate validation.
       --redis-use-tls                         Use TLS when connecting to Redis. 
       --redisdb int                           Redis database.

--- a/util/cache/azure.go
+++ b/util/cache/azure.go
@@ -51,7 +51,7 @@ func (a *azureCredentialsProviderFactory) Name() string {
 // "azure" is the selected backend.
 func (a *azureCredentialsProviderFactory) AddFlags(cmd *cobra.Command, flagPrefix, envPrefix string) {
 	cmd.Flags().StringVar(&a.clientID, flagPrefix+"redis-azure-client-id", env.StringFromEnv(envPrefix+"REDIS_AZURE_CLIENT_ID", ""),
-		"Optional override for the Microsoft Entra ID application/client ID used to acquire Redis access tokens. Defaults to the AZURE_CLIENT_ID injected by the workload-identity webhook. Only honoured when --redis-credentials-provider=azure.")
+		"Microsoft Entra ID application/client ID used to acquire Redis access tokens. When unset, falls back to azidentity.DefaultAzureCredential (which honours the AZURE_CLIENT_ID env var injected by the workload-identity admission webhook). Only honoured when --redis-credentials-provider=azure.")
 	cmd.Flags().StringVar(&a.scope, flagPrefix+"redis-azure-scope", env.StringFromEnv(envPrefix+"REDIS_AZURE_SCOPE", DefaultAzureCacheForRedisScope),
 		"OAuth scope to request when acquiring Microsoft Entra ID tokens for Redis. Override only when targeting a non-public Azure cloud (e.g. Azure Government). Only honoured when --redis-credentials-provider=azure.")
 }

--- a/util/cache/azure.go
+++ b/util/cache/azure.go
@@ -1,0 +1,171 @@
+package cache
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/argoproj/argo-cd/v3/util/env"
+)
+
+// AzureRedisCredentialsProviderName is the value passed to
+// --redis-credentials-provider to select the Microsoft Entra ID workload
+// identity backend.
+const AzureRedisCredentialsProviderName = "azure"
+
+// DefaultAzureCacheForRedisScope is the OAuth scope used to obtain access
+// tokens for Azure Cache for Redis when authenticating via Microsoft Entra ID.
+// See: https://learn.microsoft.com/azure/azure-cache-for-redis/cache-azure-active-directory-for-authentication
+const DefaultAzureCacheForRedisScope = "https://redis.azure.com/.default"
+
+func init() {
+	RegisterRedisCredentialsProvider(&azureCredentialsProviderFactory{})
+}
+
+// azureCredentialsProviderFactory wires the Microsoft Entra ID (workload
+// identity) Redis authentication flow into the RedisCredentialsProviderFactory
+// registry. The factory holds the parsed flag values for its backend so that
+// AddFlags and Build share state via the same struct instance.
+type azureCredentialsProviderFactory struct {
+	clientID string
+	scope    string
+}
+
+// Name returns the registry key for this factory; matches the value users
+// pass to --redis-credentials-provider.
+func (a *azureCredentialsProviderFactory) Name() string {
+	return AzureRedisCredentialsProviderName
+}
+
+// AddFlags registers the Azure-specific knobs. They live alongside the
+// generic --redis-credentials-provider switch and only have an effect when
+// "azure" is the selected backend.
+func (a *azureCredentialsProviderFactory) AddFlags(cmd *cobra.Command, flagPrefix, envPrefix string) {
+	cmd.Flags().StringVar(&a.clientID, flagPrefix+"redis-azure-client-id", env.StringFromEnv(envPrefix+"REDIS_AZURE_CLIENT_ID", ""),
+		"Optional override for the Microsoft Entra ID application/client ID used to acquire Redis access tokens. Defaults to the AZURE_CLIENT_ID injected by the workload-identity webhook. Only honoured when --redis-credentials-provider=azure.")
+	cmd.Flags().StringVar(&a.scope, flagPrefix+"redis-azure-scope", env.StringFromEnv(envPrefix+"REDIS_AZURE_SCOPE", DefaultAzureCacheForRedisScope),
+		"OAuth scope to request when acquiring Microsoft Entra ID tokens for Redis. Override only when targeting a non-public Azure cloud (e.g. Azure Government). Only honoured when --redis-credentials-provider=azure.")
+}
+
+// Build constructs the credentials closure that will be wired into go-redis.
+// loadedUsername (sourced from --redis-username / REDIS_USERNAME / mounted
+// secrets) is honoured when set; otherwise the username is derived from the
+// access-token's `oid` claim on each call.
+func (a *azureCredentialsProviderFactory) Build(loadedUsername string) (RedisCredentialsProvider, error) {
+	cred, err := newAzureCredential(a.clientID)
+	if err != nil {
+		return nil, err
+	}
+	return azureCredentialsProvider(cred, loadedUsername, a.scope), nil
+}
+
+// errNoUsername is returned by azureCredentialsProvider when neither an
+// explicit username was configured nor a usable principal identifier could be
+// extracted from the issued access token.
+var errNoUsername = errors.New("redis: cannot determine Microsoft Entra ID principal username; set --redis-username or grant the workload identity an `oid` claim")
+
+// newAzureCredential returns an azcore.TokenCredential suitable for use inside
+// an Argo CD pod that has been federated with a Microsoft Entra ID workload
+// identity. When clientID is non-empty, it constructs an explicit
+// WorkloadIdentityCredential so the override is honoured regardless of the
+// AZURE_CLIENT_ID env var injected by the workload-identity admission webhook.
+// Otherwise it falls back to DefaultAzureCredential, which transparently picks
+// between the workload identity, managed identity and developer credential
+// flows.
+//
+// This is exposed as a package-level var (rather than a func) so tests can
+// substitute a stub credential.
+var newAzureCredential = func(clientID string) (azcore.TokenCredential, error) {
+	if clientID != "" {
+		cred, err := azidentity.NewWorkloadIdentityCredential(&azidentity.WorkloadIdentityCredentialOptions{
+			ClientID: clientID,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("redis: failed to construct Microsoft Entra ID workload identity credential: %w", err)
+		}
+		return cred, nil
+	}
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		return nil, fmt.Errorf("redis: failed to construct Microsoft Entra ID credential: %w", err)
+	}
+	return cred, nil
+}
+
+// azureCredentialsProvider returns a function compatible with
+// redis.Options.CredentialsProviderContext that resolves to (username,
+// access-token) on every new connection.
+//
+// The username is sourced from `staticUsername` when non-empty (for
+// deployments that prefer to plumb the principal's object ID explicitly), and
+// otherwise extracted from the `oid` (or `sub`) claim of the issued JWT. The
+// password is always a freshly issued access token; azcore credential
+// implementations cache and proactively refresh tokens, so the per-call cost
+// here is negligible in steady state.
+func azureCredentialsProvider(cred azcore.TokenCredential, staticUsername, scope string) func(ctx context.Context) (string, string, error) {
+	if scope == "" {
+		scope = DefaultAzureCacheForRedisScope
+	}
+	return func(ctx context.Context) (string, string, error) {
+		tok, err := cred.GetToken(ctx, policy.TokenRequestOptions{
+			Scopes: []string{scope},
+		})
+		if err != nil {
+			return "", "", fmt.Errorf("redis: failed to acquire Microsoft Entra ID token: %w", err)
+		}
+		username := staticUsername
+		if username == "" {
+			username, err = extractPrincipalID(tok.Token)
+			if err != nil {
+				return "", "", err
+			}
+		}
+		if username == "" {
+			return "", "", errNoUsername
+		}
+		log.WithField("username", username).Debug("redis: acquired Microsoft Entra ID access token")
+		return username, tok.Token, nil
+	}
+}
+
+// extractPrincipalID returns the `oid` claim from the supplied JWT, falling
+// back to the `sub` claim when `oid` is absent. It performs no signature
+// verification: the caller already trusts the token issuer (it just produced
+// it via azidentity); we only need to read the payload to recover the
+// principal identifier that Azure Cache for Redis expects as the AUTH
+// username.
+func extractPrincipalID(token string) (string, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) < 2 {
+		return "", errors.New("redis: invalid JWT format on access token")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		// Fall back to standard padding in case the token uses RFC 7519
+		// padding (rare in practice, but cheap to support).
+		payload, err = base64.URLEncoding.DecodeString(parts[1])
+		if err != nil {
+			return "", fmt.Errorf("redis: failed to decode access token payload: %w", err)
+		}
+	}
+	var claims struct {
+		OID string `json:"oid"`
+		Sub string `json:"sub"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return "", fmt.Errorf("redis: failed to parse access token payload: %w", err)
+	}
+	if claims.OID != "" {
+		return claims.OID, nil
+	}
+	return claims.Sub, nil
+}

--- a/util/cache/azure_test.go
+++ b/util/cache/azure_test.go
@@ -1,0 +1,164 @@
+package cache
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeTokenCredential implements azcore.TokenCredential for tests. It returns
+// a canned token and records the scopes it was called with so tests can
+// assert on them.
+type fakeTokenCredential struct {
+	token       string
+	err         error
+	calls       int
+	lastScopes  []string
+	lastTimeout time.Duration
+}
+
+func (f *fakeTokenCredential) GetToken(_ context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	f.calls++
+	f.lastScopes = opts.Scopes
+	if f.err != nil {
+		return azcore.AccessToken{}, f.err
+	}
+	return azcore.AccessToken{
+		Token:     f.token,
+		ExpiresOn: time.Now().Add(time.Hour),
+	}, nil
+}
+
+// makeJWT constructs a minimally-valid unsigned JWT carrying the supplied
+// claims payload. Real Entra ID tokens are signed; we don't validate
+// signatures in extractPrincipalID, so a stub is sufficient.
+func makeJWT(t *testing.T, payloadJSON string) string {
+	t.Helper()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(payloadJSON))
+	return header + "." + payload + ".sig"
+}
+
+func TestExtractPrincipalID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("prefers oid over sub", func(t *testing.T) {
+		tok := makeJWT(t, `{"oid":"00000000-0000-0000-0000-000000000001","sub":"sub-value"}`)
+		got, err := extractPrincipalID(tok)
+		require.NoError(t, err)
+		assert.Equal(t, "00000000-0000-0000-0000-000000000001", got)
+	})
+
+	t.Run("falls back to sub", func(t *testing.T) {
+		tok := makeJWT(t, `{"sub":"sub-value"}`)
+		got, err := extractPrincipalID(tok)
+		require.NoError(t, err)
+		assert.Equal(t, "sub-value", got)
+	})
+
+	t.Run("returns empty when neither claim present", func(t *testing.T) {
+		tok := makeJWT(t, `{"aud":"redis"}`)
+		got, err := extractPrincipalID(tok)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("rejects malformed token", func(t *testing.T) {
+		_, err := extractPrincipalID("not.a-jwt")
+		require.Error(t, err)
+	})
+
+	t.Run("rejects single-segment token", func(t *testing.T) {
+		_, err := extractPrincipalID("onlyone")
+		require.Error(t, err)
+	})
+
+	t.Run("rejects undecodable payload", func(t *testing.T) {
+		_, err := extractPrincipalID("aaa.&&&.sig")
+		require.Error(t, err)
+	})
+}
+
+func TestAzureCredentialsProvider_StaticUsername(t *testing.T) {
+	t.Parallel()
+
+	cred := &fakeTokenCredential{token: makeJWT(t, `{"oid":"derived"}`)}
+	provider := azureCredentialsProvider(cred, "explicit-oid", "")
+
+	user, pass, err := provider(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "explicit-oid", user, "explicit username must take precedence over oid claim")
+	assert.Equal(t, cred.token, pass)
+	assert.Equal(t, []string{DefaultAzureCacheForRedisScope}, cred.lastScopes,
+		"default scope must be used when none configured")
+}
+
+func TestAzureCredentialsProvider_DerivesUsernameFromToken(t *testing.T) {
+	t.Parallel()
+
+	cred := &fakeTokenCredential{token: makeJWT(t, `{"oid":"derived-oid"}`)}
+	provider := azureCredentialsProvider(cred, "", "")
+
+	user, pass, err := provider(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "derived-oid", user)
+	assert.Equal(t, cred.token, pass)
+}
+
+func TestAzureCredentialsProvider_CustomScope(t *testing.T) {
+	t.Parallel()
+
+	cred := &fakeTokenCredential{token: makeJWT(t, `{"oid":"x"}`)}
+	provider := azureCredentialsProvider(cred, "", "https://example.invalid/.default")
+
+	_, _, err := provider(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"https://example.invalid/.default"}, cred.lastScopes)
+}
+
+func TestAzureCredentialsProvider_PropagatesTokenError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("federated token unavailable")
+	cred := &fakeTokenCredential{err: wantErr}
+	provider := azureCredentialsProvider(cred, "", "")
+
+	_, _, err := provider(context.Background())
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "federated token unavailable"),
+		"wrapped error must include the underlying credential failure: %v", err)
+}
+
+func TestAzureCredentialsProvider_NoUsernameAvailable(t *testing.T) {
+	t.Parallel()
+
+	cred := &fakeTokenCredential{token: makeJWT(t, `{"aud":"redis"}`)}
+	provider := azureCredentialsProvider(cred, "", "")
+
+	_, _, err := provider(context.Background())
+	require.ErrorIs(t, err, errNoUsername)
+}
+
+func TestAzureCredentialsProvider_RefreshesTokenPerCall(t *testing.T) {
+	// go-redis invokes CredentialsProviderContext on every new connection.
+	// The provider therefore *must* call GetToken on each invocation —
+	// caching is the credential implementation's responsibility, not ours.
+	t.Parallel()
+
+	cred := &fakeTokenCredential{token: makeJWT(t, `{"oid":"x"}`)}
+	provider := azureCredentialsProvider(cred, "", "")
+
+	for i := 0; i < 3; i++ {
+		_, _, err := provider(context.Background())
+		require.NoError(t, err)
+	}
+	assert.Equal(t, 3, cred.calls)
+}

--- a/util/cache/azure_test.go
+++ b/util/cache/azure_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
-	"strings"
 	"testing"
 	"time"
 
@@ -18,11 +17,10 @@ import (
 // a canned token and records the scopes it was called with so tests can
 // assert on them.
 type fakeTokenCredential struct {
-	token       string
-	err         error
-	calls       int
-	lastScopes  []string
-	lastTimeout time.Duration
+	token      string
+	err        error
+	calls      int
+	lastScopes []string
 }
 
 func (f *fakeTokenCredential) GetToken(_ context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
@@ -51,6 +49,7 @@ func TestExtractPrincipalID(t *testing.T) {
 	t.Parallel()
 
 	t.Run("prefers oid over sub", func(t *testing.T) {
+		t.Parallel()
 		tok := makeJWT(t, `{"oid":"00000000-0000-0000-0000-000000000001","sub":"sub-value"}`)
 		got, err := extractPrincipalID(tok)
 		require.NoError(t, err)
@@ -58,6 +57,7 @@ func TestExtractPrincipalID(t *testing.T) {
 	})
 
 	t.Run("falls back to sub", func(t *testing.T) {
+		t.Parallel()
 		tok := makeJWT(t, `{"sub":"sub-value"}`)
 		got, err := extractPrincipalID(tok)
 		require.NoError(t, err)
@@ -65,6 +65,7 @@ func TestExtractPrincipalID(t *testing.T) {
 	})
 
 	t.Run("returns empty when neither claim present", func(t *testing.T) {
+		t.Parallel()
 		tok := makeJWT(t, `{"aud":"redis"}`)
 		got, err := extractPrincipalID(tok)
 		require.NoError(t, err)
@@ -72,16 +73,19 @@ func TestExtractPrincipalID(t *testing.T) {
 	})
 
 	t.Run("rejects malformed token", func(t *testing.T) {
+		t.Parallel()
 		_, err := extractPrincipalID("not.a-jwt")
 		require.Error(t, err)
 	})
 
 	t.Run("rejects single-segment token", func(t *testing.T) {
+		t.Parallel()
 		_, err := extractPrincipalID("onlyone")
 		require.Error(t, err)
 	})
 
 	t.Run("rejects undecodable payload", func(t *testing.T) {
+		t.Parallel()
 		_, err := extractPrincipalID("aaa.&&&.sig")
 		require.Error(t, err)
 	})
@@ -133,8 +137,8 @@ func TestAzureCredentialsProvider_PropagatesTokenError(t *testing.T) {
 
 	_, _, err := provider(context.Background())
 	require.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), "federated token unavailable"),
-		"wrapped error must include the underlying credential failure: %v", err)
+	assert.Contains(t, err.Error(), "federated token unavailable",
+		"wrapped error must include the underlying credential failure")
 }
 
 func TestAzureCredentialsProvider_NoUsernameAvailable(t *testing.T) {
@@ -156,7 +160,7 @@ func TestAzureCredentialsProvider_RefreshesTokenPerCall(t *testing.T) {
 	cred := &fakeTokenCredential{token: makeJWT(t, `{"oid":"x"}`)}
 	provider := azureCredentialsProvider(cred, "", "")
 
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		_, _, err := provider(context.Background())
 		require.NoError(t, err)
 	}

--- a/util/cache/cache.go
+++ b/util/cache/cache.go
@@ -47,7 +47,7 @@ func NewCache(client CacheClient) *Cache {
 	return &Cache{client}
 }
 
-func buildRedisClient(redisAddress, password, username string, redisDB, maxRetries int, tlsConfig *tls.Config) *redis.Client {
+func buildRedisClient(redisAddress, password, username string, redisDB, maxRetries int, tlsConfig *tls.Config, credsProvider redisCredentialsProvider) *redis.Client {
 	opts := &redis.Options{
 		Addr:       redisAddress,
 		Password:   password,
@@ -56,17 +56,24 @@ func buildRedisClient(redisAddress, password, username string, redisDB, maxRetri
 		TLSConfig:  tlsConfig,
 		Username:   username,
 	}
+	if credsProvider != nil {
+		// CredentialsProviderContext takes precedence over the static
+		// Username/Password fields above for every new connection
+		// (including reconnects), which is exactly the rotation behaviour
+		// AAD-issued tokens require.
+		opts.CredentialsProviderContext = credsProvider
+	}
 
 	client := redis.NewClient(opts)
 
 	client.AddHook(redis.Hook(NewArgoRedisHook(func() {
-		*client = *buildRedisClient(redisAddress, password, username, redisDB, maxRetries, tlsConfig)
+		*client = *buildRedisClient(redisAddress, password, username, redisDB, maxRetries, tlsConfig, credsProvider)
 	})))
 
 	return client
 }
 
-func buildFailoverRedisClient(sentinelMaster, sentinelUsername, sentinelPassword, password, username string, redisDB, maxRetries int, tlsConfig *tls.Config, sentinelAddresses []string) *redis.Client {
+func buildFailoverRedisClient(sentinelMaster, sentinelUsername, sentinelPassword, password, username string, redisDB, maxRetries int, tlsConfig *tls.Config, sentinelAddresses []string, credsProvider redisCredentialsProvider) *redis.Client {
 	opts := &redis.FailoverOptions{
 		MasterName:       sentinelMaster,
 		SentinelAddrs:    sentinelAddresses,
@@ -78,15 +85,23 @@ func buildFailoverRedisClient(sentinelMaster, sentinelUsername, sentinelPassword
 		SentinelUsername: sentinelUsername,
 		SentinelPassword: sentinelPassword,
 	}
+	if credsProvider != nil {
+		opts.CredentialsProviderContext = credsProvider
+	}
 
 	client := redis.NewFailoverClient(opts)
 
 	client.AddHook(redis.Hook(NewArgoRedisHook(func() {
-		*client = *buildFailoverRedisClient(sentinelMaster, sentinelUsername, sentinelPassword, password, username, redisDB, maxRetries, tlsConfig, sentinelAddresses)
+		*client = *buildFailoverRedisClient(sentinelMaster, sentinelUsername, sentinelPassword, password, username, redisDB, maxRetries, tlsConfig, sentinelAddresses, credsProvider)
 	})))
 
 	return client
 }
+
+// redisCredentialsProvider is an unexported alias retained for the existing
+// builder signatures in this file. New code should depend on the exported
+// RedisCredentialsProvider type from credentials.go.
+type redisCredentialsProvider = RedisCredentialsProvider
 
 type Options struct {
 	FlagPrefix      string
@@ -219,6 +234,7 @@ func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...Options) func() (*Cache, err
 	redisUseTLS := false
 	insecureRedis := false
 	compressionStr := ""
+	credentialsProviderName := ""
 	opt := mergeOptions(opts...)
 	var defaultCacheExpiration time.Duration
 
@@ -244,6 +260,14 @@ func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...Options) func() (*Cache, err
 	redisCACertificateSrc := getFlagVal(cmd, opt, "redis-ca-certificate", cmd.Flags().GetString)
 	cmd.Flags().StringVar(&compressionStr, opt.FlagPrefix+CLIFlagRedisCompress, env.StringFromEnv(opt.getEnvPrefix()+"REDIS_COMPRESSION", string(RedisCompressionGZip)), "Enable compression for data sent to Redis with the required compression algorithm. (possible values: gzip, none)")
 	compressionStrSrc := getFlagVal(cmd, opt, CLIFlagRedisCompress, cmd.Flags().GetString)
+	cmd.Flags().StringVar(&credentialsProviderName, opt.FlagPrefix+"redis-credentials-provider", env.StringFromEnv(opt.getEnvPrefix()+"REDIS_CREDENTIALS_PROVIDER", ""),
+		fmt.Sprintf("Use a registered credentials provider to authenticate to Redis dynamically (e.g. cloud-provider workload identity). Registered providers: %v. When set, --redis-password / REDIS_PASSWORD are ignored.", registeredRedisCredentialsProviderNames()))
+	credentialsProviderNameSrc := getFlagVal(cmd, opt, "redis-credentials-provider", cmd.Flags().GetString)
+	// Each registered factory contributes its own backend-specific flags. They
+	// are visible in --help regardless of which provider is selected, which
+	// keeps documentation discoverable; the values only take effect when the
+	// matching --redis-credentials-provider name is chosen.
+	addRedisCredentialsProviderFlags(cmd, opt.FlagPrefix, opt.getEnvPrefix())
 	return func() (*Cache, error) {
 		redisAddress := redisAddressSrc()
 		redisDB := redisDBSrc()
@@ -256,6 +280,7 @@ func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...Options) func() (*Cache, err
 		insecureRedis := insecureRedisSrc()
 		redisCACertificate := redisCACertificateSrc()
 		compressionStr := compressionStrSrc()
+		credentialsProviderName := credentialsProviderNameSrc()
 
 		var tlsConfig *tls.Config
 		if redisUseTLS {
@@ -295,13 +320,42 @@ func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...Options) func() (*Cache, err
 		if err != nil {
 			return nil, err
 		}
+		// Wire up the selected RedisCredentialsProviderFactory (e.g. the
+		// Azure Entra ID workload identity provider). Static
+		// --redis-password / REDIS_PASSWORD values are intentionally
+		// discarded when a dynamic provider is active: cloud-issued tokens
+		// are short-lived and the static value would only be used until the
+		// first reconnect, which is more confusing than helpful.
+		var credsProvider redisCredentialsProvider
+		if credentialsProviderName != "" {
+			// Sentinel-fronted Redis is incompatible with cloud-managed
+			// caches that the credentials providers target (Azure Cache
+			// for Redis, GCP Memorystore, AWS ElastiCache all front HA
+			// behind their own managed endpoint, not sentinel). Mixing
+			// the two is almost always a misconfiguration; fail fast
+			// with a clear message rather than letting it fail at
+			// connect time.
+			if len(sentinelAddresses) > 0 {
+				return nil, fmt.Errorf("--redis-credentials-provider=%q is incompatible with sentinel-mode (--sentinel); cloud-managed Redis services do not use sentinel", credentialsProviderName)
+			}
+			factory, lookupErr := lookupRedisCredentialsProvider(credentialsProviderName)
+			if lookupErr != nil {
+				return nil, lookupErr
+			}
+			provider, buildErr := factory.Build(username)
+			if buildErr != nil {
+				return nil, buildErr
+			}
+			credsProvider = provider
+			password = ""
+		}
 		maxRetries := env.ParseNumFromEnv(envRedisRetryCount, defaultRedisRetryCount, 0, math.MaxInt32)
 		compression, err := CompressionTypeFromString(compressionStr)
 		if err != nil {
 			return nil, err
 		}
 		if len(sentinelAddresses) > 0 {
-			client := buildFailoverRedisClient(sentinelMaster, sentinelUsername, sentinelPassword, password, username, redisDB, maxRetries, tlsConfig, sentinelAddresses)
+			client := buildFailoverRedisClient(sentinelMaster, sentinelUsername, sentinelPassword, password, username, redisDB, maxRetries, tlsConfig, sentinelAddresses, credsProvider)
 			opt.callOnClientCreated(client)
 			return NewCache(NewRedisCache(client, defaultCacheExpiration, compression)), nil
 		}
@@ -309,7 +363,7 @@ func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...Options) func() (*Cache, err
 			redisAddress = common.DefaultRedisAddr
 		}
 
-		client := buildRedisClient(redisAddress, password, username, redisDB, maxRetries, tlsConfig)
+		client := buildRedisClient(redisAddress, password, username, redisDB, maxRetries, tlsConfig, credsProvider)
 		opt.callOnClientCreated(client)
 		return NewCache(NewRedisCache(client, defaultCacheExpiration, compression)), nil
 	}

--- a/util/cache/cache_test.go
+++ b/util/cache/cache_test.go
@@ -1,6 +1,8 @@
 package cache
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -184,4 +186,165 @@ func TestCredentialFileHandling(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "value", val)
 	})
+}
+
+// TestAddCacheFlagsToCmd_RegistersProviderFlags verifies that every registered
+// factory's AddFlags callback is invoked, so backend-specific flags exist on
+// the command regardless of which provider (if any) is selected at runtime.
+func TestAddCacheFlagsToCmd_RegistersProviderFlags(t *testing.T) {
+	withCleanRegistry(t)
+	stub := &stubProviderFactory{name: "stubcloud"}
+	RegisterRedisCredentialsProvider(stub)
+
+	cmd := &cobra.Command{}
+	_ = AddCacheFlagsToCmd(cmd)
+
+	assert.Equal(t, 1, stub.addFlagsCalls,
+		"AddCacheFlagsToCmd must walk the credentials-provider registry on flag setup")
+	require.NotNil(t, cmd.Flags().Lookup("redis-credentials-provider"),
+		"the generic selector flag must be registered")
+}
+
+// TestAddCacheFlagsToCmd_NoProviderSelected covers the default code path:
+// when --redis-credentials-provider is empty, the registry is not consulted
+// and the cache is built without a credentials closure.
+func TestAddCacheFlagsToCmd_NoProviderSelected(t *testing.T) {
+	withCleanRegistry(t)
+	stub := &stubProviderFactory{name: "stubcloud"}
+	RegisterRedisCredentialsProvider(stub)
+
+	cmd := &cobra.Command{}
+	cacheFn := AddCacheFlagsToCmd(cmd)
+	cache, err := cacheFn()
+	require.NoError(t, err)
+	assert.Equal(t, 0, stub.buildCalls,
+		"Build must not run when --redis-credentials-provider is unset")
+	assert.NotNil(t, cache)
+}
+
+// TestAddCacheFlagsToCmd_SelectsRegisteredProvider verifies the happy path:
+// when --redis-credentials-provider matches a registered factory, the
+// factory's Build is invoked exactly once and is handed the loaded username.
+func TestAddCacheFlagsToCmd_SelectsRegisteredProvider(t *testing.T) {
+	withCleanRegistry(t)
+	stub := &stubProviderFactory{
+		name:             "stubcloud",
+		providerUsername: "from-provider",
+		providerPassword: "from-provider-tok",
+	}
+	RegisterRedisCredentialsProvider(stub)
+
+	t.Setenv(envRedisUsername, "loaded-user")
+	t.Setenv(envRedisPassword, "static-password")
+
+	cmd := &cobra.Command{}
+	cacheFn := AddCacheFlagsToCmd(cmd)
+	require.NoError(t, cmd.Flags().Set("redis-credentials-provider", "stubcloud"))
+
+	cache, err := cacheFn()
+	require.NoError(t, err)
+	require.NotNil(t, cache)
+
+	assert.Equal(t, 1, stub.buildCalls)
+	assert.Equal(t, "loaded-user", stub.lastLoadedUser,
+		"factory must receive the username already resolved from env/file")
+}
+
+// TestAddCacheFlagsToCmd_UnknownProvider asserts that selecting an unregistered
+// provider name fails fast with a message that lists the registered names —
+// vital for typo diagnosis on a single-line config.
+func TestAddCacheFlagsToCmd_UnknownProvider(t *testing.T) {
+	withCleanRegistry(t)
+	RegisterRedisCredentialsProvider(&stubProviderFactory{name: "stubcloud"})
+
+	cmd := &cobra.Command{}
+	cacheFn := AddCacheFlagsToCmd(cmd)
+	require.NoError(t, cmd.Flags().Set("redis-credentials-provider", "typo"))
+
+	_, err := cacheFn()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unknown redis credentials provider "typo"`)
+	assert.Contains(t, err.Error(), "stubcloud",
+		"error must enumerate registered providers so users can correct the typo")
+}
+
+// TestAddCacheFlagsToCmd_ProviderBuildErrorPropagates ensures factory failures
+// surface to the caller rather than being swallowed.
+func TestAddCacheFlagsToCmd_ProviderBuildErrorPropagates(t *testing.T) {
+	withCleanRegistry(t)
+	wantErr := errors.New("federated token unavailable")
+	RegisterRedisCredentialsProvider(&stubProviderFactory{name: "stubcloud", buildErr: wantErr})
+
+	cmd := &cobra.Command{}
+	cacheFn := AddCacheFlagsToCmd(cmd)
+	require.NoError(t, cmd.Flags().Set("redis-credentials-provider", "stubcloud"))
+
+	_, err := cacheFn()
+	require.ErrorIs(t, err, wantErr)
+}
+
+// TestAddCacheFlagsToCmd_ProviderRejectsSentinel asserts that selecting a
+// credentials provider while sentinel addresses are configured fails with a
+// clear, actionable message — sentinel mode is incompatible with the
+// cloud-managed Redis services these providers target.
+func TestAddCacheFlagsToCmd_ProviderRejectsSentinel(t *testing.T) {
+	withCleanRegistry(t)
+	RegisterRedisCredentialsProvider(&stubProviderFactory{name: "stubcloud"})
+
+	cmd := &cobra.Command{}
+	cacheFn := AddCacheFlagsToCmd(cmd)
+	require.NoError(t, cmd.Flags().Set("redis-credentials-provider", "stubcloud"))
+	require.NoError(t, cmd.Flags().Set("sentinel", "sentinel-1:26379"))
+
+	_, err := cacheFn()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "incompatible with sentinel-mode")
+	assert.Contains(t, err.Error(), "stubcloud")
+}
+
+// TestBuildRedisClient_SetsCredentialsProvider verifies that a non-nil
+// provider is propagated into the underlying go-redis Options. We can't
+// inspect the struct field directly (it's a closure), but we can compare
+// pointers to the same closure to prove the wiring.
+func TestBuildRedisClient_SetsCredentialsProvider(t *testing.T) {
+	called := 0
+	provider := func(_ context.Context) (string, string, error) {
+		called++
+		return "u", "p", nil
+	}
+
+	client := buildRedisClient("redis:6379", "static", "static-user", 0, 0, nil, provider)
+	require.NotNil(t, client)
+	require.NotNil(t, client.Options().CredentialsProviderContext,
+		"provider closure must be wired into go-redis Options")
+
+	_, _, err := client.Options().CredentialsProviderContext(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, called, "go-redis must invoke our provider, not bypass it")
+}
+
+// TestBuildRedisClient_NilProviderLeavesOptionsAlone makes sure the default
+// (no provider) code path doesn't accidentally install a nil
+// CredentialsProviderContext, which would crash go-redis on every connect.
+func TestBuildRedisClient_NilProviderLeavesOptionsAlone(t *testing.T) {
+	client := buildRedisClient("redis:6379", "static", "static-user", 0, 0, nil, nil)
+	require.NotNil(t, client)
+	assert.Nil(t, client.Options().CredentialsProviderContext,
+		"no provider configured -> CredentialsProviderContext must remain nil")
+}
+
+// TestBuildFailoverRedisClient_SetsCredentialsProvider mirrors
+// TestBuildRedisClient_SetsCredentialsProvider for the sentinel client. We
+// keep the wiring even though the public flow rejects sentinel + provider —
+// future providers (e.g. self-hosted Redis Enterprise behind sentinel with
+// ACLs) may want it.
+func TestBuildFailoverRedisClient_SetsCredentialsProvider(t *testing.T) {
+	provider := func(_ context.Context) (string, string, error) {
+		return "u", "p", nil
+	}
+	client := buildFailoverRedisClient("master", "", "", "static", "user", 0, 0, nil,
+		[]string{"s-0:26379"}, provider)
+	require.NotNil(t, client)
+	require.NotNil(t, client.Options().CredentialsProviderContext,
+		"provider closure must be wired into go-redis FailoverOptions too")
 }

--- a/util/cache/credentials.go
+++ b/util/cache/credentials.go
@@ -1,0 +1,120 @@
+package cache
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/spf13/cobra"
+)
+
+// RedisCredentialsProvider matches the signature go-redis expects for
+// dynamic per-connection credentials (redis.Options.CredentialsProviderContext).
+// It is invoked by go-redis on every new connection (including reconnects),
+// which makes it the natural extension point for short-lived, automatically
+// rotated credentials such as cloud-provider-issued OAuth tokens.
+type RedisCredentialsProvider = func(ctx context.Context) (username, password string, err error)
+
+// RedisCredentialsProviderFactory builds a RedisCredentialsProvider for a
+// specific authentication backend (Microsoft Entra ID, GCP Memorystore IAM,
+// AWS ElastiCache IAM, …).
+//
+// Implementations register themselves via package-level init() calls to
+// RegisterRedisCredentialsProvider. The active backend is selected at runtime
+// by --redis-credentials-provider; the factory whose Name() matches that flag
+// is asked to Build the provider closure that will be wired into the redis
+// client. Backends that aren't selected are inert: their AddFlags-registered
+// flags are still parseable for documentation purposes but have no effect.
+type RedisCredentialsProviderFactory interface {
+	// Name returns the identifier used to select this factory via the
+	// --redis-credentials-provider flag (e.g. "azure", "gcp", "aws").
+	Name() string
+
+	// AddFlags lets the factory register its own backend-specific flags on
+	// the supplied cobra command. Flags should be prefixed with `flagPrefix`
+	// (the FlagPrefix from Options, usually empty) and namespaced under the
+	// provider name to avoid collisions across backends — e.g.
+	// "redis-azure-client-id" rather than "redis-client-id".
+	//
+	// envPrefix is the matching upper-snake-cased prefix applied to env vars
+	// that back the flag defaults (e.g. "REPOSERVER_" producing
+	// "REPOSERVER_REDIS_AZURE_CLIENT_ID").
+	AddFlags(cmd *cobra.Command, flagPrefix, envPrefix string)
+
+	// Build is invoked when the user has selected this factory by name. It
+	// returns the closure that will be assigned to
+	// redis.Options.CredentialsProviderContext.
+	//
+	// loadedUsername is the Redis username already resolved from
+	// --redis-username, REDIS_USERNAME or the credentials-mount file. The
+	// factory is free to honour, override, or ignore it; for AAD-style flows
+	// the username is typically derived from the issued token instead.
+	Build(loadedUsername string) (RedisCredentialsProvider, error)
+}
+
+var (
+	redisCredentialsProvidersMu sync.RWMutex
+	redisCredentialsProviders   = map[string]RedisCredentialsProviderFactory{}
+)
+
+// RegisterRedisCredentialsProvider registers a factory in the package-level
+// registry. Intended to be called from init() functions of provider
+// implementations. Panics on duplicate registration so that double-registers
+// surface as a fail-fast process start rather than as silently shadowed
+// behaviour at runtime.
+func RegisterRedisCredentialsProvider(f RedisCredentialsProviderFactory) {
+	redisCredentialsProvidersMu.Lock()
+	defer redisCredentialsProvidersMu.Unlock()
+	if _, exists := redisCredentialsProviders[f.Name()]; exists {
+		panic(fmt.Sprintf("redis credentials provider %q already registered", f.Name()))
+	}
+	redisCredentialsProviders[f.Name()] = f
+}
+
+// lookupRedisCredentialsProvider returns the registered factory for `name`,
+// or an error listing the registered names if no match exists.
+func lookupRedisCredentialsProvider(name string) (RedisCredentialsProviderFactory, error) {
+	redisCredentialsProvidersMu.RLock()
+	defer redisCredentialsProvidersMu.RUnlock()
+	f, ok := redisCredentialsProviders[name]
+	if !ok {
+		return nil, fmt.Errorf("unknown redis credentials provider %q (registered: %v)", name, registeredRedisCredentialsProviderNamesLocked())
+	}
+	return f, nil
+}
+
+// registeredRedisCredentialsProviderNames returns the sorted list of
+// registered factory names. Useful for --help and error messages.
+func registeredRedisCredentialsProviderNames() []string {
+	redisCredentialsProvidersMu.RLock()
+	defer redisCredentialsProvidersMu.RUnlock()
+	return registeredRedisCredentialsProviderNamesLocked()
+}
+
+// registeredRedisCredentialsProviderNamesLocked is the lock-free body of
+// registeredRedisCredentialsProviderNames; the caller must hold the registry
+// read or write lock.
+func registeredRedisCredentialsProviderNamesLocked() []string {
+	names := make([]string, 0, len(redisCredentialsProviders))
+	for n := range redisCredentialsProviders {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// addRedisCredentialsProviderFlags invokes AddFlags on every registered
+// factory in a stable, sorted order so that --help output is deterministic.
+func addRedisCredentialsProviderFlags(cmd *cobra.Command, flagPrefix, envPrefix string) {
+	redisCredentialsProvidersMu.RLock()
+	names := registeredRedisCredentialsProviderNamesLocked()
+	factories := make([]RedisCredentialsProviderFactory, 0, len(names))
+	for _, n := range names {
+		factories = append(factories, redisCredentialsProviders[n])
+	}
+	redisCredentialsProvidersMu.RUnlock()
+	for _, f := range factories {
+		f.AddFlags(cmd, flagPrefix, envPrefix)
+	}
+}

--- a/util/cache/credentials_test.go
+++ b/util/cache/credentials_test.go
@@ -1,0 +1,133 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubProviderFactory is a test double for RedisCredentialsProviderFactory
+// that lets each test instantiate it under a fresh registry name and
+// observe how AddFlags / Build are invoked.
+type stubProviderFactory struct {
+	name             string
+	addFlagsCalls    int
+	lastFlagPrefix   string
+	lastEnvPrefix    string
+	buildCalls       int
+	lastLoadedUser   string
+	buildErr         error
+	providerUsername string
+	providerPassword string
+}
+
+func (s *stubProviderFactory) Name() string { return s.name }
+
+func (s *stubProviderFactory) AddFlags(_ *cobra.Command, flagPrefix, envPrefix string) {
+	s.addFlagsCalls++
+	s.lastFlagPrefix = flagPrefix
+	s.lastEnvPrefix = envPrefix
+}
+
+func (s *stubProviderFactory) Build(loadedUsername string) (RedisCredentialsProvider, error) {
+	s.buildCalls++
+	s.lastLoadedUser = loadedUsername
+	if s.buildErr != nil {
+		return nil, s.buildErr
+	}
+	user := s.providerUsername
+	pass := s.providerPassword
+	return func(ctx context.Context) (string, string, error) {
+		return user, pass, nil
+	}, nil
+}
+
+// withCleanRegistry swaps the global registry for a test-local one and
+// restores the original on cleanup. Required because RegisterRedisCredentialsProvider
+// panics on duplicate names; tests must not leak factories into each other.
+func withCleanRegistry(t *testing.T) {
+	t.Helper()
+	redisCredentialsProvidersMu.Lock()
+	saved := redisCredentialsProviders
+	redisCredentialsProviders = map[string]RedisCredentialsProviderFactory{}
+	redisCredentialsProvidersMu.Unlock()
+	t.Cleanup(func() {
+		redisCredentialsProvidersMu.Lock()
+		redisCredentialsProviders = saved
+		redisCredentialsProvidersMu.Unlock()
+	})
+}
+
+func TestRegisterRedisCredentialsProvider(t *testing.T) {
+	withCleanRegistry(t)
+
+	RegisterRedisCredentialsProvider(&stubProviderFactory{name: "alpha"})
+	RegisterRedisCredentialsProvider(&stubProviderFactory{name: "beta"})
+
+	assert.Equal(t, []string{"alpha", "beta"}, registeredRedisCredentialsProviderNames())
+}
+
+func TestRegisterRedisCredentialsProvider_DuplicatePanics(t *testing.T) {
+	withCleanRegistry(t)
+
+	RegisterRedisCredentialsProvider(&stubProviderFactory{name: "dup"})
+	assert.PanicsWithValue(t,
+		`redis credentials provider "dup" already registered`,
+		func() {
+			RegisterRedisCredentialsProvider(&stubProviderFactory{name: "dup"})
+		})
+}
+
+func TestLookupRedisCredentialsProvider(t *testing.T) {
+	withCleanRegistry(t)
+
+	want := &stubProviderFactory{name: "azure"}
+	RegisterRedisCredentialsProvider(want)
+
+	got, err := lookupRedisCredentialsProvider("azure")
+	require.NoError(t, err)
+	assert.Same(t, want, got)
+}
+
+func TestLookupRedisCredentialsProvider_Unknown(t *testing.T) {
+	withCleanRegistry(t)
+
+	RegisterRedisCredentialsProvider(&stubProviderFactory{name: "azure"})
+
+	_, err := lookupRedisCredentialsProvider("gcp")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unknown redis credentials provider "gcp"`)
+	assert.Contains(t, err.Error(), "azure", "error must list registered names so users can correct typos")
+}
+
+func TestAddRedisCredentialsProviderFlags_DelegatesToAllFactories(t *testing.T) {
+	withCleanRegistry(t)
+
+	a := &stubProviderFactory{name: "alpha"}
+	b := &stubProviderFactory{name: "beta"}
+	RegisterRedisCredentialsProvider(a)
+	RegisterRedisCredentialsProvider(b)
+
+	cmd := &cobra.Command{}
+	addRedisCredentialsProviderFlags(cmd, "repo-", "REPO_")
+
+	assert.Equal(t, 1, a.addFlagsCalls)
+	assert.Equal(t, 1, b.addFlagsCalls)
+	assert.Equal(t, "repo-", a.lastFlagPrefix)
+	assert.Equal(t, "REPO_", b.lastEnvPrefix)
+}
+
+func TestStubFactory_BuildPropagatesError(t *testing.T) {
+	withCleanRegistry(t)
+
+	wantErr := errors.New("boom")
+	f := &stubProviderFactory{name: "x", buildErr: wantErr}
+
+	_, err := f.Build("ignored")
+	require.ErrorIs(t, err, wantErr)
+	assert.Equal(t, "ignored", f.lastLoadedUser)
+}

--- a/util/cache/credentials_test.go
+++ b/util/cache/credentials_test.go
@@ -41,7 +41,7 @@ func (s *stubProviderFactory) Build(loadedUsername string) (RedisCredentialsProv
 	}
 	user := s.providerUsername
 	pass := s.providerPassword
-	return func(ctx context.Context) (string, string, error) {
+	return func(_ context.Context) (string, string, error) {
 		return user, pass, nil
 	}, nil
 }


### PR DESCRIPTION
## Why

Argo CD currently can only authenticate to external Redis with a long-lived access key. Operators on Azure (AKS) authenticate every other workload — Cosmos DB, Service Bus, Storage, Key Vault — via [workload identity](https://azure.github.io/azure-workload-identity/), so the Redis access key is the only piece of cluster state with a static credential. Azure Cache for Redis has supported [Microsoft Entra ID auth](https://learn.microsoft.com/azure/azure-cache-for-redis/cache-azure-active-directory-for-authentication) as the recommended mode since 2024; this PR lets Argo CD use it.

Tracks #19133, #19136.

## What

Three opt-in flags wired into `util/cache.AddCacheFlagsToCmd` (and therefore inherited by every Argo CD binary that uses the shared cache client — server, application-controller, repo-server, applicationset-controller, notifications):

- `--redis-azure-workload-identity` (`REDIS_AZURE_WORKLOAD_IDENTITY`) — opt in
- `--redis-azure-client-id` (`REDIS_AZURE_CLIENT_ID`) — optional override for the Entra ID app/client ID, defaults to the `AZURE_CLIENT_ID` env var injected by the workload-identity webhook
- `--redis-azure-scope` (`REDIS_AZURE_SCOPE`) — defaults to `https://redis.azure.com/.default`; override only for non-public Azure clouds (e.g. Azure Government)

When the flag is enabled, the cache builder constructs an `azidentity` credential and wires it to `redis.Options.CredentialsProviderContext`. go-redis invokes the provider on every new connection and every reconnect, so when the AAD token rotates (~60 min) Argo CD picks up the new token transparently — no daemon, no restart, no shared-cache eviction. The principal's object ID (the `oid` JWT claim, falling back to `sub`) is surfaced as the AUTH username, which is the format Azure Cache for Redis expects under AAD auth.

Static `--redis-password` / `REDIS_PASSWORD` is intentionally discarded under WI mode: AAD tokens live ~1h, so a static password would only apply until the first reconnect — more confusing than helpful.

No new dependencies. `azidentity` and `go-redis/v9` are already vendored. The flag defaults to `false`; existing deployments are unaffected.

## Proposal

[`docs/proposals/redis-azure-workload-identity.md`](docs/proposals/redis-azure-workload-identity.md) — full design, alternatives, security review, open questions.

Happy to split the proposal into its own PR if reviewers prefer the two-step `proposal → implementation` flow.

## Tests

13 new test cases in `util/cache/azure_test.go` covering:
- `oid` precedence over `sub` and the no-claim case
- malformed JWT handling (single-segment, undecodable payload)
- static-username precedence over JWT-derived username
- custom-scope plumbing
- error propagation from the credential
- per-call refresh invariant (the provider re-acquires on every call so go-redis' built-in reconnect refresh works)

All 13 pass; the rest of `util/cache/...` continues to pass on master.

## Docs

- `docs/operator-manual/argocd-cmd-params-cm.yaml` — three new keys with comments
- `docs/operator-manual/upgrading/3.4-3.5.md` — opt-in note under "Other Changes"
- `docs/operator-manual/server-commands/argocd-{server,application-controller,repo-server}.md` — auto-regenerated via `make clidocsgen`

## Checklist

- [x] DCO sign-off
- [x] Tests added
- [x] Docs updated (incl. auto-generated CLI docs)
- [x] Proposal under `docs/proposals/`
- [x] Backward compatible — flag defaults to `false`, existing static-password path is unchanged

## Open question for reviewers

Naming: `--redis-azure-workload-identity` vs `--redis-aad-workload-identity` vs `--redis-entra-workload-identity`. Picked `azure` because that matches `azidentity` / `azurerm` already in the repo; happy to change.