### PR TITLE
fix(source-integrity): Prevent key id masking

### DIFF
--- a/util/sourceintegrity/source_integrity.go
+++ b/util/sourceintegrity/source_integrity.go
@@ -186,18 +186,18 @@ func describeProblems(g *v1alpha1.SourceIntegrityGitPolicyGPG, signatureInfos []
 			}
 		}
 
-		// Do not report the same key twice unless:
-		// - the revision is unsigned (unsigned commits can have different authors, so they are all worth reporting)
-		// - the revision is a tag (tags are signed separately from commits)
-		if signatureInfo.SignatureKeyID != "" && git.IsCommitSHA(signatureInfo.Revision) {
-			if _, exists := reportedKeys[signatureInfo.SignatureKeyID]; exists {
-				continue
-			}
-			reportedKeys[signatureInfo.SignatureKeyID] = nil
-		}
-
 		problem := gpgProblemMessage(g, signatureInfo)
 		if problem != "" {
+			// Do not report the same key twice unless:
+			// - the revision is unsigned (unsigned commits can have different authors, so they are all worth reporting)
+			// - the revision is a tag (tags are signed separately from commits)
+			if signatureInfo.SignatureKeyID != "" && git.IsCommitSHA(signatureInfo.Revision) {
+				if _, exists := reportedKeys[signatureInfo.SignatureKeyID]; exists {
+					continue
+				}
+				reportedKeys[signatureInfo.SignatureKeyID] = nil
+			}
+
 			problems = append(problems, problem)
 
 			// Report at most 10 problems

--- a/util/sourceintegrity/source_integrity_test.go
+++ b/util/sourceintegrity/source_integrity_test.go
@@ -375,6 +375,7 @@ func TestDescribeProblems(t *testing.T) {
 			gpg:  &policy,
 			sigs: []git.RevisionSignatureInfo{
 				sig("revoked", git.GPGVerificationResultRevokedKey),
+				sig(kGood, git.GPGVerificationResultGood),
 				sig("", git.GPGVerificationResultUnsigned),
 				sig("untrusted", git.GPGVerificationResultUntrusted),
 				sig("missing", git.GPGVerificationResultMissingKey),
@@ -401,7 +402,31 @@ func TestDescribeProblems(t *testing.T) {
 				"Failed verifying revision " + r + " by '" + a + "': bad signature (key_id=more_bad)",
 				"Failed verifying revision " + r + " by '" + a + "': bad signature (key_id=outright_terrible)",
 			},
-			legacy: "Invalid signature from Commit Author <nereply@acme.com> key revoked",
+			legacy: "Invalid signature from " + a + " key revoked",
+		},
+		{
+			name: "legacy verification is possitive even when older commits are untrusted, legacy is always shallow",
+			gpg:  &policy,
+			sigs: []git.RevisionSignatureInfo{
+				sig(kGood, git.GPGVerificationResultGood),
+				sig("bad", git.GPGVerificationResultBad),
+			},
+			expected: []string{
+				"Failed verifying revision " + r + " by '" + a + "': bad signature (key_id=bad)",
+			},
+			legacy: "Good signature from " + a + " key AAAAAAAAAAAAAAAA",
+		},
+		{
+			name: "do not collapse commits by key when they differ by the result",
+			gpg:  &policy,
+			sigs: []git.RevisionSignatureInfo{
+				sig(kGood, git.GPGVerificationResultGood),
+				sig(kGood, git.GPGVerificationResultBad),
+			},
+			expected: []string{
+				"Failed verifying revision " + r + " by '" + a + "': bad signature (key_id=" + kGood + ")",
+			},
+			legacy: "Good signature from " + a + " key AAAAAAAAAAAAAAAA",
 		},
 	}
 


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Old implementation made sure that no GPG key is reported multiple times using the
`reportedKeys` map keys for its set-like properties. This was to squeeze as much
info as possible into the 10 problems reported (not to overwhelm admins with
potentially thousands entries). This was supposedly safe because what matters
to tell trusted revisions from the untrusted ones is, that they report 1 or more
problems.

However, the implementation was also tracking trusted revision's GPG keys in
`reportedKeys` map by mistake. This have caused that malicious actor can inject
an untrusted commit into a git history violating the guarantees of the `strict`
mode, provided it will later have a descendant commit correctly signed by the same
GPG key ID. This can happen when such malicious commit fakes the GPG key ID of
a maintainer, and that maintainer merges it with signed commit despite the
malicious commit is unsigned.

While such commit signature cannot be considered cryptographically
valid by GPG, the Argo CD implementation was ignoring its true commit signature
status reported by git, precisely because its problem report was erroneously
deduplicated into the `reportedKeys` entry for the valid descendant with colliding
GPG key ID.

**Big thanks to @kanywst for finding and reporting the issue responsibly via GHSA!** Thankfully the buggy code had not been released, so we were able to fix it via this PR outside the GHSA process.


Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
