### PR TITLE
fix: auto-sync skipped when newer commit arrives during sync with manifest-generate-paths (#27875)

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -1895,7 +1895,13 @@ func (ctrl *ApplicationController) processAppRefreshQueueItem() (processNext boo
 
 	canSync, _ := project.Spec.SyncWindows.Matches(app).CanSync(false, nil)
 	if canSync {
-		syncErrCond, opDuration := ctrl.autoSync(app, compareResult.syncStatus, compareResult.resources, compareResult.revisionsMayHaveChanges)
+		// The manifest-generate-paths optimization can report no changes for a newer commit that
+		// arrives while the app is still syncing, which would skip auto-sync and leave the app
+		// stuck OutOfSync. Only use it to avoid regenerating manifests, never to gate the sync
+		// decision: when the app is OutOfSync, always let autoSync compare the desired revision
+		// against the last synced one (#27875).
+		shouldCompareRevisions := compareResult.revisionsMayHaveChanges || compareResult.syncStatus.Status == appv1.SyncStatusCodeOutOfSync
+		syncErrCond, opDuration := ctrl.autoSync(app, compareResult.syncStatus, compareResult.resources, shouldCompareRevisions)
 		setOpDuration = opDuration
 		if syncErrCond != nil {
 			app.Status.SetConditions(

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -735,6 +735,51 @@ func TestAutoSyncMultiSourceWithoutSelfHeal(t *testing.T) {
 	})
 }
 
+func TestAutoSyncManifestGeneratePathsNewCommit(t *testing.T) {
+	// Regression for #27875: with the manifest-generate-paths annotation, an app must still
+	// auto-sync to a newer commit while it is OutOfSync, and must not sync when it is already
+	// synced to that revision.
+	revA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	revB := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+	t.Run("NewCommitTriggersAutoSync", func(t *testing.T) {
+		app := newFakeApp()
+		app.Annotations = map[string]string{v1alpha1.AnnotationKeyManifestGeneratePaths: "."}
+		app.Spec.SyncPolicy.Automated.SelfHeal = new(false)
+		app.Status.OperationState.SyncResult.Revision = revA
+		ctrl := newFakeController(t.Context(), &fakeData{apps: []runtime.Object{app}}, nil)
+		syncStatus := v1alpha1.SyncStatus{
+			Status:   v1alpha1.SyncStatusCodeOutOfSync,
+			Revision: revB,
+		}
+		cond, _ := ctrl.autoSync(app, &syncStatus, []v1alpha1.ResourceStatus{{Name: "guestbook", Kind: kube.DeploymentKind, Status: v1alpha1.SyncStatusCodeOutOfSync}}, syncStatus.Status == v1alpha1.SyncStatusCodeOutOfSync)
+		assert.Nil(t, cond)
+		app, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(test.FakeArgoCDNamespace).Get(t.Context(), "my-app", metav1.GetOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, app.Operation)
+		require.NotNil(t, app.Operation.Sync)
+		assert.Equal(t, revB, app.Operation.Sync.Revision)
+		assert.Empty(t, app.Operation.Sync.Resources)
+	})
+
+	t.Run("SameRevisionDriftDoesNotTriggerAutoSync", func(t *testing.T) {
+		app := newFakeApp()
+		app.Annotations = map[string]string{v1alpha1.AnnotationKeyManifestGeneratePaths: "."}
+		app.Spec.SyncPolicy.Automated.SelfHeal = new(false)
+		app.Status.OperationState.SyncResult.Revision = revB
+		ctrl := newFakeController(t.Context(), &fakeData{apps: []runtime.Object{app}}, nil)
+		syncStatus := v1alpha1.SyncStatus{
+			Status:   v1alpha1.SyncStatusCodeOutOfSync,
+			Revision: revB,
+		}
+		cond, _ := ctrl.autoSync(app, &syncStatus, []v1alpha1.ResourceStatus{{Name: "guestbook", Kind: kube.DeploymentKind, Status: v1alpha1.SyncStatusCodeOutOfSync}}, syncStatus.Status == v1alpha1.SyncStatusCodeOutOfSync)
+		assert.Nil(t, cond)
+		app, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(test.FakeArgoCDNamespace).Get(t.Context(), "my-app", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Nil(t, app.Operation)
+	})
+}
+
 func TestAutoSyncNotAllowEmpty(t *testing.T) {
 	app := newFakeApp()
 	app.Spec.SyncPolicy.Automated.Prune = new(true)


### PR DESCRIPTION
Closes #27875

### What

Applications with an automated sync policy and the
`argocd.argoproj.io/manifest-generate-paths` annotation can stop auto-syncing
when a new commit lands while a sync is already in progress. The application
reports OutOfSync but never syncs, and stays stuck until a manual sync or an
application-controller restart.

### Why

With the annotation set, the controller uses the manifest-generate-paths
optimization (`revisionsMayHaveChanges`) to decide whether to compare revisions
before auto-syncing. If a newer commit B arrives while the app is still synced
to A, `UpdateRevisionForPaths` can report no changes, so `revisionsMayHaveChanges`
is false. `autoSync` then skips the revision comparison and treats the sync as
already attempted, even though the app is OutOfSync against B. Without selfHeal
nothing recovers it.

The optimization exists to avoid regenerating manifests when only irrelevant
paths change. It should not gate the sync decision itself.

### How

At the `autoSync` call site, also compare revisions whenever the app is OutOfSync:

    shouldCompareRevisions := compareResult.revisionsMayHaveChanges ||
        compareResult.syncStatus.Status == appv1.SyncStatusCodeOutOfSync

The optimization still avoids manifest regeneration, but it can no longer skip a
needed sync. Apps already synced to the target revision are unaffected, and
selfHeal:false apps are still not force-healed for drift at the same revision
(related #26769).

### Testing

Added `TestAutoSyncManifestGeneratePathsNewCommit` covering the new-commit case
(auto-sync triggers) and the same-revision drift case (no auto-sync with selfHeal
disabled).

Also verified on a live cluster: an app with the annotation, automated sync and
no selfHeal auto-synced to a new in-path commit within 20s, while an off-path
commit was correctly skipped.

---

Checklist:

* [x] This is a bug fix.
* [x] The title states what changed and the related issue number.
* [x] The title conforms to the PR title guidelines.
* [x] I've included "Closes #27875" in the description.
* [ ] CLI/UI changes: not applicable.
* [x] Does this PR require documentation updates? No.
* [x] I have signed off all my commits (DCO).
* [x] I have written unit tests for my change.
* [x] My build is green.
* [x] I've described why this PR is necessary and what it solves.
* [x] For bug fixes, this should be cherry-picked into release-3.4 (the regression is present in 3.4.x).
