### PR TITLE
fix(health): treat nil return from Lua health status script as n/a instead of unknown

### DIFF
--- a/util/lua/health_test.go
+++ b/util/lua/health_test.go
@@ -18,8 +18,8 @@ type TestStructure struct {
 }
 
 type IndividualTest struct {
-	InputPath    string              `yaml:"inputPath"`
-	HealthStatus health.HealthStatus `yaml:"healthStatus"`
+	InputPath    string               `yaml:"inputPath"`
+	HealthStatus *health.HealthStatus `yaml:"healthStatus"`
 }
 
 func getObj(t *testing.T, path string) *unstructured.Unstructured {
@@ -56,7 +56,7 @@ func TestLuaHealthScript(t *testing.T) {
 				require.NoError(t, err)
 				result, err := vm.ExecuteHealthLua(obj, script)
 				require.NoError(t, err)
-				assert.Equal(t, &test.HealthStatus, result)
+				assert.Equal(t, test.HealthStatus, result)
 			})
 		}
 		return nil

--- a/util/lua/lua.go
+++ b/util/lua/lua.go
@@ -159,7 +159,7 @@ func (vm VM) ExecuteHealthLua(obj *unstructured.Unstructured, script string) (*h
 
 		return healthStatus, nil
 	} else if returnValue.Type() == lua.LTNil {
-		return &health.HealthStatus{}, nil
+		return nil, nil
 	}
 	return nil, fmt.Errorf(incorrectReturnType, "table", returnValue.Type().String())
 }

--- a/util/lua/lua_test.go
+++ b/util/lua/lua_test.go
@@ -154,8 +154,7 @@ func TestNoReturnHealthStatusStatus(t *testing.T) {
 	vm := VM{}
 	status, err := vm.ExecuteHealthLua(testObj, validReturnNothingHealthStatusStatus)
 	require.NoError(t, err)
-	expectedStatus := &health.HealthStatus{}
-	assert.Equal(t, expectedStatus, status)
+	assert.Nil(t, status)
 }
 
 const validNilHealthStatusStatus = `local healthStatus = {}
@@ -168,8 +167,7 @@ func TestNilHealthStatusStatus(t *testing.T) {
 	vm := VM{}
 	status, err := vm.ExecuteHealthLua(testObj, validNilHealthStatusStatus)
 	require.NoError(t, err)
-	expectedStatus := &health.HealthStatus{}
-	assert.Equal(t, expectedStatus, status)
+	assert.Nil(t, status)
 }
 
 const validEmptyArrayHealthStatusStatus = `local healthStatus = {}


### PR DESCRIPTION
Custom Lua health check scripts currently have no way to indicate that no health status should apply to a resource. This is extremely useful for generic health checks covering multiple resources in an API group, where some resources shouldn't report a health status at all.

**Actual behavior**
`return nil` from a Lua health check script results in the resource's health status being reported as `Unknown`.

**Expected behavior**
`return nil`  should result in the health status being absent, i.e., equivalent to there being no health check defined for the object.

Note: As far as I've checked, none of the currently built-in health check scripts would be affected by this change.

---

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
