### PR TITLE
fix: deleted resource are incorrectly shown in UI

### DIFF
--- a/gitops-engine/pkg/cache/cluster.go
+++ b/gitops-engine/pkg/cache/cluster.go
@@ -28,7 +28,7 @@ import (
 	"context"
 	"fmt"
 	"runtime/debug"
-	"strings"
+	"slices"
 	"sync"
 	"time"
 
@@ -1019,6 +1019,7 @@ func (c *clusterCache) sync() error {
 
 	c.apisMeta = make(map[schema.GroupKind]*apiMeta)
 	c.resources = make(map[kube.ResourceKey]*Resource)
+	c.nsIndex = make(map[string]map[kube.ResourceKey]*Resource)
 	c.namespacedResources = make(map[schema.GroupKind]bool)
 	c.parentUIDToChildren = make(map[types.UID]map[kube.ResourceKey]struct{})
 	config := c.config
@@ -1417,7 +1418,7 @@ func buildGraph(nsNodes map[kube.ResourceKey]*Resource) map[kube.ResourceKey]map
 						// It is ok to pick any object, but we need to make sure we pick the same child after every refresh.
 						key1 := r.ResourceKey()
 						key2 := childNode.ResourceKey()
-						if strings.Compare(key1.String(), key2.String()) > 0 {
+						if key1.String() > key2.String() {
 							graph[uidNodeKey][childNode.Ref.UID] = childNode
 						}
 					}
@@ -1437,12 +1438,7 @@ func (c *clusterCache) IsNamespaced(gk schema.GroupKind) (bool, error) {
 }
 
 func (c *clusterCache) managesNamespace(namespace string) bool {
-	for _, ns := range c.namespaces {
-		if ns == namespace {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(c.namespaces, namespace)
 }
 
 // GetManagedLiveObjs helps finding matching live K8S resources for a given resources list.

--- a/gitops-engine/pkg/cache/cluster_test.go
+++ b/gitops-engine/pkg/cache/cluster_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -152,7 +151,7 @@ func getChildren(cluster *clusterCache, un *unstructured.Unstructured) []*Resour
 // Benchmark_sync is meant to simulate cluster initialization when populateResourceInfoHandler does nontrivial work.
 func Benchmark_sync(t *testing.B) {
 	resources := []runtime.Object{}
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		resources = append(resources, &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      fmt.Sprintf("pod-%d", i),
@@ -212,13 +211,12 @@ func Benchmark_sync_CrossNamespace(b *testing.B) {
 
 	for _, tc := range testCases {
 		b.Run(tc.name, func(b *testing.B) {
-
 			resources := []runtime.Object{}
 
 			// Create cluster-scoped parents (ClusterRoles)
 			numClusterParents := 100
 			clusterUIDs := make(map[string]types.UID)
-			for i := 0; i < numClusterParents; i++ {
+			for i := range numClusterParents {
 				uid := types.UID(fmt.Sprintf("cluster-uid-%d", i))
 				clusterUIDs[fmt.Sprintf("cluster-role-%d", i)] = uid
 				resources = append(resources, &rbacv1.ClusterRole{
@@ -885,6 +883,49 @@ func TestChildDeletedEvent(t *testing.T) {
 	assert.Equal(t, []*Resource{}, rsChildren)
 }
 
+// TestResyncClearsStaleNamespaceIndex reproduces the "ghost resource" bug where a resource that
+// disappeared from the cluster between full resyncs stayed orphaned in nsIndex. This causes the
+// resource to show up in the application tree forever, even if it has already been deleted.
+func TestResyncClearsStaleNamespaceIndex(t *testing.T) {
+	t.Parallel()
+	pod := testPod1()
+	cluster := newCluster(t, pod, testRS(), testDeploy())
+	require.NoError(t, cluster.EnsureSynced())
+
+	podKey := kube.GetResourceKey(mustToUnstructured(pod))
+
+	// Sanity check: the pod is initially indexed in both resources and nsIndex.
+	cluster.lock.RLock()
+	_, inResources := cluster.resources[podKey]
+	_, inNSIndex := cluster.nsIndex[podKey.Namespace][podKey]
+	cluster.lock.RUnlock()
+	require.True(t, inResources, "pod should be in resources after initial sync")
+	require.True(t, inNSIndex, "pod should be in nsIndex after initial sync")
+
+	// Simulate the pod disappearing from the cluster while its delete event is missed: it is gone
+	// from the API server's list responses, but no watch.Deleted event is ever delivered.
+	dynClient := cluster.kubectl.(*kubetest.MockKubectlCmd).DynamicClient.(*fake.FakeDynamicClient)
+	require.NoError(t, dynClient.Tracker().Delete(
+		schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+		pod.Namespace, pod.Name,
+	))
+
+	// A full resync (periodic cluster resync or Invalidate + EnsureSynced) rebuilds the cache.
+	require.NoError(t, cluster.sync())
+
+	cluster.lock.RLock()
+	_, inResources = cluster.resources[podKey]
+	_, inNSIndex = cluster.nsIndex[podKey.Namespace][podKey]
+	cluster.lock.RUnlock()
+	assert.False(t, inResources, "stale pod must not remain in resources after resync")
+	assert.False(t, inNSIndex, "stale pod must not remain in nsIndex after resync")
+
+	// The stale pod must not be rendered as a child during hierarchy traversal.
+	for _, child := range getChildren(cluster, mustToUnstructured(testRS())) {
+		assert.NotEqual(t, podKey, child.ResourceKey(), "stale pod must not appear in the resource hierarchy")
+	}
+}
+
 func TestProcessNewChildEvent(t *testing.T) {
 	cluster := newCluster(t, testPod1(), testRS(), testDeploy())
 	err := cluster.EnsureSynced()
@@ -907,7 +948,7 @@ func TestProcessNewChildEvent(t *testing.T) {
 
 	rsChildren := getChildren(cluster, mustToUnstructured(testRS()))
 	sort.Slice(rsChildren, func(i, j int) bool {
-		return strings.Compare(rsChildren[i].Ref.Name, rsChildren[j].Ref.Name) < 0
+		return rsChildren[i].Ref.Name < rsChildren[j].Ref.Name
 	})
 	assert.Equal(t, []*Resource{{
 		Ref: corev1.ObjectReference{
@@ -1004,7 +1045,7 @@ func TestGetDuplicatedChildren(t *testing.T) {
 	require.NoError(t, err)
 
 	// Get children multiple times to make sure the right child is picked up every time.
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		children := getChildren(cluster, mustToUnstructured(testDeploy()))
 		assert.Len(t, children, 1)
 		assert.Equal(t, "apps/v1", children[0].Ref.APIVersion)
@@ -1821,7 +1862,7 @@ func Test_watchEvents_Deadlock(t *testing.T) {
 	err := cluster.EnsureSynced()
 	require.NoError(t, err)
 
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		done := make(chan bool, 1)
 		go func() {
 			// Stop the watches, so startMissingWatches will restart them
@@ -1853,7 +1894,7 @@ func Test_watchEvents_Deadlock(t *testing.T) {
 
 func buildTestResourceMap() map[kube.ResourceKey]*Resource {
 	ns := make(map[kube.ResourceKey]*Resource)
-	for i := 0; i < 100000; i++ {
+	for i := range 100000 {
 		name := fmt.Sprintf("test-%d", i)
 		ownerName := fmt.Sprintf("test-%d", i/10)
 		uid := uuid.New().String()
@@ -1926,7 +1967,7 @@ func buildClusterParentTestResourceMap(
 
 	// Create cluster-scoped parents (ClusterRoles)
 	clusterParentUIDs := make(map[string]string)
-	for i := 0; i < clusterParents; i++ {
+	for i := range clusterParents {
 		clusterRoleName := fmt.Sprintf("cluster-role-%d", i)
 		uid := uuid.New().String()
 		clusterParentUIDs[clusterRoleName] = uid
@@ -1954,7 +1995,7 @@ rules:
 
 	// Generate namespace names
 	namespaces := make([]string, totalNamespaces)
-	for i := 0; i < totalNamespaces; i++ {
+	for i := range totalNamespaces {
 		namespaces[i] = fmt.Sprintf("ns-%d", i)
 	}
 
@@ -2025,13 +2066,6 @@ metadata:
 	return resources
 }
 
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
 // BenchmarkIterateHierarchyV2_ClusterParentTraversal benchmarks full hierarchy traversal
 // starting from cluster-scoped parents with varying percentages of namespaces containing
 // cross-namespace children. This tests the actual performance impact of the cross-namespace
@@ -2067,7 +2101,6 @@ func BenchmarkIterateHierarchyV2_ClusterParentTraversal(b *testing.B) {
 
 	for _, tc := range testCases {
 		b.Run(tc.name, func(b *testing.B) {
-
 			cluster := newCluster(b).WithAPIResources([]kube.APIResourceInfo{{
 				GroupKind:            schema.GroupKind{Group: "rbac.authorization.k8s.io", Kind: "ClusterRole"},
 				GroupVersionResource: schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"},
@@ -2172,11 +2205,12 @@ func BenchmarkIterateHierarchyV2_MultiLevelClusterScoped(b *testing.B) {
 			// Create root cluster-scoped parent (Namespace, simulating Provider)
 			rootUID := uuid.New().String()
 			rootYaml := fmt.Sprintf(`
-apiVersion: v1
+			apiVersion: v1
 kind: Namespace
 metadata:
   name: root-parent
-  uid: %s`, rootUID)
+  uid: %s
+`, rootUID)
 			rootKey := kube.ResourceKey{Kind: "Namespace", Name: "root-parent"}
 			cluster.setNode(cacheTest.newResource(strToUnstructured(rootYaml)))
 
@@ -2482,7 +2516,7 @@ func BenchmarkSync_ParentToChildrenIndex(b *testing.B) {
 			numChildren := tc.totalResources - numParents
 			numWithOwnerRefs := (numChildren * tc.pctWithOwnerRefs) / 100
 
-			for i := 0; i < numChildren; i++ {
+			for i := range numChildren {
 				pod := &corev1.Pod{
 					TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
 					ObjectMeta: metav1.ObjectMeta{

--- a/gitops-engine/pkg/cache/cluster_test.go
+++ b/gitops-engine/pkg/cache/cluster_test.go
@@ -21,10 +21,10 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -1479,7 +1479,6 @@ func testClusterChild() *rbacv1.ClusterRole {
 	}
 }
 
-
 func TestIterateHierarchyV2_ClusterScopedParent_FindsAllChildren(t *testing.T) {
 	// Test that cluster-scoped parents automatically find all their children (both cluster-scoped and namespaced)
 	// This is the core behavior of the new implementation - cross-namespace relationships are always tracked
@@ -2090,13 +2089,13 @@ func BenchmarkIterateHierarchyV2_ClusterParentTraversal(b *testing.B) {
 
 		// Secondary dimension: Within a namespace, % of resources that are cross-NS
 		// 5,000 total resources, 2% of namespaces (1/50) have cross-NS children
-		{"50NS_2pct_100perNS_10cross", 50, 100, 1, 10},  // 10% of namespace resources (10/100)
-		{"50NS_2pct_100perNS_25cross", 50, 100, 1, 25},  // 25% of namespace resources (25/100)
-		{"50NS_2pct_100perNS_50cross", 50, 100, 1, 50},  // 50% of namespace resources (50/100)
+		{"50NS_2pct_100perNS_10cross", 50, 100, 1, 10}, // 10% of namespace resources (10/100)
+		{"50NS_2pct_100perNS_25cross", 50, 100, 1, 25}, // 25% of namespace resources (25/100)
+		{"50NS_2pct_100perNS_50cross", 50, 100, 1, 50}, // 50% of namespace resources (50/100)
 
 		// Edge cases
-		{"100NS_1pct_100perNS_10cross", 100, 100, 1, 10},   // 1% of namespaces (1/100) - extreme clustering
-		{"50NS_100pct_100perNS_10cross", 50, 100, 50, 10},  // 100% of namespaces - worst case
+		{"100NS_1pct_100perNS_10cross", 100, 100, 1, 10},  // 1% of namespaces (1/100) - extreme clustering
+		{"50NS_100pct_100perNS_10cross", 50, 100, 50, 10}, // 100% of namespaces - worst case
 	}
 
 	for _, tc := range testCases {
@@ -2113,7 +2112,7 @@ func BenchmarkIterateHierarchyV2_ClusterParentTraversal(b *testing.B) {
 
 			// CRITICAL: Initialize namespacedResources so setNode will populate orphanedChildren index
 			cluster.namespacedResources = map[schema.GroupKind]bool{
-				{Group: "", Kind: "Pod"}:                                   true,
+				{Group: "", Kind: "Pod"}:                                  true,
 				{Group: "rbac.authorization.k8s.io", Kind: "ClusterRole"}: false,
 			}
 
@@ -2163,10 +2162,10 @@ func BenchmarkIterateHierarchyV2_ClusterParentTraversal(b *testing.B) {
 // multi-level cluster-scoped hierarchies: ClusterScoped -> ClusterScoped -> Namespaced
 func BenchmarkIterateHierarchyV2_MultiLevelClusterScoped(b *testing.B) {
 	testCases := []struct {
-		name                  string
-		intermediateChildren  int // Number of intermediate cluster-scoped children per root
+		name                    string
+		intermediateChildren    int // Number of intermediate cluster-scoped children per root
 		namespacedGrandchildren int // Number of namespaced grandchildren per intermediate
-		totalNamespaces       int
+		totalNamespaces         int
 	}{
 		// Baseline: no multi-level hierarchy
 		{"NoMultiLevel", 0, 0, 10},
@@ -2197,15 +2196,15 @@ func BenchmarkIterateHierarchyV2_MultiLevelClusterScoped(b *testing.B) {
 			}})
 
 			cluster.namespacedResources = map[schema.GroupKind]bool{
-				{Group: "", Kind: "Pod"}:                                   true,
-				{Group: "", Kind: "Namespace"}:                             false,
+				{Group: "", Kind: "Pod"}:                                  true,
+				{Group: "", Kind: "Namespace"}:                            false,
 				{Group: "rbac.authorization.k8s.io", Kind: "ClusterRole"}: false,
 			}
 
 			// Create root cluster-scoped parent (Namespace, simulating Provider)
 			rootUID := uuid.New().String()
 			rootYaml := fmt.Sprintf(`
-			apiVersion: v1
+apiVersion: v1
 kind: Namespace
 metadata:
   name: root-parent
@@ -2494,10 +2493,9 @@ func BenchmarkSync_ParentToChildrenIndex(b *testing.B) {
 			resources := make([]runtime.Object, 0, tc.totalResources)
 
 			// Create parent resources (deployments) - these won't have owner refs
-			numParents := tc.totalResources / 10 // 10% are parents
-			if numParents < 1 {
-				numParents = 1
-			}
+			numParents := max(
+				// 10% are parents
+				tc.totalResources/10, 1)
 			parentUIDs := make([]types.UID, numParents)
 			for i := 0; i < numParents; i++ {
 				uid := types.UID(fmt.Sprintf("deploy-uid-%d", i))
@@ -2562,7 +2560,7 @@ func BenchmarkSync_ParentToChildrenIndex(b *testing.B) {
 // set-based storage so add/remove operations are O(1) regardless of children count.
 func BenchmarkUpdateParentUIDToChildren(b *testing.B) {
 	testCases := []struct {
-		name            string
+		name              string
 		childrenPerParent int
 	}{
 		{"10children", 10},


### PR DESCRIPTION
Closes #9226

The bug cannot be reproduced on demand, so this is an attempt to fix it. Resources deleted from the cluster (e.g. Pods) keep showing in the Argo resource tree until the controller restarts. The live manifest returns 404, but the tree view keeps rendering them. Invalidating the cluster cache or refreshing the app has no effect.

### Potential root cause

`clusterCache.sync()` resets `resources`, `namespacedResources`, and `parentUIDToChildren`, but never resets `nsIndex`. On a full resync, any resource that disappeared from the cluster is never re-added (no `setNode`) and never removed (no `onNodeRemoved`), so it stays in `nsIndex` forever. The hierarchy traversal builds its graph from `nsIndex`, so the ghost keeps being rendered and saved to redis. `replaceResourceCache` only scans `resources`, and `Invalidate()`/`sync()` never touch `nsIndex`, so only a process restart clears it.

Hopefully, this is the cause of the bug. Otherwise, there's no reason not to clean the nsIndex alongside resources anyway.
