### PR TITLE
chore(perf): omit managedFields and last-applied from health obj

### DIFF
--- a/docs/operator-manual/health.md
+++ b/docs/operator-manual/health.md
@@ -146,6 +146,18 @@ specify a wildcard in the resource kind, and anywhere in the resource group, lik
 > style keys do not work since wildcards (`*`) are not supported in Kubernetes configmap keys.
 
 The `obj` is a global variable which contains the resource. The script must return an object with status and optional message field.
+
+#### Lua `obj` fields available to health checks
+
+Health check scripts receive a subset of the live resource. To reduce evaluation cost, Argo CD does **not** expose the following server-side metadata on `obj`:
+
+- `metadata.managedFields`
+- `metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"]`
+
+All other fields on the resource—including `spec`, `status`, labels, and other annotations—are available. Resource action scripts are not subject to this limitation.
+
+If you upgrade from Argo CD 3.5 or earlier and a custom health check relied on either field above, update the script before upgrading to 3.6. See [v3.5 to 3.6 upgrade notes](upgrading/3.5-3.6.md).
+
 The custom health check might return one of the following health statuses:
 
   * `Healthy` - the resource is healthy

--- a/docs/operator-manual/upgrading/3.5-3.6.md
+++ b/docs/operator-manual/upgrading/3.5-3.6.md
@@ -1,0 +1,38 @@
+# v3.5 to 3.6
+
+## Breaking Changes
+
+### Custom Lua health checks no longer receive server metadata fields
+
+Argo CD 3.6 omits selected Kubernetes server-side metadata from the Lua `obj` passed to **health check scripts only**. The following fields are no longer available in custom health checks (including scripts in `argocd-cm` and bundled `resource_customizations`):
+
+- `obj.metadata.managedFields`
+- `obj.metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"]`
+
+These fields are bookkeeping data written by Kubernetes and kubectl. They are frequently large, are not part of application spec/status, and no bundled Argo CD health check reads them.
+
+**Impact:**
+
+- Custom health scripts that read `obj.metadata.managedFields` or the `kubectl.kubernetes.io/last-applied-configuration` annotation will no longer see those values and must be updated to use other resource fields (typically `spec` and `status`).
+- All other metadata (labels, annotations except last-applied-configuration, name, namespace, generation, and so on) remains available.
+- Resource **actions** and **action discovery** scripts are unchanged and still receive the full object.
+
+No action is required for users whose custom health checks already inspect only `spec`, `status`, or application-relevant annotations.
+
+See [Resource Health](../health.md#lua-obj-fields-available-to-health-checks) for the documented scope of the health-check `obj`.
+
+## Behavioral Improvements / Fixes
+
+## API Changes
+
+## Security Changes
+
+## Deprecated Items
+
+## Kustomize Upgraded
+
+## Helm Upgraded
+
+## Custom Healthchecks Added
+
+## Other Changes

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -138,6 +138,7 @@ nav:
     - operator-manual/server-commands/additional-configuration-method.md
   - Upgrading:
     - operator-manual/upgrading/overview.md
+    - operator-manual/upgrading/3.5-3.6.md
     - operator-manual/upgrading/3.4-3.5.md
     - operator-manual/upgrading/3.3-3.4.md
     - operator-manual/upgrading/3.2-3.3.md

--- a/util/lua/health_object_decode_bench_test.go
+++ b/util/lua/health_object_decode_bench_test.go
@@ -1,0 +1,128 @@
+package lua
+
+import (
+	"encoding/json"
+	"testing"
+
+	lua "github.com/yuin/gopher-lua"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// realisticManagedFields mirrors metadata.managedFields on a live Pod: kube-controller-manager
+// owns spec, kubelet owns status. Testdata omits this block, but every real object carries one.
+const realisticManagedFields = `[
+  {
+    "manager": "kube-controller-manager",
+    "operation": "Update",
+    "apiVersion": "v1",
+    "time": "2026-06-12T17:00:00Z",
+    "fieldsType": "FieldsV1",
+    "fieldsV1": {
+      "f:metadata": {
+        "f:labels": {".": {}, "f:app": {}},
+        "f:ownerReferences": {
+          ".": {},
+          "k:{\"uid\":\"a1b2c3d4-0000-1111-2222-333344445555\"}": {}
+        }
+      },
+      "f:spec": {
+        "f:containers": {
+          "k:{\"name\":\"app\"}": {
+            ".": {},
+            "f:image": {},
+            "f:name": {},
+            "f:resources": {
+              ".": {},
+              "f:limits": {".": {}, "f:cpu": {}, "f:memory": {}},
+              "f:requests": {".": {}, "f:cpu": {}, "f:memory": {}}
+            }
+          }
+        },
+        "f:restartPolicy": {}
+      }
+    }
+  },
+  {
+    "manager": "kubelet",
+    "operation": "Update",
+    "apiVersion": "v1",
+    "time": "2026-06-12T17:00:05Z",
+    "fieldsType": "FieldsV1",
+    "subresource": "status",
+    "fieldsV1": {
+      "f:status": {
+        "f:conditions": {
+          "k:{\"type\":\"Ready\"}": {
+            ".": {},
+            "f:status": {},
+            "f:type": {}
+          }
+        },
+        "f:containerStatuses": {},
+        "f:phase": {},
+        "f:podIP": {}
+      }
+    }
+  }
+]`
+
+func benchmarkHealthObject(b *testing.B) map[string]any {
+	b.Helper()
+	var managedFields []any
+	if err := json.Unmarshal([]byte(realisticManagedFields), &managedFields); err != nil {
+		b.Fatal(err)
+	}
+	return map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"name":      "app-abc123",
+			"namespace": "default",
+			"labels": map[string]any{
+				"app": "demo",
+			},
+			"annotations": map[string]any{
+				corev1.LastAppliedConfigAnnotation: `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"app-abc123","namespace":"default"},"spec":{"containers":[{"name":"app","image":"demo:1"}]}}`,
+				"example.com/health-signal":        "ok",
+			},
+			"managedFields": managedFields,
+		},
+		"spec": map[string]any{
+			"containers": []any{
+				map[string]any{
+					"name":  "app",
+					"image": "demo:1",
+				},
+			},
+		},
+		"status": map[string]any{
+			"phase": "Running",
+			"conditions": []any{
+				map[string]any{
+					"type":   "Ready",
+					"status": "True",
+				},
+			},
+		},
+	}
+}
+
+func BenchmarkHealthObjectDecode(b *testing.B) {
+	obj := benchmarkHealthObject(b)
+	L := lua.NewState()
+	defer L.Close()
+
+	b.Run("full", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			decodeValue(L, obj)
+		}
+	})
+
+	b.Run("health", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			decodeHealthObject(L, obj)
+		}
+	})
+}

--- a/util/lua/lua.go
+++ b/util/lua/lua.go
@@ -18,6 +18,7 @@ import (
 	"github.com/argoproj/argo-cd/gitops-engine/pkg/health"
 	glob "github.com/bmatcuk/doublestar/v4"
 	lua "github.com/yuin/gopher-lua"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	luajson "layeh.com/gopher-json"
@@ -69,10 +70,14 @@ type VM struct {
 }
 
 func (vm VM) runLua(obj *unstructured.Unstructured, script string) (*lua.LState, error) {
-	return vm.runLuaWithResourceActionParameters(obj, script, nil)
+	return vm.runLuaScript(obj, script, nil, true)
 }
 
 func (vm VM) runLuaWithResourceActionParameters(obj *unstructured.Unstructured, script string, resourceActionParameters []*applicationpkg.ResourceActionParameters) (*lua.LState, error) {
+	return vm.runLuaScript(obj, script, resourceActionParameters, false)
+}
+
+func (vm VM) runLuaScript(obj *unstructured.Unstructured, script string, resourceActionParameters []*applicationpkg.ResourceActionParameters, forHealth bool) (*lua.LState, error) {
 	l := lua.NewState(lua.Options{
 		SkipOpenLibs: !vm.UseOpenLibs,
 	})
@@ -111,7 +116,12 @@ func (vm VM) runLuaWithResourceActionParameters(obj *unstructured.Unstructured, 
 	}
 	l.SetGlobal("actionParams", actionParams) // Set the actionParams table as a global variable
 
-	objectValue := decodeValue(l, obj.Object)
+	var objectValue lua.LValue
+	if forHealth {
+		objectValue = decodeHealthObject(l, obj.Object)
+	} else {
+		objectValue = decodeValue(l, obj.Object)
+	}
 	l.SetGlobal("obj", objectValue)
 	err := l.DoString(script)
 
@@ -598,6 +608,50 @@ func isValidHealthStatusCode(statusCode health.HealthStatusCode) bool {
 // Took logic from the link below and added the int, int32, and int64 types since the value would have type int64
 // while actually running in the controller and it was not reproducible through testing.
 // https://github.com/layeh/gopher-json/blob/97fed8db84274c421dbfffbb28ec859901556b97/json.go#L154
+// decodeHealthObject decodes obj for health scripts, omitting metadata fields that no health
+// script reads but that inflate live objects (managedFields, last-applied-configuration).
+func decodeHealthObject(l *lua.LState, obj map[string]any) lua.LValue {
+	tbl := l.CreateTable(0, len(obj))
+	for key, item := range obj {
+		if key == "metadata" {
+			if md, ok := item.(map[string]any); ok {
+				tbl.RawSetH(lua.LString(key), decodeHealthMetadata(l, md))
+				continue
+			}
+		}
+		tbl.RawSetH(lua.LString(key), decodeValue(l, item))
+	}
+	return tbl
+}
+
+func decodeHealthMetadata(l *lua.LState, md map[string]any) lua.LValue {
+	tbl := l.CreateTable(0, len(md))
+	for key, item := range md {
+		switch key {
+		case "managedFields":
+			continue
+		case "annotations":
+			if annots, ok := item.(map[string]any); ok {
+				tbl.RawSetH(lua.LString(key), decodeHealthAnnotations(l, annots))
+				continue
+			}
+		}
+		tbl.RawSetH(lua.LString(key), decodeValue(l, item))
+	}
+	return tbl
+}
+
+func decodeHealthAnnotations(l *lua.LState, annots map[string]any) lua.LValue {
+	tbl := l.CreateTable(0, len(annots))
+	for key, item := range annots {
+		if key == corev1.LastAppliedConfigAnnotation {
+			continue
+		}
+		tbl.RawSetH(lua.LString(key), decodeValue(l, item))
+	}
+	return tbl
+}
+
 func decodeValue(l *lua.LState, value any) lua.LValue {
 	switch converted := value.(type) {
 	case bool:

--- a/util/lua/lua_test.go
+++ b/util/lua/lua_test.go
@@ -186,6 +186,38 @@ func TestEmptyHealthStatusStatus(t *testing.T) {
 	assert.Equal(t, expectedStatus, status)
 }
 
+const verifyHealthObjectMetadataScript = `
+if obj.metadata.managedFields ~= nil then
+  return { status = "Degraded", message = "managedFields visible" }
+end
+if obj.metadata.annotations ~= nil and obj.metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"] ~= nil then
+  return { status = "Degraded", message = "last-applied visible" }
+end
+if obj.metadata.annotations == nil or obj.metadata.annotations["example.com/health-signal"] ~= "ok" then
+  return { status = "Degraded", message = "expected annotation missing" }
+end
+return { status = "Healthy", message = "ok" }
+`
+
+func TestExecuteHealthLuaOmitsServerMetadata(t *testing.T) {
+	t.Parallel()
+	testObj := StrToUnstructured(objJSON)
+	md := testObj.Object["metadata"].(map[string]any)
+	md["managedFields"] = []any{map[string]any{"manager": "kube-controller-manager"}}
+	annots, ok := md["annotations"].(map[string]any)
+	if !ok {
+		annots = map[string]any{}
+		md["annotations"] = annots
+	}
+	annots["kubectl.kubernetes.io/last-applied-configuration"] = `{"apiVersion":"v1","kind":"Rollout"}`
+	annots["example.com/health-signal"] = "ok"
+
+	vm := VM{}
+	status, err := vm.ExecuteHealthLua(testObj, verifyHealthObjectMetadataScript)
+	require.NoError(t, err)
+	assert.Equal(t, &health.HealthStatus{Status: "Healthy", Message: "ok"}, status)
+}
+
 const infiniteLoop = `while true do ; end`
 
 func TestHandleInfiniteLoop(t *testing.T) {


### PR DESCRIPTION
## Summary

- Drop `metadata.managedFields` and `metadata.annotations[kubectl.kubernetes.io/last-applied-configuration]` when decoding the Lua `obj` for **health checks only**.
- Resource actions and discovery still receive the full object via `decodeValue`.
- No built-in health script reads either field; other annotations used by health scripts (e.g. `rollout.argoproj.io/workload-generation`, `cnpg.io/reconciliationLoop`) are preserved.

Related to #28255 (Lua health migration makes decode cost matter). Independent of #28275.

## Benchmark

`go test ./util/lua/... -run='^$' -bench='BenchmarkHealthObjectDecode' -benchmem -count=10`

Pod-shaped object with realistic `managedFields` and a last-applied-configuration annotation (Apple M3 Max, darwin/arm64):

| Sub-benchmark | ns/op | B/op | allocs/op |
|---|---|---|---|
| full (`decodeValue`) | ~15,100 | ~24,560 | 425 |
| health (`decodeHealthObject`) | ~4,280 | ~7,312 | 125 |

Roughly **~72% less CPU**, **~70% less memory**, and **300 fewer allocations** on the object-decode step.

## Test plan

- [x] `go test ./util/lua/...` (includes bundled `resource_customizations/*/health_test.yaml`)
- [x] `TestExecuteHealthLuaOmitsServerMetadata` verifies stripped fields are invisible and other annotations remain

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

Made with [Cursor](https://cursor.com)