### PR TITLE
fix(server): make server.glob.cache.size optional (#28242)

### DIFF
--- a/manifests/base/server/argocd-server-deployment.yaml
+++ b/manifests/base/server/argocd-server-deployment.yaml
@@ -321,6 +321,7 @@ spec:
                 configMapKeyRef:
                   name: argocd-cmd-params-cm
                   key: server.glob.cache.size
+                  optional: true
             - name: ARGOCD_SERVER_WEBHOOK_REFRESH_WORKERS
               valueFrom:
                 configMapKeyRef:

--- a/manifests/ha/install-with-hydrator.yaml
+++ b/manifests/ha/install-with-hydrator.yaml
@@ -34212,6 +34212,7 @@ spec:
             configMapKeyRef:
               key: server.glob.cache.size
               name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_SERVER_WEBHOOK_REFRESH_WORKERS
           valueFrom:
             configMapKeyRef:

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -34042,6 +34042,7 @@ spec:
             configMapKeyRef:
               key: server.glob.cache.size
               name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_SERVER_WEBHOOK_REFRESH_WORKERS
           valueFrom:
             configMapKeyRef:

--- a/manifests/ha/namespace-install-with-hydrator.yaml
+++ b/manifests/ha/namespace-install-with-hydrator.yaml
@@ -3310,6 +3310,7 @@ spec:
             configMapKeyRef:
               key: server.glob.cache.size
               name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_SERVER_WEBHOOK_REFRESH_WORKERS
           valueFrom:
             configMapKeyRef:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -3140,6 +3140,7 @@ spec:
             configMapKeyRef:
               key: server.glob.cache.size
               name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_SERVER_WEBHOOK_REFRESH_WORKERS
           valueFrom:
             configMapKeyRef:

--- a/manifests/install-with-hydrator.yaml
+++ b/manifests/install-with-hydrator.yaml
@@ -33180,6 +33180,7 @@ spec:
             configMapKeyRef:
               key: server.glob.cache.size
               name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_SERVER_WEBHOOK_REFRESH_WORKERS
           valueFrom:
             configMapKeyRef:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -33008,6 +33008,7 @@ spec:
             configMapKeyRef:
               key: server.glob.cache.size
               name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_SERVER_WEBHOOK_REFRESH_WORKERS
           valueFrom:
             configMapKeyRef:

--- a/manifests/namespace-install-with-hydrator.yaml
+++ b/manifests/namespace-install-with-hydrator.yaml
@@ -2278,6 +2278,7 @@ spec:
             configMapKeyRef:
               key: server.glob.cache.size
               name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_SERVER_WEBHOOK_REFRESH_WORKERS
           valueFrom:
             configMapKeyRef:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -2106,6 +2106,7 @@ spec:
             configMapKeyRef:
               key: server.glob.cache.size
               name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_SERVER_WEBHOOK_REFRESH_WORKERS
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
`server.glob.cache.size` falls back to 10000 if not set.

This aligns with other fields from argocd-cmd-params-cm.