### PR TITLE
fix(reposerver): honor depth of referenced source instead of primary source

### DIFF
--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -887,7 +887,11 @@ func (s *Service) runManifestGenAsync(ctx context.Context, repoRoot, commitSHA, 
 							return
 						}
 						closer, err := s.repoLock.Lock(gitClient.Root(), referencedCommitSHA, true, func(clean bool) (goio.Closer, error) {
-							return s.checkoutRevision(gitClient, referencedCommitSHA, s.initConstants.SubmoduleEnabled, q.Repo.Depth, clean)
+							// Use the referenced source's own depth instead of the primary source's depth.
+							// For multi-source Applications where the primary source is a Helm/OCI artifact,
+							// q.Repo.Depth is unset (0), which would otherwise force a full fetch of the
+							// referenced git repository regardless of its configured depth.
+							return s.checkoutRevision(gitClient, referencedCommitSHA, s.initConstants.SubmoduleEnabled, refSourceMapping.Repo.Depth, clean)
 						})
 						if err != nil {
 							log.Errorf("failed to acquire lock for referenced source %s", normalizedRepoURL)

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -683,6 +683,68 @@ func TestHelmChartReferencingExternalValues_InvalidRefs(t *testing.T) {
 	assert.Nil(t, response)
 }
 
+// TestHelmChartReferencingExternalValues_RefSourceDepthIsHonored is a regression
+// test for https://github.com/argoproj/argo-cd/issues/27811. For multi-source
+// Applications whose primary source is a Helm chart (or any non-git artifact),
+// the depth configured on the referenced git source must be propagated to the
+// git fetch. Previously the depth of the primary source was incorrectly used,
+// which is unset (0) for Helm/OCI primary sources and therefore caused full
+// git fetches regardless of the referenced repository's configured depth.
+func TestHelmChartReferencingExternalValues_RefSourceDepthIsHonored(t *testing.T) {
+	const refSourceDepth int64 = 1
+	service, _, _ := newServiceWithOpt(t, func(gitClient *gitmocks.Client, helmClient *helmmocks.Client, _ *ocimocks.Client, paths *iomocks.TempPaths) {
+		gitClient.EXPECT().Init().Return(nil)
+		gitClient.EXPECT().IsRevisionPresent(mock.Anything).Return(false)
+		// Strict expectation: Fetch must be invoked with the referenced source's
+		// depth (refSourceDepth), not the primary source's depth (which is 0
+		// because the primary source is Helm and Repository.Depth is unset).
+		// Any call with a different depth would fail this assertion.
+		gitClient.EXPECT().Fetch(mock.Anything, refSourceDepth).Return(nil)
+		gitClient.EXPECT().Checkout(mock.Anything, mock.Anything, mock.Anything).Return("", nil)
+		gitClient.EXPECT().LsRemote(mock.Anything).Return(mock.Anything, nil)
+		gitClient.EXPECT().CommitSHA().Return(mock.Anything, nil)
+		gitClient.EXPECT().Root().Return(".")
+		gitClient.EXPECT().RepoURL().Return("https://git.example.com/test/repo")
+		gitClient.EXPECT().IsAnnotatedTag(mock.Anything).Return(false)
+		gitClient.EXPECT().VerifyCommitSignature(mock.Anything).Return("", nil)
+
+		helmClient.EXPECT().GetIndex(mock.AnythingOfType("bool"), mock.Anything).Return(&helm.Index{Entries: map[string]helm.Entries{
+			"my-chart": {{Version: "1.0.0"}, {Version: "1.1.0"}},
+		}}, nil)
+		helmClient.EXPECT().GetTags(mock.Anything, mock.Anything).Return(nil, nil)
+		helmClient.EXPECT().ExtractChart("my-chart", "1.1.0", false, int64(0), false).Return("./testdata/my-chart", utilio.NopCloser, nil)
+		helmClient.EXPECT().CleanChartCache("my-chart", "1.1.0").Return(nil)
+
+		paths.EXPECT().Add(mock.Anything, mock.Anything).Return()
+		paths.EXPECT().GetPath(mock.Anything).Return(".", nil)
+		paths.EXPECT().GetPathIfExists(mock.Anything).Return(".")
+		paths.EXPECT().GetPaths().Return(map[string]string{"fake-nonce": "."})
+	}, ".")
+
+	spec := v1alpha1.ApplicationSpec{
+		Sources: []v1alpha1.ApplicationSource{
+			{RepoURL: "https://helm.example.com", Chart: "my-chart", TargetRevision: ">= 1.0.0", Helm: &v1alpha1.ApplicationSourceHelm{
+				ValueFiles: []string{"$ref/testdata/my-chart/my-chart-values.yaml"},
+			}},
+			{Ref: "ref", RepoURL: "https://git.example.com/test/repo"},
+		},
+	}
+	refSources, err := argo.GetRefSources(t.Context(), spec.Sources, spec.Project, func(_ context.Context, _ string, _ string) (*v1alpha1.Repository, error) {
+		return &v1alpha1.Repository{
+			Repo:  "https://git.example.com/test/repo",
+			Depth: refSourceDepth,
+		}, nil
+	}, []string{})
+	require.NoError(t, err)
+	request := &apiclient.ManifestRequest{
+		Repo: &v1alpha1.Repository{}, ApplicationSource: &spec.Sources[0], NoCache: true, RefSources: refSources, HasMultipleSources: true, ProjectName: "something",
+		ProjectSourceRepos: []string{"*"},
+	}
+	response, err := service.GenerateManifest(t.Context(), request)
+	require.NoError(t, err)
+	assert.NotNil(t, response)
+}
+
 func TestHelmChartReferencingExternalValues_OutOfBounds_Symlink(t *testing.T) {
 	service := newService(t, ".")
 	err := os.Mkdir("testdata/oob-symlink", 0o755)


### PR DESCRIPTION
<!-- If this is your first time, please read our contributor guidelines: https://github.com/argoproj/argo-cd/tree/master/CONTRIBUTING.md -->

Fixes #27811

## Description

For multi-source Applications, the checkout of a referenced source (e.g. `$values` in the Helm + git refs pattern) was using `q.Repo.Depth` — the depth of the **primary** source — instead of the referenced source's own depth (`refSourceMapping.Repo.Depth`).

For multi-source Applications whose primary source is a Helm or OCI artifact, `q.Repo.Depth` is always unset (`0`) because the primary `Repository` has no meaningful git depth. As a result, the referenced git repository was always fetched with full history regardless of the depth configured on its repository Secret, and the resulting `git fetch` command contained no `--depth` flag.

This caused `repo-server` to accumulate large `objects/pack/` files (multi-GB) on referenced repositories with many tags, even though `depth: "1"` was correctly set on their repository Secret.

### Change

Use `refSourceMapping.Repo.Depth` instead of `q.Repo.Depth` when checking out the referenced source. Each source's depth is now honored independently.

### Reproduction (before the fix)

1. Create a repository Secret for a git repo with `depth: "1"`:

    ```yaml
    apiVersion: v1
    kind: Secret
    metadata:
      name: my-repo
      namespace: argocd
      labels:
        argocd.argoproj.io/secret-type: repository
    stringData:
      url: https://github.com/example/my-repo
      type: git
      depth: "1"
    ```

2. Create a multi-source Application using the repo as a `$values` reference:

    ```yaml
    apiVersion: argoproj.io/v1alpha1
    kind: Application
    metadata:
      name: example
      namespace: argocd
    spec:
      project: default
      destination: { server: https://kubernetes.default.svc, namespace: default }
      sources:
        - chart: my-chart
          repoURL: https://charts.example.com
          targetRevision: 1.0.0
          helm:
            valueFiles:
              - $values/values.yaml
        - ref: values
          repoURL: https://github.com/example/my-repo
          targetRevision: HEAD
    ```

3. In `repo-server` logs, observe:

    ```
    git fetch origin --tags --force --prune
    ```

    → `--depth` is missing, full history is fetched.

After the fix:

```
git fetch origin <sha> --depth 1 --force --prune
```

### Testing

- Added `TestHelmChartReferencingExternalValues_RefSourceDepthIsHonored` covering the regression. The test sets up a Helm primary source with no depth and a git referenced source with `Depth: 1`, then asserts that `gitClient.Fetch` is invoked with depth `1` (not `0`).
- Verified the new test fails on the current `master` (`gitClient.Fetch` is invoked with `0`) and passes after the change.
- Existing `TestHelmChartReferencingExternalValues*` tests still pass.

### Checklist

- [x] Either (a) I've created an [enhancement proposal] and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [x] The title of the PR conforms to the [Toolchain Guide].
- [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
- [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. (N/A — no user-facing surface)
- [x] Does this PR require documentation updates? (No — internal behavior change)
- [x] I've updated documentation as required by this PR. (N/A)
- [x] I have signed off all my commits as required by [DCO].
- [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
- [x] My build is green ([troubleshooting builds]).
- [x] My new feature complies with the [feature status] guidelines.
- [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
- [x] Optional. My organization is added to USERS.md. (N/A)
- [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may require additional backport pull requests to be filed). Backports requested for: `release-3.3`, `release-3.4`, `release-3.5`.

[enhancement proposal]: https://github.com/argoproj/argo-cd/blob/master/docs/proposals/README.md
[Toolchain Guide]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[DCO]: https://github.com/apps/dco
[troubleshooting builds]: https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/
[feature status]: https://github.com/argoproj/argo-cd/blob/master/docs/operator-manual/feature-status.md
