### PR TITLE
fix(cli): `app wait`/blocking `app sync` hang when a competing operation overtakes the tracked one

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -1627,6 +1627,9 @@ func NewApplicationWaitCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 				c.HelpFunc()(c, args)
 				os.Exit(1)
 			}
+			if err := validateAppWaitPollInterval(pollInterval); err != nil {
+				log.Fatalf("invalid --app-wait-poll-interval: %v", err)
+			}
 			watch = getWatchOpts(watch)
 			selectedResources, err := parseSelectedResources(resources)
 			errors.CheckError(err)
@@ -1668,7 +1671,7 @@ func NewApplicationWaitCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 	command.Flags().UintVar(&timeout, "timeout", defaultCheckTimeoutSeconds, "Time out after this many seconds")
 	command.Flags().StringVarP(&appNamespace, "app-namespace", "N", "", "Only wait for an application  in namespace")
 	command.Flags().StringVarP(&output, "output", "o", "wide", "Output format. One of: json|yaml|wide|tree|tree=detailed")
-	command.Flags().DurationVar(&pollInterval, "app-wait-poll-interval", appWaitPollInterval, "Fallback re-fetch cadence for the watch loop, used when the watch goes quiet (e.g. competing operations). Defaults to ARGOCD_APP_WAIT_POLL_INTERVAL or 5s.")
+	command.Flags().DurationVar(&pollInterval, "app-wait-poll-interval", appWaitPollInterval, "Fallback re-fetch cadence for the watch loop, used when the watch goes quiet (e.g. competing operations). Must be between 1s and 1h. Defaults to ARGOCD_APP_WAIT_POLL_INTERVAL or 5s.")
 	return command
 }
 
@@ -2362,8 +2365,24 @@ func checkAppWaitConditions(app *argoappv1.Application, watch watchOpts, selecte
 // terminal transition that was never delivered as an event — it does not slow
 // down a normal wait. Configurable installation-wide via
 // ARGOCD_APP_WAIT_POLL_INTERVAL (e.g. "10s") or per-invocation via the
-// `--app-wait-poll-interval` flag on `argocd app wait`.
-var appWaitPollInterval = env.ParseDurationFromEnv("ARGOCD_APP_WAIT_POLL_INTERVAL", 5*time.Second, 1*time.Second, 1*time.Hour)
+// `--app-wait-poll-interval` flag on `argocd app wait`. Values outside
+// [appWaitPollIntervalMin, appWaitPollIntervalMax] are rejected — the lower
+// bound guards against `time.NewTicker` panicking on non-positive durations
+// and against hot-looping the API server, the upper bound catches obviously
+// bogus values.
+const (
+	appWaitPollIntervalMin = 1 * time.Second
+	appWaitPollIntervalMax = 1 * time.Hour
+)
+
+var appWaitPollInterval = env.ParseDurationFromEnv("ARGOCD_APP_WAIT_POLL_INTERVAL", 5*time.Second, appWaitPollIntervalMin, appWaitPollIntervalMax)
+
+func validateAppWaitPollInterval(d time.Duration) error {
+	if d < appWaitPollIntervalMin || d > appWaitPollIntervalMax {
+		return fmt.Errorf("must be between %s and %s, got %s", appWaitPollIntervalMin, appWaitPollIntervalMax, d)
+	}
+	return nil
+}
 
 // waitOnApplicationStatus watches an application and blocks until either the desired watch conditions
 // are fulfilled or we reach the timeout. Returns the app once desired conditions have been filled.

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -1593,6 +1593,7 @@ func NewApplicationWaitCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 		resources    []string
 		output       string
 		appNamespace string
+		pollInterval time.Duration
 	)
 	command := &cobra.Command{
 		Use:   "wait [APPNAME.. | -l selector]",
@@ -1645,7 +1646,7 @@ func NewApplicationWaitCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 				if appNamespace != "" && !strings.Contains(appName, "/") {
 					appName = appNamespace + "/" + appName
 				}
-				_, _, err := waitOnApplicationStatus(ctx, acdClient, appName, timeout, watch, selectedResources, output)
+				_, _, err := waitOnApplicationStatus(ctx, acdClient, appName, timeout, watch, selectedResources, output, pollInterval)
 				if err != nil {
 					if isContextCanceledErr(err) {
 						log.Fatalf("timed out (%ds) waiting for app %q to match the expected conditions", timeout, appName)
@@ -1667,6 +1668,7 @@ func NewApplicationWaitCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 	command.Flags().UintVar(&timeout, "timeout", defaultCheckTimeoutSeconds, "Time out after this many seconds")
 	command.Flags().StringVarP(&appNamespace, "app-namespace", "N", "", "Only wait for an application  in namespace")
 	command.Flags().StringVarP(&output, "output", "o", "wide", "Output format. One of: json|yaml|wide|tree|tree=detailed")
+	command.Flags().DurationVar(&pollInterval, "app-wait-poll-interval", appWaitPollInterval, "Fallback re-fetch cadence for the watch loop, used when the watch goes quiet (e.g. competing operations). Defaults to ARGOCD_APP_WAIT_POLL_INTERVAL or 5s.")
 	return command
 }
 
@@ -2039,7 +2041,7 @@ func NewApplicationSyncCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 				errors.CheckError(err)
 
 				if !async {
-					app, opState, err := waitOnApplicationStatus(ctx, acdClient, appQualifiedName, timeout, watchOpts{operation: true}, selectedResources, output)
+					app, opState, err := waitOnApplicationStatus(ctx, acdClient, appQualifiedName, timeout, watchOpts{operation: true}, selectedResources, output, appWaitPollInterval)
 					errors.CheckError(err)
 
 					if !dryRun {
@@ -2352,21 +2354,21 @@ func checkAppWaitConditions(app *argoappv1.Application, watch watchOpts, selecte
 	return ready, operationInProgress
 }
 
-// appWaitPollInterval controls how often waitOnApplicationStatus re-fetches the
-// application as a fallback when the watch event stream goes quiet (e.g. two
-// overlapping sync operations where the terminal event is never delivered).
-// The watch still drives the common case (it returns as soon as an event
-// satisfies the conditions), so this only bounds how quickly the fallback
-// notices a terminal transition that was never delivered as an event — it does
-// not slow down a normal wait. Configurable via ARGOCD_APP_WAIT_POLL_INTERVAL
-// (e.g. "10s") for installations that want a different cadence; overridable in
-// tests.
+// appWaitPollInterval is the default poll cadence for the waitOnApplicationStatus
+// fallback re-fetch — used when the watch event stream goes quiet (e.g. two
+// overlapping sync operations where the terminal event is never delivered). The
+// watch still drives the common case (it returns as soon as an event satisfies
+// the conditions), so this only bounds how quickly the fallback notices a
+// terminal transition that was never delivered as an event — it does not slow
+// down a normal wait. Configurable installation-wide via
+// ARGOCD_APP_WAIT_POLL_INTERVAL (e.g. "10s") or per-invocation via the
+// `--app-wait-poll-interval` flag on `argocd app wait`.
 var appWaitPollInterval = env.ParseDurationFromEnv("ARGOCD_APP_WAIT_POLL_INTERVAL", 5*time.Second, 1*time.Second, 1*time.Hour)
 
 // waitOnApplicationStatus watches an application and blocks until either the desired watch conditions
 // are fulfilled or we reach the timeout. Returns the app once desired conditions have been filled.
 // Additionally return the operationState at time of fulfilment (which may be different than returned app).
-func waitOnApplicationStatus(ctx context.Context, acdClient argocdclient.Client, appName string, timeout uint, watch watchOpts, selectedResources []*argoappv1.SyncOperationResource, output string) (*argoappv1.Application, *argoappv1.OperationState, error) {
+func waitOnApplicationStatus(ctx context.Context, acdClient argocdclient.Client, appName string, timeout uint, watch watchOpts, selectedResources []*argoappv1.SyncOperationResource, output string, pollInterval time.Duration) (*argoappv1.Application, *argoappv1.OperationState, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -2556,7 +2558,7 @@ func waitOnApplicationStatus(ctx context.Context, acdClient argocdclient.Client,
 	// return conditions independently of the event stream; it only checks for
 	// completion and never prints, so progress output stays watch-event driven.
 	// Follow-up to #12211.
-	pollTicker := time.NewTicker(appWaitPollInterval)
+	pollTicker := time.NewTicker(pollInterval)
 	defer pollTicker.Stop()
 
 	for {
@@ -2828,7 +2830,7 @@ func NewApplicationRollbackCommand(clientOpts *argocdclient.ClientOptions) *cobr
 
 			_, _, err = waitOnApplicationStatus(ctx, acdClient, app.QualifiedName(), timeout, watchOpts{
 				operation: true,
-			}, nil, output)
+			}, nil, output, appWaitPollInterval)
 			errors.CheckError(err)
 		},
 	}

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -47,6 +47,7 @@ import (
 	"github.com/argoproj/argo-cd/v3/util/argo"
 	"github.com/argoproj/argo-cd/v3/util/argo/normalizers"
 	"github.com/argoproj/argo-cd/v3/util/cli"
+	"github.com/argoproj/argo-cd/v3/util/env"
 	"github.com/argoproj/argo-cd/v3/util/errors"
 	"github.com/argoproj/argo-cd/v3/util/git"
 	"github.com/argoproj/argo-cd/v3/util/grpc"
@@ -2351,6 +2352,17 @@ func checkAppWaitConditions(app *argoappv1.Application, watch watchOpts, selecte
 	return ready, operationInProgress
 }
 
+// appWaitPollInterval controls how often waitOnApplicationStatus re-fetches the
+// application as a fallback when the watch event stream goes quiet (e.g. two
+// overlapping sync operations where the terminal event is never delivered).
+// The watch still drives the common case (it returns as soon as an event
+// satisfies the conditions), so this only bounds how quickly the fallback
+// notices a terminal transition that was never delivered as an event — it does
+// not slow down a normal wait. Configurable via ARGOCD_APP_WAIT_POLL_INTERVAL
+// (e.g. "10s") for installations that want a different cadence; overridable in
+// tests.
+var appWaitPollInterval = env.ParseDurationFromEnv("ARGOCD_APP_WAIT_POLL_INTERVAL", 5*time.Second, 1*time.Second, 1*time.Hour)
+
 // waitOnApplicationStatus watches an application and blocks until either the desired watch conditions
 // are fulfilled or we reach the timeout. Returns the app once desired conditions have been filled.
 // Additionally return the operationState at time of fulfilment (which may be different than returned app).
@@ -2492,27 +2504,27 @@ func waitOnApplicationStatus(ctx context.Context, acdClient argocdclient.Client,
 	}
 
 	appEventCh := acdClient.WatchApplicationWithRetry(ctx, appName, appWithLock.GetApp().ResourceVersion)
-	for appEvent := range appEventCh {
-		appWithLock.SetApp(&appEvent.Application)
-		app = appWithLock.GetApp()
 
-		finalOperationState = app.Status.OperationState
-
-		if watch.delete && appEvent.Type == k8swatch.Deleted {
-			fmt.Printf("Application '%s' deleted\n", app.QualifiedName())
-			return nil, nil, nil
-		}
-
+	// checkReturn evaluates the wait conditions and, when they are satisfied,
+	// prints the final status and reports done=true. It does NOT print
+	// intermediate resource states — that stays watch-event driven (see
+	// printResourceStates) so the poll fallback does not change output cadence.
+	checkReturn := func(app *argoappv1.Application) (retApp *argoappv1.Application, done bool) {
 		selectedResourcesAreReady, operationInProgress := checkAppWaitConditions(app, watch, selectedResources)
 		if app.Operation != nil && !app.Operation.DryRun() {
 			refresh = true
 		}
-
 		if selectedResourcesAreReady && (!operationInProgress || !watch.operation) {
-			app = printFinalStatus(app)
-			return app, finalOperationState, nil
+			return printFinalStatus(app), true
 		}
+		return nil, false
+	}
 
+	// printResourceStates prints changed resource states and detects a
+	// health-degraded transition. Driven by watch events only, preserving the
+	// pre-poll-fallback output cadence. Returns a non-nil error if the wait must
+	// abort because a resource's health degraded.
+	printResourceStates := func(app *argoappv1.Application) error {
 		newStates := groupResourceStates(app, selectedResources)
 		for _, newState := range newStates {
 			var doPrint bool
@@ -2520,7 +2532,7 @@ func waitOnApplicationStatus(ctx context.Context, acdClient argocdclient.Client,
 			if prevState, found := prevStates[stateKey]; found {
 				if watch.health && prevState.Health != string(health.HealthStatusUnknown) && prevState.Health != string(health.HealthStatusDegraded) && newState.Health == string(health.HealthStatusDegraded) {
 					_ = printFinalStatus(app)
-					return nil, finalOperationState, fmt.Errorf("application '%s' health state has transitioned from %s to %s", appName, prevState.Health, newState.Health)
+					return fmt.Errorf("application '%s' health state has transitioned from %s to %s", appName, prevState.Health, newState.Health)
 				}
 				doPrint = prevState.Merge(newState)
 			} else {
@@ -2532,9 +2544,75 @@ func waitOnApplicationStatus(ctx context.Context, acdClient argocdclient.Client,
 			}
 		}
 		_ = w.Flush()
+		return nil
 	}
-	_ = printFinalStatus(appWithLock.GetApp())
-	return nil, finalOperationState, fmt.Errorf("timed out (%ds) waiting for app %q match desired state", timeout, appName)
+
+	// The watch event stream only delivers messages when the application CR
+	// changes. When two sync operations overlap (e.g. an explicit sync racing an
+	// automated sync to the same revision), the exact moment where all wait
+	// conditions hold simultaneously may never arrive as a discrete event, and
+	// once the app goes quiet no further events arrive — the wait would then
+	// block until the command timeout. A periodic re-fetch re-evaluates the
+	// return conditions independently of the event stream; it only checks for
+	// completion and never prints, so progress output stays watch-event driven.
+	// Follow-up to #12211.
+	pollTicker := time.NewTicker(appWaitPollInterval)
+	defer pollTicker.Stop()
+
+	for {
+		select {
+		case appEvent, ok := <-appEventCh:
+			if !ok {
+				_ = printFinalStatus(appWithLock.GetApp())
+				return nil, finalOperationState, fmt.Errorf("timed out (%ds) waiting for app %q match desired state", timeout, appName)
+			}
+			appWithLock.SetApp(&appEvent.Application)
+			app = appWithLock.GetApp()
+			finalOperationState = app.Status.OperationState
+
+			if watch.delete && appEvent.Type == k8swatch.Deleted {
+				fmt.Printf("Application '%s' deleted\n", app.QualifiedName())
+				return nil, nil, nil
+			}
+
+			if retApp, done := checkReturn(app); done {
+				return retApp, finalOperationState, nil
+			}
+			if err := printResourceStates(app); err != nil {
+				return nil, finalOperationState, err
+			}
+		case <-pollTicker.C:
+			polledApp, getErr := appClient.Get(ctx, &application.ApplicationQuery{
+				Name:         &appRealName,
+				AppNamespace: &appNs,
+			})
+			if getErr != nil {
+				// A NotFound means the application is gone. (As part of the fix
+				// for CVE-2022-41354 the API may return PermissionDenied for a
+				// non-existent app.) For a --delete wait that is the success
+				// condition; otherwise there is nothing left to wait for, so
+				// stop early instead of looping until the timeout.
+				switch grpc.UnwrapGRPCStatus(getErr).Code() {
+				case codes.NotFound, codes.PermissionDenied:
+					if watch.delete {
+						fmt.Printf("Application '%s' deleted\n", appName)
+						return nil, nil, nil
+					}
+					_ = printFinalStatus(appWithLock.GetApp())
+					return nil, finalOperationState, fmt.Errorf("application '%s' not found", appName)
+				}
+				// Other (transient) errors: keep watching, try again next tick.
+				continue
+			}
+			appWithLock.SetApp(polledApp)
+			app = appWithLock.GetApp()
+			finalOperationState = app.Status.OperationState
+
+			if retApp, done := checkReturn(app); done {
+				return retApp, finalOperationState, nil
+			}
+		}
+	}
 }
 
 // isContextCanceledErr returns true if the error is a context cancellation or deadline exceeded,

--- a/cmd/argocd/commands/app_test.go
+++ b/cmd/argocd/commands/app_test.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -2732,4 +2733,298 @@ func TestIsContextCanceledErr(t *testing.T) {
 		t.Parallel()
 		assert.False(t, isContextCanceledErr(errors.New("some other error")))
 	})
+}
+
+// TestWaitOnApplicationStatus_PollFallbackReturnsWhenWatchGoesQuiet simulates
+// two overlapping sync operations: the watch emits one non-satisfying event and
+// then goes quiet (never delivers the terminal event), while a periodic Get
+// eventually observes the desired Synced+Healthy state. Without the poll
+// fallback, waitOnApplicationStatus would block until the timeout.
+func TestWaitOnApplicationStatus_PollFallbackReturnsWhenWatchGoesQuiet(t *testing.T) {
+	orig := appWaitPollInterval
+	appWaitPollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { appWaitPollInterval = orig })
+
+	acdClient := &pollFallbackAcdClient{&fakeAcdClient{}}
+	ctx := t.Context()
+	watchOpts := watchOpts{sync: true, health: true, operation: true}
+
+	start := time.Now()
+	app, _, err := waitOnApplicationStatus(ctx, acdClient, "app-name", 3, watchOpts, nil, "json")
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	assert.NotNil(t, app)
+	assert.Less(t, elapsed, 2*time.Second, "poll fallback should return well before the wait timeout, took %s", elapsed)
+}
+
+// pollFallbackAcdClient: the watch emits one OutOfSync event then stays open but
+// quiet; the first Get (initial state) returns OutOfSync so the #12211 early
+// return is skipped, and later Gets (the poll) return Synced+Healthy.
+type pollFallbackAcdClient struct {
+	*fakeAcdClient
+}
+
+func (c *pollFallbackAcdClient) WatchApplicationWithRetry(_ context.Context, _ string, _ string) chan *v1alpha1.ApplicationWatchEvent {
+	appEventsCh := make(chan *v1alpha1.ApplicationWatchEvent, 1)
+	appEventsCh <- &v1alpha1.ApplicationWatchEvent{
+		Type: watch.Modified,
+		Application: v1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "argocd"},
+			Status: v1alpha1.ApplicationStatus{
+				Sync:   v1alpha1.SyncStatus{Status: v1alpha1.SyncStatusCodeOutOfSync},
+				Health: v1alpha1.AppHealthStatus{Status: health.HealthStatusProgressing},
+			},
+		},
+	}
+	// Intentionally never closed: the watch stays open but quiet, so only the
+	// poll fallback can satisfy the wait.
+	return appEventsCh
+}
+
+func (c *pollFallbackAcdClient) NewApplicationClientOrDie() (io.Closer, applicationpkg.ApplicationServiceClient) {
+	return &fakeConnection{}, &flippingFakeAppServiceClient{}
+}
+
+func (c *pollFallbackAcdClient) NewSettingsClientOrDie() (io.Closer, settingspkg.SettingsServiceClient) {
+	return &fakeConnection{}, &fakeSettingsServiceClient{}
+}
+
+// flippingFakeAppServiceClient returns OutOfSync on the first Get (initial
+// state) and Synced+Healthy on every subsequent Get (the poll fallback).
+type flippingFakeAppServiceClient struct {
+	fakeAppServiceClient
+	calls atomic.Int32
+}
+
+func (c *flippingFakeAppServiceClient) Get(_ context.Context, _ *applicationpkg.ApplicationQuery, _ ...grpc.CallOption) (*v1alpha1.Application, error) {
+	syncStatus := v1alpha1.SyncStatusCodeSynced
+	healthStatus := health.HealthStatusHealthy
+	if c.calls.Add(1) == 1 {
+		syncStatus = v1alpha1.SyncStatusCodeOutOfSync
+		healthStatus = health.HealthStatusProgressing
+	}
+	return &v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "argocd"},
+		Spec: v1alpha1.ApplicationSpec{
+			Project:     "default",
+			Destination: v1alpha1.ApplicationDestination{Server: "local", Namespace: "argocd"},
+			Source:      &v1alpha1.ApplicationSource{RepoURL: "test", TargetRevision: "master", Path: "/test"},
+		},
+		Status: v1alpha1.ApplicationStatus{
+			Sync:   v1alpha1.SyncStatus{Status: syncStatus},
+			Health: v1alpha1.AppHealthStatus{Status: healthStatus},
+		},
+	}, nil
+}
+
+// TestWaitOnApplicationStatus_HealthDegradedTransitionReturnsError exercises the
+// watch-loop path where a watched resource transitions to Degraded health: the
+// first event records the resource as Healthy, the second flips it to Degraded,
+// and the wait must abort with a "health state has transitioned" error.
+func TestWaitOnApplicationStatus_HealthDegradedTransitionReturnsError(t *testing.T) {
+	acdClient := &healthDegradedAcdClient{&fakeAcdClient{}}
+	ctx := t.Context()
+	wo := watchOpts{sync: true, health: true}
+
+	_, _, err := waitOnApplicationStatus(ctx, acdClient, "app-name", 0, wo, nil, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "health state has transitioned")
+}
+
+// healthDegradedAcdClient: initial Get is OutOfSync (so the early return is
+// skipped); the watch then emits the same resource first Healthy, then Degraded.
+type healthDegradedAcdClient struct {
+	*fakeAcdClient
+}
+
+func (c *healthDegradedAcdClient) WatchApplicationWithRetry(_ context.Context, _ string, _ string) chan *v1alpha1.ApplicationWatchEvent {
+	mk := func(h health.HealthStatusCode) *v1alpha1.ApplicationWatchEvent {
+		return &v1alpha1.ApplicationWatchEvent{
+			Type: watch.Modified,
+			Application: v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "argocd"},
+				Status: v1alpha1.ApplicationStatus{
+					Sync:   v1alpha1.SyncStatus{Status: v1alpha1.SyncStatusCodeOutOfSync},
+					Health: v1alpha1.AppHealthStatus{Status: health.HealthStatusProgressing},
+					Resources: []v1alpha1.ResourceStatus{{
+						Kind:      "Deployment",
+						Name:      "test",
+						Namespace: "default",
+						Status:    "Synced",
+						Health:    &v1alpha1.HealthStatus{Status: h},
+					}},
+				},
+			},
+		}
+	}
+	appEventsCh := make(chan *v1alpha1.ApplicationWatchEvent, 3)
+	appEventsCh <- mk(health.HealthStatusHealthy)
+	appEventsCh <- mk(health.HealthStatusHealthy) // seen again, not degraded -> merge path
+	appEventsCh <- mk(health.HealthStatusDegraded)
+	close(appEventsCh)
+	return appEventsCh
+}
+
+func (c *healthDegradedAcdClient) NewApplicationClientOrDie() (io.Closer, applicationpkg.ApplicationServiceClient) {
+	return &fakeConnection{}, &fakeAppServiceClient{}
+}
+
+func (c *healthDegradedAcdClient) NewSettingsClientOrDie() (io.Closer, settingspkg.SettingsServiceClient) {
+	return &fakeConnection{}, &fakeSettingsServiceClient{}
+}
+
+// TestWaitOnApplicationStatus_PollFallbackToleratesTransientGetError verifies the
+// poll fallback skips a failed re-fetch (transient API error) and returns once a
+// later poll observes the desired state.
+func TestWaitOnApplicationStatus_PollFallbackToleratesTransientGetError(t *testing.T) {
+	orig := appWaitPollInterval
+	appWaitPollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { appWaitPollInterval = orig })
+
+	acdClient := &pollErrorAcdClient{&fakeAcdClient{}}
+	ctx := t.Context()
+	wo := watchOpts{sync: true, health: true, operation: true}
+
+	app, _, err := waitOnApplicationStatus(ctx, acdClient, "app-name", 3, wo, nil, "json")
+	require.NoError(t, err)
+	assert.NotNil(t, app)
+}
+
+// pollErrorAcdClient: the watch emits one OutOfSync event and stays quiet; the
+// poll Get errors once (transient) and then returns Synced+Healthy.
+type pollErrorAcdClient struct {
+	*fakeAcdClient
+}
+
+func (c *pollErrorAcdClient) WatchApplicationWithRetry(_ context.Context, _ string, _ string) chan *v1alpha1.ApplicationWatchEvent {
+	appEventsCh := make(chan *v1alpha1.ApplicationWatchEvent, 1)
+	appEventsCh <- &v1alpha1.ApplicationWatchEvent{
+		Type: watch.Modified,
+		Application: v1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "argocd"},
+			Status: v1alpha1.ApplicationStatus{
+				Sync:   v1alpha1.SyncStatus{Status: v1alpha1.SyncStatusCodeOutOfSync},
+				Health: v1alpha1.AppHealthStatus{Status: health.HealthStatusProgressing},
+			},
+		},
+	}
+	return appEventsCh
+}
+
+func (c *pollErrorAcdClient) NewApplicationClientOrDie() (io.Closer, applicationpkg.ApplicationServiceClient) {
+	return &fakeConnection{}, &erroringFakeAppServiceClient{}
+}
+
+func (c *pollErrorAcdClient) NewSettingsClientOrDie() (io.Closer, settingspkg.SettingsServiceClient) {
+	return &fakeConnection{}, &fakeSettingsServiceClient{}
+}
+
+// erroringFakeAppServiceClient: Get returns OutOfSync on the first (initial) call
+// so the early return is skipped, errors on the second (first poll), then returns
+// Synced+Healthy.
+type erroringFakeAppServiceClient struct {
+	fakeAppServiceClient
+	calls atomic.Int32
+}
+
+func (c *erroringFakeAppServiceClient) Get(_ context.Context, _ *applicationpkg.ApplicationQuery, _ ...grpc.CallOption) (*v1alpha1.Application, error) {
+	switch c.calls.Add(1) {
+	case 1:
+		return &v1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "argocd"},
+			Spec: v1alpha1.ApplicationSpec{
+				Project:     "default",
+				Destination: v1alpha1.ApplicationDestination{Server: "local", Namespace: "argocd"},
+				Source:      &v1alpha1.ApplicationSource{RepoURL: "test", TargetRevision: "master", Path: "/test"},
+			},
+			Status: v1alpha1.ApplicationStatus{
+				Sync:   v1alpha1.SyncStatus{Status: v1alpha1.SyncStatusCodeOutOfSync},
+				Health: v1alpha1.AppHealthStatus{Status: health.HealthStatusProgressing},
+			},
+		}, nil
+	case 2:
+		return nil, errors.New("transient API error")
+	default:
+		return &v1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "argocd"},
+			Spec: v1alpha1.ApplicationSpec{
+				Project:     "default",
+				Destination: v1alpha1.ApplicationDestination{Server: "local", Namespace: "argocd"},
+				Source:      &v1alpha1.ApplicationSource{RepoURL: "test", TargetRevision: "master", Path: "/test"},
+			},
+			Status: v1alpha1.ApplicationStatus{
+				Sync:   v1alpha1.SyncStatus{Status: v1alpha1.SyncStatusCodeSynced},
+				Health: v1alpha1.AppHealthStatus{Status: health.HealthStatusHealthy},
+			},
+		}, nil
+	}
+}
+
+// TestWaitOnApplicationStatus_PollNotFoundDeleteSucceeds verifies that when the
+// poll fallback observes the app is gone (NotFound), a --delete wait returns
+// successfully — the symmetric quiet-watch case for deletions.
+func TestWaitOnApplicationStatus_PollNotFoundDeleteSucceeds(t *testing.T) {
+	orig := appWaitPollInterval
+	appWaitPollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { appWaitPollInterval = orig })
+
+	app, _, err := waitOnApplicationStatus(t.Context(), &pollNotFoundAcdClient{&fakeAcdClient{}}, "app-name", 3, watchOpts{delete: true}, nil, "")
+	require.NoError(t, err)
+	assert.Nil(t, app)
+}
+
+// TestWaitOnApplicationStatus_PollNotFoundReturnsError verifies that when the
+// poll fallback observes the app is gone (NotFound) on a non-delete wait, it
+// stops early with a "not found" error instead of looping until the timeout.
+func TestWaitOnApplicationStatus_PollNotFoundReturnsError(t *testing.T) {
+	orig := appWaitPollInterval
+	appWaitPollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { appWaitPollInterval = orig })
+
+	_, _, err := waitOnApplicationStatus(t.Context(), &pollNotFoundAcdClient{&fakeAcdClient{}}, "app-name", 3, watchOpts{sync: true, health: true}, nil, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// pollNotFoundAcdClient: the watch stays quiet (no events); the initial Get
+// returns OutOfSync (so the early return is skipped) and every later (poll) Get
+// returns a NotFound, simulating the application being deleted.
+type pollNotFoundAcdClient struct {
+	*fakeAcdClient
+}
+
+func (c *pollNotFoundAcdClient) WatchApplicationWithRetry(_ context.Context, _ string, _ string) chan *v1alpha1.ApplicationWatchEvent {
+	return make(chan *v1alpha1.ApplicationWatchEvent) // quiet: only the poll fallback acts
+}
+
+func (c *pollNotFoundAcdClient) NewApplicationClientOrDie() (io.Closer, applicationpkg.ApplicationServiceClient) {
+	return &fakeConnection{}, &notFoundOnPollClient{}
+}
+
+func (c *pollNotFoundAcdClient) NewSettingsClientOrDie() (io.Closer, settingspkg.SettingsServiceClient) {
+	return &fakeConnection{}, &fakeSettingsServiceClient{}
+}
+
+type notFoundOnPollClient struct {
+	fakeAppServiceClient
+	calls atomic.Int32
+}
+
+func (c *notFoundOnPollClient) Get(_ context.Context, _ *applicationpkg.ApplicationQuery, _ ...grpc.CallOption) (*v1alpha1.Application, error) {
+	if c.calls.Add(1) == 1 {
+		return &v1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "argocd"},
+			Spec: v1alpha1.ApplicationSpec{
+				Project:     "default",
+				Destination: v1alpha1.ApplicationDestination{Server: "local", Namespace: "argocd"},
+				Source:      &v1alpha1.ApplicationSource{RepoURL: "test", TargetRevision: "master", Path: "/test"},
+			},
+			Status: v1alpha1.ApplicationStatus{
+				Sync:   v1alpha1.SyncStatus{Status: v1alpha1.SyncStatusCodeOutOfSync},
+				Health: v1alpha1.AppHealthStatus{Status: health.HealthStatusProgressing},
+			},
+		}, nil
+	}
+	return nil, grpcstatus.Error(grpccodes.NotFound, "application not found")
 }

--- a/cmd/argocd/commands/app_test.go
+++ b/cmd/argocd/commands/app_test.go
@@ -1863,7 +1863,7 @@ func TestWaitOnApplicationStatus_JSON_YAML_WideOutput(t *testing.T) {
 
 	output, err := captureOutput(
 		func() error {
-			_, _, _ = waitOnApplicationStatus(ctx, acdClient, "app-name", 0, watch, selectResource, "json")
+			_, _, _ = waitOnApplicationStatus(ctx, acdClient, "app-name", 0, watch, selectResource, "json", appWaitPollInterval)
 			return nil
 		},
 	)
@@ -1871,7 +1871,7 @@ func TestWaitOnApplicationStatus_JSON_YAML_WideOutput(t *testing.T) {
 	assert.True(t, json.Valid([]byte(output)))
 
 	output, err = captureOutput(func() error {
-		_, _, _ = waitOnApplicationStatus(ctx, acdClient, "app-name", 0, watch, selectResource, "yaml")
+		_, _, _ = waitOnApplicationStatus(ctx, acdClient, "app-name", 0, watch, selectResource, "yaml", appWaitPollInterval)
 		return nil
 	})
 
@@ -1880,7 +1880,7 @@ func TestWaitOnApplicationStatus_JSON_YAML_WideOutput(t *testing.T) {
 	require.NoError(t, err)
 
 	output, _ = captureOutput(func() error {
-		_, _, _ = waitOnApplicationStatus(ctx, acdClient, "app-name", 0, watch, selectResource, "")
+		_, _, _ = waitOnApplicationStatus(ctx, acdClient, "app-name", 0, watch, selectResource, "", appWaitPollInterval)
 		return nil
 	})
 	timeStr := time.Now().Format("2006-01-02T15:04:05-07:00")
@@ -1949,7 +1949,7 @@ func TestWaitOnApplicationStatus_JSON_YAML_WideOutput_With_Timeout(t *testing.T)
 	watch = getWatchOpts(watch)
 
 	output, _ := captureOutput(func() error {
-		_, _, _ = waitOnApplicationStatus(ctx, acdClient, "app-name", 5, watch, selectResource, "")
+		_, _, _ = waitOnApplicationStatus(ctx, acdClient, "app-name", 5, watch, selectResource, "", appWaitPollInterval)
 		return nil
 	})
 	timeStr := time.Now().Format("2006-01-02T15:04:05-07:00")
@@ -2157,7 +2157,7 @@ func TestWaitOnApplicationStatus_ReturnsImmediatelyWhenAlreadyInDesiredState(t *
 	}
 
 	start := time.Now()
-	_, _, err := waitOnApplicationStatus(ctx, acdClient, "app-name", 0, watch, selectResource, "json")
+	_, _, err := waitOnApplicationStatus(ctx, acdClient, "app-name", 0, watch, selectResource, "json", appWaitPollInterval)
 	elapsed := time.Since(start)
 
 	require.NoError(t, err)
@@ -2173,7 +2173,7 @@ func TestWaitOnApplicationStatus_DeleteWatchSkipsEarlyReturn(t *testing.T) {
 	ctx := t.Context()
 	watch := watchOpts{delete: true}
 
-	app, opState, err := waitOnApplicationStatus(ctx, acdClient, "app-name", 0, watch, nil, "")
+	app, opState, err := waitOnApplicationStatus(ctx, acdClient, "app-name", 0, watch, nil, "", appWaitPollInterval)
 	require.NoError(t, err)
 	assert.Nil(t, app)
 	assert.Nil(t, opState)
@@ -2188,7 +2188,7 @@ func TestWaitOnApplicationStatus_ReturnsFromWatchLoopWhenEventSatisfiesCondition
 	ctx := t.Context()
 	watch := watchOpts{sync: true, health: true}
 
-	app, _, err := waitOnApplicationStatus(ctx, acdClient, "app-name", 0, watch, nil, "json")
+	app, _, err := waitOnApplicationStatus(ctx, acdClient, "app-name", 0, watch, nil, "json", appWaitPollInterval)
 	require.NoError(t, err)
 	// The function returns via the readiness path inside the watch loop.
 	// The returned app may be re-fetched by printFinalStatus so we only
@@ -2741,16 +2741,12 @@ func TestIsContextCanceledErr(t *testing.T) {
 // eventually observes the desired Synced+Healthy state. Without the poll
 // fallback, waitOnApplicationStatus would block until the timeout.
 func TestWaitOnApplicationStatus_PollFallbackReturnsWhenWatchGoesQuiet(t *testing.T) {
-	orig := appWaitPollInterval
-	appWaitPollInterval = 10 * time.Millisecond
-	t.Cleanup(func() { appWaitPollInterval = orig })
-
 	acdClient := &pollFallbackAcdClient{&fakeAcdClient{}}
 	ctx := t.Context()
 	watchOpts := watchOpts{sync: true, health: true, operation: true}
 
 	start := time.Now()
-	app, _, err := waitOnApplicationStatus(ctx, acdClient, "app-name", 3, watchOpts, nil, "json")
+	app, _, err := waitOnApplicationStatus(ctx, acdClient, "app-name", 3, watchOpts, nil, "json", 10*time.Millisecond)
 	elapsed := time.Since(start)
 
 	require.NoError(t, err)
@@ -2827,7 +2823,7 @@ func TestWaitOnApplicationStatus_HealthDegradedTransitionReturnsError(t *testing
 	ctx := t.Context()
 	wo := watchOpts{sync: true, health: true}
 
-	_, _, err := waitOnApplicationStatus(ctx, acdClient, "app-name", 0, wo, nil, "")
+	_, _, err := waitOnApplicationStatus(ctx, acdClient, "app-name", 0, wo, nil, "", appWaitPollInterval)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "health state has transitioned")
 }
@@ -2878,15 +2874,11 @@ func (c *healthDegradedAcdClient) NewSettingsClientOrDie() (io.Closer, settingsp
 // poll fallback skips a failed re-fetch (transient API error) and returns once a
 // later poll observes the desired state.
 func TestWaitOnApplicationStatus_PollFallbackToleratesTransientGetError(t *testing.T) {
-	orig := appWaitPollInterval
-	appWaitPollInterval = 10 * time.Millisecond
-	t.Cleanup(func() { appWaitPollInterval = orig })
-
 	acdClient := &pollErrorAcdClient{&fakeAcdClient{}}
 	ctx := t.Context()
 	wo := watchOpts{sync: true, health: true, operation: true}
 
-	app, _, err := waitOnApplicationStatus(ctx, acdClient, "app-name", 3, wo, nil, "json")
+	app, _, err := waitOnApplicationStatus(ctx, acdClient, "app-name", 3, wo, nil, "json", 10*time.Millisecond)
 	require.NoError(t, err)
 	assert.NotNil(t, app)
 }
@@ -2965,11 +2957,7 @@ func (c *erroringFakeAppServiceClient) Get(_ context.Context, _ *applicationpkg.
 // poll fallback observes the app is gone (NotFound), a --delete wait returns
 // successfully — the symmetric quiet-watch case for deletions.
 func TestWaitOnApplicationStatus_PollNotFoundDeleteSucceeds(t *testing.T) {
-	orig := appWaitPollInterval
-	appWaitPollInterval = 10 * time.Millisecond
-	t.Cleanup(func() { appWaitPollInterval = orig })
-
-	app, _, err := waitOnApplicationStatus(t.Context(), &pollNotFoundAcdClient{&fakeAcdClient{}}, "app-name", 3, watchOpts{delete: true}, nil, "")
+	app, _, err := waitOnApplicationStatus(t.Context(), &pollNotFoundAcdClient{&fakeAcdClient{}}, "app-name", 3, watchOpts{delete: true}, nil, "", 10*time.Millisecond)
 	require.NoError(t, err)
 	assert.Nil(t, app)
 }
@@ -2978,11 +2966,7 @@ func TestWaitOnApplicationStatus_PollNotFoundDeleteSucceeds(t *testing.T) {
 // poll fallback observes the app is gone (NotFound) on a non-delete wait, it
 // stops early with a "not found" error instead of looping until the timeout.
 func TestWaitOnApplicationStatus_PollNotFoundReturnsError(t *testing.T) {
-	orig := appWaitPollInterval
-	appWaitPollInterval = 10 * time.Millisecond
-	t.Cleanup(func() { appWaitPollInterval = orig })
-
-	_, _, err := waitOnApplicationStatus(t.Context(), &pollNotFoundAcdClient{&fakeAcdClient{}}, "app-name", 3, watchOpts{sync: true, health: true}, nil, "")
+	_, _, err := waitOnApplicationStatus(t.Context(), &pollNotFoundAcdClient{&fakeAcdClient{}}, "app-name", 3, watchOpts{sync: true, health: true}, nil, "", 10*time.Millisecond)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 }

--- a/cmd/argocd/commands/app_test.go
+++ b/cmd/argocd/commands/app_test.go
@@ -2735,6 +2735,35 @@ func TestIsContextCanceledErr(t *testing.T) {
 	})
 }
 
+func TestValidateAppWaitPollInterval(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		value   time.Duration
+		wantErr bool
+	}{
+		{"lower bound is accepted", 1 * time.Second, false},
+		{"upper bound is accepted", 1 * time.Hour, false},
+		{"default is accepted", 5 * time.Second, false},
+		{"zero is rejected", 0, true},
+		{"negative is rejected", -1 * time.Second, true},
+		{"below lower bound is rejected", 500 * time.Millisecond, true},
+		{"above upper bound is rejected", 2 * time.Hour, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateAppWaitPollInterval(tc.value)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 // TestWaitOnApplicationStatus_PollFallbackReturnsWhenWatchGoesQuiet simulates
 // two overlapping sync operations: the watch emits one non-satisfying event and
 // then goes quiet (never delivers the terminal event), while a periodic Get

--- a/docs/user-guide/commands/argocd_app_wait.md
+++ b/docs/user-guide/commands/argocd_app_wait.md
@@ -38,19 +38,20 @@ argocd app wait [APPNAME.. | -l selector] [flags]
 ### Options
 
 ```
-  -N, --app-namespace string   Only wait for an application  in namespace
-      --degraded               Wait for degraded
-      --delete                 Wait for delete
-      --health                 Wait for health
-  -h, --help                   help for wait
-      --hydrated               Wait for hydration operations
-      --operation              Wait for pending operations
-  -o, --output string          Output format. One of: json|yaml|wide|tree|tree=detailed (default "wide")
-      --resource stringArray   Sync only specific resources as GROUP:KIND:NAME or !GROUP:KIND:NAME. Fields may be blank and '*' can be used. This option may be specified repeatedly
-  -l, --selector string        Wait for apps by label. Supports '=', '==', '!=', in, notin, exists & not exists. Matching apps must satisfy all of the specified label constraints.
-      --suspended              Wait for suspended
-      --sync                   Wait for sync
-      --timeout uint           Time out after this many seconds
+  -N, --app-namespace string              Only wait for an application  in namespace
+      --app-wait-poll-interval duration   Fallback re-fetch cadence for the watch loop, used when the watch goes quiet (e.g. competing operations). Defaults to ARGOCD_APP_WAIT_POLL_INTERVAL or 5s. (default 5s)
+      --degraded                          Wait for degraded
+      --delete                            Wait for delete
+      --health                            Wait for health
+  -h, --help                              help for wait
+      --hydrated                          Wait for hydration operations
+      --operation                         Wait for pending operations
+  -o, --output string                     Output format. One of: json|yaml|wide|tree|tree=detailed (default "wide")
+      --resource stringArray              Sync only specific resources as GROUP:KIND:NAME or !GROUP:KIND:NAME. Fields may be blank and '*' can be used. This option may be specified repeatedly
+  -l, --selector string                   Wait for apps by label. Supports '=', '==', '!=', in, notin, exists & not exists. Matching apps must satisfy all of the specified label constraints.
+      --suspended                         Wait for suspended
+      --sync                              Wait for sync
+      --timeout uint                      Time out after this many seconds
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_app_wait.md
+++ b/docs/user-guide/commands/argocd_app_wait.md
@@ -39,7 +39,7 @@ argocd app wait [APPNAME.. | -l selector] [flags]
 
 ```
   -N, --app-namespace string              Only wait for an application  in namespace
-      --app-wait-poll-interval duration   Fallback re-fetch cadence for the watch loop, used when the watch goes quiet (e.g. competing operations). Defaults to ARGOCD_APP_WAIT_POLL_INTERVAL or 5s. (default 5s)
+      --app-wait-poll-interval duration   Fallback re-fetch cadence for the watch loop, used when the watch goes quiet (e.g. competing operations). Must be between 1s and 1h. Defaults to ARGOCD_APP_WAIT_POLL_INTERVAL or 5s. (default 5s)
       --degraded                          Wait for degraded
       --delete                            Wait for delete
       --health                            Wait for health


### PR DESCRIPTION
## Summary

`argocd app wait` (and the blocking wait inside `argocd app sync`) can hang
until the command timeout when a second sync operation overtakes the one the
CLI is tracking. This is a client-only change that adds a periodic re-fetch as
a fallback to the watch event stream, so the wait returns as soon as the
application actually reaches the desired state — even if the watch never
delivers the discrete event in which all wait conditions hold simultaneously.

## The problem

`waitOnApplicationStatus` blocks on a `WatchApplicationWithRetry` event stream
and only evaluates the return conditions when an event arrives. The watch
stream only delivers a message when the Application CR changes.

When two sync operations overlap — for example an explicit `argocd app sync`
racing an automated (auto-sync) operation to the same revision — the moment at
which **all** wait conditions hold at once (Synced + Healthy + operation
finished + reconciled) may never be observed as a single discrete watch event:

- The competing operation can flip `app.Operation` / `OperationState` /
  `Sync` / `Health` in interleavings such that no single delivered event
  satisfies the full predicate.
- Once the dust settles, the CR stops changing, so the watch goes quiet and
  **no further events arrive**.

With no event to re-trigger the condition check, the wait blocks until the
command timeout, even though the application has long since reached the desired
state. This affects both `argocd app wait` and the blocking wait performed by
`argocd app sync`.

This is the same class of "no event because nothing is changing" issue
addressed for the initial state by #12211 (early return when the app already
matches the desired conditions). That fix only covers the moment **before** the
watch starts; this PR covers the symmetric case where the app reaches the
desired state **during** the wait but the satisfying transition is never
delivered as an event.

## The fix

Add a periodic poll alongside the existing watch loop:

- Convert the `for appEvent := range appEventCh` loop into a
  `for { select { ... } }` over two cases: the watch channel and a
  `time.Ticker` (default 3s, package var `appWaitPollInterval`, overridable in
  tests).
- The watch case keeps the existing behavior: handle `--delete`, evaluate the
  return conditions, and print changed resource states / detect
  health-degraded transitions.
- The poll case re-`Get`s the application and **only** re-evaluates the return
  conditions. It never prints resource lines.

Crucially, **all progress output stays watch-event driven**. The poll is a
pure completion check, so the output cadence of `app wait` (and the
JSON/YAML/wide formats) is unchanged. The condition-evaluation and
resource-printing logic are split into two small closures (`checkReturn` and
`printResourceStates`) to make this separation explicit; the channel-close path
still produces the existing `timed out (%ds) waiting for app ...` error.

No server-side or API changes — this is entirely client-side.

## Validation

Real-world validation on a blue-green deployment pipeline
(UAT), where overlapping explicit + auto-sync operations are routine:

- With the fix: the blue-green deploy stage completes in ~479s, two consecutive
  clean runs, zero hangs.
- Without the fix: the same stage hangs and only unblocks at the ~999s pipeline
  timeout.

## Tests

Added `TestWaitOnApplicationStatus_PollFallbackReturnsWhenWatchGoesQuiet`: a
mock client whose watch emits one OutOfSync event and then stays open but quiet
(never delivers a terminal event), while `Get` returns OutOfSync on the first
call (so the #12211 early return is skipped) and Synced+Healthy thereafter (the
poll). With `appWaitPollInterval` overridden to 10ms, the wait returns NoError
with a non-nil app well within the timeout. The existing
`TestWaitOnApplicationStatus_JSON_YAML_WideOutput_With_Timeout` (sensitive to
output cadence) and the rest of the wait/condition tests continue to pass.

```
go test ./cmd/argocd/commands/ -run 'TestWaitOnApplicationStatus|TestCheckAppWaitConditions|TestDefaultWaitOptions|TestOverrideWaitOptions' -count=1 -v
ok  github.com/argoproj/argo-cd/v3/cmd/argocd/commands
```

Follow-up to #12211.
