### PR TITLE
fix: TLS test when plaintext is used

### DIFF
--- a/cmd/argocd/commands/login.go
+++ b/cmd/argocd/commands/login.go
@@ -77,7 +77,7 @@ argocd login cd.argoproj.io --core`,
 			default:
 				server = args[0]
 
-				if !skipTestTLS {
+				if !skipTestTLS && !clientOpts.PlainText {
 					dialTime := 30 * time.Second
 					tlsTestResult, err := grpc_util.TestTLS(server, dialTime)
 					errors.CheckError(err)


### PR DESCRIPTION
Fix for  #28179 

When `--plaintext` is explicitly set, the user already knows the server has no TLS,  the probe is redundant. Skipping it means no TLS Client Hello is sent, no RST, port-forward survives, and login succeeds.