### PR TITLE
fix(cli): print clear timeout message when argocd app wait times out

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -1645,7 +1645,12 @@ func NewApplicationWaitCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 					appName = appNamespace + "/" + appName
 				}
 				_, _, err := waitOnApplicationStatus(ctx, acdClient, appName, timeout, watch, selectedResources, output)
-				errors.CheckError(err)
+				if err != nil {
+					if isContextCanceledErr(err) {
+						log.Fatalf("timed out (%ds) waiting for app %q to match the expected conditions", timeout, appName)
+					}
+					errors.CheckError(err)
+				}
 			}
 		},
 	}
@@ -2370,7 +2375,7 @@ func waitOnApplicationStatus(ctx context.Context, acdClient argocdclient.Client,
 
 	printFinalStatus := func(app *argoappv1.Application) *argoappv1.Application {
 		var err error
-		if refresh {
+		if refresh && ctx.Err() == nil {
 			conn, appClient := acdClient.NewApplicationClientOrDie()
 			refreshType := string(argoappv1.RefreshTypeNormal)
 			app, err = appClient.Get(ctx, &application.ApplicationQuery{
@@ -2530,6 +2535,21 @@ func waitOnApplicationStatus(ctx context.Context, acdClient argocdclient.Client,
 	}
 	_ = printFinalStatus(appWithLock.GetApp())
 	return nil, finalOperationState, fmt.Errorf("timed out (%ds) waiting for app %q match desired state", timeout, appName)
+}
+
+// isContextCanceledErr returns true if the error is a context cancellation or deadline exceeded,
+// either as a stdlib error or wrapped in a gRPC status error.
+func isContextCanceledErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if stderrors.Is(err, context.Canceled) || stderrors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	if st, ok := status.FromError(err); ok {
+		return st.Code() == codes.Canceled || st.Code() == codes.DeadlineExceeded
+	}
+	return false
 }
 
 // setParameterOverrides updates an existing or appends a new parameter override in the application

--- a/cmd/argocd/commands/app_test.go
+++ b/cmd/argocd/commands/app_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 	"google.golang.org/grpc"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -2694,4 +2696,40 @@ func (c *fakeAcdClient) WatchApplicationSetWithRetry(_ context.Context, _ string
 		appSetEventsCh <- addedEvent
 	}()
 	return appSetEventsCh
+}
+
+func TestIsContextCanceledErr(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil error returns false", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, isContextCanceledErr(nil))
+	})
+
+	t.Run("context.Canceled returns true", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, isContextCanceledErr(context.Canceled))
+	})
+
+	t.Run("context.DeadlineExceeded returns true", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, isContextCanceledErr(context.DeadlineExceeded))
+	})
+
+	t.Run("gRPC Canceled status returns true", func(t *testing.T) {
+		t.Parallel()
+		grpcErr := grpcstatus.Error(grpccodes.Canceled, "context canceled")
+		assert.True(t, isContextCanceledErr(grpcErr))
+	})
+
+	t.Run("gRPC DeadlineExceeded status returns true", func(t *testing.T) {
+		t.Parallel()
+		grpcErr := grpcstatus.Error(grpccodes.DeadlineExceeded, "deadline exceeded")
+		assert.True(t, isContextCanceledErr(grpcErr))
+	})
+
+	t.Run("unrelated error returns false", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, isContextCanceledErr(errors.New("some other error")))
+	})
 }


### PR DESCRIPTION
## Summary

When `argocd app wait --timeout N` exceeds its limit, a context cancellation propagates through the gRPC stream and can surface as:

```
level=fatal msg="rpc error: code = Canceled desc = context canceled"
```

This is confusing — users don't know if the command timed out or something else went wrong.

Fixes #14705

## Root Cause

Two issues:

1. **Race condition in `printFinalStatus`**: The AfterFunc timeout handler sets `refresh = false` before calling `cancel()`, but the watch loop can set `refresh = true` concurrently. When the context is then canceled and `printFinalStatus` runs, it attempts `appClient.Get(ctx, ...)` with an already-canceled context → crashes with `context canceled` before the clean timeout error can be returned.

2. **No fallback message for context-canceled errors at the call site**: Even without the race, if a context-canceled error reaches `errors.CheckError`, the user sees the raw gRPC error string.

## Changes

- **`cmd/argocd/commands/app.go`**:
  - In `printFinalStatus`, skip the app refresh if `ctx.Err() != nil` (context already canceled)
  - Add `isContextCanceledErr` helper (detects both stdlib and gRPC-wrapped context errors)
  - In the `app wait` Run function, call `isContextCanceledErr` and emit a clear message:
    ```
    level=fatal msg="timed out (1800s) waiting for app "my-app" to match the expected conditions"
    ```

- **`cmd/argocd/commands/app_test.go`**: Add `TestIsContextCanceledErr` with 6 sub-tests (nil, `context.Canceled`, `context.DeadlineExceeded`, gRPC Canceled, gRPC DeadlineExceeded, unrelated error)