### PR TITLE
fix(ui): Application Summary crashes on load for non-hydrator apps

### DIFF
--- a/ui/src/app/applications/components/utils.test.tsx
+++ b/ui/src/app/applications/components/utils.test.tsx
@@ -1023,6 +1023,10 @@ describe('getHydratorSyncSourceRepoURL', () => {
             })
         ).toBe('https://github.com/example/dry.git');
     });
+
+    it('returns empty string when sourceHydrator is undefined', () => {
+        expect(getHydratorSyncSourceRepoURL(undefined)).toBe('');
+    });
 });
 
 describe('getAppHydratorSyncSource', () => {

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -1503,15 +1503,15 @@ export function getAppDrySource(app?: appModels.Application): appModels.Applicat
     return getAppDefaultSource(app);
 }
 
-export function getHydratorSyncSourceRepoURL(sourceHydrator: appModels.SourceHydrator): string {
-    return sourceHydrator.syncSource?.repoURL || sourceHydrator.drySource?.repoURL || '';
+export function getHydratorSyncSourceRepoURL(sourceHydrator?: appModels.SourceHydrator): string {
+    return sourceHydrator?.syncSource?.repoURL || sourceHydrator?.drySource?.repoURL || '';
 }
 
-export function getAppHydratorSyncSource(sourceHydrator: appModels.SourceHydrator): appModels.ApplicationSource {
+export function getAppHydratorSyncSource(sourceHydrator?: appModels.SourceHydrator): appModels.ApplicationSource {
     return {
         repoURL: getHydratorSyncSourceRepoURL(sourceHydrator),
-        targetRevision: sourceHydrator.syncSource.targetBranch,
-        path: sourceHydrator.syncSource.path
+        targetRevision: sourceHydrator?.syncSource?.targetBranch || sourceHydrator?.drySource?.targetRevision || '',
+        path: sourceHydrator?.syncSource?.path || sourceHydrator?.drySource?.path || ''
     };
 }
 

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -1510,8 +1510,8 @@ export function getHydratorSyncSourceRepoURL(sourceHydrator?: appModels.SourceHy
 export function getAppHydratorSyncSource(sourceHydrator?: appModels.SourceHydrator): appModels.ApplicationSource {
     return {
         repoURL: getHydratorSyncSourceRepoURL(sourceHydrator),
-        targetRevision: sourceHydrator?.syncSource?.targetBranch || sourceHydrator?.drySource?.targetRevision || '',
-        path: sourceHydrator?.syncSource?.path || sourceHydrator?.drySource?.path || ''
+        targetRevision: sourceHydrator?.syncSource?.targetBranch || '',
+        path: sourceHydrator?.syncSource?.path || ''
     };
 }
 


### PR DESCRIPTION
### Summary

Loading the **Application Summary** panel throws a JavaScript error and the UI fails to render when the application does **not** have `spec.sourceHydrator` configured.

### Steps to reproduce

1. Open any Application that uses a standard source (no Source Hydrator).
2. Navigate to the **Summary** tab (e.g. from Application Details or Resource Details).
3. Observe a blank panel or React error boundary.

```
Something went wrong!

Consider [submitting an issue](https://github.com/argoproj/argo-cd/issues/new?labels=bug&template=bug_report.md).


Stacktrace:

TypeError: Cannot read properties of undefined (reading 'syncSource')
```
https://cd.apps.argoproj.io/applications/team-backend/api?node=argoproj.io%2FApplication%2Fteam-backend%2Fapi%2F0
