### PR TITLE
fix(appcontroller): check operation status of existing app

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -1547,9 +1547,9 @@ func (ctrl *ApplicationController) processRequestedAppOperation(app *appv1.Appli
 
 	// Before persisting a non-terminal operation phase, guard against a lost update. SyncAppState can run for a long
 	// time (e.g. waiting on hooks or resource health), during which another writer (e.g a second controller resuming
-	// the same operation during a rolling restart) may have already completed the operation and cleared spec.operation.
+	// the same operation during a rolling restart) may have already completed the operation and cleared .operation.
 	// Persisting our non-terminal phase on top of that would resurrect "Running" over a cleared operation, orphaning
-	// the operation state permanently because processRequestedAppOperation is gated on a non-nil spec.operation
+	// the operation state permanently because processRequestedAppOperation is gated on a non-nil .operation
 	// (see argoproj/argo-cd#18613, #23765). Re-fetch the latest app and bail rather than clobber the terminal result
 	// written by the other writer.
 	if !state.Phase.Completed() {
@@ -1567,7 +1567,13 @@ func (ctrl *ApplicationController) processRequestedAppOperation(app *appv1.Appli
 			// workqueue, and next time SyncAppState will operate in a Terminating phase, allowing the
 			// worker to perform cleanup (e.g. delete jobs, workflows, etc...).
 			state.Phase = synccommon.OperationTerminating
-			state.Message = freshApp.Status.OperationState.Message
+			// Adopt the terminating writer's message (e.g. "operation is terminating due to timeout")
+			// rather than a generic one, but fall back to a default if it happens to be empty.
+			if msg := freshApp.Status.OperationState.Message; msg != "" {
+				state.Message = msg
+			} else {
+				state.Message = "operation is terminating"
+			}
 		}
 	}
 

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -1567,7 +1567,7 @@ func (ctrl *ApplicationController) processRequestedAppOperation(app *appv1.Appli
 			// workqueue, and next time SyncAppState will operate in a Terminating phase, allowing the
 			// worker to perform cleanup (e.g. delete jobs, workflows, etc...).
 			state.Phase = synccommon.OperationTerminating
-			state.Message = "operation is terminating"
+			state.Message = freshApp.Status.OperationState.Message
 		}
 	}
 

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -1521,19 +1521,6 @@ func (ctrl *ApplicationController) processRequestedAppOperation(app *appv1.Appli
 	ts.AddCheckpoint("sync_app_state_ms")
 
 	switch state.Phase {
-	case synccommon.OperationRunning:
-		// It's possible for an app to be terminated while we were operating on it. We do not want
-		// to clobber the Terminated state with Running. Get the latest app state to check for this.
-		freshApp, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(app.Namespace).Get(context.Background(), app.Name, metav1.GetOptions{})
-		if err == nil {
-			if freshApp.Status.OperationState != nil && freshApp.Status.OperationState.Phase == synccommon.OperationTerminating {
-				state.Phase = synccommon.OperationTerminating
-				state.Message = "operation is terminating"
-				// after this, we will get requeued to the workqueue, but next time the
-				// SyncAppState will operate in a Terminating phase, allowing the worker to perform
-				// cleanup (e.g. delete jobs, workflows, etc...)
-			}
-		}
 	case synccommon.OperationFailed, synccommon.OperationError:
 		if !terminating && (state.RetryCount < state.Operation.Retry.Limit || state.Operation.Retry.Limit < 0) {
 			now := metav1.Now()
@@ -1555,6 +1542,32 @@ func (ctrl *ApplicationController) processRequestedAppOperation(app *appv1.Appli
 			if state.RetryCount > 0 {
 				state.Message = fmt.Sprintf("%s (retried %d times).", state.Message, state.RetryCount)
 			}
+		}
+	}
+
+	// Before persisting a non-terminal operation phase, guard against a lost update. SyncAppState can run for a long
+	// time (e.g. waiting on hooks or resource health), during which another writer (e.g a second controller resuming
+	// the same operation during a rolling restart) may have already completed the operation and cleared spec.operation.
+	// Persisting our non-terminal phase on top of that would resurrect "Running" over a cleared operation, orphaning
+	// the operation state permanently because processRequestedAppOperation is gated on a non-nil spec.operation
+	// (see argoproj/argo-cd#18613, #23765). Re-fetch the latest app and bail rather than clobber the terminal result
+	// written by the other writer.
+	if !state.Phase.Completed() {
+		freshApp, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(app.Namespace).Get(context.Background(), app.Name, metav1.GetOptions{})
+		switch {
+		case err != nil:
+			// Best effort: if we can't verify, proceed as before rather than stall the operation.
+			logCtx.WithError(err).Warn("Unable to verify operation is still in progress before persisting operation state; proceeding")
+		case freshApp.Operation == nil:
+			logCtx.Warnf("Operation was completed and cleared by another writer; skipping stale %q operation state update to avoid orphaning it", state.Phase)
+			return
+		case freshApp.Status.OperationState != nil && freshApp.Status.OperationState.Phase == synccommon.OperationTerminating:
+			// It's possible for an app to be terminated while we were operating on it. We do not want
+			// to clobber the Terminating state with Running. After this, we will get requeued to the
+			// workqueue, and next time SyncAppState will operate in a Terminating phase, allowing the
+			// worker to perform cleanup (e.g. delete jobs, workflows, etc...).
+			state.Phase = synccommon.OperationTerminating
+			state.Message = "operation is terminating"
 		}
 	}
 

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -3026,7 +3026,7 @@ func TestProcessRequestedAppOperation_SkipsStaleNonTerminalUpdateWhenOperationCl
 	fakeAppCs := ctrl.applicationClientset.(*appclientset.Clientset)
 
 	// Simulate a concurrent writer (e.g. a second controller resuming the same operation during a
-	// rolling restart or shard handoff) that already finished and cleared spec.operation.
+	// rolling restart or shard handoff) that already finished and cleared .operation.
 	clearedApp := app.DeepCopy()
 	clearedApp.Operation = nil
 	getCalled := false
@@ -3060,13 +3060,13 @@ func TestProcessRequestedAppOperation_SkipsStaleNonTerminalUpdateWhenOperationCl
 // the fake clientset, and proves the guard prevents it.
 //
 // Setup: writer A (e.g. the completing controller) has already finished the operation and cleared
-// spec.operation, leaving {phase: Succeeded, operation: nil} in the store. Writer B - a second
+// .operation, leaving {phase: Succeeded, operation: nil} in the store. Writer B - a second
 // controller that resumed the same in-progress operation during a restart or shard handoff - then
 // runs with its stale in-memory view (operation still set, phase Running) and ends up wanting to
 // persist a non-terminal phase. Because setOperationState uses a field-level merge patch that only
-// clears spec.operation on a *completed* phase, persisting B's "Running" merges phase: Running on top
+// clears .operation on a *completed* phase, persisting B's "Running" merges phase: Running on top
 // of the already-cleared operation, producing {phase: Running, operation: nil} - an orphan that no
-// reconcile path ever revisits (processRequestedAppOperation is gated on a non-nil spec.operation).
+// reconcile path ever revisits (processRequestedAppOperation is gated on a non-nil .operation).
 //
 // With the guard, B detects via a fresh read that the operation was already cleared and skips its
 // stale write, so writer A's terminal state survives. Without the guard, the final stored state is
@@ -3074,7 +3074,7 @@ func TestProcessRequestedAppOperation_SkipsStaleNonTerminalUpdateWhenOperationCl
 func TestProcessRequestedAppOperation_LostUpdateDoesNotOrphanOperationState(t *testing.T) {
 	syncOp := v1alpha1.Operation{Sync: &v1alpha1.SyncOperation{}, Retry: v1alpha1.RetryStrategy{Limit: 1}}
 
-	// The state writer A left behind: the operation completed and spec.operation was cleared.
+	// The state writer A left behind: the operation completed and .operation was cleared.
 	// "invalid-project" forces writer B's resumed sync to fail and take the retry path, which is a
 	// convenient way to make B attempt to persist a non-terminal ("Running") phase. The orphaning
 	// mechanism is identical for any non-terminal persist (e.g. the "waiting for health" state in #23765).
@@ -3135,7 +3135,7 @@ func TestProcessRequestedAppOperation_LostUpdateDoesNotOrphanInProgressSync(t *t
 
 	syncOp := v1alpha1.Operation{Sync: &v1alpha1.SyncOperation{Source: &v1alpha1.ApplicationSource{}}}
 
-	// The state writer A left behind: the operation completed and spec.operation was cleared.
+	// The state writer A left behind: the operation completed and .operation was cleared.
 	completedApp := newFakeApp()
 	completedApp.Spec.Project = "default"
 	completedApp.Operation = nil

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -3009,6 +3009,176 @@ func TestProcessRequestedAppOperation_FailedHasRetries(t *testing.T) {
 	assert.InEpsilon(t, float64(1), retryCount, 0.0001)
 }
 
+// TestProcessRequestedAppOperation_SkipsStaleNonTerminalUpdateWhenOperationCleared validates the
+// lost-update guard. This is the same setup as TestProcessRequestedAppOperation_FailedHasRetries
+// (which would persist a non-terminal "Running" retry state), except the fresh GET performed before
+// persisting reports that another writer has already completed and cleared the operation. The
+// controller must skip the stale write rather than resurrect "Running" on top of a cleared
+// operation, which is what permanently orphans the operation state (argoproj/argo-cd#18613, #23765).
+func TestProcessRequestedAppOperation_SkipsStaleNonTerminalUpdateWhenOperationCleared(t *testing.T) {
+	app := newFakeApp()
+	app.Spec.Project = "invalid-project"
+	app.Operation = &v1alpha1.Operation{
+		Sync:  &v1alpha1.SyncOperation{},
+		Retry: v1alpha1.RetryStrategy{Limit: 1},
+	}
+	ctrl := newFakeController(t.Context(), &fakeData{apps: []runtime.Object{app}}, nil)
+	fakeAppCs := ctrl.applicationClientset.(*appclientset.Clientset)
+
+	// Simulate a concurrent writer (e.g. a second controller resuming the same operation during a
+	// rolling restart or shard handoff) that already finished and cleared spec.operation.
+	clearedApp := app.DeepCopy()
+	clearedApp.Operation = nil
+	getCalled := false
+	fakeAppCs.PrependReactor("get", "applications", func(_ kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+		getCalled = true
+		return true, clearedApp, nil
+	})
+	var patches []map[string]any
+	fakeAppCs.PrependReactor("patch", "*", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+		if patchAction, ok := action.(kubetesting.PatchAction); ok {
+			p := map[string]any{}
+			require.NoError(t, json.Unmarshal(patchAction.GetPatch(), &p))
+			patches = append(patches, p)
+		}
+		return true, &v1alpha1.Application{}, nil
+	})
+
+	ctrl.processRequestedAppOperation(app)
+
+	// The guard's fresh GET must have run (proving we reached the persist path for a non-terminal phase)...
+	assert.True(t, getCalled, "expected a fresh GET before persisting the non-terminal operation state")
+	// ...and the stale retry ("Running") update must not have been persisted.
+	for _, p := range patches {
+		message, _, _ := unstructured.NestedString(p, "status", "operationState", "message")
+		assert.NotContains(t, message, "Retrying attempt", "stale non-terminal operation state must not be persisted after the operation was cleared by another writer")
+	}
+}
+
+// TestProcessRequestedAppOperation_LostUpdateDoesNotOrphanOperationState reproduces the lost-update
+// race behind argoproj/argo-cd#18613 and #23765, end to end through the real merge-patch applied by
+// the fake clientset, and proves the guard prevents it.
+//
+// Setup: writer A (e.g. the completing controller) has already finished the operation and cleared
+// spec.operation, leaving {phase: Succeeded, operation: nil} in the store. Writer B - a second
+// controller that resumed the same in-progress operation during a restart or shard handoff - then
+// runs with its stale in-memory view (operation still set, phase Running) and ends up wanting to
+// persist a non-terminal phase. Because setOperationState uses a field-level merge patch that only
+// clears spec.operation on a *completed* phase, persisting B's "Running" merges phase: Running on top
+// of the already-cleared operation, producing {phase: Running, operation: nil} - an orphan that no
+// reconcile path ever revisits (processRequestedAppOperation is gated on a non-nil spec.operation).
+//
+// With the guard, B detects via a fresh read that the operation was already cleared and skips its
+// stale write, so writer A's terminal state survives. Without the guard, the final stored state is
+// the orphan and this test fails on the phase assertion below.
+func TestProcessRequestedAppOperation_LostUpdateDoesNotOrphanOperationState(t *testing.T) {
+	syncOp := v1alpha1.Operation{Sync: &v1alpha1.SyncOperation{}, Retry: v1alpha1.RetryStrategy{Limit: 1}}
+
+	// The state writer A left behind: the operation completed and spec.operation was cleared.
+	// "invalid-project" forces writer B's resumed sync to fail and take the retry path, which is a
+	// convenient way to make B attempt to persist a non-terminal ("Running") phase. The orphaning
+	// mechanism is identical for any non-terminal persist (e.g. the "waiting for health" state in #23765).
+	completedApp := newFakeApp()
+	completedApp.Spec.Project = "invalid-project"
+	completedApp.Operation = nil
+	now := metav1.Now()
+	completedApp.Status.OperationState = &v1alpha1.OperationState{
+		Operation:  syncOp,
+		Phase:      synccommon.OperationSucceeded,
+		Message:    "successfully synced (all tasks run)",
+		StartedAt:  now,
+		FinishedAt: &now,
+	}
+
+	// Patches apply to the fake clientset tracker (no patch reactor override), so the merge-patch
+	// semantics that produce the orphan are exercised faithfully.
+	ctrl := newFakeController(t.Context(), &fakeData{apps: []runtime.Object{completedApp}}, nil)
+
+	// Writer B's stale view: it still believes the operation is in progress.
+	staleApp := completedApp.DeepCopy()
+	staleApp.Operation = &syncOp
+	staleApp.Status.OperationState = &v1alpha1.OperationState{
+		Operation: syncOp,
+		Phase:     synccommon.OperationRunning,
+		StartedAt: now,
+	}
+
+	ctrl.processRequestedAppOperation(staleApp)
+
+	stored, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(completedApp.Namespace).Get(t.Context(), completedApp.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, stored.Status.OperationState)
+	// Writer A's terminal state must survive; B must not have resurrected a non-terminal phase on top
+	// of the cleared operation.
+	assert.Truef(t, stored.Status.OperationState.Phase.Completed(),
+		"operation state was orphaned: phase=%q operation=%v", stored.Status.OperationState.Phase, stored.Operation)
+	assert.Equal(t, synccommon.OperationSucceeded, stored.Status.OperationState.Phase)
+}
+
+// TestProcessRequestedAppOperation_LostUpdateDoesNotOrphanInProgressSync is the same lost-update race
+// as TestProcessRequestedAppOperation_LostUpdateDoesNotOrphanOperationState, but here writer B's
+// SyncAppState legitimately returns OperationRunning for an *in-progress sync* - which is the actual
+// shape reported in #23765 ("successfully synced ... phase: Running" while waiting), rather than the
+// retry path. An active deny sync window keeps SyncAppState in the Running phase without needing live
+// cluster state, so this exercises the real in-progress persist that the guard must skip once another
+// writer has completed and cleared the operation.
+func TestProcessRequestedAppOperation_LostUpdateDoesNotOrphanInProgressSync(t *testing.T) {
+	blockedProj := defaultProj.DeepCopy()
+	blockedProj.Spec.SyncWindows = v1alpha1.SyncWindows{{
+		Kind:         "deny",
+		Schedule:     "0 0 * * *",
+		Duration:     "24h",
+		Clusters:     []string{"*"},
+		Namespaces:   []string{"*"},
+		Applications: []string{"*"},
+	}}
+
+	syncOp := v1alpha1.Operation{Sync: &v1alpha1.SyncOperation{Source: &v1alpha1.ApplicationSource{}}}
+
+	// The state writer A left behind: the operation completed and spec.operation was cleared.
+	completedApp := newFakeApp()
+	completedApp.Spec.Project = "default"
+	completedApp.Operation = nil
+	now := metav1.Now()
+	completedApp.Status.OperationState = &v1alpha1.OperationState{
+		Operation:  syncOp,
+		Phase:      synccommon.OperationSucceeded,
+		Message:    "successfully synced (all tasks run)",
+		StartedAt:  now,
+		FinishedAt: &now,
+	}
+
+	ctrl := newFakeController(t.Context(), &fakeData{
+		apps: []runtime.Object{completedApp, blockedProj},
+		manifestResponse: &apiclient.ManifestResponse{
+			Manifests: []string{},
+			Namespace: test.FakeDestNamespace,
+			Server:    test.FakeClusterURL,
+			Revision:  "abc123",
+		},
+		managedLiveObjs: map[kube.ResourceKey]*unstructured.Unstructured{},
+	}, nil)
+
+	// Writer B's stale view: it still believes the operation is in progress, and its sync stays
+	// Running because the sync window blocks it.
+	staleApp := completedApp.DeepCopy()
+	staleApp.Operation = &syncOp
+	staleApp.Status.OperationState = &v1alpha1.OperationState{
+		Operation: syncOp,
+		Phase:     synccommon.OperationRunning,
+		StartedAt: now,
+	}
+
+	ctrl.processRequestedAppOperation(staleApp)
+
+	stored, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(completedApp.Namespace).Get(t.Context(), completedApp.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, stored.Status.OperationState)
+	assert.Truef(t, stored.Status.OperationState.Phase.Completed(),
+		"in-progress sync orphaned the operation state: phase=%q operation=%v", stored.Status.OperationState.Phase, stored.Operation)
+	assert.Equal(t, synccommon.OperationSucceeded, stored.Status.OperationState.Phase)
+}
+
 func TestProcessRequestedAppOperation_RunningPreviouslyFailed(t *testing.T) {
 	failedAttemptFinisedAt := time.Now().Add(-time.Minute * 5)
 	app := newFakeApp()


### PR DESCRIPTION
Before proceeding to update app.status.operationstate, do a defensive check to see if this has in fact already happened/cleared. There may be cases where there are two controllers potentially updating the statuses of the same app (e.g during a rolling restart)

Potentially fixes #7890, #18613, #17155.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
