### PR TITLE
test(e2e): fix cleanup of CRDs for e2e tests (#28157)

### DIFF
--- a/test/e2e/testdata/crd-creation/crd.yaml
+++ b/test/e2e/testdata/crd-creation/crd.yaml
@@ -3,6 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: dummies.argoproj.io
+  labels:
+    e2e.argoproj.io: "true"
 spec:
   conversion:
     strategy: None

--- a/test/e2e/testdata/crd-subresource/crd.yaml
+++ b/test/e2e/testdata/crd-subresource/crd.yaml
@@ -4,6 +4,7 @@ metadata:
   name: statussubresources.argoproj.io
   labels:
     e2e.argoproj.io: "true"
+spec:
   conversion:
     strategy: None
   group: argoproj.io

--- a/test/e2e/testdata/crd-subresource/crd.yaml
+++ b/test/e2e/testdata/crd-subresource/crd.yaml
@@ -2,8 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: statussubresources.argoproj.io
-  # labels:
-  #   e2e.argoproj.io: "true"
+  labels:
+    e2e.argoproj.io: "true"
   conversion:
     strategy: None
   group: argoproj.io
@@ -49,8 +49,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: nonstatussubresources.argoproj.io
-  # labels:
-  #   e2e.argoproj.io: "true"
+  labels:
+    e2e.argoproj.io: "true"
 spec:
   conversion:
     strategy: None

--- a/test/e2e/testdata/crd-subresource/crd.yaml
+++ b/test/e2e/testdata/crd-subresource/crd.yaml
@@ -2,8 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: statussubresources.argoproj.io
-  labels:
-    e2e.argoproj.io: "true"
+  # labels:
+  #   e2e.argoproj.io: "true"
   conversion:
     strategy: None
   group: argoproj.io
@@ -49,8 +49,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: nonstatussubresources.argoproj.io
-  labels:
-    e2e.argoproj.io: "true"
+  # labels:
+  #   e2e.argoproj.io: "true"
 spec:
   conversion:
     strategy: None

--- a/test/e2e/testdata/crd-subresource/crd.yaml
+++ b/test/e2e/testdata/crd-subresource/crd.yaml
@@ -2,7 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: statussubresources.argoproj.io
-spec:
+  labels:
+    e2e.argoproj.io: "true"
   conversion:
     strategy: None
   group: argoproj.io
@@ -48,6 +49,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: nonstatussubresources.argoproj.io
+  labels:
+    e2e.argoproj.io: "true"
 spec:
   conversion:
     strategy: None

--- a/test/e2e/testdata/crd-version-differences/crd-v1alpha1.yaml
+++ b/test/e2e/testdata/crd-version-differences/crd-v1alpha1.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: fakes.argoproj.io
+  labels:
+    e2e.argoproj.io: "true"
 spec:
   conversion:
     strategy: None

--- a/test/e2e/testdata/helm-crd/crds/crd.yaml
+++ b/test/e2e/testdata/helm-crd/crds/crd.yaml
@@ -3,6 +3,8 @@ kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
   name: crontabs.stable.example.com
+  labels:
+    e2e.argoproj.io: "true"
 spec:
   # group name to use for REST API: /apis/<group>/<version>
   group: stable.example.com

--- a/test/e2e/testdata/helm3-crd/crds/crd.yaml
+++ b/test/e2e/testdata/helm3-crd/crds/crd.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: crontabs.stable.example.com
+  labels:
+    e2e.argoproj.io: "true"
 spec:
   conversion:
     strategy: None


### PR DESCRIPTION
Fixes: #28157

Adds missing label `e2e.argoproj.io: "true"` to CRD definitions
used by e2e tests. 

The label is used by the cleanup code that runs before each test
to locate and delete CRD left by previous test runs.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [X] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
