### PR TITLE
feat(controller): allow metrics label/condition flags via argocd-cmd-params-cm

### DIFF
--- a/cmd/argocd-application-controller/commands/argocd_application_controller.go
+++ b/cmd/argocd-application-controller/commands/argocd_application_controller.go
@@ -74,8 +74,8 @@ func NewCommand() *cobra.Command {
 		glogLevel                        int
 		metricsPort                      int
 		metricsCacheExpiration           time.Duration
-		metricsAplicationLabels          []string
-		metricsAplicationConditions      []string
+		metricsApplicationLabels         []string
+		metricsApplicationConditions     []string
 		metricsClusterLabels             []string
 		kubectlParallelismLimit          int64
 		cacheSource                      func() (*appstatecache.Cache, error)
@@ -207,8 +207,8 @@ func NewCommand() *cobra.Command {
 				time.Duration(repoErrorGracePeriod)*time.Second,
 				metricsPort,
 				metricsCacheExpiration,
-				metricsAplicationLabels,
-				metricsAplicationConditions,
+				metricsApplicationLabels,
+				metricsApplicationConditions,
 				metricsClusterLabels,
 				kubectlParallelismLimit,
 				persistResourceHealth,
@@ -282,9 +282,9 @@ func NewCommand() *cobra.Command {
 	command.Flags().BoolVar(&repoServerPlaintext, "repo-server-plaintext", env.ParseBoolFromEnv("ARGOCD_APPLICATION_CONTROLLER_REPO_SERVER_PLAINTEXT", false), "Disable TLS on connections to repo server")
 	command.Flags().BoolVar(&repoServerStrictTLS, "repo-server-strict-tls", env.ParseBoolFromEnv("ARGOCD_APPLICATION_CONTROLLER_REPO_SERVER_STRICT_TLS", false), "Whether to use strict validation of the TLS cert presented by the repo server")
 	errors.CheckError(command.Flags().MarkDeprecated("repo-server-strict-tls", "use --repo-server-ca-cert-path instead"))
-	command.Flags().StringSliceVar(&metricsAplicationLabels, "metrics-application-labels", []string{}, "List of Application labels that will be added to the argocd_application_labels metric")
-	command.Flags().StringSliceVar(&metricsAplicationConditions, "metrics-application-conditions", []string{}, "List of Application conditions that will be added to the argocd_application_conditions metric")
-	command.Flags().StringSliceVar(&metricsClusterLabels, "metrics-cluster-labels", []string{}, "List of Cluster labels that will be added to the argocd_cluster_labels metric")
+	command.Flags().StringSliceVar(&metricsApplicationLabels, "metrics-application-labels", env.StringsFromEnv("ARGOCD_APPLICATION_CONTROLLER_METRICS_APPLICATION_LABELS", []string{}, ","), "List of Application labels that will be added to the argocd_application_labels metric")
+	command.Flags().StringSliceVar(&metricsApplicationConditions, "metrics-application-conditions", env.StringsFromEnv("ARGOCD_APPLICATION_CONTROLLER_METRICS_APPLICATION_CONDITIONS", []string{}, ","), "List of Application conditions that will be added to the argocd_application_conditions metric")
+	command.Flags().StringSliceVar(&metricsClusterLabels, "metrics-cluster-labels", env.StringsFromEnv("ARGOCD_APPLICATION_CONTROLLER_METRICS_CLUSTER_LABELS", []string{}, ","), "List of Cluster labels that will be added to the argocd_cluster_labels metric")
 	command.Flags().StringVar(&otlpAddress, "otlp-address", env.StringFromEnv("ARGOCD_APPLICATION_CONTROLLER_OTLP_ADDRESS", ""), "OpenTelemetry collector address to send traces to")
 	command.Flags().BoolVar(&otlpInsecure, "otlp-insecure", env.ParseBoolFromEnv("ARGOCD_APPLICATION_CONTROLLER_OTLP_INSECURE", true), "OpenTelemetry collector insecure mode")
 	command.Flags().StringToStringVar(&otlpHeaders, "otlp-headers", env.ParseStringToStringFromEnv("ARGOCD_APPLICATION_CONTROLLER_OTLP_HEADERS", map[string]string{}, ","), "List of OpenTelemetry collector extra headers sent with traces, headers are comma-separated key-value pairs(e.g. key1=value1,key2=value2)")

--- a/cmd/argocd-application-controller/commands/argocd_application_controller_test.go
+++ b/cmd/argocd-application-controller/commands/argocd_application_controller_test.go
@@ -18,3 +18,26 @@ func TestNewCommand_HydrationProcessorsFlag(t *testing.T) {
 	require.NotNil(t, f, "expected --hydration-processors flag to be registered")
 	assert.Equal(t, "5", f.DefValue, "default hydration processors should be greater than 1")
 }
+
+// TestNewCommand_MetricsFlagsFromEnv verifies the metrics label/condition flags
+// default from their environment variables, so they can be configured through
+// argocd-cmd-params-cm like the other controller parameters.
+func TestNewCommand_MetricsFlagsFromEnv(t *testing.T) {
+	t.Setenv("ARGOCD_APPLICATION_CONTROLLER_METRICS_APPLICATION_LABELS", "team,env")
+	t.Setenv("ARGOCD_APPLICATION_CONTROLLER_METRICS_APPLICATION_CONDITIONS", "OrphanedResourceWarning")
+	t.Setenv("ARGOCD_APPLICATION_CONTROLLER_METRICS_CLUSTER_LABELS", "environment")
+
+	cmd := NewCommand()
+
+	labels, err := cmd.Flags().GetStringSlice("metrics-application-labels")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"team", "env"}, labels)
+
+	conditions, err := cmd.Flags().GetStringSlice("metrics-application-conditions")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"OrphanedResourceWarning"}, conditions)
+
+	clusterLabels, err := cmd.Flags().GetStringSlice("metrics-cluster-labels")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"environment"}, clusterLabels)
+}

--- a/docs/operator-manual/argocd-cmd-params-cm.yaml
+++ b/docs/operator-manual/argocd-cmd-params-cm.yaml
@@ -68,6 +68,13 @@ data:
   controller.log.level: "info"
   # Prometheus metrics cache expiration (disabled  by default. e.g. 24h0m0s)
   controller.metrics.cache.expiration: "24h0m0s"
+  # High-cardinality label/condition values can degrade Prometheus performance; use sparingly.
+  # List of Application labels added to the argocd_app_labels metric (comma separated)
+  controller.metrics.application.labels: "team,env"
+  # List of Application conditions added to the argocd_app_conditions metric (comma separated)
+  controller.metrics.application.conditions: "OrphanedResourceWarning"
+  # List of Cluster labels added to the argocd_cluster_labels metric (comma separated)
+  controller.metrics.cluster.labels: "environment"
   # Specifies timeout between application self heal attempts
   controller.self.heal.timeout.seconds: "0"
   # Specifies exponential backoff timeout parameters between application self heal attempts

--- a/docs/operator-manual/metrics.md
+++ b/docs/operator-manual/metrics.md
@@ -105,6 +105,13 @@ argocd_app_labels{label_business_unit="bu-id-1",label_team_name="my-team",name="
 argocd_app_labels{label_business_unit="bu-id-2",label_team_name="another-team",name="my-app-3",namespace="argocd",project="important-project"} 1
 ```
 
+This can also be configured through `argocd-cmd-params-cm` instead of container args, using the comma-separated `controller.metrics.application.labels` key:
+
+    controller.metrics.application.labels: "team-name,business-unit"
+
+!!! warning
+    Each distinct label value becomes a separate `argocd_app_labels` time series. Exposing labels with many distinct values increases the metric's cardinality, which can degrade Prometheus performance and increase storage requirements. Prefer low-cardinality labels and add them sparingly.
+
 ### Exposing Application conditions as Prometheus metrics
 
 There are use-cases where Argo CD Applications contain conditions that are desired to be exposed as Prometheus metrics.

--- a/docs/operator-manual/metrics.md
+++ b/docs/operator-manual/metrics.md
@@ -83,10 +83,17 @@ Some examples are:
 - Having the team name as a label to allow routing alerts to specific receivers
 - Creating dashboards broken down by business units
 
-As the Application labels are specific to each company, this feature is disabled by default. To enable it, add the
-`--metrics-application-labels` flag to the Argo CD application controller.
+As the Application labels are specific to each company, this feature is disabled by default. To enable it, set the
+comma-separated `controller.metrics.application.labels` key in the `argocd-cmd-params-cm` ConfigMap.
 
 The example below will expose the Argo CD Application labels `team-name` and `business-unit` to Prometheus:
+
+    controller.metrics.application.labels: "team-name,business-unit"
+
+!!! warning
+    Each distinct label value becomes a separate `argocd_app_labels` time series. Exposing labels with many distinct values increases the metric's cardinality, which can degrade Prometheus performance and increase storage requirements. Prefer low-cardinality labels and add them sparingly.
+
+Alternatively, the labels can be passed as `--metrics-application-labels` flags directly to the application controller:
 
     containers:
     - command:
@@ -96,7 +103,7 @@ The example below will expose the Argo CD Application labels `team-name` and `bu
       - --metrics-application-labels
       - business-unit
 
-In this case, the metric would look like:
+In either case, the metric would look like:
 
 ```
 # TYPE argocd_app_labels gauge
@@ -104,13 +111,6 @@ argocd_app_labels{label_business_unit="bu-id-1",label_team_name="my-team",name="
 argocd_app_labels{label_business_unit="bu-id-1",label_team_name="my-team",name="my-app-2",namespace="argocd",project="important-project"} 1
 argocd_app_labels{label_business_unit="bu-id-2",label_team_name="another-team",name="my-app-3",namespace="argocd",project="important-project"} 1
 ```
-
-This can also be configured through `argocd-cmd-params-cm` instead of container args, using the comma-separated `controller.metrics.application.labels` key:
-
-    controller.metrics.application.labels: "team-name,business-unit"
-
-!!! warning
-    Each distinct label value becomes a separate `argocd_app_labels` time series. Exposing labels with many distinct values increases the metric's cardinality, which can degrade Prometheus performance and increase storage requirements. Prefer low-cardinality labels and add them sparingly.
 
 ### Exposing Application conditions as Prometheus metrics
 
@@ -120,10 +120,14 @@ Some examples are:
 - Hunting orphaned resources across all deployed applications
 - Knowing which resources are excluded from ArgoCD
 
-As the Application conditions are specific to each company, this feature is disabled by default. To enable it, add the
-`--metrics-application-conditions` flag to the Argo CD application controller.
+As the Application conditions are specific to each company, this feature is disabled by default. To enable it, set the
+comma-separated `controller.metrics.application.conditions` key in the `argocd-cmd-params-cm` ConfigMap.
 
 The example below will expose the Argo CD Application condition `OrphanedResourceWarning` and `ExcludedResourceWarning` to Prometheus:
+
+    controller.metrics.application.conditions: "OrphanedResourceWarning,ExcludedResourceWarning"
+
+Alternatively, the conditions can be passed as `--metrics-application-conditions` flags directly to the application controller:
 
 ```yaml
 containers:
@@ -190,10 +194,14 @@ All the following `argocd_github_api_*` metrics can be enabled upon setting `app
 
 ### Exposing Cluster labels as Prometheus metrics
 
-As the Cluster labels are specific to each company, this feature is disabled by default. To enable it, add the
-`--metrics-cluster-labels` flag to the Argo CD application controller.
+As the Cluster labels are specific to each company, this feature is disabled by default. To enable it, set the
+comma-separated `controller.metrics.cluster.labels` key in the `argocd-cmd-params-cm` ConfigMap.
 
-The example below will expose the Argo CD Application labels `team-name` and `environment` to Prometheus:
+The example below will expose the Argo CD cluster labels `team-name` and `environment` to Prometheus:
+
+    controller.metrics.cluster.labels: "team-name,environment"
+
+Alternatively, the labels can be passed as `--metrics-cluster-labels` flags directly to the application controller:
 
     containers:
     - command:
@@ -203,7 +211,7 @@ The example below will expose the Argo CD Application labels `team-name` and `en
       - --metrics-cluster-labels
       - environment
 
-In this case, the metric would look like:
+In either case, the metric would look like:
 
 ```
 # TYPE argocd_cluster_labels gauge

--- a/docs/operator-manual/metrics.md
+++ b/docs/operator-manual/metrics.md
@@ -139,6 +139,34 @@ containers:
       - ExcludedResourceWarning
 ```
 
+### Exposing Cluster labels as Prometheus metrics
+
+As the Cluster labels are specific to each company, this feature is disabled by default. To enable it, set the
+comma-separated `controller.metrics.cluster.labels` key in the `argocd-cmd-params-cm` ConfigMap.
+
+The example below will expose the Argo CD cluster labels `team-name` and `environment` to Prometheus:
+
+    controller.metrics.cluster.labels: "team-name,environment"
+
+Alternatively, the labels can be passed as `--metrics-cluster-labels` flags directly to the application controller:
+
+    containers:
+    - command:
+      - argocd-application-controller
+      - --metrics-cluster-labels
+      - team-name
+      - --metrics-cluster-labels
+      - environment
+
+In either case, the metric would look like:
+
+```
+# TYPE argocd_cluster_labels gauge
+argocd_cluster_labels{label_environment="dev",label_team_name="team1",name="cluster1",server="server1"} 1
+argocd_cluster_labels{label_environment="staging",label_team_name="team2",name="cluster2",server="server2"} 1
+argocd_cluster_labels{label_environment="production",label_team_name="team3",name="cluster3",server="server3"} 1
+```
+
 ## Application Set Controller metrics
 
 The Application Set controller exposes the following metrics for application sets.
@@ -191,34 +219,6 @@ All the following `argocd_github_api_*` metrics can be enabled upon setting `app
 | namespace   | default       | Namespace of an ApplicationSet (namespace where the ApplicationSet CR is located, not the destination namespace).                             |
 | result      | hit           | Result of an attempt to get a transport from the kubectl (client-go) transport cache. Possible values are: hit, miss, unreachable.            |
 | verb        | List          | Kubernetes API verb used in the request. Possible values are: Get, Watch, List, Create, Delete, Patch, Update.                                |
-
-### Exposing Cluster labels as Prometheus metrics
-
-As the Cluster labels are specific to each company, this feature is disabled by default. To enable it, set the
-comma-separated `controller.metrics.cluster.labels` key in the `argocd-cmd-params-cm` ConfigMap.
-
-The example below will expose the Argo CD cluster labels `team-name` and `environment` to Prometheus:
-
-    controller.metrics.cluster.labels: "team-name,environment"
-
-Alternatively, the labels can be passed as `--metrics-cluster-labels` flags directly to the application controller:
-
-    containers:
-    - command:
-      - argocd-application-controller
-      - --metrics-cluster-labels
-      - team-name
-      - --metrics-cluster-labels
-      - environment
-
-In either case, the metric would look like:
-
-```
-# TYPE argocd_cluster_labels gauge
-argocd_cluster_labels{label_environment="dev",label_team_name="team1",name="cluster1",server="server1"} 1
-argocd_cluster_labels{label_environment="staging",label_team_name="team2",name="cluster2",server="server2"} 1
-argocd_cluster_labels{label_environment="production",label_team_name="team3",name="cluster3",server="server3"} 1
-```
 
 ## API Server Metrics
 

--- a/manifests/base/application-controller/argocd-application-controller-statefulset.yaml
+++ b/manifests/base/application-controller/argocd-application-controller-statefulset.yaml
@@ -154,6 +154,24 @@ spec:
               name: argocd-cmd-params-cm
               key: controller.metrics.cache.expiration
               optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_METRICS_APPLICATION_LABELS
+          valueFrom:
+            configMapKeyRef:
+              name: argocd-cmd-params-cm
+              key: controller.metrics.application.labels
+              optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_METRICS_APPLICATION_CONDITIONS
+          valueFrom:
+            configMapKeyRef:
+              name: argocd-cmd-params-cm
+              key: controller.metrics.application.conditions
+              optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_METRICS_CLUSTER_LABELS
+          valueFrom:
+            configMapKeyRef:
+              name: argocd-cmd-params-cm
+              key: controller.metrics.cluster.labels
+              optional: true
         - name: ARGOCD_APPLICATION_CONTROLLER_SELF_HEAL_TIMEOUT_SECONDS
           valueFrom:
             configMapKeyRef:

--- a/manifests/core-install-with-hydrator.yaml
+++ b/manifests/core-install-with-hydrator.yaml
@@ -32565,6 +32565,24 @@ spec:
               key: controller.metrics.cache.expiration
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_METRICS_APPLICATION_LABELS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.metrics.application.labels
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_METRICS_APPLICATION_CONDITIONS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.metrics.application.conditions
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_METRICS_CLUSTER_LABELS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.metrics.cluster.labels
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_APPLICATION_CONTROLLER_SELF_HEAL_TIMEOUT_SECONDS
           valueFrom:
             configMapKeyRef:

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -32393,6 +32393,24 @@ spec:
               key: controller.metrics.cache.expiration
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_METRICS_APPLICATION_LABELS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.metrics.application.labels
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_METRICS_APPLICATION_CONDITIONS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.metrics.application.conditions
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_METRICS_CLUSTER_LABELS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.metrics.cluster.labels
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_APPLICATION_CONTROLLER_SELF_HEAL_TIMEOUT_SECONDS
           valueFrom:
             configMapKeyRef:

--- a/manifests/ha/install-with-hydrator.yaml
+++ b/manifests/ha/install-with-hydrator.yaml
@@ -34805,6 +34805,24 @@ spec:
               key: controller.metrics.cache.expiration
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_METRICS_APPLICATION_LABELS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.metrics.application.labels
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_METRICS_APPLICATION_CONDITIONS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.metrics.application.conditions
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_METRICS_CLUSTER_LABELS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.metrics.cluster.labels
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_APPLICATION_CONTROLLER_SELF_HEAL_TIMEOUT_SECONDS
           valueFrom:
             configMapKeyRef:

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -34635,6 +34635,24 @@ spec:
               key: controller.metrics.cache.expiration
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_METRICS_APPLICATION_LABELS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.metrics.application.labels
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_METRICS_APPLICATION_CONDITIONS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.metrics.application.conditions
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_METRICS_CLUSTER_LABELS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.metrics.cluster.labels
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_APPLICATION_CONTROLLER_SELF_HEAL_TIMEOUT_SECONDS
           valueFrom:
             configMapKeyRef:

--- a/manifests/ha/namespace-install-with-hydrator.yaml
+++ b/manifests/ha/namespace-install-with-hydrator.yaml
@@ -3723,6 +3723,24 @@ spec:
               key: controller.metrics.cache.expiration
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_METRICS_APPLICATION_LABELS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.metrics.application.labels
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_METRICS_APPLICATION_CONDITIONS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.metrics.application.conditions
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_METRICS_CLUSTER_LABELS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.metrics.cluster.labels
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_APPLICATION_CONTROLLER_SELF_HEAL_TIMEOUT_SECONDS
           valueFrom:
             configMapKeyRef:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -3553,6 +3553,24 @@ spec:
               key: controller.metrics.cache.expiration
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_METRICS_APPLICATION_LABELS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.metrics.application.labels
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_METRICS_APPLICATION_CONDITIONS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.metrics.application.conditions
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_METRICS_CLUSTER_LABELS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.metrics.cluster.labels
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_APPLICATION_CONTROLLER_SELF_HEAL_TIMEOUT_SECONDS
           valueFrom:
             configMapKeyRef:

--- a/manifests/install-with-hydrator.yaml
+++ b/manifests/install-with-hydrator.yaml
@@ -33773,6 +33773,24 @@ spec:
               key: controller.metrics.cache.expiration
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_METRICS_APPLICATION_LABELS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.metrics.application.labels
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_METRICS_APPLICATION_CONDITIONS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.metrics.application.conditions
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_METRICS_CLUSTER_LABELS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.metrics.cluster.labels
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_APPLICATION_CONTROLLER_SELF_HEAL_TIMEOUT_SECONDS
           valueFrom:
             configMapKeyRef:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -33601,6 +33601,24 @@ spec:
               key: controller.metrics.cache.expiration
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_METRICS_APPLICATION_LABELS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.metrics.application.labels
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_METRICS_APPLICATION_CONDITIONS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.metrics.application.conditions
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_METRICS_CLUSTER_LABELS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.metrics.cluster.labels
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_APPLICATION_CONTROLLER_SELF_HEAL_TIMEOUT_SECONDS
           valueFrom:
             configMapKeyRef:

--- a/manifests/namespace-install-with-hydrator.yaml
+++ b/manifests/namespace-install-with-hydrator.yaml
@@ -2691,6 +2691,24 @@ spec:
               key: controller.metrics.cache.expiration
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_METRICS_APPLICATION_LABELS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.metrics.application.labels
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_METRICS_APPLICATION_CONDITIONS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.metrics.application.conditions
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_METRICS_CLUSTER_LABELS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.metrics.cluster.labels
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_APPLICATION_CONTROLLER_SELF_HEAL_TIMEOUT_SECONDS
           valueFrom:
             configMapKeyRef:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -2519,6 +2519,24 @@ spec:
               key: controller.metrics.cache.expiration
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_METRICS_APPLICATION_LABELS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.metrics.application.labels
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_METRICS_APPLICATION_CONDITIONS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.metrics.application.conditions
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_METRICS_CLUSTER_LABELS
+          valueFrom:
+            configMapKeyRef:
+              key: controller.metrics.cluster.labels
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_APPLICATION_CONTROLLER_SELF_HEAL_TIMEOUT_SECONDS
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
Closes #28284

The application-controller's `--metrics-application-labels`, `--metrics-application-conditions` and `--metrics-cluster-labels` flags were the only `StringSlice` flags in the controller without an environment-variable default, so they could not be set through `argocd-cmd-params-cm` like every other controller parameter — they had to be passed as raw container args (e.g. via the Helm chart's `controller.extraArgs` or a Kustomize patch).

This binds each flag to a comma-separated env var, matching the existing pattern (`--application-namespaces` → `ARGOCD_APPLICATION_NAMESPACES`, `--enable-k8s-event` → `ARGOCD_ENABLE_K8S_EVENT`, …), and wires the keys into the application-controller StatefulSet and the `argocd-cmd-params-cm` docs:

| cmd-params-cm key | env var |
| --- | --- |
| `controller.metrics.application.labels` | `ARGOCD_APPLICATION_CONTROLLER_METRICS_APPLICATION_LABELS` |
| `controller.metrics.application.conditions` | `ARGOCD_APPLICATION_CONTROLLER_METRICS_APPLICATION_CONDITIONS` |
| `controller.metrics.cluster.labels` | `ARGOCD_APPLICATION_CONTROLLER_METRICS_CLUSTER_LABELS` |

The PR also fixes `metricsApplication{Labels,Conditions}` variable typos (adding an extra `p`).

### Checklist
- [x] (a) Enhancement proposal created and linked: #28284
- [x] The title states what changed and the related issue number
- [x] The title conforms to the PR title conventions (`feat(controller): …`)
- [x] I've included "Closes #28284" in the description
- [ ] CLI/UI updated — N/A: controller configuration flag, no CLI/UI surface
- [x] Documentation updated (`metrics.md`, `argocd-cmd-params-cm.yaml`)
- [x] All commits signed off (DCO)
- [x] Unit test added (`TestNewCommand_MetricsFlagsFromEnv`)
- [ ] Build green — pending CI
- [x] Brief description of why this PR is necessary included
