### PR TITLE
fix: set InvolvedObject.Namespace to match event namespace (#28106)

### DIFF
--- a/util/argo/audit_logger.go
+++ b/util/argo/audit_logger.go
@@ -80,6 +80,13 @@ func (l *AuditLogger) logEvent(objMeta ObjectRef, gvk schema.GroupVersionKind, i
 		logFields["resource-namespace"] = objMeta.Namespace
 	}
 
+	// Kubernetes requires InvolvedObject.Namespace to match the event namespace.
+	// Cluster-scoped resources have an empty namespace and are exempt from this check.
+	involvedObjectNamespace := objMeta.Namespace
+	if objMeta.Namespace != "" {
+		involvedObjectNamespace = eventNamespace
+	}
+
 	event := corev1.Event{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        fmt.Sprintf("%v.%x", objMeta.Name, t.UnixNano()),
@@ -92,7 +99,7 @@ func (l *AuditLogger) logEvent(objMeta ObjectRef, gvk schema.GroupVersionKind, i
 		InvolvedObject: corev1.ObjectReference{
 			Kind:            gvk.Kind,
 			Name:            objMeta.Name,
-			Namespace:       objMeta.Namespace, // Keep the original namespace in InvolvedObject
+			Namespace:       involvedObjectNamespace,
 			ResourceVersion: objMeta.ResourceVersion,
 			APIVersion:      gvk.GroupVersion().String(),
 			UID:             objMeta.UID,

--- a/util/argo/audit_logger_test.go
+++ b/util/argo/audit_logger_test.go
@@ -244,7 +244,7 @@ func TestLogResourceEvent_MultiCluster_CreatesEventInArgocdNamespace(t *testing.
 
 	event := events.Items[0]
 	assert.Equal(t, "my-deployment", event.InvolvedObject.Name)
-	assert.Equal(t, _targetNs, event.InvolvedObject.Namespace, "InvolvedObject should preserve original namespace")
+	assert.Equal(t, _argocdNs, event.InvolvedObject.Namespace, "InvolvedObject.Namespace must match event namespace")
 	assert.Equal(t, _argocdNs, event.Namespace, "Event itself should be in ArgoCD namespace")
 	assert.Equal(t, "Resource action executed", event.Message)
 
@@ -350,7 +350,7 @@ func TestLogResourceEvent_DifferentKinds_AllInArgocdNamespace(t *testing.T) {
 
 			event := events.Items[0]
 			assert.Equal(t, _argocdNs, event.Namespace, "Event should be in ArgoCD namespace for %s", tc.resourceKind)
-			assert.Equal(t, tc.resourceNs, event.InvolvedObject.Namespace, "InvolvedObject should preserve original namespace")
+			assert.Equal(t, _argocdNs, event.InvolvedObject.Namespace, "InvolvedObject.Namespace must match event namespace")
 			assert.Equal(t, tc.resourceNs, event.Annotations["resource-namespace"])
 		})
 	}


### PR DESCRIPTION
Fixes #28106

## Summary

After #26667, resource audit events (e.g. for Deployments) are created in the ArgoCD namespace rather than the resource's own namespace. However, `InvolvedObject.Namespace` was left as the original resource namespace, causing Kubernetes API validation to fail with:

```
involvedObject.namespace: Invalid value: "<resource-namespace>": does not match event.namespace
```

This PR sets `InvolvedObject.Namespace` to match the event namespace. The original resource namespace is preserved in the `resource-namespace` annotation. Cluster-scoped resources (empty namespace) are exempt and keep an empty `InvolvedObject.Namespace`.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).