### PR TITLE
fix: support bearer token auth on terminal websocket endpoint

### DIFF
--- a/server/application/websocket.go
+++ b/server/application/websocket.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -46,8 +47,18 @@ type terminalSession struct {
 	terminalOpts   *TerminalOptions
 }
 
-// getToken get auth token from web socket request
+// getToken extracts the auth token from a websocket request. Consistent with
+// the rest of the API server, a bearer token provided in the Authorization
+// header is preferred over the auth cookie. This allows clients that
+// authenticate with a bearer token (rather than a cookie) to use the terminal
+// endpoint.
 func getToken(r *http.Request) (string, error) {
+	// Prefer the bearer token from the Authorization header, matching the
+	// behavior of the main API server.
+	if auth := r.Header.Get("Authorization"); strings.HasPrefix(auth, "Bearer ") {
+		return strings.TrimPrefix(auth, "Bearer "), nil
+	}
+	// Fall back to the auth cookie.
 	cookies := r.Cookies()
 	return httputil.JoinCookies(common.AuthCookieName, cookies)
 }

--- a/server/application/websocket.go
+++ b/server/application/websocket.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/argoproj/argo-cd/v3/common"
 	httputil "github.com/argoproj/argo-cd/v3/util/http"
+	jwtutil "github.com/argoproj/argo-cd/v3/util/jwt"
 	"github.com/argoproj/argo-cd/v3/util/rbac"
 	util_session "github.com/argoproj/argo-cd/v3/util/session"
 
@@ -49,18 +50,28 @@ type terminalSession struct {
 
 // getToken extracts the auth token from a websocket request. Consistent with
 // the rest of the API server, a bearer token provided in the Authorization
-// header is preferred over the auth cookie. This allows clients that
-// authenticate with a bearer token (rather than a cookie) to use the terminal
-// endpoint.
+// header is preferred over the auth cookie when it passes jwtutil.IsValid.
+// This allows clients that authenticate with a bearer token (rather than a
+// cookie) to use the terminal endpoint.
 func getToken(r *http.Request) (string, error) {
 	// Prefer the bearer token from the Authorization header, matching the
-	// behavior of the main API server.
+	// behavior of the main API server. Only accept tokens that pass
+	// jwtutil.IsValid, consistent with server.getToken.
 	if auth := r.Header.Get("Authorization"); strings.HasPrefix(auth, "Bearer ") {
-		return strings.TrimPrefix(auth, "Bearer "), nil
+		token := strings.TrimPrefix(auth, "Bearer ")
+		if jwtutil.IsValid(token) {
+			return token, nil
+		}
 	}
 	// Fall back to the auth cookie.
-	cookies := r.Cookies()
-	return httputil.JoinCookies(common.AuthCookieName, cookies)
+	token, err := httputil.JoinCookies(common.AuthCookieName, r.Cookies())
+	if err == nil && jwtutil.IsValid(token) {
+		return token, nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return "", fmt.Errorf("failed to retrieve cookie %s", common.AuthCookieName)
 }
 
 // newTerminalSession create terminalSession

--- a/server/application/websocket_test.go
+++ b/server/application/websocket_test.go
@@ -217,3 +217,36 @@ func TestTerminalSession_Write(t *testing.T) {
 
 	assert.Equal(t, expectedMessage, receivedMessage)
 }
+
+func TestGetToken(t *testing.T) {
+	t.Parallel()
+	const tokenValue = "sample-jwt-token"
+
+	t.Run("bearer token in Authorization header", func(t *testing.T) {
+		t.Parallel()
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/terminal", http.NoBody)
+		r.Header.Set("Authorization", "Bearer "+tokenValue)
+		token, err := getToken(r)
+		require.NoError(t, err)
+		assert.Equal(t, tokenValue, token)
+	})
+
+	t.Run("auth cookie when no Authorization header", func(t *testing.T) {
+		t.Parallel()
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/terminal", http.NoBody)
+		r.AddCookie(&http.Cookie{Name: common.AuthCookieName, Value: tokenValue})
+		token, err := getToken(r)
+		require.NoError(t, err)
+		assert.Equal(t, tokenValue, token)
+	})
+
+	t.Run("bearer token preferred over cookie", func(t *testing.T) {
+		t.Parallel()
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/terminal", http.NoBody)
+		r.Header.Set("Authorization", "Bearer "+tokenValue)
+		r.AddCookie(&http.Cookie{Name: common.AuthCookieName, Value: "cookie-token"})
+		token, err := getToken(r)
+		require.NoError(t, err)
+		assert.Equal(t, tokenValue, token)
+	})
+}

--- a/server/application/websocket_test.go
+++ b/server/application/websocket_test.go
@@ -220,7 +220,9 @@ func TestTerminalSession_Write(t *testing.T) {
 
 func TestGetToken(t *testing.T) {
 	t.Parallel()
-	const tokenValue = "sample-jwt-token"
+	// jwtutil.IsValid only checks JWT shape (three dot-separated segments).
+	const tokenValue = "header.payload.signature"
+	const cookieToken = "cookie.payload.signature"
 
 	t.Run("bearer token in Authorization header", func(t *testing.T) {
 		t.Parallel()
@@ -244,9 +246,35 @@ func TestGetToken(t *testing.T) {
 		t.Parallel()
 		r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/terminal", http.NoBody)
 		r.Header.Set("Authorization", "Bearer "+tokenValue)
-		r.AddCookie(&http.Cookie{Name: common.AuthCookieName, Value: "cookie-token"})
+		r.AddCookie(&http.Cookie{Name: common.AuthCookieName, Value: cookieToken})
 		token, err := getToken(r)
 		require.NoError(t, err)
 		assert.Equal(t, tokenValue, token)
+	})
+
+	t.Run("invalid bearer falls back to valid cookie", func(t *testing.T) {
+		t.Parallel()
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/terminal", http.NoBody)
+		r.Header.Set("Authorization", "Bearer not-a-jwt")
+		r.AddCookie(&http.Cookie{Name: common.AuthCookieName, Value: cookieToken})
+		token, err := getToken(r)
+		require.NoError(t, err)
+		assert.Equal(t, cookieToken, token)
+	})
+
+	t.Run("rejects invalid bearer without cookie", func(t *testing.T) {
+		t.Parallel()
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/terminal", http.NoBody)
+		r.Header.Set("Authorization", "Bearer not-a-jwt")
+		_, err := getToken(r)
+		require.Error(t, err)
+	})
+
+	t.Run("rejects invalid cookie token", func(t *testing.T) {
+		t.Parallel()
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/terminal", http.NoBody)
+		r.AddCookie(&http.Cookie{Name: common.AuthCookieName, Value: "not-a-jwt"})
+		_, err := getToken(r)
+		require.Error(t, err)
 	})
 }


### PR DESCRIPTION
## Summary

The `/terminal` websocket endpoint extracts the auth token only from the auth cookie, so clients authenticating with a **bearer token** get a 401 instead of completing the websocket handshake (101). Every other API endpoint already accepts `Authorization: Bearer <token>` and prefers it over the cookie (see `server.getToken`).

## Changes

- `getToken` in `server/application/websocket.go` now prefers a Bearer token from the `Authorization` header and falls back to the auth cookie, consistent with the main API server.
- Added unit tests covering the bearer-header, cookie, and bearer-preferred-over-cookie cases.

## Testing

`go test ./server/application/ -run TestGetToken` passes.

Fixes #11068