### PR TITLE
feat(ui): add Application Namespace field to app create form

### DIFF
--- a/ui/src/app/applications/components/application-create-panel/application-create-panel.scss
+++ b/ui/src/app/applications/components/application-create-panel/application-create-panel.scss
@@ -31,18 +31,6 @@
         margin-top: 0.75em;
     }
 
-    &__ns-hint {
-        margin-top: 0.25em;
-        font-size: 12px;
-        @include themify($themes) {
-            color: themed('text-2');
-        }
-
-        i {
-            margin-right: 4px;
-        }
-    }
-
     &__multi-source-block {
         margin-bottom: 0.5em;
 

--- a/ui/src/app/applications/components/application-create-panel/application-create-panel.scss
+++ b/ui/src/app/applications/components/application-create-panel/application-create-panel.scss
@@ -31,6 +31,18 @@
         margin-top: 0.75em;
     }
 
+    &__ns-hint {
+        margin-top: 0.25em;
+        font-size: 12px;
+        @include themify($themes) {
+            color: themed('text-2');
+        }
+
+        i {
+            margin-right: 4px;
+        }
+    }
+
     &__multi-source-block {
         margin-bottom: 0.5em;
 

--- a/ui/src/app/applications/components/application-create-panel/application-create-panel.tsx
+++ b/ui/src/app/applications/components/application-create-panel/application-create-panel.tsx
@@ -119,6 +119,7 @@ export const ApplicationCreatePanel = (props: {
     const lastOciUrl = React.useRef('');
     const [isHydratorEnabled, setIsHydratorEnabled] = React.useState(!!app.spec.sourceHydrator);
     const [savedSyncSource, setSavedSyncSource] = React.useState(app.spec.sourceHydrator?.syncSource || {targetBranch: '', path: ''});
+    const [selectedProjectDetails, setSelectedProjectDetails] = React.useState<models.Project>(null);
     let destinationComboValue = destinationFieldChanges.destFormat;
     const authSettingsCtx = React.useContext(AuthSettingsCtx);
 
@@ -133,6 +134,18 @@ export const ApplicationCreatePanel = (props: {
             debouncedOnAppChanged.cancel();
         };
     }, [debouncedOnAppChanged]);
+
+    React.useEffect(() => {
+        const projectName = app.spec.project;
+        if (projectName && authSettingsCtx?.appsInAnyNamespaceEnabled) {
+            services.projects
+                .get(projectName)
+                .then(proj => setSelectedProjectDetails(proj))
+                .catch(() => setSelectedProjectDetails(null));
+        } else {
+            setSelectedProjectDetails(null);
+        }
+    }, [app.spec.project, authSettingsCtx?.appsInAnyNamespaceEnabled]);
 
     const currentName = app.spec.destination.name;
     const currentServer = app.spec.destination.server;
@@ -174,6 +187,10 @@ export const ApplicationCreatePanel = (props: {
             delete data.spec.destination.name;
         } else {
             delete data.spec.destination.server;
+        }
+
+        if (!data.metadata.namespace) {
+            delete data.metadata.namespace;
         }
 
         if (data.spec.sourceHydrator && !data.spec.sourceHydrator.hydrateTo?.targetBranch) {
@@ -261,6 +278,30 @@ export const ApplicationCreatePanel = (props: {
                                     const hasHydrator = !!a.spec.sourceHydrator;
                                     const source = a.spec.source;
 
+                                    const appNsError = (() => {
+                                        if (!authSettingsCtx?.appsInAnyNamespaceEnabled || !a.metadata.namespace) {
+                                            return undefined;
+                                        }
+                                        const allowed = selectedProjectDetails?.spec?.sourceNamespaces;
+                                        if (allowed && allowed.length > 0) {
+                                            const ns = a.metadata.namespace;
+                                            const isAllowed = allowed.some(pattern => {
+                                                // support simple glob: exact match or trailing-wildcard prefix match
+                                                if (pattern === '*' || pattern === ns) {
+                                                    return true;
+                                                }
+                                                if (pattern.endsWith('*')) {
+                                                    return ns.startsWith(pattern.slice(0, -1));
+                                                }
+                                                return false;
+                                            });
+                                            if (!isAllowed) {
+                                                return `Namespace "${ns}" is not permitted by project "${a.spec.project}". Allowed: ${allowed.join(', ')}`;
+                                            }
+                                        }
+                                        return undefined;
+                                    })();
+
                                     const destinationErrors = {
                                         'spec.destination.server':
                                             !a.spec.destination.server && (!a.spec.destination.hasOwnProperty('name') || a.spec.destination.name === '')
@@ -275,6 +316,7 @@ export const ApplicationCreatePanel = (props: {
                                     if (multiSourceMode && !hasHydrator) {
                                         const errs: Record<string, string | undefined> = {
                                             'metadata.name': !a.metadata.name ? 'Application Name is required' : undefined,
+                                            'metadata.namespace': appNsError,
                                             'spec.project': !a.spec.project ? 'Project Name is required' : undefined,
                                             ...destinationErrors
                                         };
@@ -291,6 +333,7 @@ export const ApplicationCreatePanel = (props: {
 
                                     return {
                                         'metadata.name': !a.metadata.name ? 'Application Name is required' : undefined,
+                                        'metadata.namespace': appNsError,
                                         'spec.project': !a.spec.project ? 'Project Name is required' : undefined,
                                         'spec.source.repoURL': !hasHydrator && !source?.repoURL ? 'Repository URL is required' : undefined,
                                         'spec.source.targetRevision':
@@ -342,6 +385,27 @@ export const ApplicationCreatePanel = (props: {
                                                     }}
                                                 />
                                             </div>
+                                            {authSettingsCtx?.appsInAnyNamespaceEnabled && (
+                                                <div className='argo-form-row'>
+                                                    <FormField
+                                                        formApi={api}
+                                                        label='Application Namespace'
+                                                        qeId='application-create-field-app-namespace'
+                                                        field='metadata.namespace'
+                                                        component={AutocompleteField}
+                                                        componentProps={{
+                                                            items: selectedProjectDetails?.spec?.sourceNamespaces || [],
+                                                            filterSuggestions: true
+                                                        }}
+                                                    />
+                                                    {selectedProjectDetails?.spec?.sourceNamespaces?.length > 0 && (
+                                                        <p className='application-create-panel__ns-hint'>
+                                                            <i className='fa fa-info-circle' /> Allowed namespaces for project &quot;{formApp.spec.project}&quot;:{' '}
+                                                            {selectedProjectDetails.spec.sourceNamespaces.join(', ')}
+                                                        </p>
+                                                    )}
+                                                </div>
+                                            )}
                                             <div className='argo-form-row'>
                                                 <FormField
                                                     formApi={api}

--- a/ui/src/app/applications/components/application-create-panel/application-create-panel.tsx
+++ b/ui/src/app/applications/components/application-create-panel/application-create-panel.tsx
@@ -394,16 +394,17 @@ export const ApplicationCreatePanel = (props: {
                                                         field='metadata.namespace'
                                                         component={AutocompleteField}
                                                         componentProps={{
-                                                            items: selectedProjectDetails?.spec?.sourceNamespaces || [],
+                                                            items: (() => {
+                                                                const sourceNamespaces = selectedProjectDetails?.spec?.sourceNamespaces || [];
+                                                                // Don't show dropdown list for wildcard permissions
+                                                                if (sourceNamespaces.length === 1 && sourceNamespaces[0] === '*') {
+                                                                    return [];
+                                                                }
+                                                                return sourceNamespaces;
+                                                            })(),
                                                             filterSuggestions: true
                                                         }}
                                                     />
-                                                    {selectedProjectDetails?.spec?.sourceNamespaces?.length > 0 && (
-                                                        <p className='application-create-panel__ns-hint'>
-                                                            <i className='fa fa-info-circle' /> Allowed namespaces for project &quot;{formApp.spec.project}&quot;:{' '}
-                                                            {selectedProjectDetails.spec.sourceNamespaces.join(', ')}
-                                                        </p>
-                                                    )}
                                                 </div>
                                             )}
                                             <div className='argo-form-row'>


### PR DESCRIPTION
## Summary

Adds an optional **Application Namespace** field to the application create form, so users no longer need to use "Edit as YAML" to set `metadata.namespace` on the Application CR.

Addresses #21776

## Changes

- **`application-create-panel.tsx`**
  - New `selectedProjectDetails` state to hold the fetched AppProject
  - `useEffect` that calls `services.projects.get()` whenever the selected project changes (only when `appsInAnyNamespaceEnabled` is true)
  - New **Application Namespace** `AutocompleteField` in the General panel, gated on `appsInAnyNamespaceEnabled`; pre-populates suggestions from `spec.sourceNamespaces` of the selected project
  - Hint text below the field: _"Allowed namespaces for project X: ..."_ when `sourceNamespaces` is set
  - Client-side validation in `validateError` that warns when the entered namespace doesn't match the project's `sourceNamespaces` patterns
  - `onCreateApp` strips an empty `metadata.namespace` before submission, preserving existing single-namespace behaviour

- **`application-create-panel.scss`**
  - `__ns-hint` modifier style for the hint paragraph

## Behaviour

| Scenario | Result |
|---|---|
| `appsInAnyNamespaceEnabled` is false (default install) | Field is hidden; no change to existing behaviour |
| `appsInAnyNamespaceEnabled` is true, field left empty | `metadata.namespace` omitted; server defaults to Argo CD install namespace |
| `appsInAnyNamespaceEnabled` is true, project has `sourceNamespaces` | Dropdown suggests allowed namespaces; hint lists them |
| User types a namespace not in `sourceNamespaces` | Inline validation error shown before submission |

## Testing

Tested via `pnpm run lint` (TypeScript type-check passes with zero errors).

Manual verification requires a multi-namespace Argo CD install with `--application-namespaces` set.