### PR TITLE
fix: argocd app manifest --(hard)-refresh option

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -364,7 +364,7 @@ func NewApplicationGetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Com
   # Show application parameters and overrides for a source named "test"
   argocd app get my-app --show-params --source-name test
 
-  # Refresh application data when retrieving
+  # Refresh application data when retrieving (does not bypass manifest cache; use --hard-refresh for that)
   argocd app get my-app --refresh
 
   # Perform a hard refresh, including refreshing application data and target manifests cache
@@ -503,7 +503,7 @@ func NewApplicationGetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Com
 	command.Flags().UintVar(&timeout, "timeout", defaultCheckTimeoutSeconds, "Time out after this many seconds")
 	command.Flags().BoolVar(&showOperation, "show-operation", false, "Show application operation")
 	command.Flags().BoolVar(&showParams, "show-params", false, "Show application parameters and overrides")
-	command.Flags().BoolVar(&refresh, "refresh", false, "Refresh application data when retrieving")
+	command.Flags().BoolVar(&refresh, "refresh", false, "Refresh application data when retrieving (does not bypass manifest cache; use --hard-refresh for that)")
 	command.Flags().BoolVar(&hardRefresh, "hard-refresh", false, "Refresh application data as well as target manifests cache")
 	command.Flags().StringVarP(&appNamespace, "app-namespace", "N", "", "Only get application from namespace")
 	command.Flags().IntVar(&sourcePosition, "source-position", -1, "Position of the source from the list of sources of the app. Counting starts at 1.")
@@ -2956,7 +2956,7 @@ func NewApplicationManifestsCommand(clientOpts *argocdclient.ClientOptions) *cob
 	command.Flags().StringArrayVar(&sourceNames, "source-names", []string{}, "List of source names. Default is an empty array.")
 	command.Flags().StringVar(&local, "local", "", "If set, show locally-generated manifests. Value is the absolute path to app manifests within the manifest repo. Example: '/home/username/apps/env/app-1'.")
 	command.Flags().StringVar(&localRepoRoot, "local-repo-root", ".", "Path to the local repository root. Used together with --local allows setting the repository root. Example: '/home/username/apps'.")
-	command.Flags().BoolVar(&refresh, "refresh", false, "Refresh application data when retrieving")
+	command.Flags().BoolVar(&refresh, "refresh", false, "Refresh application data when retrieving (does not bypass manifest cache; use --hard-refresh for that)")
 	command.Flags().BoolVar(&hardRefresh, "hard-refresh", false, "Refresh application data as well as target manifests cache")
 	return command
 }

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -2804,6 +2804,8 @@ func NewApplicationManifestsCommand(clientOpts *argocdclient.ClientOptions) *cob
 		local           string
 		localRepoRoot   string
 		appNamespace    string
+		refresh         bool
+		hardRefresh     bool
 	)
 	command := &cobra.Command{
 		Use:   "manifests APPNAME",
@@ -2855,6 +2857,7 @@ func NewApplicationManifestsCommand(clientOpts *argocdclient.ClientOptions) *cob
 			app, err := appIf.Get(context.Background(), &application.ApplicationQuery{
 				Name:         &appName,
 				AppNamespace: &appNs,
+				Refresh:      getRefreshType(refresh, hardRefresh),
 			})
 			errors.CheckError(err)
 
@@ -2900,6 +2903,7 @@ func NewApplicationManifestsCommand(clientOpts *argocdclient.ClientOptions) *cob
 						Revision:        new(revision),
 						Revisions:       revisions,
 						SourcePositions: sourcePositions,
+						NoCache:         &hardRefresh,
 					}
 					res, err := appIf.GetManifests(ctx, &q)
 					errors.CheckError(err)
@@ -2914,6 +2918,7 @@ func NewApplicationManifestsCommand(clientOpts *argocdclient.ClientOptions) *cob
 						Name:         &appName,
 						AppNamespace: &appNs,
 						Revision:     new(revision),
+						NoCache:      &hardRefresh,
 					}
 					res, err := appIf.GetManifests(ctx, &q)
 					errors.CheckError(err)
@@ -2951,6 +2956,8 @@ func NewApplicationManifestsCommand(clientOpts *argocdclient.ClientOptions) *cob
 	command.Flags().StringArrayVar(&sourceNames, "source-names", []string{}, "List of source names. Default is an empty array.")
 	command.Flags().StringVar(&local, "local", "", "If set, show locally-generated manifests. Value is the absolute path to app manifests within the manifest repo. Example: '/home/username/apps/env/app-1'.")
 	command.Flags().StringVar(&localRepoRoot, "local-repo-root", ".", "Path to the local repository root. Used together with --local allows setting the repository root. Example: '/home/username/apps'.")
+	command.Flags().BoolVar(&refresh, "refresh", false, "Refresh application data when retrieving")
+	command.Flags().BoolVar(&hardRefresh, "hard-refresh", false, "Refresh application data as well as target manifests cache")
 	return command
 }
 

--- a/cmd/argocd/commands/app_diff.go
+++ b/cmd/argocd/commands/app_diff.go
@@ -787,7 +787,7 @@ func NewApplicationDiffCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 			}
 		},
 	}
-	command.Flags().BoolVar(&refresh, "refresh", false, "Refresh application data when retrieving")
+	command.Flags().BoolVar(&refresh, "refresh", false, "Refresh application data when retrieving (does not bypass manifest cache; use --hard-refresh for that)")
 	command.Flags().BoolVar(&hardRefresh, "hard-refresh", false, "Refresh application data as well as target manifests cache")
 	command.Flags().BoolVar(&exitCode, "exit-code", true, "Return non-zero exit code when there is a diff. May also return non-zero exit code if there is an error.")
 	command.Flags().IntVar(&diffExitCode, "diff-exit-code", 1, "Return specified exit code when there is a diff. Typical error code is 20 but use another exit code if you want to differentiate from the generic exit code (20) returned by all CLI commands.")

--- a/docs/user-guide/commands/argocd_app_diff.md
+++ b/docs/user-guide/commands/argocd_app_diff.md
@@ -27,7 +27,7 @@ argocd app diff APPNAME [flags]
       --local string                                      Compare live app to a local manifests
       --local-include stringArray                         Used with --server-side-generate, specify patterns of filenames to send. Matching is based on filename and not path. (default [*.yaml,*.yml,*.json])
       --local-repo-root string                            Path to the repository root. Used together with --local allows setting the repository root (default "/")
-      --refresh                                           Refresh application data when retrieving
+      --refresh                                           Refresh application data when retrieving (does not bypass manifest cache; use --hard-refresh for that)
       --revision string                                   Compare live app to a particular revision
       --revisions stringArray                             Show manifests at specific revisions for source position in source-positions
       --server-side-diff                                  Use server-side diff to calculate the diff. This will default to true if the ServerSideDiff annotation is set on the application.
@@ -71,5 +71,4 @@ argocd app diff APPNAME [flags]
 
 ### SEE ALSO
 
-* [argocd app](argocd_app.md)	 - Manage applications
-
+- [argocd app](argocd_app.md) - Manage applications

--- a/docs/user-guide/commands/argocd_app_diff.md
+++ b/docs/user-guide/commands/argocd_app_diff.md
@@ -71,4 +71,4 @@ argocd app diff APPNAME [flags]
 
 ### SEE ALSO
 
-- [argocd app](argocd_app.md) - Manage applications
+* [argocd app](argocd_app.md)	 - Manage applications

--- a/docs/user-guide/commands/argocd_app_diff.md
+++ b/docs/user-guide/commands/argocd_app_diff.md
@@ -72,3 +72,4 @@ argocd app diff APPNAME [flags]
 ### SEE ALSO
 
 * [argocd app](argocd_app.md)	 - Manage applications
+

--- a/docs/user-guide/commands/argocd_app_get.md
+++ b/docs/user-guide/commands/argocd_app_get.md
@@ -32,7 +32,7 @@ argocd app get APPNAME [flags]
   # Show application parameters and overrides for a source named "test"
   argocd app get my-app --show-params --source-name test
   
-  # Refresh application data when retrieving
+  # Refresh application data when retrieving (does not bypass manifest cache; use --hard-refresh for that)
   argocd app get my-app --refresh
   
   # Perform a hard refresh, including refreshing application data and target manifests cache
@@ -52,7 +52,7 @@ argocd app get APPNAME [flags]
       --hard-refresh           Refresh application data as well as target manifests cache
   -h, --help                   help for get
   -o, --output string          Output format. One of: json|yaml|wide|tree (default "wide")
-      --refresh                Refresh application data when retrieving
+      --refresh                Refresh application data when retrieving (does not bypass manifest cache; use --hard-refresh for that)
       --show-operation         Show application operation
       --show-params            Show application parameters and overrides
       --source-name string     Name of the source from the list of sources of the app.

--- a/docs/user-guide/commands/argocd_app_manifests.md
+++ b/docs/user-guide/commands/argocd_app_manifests.md
@@ -28,9 +28,11 @@ argocd app manifests APPNAME [flags]
 
 ```
   -N, --app-namespace string          Namespace of the application
+      --hard-refresh                  Refresh application data as well as target manifests cache
   -h, --help                          help for manifests
       --local string                  If set, show locally-generated manifests. Value is the absolute path to app manifests within the manifest repo. Example: '/home/username/apps/env/app-1'.
       --local-repo-root string        Path to the local repository root. Used together with --local allows setting the repository root. Example: '/home/username/apps'. (default ".")
+      --refresh                       Refresh application data when retrieving
       --revision string               Show manifests at a specific revision
       --revisions stringArray         Show manifests at specific revisions for the source at position in source-positions
       --source string                 Source of manifests. One of: live|git (default "git")

--- a/docs/user-guide/commands/argocd_app_manifests.md
+++ b/docs/user-guide/commands/argocd_app_manifests.md
@@ -32,7 +32,7 @@ argocd app manifests APPNAME [flags]
   -h, --help                          help for manifests
       --local string                  If set, show locally-generated manifests. Value is the absolute path to app manifests within the manifest repo. Example: '/home/username/apps/env/app-1'.
       --local-repo-root string        Path to the local repository root. Used together with --local allows setting the repository root. Example: '/home/username/apps'. (default ".")
-      --refresh                       Refresh application data when retrieving
+      --refresh                       Refresh application data when retrieving (does not bypass manifest cache; use --hard-refresh for that)
       --revision string               Show manifests at a specific revision
       --revisions stringArray         Show manifests at specific revisions for the source at position in source-positions
       --source string                 Source of manifests. One of: live|git (default "git")


### PR DESCRIPTION
When using `argocd app manifest` with `--revisions` on a freshly pushed branch, the CLI returns the following error because it doesn't know about the branch:

```
$ argocd app manifests argo-cd/app-example --revisions mbaur-test-1 --source-positions 1
{"level":"fatal","msg":"rpc error: code = Unknown desc = unable to resolve 'mbaur-test-1' to a commit SHA","time":"2026-06-17T13:19:54+02:00"}
```

To resolve this, this PR adds the already existing `--refresh` and `--hard-refresh` flags for `app manifest`.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
