### PR TITLE
fix(ui): pretty print JSON annotations in application summary

### DIFF
--- a/ui/src/app/applications/components/application-summary/application-summary.tsx
+++ b/ui/src/app/applications/components/application-summary/application-summary.tsx
@@ -60,6 +60,20 @@ function processPath(path: string) {
     return '';
 }
 
+function formatAnnotationValue(value: string) {
+    const trimmed = value.trim();
+
+    try {
+        if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+            return JSON.stringify(JSON.parse(trimmed), null, 2);
+        }
+    } catch {
+        // Ignore invalid JSON and return original value
+    }
+
+    return value;
+}
+
 export interface ApplicationSummaryProps {
     app: models.Application;
     updateApp: (app: models.Application, query: {validate?: boolean}) => Promise<any>;
@@ -112,9 +126,11 @@ export const ApplicationSummary = (props: ApplicationSummaryProps) => {
             title: 'ANNOTATIONS',
             view: (
                 <Expandable height={48}>
-                    {Object.keys(app.metadata.annotations || {})
-                        .map(annotation => `${annotation}=${app.metadata.annotations[annotation]}`)
-                        .join(' ')}
+                    <pre style={{whiteSpace: 'pre-wrap', margin: 0}}>
+                        {Object.keys(app.metadata.annotations || {})
+                            .map(annotation => `${annotation}=${formatAnnotationValue(app.metadata.annotations[annotation])}`)
+                            .join('\n\n')}
+                    </pre>
                 </Expandable>
             ),
             edit: (formApi: FormApi) => <EditAnnotations formApi={formApi} app={app} />


### PR DESCRIPTION
Fixes #27836

## What does this PR do?

Annotations in the Application Summary view are currently rendered as plain strings, which makes JSON annotation values difficult to read.

This PR adds formatting for annotation values that contain valid JSON objects or arrays. When a valid JSON value is detected, it is pretty-printed with indentation to improve readability. Non-JSON annotation values continue to be rendered unchanged.

The annotations section is rendered inside a `<pre>` element to preserve indentation and line breaks while remaining within the existing expandable view.

## Testing

* Ran `pnpm lint`
* Ran `pnpm build`

Checklist:

* [x] Either (a) I've created an enhancement proposal and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the Title of the PR.
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by DCO.
* [ ] I have written unit and/or e2e tests for my change.
* [x] My build is green.
* [ ] My new feature complies with the feature status guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).
