### PR TITLE
fix: exclude live status from normalization

### DIFF
--- a/controller/sync.go
+++ b/controller/sync.go
@@ -425,7 +425,24 @@ func normalizeTargetResources(cr *comparisonResult) ([]*unstructured.Unstructure
 			lookupPatchMeta = &meta
 		}
 
-		livePatch, err := getMergePatch(normalized.Lives[idx], live, lookupPatchMeta)
+		// RespectIgnoreDifferences preserves ignored fields by copying their live
+		// values into the target that is applied during sync. `status` must be
+		// excluded from that copy: it is owned by the resource's own controller,
+		// never by the sync. Merging live `status` into the apply makes the sync
+		// field manager (ArgoCDSSAManager, "argocd-controller") a co-owner of
+		// `status` under server-side apply. For resources without a /status
+		// subresource (e.g. argoproj.io/Application) this freezes a stale
+		// status.operationState.phase that the controller can no longer correct.
+		liveForPatch, normalizedLiveForPatch := live, normalized.Lives[idx]
+		liveForPatch = liveForPatch.DeepCopy()
+		unstructured.RemoveNestedField(liveForPatch.Object, "status")
+
+		if normalizedLiveForPatch != nil {
+			normalizedLiveForPatch = normalizedLiveForPatch.DeepCopy()
+			unstructured.RemoveNestedField(normalizedLiveForPatch.Object, "status")
+		}
+
+		livePatch, err := getMergePatch(normalizedLiveForPatch, liveForPatch, lookupPatchMeta)
 		if err != nil {
 			return nil, err
 		}

--- a/controller/sync_test.go
+++ b/controller/sync_test.go
@@ -399,8 +399,9 @@ func TestNormalizeTargetResources(t *testing.T) {
 		assert.Equal(t, "2.0", iksmVersion)
 	})
 	t.Run("will not copy live status into the apply target", func(t *testing.T) {
-		// given: status is an ignored field (the default ignoreResourceStatusField
-		// behavior) and the live resource has an in-flight operationState.
+		// given: status is configured as an ignored field (equivalent to the
+		// default ignoreResourceStatusField=crd behavior) and the live resource
+		// has an in-flight operationState.
 		ignore := v1alpha1.ResourceIgnoreDifferences{
 			Group:        "*",
 			Kind:         "*",

--- a/controller/sync_test.go
+++ b/controller/sync_test.go
@@ -398,6 +398,30 @@ func TestNormalizeTargetResources(t *testing.T) {
 		iksmVersion := targets[0].GetAnnotations()["iksm-version"]
 		assert.Equal(t, "2.0", iksmVersion)
 	})
+	t.Run("will not copy live status into the apply target", func(t *testing.T) {
+		// given: status is an ignored field (the default ignoreResourceStatusField
+		// behavior) and the live resource has an in-flight operationState.
+		ignore := v1alpha1.ResourceIgnoreDifferences{
+			Group:        "*",
+			Kind:         "*",
+			JSONPointers: []string{"/status"},
+		}
+		f := setup(t, []v1alpha1.ResourceIgnoreDifferences{ignore})
+		live := f.comparisonResult.reconciliationResult.Live[0]
+		require.NoError(t, unstructured.SetNestedField(
+			live.Object, "Running", "status", "operationState", "phase"))
+
+		// when
+		targets, err := normalizeTargetResources(f.comparisonResult)
+
+		// then: live status must not be merged into the target that gets applied,
+		// otherwise the SSA sync manager co-owns and freezes operationState.phase.
+		require.NoError(t, err)
+		require.Len(t, targets, 1)
+		_, found, err := unstructured.NestedMap(targets[0].Object, "status")
+		require.NoError(t, err)
+		assert.False(t, found, "live status must not be merged into the apply target")
+	})
 	t.Run("will not modify target resource if ignore difference is not configured", func(t *testing.T) {
 		// given
 		f := setup(t, []v1alpha1.ResourceIgnoreDifferences{})


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
