### PR TITLE
chore: use test contexts throughout

### DIFF
--- a/applicationset/generators/scm_provider_test.go
+++ b/applicationset/generators/scm_provider_test.go
@@ -1,7 +1,6 @@
 package generators
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -326,13 +325,13 @@ func TestNewSCMHTTPClient(t *testing.T) {
 		assert.True(t, ok)
 		assert.NotNil(t, tr.Proxy)
 
-		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://github.com", http.NoBody)
+		req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://github.com", http.NoBody)
 		u, err := tr.Proxy(req)
 		require.NoError(t, err)
 		assert.NotNil(t, u)
 		assert.Equal(t, "proxy.example.com:8080", u.Host)
 
-		reqNoProxy, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com", http.NoBody)
+		reqNoProxy, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
 		u, err = tr.Proxy(reqNoProxy)
 		require.NoError(t, err)
 		assert.Nil(t, u)
@@ -389,7 +388,7 @@ func TestGithubProvider_ProxyWithoutMetrics(t *testing.T) {
 		require.True(t, ok)
 		require.NotNil(t, tr.Proxy)
 
-		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://github.com", http.NoBody)
+		req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://github.com", http.NoBody)
 		u, err := tr.Proxy(req)
 		require.NoError(t, err)
 		assert.Equal(t, "proxy.example.com:8080", u.Host)

--- a/applicationset/utils/client_test.go
+++ b/applicationset/utils/client_test.go
@@ -66,7 +66,7 @@ func TestCreateSyncsCache(t *testing.T) {
 	app := &application.Application{
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "argocd"},
 	}
-	require.NoError(t, c.Create(context.Background(), app))
+	require.NoError(t, c.Create(t.Context(), app))
 
 	require.Contains(t, store.List(), app)
 }
@@ -85,7 +85,7 @@ func TestUpdateSyncsCache(t *testing.T) {
 
 	updatedApp := app.DeepCopy()
 	updatedApp.Labels["foo"] = "bar-UPDATED"
-	require.NoError(t, c.Update(context.Background(), updatedApp))
+	require.NoError(t, c.Update(t.Context(), updatedApp))
 
 	updated, _, err := store.GetByKey("test")
 	require.NoError(t, err)
@@ -104,7 +104,7 @@ func TestDeleteSyncsCache(t *testing.T) {
 	c, store, err := newClient(app)
 	require.NoError(t, err)
 
-	require.NoError(t, c.Delete(context.Background(), app))
+	require.NoError(t, c.Delete(t.Context(), app))
 
 	require.Empty(t, store.List())
 }

--- a/cmd/argocd-k8s-auth/commands/aws_test.go
+++ b/cmd/argocd-k8s-auth/commands/aws_test.go
@@ -17,7 +17,7 @@ func TestGetSignedRequest(t *testing.T) {
 
 	t.Run("returns error when context is cancelled", func(t *testing.T) {
 		t.Parallel()
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		cancel()
 
 		url, err := getSignedRequest(ctx, "my-cluster", "", "")
@@ -28,7 +28,7 @@ func TestGetSignedRequest(t *testing.T) {
 
 	t.Run("returns error for non-existent profile", func(t *testing.T) {
 		t.Parallel()
-		ctx := context.Background()
+		ctx := t.Context()
 		profile := "argocd-k8s-auth-test-nonexistent-profile-12345"
 
 		url, err := getSignedRequest(ctx, "my-cluster", "", profile)
@@ -40,7 +40,7 @@ func TestGetSignedRequest(t *testing.T) {
 
 	t.Run("returns error when roleARN is provided and assume role fails", func(t *testing.T) {
 		t.Parallel()
-		ctx := context.Background()
+		ctx := t.Context()
 		cfg, err := config.LoadDefaultConfig(ctx,
 			config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
 			config.WithRegion("us-east-1"),

--- a/cmd/argocd/commands/app_diff_test.go
+++ b/cmd/argocd/commands/app_diff_test.go
@@ -104,7 +104,7 @@ func mockDiffStrategyNoneModified() diffStrategy {
 
 // TestComputeDiff_DefaultCase tests the default case with both live and target resources
 func TestCompareManifests_DefaultCase(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create test resources with both live and target states
 	liveDeployment := createTestUnstructured(&appsv1.Deployment{
@@ -146,7 +146,7 @@ func TestCompareManifests_DefaultCase(t *testing.T) {
 
 // TestComputeDiff_AddedResource tests when a resource exists in target but not live
 func TestCompareManifests_AddedResource(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create a target-only resource (added) - no live state
 	targetDeployment := createTestUnstructured(&appsv1.Deployment{
@@ -177,7 +177,7 @@ func TestCompareManifests_AddedResource(t *testing.T) {
 
 // TestComputeDiff_RemovedResource tests when a resource exists in live but not target
 func TestCompareManifests_RemovedResource(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create a live-only resource (removed) - no target state
 	liveDeployment := createTestUnstructured(&appsv1.Deployment{
@@ -208,7 +208,7 @@ func TestCompareManifests_RemovedResource(t *testing.T) {
 
 // TestComputeDiff_MultipleResources tests handling multiple resources
 func TestCompareManifests_MultipleResources(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create multiple resources
 	liveDeployment := createTestUnstructured(&appsv1.Deployment{
@@ -287,7 +287,7 @@ func TestCompareManifests_MultipleResources(t *testing.T) {
 
 // TestComputeDiff_EmptyResources tests with no resources
 func TestCompareManifests_EmptyResources(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	getLiveManifests := mockManifestProvider([]*unstructured.Unstructured{})
 	getTargetManifests := mockManifestProvider([]*unstructured.Unstructured{})
@@ -301,7 +301,7 @@ func TestCompareManifests_EmptyResources(t *testing.T) {
 
 // TestComputeDiff_MixedAddedRemovedModified tests a scenario with added, removed, and modified resources
 func TestCompareManifests_MixedAddedRemovedModified(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Modified resource (exists in both live and target)
 	liveDeployment := createTestUnstructured(&appsv1.Deployment{
@@ -391,7 +391,7 @@ func TestCompareManifests_MixedAddedRemovedModified(t *testing.T) {
 
 // TestComputeDiff_NoModifications tests that resources without modifications are not returned
 func TestCompareManifests_NoModifications(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	liveDeployment := createTestUnstructured(&appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
@@ -497,7 +497,7 @@ func TestManifestsToUnstructured(t *testing.T) {
 }
 
 func TestNewMultiSourceRevisionProvider(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	deployment := createTestUnstructured(&appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
@@ -550,7 +550,7 @@ func TestNewMultiSourceRevisionProvider(t *testing.T) {
 }
 
 func TestNewSingleRevisionProvider(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	service := createTestUnstructured(&corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -601,7 +601,7 @@ func TestNewSingleRevisionProvider(t *testing.T) {
 }
 
 func TestNewDefaultTargetProvider(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("Success with multiple items", func(t *testing.T) {
 		deployment := createTestUnstructured(&appsv1.Deployment{
@@ -678,7 +678,7 @@ func TestNewDefaultTargetProvider(t *testing.T) {
 }
 
 func TestNewLiveManifestProvider(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("Success", func(t *testing.T) {
 		deployment := createTestUnstructured(&appsv1.Deployment{
@@ -793,7 +793,7 @@ func TestNewLiveManifestProvider(t *testing.T) {
 // Test Diff Strategy Functions
 
 func TestNewServerSideDiffStrategy(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	deployment := createTestUnstructured(&appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
@@ -1129,7 +1129,7 @@ func TestNewServerSideDiffStrategy(t *testing.T) {
 }
 
 func TestNewClientSideDiffStrategy(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	deployment := createTestUnstructured(&appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
@@ -1328,7 +1328,7 @@ func TestNewClientSideDiffStrategy(t *testing.T) {
 }
 
 func TestNewNormalizeTargetManifestsProvider(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("Normalizes manifests with tracking labels", func(t *testing.T) {
 		deployment := createTestUnstructured(&appsv1.Deployment{

--- a/cmd/argocd/commands/app_test.go
+++ b/cmd/argocd/commands/app_test.go
@@ -1004,7 +1004,7 @@ func TestNewApplicationUnsetCommand_Validation(t *testing.T) {
 		_ = cmd.Execute()
 	}
 
-	cmd := exec.CommandContext(context.Background(), os.Args[0], "-test.run=TestNewApplicationUnsetCommand_Validation")
+	cmd := exec.CommandContext(t.Context(), os.Args[0], "-test.run=TestNewApplicationUnsetCommand_Validation")
 	cmd.Env = append(os.Environ(), "BE_CRASHER=1")
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr

--- a/cmd/argocd/commands/applicationset_test.go
+++ b/cmd/argocd/commands/applicationset_test.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"context"
 	"errors"
 	"io"
 	"os"
@@ -42,7 +41,7 @@ func TestAppSetDeleteWaitFlow(t *testing.T) {
 // waits for ResourcesUpToDate from the watch before completing.
 func TestAppSetCreateWaitFlow(t *testing.T) {
 	fakeClient := &fakeAcdClient{}
-	ctx := context.Background()
+	ctx := t.Context()
 
 	err := waitForApplicationSetResourcesUpToDate(ctx, fakeClient, "test-appset")
 	require.NoError(t, err)

--- a/cmpserver/plugin/plugin_test.go
+++ b/cmpserver/plugin/plugin_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-cd/v3/cmpserver/apiclient"

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -1196,7 +1196,7 @@ func TestFinalizeAppDeletion(t *testing.T) {
 		app := newFakeApp()
 		app.SetPreDeleteFinalizer()
 		app.Spec.Destination.Namespace = test.FakeArgoCDNamespace
-		ctrl := newFakeController(context.Background(), &fakeData{
+		ctrl := newFakeController(t.Context(), &fakeData{
 			manifestResponses: []*apiclient.ManifestResponse{{
 				Manifests: []string{fakePreDeleteHook},
 			}},
@@ -1236,7 +1236,7 @@ func TestFinalizeAppDeletion(t *testing.T) {
 		app.Name = "this-application-name-is-deliberately-seventy-characters-long-12345678"
 		app.SetPreDeleteFinalizer()
 		app.Spec.Destination.Namespace = test.FakeArgoCDNamespace
-		ctrl := newFakeController(context.Background(), &fakeData{
+		ctrl := newFakeController(t.Context(), &fakeData{
 			manifestResponses: []*apiclient.ManifestResponse{{
 				Manifests: []string{fakePreDeleteHook},
 			}},
@@ -1363,7 +1363,7 @@ func TestFinalizeAppDeletion(t *testing.T) {
 		app.Spec.Destination.Namespace = test.FakeArgoCDNamespace
 		liveHook := &unstructured.Unstructured{Object: newFakePreDeleteHook()}
 		require.NoError(t, unstructured.SetNestedField(liveHook.Object, "Succeeded", "status", "phase"))
-		ctrl := newFakeController(context.Background(), &fakeData{
+		ctrl := newFakeController(t.Context(), &fakeData{
 			manifestResponses: []*apiclient.ManifestResponse{{
 				Manifests: []string{fakePreDeleteHook},
 			}},
@@ -4032,7 +4032,7 @@ func TestPersistAppStatus_AnnotationManagement(t *testing.T) {
 		ctrl.persistReconciliationStatus(origApp, newStatus)
 
 		// Verify the patch was created correctly
-		patchedApp, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(app.Namespace).Get(context.Background(), app.Name, metav1.GetOptions{})
+		patchedApp, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(app.Namespace).Get(t.Context(), app.Name, metav1.GetOptions{})
 		require.NoError(t, err)
 
 		// Refresh annotation should be deleted
@@ -4073,7 +4073,7 @@ func TestPersistAppStatus_AnnotationManagement(t *testing.T) {
 		ctrl.persistAppStatus(origApp, newStatus, newAnnotations)
 
 		// Verify the patch was created correctly
-		patchedApp, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(app.Namespace).Get(context.Background(), app.Name, metav1.GetOptions{})
+		patchedApp, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(app.Namespace).Get(t.Context(), app.Name, metav1.GetOptions{})
 		require.NoError(t, err)
 
 		// Hydrate annotation should be deleted

--- a/controller/state_test.go
+++ b/controller/state_test.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"strings"
@@ -2550,7 +2549,7 @@ func Test_EvaluateAppRevisionsChanges(t *testing.T) {
 			ctrl := newFakeController(t.Context(), &tc.data, nil)
 
 			hasChanges, resolvedRevisions, err := ctrl.appStateManager.EvaluateAppRevisionsChanges(
-				context.Background(),
+				t.Context(),
 				tc.app,
 				tc.sources,
 				tc.revisions,

--- a/gitops-engine/pkg/cache/cluster_nil_fix_test.go
+++ b/gitops-engine/pkg/cache/cluster_nil_fix_test.go
@@ -88,10 +88,10 @@ func TestListResourcesNilPointerFix(t *testing.T) {
 	mockClient := &mockResourceInterface{}
 
 	// This should not panic even though mockClient.List() returns (nil, error)
-	_, err := cache.listResources(context.Background(), mockClient, func(listPager *pager.ListPager) error {
+	_, err := cache.listResources(t.Context(), mockClient, func(listPager *pager.ListPager) error {
 		// The fix ensures the pager receives a non-nil UnstructuredList
 		// preventing panic in GetContinue()
-		return listPager.EachListItem(context.Background(), metav1.ListOptions{}, func(obj runtime.Object) error {
+		return listPager.EachListItem(t.Context(), metav1.ListOptions{}, func(obj runtime.Object) error {
 			return nil
 		})
 	})

--- a/gitops-engine/pkg/utils/kube/resource_ops_test.go
+++ b/gitops-engine/pkg/utils/kube/resource_ops_test.go
@@ -1,7 +1,6 @@
 package kube
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 
@@ -53,14 +52,14 @@ func TestAuthReconcileWithMissingNamespace(t *testing.T) {
 		role := testingutils.NewRole()
 		role.SetNamespace(namespace)
 
-		_, err := k.rbacReconcile(context.Background(), role, cmdutil.DryRunNone)
+		_, err := k.rbacReconcile(t.Context(), role, cmdutil.DryRunNone)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), `namespaces "test-ns" not found`)
 
 		roleBinding := testingutils.NewRoleBinding()
 		roleBinding.SetNamespace(namespace)
 
-		_, err = k.rbacReconcile(context.Background(), roleBinding, cmdutil.DryRunNone)
+		_, err = k.rbacReconcile(t.Context(), roleBinding, cmdutil.DryRunNone)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), `namespaces "test-ns" not found`)
 	})
@@ -73,13 +72,13 @@ func TestAuthReconcileWithMissingNamespace(t *testing.T) {
 		clusterRole := testingutils.NewClusterRole()
 		clusterRole.SetNamespace(namespace)
 
-		_, err := k.rbacReconcile(context.Background(), clusterRole, cmdutil.DryRunNone)
+		_, err := k.rbacReconcile(t.Context(), clusterRole, cmdutil.DryRunNone)
 		require.NoError(t, err)
 
 		clusterRoleBinding := testingutils.NewClusterRoleBinding()
 		clusterRoleBinding.SetNamespace(namespace)
 
-		_, err = k.rbacReconcile(context.Background(), clusterRoleBinding, cmdutil.DryRunNone)
+		_, err = k.rbacReconcile(t.Context(), clusterRoleBinding, cmdutil.DryRunNone)
 		require.NoError(t, err)
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -301,7 +301,7 @@ require (
 	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/apiserver v0.36.1 // indirect
 	k8s.io/cli-runtime v0.36.1 // indirect
 	k8s.io/component-base v0.36.1 // indirect

--- a/pkg/apiclient/apiclient_test.go
+++ b/pkg/apiclient/apiclient_test.go
@@ -1,7 +1,6 @@
 package apiclient
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -77,7 +76,7 @@ func TestExecuteRequest_ClosesBodyOnHTTPError(t *testing.T) {
 	}
 
 	// Execute request that should fail with HTTP 500
-	ctx := context.Background()
+	ctx := t.Context()
 	md := metadata.New(map[string]string{})
 	_, err := c.executeRequest(ctx, "/test.Service/Method", []byte("test"), md)
 
@@ -121,7 +120,7 @@ func TestExecuteRequest_ClosesBodyOnGRPCError(t *testing.T) {
 	}
 
 	// Execute request that should fail with gRPC error
-	ctx := context.Background()
+	ctx := t.Context()
 	md := metadata.New(map[string]string{})
 	_, err := c.executeRequest(ctx, "/test.Service/Method", []byte("test"), md)
 
@@ -184,7 +183,7 @@ func TestExecuteRequest_ConcurrentErrorRequests_NoConnectionLeak(t *testing.T) {
 	for range iterations {
 		for range concurrency {
 			wg.Go(func() {
-				ctx := context.Background()
+				ctx := t.Context()
 				md := metadata.New(map[string]string{})
 				_, err := c.executeRequest(ctx, "/application.ApplicationService/ManagedResources", []byte("test"), md)
 				// We expect errors
@@ -232,7 +231,7 @@ func TestExecuteRequest_SuccessDoesNotCloseBodyPrematurely(t *testing.T) {
 	}
 
 	// Execute successful request
-	ctx := context.Background()
+	ctx := t.Context()
 	md := metadata.New(map[string]string{})
 	resp, err := c.executeRequest(ctx, "/test.Service/Method", []byte("test"), md)
 

--- a/reposerver/apiclient/clientset_test.go
+++ b/reposerver/apiclient/clientset_test.go
@@ -300,7 +300,7 @@ func TestMTLSIntegration_NoClientCert_IsRejected(t *testing.T) {
 		}
 	}(conn)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 	conn.Connect()
 	for {
@@ -407,7 +407,7 @@ func TestMTLSIntegration_HealthCheckEphemeralCert_IsAccepted(t *testing.T) {
 // that DisableTLS=true on the client side still works after this PR.
 func TestMTLSIntegration_DisableTLS_PlaintextConnection(t *testing.T) {
 	t.Parallel()
-	lis, err := new(net.ListenConfig).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	lis, err := new(net.ListenConfig).Listen(t.Context(), "tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
 	srv := grpc.NewServer() // no TLS credentials
@@ -549,7 +549,7 @@ func extractServerCert(t *testing.T, addr string, clientCert *tls.Certificate) (
 		Certificates:       []tls.Certificate{*clientCert},
 	}
 	d := &tls.Dialer{Config: cfg}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 	conn, err := d.DialContext(ctx, "tcp", addr)
 	if err != nil {
@@ -593,7 +593,7 @@ func newMTLSServer(t *testing.T, clientCAs *x509.CertPool) *mTLSServerFixture {
 		MinVersion:   tls.VersionTLS12,
 	}
 
-	lis, err := new(net.ListenConfig).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	lis, err := new(net.ListenConfig).Listen(t.Context(), "tcp", "127.0.0.1:0")
 	require.NoError(t, err, "binding test listener")
 
 	srv := grpc.NewServer(grpc.Creds(credentials.NewTLS(serverTLSCfg)))
@@ -609,7 +609,7 @@ func newMTLSServer(t *testing.T, clientCAs *x509.CertPool) *mTLSServerFixture {
 
 func healthCheck(t *testing.T, conn *grpc.ClientConn) error {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 	resp, err := grpc_health_v1.NewHealthClient(conn).Check(ctx, &grpc_health_v1.HealthCheckRequest{})
 	if err != nil {

--- a/server/application/application_test.go
+++ b/server/application/application_test.go
@@ -4988,7 +4988,7 @@ func TestTerminateOperationWithConflicts(t *testing.T) {
 	}
 
 	appServer := newTestAppServer(t, testApp)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Get the fake clientset from the deepCopy wrapper
 	fakeAppCs := appServer.appclientset.(*deepCopyAppClientset).GetUnderlyingClientSet().(*apps.Clientset)

--- a/server/application/logs_test.go
+++ b/server/application/logs_test.go
@@ -18,7 +18,7 @@ func TestParseLogsStream_Successful(t *testing.T) {
 
 	res := make(chan logEntry)
 	go func() {
-		parseLogsStream(context.Background(), "test", r, res)
+		parseLogsStream(t.Context(), "test", r, res)
 		close(res)
 	}()
 
@@ -42,7 +42,7 @@ func TestParseLogsStream_ParsingError(t *testing.T) {
 
 	res := make(chan logEntry)
 	go func() {
-		parseLogsStream(context.Background(), "test", r, res)
+		parseLogsStream(t.Context(), "test", r, res)
 		close(res)
 	}()
 
@@ -59,19 +59,19 @@ func TestMergeLogStreams(t *testing.T) {
 	t.Parallel()
 	first := make(chan logEntry)
 	go func() {
-		parseLogsStream(context.Background(), "first", io.NopCloser(strings.NewReader(`2021-02-09T00:00:01Z 1
+		parseLogsStream(t.Context(), "first", io.NopCloser(strings.NewReader(`2021-02-09T00:00:01Z 1
 2021-02-09T00:00:03Z 3`)), first)
 		close(first)
 	}()
 
 	second := make(chan logEntry)
 	go func() {
-		parseLogsStream(context.Background(), "second", io.NopCloser(strings.NewReader(`2021-02-09T00:00:02Z 2
+		parseLogsStream(t.Context(), "second", io.NopCloser(strings.NewReader(`2021-02-09T00:00:02Z 2
 2021-02-09T00:00:04Z 4`)), second)
 		close(second)
 	}()
 
-	merged := mergeLogStreams(context.Background(), []chan logEntry{first, second}, time.Second)
+	merged := mergeLogStreams(t.Context(), []chan logEntry{first, second}, time.Second)
 	var lines []string
 	for entry := range merged {
 		lines = append(lines, entry.line)
@@ -80,25 +80,25 @@ func TestMergeLogStreams(t *testing.T) {
 	assert.Equal(t, []string{"1", "2", "3", "4"}, lines)
 }
 
-func TestMergeLogStreams_RaceCondition(_ *testing.T) {
+func TestMergeLogStreams_RaceCondition(t *testing.T) {
 	// Test for regression of this issue: https://github.com/argoproj/argo-cd/issues/7006
 	for i := range 5000 {
 		first := make(chan logEntry)
 		second := make(chan logEntry)
 
 		go func() {
-			parseLogsStream(context.Background(), "first", io.NopCloser(strings.NewReader(`2021-02-09T00:00:01Z 1`)), first)
+			parseLogsStream(t.Context(), "first", io.NopCloser(strings.NewReader(`2021-02-09T00:00:01Z 1`)), first)
 			time.Sleep(time.Duration(i%3) * time.Millisecond)
 			close(first)
 		}()
 
 		go func() {
-			parseLogsStream(context.Background(), "second", io.NopCloser(strings.NewReader(`2021-02-09T00:00:02Z 2`)), second)
+			parseLogsStream(t.Context(), "second", io.NopCloser(strings.NewReader(`2021-02-09T00:00:02Z 2`)), second)
 			time.Sleep(time.Duration((i+1)%3) * time.Millisecond)
 			close(second)
 		}()
 
-		merged := mergeLogStreams(context.Background(), []chan logEntry{first, second}, 1*time.Millisecond)
+		merged := mergeLogStreams(t.Context(), []chan logEntry{first, second}, 1*time.Millisecond)
 
 		// Drain the channel
 		for range merged {
@@ -114,7 +114,7 @@ func TestMergeLogStreams_RaceCondition(_ *testing.T) {
 // to close the merged channel promptly, allowing all internal goroutines to exit without leaking.
 func TestMergeLogStreams_ContextCancellation(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 
 	// unbuffered pipe: write end will block until someone reads
 	pr, pw := io.Pipe()

--- a/server/applicationset/applicationset_test.go
+++ b/server/applicationset/applicationset_test.go
@@ -144,7 +144,7 @@ func newTestAppSetServerWithEnforcerConfigure(t *testing.T, f func(*rbac.Enforce
 	// populate the app informer with the fake objects
 	appInformer := factory.Argoproj().V1alpha1().Applications().Informer()
 	// TODO(jessesuen): probably should return cancel function so tests can stop background informer
-	// ctx, cancel := context.WithCancel(context.Background())
+	// ctx, cancel := context.WithCancel(t.Context())
 	go appInformer.Run(ctx.Done())
 	if !k8scache.WaitForCacheSync(ctx.Done(), appInformer.HasSynced) {
 		panic("Timed out waiting for caches to sync")

--- a/test/e2e/cross_namespace_ownership_test.go
+++ b/test/e2e/cross_namespace_ownership_test.go
@@ -1,7 +1,6 @@
 package e2e
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -99,7 +98,7 @@ rules:
 			defer io.Close(closer)
 
 			// Invalidate cache for the default cluster (https://kubernetes.default.svc)
-			cluster, err := clusterClient.InvalidateCache(context.Background(), &clusterpkg.ClusterQuery{
+			cluster, err := clusterClient.InvalidateCache(t.Context(), &clusterpkg.ClusterQuery{
 				Server: "https://kubernetes.default.svc",
 			})
 			if err != nil {
@@ -118,7 +117,7 @@ rules:
 			closer, cdClient := ArgoCDClientset.NewApplicationClientOrDie()
 			defer io.Close(closer)
 
-			tree, err := cdClient.ResourceTree(context.Background(), &applicationpkg.ResourcesQuery{
+			tree, err := cdClient.ResourceTree(t.Context(), &applicationpkg.ResourcesQuery{
 				ApplicationName: &app.Name,
 				AppNamespace:    &app.Namespace,
 			})
@@ -232,7 +231,7 @@ rules:
 			closer, cdClient := ArgoCDClientset.NewApplicationClientOrDie()
 			defer io.Close(closer)
 
-			tree, err := cdClient.ResourceTree(context.Background(), &applicationpkg.ResourcesQuery{
+			tree, err := cdClient.ResourceTree(t.Context(), &applicationpkg.ResourcesQuery{
 				ApplicationName: &app.Name,
 				AppNamespace:    &app.Namespace,
 			})

--- a/util/app/discovery/discovery_test.go
+++ b/util/app/discovery/discovery_test.go
@@ -1,7 +1,6 @@
 package discovery
 
 import (
-	"context"
 	"testing"
 
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
@@ -62,7 +61,7 @@ func Test_cmpSupports_invalidSocketPath_outsideDir(t *testing.T) {
 	// fileName with a path traversal that causes the address to be outside the plugin socket dir
 	fileName := "../outside.sock"
 
-	conn, client, found, err := cmpSupports(context.Background(), pluginSockFilePath, "appPath", "repoPath", fileName, nil, nil, true)
+	conn, client, found, err := cmpSupports(t.Context(), pluginSockFilePath, "appPath", "repoPath", fileName, nil, nil, true)
 	require.False(t, found)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "outside plugin socket dir")
@@ -78,7 +77,7 @@ func Test_cmpSupports_dialFailure_returnsError(t *testing.T) {
 	pluginSockFilePath := t.TempDir()
 	fileName := "nonexistent.sock"
 
-	conn, client, found, err := cmpSupports(context.Background(), pluginSockFilePath, "appPath", "repoPath", fileName, nil, nil, true)
+	conn, client, found, err := cmpSupports(t.Context(), pluginSockFilePath, "appPath", "repoPath", fileName, nil, nil, true)
 	require.False(t, found)
 	require.Error(t, err)
 	// We expect the error to at least indicate dialing failure; exact wording may vary,

--- a/util/argo/audit_logger_test.go
+++ b/util/argo/audit_logger_test.go
@@ -2,7 +2,6 @@ package argo
 
 import (
 	"bytes"
-	"context"
 	"sync"
 	"testing"
 
@@ -103,7 +102,7 @@ func TestLogAppProjEvent(t *testing.T) {
 	})
 
 	// Verify event was created in the AppProject's namespace (argocd)
-	events, err := fakeClient.CoreV1().Events(_argocdNs).List(context.Background(), metav1.ListOptions{})
+	events, err := fakeClient.CoreV1().Events(_argocdNs).List(t.Context(), metav1.ListOptions{})
 	require.NoError(t, err)
 	require.Len(t, events.Items, 1)
 
@@ -146,7 +145,7 @@ func TestLogAppEvent(t *testing.T) {
 	})
 
 	// Verify event was created in the Application's namespace (argocd)
-	events, err := fakeClient.CoreV1().Events(_argocdNs).List(context.Background(), metav1.ListOptions{})
+	events, err := fakeClient.CoreV1().Events(_argocdNs).List(t.Context(), metav1.ListOptions{})
 	require.NoError(t, err)
 	require.Len(t, events.Items, 1)
 
@@ -235,11 +234,11 @@ func TestLogResourceEvent_MultiCluster_CreatesEventInArgocdNamespace(t *testing.
 		logger.LogResourceEvent(&res, ei, "Resource action executed", "admin")
 	})
 
-	events, err := fakeClient.CoreV1().Events(_targetNs).List(context.Background(), metav1.ListOptions{})
+	events, err := fakeClient.CoreV1().Events(_targetNs).List(t.Context(), metav1.ListOptions{})
 	require.NoError(t, err)
 	assert.Empty(t, events.Items, "No event should be created in target namespace")
 
-	events, err = fakeClient.CoreV1().Events(_argocdNs).List(context.Background(), metav1.ListOptions{})
+	events, err = fakeClient.CoreV1().Events(_argocdNs).List(t.Context(), metav1.ListOptions{})
 	require.NoError(t, err)
 	require.Len(t, events.Items, 1, "Event should be created in ArgoCD namespace")
 
@@ -275,7 +274,7 @@ func TestLogAppSetEvent_CreatesEventInAppSetNamespace(t *testing.T) {
 	})
 
 	// Verify event was created in the ApplicationSet's namespace (argocd)
-	events, err := fakeClient.CoreV1().Events(_argocdNs).List(context.Background(), metav1.ListOptions{})
+	events, err := fakeClient.CoreV1().Events(_argocdNs).List(t.Context(), metav1.ListOptions{})
 	require.NoError(t, err)
 	require.Len(t, events.Items, 1)
 
@@ -345,7 +344,7 @@ func TestLogResourceEvent_DifferentKinds_AllInArgocdNamespace(t *testing.T) {
 				logger.LogResourceEvent(&res, ei, "Action ran", "admin")
 			})
 
-			events, err := fakeClient.CoreV1().Events(_argocdNs).List(context.Background(), metav1.ListOptions{})
+			events, err := fakeClient.CoreV1().Events(_argocdNs).List(t.Context(), metav1.ListOptions{})
 			require.NoError(t, err)
 			require.Len(t, events.Items, 1)
 
@@ -383,7 +382,7 @@ func TestLogResourceEvent_EmptyNamespace(t *testing.T) {
 	})
 
 	// Event should be created in ArgoCD namespace (not empty namespace)
-	events, err := fakeClient.CoreV1().Events(_argocdNs).List(context.Background(), metav1.ListOptions{})
+	events, err := fakeClient.CoreV1().Events(_argocdNs).List(t.Context(), metav1.ListOptions{})
 	require.NoError(t, err)
 	require.Len(t, events.Items, 1)
 

--- a/util/git/creds_test.go
+++ b/util/git/creds_test.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"context"
 	_ "embed"
 	"encoding/base64"
 	"encoding/json"
@@ -558,7 +557,7 @@ func TestDiscoverGitHubAppInstallationID(t *testing.T) {
 		})
 
 		// Execute
-		ctx := context.Background()
+		ctx := t.Context()
 		actualId, err := DiscoverGitHubAppInstallationID(ctx, appId, "fake-key", "", org)
 
 		// Assert
@@ -593,7 +592,7 @@ func TestDiscoverGitHubAppInstallationID(t *testing.T) {
 		})
 
 		// Execute & Assert
-		ctx := context.Background()
+		ctx := t.Context()
 		// Pass the mock server URL as the enterpriseBaseURL so the GitHub client uses it
 		// Note: The mock server will have a different domain (e.g., 127.0.0.1) than the first test (github.com),
 		// so there's no cache collision between the two subtests.
@@ -625,7 +624,7 @@ func TestDiscoverGitHubAppInstallationID(t *testing.T) {
 			}
 		})
 
-		ctx := context.Background()
+		ctx := t.Context()
 		actualId, err := DiscoverGitHubAppInstallationID(ctx, 12345, fakeGitHubAppPrivateKey, server.URL, "target-org")
 		require.NoError(t, err)
 		assert.Equal(t, int64(22222), actualId, "should return the installation ID for the requested org, not the last one in the list")

--- a/util/notification/argocd/service_test.go
+++ b/util/notification/argocd/service_test.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -45,7 +44,7 @@ func TestGetAppProject(t *testing.T) {
 	t.Run("returns AppProject when found", func(t *testing.T) {
 		t.Parallel()
 		svc, _ := newTestService(t, appProject)
-		result, err := svc.GetAppProject(context.Background(), "my-project", "default")
+		result, err := svc.GetAppProject(t.Context(), "my-project", "default")
 		require.NoError(t, err)
 		assert.Equal(t, "my-project", result.GetName())
 		assert.Equal(t, "default", result.GetNamespace())
@@ -60,7 +59,7 @@ func TestGetAppProject(t *testing.T) {
 			},
 		}
 		svc, _ := newTestService(t, defaultProject)
-		result, err := svc.GetAppProject(context.Background(), "", "default")
+		result, err := svc.GetAppProject(t.Context(), "", "default")
 		require.NoError(t, err)
 		assert.Equal(t, "default", result.GetName())
 	})
@@ -68,7 +67,7 @@ func TestGetAppProject(t *testing.T) {
 	t.Run("returns error when AppProject not found", func(t *testing.T) {
 		t.Parallel()
 		svc, _ := newTestService(t)
-		result, err := svc.GetAppProject(context.Background(), "nonexistent", "default")
+		result, err := svc.GetAppProject(t.Context(), "nonexistent", "default")
 		require.Error(t, err)
 		assert.Nil(t, result)
 	})

--- a/util/settings/settings_test.go
+++ b/util/settings/settings_test.go
@@ -2568,7 +2568,7 @@ func TestGetHydratorReadmeTemplate(t *testing.T) {
 
 	t.Run("ConfigMapError", func(t *testing.T) {
 		kubeClient := fake.NewClientset()
-		settingsManager := NewSettingsManager(context.Background(), kubeClient, "default")
+		settingsManager := NewSettingsManager(t.Context(), kubeClient, "default")
 		template, err := settingsManager.GetHydratorReadmeTemplate()
 		require.Error(t, err)
 		assert.Equal(t, DefaultManifestHydrationReadmeTemplate, template)


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
