### PR TITLE
fix(gitops-engine): race condition on empty-uid backfill

### DIFF
--- a/gitops-engine/pkg/cache/cluster.go
+++ b/gitops-engine/pkg/cache/cluster.go
@@ -1468,9 +1468,12 @@ func buildGraph(nsNodes map[kube.ResourceKey]*Resource) map[kube.ResourceKey]map
 
 	// Loop through all nodes, calling each one "childNode," because we're only bothering with it if it has a parent.
 	for _, childNode := range nsNodes {
-		for i, ownerRef := range childNode.OwnerRefs {
-			// First, backfill UID of inferred owner child references.
-			if ownerRef.UID == "" {
+		for _, ownerRef := range childNode.OwnerRefs {
+			// Resolve empty owner-ref UIDs into a local variable only. childNode is shared
+			// cache state and IterateHierarchyV2 may run concurrently under RLock.
+			ownerUID := ownerRef.UID
+			if ownerUID == "" {
+				// First, backfill UID of inferred owner child references.
 				group, err := schema.ParseGroupVersion(ownerRef.APIVersion)
 				if err != nil {
 					// APIVersion is invalid, so we couldn't find the parent.
@@ -1481,12 +1484,11 @@ func buildGraph(nsNodes map[kube.ResourceKey]*Resource) map[kube.ResourceKey]map
 					// No resource found with the given graph key, so move on.
 					continue
 				}
-				ownerRef.UID = graphKeyNode.Ref.UID
-				childNode.OwnerRefs[i] = ownerRef
+				ownerUID = graphKeyNode.Ref.UID
 			}
 
 			// Now that we have the UID of the parent, update the graph.
-			uidNodes, ok := nodesByUID[ownerRef.UID]
+			uidNodes, ok := nodesByUID[ownerUID]
 			if ok {
 				for _, uidNode := range uidNodes {
 					// Cache ResourceKey() to avoid repeated expensive calls

--- a/gitops-engine/pkg/cache/cluster_test.go
+++ b/gitops-engine/pkg/cache/cluster_test.go
@@ -1481,6 +1481,79 @@ func TestIterateHierarchyV2(t *testing.T) {
 	})
 }
 
+// TestIterateHierarchyV2_ConcurrentUIDBackfill stresses concurrent IterateHierarchyV2 calls
+// on shared cluster state with empty owner-ref UIDs. UID resolution uses local copies during
+// buildGraph and must not mutate cached OwnerRefs. Run with -race to verify:
+//
+//	go test -race -run TestIterateHierarchyV2_ConcurrentUIDBackfill ./gitops-engine/pkg/cache/
+func TestIterateHierarchyV2_ConcurrentUIDBackfill(t *testing.T) {
+	// Several pods with name-only owner refs exercise the empty-UID resolution path.
+	extraPods := make([]runtime.Object, 0, 8)
+	for i := range 8 {
+		extraPods = append(extraPods, &corev1.Pod{
+			TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              fmt.Sprintf("helm-guestbook-pod-extra-%d", i),
+				Namespace:         "default",
+				UID:               types.UID(fmt.Sprintf("extra-pod-%d", i)),
+				ResourceVersion:   "123",
+				CreationTimestamp: metav1.NewTime(testCreationTime),
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "apps/v1",
+					Kind:       "ReplicaSet",
+					Name:       "helm-guestbook-rs",
+				}},
+			},
+		})
+	}
+
+	objs := []runtime.Object{testPod1(), testPod2(), testRS(), testExtensionsRS(), testDeploy()}
+	objs = append(objs, extraPods...)
+	cluster := newCluster(t, objs...)
+	require.NoError(t, cluster.EnsureSynced())
+
+	// Empty owner-ref UIDs are resolved locally during traversal, not written to the cache.
+	for _, key := range []kube.ResourceKey{
+		kube.GetResourceKey(mustToUnstructured(testPod2())),
+		getResourceKey(t, extraPods[0]),
+	} {
+		res := cluster.resources[key]
+		require.NotNil(t, res)
+		require.Len(t, res.OwnerRefs, 1)
+		require.Empty(t, res.OwnerRefs[0].UID, "%s owner ref UID must remain empty in cache", key.Name)
+	}
+
+	// Different entry points all traverse the same namespace graph concurrently.
+	startKeys := [][]kube.ResourceKey{
+		{kube.GetResourceKey(mustToUnstructured(testDeploy()))},
+		{kube.GetResourceKey(mustToUnstructured(testRS()))},
+		{kube.GetResourceKey(mustToUnstructured(testPod2()))},
+	}
+
+	const (
+		goroutines = 64
+		iterations = 50
+	)
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := range goroutines {
+		go func(worker int) {
+			defer wg.Done()
+			<-start
+			keys := startKeys[worker%len(startKeys)]
+			for range iterations {
+				cluster.IterateHierarchyV2(keys, func(_ *Resource, _ map[kube.ResourceKey]*Resource) bool {
+					return true
+				})
+			}
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+}
+
 func testClusterParent() *corev1.Namespace {
 	return &corev1.Namespace{
 		TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
This fixes a data race witnessed in a [recent unrelated ci run](https://github.com/argoproj/argo-cd/actions/runs/27765742699/job/82152496459?pr=28334) and reproduced via a unit test in this PR.

Sometimes owner refs don't have UIDs. This can happen either because the controller managing the child resource doesn't set the UID or because we've built a synthetic parent-child relationship in gitops-engine that doesn't exist in the k8s view of the resources (we do this for a few kinds).

In these cases, we go _find_ the UID for the parent resource and set it on the owner ref.

Today we backfill that UID as a side-effect of running `buildGraph`. But `buildGraph` is meant to be read-only (it runs behind an RLock). 

This PR changes the behavior to use an ephemeral copy of the UID to build the graph without writing it back to the cache. This fixes the race but comes with some downsides:

1. Performance: we have to recalculate the owner ref for every `buildGraph` call instead of only once. In practice, this should be a minimal impact since empty UIDs are rare and finding the parent isn't very slow.
2. `argocd app resources --output tree` correctness: the CLI relies on the owner ref UID being set. In cases where we don't have a UID, children go missing from the tree. 

imo the downsides are acceptable. I'll look at introducing a more official cache owner ref backfill method, but it got very complicated in my last attempt. It might not be worth ever doing.