### PR TITLE
docs: proposal for multiple drySources in source hydrator (#26804)

### DIFF
--- a/docs/proposals/multiple-dry-sources-for-hydrator-ui.md
+++ b/docs/proposals/multiple-dry-sources-for-hydrator-ui.md
@@ -91,8 +91,8 @@ All TypeScript interfaces are updated to mirror the Go API changes from the pare
 
 * `DrySource` — add optional `chart`, `ref`, and `name` fields
 * `SourceHydrator` — `drySource` becomes optional, add `drySources?: DrySource[]`
-* `HydrateOperation` / `SuccessfulHydrateOperation` — add `dryRevisions?: string[]` alongside existing `drySHA`. Each entry is the resolved revision for the corresponding dry source (git SHA, chart version, or OCI digest). Follows the `Revision`/`Revisions` pattern from `SyncOperation`.
-* `SourceHydratorStatus` — add `lastComparedDryRevisions?: string[]`.
+* `HydrateOperation` / `SuccessfulHydrateOperation` — `drySHA` replaced by `dryRevision: string` (singular, for `drySource`) and `dryRevisions: string[]` (plural, for `drySources`). Matches the `revision`/`revisions` pattern on `SyncOperation`.
+* `SourceHydratorStatus` — `lastComparedDryRevision` remains, `lastComparedDryRevisions: string[]` added for plural.
 
 #### 2. Utility Function Changes (`utils.tsx`)
 
@@ -103,7 +103,7 @@ All TypeScript interfaces are updated to mirror the Go API changes from the pare
 
 #### 3. Display Component Changes
 
-**`application-hydrate-operation-state.tsx`** — updated to iterate over `dryRevisions` when present, rendering a revision link per source with the source name or repo URL as label. Falls back to the singular `drySHA` for backward compatibility with apps that haven't been re-hydrated.
+**`application-hydrate-operation-state.tsx`** — updated to iterate over `dryRevisions`, rendering a revision link per source with the source name or repo URL as label.
 
 **`application-status-panel.tsx`** — the `hydrationStatusMessage()` utility fix handles this. No direct component changes needed.
 
@@ -141,7 +141,7 @@ No new security concerns. The UI changes are purely presentational and use exist
 
 **Upgrade**: The UI gracefully handles both forms. When the backend returns `drySources`, the UI renders the list. When it returns `drySource`, the UI renders the single-source view. No user action required.
 
-**Downgrade**: If the UI is downgraded before the backend, the old UI ignores unknown fields (`drySources`, `drySHAs`, etc.) and renders using `drySource` / `drySHA` — which the backend continues to populate for backward compatibility.
+**Downgrade**: The hydrator is beta. If the UI is downgraded before the backend, the old UI will not recognize `drySources` or `dryRevisions` and will fail to render hydrator status for multi-source apps. Single-source `drySource` apps are unaffected.
 
 ## Drawbacks
 

--- a/docs/proposals/multiple-dry-sources-for-hydrator-ui.md
+++ b/docs/proposals/multiple-dry-sources-for-hydrator-ui.md
@@ -91,19 +91,19 @@ All TypeScript interfaces are updated to mirror the Go API changes from the pare
 
 * `DrySource` — add optional `chart`, `ref`, and `name` fields
 * `SourceHydrator` — `drySource` becomes optional, add `drySources?: DrySource[]`
-* `HydrateOperation` / `SuccessfulHydrateOperation` — add `drySHAs?: string[]`
-* `SourceHydratorStatus` — add `lastComparedDryRevisions?: string[]`
+* `HydrateOperation` / `SuccessfulHydrateOperation` — add `dryRevisions?: string[]` alongside existing `drySHA`. Each entry is the resolved revision for the corresponding dry source (git SHA, chart version, or OCI digest). Follows the `Revision`/`Revisions` pattern from `SyncOperation`.
+* `SourceHydratorStatus` — add `lastComparedDryRevisions?: string[]`.
 
 #### 2. Utility Function Changes (`utils.tsx`)
 
 * **`getAppDrySource(app)`** — updated to check `drySources` first and return the first entry when set. Falls back to `drySource` (singular). Both paths return all fields including `chart`, `ref`, `name`, and tool-specific configs.
 * **New: `getAppDrySources(app)`** — returns all dry sources as `ApplicationSource[]`, with the same fallback to wrapping the singular `drySource` in a single-element array.
 * **`getHydratorSyncSourceRepoURL(sourceHydrator)`** — updated fallback chain: `syncSource.repoURL` → `drySources[0].repoURL` → `drySource.repoURL`.
-* **`hydrationStatusMessage(app)`** — updated to show multiple dry SHAs when available, displaying source name or index next to each SHA for disambiguation.
+* **`hydrationStatusMessage(app)`** — updated to show per-source revisions from `dryRevisions` when available, displaying source name or repo URL next to each revision. Handles heterogeneous revision types (git SHA, chart version, OCI digest).
 
 #### 3. Display Component Changes
 
-**`application-hydrate-operation-state.tsx`** — updated to iterate over `drySHAs` when present, rendering a revision link per source with the source name or repo URL as label. Falls back to the singular `drySHA` for backward compatibility.
+**`application-hydrate-operation-state.tsx`** — updated to iterate over `dryRevisions` when present, rendering a revision link per source with the source name or repo URL as label. Falls back to the singular `drySHA` for backward compatibility with apps that haven't been re-hydrated.
 
 **`application-status-panel.tsx`** — the `hydrationStatusMessage()` utility fix handles this. No direct component changes needed.
 

--- a/docs/proposals/multiple-dry-sources-for-hydrator-ui.md
+++ b/docs/proposals/multiple-dry-sources-for-hydrator-ui.md
@@ -1,0 +1,156 @@
+---
+title: "UI: Multiple DrySources for SourceHydrator"
+authors:
+  - "@frankkerschbaumer"
+sponsors:
+  - TBD
+reviewers:
+  - "@crenshaw-dev"
+  - TBD
+approvers:
+  - "@crenshaw-dev"
+  - TBD
+
+creation-date: 2026-06-11
+last-updated: 2026-06-11
+---
+
+# UI: Multiple DrySources for SourceHydrator
+
+UI changes to support multiple dry sources and `DrySource` field parity with `ApplicationSource` in the Source Hydrator.
+
+**Parent proposal**: [Multiple DrySources for SourceHydrator](multiple-dry-sources-for-hydrator.md)
+
+## Open Questions
+
+* How should multiple dry source revisions be displayed in the status panel — as a list, a collapsed summary ("3 sources hydrated"), or inline with source names?
+* Should the create panel support adding `drySources` entries from day one, or only support editing existing `drySources` (created via YAML/kubectl)?
+
+## Summary
+
+The parent proposal adds `drySources` (plural), `chart`, `ref`, and `name` fields to the hydrator API. This companion proposal covers the UI changes required to display, create, and edit applications using these new fields. The changes span TypeScript model interfaces, utility functions, display components, and create/edit forms.
+
+## Motivation
+
+Without UI updates, applications using `drySources` will either render incorrectly (showing only the first source or empty fields) or break utility functions that assume a singular `drySource`. Users who configure `drySources` via YAML or kubectl need the UI to accurately reflect their configuration.
+
+### Goals
+
+1. **Update TypeScript models** — add all new fields from the API changes so the UI can consume them.
+
+2. **Fix utility functions** — ensure helper functions handle `drySources` (plural) with correct fallback to `drySource` (singular).
+
+3. **Update display components** — hydration status, revision links, and operation details render correctly for multi-source applications.
+
+4. **Support create/edit for drySources** — the create panel and summary editor support adding, removing, and editing multiple dry source entries.
+
+### Non-Goals
+
+* **Backend API changes** — covered by the parent proposal.
+* **Mobile or responsive layout redesign** — existing layout patterns are reused.
+
+## Proposal
+
+### Affected Files
+
+| Category | File | Change |
+|----------|------|--------|
+| Models | `ui/src/app/shared/models.ts` | Add new fields to interfaces |
+| Utilities | `ui/src/app/applications/components/utils.tsx` | Handle plural dry sources in helpers |
+| Tests | `ui/src/app/applications/components/utils.test.tsx` | Add plural test cases |
+| Create | `ui/src/app/applications/components/application-create-panel/hydrator-source-panel.tsx` | Multi-source form |
+| Create | `ui/src/app/applications/components/application-create-panel/application-create-panel.tsx` | Toggle logic for plural |
+| Edit | `ui/src/app/applications/components/application-summary/application-summary.tsx` | List rendering for plural |
+| Display | `ui/src/app/applications/components/application-hydrate-operation-state/application-hydrate-operation-state.tsx` | Multiple revision links |
+| Display | `ui/src/app/applications/components/application-status-panel/application-status-panel.tsx` | Status message for plural |
+| Display | `ui/src/app/applications/components/application-parameters/application-parameters.tsx` | Dry source details |
+| Display | `ui/src/app/applications/components/application-details/application-details.tsx` | Hydrate operation state extraction |
+| No change | `ui/src/app/applications/components/applications-list/application-table-row.tsx` | Phase icon only — no change |
+| No change | `ui/src/app/applications/components/applications-list/application-tile.tsx` | Phase icon only — no change |
+| No change | `ui/src/app/applications/components/applications-list/applications-summary.tsx` | Phase stats — no change |
+
+### Use Cases
+
+#### Use case 1: Viewing a multi-source hydrated application
+
+As a user, I want to see all dry sources listed in the application details and status panels, with individual revision links for each source, so I can understand which sources contributed to the hydrated output.
+
+#### Use case 2: Creating an application with multiple dry sources
+
+As a user, I want to add multiple dry source entries in the application create panel — including OCI charts and ref-only entries for shared values.
+
+#### Use case 3: Editing dry sources on an existing application
+
+As a user, I want to add, remove, or reorder dry source entries in the application summary editor, with the same validation the backend enforces (mutual exclusion, ref uniqueness, repoURL required).
+
+### Implementation Details
+
+#### 1. Model Changes (`models.ts`)
+
+All TypeScript interfaces are updated to mirror the Go API changes from the parent proposal:
+
+* `DrySource` — add optional `chart`, `ref`, and `name` fields
+* `SourceHydrator` — `drySource` becomes optional, add `drySources?: DrySource[]`
+* `HydrateOperation` / `SuccessfulHydrateOperation` — add `drySHAs?: string[]`
+* `SourceHydratorStatus` — add `lastComparedDryRevisions?: string[]`
+
+#### 2. Utility Function Changes (`utils.tsx`)
+
+* **`getAppDrySource(app)`** — updated to check `drySources` first and return the first entry when set. Falls back to `drySource` (singular). Both paths return all fields including `chart`, `ref`, `name`, and tool-specific configs.
+* **New: `getAppDrySources(app)`** — returns all dry sources as `ApplicationSource[]`, with the same fallback to wrapping the singular `drySource` in a single-element array.
+* **`getHydratorSyncSourceRepoURL(sourceHydrator)`** — updated fallback chain: `syncSource.repoURL` → `drySources[0].repoURL` → `drySource.repoURL`.
+* **`hydrationStatusMessage(app)`** — updated to show multiple dry SHAs when available, displaying source name or index next to each SHA for disambiguation.
+
+#### 3. Display Component Changes
+
+**`application-hydrate-operation-state.tsx`** — updated to iterate over `drySHAs` when present, rendering a revision link per source with the source name or repo URL as label. Falls back to the singular `drySHA` for backward compatibility.
+
+**`application-status-panel.tsx`** — the `hydrationStatusMessage()` utility fix handles this. No direct component changes needed.
+
+#### 4. Create/Edit Panel Changes
+
+**`hydrator-source-panel.tsx`** — the most significant UI change. Currently renders three static sections (Dry Source, Sync Source, Hydrate To) with hardcoded field paths. Updated to:
+
+* Detect whether `drySources` or `drySource` is in use
+* Render a dynamic list of dry source entries with add/remove buttons
+* Each entry renders the same field set (repoURL, targetRevision, path, chart, ref, name) plus tool-specific config (helm, kustomize, directory, plugin)
+* Follow the same list pattern used by `sources` in the regular create panel
+
+The Sync Source and Hydrate To sections remain unchanged — they are singular regardless of how many dry sources exist.
+
+**`application-create-panel.tsx`** — toggle logic updated:
+
+* On enable: if `spec.sources` exists, convert to `spec.sourceHydrator.drySources`; if `spec.source` exists, convert to `spec.sourceHydrator.drySource`
+* On disable: reverse conversion, preserving the singular/plural form
+
+**`application-summary.tsx`** — edit view updated to render dry sources as a list with inline editing, matching the pattern used for `sources` editing in the non-hydrator path.
+
+### Security Considerations
+
+No new security concerns. The UI changes are purely presentational and use existing Argo CD RBAC for any write operations. All validation occurs server-side.
+
+### Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Complex multi-source form is confusing for users | Reuse the existing `sources` create panel UX patterns. Show `drySource` (singular) by default, with an explicit toggle or "Add source" button to switch to `drySources`. |
+| Rendering many dry sources clutters the status panel | Show a collapsed summary ("3 dry sources hydrated") with expand-on-click for individual revision details. |
+| Backward compatibility with apps created before the API change | Utility functions fall back to `drySource` (singular) when `drySources` is absent. The UI never assumes plural. |
+
+### Upgrade / Downgrade Strategy
+
+**Upgrade**: The UI gracefully handles both forms. When the backend returns `drySources`, the UI renders the list. When it returns `drySource`, the UI renders the single-source view. No user action required.
+
+**Downgrade**: If the UI is downgraded before the backend, the old UI ignores unknown fields (`drySources`, `drySHAs`, etc.) and renders using `drySource` / `drySHA` — which the backend continues to populate for backward compatibility.
+
+## Drawbacks
+
+* **Increased form complexity** — the create/edit panel for hydrator becomes significantly more complex with dynamic source list management. This is mitigated by reusing established patterns from the `sources` create panel.
+
+* **Testing surface** — files across models, utilities, display, and form components need changes. Automated tests for utility functions and snapshot tests for display components help manage regression risk.
+
+## Alternatives
+
+1. **YAML-only for drySources** — support `drySources` only via YAML/kubectl, with no create/edit form. The UI would display but not edit multiple dry sources. Simpler to implement but creates a second-class experience for multi-source hydrator users.
+
+2. **Embed in existing sources UI** — reuse the existing multi-source form components instead of building hydrator-specific ones. Rejected because the hydrator source panel has different fields (syncSource, hydrateTo) that don't map to the regular source panel structure.

--- a/docs/proposals/multiple-dry-sources-for-hydrator.md
+++ b/docs/proposals/multiple-dry-sources-for-hydrator.md
@@ -1,0 +1,260 @@
+---
+title: Multiple DrySources for SourceHydrator
+authors:
+  - "@frankkerschbaumer"
+sponsors:
+  - TBD
+reviewers:
+  - "@crenshaw-dev"
+  - TBD
+approvers:
+  - "@crenshaw-dev"
+  - TBD
+
+creation-date: 2026-06-04
+last-updated: 2026-06-11
+---
+
+# Multiple DrySources for SourceHydrator
+
+Support more than one dry source for an Application using the Source Hydrator.
+
+Related Issues:
+
+* [Multiple DrySources for an Application (#26804)](https://github.com/argoproj/argo-cd/issues/26804)
+* [Multiple Sources for Application (#677)](https://github.com/argoproj/argo-cd/issues/677) — the original `sources` proposal that this mirrors
+* [Future-Proofing the Source Hydrator API](https://hackmd.io/@crenshaw-dev/SygQ3BNx1x) — @crenshaw-dev's API shape comparison, recommending Proposal 1 (`sourceHydrator.drySources`), which this proposal implements
+
+## Open Questions
+
+* How should the commit message template handle multiple dry source repos? This proposal uses the first dry source's commit metadata, but a more descriptive format may be preferred.
+* The manifest hydrator proposal is explicitly opinionated against nondeterministic configuration injection. Multiple dry sources from different repos mean the combination of source versions is held externally to any single git repo. Is this an acceptable trade-off given that the same pattern already exists with `sources` in the non-hydrator path?
+
+## Summary
+
+This proposal has two parts:
+
+1. **Bring `DrySource` to parity with `ApplicationSource`** — add the missing `Chart`, `Ref`, and `Name` fields to the `DrySource` struct, enabling OCI/Helm chart hydration and cross-source value file references. This benefits both singular `drySource` and plural `drySources` users since both use the same struct.
+
+2. **Add `drySources` (plural) to `SourceHydrator`** — following the same `source`/`sources` pattern already established on `ApplicationSpec`. When `drySources` is specified, Argo CD ignores `drySource` (singular), fetches and renders manifests from all dry sources, merges them into a single manifest set, and commits the combined result to the sync target.
+
+## Motivation
+
+Organizations frequently compose applications from multiple repositories — a Helm chart in one repo, shared configuration values in another, and platform-level base manifests in a third. Today, the only way to combine these with the hydrator is to pre-merge them externally (e.g. in CI) before pointing `drySource` at the result. This forces prospective users away from using the source hydrator back to the CI-based hydration pattern that the hydrator was designed to replace.
+
+The `sources` (plural) field on `ApplicationSpec` already solves this problem for direct sync. This proposal brings the same capability to the hydrator pipeline, allowing users to declare multiple dry sources and have Argo CD handle the rendering and merging.
+
+### Goals
+
+1. **Bring `DrySource` to field parity with `ApplicationSource`** — add `Chart`, `Ref`, and `Name` to the `DrySource` struct. This enables OCI/Helm chart hydration and cross-source value file references for both `drySource` (singular) and `drySources` (plural) users.
+
+2. **Support multiple dry sources per Application** — users can specify a `drySources` array on `SourceHydrator`. Argo CD compiles manifests from all dry sources and commits the combined output.
+
+3. **Follow the established `source`/`sources` pattern** — the API design, precedence logic, helper methods, and validation mirror the existing `ApplicationSpec.Source`/`Sources` pattern to minimize surprise for users and maintainers.
+
+4. **Maintain full backward compatibility** — existing applications using `drySource` (singular) continue to work with zero changes.
+
+### Non-Goals
+
+* **Partial hydration** — when any dry source changes, all sources are re-rendered and committed together. Incremental/partial hydration of individual sources is not a goal.
+* **Independent sync per dry source** — all dry sources produce a single merged manifest set committed to one sync path. Splitting dry sources into separate sync paths would lead to more sprawl in sync logic.
+* **UI changes** — all UI updates (models, utility functions, display components, create/edit panels) are out of scope and will be covered in a separate proposal.
+
+## Proposal
+
+### Use Cases
+
+#### Use case 1: Application composed from multiple repos
+
+As a user, I want to compose an application from manifests spread across multiple repositories — app manifests, shared configmaps, and platform base layers — and have the hydrator merge them.
+
+```yaml
+spec:
+  sourceHydrator:
+    drySources:
+      - repoURL: https://github.com/mycompany/billing-app.git
+        path: manifests
+        targetRevision: v2.1.0
+      - repoURL: https://github.com/mycompany/common-settings.git
+        path: configmaps-billing
+        targetRevision: HEAD
+      - repoURL: https://github.com/mycompany/platform-base.git
+        path: overlays/prod
+        targetRevision: main
+        kustomize:
+          namePrefix: billing-
+    syncSource:
+      repoURL: https://github.com/mycompany/billing-app.git
+      targetBranch: environments/prod
+      path: billing-hydrated
+```
+
+#### Use case 2: Helm chart with values from another repo using `$ref`
+
+As a user, I want to deploy a Helm chart from one repository using values files stored in a separate configuration repository, referencing them via `$ref`, and have the hydrator render and commit the combined result.
+
+```yaml
+spec:
+  sourceHydrator:
+    drySources:
+      - repoURL: https://github.com/mycompany/billing-app.git
+        path: charts/billing
+        targetRevision: v2.1.0
+        helm:
+          releaseName: billing
+          valueFiles:
+            - values-prod.yaml
+            - $common/values-shared.yaml
+      - repoURL: https://github.com/mycompany/common-settings.git
+        ref: common
+        path: helm-values
+        targetRevision: HEAD
+    syncSource:
+      repoURL: https://github.com/mycompany/billing-app.git
+      targetBranch: environments/prod-next
+      path: billing-hydrated
+```
+
+#### Use case 3: OCI Helm chart with external values (push-to-stage)
+
+As a user, I want to hydrate an OCI-hosted Helm chart using values files from a separate git repo, push to a staging branch for review, and sync from the production branch after approval.
+
+```yaml
+spec:
+  sourceHydrator:
+    drySources:
+      - repoURL: https://github.com/mycompany/infra.git
+        targetRevision: main
+        ref: app-values
+      - repoURL: us-docker.pkg.dev/mycompany/helm-charts
+        targetRevision: 0.2.2
+        chart: my-app
+        helm:
+          valueFiles:
+            - $app-values/environments/prod/values.yaml
+    syncSource:
+      repoURL: https://github.com/mycompany/infra.git
+      targetBranch: environments/prod
+      path: my-app-hydrated
+    hydrateTo:
+      targetBranch: environments/prod-next
+```
+
+### Implementation Details
+
+#### API Changes
+
+**`SourceHydrator` struct** — add a `DrySources []DrySource` field (protobuf field 4). `DrySource` changes from a value type to a pointer (`*DrySource`) to support `omitempty` correctly, matching the `Source *ApplicationSource` pattern on `ApplicationSpec`. When `drySources` is set, `drySource` is ignored for hydration purposes (same precedence as `sources` over `source`). Users set one or the other, never both — mutual exclusion is enforced by validation.
+
+**`DrySource` struct** — add three new fields to reach parity with `ApplicationSource`:
+
+* `Chart` — a Helm chart name, enabling Helm repo and OCI registry sources
+* `Ref` — a reference key enabling cross-source Helm value file references (e.g. `$ref-name/path/to/values.yaml`)
+* `Name` — display name for the UI
+
+**Status types** — `HydrateOperation` and `SuccessfulHydrateOperation` gain a `DrySHAs []string` field alongside the existing singular `DrySHA`. `SourceHydratorStatus` gains `LastComparedDryRevisions []string` alongside the existing `LastComparedDryRevision`. Singular fields continue to be populated (first entry or composite hash) for backward compatibility.
+
+**`SyncSource.RepoURL`** already exists as an optional field. No changes needed.
+
+#### Helper Methods
+
+New methods on `SourceHydrator`, following the `ApplicationSpec.GetSources()`/`HasMultipleSources()` pattern:
+
+* `HasMultipleDrySources()` — returns `len(s.DrySources) > 0`
+* `GetDrySources()` — returns all dry sources as `ApplicationSources`. When plural is set, converts each via `ToApplicationSource()`. Otherwise wraps the singular `drySource` in a single-element slice.
+
+New method on `DrySource`:
+
+* `ToApplicationSource()` — converts a `DrySource` to an `ApplicationSource`, mapping all fields including the new `Chart`, `Ref`, and `Name`. Existing `GetDrySource()` refactored to call this.
+
+`GetSyncSource()` and `GetHydrateToSource()` updated: when `HasMultipleDrySources()` and `SyncSource.RepoURL` is empty, fall back to `DrySources[0].RepoURL`.
+
+`DeepEquals()` updated to compare both `DrySource` (nil-safe pointer comparison) and `DrySources` (element-wise via `DrySource.Equals()`).
+
+#### Validation
+
+* **At least one source required**: either `drySource` must be non-nil with a non-empty `repoURL`, or `drySources` must have at least one entry. The existing `validateSourceHydrator()` check (`DrySource.RepoURL == ""` → error) must change to `DrySource == nil && len(DrySources) == 0` → error.
+* **Mutual exclusion**: setting both `drySource` (non-nil) and `drySources` (non-empty) is a validation error.
+* **Per-entry validation**: each entry in `drySources` must have a non-empty `repoURL`.
+* **Ref uniqueness**: `ref` keys must be unique across all dry sources and match `^[a-zA-Z0-9_-]+$` (same validation as `ApplicationSource.Ref`).
+* **Project permissions**: each dry source's RepoURL must be permitted by the Application's project. `ValidatePermissions()` must iterate over `GetDrySources()` rather than calling `GetDrySource()` once.
+
+#### Hydration Flow with Multiple Dry Sources
+
+When any dry source has a new revision, the full set is re-hydrated:
+
+1. `appNeedsHydration()` calls `newRevisionHasChanges()` which evaluates each dry source via `EvaluateAppRevisionsChanges()`. If any source has changes, hydration is triggered.
+
+2. `getManifests()` fetches and renders manifests from all dry sources. Each dry source is rendered independently via a separate `GenerateManifest()` call (one per source). Dry sources with a `ref` field are resolved into a `RefTargetRevisionMapping` and passed to the rendering call, enabling Helm value file references like `$ref-name/path/to/values.yaml`. All manifest objects are appended into a single `PathDetails` in source order (same append semantics as `sources` in the sync path). If two dry sources produce resources with the same GVK+namespace+name, both are included — conflict detection is handled at sync time, not hydration time.
+
+3. `hydrate()` resolves static SHAs for all dry sources from the first app, then renders remaining apps pinned to those same SHAs. Individual SHAs are stored in `DrySHAs` as an ordered vector (one per `drySources` entry, by array index). De-duplication compares this vector element-by-element against `LastSuccessfulOperation.DrySHAs`. A composite SHA (deterministic SHA-256 hash of all individual SHAs in order) is computed for the commit note and `hydrator.metadata` file.
+
+4. All paths are committed in a single commit to the sync target branch.
+
+#### Hydration Queue Key
+
+The current queue key groups apps by `{SourceRepoURL, SourceTargetRevision, DestinationRepoURL, DestinationBranch}`. With multiple dry sources, `SourceRepoURL` and `SourceTargetRevision` are replaced by a `SourcesFingerprint` — a deterministic hash of all normalized dry source URLs and target revisions. The key retains `DestinationRepoURL` and `DestinationBranch`.
+
+#### Changes to Controller Dependencies
+
+The `Dependencies` interface methods `GetRepoObjs` and `EvaluateAppRevisionsChanges` are updated to accept slices (`sources []ApplicationSource`, `revisions []string`) instead of single values. `GetRepoObjs` already wraps the single dry source into a slice internally — this change makes the slice the public API and removes the `len(resp) != 1` assertion. `EvaluateAppRevisionsChanges` return type changes from `(bool, string, error)` to `(bool, []string, error)` to return all resolved revisions.
+
+This cascades through `newRevisionHasChanges()` (now evaluates all dry sources), `appNeedsHydration()` (receives `[]string` resolved revisions), and `ProcessAppHydrateQueueItem()` (persists `LastComparedDryRevisions` alongside `LastComparedDryRevision`).
+
+#### Commit Server Changes
+
+`CommitHydratedManifestsRequest` in `commit.proto` gains `repeated string dryShas` and `repeated string repoURLs` fields alongside the existing singular `drySha`. The `HydratorCommitMetadata` struct in `util/hydrator/hydrator.go` is extended with `DrySHAs` and `RepoURLs` fields. `GetCommitMetadata()` is updated to accept slices and populate both singular (first entry) and plural fields.
+
+The `hydrator.metadata` file and git commit note (`refs/notes/hydrator.metadata`) are extended with `dryShas` and `repoURLs` arrays. The existing singular `drySha` and `repoURL` fields are preserved with the composite hash and first source's URL respectively, ensuring backward compatibility with external consumers.
+
+#### GitOps Promoter Compatibility
+
+The [GitOps Promoter](https://github.com/argoproj-labs/gitops-promoter) reads the `hydrator.metadata` file and git notes to track promotion lineage. It uses `HydratorMetadata.DrySha` to determine which dry commit produced a given hydrated branch.
+
+With multiple dry sources, the composite `DrySha` remains a unique identifier of the complete dry state — if any source changes, the composite changes. The promoter can continue using `DrySha` for lineage tracking without modification. The `DryShas` array provides optional granularity for display (e.g. showing which individual sources were promoted).
+
+The `HydratorMetadata` struct in the promoter (`api/v1alpha1/changetransferpolicy_types.go`) would need a `DryShas []string` field added to consume the new array, but this is additive and does not break existing behavior.
+
+### Security Considerations
+
+* Each dry source repository must be permitted by the Application's `AppProject`. The validation logic is extended to check all dry sources, not just the first.
+* Write credentials for the sync target are resolved the same way as today — only the destination repo requires write access.
+* No new authentication mechanisms are introduced. Each dry source repo uses existing Argo CD repository credentials.
+
+### Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Increased hydration latency with many dry sources | Manifest generation for different dry sources can be parallelized (the existing `errgroup` pattern in `hydrate()` already does this for multiple apps). |
+| Queue key change causes brief re-hydration during rolling upgrade | The queue key is internal and self-healing — the next `ProcessAppHydrateQueueItem` call re-enqueues with the new key format. Hydration is idempotent. |
+| Composite DrySHA in commit notes is less human-readable | Individual per-source SHAs are preserved in `DrySHAs` status fields for auditability. The composite SHA is only used for the commit note dedup mechanism. |
+| `DrySHA` → `DrySHAs` upgrade path during rolling update | De-duplication logic falls back to comparing singular `DrySHA` against `DrySHAs[0]` when `DrySHAs` is empty, ensuring the transition is seamless. |
+
+### Upgrade / Downgrade Strategy
+
+**Upgrade:**
+
+* Existing applications using `drySource` (singular) continue to work unchanged. All new fields are `omitempty`.
+* The `GetDrySources()` helper transparently wraps a singular `drySource` into a single-element slice, so all internal code paths work with both forms.
+* `DrySHA` (singular) continues to be populated alongside `DrySHAs` (plural) for backward compatibility with any external tooling reading Application status.
+* The `HydrationQueueKey` format change is internal. On upgrade, in-flight queue items using the old key format are simply not matched — the next reconciliation loop re-enqueues with the new format. No data loss occurs because hydration is idempotent.
+
+**Downgrade:**
+
+* If a user downgrades after creating applications with `drySources`, the older Argo CD version will ignore the unknown `drySources` field (standard Kubernetes behavior for unknown fields in CRDs).
+* The `drySource` (singular) field will be empty for these apps, so the older version will fail validation with "drySource.repoURL is required". Users must convert their apps back to `drySource` before downgrading.
+* Status fields `DrySHAs` and `LastComparedDryRevisions` are ignored by older versions — the singular `DrySHA` and `LastComparedDryRevision` fields remain populated and functional.
+
+## Drawbacks
+
+* **Increased complexity in the hydrator pipeline** — every code path that touches `DrySource` must now handle the plural form. This is mitigated by the `GetDrySources()` helper which abstracts the singular/plural distinction, matching the proven `GetSources()` pattern.
+
+* **All-or-nothing re-hydration** — when any single dry source changes, all sources are re-rendered. For applications with many large dry sources, this may be slower than necessary. However, this matches how `sources` works for sync and keeps the implementation simple. Partial hydration could be explored as a future optimization.
+
+## Alternatives
+
+1. **Use ApplicationSets to compose from multiple repos** — users can create separate Applications per repo and use an ApplicationSet to coordinate them. This works but loses the single-Application view and requires more complex orchestration for deployment ordering.
+
+2. **Pre-merge in CI** — users can use CI pipelines to merge manifests from multiple repos into a single repo, then point `drySource` at the merged result. This is the status quo workaround and defeats the purpose of the hydrator.
+
+3. **Extend `sources` to work with the hydrator** — instead of adding `drySources` to `SourceHydrator`, extend the top-level `sources` field to work with hydration. This was rejected because it conflates two different concepts (sync sources vs. dry sources) and would require significant changes to how `sources` interacts with the sync pipeline.

--- a/docs/proposals/multiple-dry-sources-for-hydrator.md
+++ b/docs/proposals/multiple-dry-sources-for-hydrator.md
@@ -46,7 +46,7 @@ The `sources` (plural) field on `ApplicationSpec` already solves this problem fo
 
 ### Goals
 
-1. **Bring `DrySource` to field parity with `ApplicationSource`** — add `Chart`, `Ref`, and `Name` to the `DrySource` struct. This enables OCI/Helm chart hydration and cross-source value file references for both `drySource` (singular) and `drySources` (plural) users.
+1. **Bring `DrySource` to full field parity with `ApplicationSource`** — add `Chart`, `Ref`, and `Name` to the `DrySource` struct. This explicitly includes OCI/Helm chart repo support (via `Chart`) and cross-source value file references (via `Ref`). These fields benefit both `drySource` (singular) and `drySources` (plural) users since both share the same struct.
 
 2. **Support multiple dry sources per Application** — users can specify a `drySources` array on `SourceHydrator`. Argo CD compiles manifests from all dry sources and commits the combined output.
 
@@ -57,7 +57,7 @@ The `sources` (plural) field on `ApplicationSpec` already solves this problem fo
 ### Non-Goals
 
 * **Partial hydration** — when any dry source changes, all sources are re-rendered and committed together. Incremental/partial hydration of individual sources is not a goal.
-* **Independent sync per dry source** — all dry sources produce a single merged manifest set committed to one sync path. Splitting dry sources into separate sync paths would lead to more sprawl in sync logic.
+* **Per-source sync paths** — all dry sources are merged into a single manifest set committed to one `syncSource` path. Routing individual dry sources to different sync paths or branches is not supported.
 * **UI changes** — all UI updates (models, utility functions, display components, create/edit panels) are out of scope and will be covered in a separate proposal.
 
 ## Proposal

--- a/docs/proposals/multiple-dry-sources-for-hydrator.md
+++ b/docs/proposals/multiple-dry-sources-for-hydrator.md
@@ -59,6 +59,7 @@ The `sources` (plural) field on `ApplicationSpec` already solves this problem fo
 * **Partial hydration** — when any dry source changes, all sources are re-rendered and committed together. Incremental/partial hydration of individual sources is not a goal.
 * **Per-source sync paths** — all dry sources are merged into a single manifest set committed to one `syncSource` path. Routing individual dry sources to different sync paths or branches is not supported.
 * **Backward compatibility for hydrator status fields and metadata schema** — the hydrator is beta. `DrySHA` is replaced by `DryRevision`/`DryRevisions` (matching the `Revision`/`Revisions` convention on `SyncOperation`). The `hydrator.metadata` file schema changes from a flat object to a list. These are breaking changes.
+* **References contract for non-git sources** — today, `references` in the hydrator metadata is populated from git trailers on the dry commit. Extending this to OCI metadata or Helm chart metadata is deferred to a follow-up proposal.
 * **UI changes** — all UI updates (models, utility functions, display components, create/edit panels) are out of scope and will be covered in a separate proposal.
 
 > **Note**: Helm/OCI chart support and cross-source `$ref` value file references are explicitly **in scope** as part of the `DrySource` parity goal (Goal 1). The intent is for `drySources` to be functionally identical to `sources` — anything you can do with an `ApplicationSource` entry in `sources`, you can do with a `DrySource` entry in `drySources`.

--- a/docs/proposals/multiple-dry-sources-for-hydrator.md
+++ b/docs/proposals/multiple-dry-sources-for-hydrator.md
@@ -151,7 +151,12 @@ spec:
 * `Ref` — a reference key enabling cross-source Helm value file references (e.g. `$ref-name/path/to/values.yaml`)
 * `Name` — display name for the UI
 
-**Status types** — `HydrateOperation` and `SuccessfulHydrateOperation` gain a `DrySHAs []string` field alongside the existing singular `DrySHA`. `SourceHydratorStatus` gains `LastComparedDryRevisions []string` alongside the existing `LastComparedDryRevision`. Singular fields continue to be populated (first entry or composite hash) for backward compatibility.
+**Status types** — following the existing `Revision`/`Revisions` pattern on `SyncOperation`, the hydration status types gain parallel plural fields:
+
+* `HydrateOperation` and `SuccessfulHydrateOperation` gain `DryRevisions []string` alongside the existing `DrySHA`. Each entry is the resolved revision for the corresponding dry source — a git SHA, Helm chart version, or OCI digest depending on source type. The existing `DrySHA` field carries the first source's resolved revision for backward compatibility (matching how `SyncOperation.Revision` holds the first source's revision).
+* `SourceHydratorStatus` gains `LastComparedDryRevisions []string` alongside the existing `LastComparedDryRevision`.
+
+Per-source detail beyond the revision string (author, commands, etc.) is handled by the list-based `hydrator.metadata` file (see Commit Server Changes below).
 
 **`SyncSource.RepoURL`** already exists as an optional field. No changes needed.
 
@@ -186,7 +191,7 @@ When any dry source has a new revision, the full set is re-hydrated:
 
 2. `getManifests()` fetches and renders manifests from all dry sources. Each dry source is rendered independently via a separate `GenerateManifest()` call (one per source). Dry sources with a `ref` field are resolved into a `RefTargetRevisionMapping` and passed to the rendering call, enabling Helm value file references like `$ref-name/path/to/values.yaml`. All manifest objects are appended into a single `PathDetails` in source order (same append semantics as `sources` in the sync path). If two dry sources produce resources with the same GVK+namespace+name, both are included — conflict detection is handled at sync time, not hydration time.
 
-3. `hydrate()` resolves static SHAs for all dry sources from the first app, then renders remaining apps pinned to those same SHAs. Individual SHAs are stored in `DrySHAs` as an ordered vector (one per `drySources` entry, by array index). De-duplication compares this vector element-by-element against `LastSuccessfulOperation.DrySHAs`. A composite SHA (deterministic SHA-256 hash of all individual SHAs in order) is computed for the commit note and `hydrator.metadata` file.
+3. `hydrate()` resolves static revisions for all dry sources from the first app, then renders remaining apps pinned to those same revisions. The resolved revisions are stored in `DryRevisions` (one per source, by array index). De-duplication compares this vector element-by-element against `LastSuccessfulOperation.DryRevisions`. `DrySHA` is set to the first source's revision for backward compatibility. Each source's full metadata (author, commands, etc.) is written to the `hydrator.metadata` file (see Commit Server Changes).
 
 4. All paths are committed in a single commit to the sync target branch.
 
@@ -198,21 +203,51 @@ The current queue key groups apps by `{SourceRepoURL, SourceTargetRevision, Dest
 
 The `Dependencies` interface methods `GetRepoObjs` and `EvaluateAppRevisionsChanges` are updated to accept slices (`sources []ApplicationSource`, `revisions []string`) instead of single values. `GetRepoObjs` already wraps the single dry source into a slice internally — this change makes the slice the public API and removes the `len(resp) != 1` assertion. `EvaluateAppRevisionsChanges` return type changes from `(bool, string, error)` to `(bool, []string, error)` to return all resolved revisions.
 
-This cascades through `newRevisionHasChanges()` (now evaluates all dry sources), `appNeedsHydration()` (receives `[]string` resolved revisions), and `ProcessAppHydrateQueueItem()` (persists `LastComparedDryRevisions` alongside `LastComparedDryRevision`).
+This cascades through `newRevisionHasChanges()` (now evaluates all dry sources), `appNeedsHydration()` (receives `[]string` resolved revisions), and `ProcessAppHydrateQueueItem()` (persists all resolved revisions in `LastComparedDryRevisions` and the first in `LastComparedDryRevision` for backward compat).
 
 #### Commit Server Changes
 
-`CommitHydratedManifestsRequest` in `commit.proto` gains `repeated string dryShas` and `repeated string repoURLs` fields alongside the existing singular `drySha`. The `HydratorCommitMetadata` struct in `util/hydrator/hydrator.go` is extended with `DrySHAs` and `RepoURLs` fields. `GetCommitMetadata()` is updated to accept slices and populate both singular (first entry) and plural fields.
+The current `hydrator.metadata` file is a flat object with fields (`repoURL`, `drySha`, `author`, `subject`, `date`, `commands`) that all relate to a single git source. This schema doesn't extend cleanly to multiple sources because:
 
-The `hydrator.metadata` file and git commit note (`refs/notes/hydrator.metadata`) are extended with `dryShas` and `repoURLs` arrays. The existing singular `drySha` and `repoURL` fields are preserved with the composite hash and first source's URL respectively, ensuring backward compatibility with external consumers.
+* Not every source type has a "SHA" — git sources resolve to commit SHAs, Helm chart repos have versions, OCI registries have digests.
+* The commit metadata fields (`author`, `subject`, `date`) are specific to a single git commit and have no meaning for non-git sources.
+
+To address this, the `hydrator.metadata` schema is replaced with a **list of per-source objects**. Each object carries only the fields relevant to its source type:
+
+```json
+{
+  "sources": [
+    {
+      "repoURL": "us-docker.pkg.dev/mycompany/helm-charts",
+      "chart": "my-app",
+      "revision": "0.2.2",
+      "commands": ["helm template ..."]
+    },
+    {
+      "repoURL": "https://github.com/mycompany/infra.git",
+      "revision": "bb2222",
+      "author": "Jane Doe",
+      "date": "2026-06-11T10:00:00Z",
+      "subject": "Update prod values",
+      "commands": []
+    }
+  ]
+}
+```
+
+The git commit note (`refs/notes/hydrator.metadata`) uses the same list schema. For single-source apps, the list has one entry — functionally identical to the current flat object, just wrapped in `{"sources": [...]}`.
+
+`CommitHydratedManifestsRequest` in `commit.proto` is updated to carry per-source metadata as a repeated message field (field number 11+, since the highest existing field is 10). The `HydratorCommitMetadata` struct in `util/hydrator/hydrator.go` is refactored to represent a list of source metadata entries, with `GetCommitMetadata()` accepting a slice of sources and returning a slice of per-source metadata. The `WriteForPaths()` function in `hydratorhelper.go` is updated to accept the sources list instead of scalar `repoUrl` and `drySha` parameters.
+
+The README template (configurable via `argocd-cm`) currently references `.RepoURL`, `.DrySHA`, and `.Commands` directly from a flat metadata object. With the list-based schema, the template is updated to iterate over `.Sources` or use the first source's fields. The default template is updated accordingly.
 
 #### GitOps Promoter Compatibility
 
-The [GitOps Promoter](https://github.com/argoproj-labs/gitops-promoter) reads the `hydrator.metadata` file and git notes to track promotion lineage. It uses `HydratorMetadata.DrySha` to determine which dry commit produced a given hydrated branch.
+The [GitOps Promoter](https://github.com/argoproj-labs/gitops-promoter) reads the `hydrator.metadata` file and git notes to track promotion lineage. It currently expects a flat object with a top-level `drySha` field.
 
-With multiple dry sources, the composite `DrySha` remains a unique identifier of the complete dry state — if any source changes, the composite changes. The promoter can continue using `DrySha` for lineage tracking without modification. The `DryShas` array provides optional granularity for display (e.g. showing which individual sources were promoted).
+With the list-based schema, the promoter's `HydratorMetadata` struct needs to be updated to read `sources[]` and extract per-source revisions. For lineage tracking, the promoter can compute a composite revision (hash of all per-source revisions) or track individual source revisions — depending on what granularity is needed for promotion rules.
 
-The `HydratorMetadata` struct in the promoter (`api/v1alpha1/changetransferpolicy_types.go`) would need a `DryShas []string` field added to consume the new array, but this is additive and does not break existing behavior.
+This is a breaking change for the promoter's metadata parsing, but the promoter is maintained by the same team (@crenshaw-dev, @zachaller) and can be updated in coordination with them.
 
 ### Security Considerations
 
@@ -226,8 +261,7 @@ The `HydratorMetadata` struct in the promoter (`api/v1alpha1/changetransferpolic
 |------|------------|
 | Increased hydration latency with many dry sources | Manifest generation for different dry sources can be parallelized (the existing `errgroup` pattern in `hydrate()` already does this for multiple apps). |
 | Queue key change causes brief re-hydration during rolling upgrade | The queue key is internal and self-healing — the next `ProcessAppHydrateQueueItem` call re-enqueues with the new key format. Hydration is idempotent. |
-| Composite DrySHA in commit notes is less human-readable | Individual per-source SHAs are preserved in `DrySHAs` status fields for auditability. The composite SHA is only used for the commit note dedup mechanism. |
-| `DrySHA` → `DrySHAs` upgrade path during rolling update | De-duplication logic falls back to comparing singular `DrySHA` against `DrySHAs[0]` when `DrySHAs` is empty, ensuring the transition is seamless. |
+| `hydrator.metadata` schema change breaks existing consumers | The hydrator is still beta. The GitOps Promoter is maintained by the same team and can be updated in coordination. Single-source apps produce a one-element list, making migration straightforward. |
 
 ### Upgrade / Downgrade Strategy
 
@@ -235,14 +269,16 @@ The `HydratorMetadata` struct in the promoter (`api/v1alpha1/changetransferpolic
 
 * Existing applications using `drySource` (singular) continue to work unchanged. All new fields are `omitempty`.
 * The `GetDrySources()` helper transparently wraps a singular `drySource` into a single-element slice, so all internal code paths work with both forms.
-* `DrySHA` (singular) continues to be populated alongside `DrySHAs` (plural) for backward compatibility with any external tooling reading Application status.
+* `DrySHA` carries the first source's resolved revision. `DryRevisions` carries all per-source revisions. For single-source apps, both contain the same value as before.
+* The `hydrator.metadata` file changes from a flat object to `{"sources": [...]}`. Single-source apps produce a one-element list. External consumers (GitOps Promoter) need to be updated to read the new schema.
 * The `HydrationQueueKey` format change is internal. On upgrade, in-flight queue items using the old key format are simply not matched — the next reconciliation loop re-enqueues with the new format. No data loss occurs because hydration is idempotent.
 
 **Downgrade:**
 
 * If a user downgrades after creating applications with `drySources`, the older Argo CD version will ignore the unknown `drySources` field (standard Kubernetes behavior for unknown fields in CRDs).
 * The `drySource` (singular) field will be empty for these apps, so the older version will fail validation with "drySource.repoURL is required". Users must convert their apps back to `drySource` before downgrading.
-* Status fields `DrySHAs` and `LastComparedDryRevisions` are ignored by older versions — the singular `DrySHA` and `LastComparedDryRevision` fields remain populated and functional.
+* Status fields `DryRevisions` and `LastComparedDryRevisions` are ignored by older versions — the singular `DrySHA` and `LastComparedDryRevision` fields remain populated and functional.
+* The `hydrator.metadata` schema change is not backward compatible — older versions expect a flat object. The GitOps Promoter must be updated to the new schema before or alongside the Argo CD upgrade.
 
 ## Drawbacks
 

--- a/docs/proposals/multiple-dry-sources-for-hydrator.md
+++ b/docs/proposals/multiple-dry-sources-for-hydrator.md
@@ -28,6 +28,7 @@ Related Issues:
 ## Open Questions
 
 * How should the commit message template handle multiple dry source repos? This proposal uses the first dry source's commit metadata, but a more descriptive format may be preferred.
+* The current `HydrationQueueKey` uses plain struct equality (`!=`) with string fields. With multiple dry sources, the key needs to represent a variable-length source list in a comparable form. Options include a serialized string, a hash, or switching to `reflect.DeepEqual` for key comparison. The right approach depends on performance tradeoffs with large app lists.
 
 ## Summary
 
@@ -51,13 +52,16 @@ The `sources` (plural) field on `ApplicationSpec` already solves this problem fo
 
 3. **Follow the established `source`/`sources` pattern** — the API design, precedence logic, helper methods, and validation mirror the existing `ApplicationSpec.Source`/`Sources` pattern to minimize surprise for users and maintainers.
 
-4. **Maintain full backward compatibility** — existing applications using `drySource` (singular) continue to work with zero changes.
+4. **Backward compatibility for `drySource` (singular)** — existing applications using `drySource` (singular) continue to work. The `GetDrySources()` helper wraps it transparently.
 
 ### Non-Goals
 
 * **Partial hydration** — when any dry source changes, all sources are re-rendered and committed together. Incremental/partial hydration of individual sources is not a goal.
 * **Per-source sync paths** — all dry sources are merged into a single manifest set committed to one `syncSource` path. Routing individual dry sources to different sync paths or branches is not supported.
+* **Backward compatibility for hydrator status fields and metadata schema** — the hydrator is beta. `DrySHA` is replaced by `DryRevision`/`DryRevisions` (matching the `Revision`/`Revisions` convention on `SyncOperation`). The `hydrator.metadata` file schema changes from a flat object to a list. These are breaking changes.
 * **UI changes** — all UI updates (models, utility functions, display components, create/edit panels) are out of scope and will be covered in a separate proposal.
+
+> **Note**: Helm/OCI chart support and cross-source `$ref` value file references are explicitly **in scope** as part of the `DrySource` parity goal (Goal 1). The intent is for `drySources` to be functionally identical to `sources` — anything you can do with an `ApplicationSource` entry in `sources`, you can do with a `DrySource` entry in `drySources`.
 
 ## Proposal
 
@@ -151,10 +155,10 @@ spec:
 * `Ref` — a reference key enabling cross-source Helm value file references (e.g. `$ref-name/path/to/values.yaml`)
 * `Name` — display name for the UI
 
-**Status types** — following the existing `Revision`/`Revisions` pattern on `SyncOperation`, the hydration status types gain parallel plural fields:
+**Status types** — `SyncOperation` tracks revisions with both `Revision string` (singular, legacy) and `Revisions []string` (plural, for multi-source). The singular field exists only because it predates multi-source support. Since the hydrator is beta, we skip the legacy singular field and go straight to a slice:
 
-* `HydrateOperation` and `SuccessfulHydrateOperation` gain `DryRevisions []string` alongside the existing `DrySHA`. Each entry is the resolved revision for the corresponding dry source — a git SHA, Helm chart version, or OCI digest depending on source type. The existing `DrySHA` field carries the first source's resolved revision for backward compatibility (matching how `SyncOperation.Revision` holds the first source's revision).
-* `SourceHydratorStatus` gains `LastComparedDryRevisions []string` alongside the existing `LastComparedDryRevision`.
+* `HydrateOperation` and `SuccessfulHydrateOperation`: `DrySHA string` is replaced by `DryRevision string` (singular, for `drySource`) and `DryRevisions []string` (plural, for `drySources`). This matches the `Revision`/`Revisions` pattern on `SyncOperation`. Each entry is the resolved revision for the corresponding dry source — a git SHA, Helm chart version, or OCI digest depending on source type. When `drySources` is used, `DryRevision` holds the first source's revision. `HydratedSHA` remains unchanged (it's a single git SHA on the hydrated branch).
+* `SourceHydratorStatus`: `LastComparedDryRevision string` remains (for `drySource`), `LastComparedDryRevisions []string` is added (for `drySources`).
 
 Per-source detail beyond the revision string (author, commands, etc.) is handled by the list-based `hydrator.metadata` file (see Commit Server Changes below).
 
@@ -178,7 +182,7 @@ New method on `DrySource`:
 #### Validation
 
 * **At least one source required**: either `drySource` must be non-nil with a non-empty `repoURL`, or `drySources` must have at least one entry. The existing `validateSourceHydrator()` check (`DrySource.RepoURL == ""` → error) must change to `DrySource == nil && len(DrySources) == 0` → error.
-* **Mutual exclusion**: setting both `drySource` (non-nil) and `drySources` (non-empty) is a validation error.
+* **Precedence**: if both `drySource` and `drySources` are set, `drySources` silently takes precedence. This matches how `source`/`sources` works on `ApplicationSpec` — no mutual exclusion error.
 * **Per-entry validation**: each entry in `drySources` must have a non-empty `repoURL`.
 * **Ref uniqueness**: `ref` keys must be unique across all dry sources and match `^[a-zA-Z0-9_-]+$` (same validation as `ApplicationSource.Ref`).
 * **Project permissions**: each dry source's RepoURL must be permitted by the Application's project. `ValidatePermissions()` must iterate over `GetDrySources()` rather than calling `GetDrySource()` once.
@@ -191,19 +195,17 @@ When any dry source has a new revision, the full set is re-hydrated:
 
 2. `getManifests()` fetches and renders manifests from all dry sources. Each dry source is rendered independently via a separate `GenerateManifest()` call (one per source). Dry sources with a `ref` field are resolved into a `RefTargetRevisionMapping` and passed to the rendering call, enabling Helm value file references like `$ref-name/path/to/values.yaml`. All manifest objects are appended into a single `PathDetails` in source order (same append semantics as `sources` in the sync path). If two dry sources produce resources with the same GVK+namespace+name, both are included — conflict detection is handled at sync time, not hydration time.
 
-3. `hydrate()` resolves static revisions for all dry sources from the first app, then renders remaining apps pinned to those same revisions. The resolved revisions are stored in `DryRevisions` (one per source, by array index). De-duplication compares this vector element-by-element against `LastSuccessfulOperation.DryRevisions`. `DrySHA` is set to the first source's revision for backward compatibility. Each source's full metadata (author, commands, etc.) is written to the `hydrator.metadata` file (see Commit Server Changes).
+3. `hydrate()` resolves static revisions for all dry sources from the first app, then renders remaining apps pinned to those same revisions. For singular `drySource`, the resolved revision is stored in `DryRevision`. For plural `drySources`, revisions are stored in `DryRevisions` (one per source, by array index). De-duplication compares against `LastSuccessfulOperation` — single string comparison for `DryRevision`, element-by-element for `DryRevisions`. Each source's full metadata (author, commands, etc.) is written to the `hydrator.metadata` file (see Commit Server Changes).
 
 4. All paths are committed in a single commit to the sync target branch.
 
 #### Hydration Queue Key
 
-The current queue key groups apps by `{SourceRepoURL, SourceTargetRevision, DestinationRepoURL, DestinationBranch}`. With multiple dry sources, `SourceRepoURL` and `SourceTargetRevision` are replaced by a `SourcesFingerprint` — a deterministic hash of all normalized dry source URLs and target revisions. The key retains `DestinationRepoURL` and `DestinationBranch`.
+The current queue key groups apps by `{SourceRepoURL, SourceTargetRevision, DestinationRepoURL, DestinationBranch}`. With multiple dry sources, the key is derived from the full `drySources` list plus the destination. Apps with the same set of dry sources (same URLs and target revisions) going to the same destination are batched together — same dedup behavior as today, extended to multiple sources.
 
 #### Changes to Controller Dependencies
 
-The `Dependencies` interface methods `GetRepoObjs` and `EvaluateAppRevisionsChanges` are updated to accept slices (`sources []ApplicationSource`, `revisions []string`) instead of single values. `GetRepoObjs` already wraps the single dry source into a slice internally — this change makes the slice the public API and removes the `len(resp) != 1` assertion. `EvaluateAppRevisionsChanges` return type changes from `(bool, string, error)` to `(bool, []string, error)` to return all resolved revisions.
-
-This cascades through `newRevisionHasChanges()` (now evaluates all dry sources), `appNeedsHydration()` (receives `[]string` resolved revisions), and `ProcessAppHydrateQueueItem()` (persists all resolved revisions in `LastComparedDryRevisions` and the first in `LastComparedDryRevision` for backward compat).
+The `Dependencies` interface methods `GetRepoObjs` and `EvaluateAppRevisionsChanges` remain single-source — they continue to accept one `ApplicationSource` and one `revision string`. The hydrator owns the multi-source orchestration: `getManifests()` iterates over `GetDrySources()`, calling `GetRepoObjs` once per dry source, then merges the results. Similarly, `newRevisionHasChanges()` calls `EvaluateAppRevisionsChanges` per source and returns true if any source has changes. Error collection and manifest merging happen in the hydrator, not in the dependencies layer.
 
 #### Commit Server Changes
 
@@ -262,23 +264,24 @@ This is a breaking change for the promoter's metadata parsing, but the promoter 
 | Increased hydration latency with many dry sources | Manifest generation for different dry sources can be parallelized (the existing `errgroup` pattern in `hydrate()` already does this for multiple apps). |
 | Queue key change causes brief re-hydration during rolling upgrade | The queue key is internal and self-healing — the next `ProcessAppHydrateQueueItem` call re-enqueues with the new key format. Hydration is idempotent. |
 | `hydrator.metadata` schema change breaks existing consumers | The hydrator is still beta. The GitOps Promoter is maintained by the same team and can be updated in coordination. Single-source apps produce a one-element list, making migration straightforward. |
+| Custom commit message templates break silently | Users who customized the hydrator commit message template in `argocd-cm` reference `.RepoURL`, `.DrySHA`, and `.Commands` as top-level fields. These change with the list-based schema. The upgrade docs should call out that custom templates need updating. |
 
 ### Upgrade / Downgrade Strategy
 
 **Upgrade:**
 
-* Existing applications using `drySource` (singular) continue to work unchanged. All new fields are `omitempty`.
-* The `GetDrySources()` helper transparently wraps a singular `drySource` into a single-element slice, so all internal code paths work with both forms.
-* `DrySHA` carries the first source's resolved revision. `DryRevisions` carries all per-source revisions. For single-source apps, both contain the same value as before.
-* The `hydrator.metadata` file changes from a flat object to `{"sources": [...]}`. Single-source apps produce a one-element list. External consumers (GitOps Promoter) need to be updated to read the new schema.
-* The `HydrationQueueKey` format change is internal. On upgrade, in-flight queue items using the old key format are simply not matched — the next reconciliation loop re-enqueues with the new format. No data loss occurs because hydration is idempotent.
+`drySources` is a new feature — there are no existing users to migrate. For existing `drySource` (singular) apps:
+
+* `drySource` continues to work unchanged. `GetDrySources()` wraps it into a single-element slice transparently.
+* `DrySHA` is replaced by `DryRevision` (same value, just renamed to match the `Revision` convention). On first reconciliation after upgrade, existing apps will have an empty `DryRevision` and trigger a one-time re-hydration (idempotent, self-healing).
+* The `hydrator.metadata` file changes from a flat object to `{"sources": [...]}` with a single entry. External consumers (GitOps Promoter) must be updated to read the new schema.
 
 **Downgrade:**
 
-* If a user downgrades after creating applications with `drySources`, the older Argo CD version will ignore the unknown `drySources` field (standard Kubernetes behavior for unknown fields in CRDs).
-* The `drySource` (singular) field will be empty for these apps, so the older version will fail validation with "drySource.repoURL is required". Users must convert their apps back to `drySource` before downgrading.
-* Status fields `DryRevisions` and `LastComparedDryRevisions` are ignored by older versions — the singular `DrySHA` and `LastComparedDryRevision` fields remain populated and functional.
-* The `hydrator.metadata` schema change is not backward compatible — older versions expect a flat object. The GitOps Promoter must be updated to the new schema before or alongside the Argo CD upgrade.
+The hydrator is beta. Downgrading is not expected to be seamless:
+
+* `DryRevision`/`DryRevisions` replace `DrySHA`. Older versions will see an empty `DrySHA` and trigger re-hydration (self-healing).
+* The `hydrator.metadata` schema is not backward compatible. The GitOps Promoter must be updated before or alongside the Argo CD upgrade.
 
 ## Drawbacks
 

--- a/docs/proposals/multiple-dry-sources-for-hydrator.md
+++ b/docs/proposals/multiple-dry-sources-for-hydrator.md
@@ -28,7 +28,6 @@ Related Issues:
 ## Open Questions
 
 * How should the commit message template handle multiple dry source repos? This proposal uses the first dry source's commit metadata, but a more descriptive format may be preferred.
-* The manifest hydrator proposal is explicitly opinionated against nondeterministic configuration injection. Multiple dry sources from different repos mean the combination of source versions is held externally to any single git repo. Is this an acceptable trade-off given that the same pattern already exists with `sources` in the non-hydrator path?
 
 ## Summary
 


### PR DESCRIPTION
## Summary

Design proposal for adding `drySources` (plural) to `SourceHydrator` and bringing `DrySource` to field parity with `ApplicationSource`, as discussed in #26804.

**Two proposals included:**
- `multiple-dry-sources-for-hydrator.md` — backend API, controller, commit server, and promoter compatibility
- `multiple-dry-sources-for-hydrator-ui.md` — companion UI proposal (separate scope)

Closes #26804

---

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.