### PR TITLE
docs(hydrator): promote Source Hydrator from alpha to beta

### DIFF
--- a/docs/operator-manual/argocd-cmd-params-cm.yaml
+++ b/docs/operator-manual/argocd-cmd-params-cm.yaml
@@ -19,7 +19,7 @@ data:
   # Redis database
   redis.db:
 
-  # Enables the alpha "manifest hydrator" feature. (default "false")
+  # Enables the beta "manifest hydrator" feature. (default "false")
   hydrator.enabled: "false"
 
   # Open-Telemetry collector address: (e.g. "otel-collector:4317")

--- a/docs/operator-manual/feature-maturity.md
+++ b/docs/operator-manual/feature-maturity.md
@@ -24,7 +24,7 @@ to indicate their stability and maturity. These are the statuses of non-stable f
 | [Dynamic Cluster Distribution][7]         | v2.9.0     | Alpha  |
 | [Cluster Sharding: consistent-hashing][9] | v2.12.0    | Alpha  |
 | [Service Account Impersonation][10]       | v2.13.0    | Beta   |
-| [Source Hydrator][11]                     | v2.14.0    | Alpha  |
+| [Source Hydrator][11]                     | v2.14.0    | Beta   |
 | [ApplicationSet Web UI][12]               | v3.5.0     | Alpha  |
 
 ## Unstable Configurations
@@ -34,6 +34,7 @@ to indicate their stability and maturity. These are the statuses of non-stable f
 | Feature                         | Property                                                                                | Status |
 | ------------------------------- | --------------------------------------------------------------------------------------- | ------ |
 | [Skip Application Reconcile][4] | `metadata.annotations[argocd.argoproj.io/skip-reconcile]`                               | Alpha  |
+| [Source Hydrator][11]           | `spec.sourceHydrator.*`                                                                 | Beta   |
 
 ### AppProject CRD
 
@@ -64,6 +65,9 @@ to indicate their stability and maturity. These are the statuses of non-stable f
 | [Cluster Sharding: consistent-hashing][9] | `ConfigMap/argocd-cmd-params-cm`              | `controller.sharding.algorithm: consistent-hashing`         | Alpha  |
 | [Cluster Sharding: consistent-hashing][9] | `StatefulSet/argocd-application-controller`   | `ARGOCD_CONTROLLER_SHARDING_ALGORITHM=consistent-hashing`   | Alpha  |
 | [Service Account Impersonation][10]       | `ConfigMap/argocd-cm`                         | `application.sync.impersonation.enabled`                    | Beta   |
+| [Source Hydrator][11]                     | `ConfigMap/argocd-cmd-params-cm`              | `hydrator.enabled`                                          | Beta   |
+| [Source Hydrator][11]                     | `Deployment/argocd-application-controller`    | `ARGOCD_HYDRATOR_ENABLED`                                   | Beta   |
+| [Source Hydrator][11]                     | `Deployment/argocd-server`                    | `ARGOCD_HYDRATOR_ENABLED`                                   | Beta   |
 
 [2]: applicationset/Progressive-Syncs.md
 [3]: ../developer-guide/extensions/proxy-extensions.md

--- a/docs/user-guide/source-hydrator.md
+++ b/docs/user-guide/source-hydrator.md
@@ -1,6 +1,10 @@
 # Source Hydrator
 
-**Current feature state**: Alpha
+> [!WARNING]
+> **Beta Feature (Since v3.5.0)**
+>
+> This is a [beta-quality](https://github.com/argoproj/argoproj/blob/main/community/feature-status.md#beta)
+> feature that pushes hydrated manifests to git before syncing them to the cluster.
 
 Tools like Helm and Kustomize allow users to express their Kubernetes manifests in a more concise and reusable way
 (keeping it DRY - Don't Repeat Yourself). However, these tools can obscure the actual Kubernetes manifests that are

--- a/ui/src/app/settings/components/repos-list/repos-list.tsx
+++ b/ui/src/app/settings/components/repos-list/repos-list.tsx
@@ -1184,9 +1184,9 @@ export const ReposList = ({match, location}: RouteComponentProps) => {
                                             <div className='white-box'>
                                                 <p>SAVE AS WRITE CREDENTIAL (BETA)</p>
                                                 <p>
-                                                    The Source Hydrator is a Beta feature which enables Applications to push hydrated manifests to git before syncing. To use
-                                                    Source Hydrator for a repository, you must save two credentials: a read credential for pulling manifests and a write credential
-                                                    for pushing hydrated manifests. If you add a write credential for a repository, then{' '}
+                                                    The Source Hydrator is a Beta feature which enables Applications to push hydrated manifests to git before syncing. To use Source
+                                                    Hydrator for a repository, you must save two credentials: a read credential for pulling manifests and a write credential for
+                                                    pushing hydrated manifests. If you add a write credential for a repository, then{' '}
                                                     <strong>any Application that can sync from the repo can also push hydrated manifests to that repo.</strong> Do not use this
                                                     feature until you've read its documentation and understand the security implications.
                                                 </p>

--- a/ui/src/app/settings/components/repos-list/repos-list.tsx
+++ b/ui/src/app/settings/components/repos-list/repos-list.tsx
@@ -1182,9 +1182,9 @@ export const ReposList = ({match, location}: RouteComponentProps) => {
                                     <form onSubmit={formApi.submitForm} role='form' className='repos-list width-control'>
                                         {authSettings?.hydratorEnabled && (
                                             <div className='white-box'>
-                                                <p>SAVE AS WRITE CREDENTIAL (ALPHA)</p>
+                                                <p>SAVE AS WRITE CREDENTIAL (BETA)</p>
                                                 <p>
-                                                    The Source Hydrator is an Alpha feature which enables Applications to push hydrated manifests to git before syncing. To use
+                                                    The Source Hydrator is a Beta feature which enables Applications to push hydrated manifests to git before syncing. To use
                                                     Source Hydrator for a repository, you must save two credentials: a read credential for pulling manifests and a write credential
                                                     for pushing hydrated manifests. If you add a write credential for a repository, then{' '}
                                                     <strong>any Application that can sync from the repo can also push hydrated manifests to that repo.</strong> Do not use this


### PR DESCRIPTION
## Summary

- Promote Source Hydrator from Alpha to Beta in feature maturity documentation
- Update user guide with beta feature status admonition (since v3.5.0)
- Update repository write credential UI labels from Alpha to Beta
- Update `hydrator.enabled` cmd-params comment to reflect beta status

Closes #28143