### PR TITLE
test: add t.Parallel() to health and lua health tests

### DIFF
--- a/gitops-engine/pkg/health/health_test.go
+++ b/gitops-engine/pkg/health/health_test.go
@@ -34,6 +34,7 @@ func getHealthStatus(t *testing.T, yamlPath string) *HealthStatus {
 }
 
 func TestDeploymentHealth(t *testing.T) {
+	t.Parallel()
 	assertAppHealth(t, "../utils/kube/testdata/nginx.yaml", HealthStatusHealthy)
 	assertAppHealth(t, "./testdata/deployment-progressing.yaml", HealthStatusProgressing)
 	assertAppHealth(t, "./testdata/deployment-suspended.yaml", HealthStatusSuspended)
@@ -41,23 +42,28 @@ func TestDeploymentHealth(t *testing.T) {
 }
 
 func TestStatefulSetHealth(t *testing.T) {
+	t.Parallel()
 	assertAppHealth(t, "./testdata/statefulset.yaml", HealthStatusHealthy)
 }
 
 func TestStatefulSetOnDeleteHealth(t *testing.T) {
+	t.Parallel()
 	assertAppHealth(t, "./testdata/statefulset-ondelete.yaml", HealthStatusHealthy)
 }
 
 func TestDaemonSetOnDeleteHealth(t *testing.T) {
+	t.Parallel()
 	assertAppHealth(t, "./testdata/daemonset-ondelete.yaml", HealthStatusHealthy)
 }
 
 func TestPVCHealth(t *testing.T) {
+	t.Parallel()
 	assertAppHealth(t, "./testdata/pvc-bound.yaml", HealthStatusHealthy)
 	assertAppHealth(t, "./testdata/pvc-pending.yaml", HealthStatusProgressing)
 }
 
 func TestServiceHealth(t *testing.T) {
+	t.Parallel()
 	assertAppHealth(t, "./testdata/svc-clusterip.yaml", HealthStatusHealthy)
 	assertAppHealth(t, "./testdata/svc-loadbalancer.yaml", HealthStatusHealthy)
 	assertAppHealth(t, "./testdata/svc-loadbalancer-unassigned.yaml", HealthStatusProgressing)
@@ -65,16 +71,19 @@ func TestServiceHealth(t *testing.T) {
 }
 
 func TestIngressHealth(t *testing.T) {
+	t.Parallel()
 	assertAppHealth(t, "./testdata/ingress.yaml", HealthStatusHealthy)
 	assertAppHealth(t, "./testdata/ingress-unassigned.yaml", HealthStatusProgressing)
 	assertAppHealth(t, "./testdata/ingress-nonemptylist.yaml", HealthStatusHealthy)
 }
 
 func TestCRD(t *testing.T) {
+	t.Parallel()
 	assert.Nil(t, getHealthStatus(t, "./testdata/knative-service.yaml"))
 }
 
 func TestJob(t *testing.T) {
+	t.Parallel()
 	assertAppHealth(t, "./testdata/job-running.yaml", HealthStatusProgressing)
 	assertAppHealth(t, "./testdata/job-failed.yaml", HealthStatusDegraded)
 	assertAppHealth(t, "./testdata/job-succeeded.yaml", HealthStatusHealthy)
@@ -82,6 +91,7 @@ func TestJob(t *testing.T) {
 }
 
 func TestHPA(t *testing.T) {
+	t.Parallel()
 	assertAppHealth(t, "./testdata/hpa-v2-healthy.yaml", HealthStatusHealthy)
 	assertAppHealth(t, "./testdata/hpa-v2-degraded.yaml", HealthStatusDegraded)
 	assertAppHealth(t, "./testdata/hpa-v2-progressing.yaml", HealthStatusProgressing)
@@ -94,6 +104,7 @@ func TestHPA(t *testing.T) {
 }
 
 func TestPod(t *testing.T) {
+	t.Parallel()
 	assertAppHealth(t, "./testdata/pod-pending.yaml", HealthStatusProgressing)
 	assertAppHealth(t, "./testdata/pod-running-not-ready.yaml", HealthStatusProgressing)
 	assertAppHealth(t, "./testdata/pod-crashloop.yaml", HealthStatusDegraded)
@@ -108,11 +119,13 @@ func TestPod(t *testing.T) {
 }
 
 func TestApplication(t *testing.T) {
+	t.Parallel()
 	assert.Nil(t, getHealthStatus(t, "./testdata/application-healthy.yaml"))
 	assert.Nil(t, getHealthStatus(t, "./testdata/application-degraded.yaml"))
 }
 
 func TestAPIService(t *testing.T) {
+	t.Parallel()
 	assertAppHealth(t, "./testdata/apiservice-v1-true.yaml", HealthStatusHealthy)
 	assertAppHealth(t, "./testdata/apiservice-v1-false.yaml", HealthStatusProgressing)
 	assertAppHealth(t, "./testdata/apiservice-v1beta1-true.yaml", HealthStatusHealthy)
@@ -120,6 +133,7 @@ func TestAPIService(t *testing.T) {
 }
 
 func TestGetArgoWorkflowHealth(t *testing.T) {
+	t.Parallel()
 	sampleWorkflow := unstructured.Unstructured{
 		Object: map[string]any{
 			"spec": map[string]any{

--- a/util/lua/health_test.go
+++ b/util/lua/health_test.go
@@ -1,9 +1,11 @@
 package lua
 
 import (
+	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
+	"sort"
 	"testing"
 
 	"github.com/argoproj/argo-cd/gitops-engine/pkg/health"
@@ -22,44 +24,76 @@ type IndividualTest struct {
 	HealthStatus health.HealthStatus `yaml:"healthStatus"`
 }
 
-func getObj(t *testing.T, path string) *unstructured.Unstructured {
-	t.Helper()
-	yamlBytes, err := os.ReadFile(path)
-	require.NoError(t, err)
-	obj := make(map[string]any)
-	err = yaml.Unmarshal(yamlBytes, &obj)
-	require.NoError(t, err)
+type healthTestCase struct {
+	name      string
+	inputPath string
+	expected  health.HealthStatus
+}
 
+func parseObj(t *testing.T, yamlBytes []byte) *unstructured.Unstructured {
+	t.Helper()
+	obj := make(map[string]any)
+	err := yaml.Unmarshal(yamlBytes, &obj)
+	require.NoError(t, err)
 	return &unstructured.Unstructured{Object: obj}
 }
 
-func TestLuaHealthScript(t *testing.T) {
-	err := filepath.Walk("../../resource_customizations", func(path string, _ os.FileInfo, err error) error {
-		if !strings.Contains(path, "health.lua") {
+func collectHealthTestCases(t *testing.T) []healthTestCase {
+	t.Helper()
+	var cases []healthTestCase
+	err := filepath.WalkDir("../../resource_customizations", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Base(path) != "health.lua" {
 			return nil
 		}
-		require.NoError(t, err)
 		dir := filepath.Dir(path)
-		yamlBytes, err := os.ReadFile(dir + "/health_test.yaml")
-		require.NoError(t, err)
+		testYAMLPath := filepath.Join(dir, "health_test.yaml")
+		yamlBytes, err := os.ReadFile(testYAMLPath)
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", testYAMLPath, err)
+		}
 		var resourceTest TestStructure
-		err = yaml.Unmarshal(yamlBytes, &resourceTest)
-		require.NoError(t, err)
-		for i := range resourceTest.Tests {
-			test := resourceTest.Tests[i]
-			t.Run(filepath.Join(strings.TrimPrefix(dir, "../../resource_customizations/"), test.InputPath), func(t *testing.T) {
-				vm := VM{
-					UseOpenLibs: true,
-				}
-				obj := getObj(t, filepath.Join(dir, test.InputPath))
-				script, _, err := vm.GetHealthScript(obj)
-				require.NoError(t, err)
-				result, err := vm.ExecuteHealthLua(obj, script)
-				require.NoError(t, err)
-				assert.Equal(t, &test.HealthStatus, result)
+		if err := yaml.Unmarshal(yamlBytes, &resourceTest); err != nil {
+			return fmt.Errorf("parsing %s: %w", testYAMLPath, err)
+		}
+		resourcePrefix, err := filepath.Rel("../../resource_customizations", dir)
+		if err != nil {
+			return fmt.Errorf("computing prefix from %s: %w", dir, err)
+		}
+		for _, test := range resourceTest.Tests {
+			cases = append(cases, healthTestCase{
+				name:      filepath.ToSlash(filepath.Join(resourcePrefix, test.InputPath)),
+				inputPath: filepath.Join(dir, test.InputPath),
+				expected:  test.HealthStatus,
 			})
 		}
 		return nil
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
+	sort.Slice(cases, func(i, j int) bool { return cases[i].name < cases[j].name })
+	return cases
+}
+
+func TestLuaHealthScript(t *testing.T) {
+	cases := collectHealthTestCases(t)
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			yamlBytes, err := os.ReadFile(tc.inputPath)
+			require.NoError(t, err)
+			obj := parseObj(t, yamlBytes)
+			vm := VM{
+				UseOpenLibs: true,
+			}
+			script, _, err := vm.GetHealthScript(obj)
+			require.NoError(t, err)
+			result, err := vm.ExecuteHealthLua(obj, script)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.Equal(t, tc.expected, *result)
+		})
+	}
 }

--- a/util/lua/health_test.go
+++ b/util/lua/health_test.go
@@ -38,6 +38,15 @@ func parseObj(t *testing.T, yamlBytes []byte) *unstructured.Unstructured {
 	return &unstructured.Unstructured{Object: obj}
 }
 
+// getObj reads a YAML file and returns an unstructured object.
+// Deprecated: Use parseObj with pre-read bytes instead, to support parallel subtests.
+func getObj(t *testing.T, path string) *unstructured.Unstructured {
+	t.Helper()
+	yamlBytes, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return parseObj(t, yamlBytes)
+}
+
 func collectHealthTestCases(t *testing.T) []healthTestCase {
 	t.Helper()
 	var cases []healthTestCase


### PR DESCRIPTION
Splits the health and lua test changes from #28177 into a separate PR for focused review.

Adds t.Parallel() to individual test functions in gitops-engine/pkg/health/health_test.go and refactors util/lua/health_test.go to collect testdata sequentially before running parallel subtests, avoiding filesystem contention.

Signed-off-by: Lohit Kolluri <lohitkolluri@gmail.com>