### PR TITLE
fix(ui): clarify credential templates list in repositories settings

### DIFF
--- a/ui/src/app/settings/components/repos-list/repos-list.tsx
+++ b/ui/src/app/settings/components/repos-list/repos-list.tsx
@@ -999,7 +999,7 @@ export const ReposList = ({match, location}: RouteComponentProps) => {
                                     <div className='argo-table-list__head'>
                                         <div className='row'>
                                             <div className='columns small-9'>CREDENTIALS TEMPLATE URL</div>
-                                            <div className='columns small-3'>CREDS</div>
+                                            <div className='columns small-3'>Credentials</div>
                                         </div>
                                     </div>
                                     {creds.map(repo => (
@@ -1009,7 +1009,7 @@ export const ReposList = ({match, location}: RouteComponentProps) => {
                                                     <i className='icon argo-icon-git' /> <Repo url={repo.url} />
                                                 </div>
                                                 <div className='columns small-3'>
-                                                    -
+                                                    <i className='fa fa-key' /> Configured
                                                     <DropDownMenu
                                                         anchor={() => (
                                                             <button className='argo-button argo-button--light argo-button--lg argo-button--short'>
@@ -1122,7 +1122,7 @@ export const ReposList = ({match, location}: RouteComponentProps) => {
                                         <div className='argo-table-list__head'>
                                             <div className='row'>
                                                 <div className='columns small-9'>CREDENTIALS TEMPLATE URL</div>
-                                                <div className='columns small-3'>CREDS</div>
+                                                <div className='columns small-3'>Credentials</div>
                                             </div>
                                         </div>
                                         {creds.map(repo => (
@@ -1132,7 +1132,7 @@ export const ReposList = ({match, location}: RouteComponentProps) => {
                                                         <i className='icon argo-icon-git' /> <Repo url={repo.url} />
                                                     </div>
                                                     <div className='columns small-3'>
-                                                        -
+                                                        <i className='fa fa-key' /> Configured
                                                         <DropDownMenu
                                                             anchor={() => (
                                                                 <button className='argo-button argo-button--light argo-button--lg argo-button--short'>

--- a/ui/src/app/settings/components/repos-list/repos-list.tsx
+++ b/ui/src/app/settings/components/repos-list/repos-list.tsx
@@ -999,7 +999,7 @@ export const ReposList = ({match, location}: RouteComponentProps) => {
                                     <div className='argo-table-list__head'>
                                         <div className='row'>
                                             <div className='columns small-9'>CREDENTIALS TEMPLATE URL</div>
-                                            <div className='columns small-3'>Credentials</div>
+                                            <div className='columns small-3'>CREDENTIALS</div>
                                         </div>
                                     </div>
                                     {creds.map(repo => (
@@ -1122,7 +1122,7 @@ export const ReposList = ({match, location}: RouteComponentProps) => {
                                         <div className='argo-table-list__head'>
                                             <div className='row'>
                                                 <div className='columns small-9'>CREDENTIALS TEMPLATE URL</div>
-                                                <div className='columns small-3'>Credentials</div>
+                                                <div className='columns small-3'>CREDENTIALS</div>
                                             </div>
                                         </div>
                                         {creds.map(repo => (


### PR DESCRIPTION
Addresses part of #12273. The credential-templates list under Settings → Repositories used the abbreviation `CREDS` for the column header and a bare `-` as the value placeholder, which was unclear.

This renames the column to `Credentials` and replaces the `-` with a key icon and a `Configured` label, in both the read and write credential-template tables.

The broader column-layout / repository-association work mentioned in the issue is left for a follow-up.
