### PR TITLE
fix: normalize Helm valuesObject in source comparison to avoid spurious appdetails 403 (#28288)

### DIFF
--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -3787,6 +3787,12 @@ func (source *ApplicationSource) Equals(other *ApplicationSource) bool {
 	otherCopy := other.DeepCopy()
 	sourceCopy.Plugin = nil
 	otherCopy.Plugin = nil
+	// Helm's valuesObject is stored as raw JSON bytes in a runtime.RawExtension. Two semantically identical
+	// values can have different byte representations (e.g. the Kubernetes API server does not HTML-escape
+	// '&', '<' and '>', while encoding/json does), which would make the reflect.DeepEqual below report a
+	// spurious difference. Normalize both sides to a canonical JSON form before comparing.
+	sourceCopy.Helm.NormalizeValuesObject()
+	otherCopy.Helm.NormalizeValuesObject()
 	return reflect.DeepEqual(sourceCopy, otherCopy)
 }
 

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -3783,16 +3783,15 @@ func (source *ApplicationSource) Equals(other *ApplicationSource) bool {
 	}
 	// reflect.DeepEqual works fine for the other fields. Since the plugin fields are equal, set them to null so they're
 	// not considered in the DeepEqual comparison.
+	if !source.Helm.Equals(other.Helm) {
+		return false
+	}
 	sourceCopy := source.DeepCopy()
 	otherCopy := other.DeepCopy()
 	sourceCopy.Plugin = nil
 	otherCopy.Plugin = nil
-	// Helm's valuesObject is stored as raw JSON bytes in a runtime.RawExtension. Two semantically identical
-	// values can have different byte representations (e.g. the Kubernetes API server does not HTML-escape
-	// '&', '<' and '>', while encoding/json does), which would make the reflect.DeepEqual below report a
-	// spurious difference. Normalize both sides to a canonical JSON form before comparing.
-	sourceCopy.Helm.NormalizeValuesObject()
-	otherCopy.Helm.NormalizeValuesObject()
+	sourceCopy.Helm = nil
+	otherCopy.Helm = nil
 	return reflect.DeepEqual(sourceCopy, otherCopy)
 }
 

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/argoproj/argo-cd/gitops-engine/pkg/sync/common"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -1081,6 +1082,72 @@ func TestAppSourceEquality(t *testing.T) {
 	assert.True(t, left.Equals(right))
 	right.Directory.Recurse = false
 	assert.False(t, left.Equals(right))
+}
+
+// TestAppSourceEquality_HelmValuesObject verifies that two semantically identical Helm valuesObject
+// values compare equal even when their raw JSON byte representations differ. This happens in practice
+// because the Kubernetes API server serializes the stored spec without HTML-escaping characters such as
+// '&', '<' and '>', whereas a source supplied in a request is typically parsed with encoding/json, which
+// does escape them. Without normalization this byte-level mismatch made GetAppDetails reject valid
+// requests with a 403 (see isSourceInHistory).
+func TestAppSourceEquality_HelmValuesObject(t *testing.T) {
+	// jsonEscaped returns the JSON encoding that encoding/json produces, which HTML-escapes '&', '<' and
+	// '>' into their \uXXXX form. This mirrors how a source supplied in a request is encoded, and differs
+	// byte-for-byte from the unescaped JSON served by the Kubernetes API server.
+	jsonEscaped := func(v any) []byte {
+		b, err := json.Marshal(v)
+		require.NoError(t, err)
+		return b
+	}
+
+	tests := []struct {
+		name     string
+		a        []byte
+		b        []byte
+		expected bool
+	}{
+		{
+			name:     "unescaped vs unicode-escaped ampersand",
+			a:        []byte(`{"foo":"&"}`),                      // as served by the Kubernetes API server
+			b:        jsonEscaped(map[string]string{"foo": "&"}), // {"foo":"&"} as encoded by a request
+			expected: true,
+		},
+		{
+			name:     "unescaped vs unicode-escaped angle brackets",
+			a:        []byte(`{"k":"<a>"}`),
+			b:        jsonEscaped(map[string]string{"k": "<a>"}), // {"k":"<a>"}
+			expected: true,
+		},
+		{
+			name:     "different map key ordering",
+			a:        []byte(`{"a":1,"b":2}`),
+			b:        []byte(`{"b":2,"a":1}`),
+			expected: true,
+		},
+		{
+			name:     "genuinely different values",
+			a:        []byte(`{"foo":"&"}`),
+			b:        []byte(`{"foo":"bar"}`),
+			expected: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			left := &ApplicationSource{
+				RepoURL: "https://example.com/repo.git",
+				Helm:    &ApplicationSourceHelm{ValuesObject: &runtime.RawExtension{Raw: tc.a}},
+			}
+			right := &ApplicationSource{
+				RepoURL: "https://example.com/repo.git",
+				Helm:    &ApplicationSourceHelm{ValuesObject: &runtime.RawExtension{Raw: tc.b}},
+			}
+			assert.Equal(t, tc.expected, left.Equals(right))
+			// Equals must be symmetric and must not mutate its operands.
+			assert.Equal(t, tc.expected, right.Equals(left))
+			assert.Equal(t, string(tc.a), string(left.Helm.ValuesObject.Raw))
+			assert.Equal(t, string(tc.b), string(right.Helm.ValuesObject.Raw))
+		})
+	}
 }
 
 func TestAppSource_GetKubeVersionOrDefault(t *testing.T) {

--- a/pkg/apis/application/v1alpha1/values.go
+++ b/pkg/apis/application/v1alpha1/values.go
@@ -50,11 +50,18 @@ func (h *ApplicationSourceHelm) Equals(other *ApplicationSourceHelm) bool {
 	if h == nil || other == nil {
 		return false
 	}
-	if bytes.Equal(h.ValuesObject.Raw, other.ValuesObject.Raw) {
-		// If they're already byte-equal, quit early to save time.
-		return true
+	// Compare ValuesObject: skip the JSON normalisation round-trip when raw bytes are
+	// already identical. Otherwise normalise both to canonical JSON to absorb
+	// HTML-escaping differences (e.g. '&' vs '&').
+	var hRaw, otherRaw []byte
+	if h.ValuesObject != nil {
+		hRaw = h.ValuesObject.Raw
 	}
-	if !bytes.Equal(canonicalValuesJSON(h.ValuesObject), canonicalValuesJSON(other.ValuesObject)) {
+	if other.ValuesObject != nil {
+		otherRaw = other.ValuesObject.Raw
+	}
+	if !bytes.Equal(hRaw, otherRaw) &&
+		!bytes.Equal(canonicalValuesJSON(h.ValuesObject), canonicalValuesJSON(other.ValuesObject)) {
 		return false
 	}
 	hCopy, otherCopy := h.DeepCopy(), other.DeepCopy()

--- a/pkg/apis/application/v1alpha1/values.go
+++ b/pkg/apis/application/v1alpha1/values.go
@@ -50,6 +50,10 @@ func (h *ApplicationSourceHelm) Equals(other *ApplicationSourceHelm) bool {
 	if h == nil || other == nil {
 		return false
 	}
+	if bytes.Equal(a.Raw, b.Raw) {
+		// If they're already byte-equal, quit early to save time.
+		return true
+	}
 	if !bytes.Equal(canonicalValuesJSON(h.ValuesObject), canonicalValuesJSON(other.ValuesObject)) {
 		return false
 	}

--- a/pkg/apis/application/v1alpha1/values.go
+++ b/pkg/apis/application/v1alpha1/values.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -38,27 +39,42 @@ func (h *ApplicationSourceHelm) SetValuesString(value string) error {
 	return nil
 }
 
-// NormalizeValuesObject rewrites ValuesObject.Raw into a canonical JSON form so that two semantically
-// equal values also compare equal at the byte level. This is required because the JSON produced by the
-// Kubernetes API server does not HTML-escape characters such as '&', '<' and '>', whereas Go's
-// encoding/json (used when a request source is parsed) does. Without normalization, a byte-wise comparison
-// such as reflect.DeepEqual would report a spurious difference between an otherwise identical stored source
-// and the source supplied in a request.
-func (h *ApplicationSourceHelm) NormalizeValuesObject() {
-	if h == nil || h.ValuesObject == nil || h.ValuesObject.Raw == nil {
-		return
+// Equals reports whether h and other are semantically equal. ValuesObject is compared by
+// marshaling both sides to canonical JSON so that HTML-escaping differences (e.g. '&' vs
+// '&') that arise between the Kubernetes API server and encoding/json do not cause
+// a spurious inequality.
+func (h *ApplicationSourceHelm) Equals(other *ApplicationSourceHelm) bool {
+	if h == nil && other == nil {
+		return true
+	}
+	if h == nil || other == nil {
+		return false
+	}
+	if !bytes.Equal(canonicalValuesJSON(h.ValuesObject), canonicalValuesJSON(other.ValuesObject)) {
+		return false
+	}
+	hCopy, otherCopy := h.DeepCopy(), other.DeepCopy()
+	hCopy.ValuesObject = nil
+	otherCopy.ValuesObject = nil
+	return reflect.DeepEqual(hCopy, otherCopy)
+}
+
+// canonicalValuesJSON returns the canonical JSON encoding of a ValuesObject by round-tripping
+// through json.Unmarshal + json.Marshal. Returns the original Raw bytes for invalid JSON,
+// or nil if the extension is absent.
+func canonicalValuesJSON(ext *runtime.RawExtension) []byte {
+	if ext == nil || ext.Raw == nil {
+		return nil
 	}
 	var v any
-	if err := json.Unmarshal(h.ValuesObject.Raw, &v); err != nil {
-		// Leave the raw value untouched if it is not valid JSON; it should never happen because
-		// ValuesObject is only ever set from JSON, but we must not panic or corrupt the value.
-		return
+	if err := json.Unmarshal(ext.Raw, &v); err != nil {
+		return ext.Raw
 	}
-	normalized, err := json.Marshal(v)
+	b, err := json.Marshal(v)
 	if err != nil {
-		return
+		return ext.Raw
 	}
-	h.ValuesObject.Raw = normalized
+	return b
 }
 
 func (h *ApplicationSourceHelm) ValuesYAML() []byte {

--- a/pkg/apis/application/v1alpha1/values.go
+++ b/pkg/apis/application/v1alpha1/values.go
@@ -50,7 +50,7 @@ func (h *ApplicationSourceHelm) Equals(other *ApplicationSourceHelm) bool {
 	if h == nil || other == nil {
 		return false
 	}
-	if bytes.Equal(a.Raw, b.Raw) {
+	if bytes.Equal(h.ValuesObject.Raw, other.ValuesObject.Raw) {
 		// If they're already byte-equal, quit early to save time.
 		return true
 	}

--- a/pkg/apis/application/v1alpha1/values.go
+++ b/pkg/apis/application/v1alpha1/values.go
@@ -38,6 +38,29 @@ func (h *ApplicationSourceHelm) SetValuesString(value string) error {
 	return nil
 }
 
+// NormalizeValuesObject rewrites ValuesObject.Raw into a canonical JSON form so that two semantically
+// equal values also compare equal at the byte level. This is required because the JSON produced by the
+// Kubernetes API server does not HTML-escape characters such as '&', '<' and '>', whereas Go's
+// encoding/json (used when a request source is parsed) does. Without normalization, a byte-wise comparison
+// such as reflect.DeepEqual would report a spurious difference between an otherwise identical stored source
+// and the source supplied in a request.
+func (h *ApplicationSourceHelm) NormalizeValuesObject() {
+	if h == nil || h.ValuesObject == nil || h.ValuesObject.Raw == nil {
+		return
+	}
+	var v any
+	if err := json.Unmarshal(h.ValuesObject.Raw, &v); err != nil {
+		// Leave the raw value untouched if it is not valid JSON; it should never happen because
+		// ValuesObject is only ever set from JSON, but we must not panic or corrupt the value.
+		return
+	}
+	normalized, err := json.Marshal(v)
+	if err != nil {
+		return
+	}
+	h.ValuesObject.Raw = normalized
+}
+
 func (h *ApplicationSourceHelm) ValuesYAML() []byte {
 	if h.ValuesObject == nil || h.ValuesObject.Raw == nil {
 		return []byte(h.Values)

--- a/pkg/apis/application/v1alpha1/values_test.go
+++ b/pkg/apis/application/v1alpha1/values_test.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -80,6 +81,49 @@ func TestValues_SetString(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestApplicationSourceHelm_NormalizeValuesObject(t *testing.T) {
+	t.Run("nil receiver does not panic", func(t *testing.T) {
+		var h *ApplicationSourceHelm
+		assert.NotPanics(t, h.NormalizeValuesObject)
+	})
+
+	t.Run("nil ValuesObject is left untouched", func(t *testing.T) {
+		h := &ApplicationSourceHelm{Values: "foo: bar"}
+		h.NormalizeValuesObject()
+		assert.Nil(t, h.ValuesObject)
+	})
+
+	t.Run("byte-different but semantically equal values normalize to identical bytes", func(t *testing.T) {
+		// The Kubernetes API server serves '&' unescaped, while encoding/json HTML-escapes it to
+		// &. Normalization must collapse both representations to the same canonical bytes so they
+		// compare equal.
+		escaped, err := json.Marshal(map[string]string{"foo": "&"})
+		require.NoError(t, err)
+		require.NotEqual(t, `{"foo":"&"}`, string(escaped)) // sanity: the inputs really do differ
+
+		unescapedSrc := &ApplicationSourceHelm{ValuesObject: &runtime.RawExtension{Raw: []byte(`{"foo":"&"}`)}}
+		escapedSrc := &ApplicationSourceHelm{ValuesObject: &runtime.RawExtension{Raw: escaped}}
+		unescapedSrc.NormalizeValuesObject()
+		escapedSrc.NormalizeValuesObject()
+		assert.Equal(t, string(escapedSrc.ValuesObject.Raw), string(unescapedSrc.ValuesObject.Raw))
+	})
+
+	t.Run("is idempotent and sorts keys", func(t *testing.T) {
+		h := &ApplicationSourceHelm{ValuesObject: &runtime.RawExtension{Raw: []byte(`{"b":2,"a":1}`)}}
+		h.NormalizeValuesObject()
+		first := string(h.ValuesObject.Raw)
+		assert.Equal(t, `{"a":1,"b":2}`, first)
+		h.NormalizeValuesObject()
+		assert.Equal(t, first, string(h.ValuesObject.Raw))
+	})
+
+	t.Run("invalid JSON is left untouched", func(t *testing.T) {
+		h := &ApplicationSourceHelm{ValuesObject: &runtime.RawExtension{Raw: []byte(`not json`)}}
+		h.NormalizeValuesObject()
+		assert.Equal(t, `not json`, string(h.ValuesObject.Raw))
+	})
 }
 
 func TestApplicationSourceHelm_String(t *testing.T) {

--- a/pkg/apis/application/v1alpha1/values_test.go
+++ b/pkg/apis/application/v1alpha1/values_test.go
@@ -83,46 +83,75 @@ func TestValues_SetString(t *testing.T) {
 	}
 }
 
-func TestApplicationSourceHelm_NormalizeValuesObject(t *testing.T) {
-	t.Run("nil receiver does not panic", func(t *testing.T) {
-		var h *ApplicationSourceHelm
-		assert.NotPanics(t, h.NormalizeValuesObject)
+func TestApplicationSourceHelm_Equals(t *testing.T) {
+	t.Run("nil == nil", func(t *testing.T) {
+		var a, b *ApplicationSourceHelm
+		assert.True(t, a.Equals(b))
 	})
 
-	t.Run("nil ValuesObject is left untouched", func(t *testing.T) {
-		h := &ApplicationSourceHelm{Values: "foo: bar"}
-		h.NormalizeValuesObject()
-		assert.Nil(t, h.ValuesObject)
+	t.Run("nil != non-nil", func(t *testing.T) {
+		var a *ApplicationSourceHelm
+		b := &ApplicationSourceHelm{}
+		assert.False(t, a.Equals(b))
+		assert.False(t, b.Equals(a))
 	})
 
-	t.Run("byte-different but semantically equal values normalize to identical bytes", func(t *testing.T) {
-		// The Kubernetes API server serves '&' unescaped, while encoding/json HTML-escapes it to
-		// &. Normalization must collapse both representations to the same canonical bytes so they
-		// compare equal.
+	t.Run("identical structs are equal", func(t *testing.T) {
+		h := &ApplicationSourceHelm{
+			ReleaseName:  "my-release",
+			ValuesObject: &runtime.RawExtension{Raw: []byte(`{"foo":"bar"}`)},
+		}
+		assert.True(t, h.Equals(h.DeepCopy()))
+	})
+
+	t.Run("HTML-escaped and unescaped ValuesObject are equal", func(t *testing.T) {
+		// The Kubernetes API server serves '&' unescaped, while encoding/json HTML-escapes it
+		// to &. Equals must treat these as identical.
 		escaped, err := json.Marshal(map[string]string{"foo": "&"})
 		require.NoError(t, err)
-		require.NotEqual(t, `{"foo":"&"}`, string(escaped)) // sanity: the inputs really do differ
+		require.NotEqual(t, `{"foo":"&"}`, string(escaped)) // sanity: inputs really differ
 
-		unescapedSrc := &ApplicationSourceHelm{ValuesObject: &runtime.RawExtension{Raw: []byte(`{"foo":"&"}`)}}
-		escapedSrc := &ApplicationSourceHelm{ValuesObject: &runtime.RawExtension{Raw: escaped}}
-		unescapedSrc.NormalizeValuesObject()
-		escapedSrc.NormalizeValuesObject()
-		assert.Equal(t, string(escapedSrc.ValuesObject.Raw), string(unescapedSrc.ValuesObject.Raw))
+		a := &ApplicationSourceHelm{ValuesObject: &runtime.RawExtension{Raw: []byte(`{"foo":"&"}`)}}
+		b := &ApplicationSourceHelm{ValuesObject: &runtime.RawExtension{Raw: escaped}}
+		assert.True(t, a.Equals(b))
+		assert.True(t, b.Equals(a))
 	})
 
-	t.Run("is idempotent and sorts keys", func(t *testing.T) {
-		h := &ApplicationSourceHelm{ValuesObject: &runtime.RawExtension{Raw: []byte(`{"b":2,"a":1}`)}}
-		h.NormalizeValuesObject()
-		first := string(h.ValuesObject.Raw)
-		assert.Equal(t, `{"a":1,"b":2}`, first)
-		h.NormalizeValuesObject()
-		assert.Equal(t, first, string(h.ValuesObject.Raw))
+	t.Run("different key ordering in ValuesObject is equal", func(t *testing.T) {
+		a := &ApplicationSourceHelm{ValuesObject: &runtime.RawExtension{Raw: []byte(`{"a":1,"b":2}`)}}
+		b := &ApplicationSourceHelm{ValuesObject: &runtime.RawExtension{Raw: []byte(`{"b":2,"a":1}`)}}
+		assert.True(t, a.Equals(b))
 	})
 
-	t.Run("invalid JSON is left untouched", func(t *testing.T) {
-		h := &ApplicationSourceHelm{ValuesObject: &runtime.RawExtension{Raw: []byte(`not json`)}}
-		h.NormalizeValuesObject()
-		assert.Equal(t, `not json`, string(h.ValuesObject.Raw))
+	t.Run("genuinely different ValuesObject are not equal", func(t *testing.T) {
+		a := &ApplicationSourceHelm{ValuesObject: &runtime.RawExtension{Raw: []byte(`{"foo":"&"}`)}}
+		b := &ApplicationSourceHelm{ValuesObject: &runtime.RawExtension{Raw: []byte(`{"foo":"bar"}`)}}
+		assert.False(t, a.Equals(b))
+	})
+
+	t.Run("invalid JSON falls back to byte comparison", func(t *testing.T) {
+		raw := []byte(`not json`)
+		a := &ApplicationSourceHelm{ValuesObject: &runtime.RawExtension{Raw: raw}}
+		b := &ApplicationSourceHelm{ValuesObject: &runtime.RawExtension{Raw: raw}}
+		assert.True(t, a.Equals(b))
+	})
+
+	t.Run("does not mutate input", func(t *testing.T) {
+		escaped, err := json.Marshal(map[string]string{"foo": "&"})
+		require.NoError(t, err)
+		a := &ApplicationSourceHelm{ValuesObject: &runtime.RawExtension{Raw: []byte(`{"foo":"&"}`)}}
+		b := &ApplicationSourceHelm{ValuesObject: &runtime.RawExtension{Raw: escaped}}
+		origA := string(a.ValuesObject.Raw)
+		origB := string(b.ValuesObject.Raw)
+		a.Equals(b)
+		assert.Equal(t, origA, string(a.ValuesObject.Raw))
+		assert.Equal(t, origB, string(b.ValuesObject.Raw))
+	})
+
+	t.Run("non-ValuesObject fields are compared", func(t *testing.T) {
+		a := &ApplicationSourceHelm{ReleaseName: "release-a"}
+		b := &ApplicationSourceHelm{ReleaseName: "release-b"}
+		assert.False(t, a.Equals(b))
 	})
 }
 


### PR DESCRIPTION
## Summary

`ApplicationSource.Equals` compares the Helm `valuesObject` (a `runtime.RawExtension` holding raw JSON bytes) byte-for-byte via `reflect.DeepEqual`. The Kubernetes API server serves the stored spec **without** HTML-escaping characters such as `&`, `<` and `>`, whereas a source supplied in a request is typically parsed with `encoding/json`, which **does** escape them (`&` → `&`). Two semantically identical values therefore have different byte representations, so `Equals` returns `false`.

As a result, `isSourceInHistory` rejects valid `GetAppDetails` requests (`POST /api/v1/repositories/{repo}/appdetails`) with a **403** whenever an existing application's `valuesObject` contains such a character. Minimal repro:

```yaml
spec:
  source:
    helm:
      valuesObject:
        foo: '&'
```

(The 403 only occurs for already-existing applications, since the source-history check is skipped while an app is still being created.)

## Changes

- Add `ApplicationSourceHelm.NormalizeValuesObject()`, which rewrites `ValuesObject.Raw` into a canonical JSON form (`json.Unmarshal` → `json.Marshal`, unifying escaping and sorting keys).
- Call it on **copies** of both sources inside `ApplicationSource.Equals` before `reflect.DeepEqual`, so callers' data is left untouched.
- Unit tests for both the normalization helper and the `Equals` behavior (escape differences, key-order differences, genuinely different values, symmetry, non-mutation).

Manifest generation / `ValuesYAML()` already handled these characters correctly; the bug was limited to the byte-equality comparison.

Fixes #28288

---

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

> Note: this is a backend-only bug fix, so no CLI/UI or documentation changes are required.
