### PR TITLE
fix(health): PromotionStrategy stuck Progressing after no-op re-hydration (#28124)

### DIFF
--- a/resource_customizations/promoter.argoproj.io/PromotionStrategy/health.lua
+++ b/resource_customizations/promoter.argoproj.io/PromotionStrategy/health.lua
@@ -105,12 +105,11 @@ local function getShortSha(sha)
     return sha
 end
 
--- Find the first environment with a proposed commit dry sha that doesn't match the active one. Loop over its commit
--- statuses and build a summary about how many are pending, successful, or failed. Return a Progressing status for this
--- in-progress environment.
+-- Find the first environment with a genuinely promotable diff: proposed metadata dry sha differs from active. When only
+-- the hydrator note advanced (no-op re-hydration), proposed.dry.sha still matches active.dry.sha and no promotion is
+-- needed even if getProposedDrySha (note-based) differs from active.dry.sha.
 for _, env in ipairs(obj.status.environments) do
-    local envProposedSha = getProposedDrySha(env)
-    if envProposedSha ~= env.active.dry.sha then
+    if env.proposed.dry.sha ~= env.active.dry.sha then
         local pendingCount = 0
         local successCount = 0
         local failureCount = 0
@@ -135,7 +134,7 @@ for _, env in ipairs(obj.status.environments) do
         hs.message =
             "Promotion in progress for environment '" .. env.branch ..
             "' from '" .. getShortSha(env.active.dry.sha) ..
-            "' to '" .. getShortSha(envProposedSha) .. "': " ..
+            "' to '" .. getShortSha(env.proposed.dry.sha) .. "': " ..
             pendingCount .. " pending, " .. successCount .. " successful, " .. failureCount .. " failed. "
 
         if pendingCount > 0 then
@@ -144,6 +143,7 @@ for _, env in ipairs(obj.status.environments) do
         if failureCount > 0 then
             hs.message = hs.message .. "Failed commit statuses: " .. table.concat(failedKeys, ", ") .. ". "
         end
+        hs.message = hs.message .. "Hydrator has processed dry commit '" .. getShortSha(getProposedDrySha(env)) .. "'. "
         return hs
     end
 end
@@ -186,5 +186,5 @@ end
 -- If all environments have the same proposed commit dry sha as the active one, we can consider the promotion strategy
 -- healthy. This means all environments are in sync and no further action is needed.
 hs.status = "Healthy"
-hs.message = "All environments are up-to-date on commit '" .. getShortSha(getProposedDrySha(obj.status.environments[1])) .. "'."
+hs.message = "All environments are up-to-date on commit '" .. getShortSha(obj.status.environments[1].active.dry.sha) .. "'. Hydrator has processed dry commit '" .. getShortSha(getProposedDrySha(obj.status.environments[1])) .. "'."
 return hs

--- a/resource_customizations/promoter.argoproj.io/PromotionStrategy/health_test.yaml
+++ b/resource_customizations/promoter.argoproj.io/PromotionStrategy/health_test.yaml
@@ -33,11 +33,11 @@ tests:
   inputPath: testdata/proposed-dry-sha-missing.yaml
 - healthStatus:
     status: Progressing
-    message: "Promotion in progress for environment 'dev' from 'abc1234' to 'def5678': 1 pending, 0 successful, 1 failed. Pending commit statuses: test-pending. Failed commit statuses: test-failed. "
+    message: "Promotion in progress for environment 'dev' from 'abc1234' to 'def5678': 1 pending, 0 successful, 1 failed. Pending commit statuses: test-pending. Failed commit statuses: test-failed. Hydrator has processed dry commit 'def5678'. "
   inputPath: testdata/progressing-failed-pending.yaml
 - healthStatus:
     status: Healthy
-    message: All environments are up-to-date on commit 'abc1234'.
+    message: All environments are up-to-date on commit 'abc1234'. Hydrator has processed dry commit 'abc1234'.
   inputPath: testdata/all-healthy.yaml
 - healthStatus:
     status: Progressing
@@ -49,5 +49,9 @@ tests:
   inputPath: testdata/missing-sha-and-not-ready.yaml
 - healthStatus:
     status: Progressing
-    message: "Promotion in progress for environment 'dev' from 'abc1234' to 'new9999': 0 pending, 0 successful, 0 failed. "
+    message: "Promotion in progress for environment 'dev' from 'abc1234' to 'old1111': 0 pending, 0 successful, 0 failed. Hydrator has processed dry commit 'new9999'. "
   inputPath: testdata/proposed-note-dry-sha-preferred.yaml
+- healthStatus:
+    status: Healthy
+    message: All environments are up-to-date on commit '56057f1'. Hydrator has processed dry commit 'ab3c473'.
+  inputPath: testdata/no-op-rehydration-note-ahead.yaml

--- a/resource_customizations/promoter.argoproj.io/PromotionStrategy/testdata/no-op-rehydration-note-ahead.yaml
+++ b/resource_customizations/promoter.argoproj.io/PromotionStrategy/testdata/no-op-rehydration-note-ahead.yaml
@@ -1,0 +1,38 @@
+apiVersion: promoter.argoproj.io/v1alpha1
+kind: PromotionStrategy
+metadata:
+  name: test
+  generation: 1
+spec: {}
+status:
+  conditions:
+    - type: Ready
+      status: "True"
+      observedGeneration: 1
+  environments:
+    - branch: group-a
+      active:
+        dry:
+          sha: 56057f1abcdef0
+        commitStatuses:
+          - key: test
+            phase: success
+      proposed:
+        dry:
+          sha: 56057f1abcdef0
+        note:
+          drySha: ab3c473abcdef0
+        commitStatuses: []
+    - branch: group-b
+      active:
+        dry:
+          sha: 56057f1abcdef0
+        commitStatuses:
+          - key: test
+            phase: success
+      proposed:
+        dry:
+          sha: 56057f1abcdef0
+        note:
+          drySha: ab3c473abcdef0
+        commitStatuses: []


### PR DESCRIPTION
Fixes #28124

## Summary

- Gate PromotionStrategy "promotion in progress" on `proposed.dry.sha ~= active.dry.sha`, matching gitops-promoter and ChangeTransferPolicy health logic
- Avoids indefinite **Progressing** when a git-notes hydrator advances `proposed.note.drySha` on a no-op re-hydration but hydrated output is unchanged
- Clarify health messages: "promoting to" uses the proposed branch dry SHA; append `Hydrator has processed dry commit '<note, fallback>'` in both progressing and healthy states

Related: [argoproj-labs/gitops-promoter#1541](https://github.com/argoproj-labs/gitops-promoter/issues/1541)

## Test plan

- [x] `go test -mod=mod -v ./util/lua/ -run 'TestLuaHealthScript/promoter.argoproj.io/PromotionStrategy'`
- [x] Added `testdata/no-op-rehydration-note-ahead.yaml` covering the stuck Progressing scenario

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).


Made with [Cursor](https://cursor.com)