### PR TITLE
feat: add repo name to source panel dropdown in app creation UI

### DIFF
--- a/ui/src/app/applications/components/application-create-panel/application-create-panel.tsx
+++ b/ui/src/app/applications/components/application-create-panel/application-create-panel.tsx
@@ -234,7 +234,7 @@ export const ApplicationCreatePanel = (props: {
                 ]).then(([projects, clusters, reposInfo]) => ({projects, clusters, reposInfo}))
             }>
             {({projects, clusters, reposInfo}) => {
-                const repos = reposInfo.map(info => info.repo).sort();
+                const repos = [...reposInfo].sort((curr, next) => curr.repo.localeCompare(next.repo));
                 const repoInfo = reposInfo.find(info => info.repo === app.spec.source?.repoURL);
                 if (repoInfo) {
                     normalizeAppSource(app, repoInfo.type || currentRepoType.current || 'git');

--- a/ui/src/app/applications/components/application-create-panel/application-create-panel.tsx
+++ b/ui/src/app/applications/components/application-create-panel/application-create-panel.tsx
@@ -434,7 +434,7 @@ export const ApplicationCreatePanel = (props: {
                                                     </div>
                                                 )}
                                                 {isHydratorEnabled ? (
-                                                    <HydratorSourcePanel formApi={api} repos={repos} />
+                                                    <HydratorSourcePanel formApi={api} repos={repos.map(repo => repo.repo)} />
                                                 ) : (
                                                     <React.Fragment>
                                                         <SourcePanel

--- a/ui/src/app/applications/components/application-create-panel/collapsible-multi-source-section.tsx
+++ b/ui/src/app/applications/components/application-create-panel/collapsible-multi-source-section.tsx
@@ -7,7 +7,7 @@ import {SourcePanel} from './source-panel';
 export function CollapsibleMultiSourceSection(props: {
     index: number;
     formApi: FormApi;
-    repos: string[];
+    repos: models.Repository[];
     reposInfo: models.Repository[];
     formApp: models.Application;
     canRemove?: boolean;

--- a/ui/src/app/applications/components/application-create-panel/source-panel.tsx
+++ b/ui/src/app/applications/components/application-create-panel/source-panel.tsx
@@ -1,4 +1,4 @@
-import {AutocompleteField, DataLoader, DropDownMenu, FormField} from 'argo-ui';
+import {AutocompleteField, AutocompleteOption, DataLoader, DropDownMenu, FormField} from 'argo-ui';
 import * as React from 'react';
 import {FormApi} from 'argo-ui';
 import {RevisionHelpIcon} from '../../../shared/components';
@@ -23,7 +23,7 @@ function fieldPath(sourceIndex: number | undefined, field: string): string {
 
 export interface SourcePanelProps {
     formApi: FormApi;
-    repos: string[];
+    repos: models.Repository[];
     repoInfo?: models.Repository;
     sourceIndex?: number;
     suppressMultiSourceHeading?: boolean;
@@ -65,7 +65,12 @@ export const SourcePanel = (props: SourcePanelProps) => {
                         field={fieldPath(idx, 'repoURL')}
                         component={AutocompleteField}
                         componentProps={{
-                            items: props.repos,
+                            items: props.repos.map(
+                                (r): AutocompleteOption => ({
+                                    value: r.repo,
+                                    label: r.name ? `${r.repo} -- ${r.name}` : r.repo
+                                })
+                            ),
                             filterSuggestions: true
                         }}
                     />

--- a/ui/src/app/applications/components/application-create-panel/source-panel.tsx
+++ b/ui/src/app/applications/components/application-create-panel/source-panel.tsx
@@ -65,12 +65,10 @@ export const SourcePanel = (props: SourcePanelProps) => {
                         field={fieldPath(idx, 'repoURL')}
                         component={AutocompleteField}
                         componentProps={{
-                            items: props.repos.map(
-                                (r): AutocompleteOption => ({
-                                    value: r.repo,
-                                    label: r.name ? `${r.repo} -- ${r.name}` : r.repo
-                                })
-                            ),
+                            items: props.repos.map((r): AutocompleteOption => ({
+                                value: r.repo,
+                                label: r.name ? `${r.repo} -- ${r.name}` : r.repo
+                            })),
                             filterSuggestions: true
                         }}
                     />


### PR DESCRIPTION
Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

For #24719 
Currently, the formatting of the text in the UI is not ideal, as the URL and the repo name is separate by "--" (see image attached). Ideally, it would be formatted as separate columns, but this may require extending `ui/node_modules/argo-ui/src/components/autocomplete/autocomplete.tsx` and I would like the maintainers' opinions on this before I touch it. 

Additionally, I used the "name" given to the repo when it was connected to Argo CD, instead of the actual repo name itself found as the suffix of the repo URL, as it is more intuitive. 

<img width="494" height="293" alt="image" src="https://github.com/user-attachments/assets/2c3e9db2-9f9b-4c04-8b71-13bfc0bd64d5" />
