### PR TITLE
fix: rename argocd-rbac-cm scopes key to claims

### DIFF
--- a/docs/operator-manual/argocd-rbac-cm.yaml
+++ b/docs/operator-manual/argocd-rbac-cm.yaml
@@ -33,9 +33,10 @@ data:
   # but will see no apps, projects, etc...
   policy.default: role:readonly
 
-  # scopes controls which OIDC scopes to examine during rbac enforcement (in addition to `sub` scope).
-  # If omitted, defaults to: '[groups]'. The scope value can be a string, or a list of strings.
-  scopes: '[cognito:groups, email]'
+  # claims controls which OIDC claims to examine during rbac enforcement (in addition to the `sub` claim).
+  # If omitted, defaults to: '[groups]'. The value can be a string, or a list of strings.
+  # `scopes` is accepted as a deprecated alias for backward compatibility.
+  claims: '[cognito:groups, email]'
 
   # matchMode configures the matchers function for casbin.
   # There are two options for this, 'glob' for glob matcher or 'regex' for regex matcher. If omitted or mis-configured,

--- a/docs/operator-manual/rbac.md
+++ b/docs/operator-manual/rbac.md
@@ -327,10 +327,12 @@ When the `example-user` executes the `extensions/DaemonSet/test` action, the fol
 
 ## Using SSO Users/Groups
 
-The `scopes` field controls which OIDC scopes to examine during RBAC enforcement (in addition to `sub` scope).
-If omitted, it defaults to `'[groups]'`. The scope value can be a string, or a list of strings.
+The `claims` field controls which OIDC claims to examine during RBAC enforcement (in addition to the `sub` claim).
+If omitted, it defaults to `'[groups]'`. The value can be a string, or a list of strings.
 
-For more information on `scopes` please review the [User Management Documentation](user-management/index.md).
+> `claims` was previously named `scopes`. The `scopes` key continues to work as a deprecated alias for backward compatibility, but `claims` is preferred.
+
+For more information please review the [User Management Documentation](user-management/index.md).
 
 The following example shows targeting `email` as well as `groups` from your OIDC provider, and also demonstrates explicit role assignments and role-to-role inheritance:
 
@@ -351,7 +353,7 @@ data:
     g, admin, role:admin
     g, role:admin, role:readonly
   policy.default: role:readonly
-  scopes: '[groups, email]'
+  claims: '[groups, email]'
 ```
 
 Here:

--- a/server/server.go
+++ b/server/server.go
@@ -890,10 +890,18 @@ func (server *ArgoCDServer) watchSettings() {
 func (server *ArgoCDServer) rbacPolicyLoader(ctx context.Context) {
 	err := server.enf.RunPolicyLoader(ctx, func(cm *corev1.ConfigMap) error {
 		var scopes []string
-		if scopesStr, ok := cm.Data[rbac.ConfigMapScopesKey]; scopesStr != "" && ok {
+		// "claims" is the canonical key; "scopes" is kept as a deprecated
+		// alias for backward compatibility.
+		scopesStr, ok := cm.Data[rbac.ConfigMapClaimsKey]
+		if !ok || scopesStr == "" {
+			if legacyStr, legacyOK := cm.Data[rbac.ConfigMapScopesKey]; legacyOK && legacyStr != "" {
+				log.Warnf("the %q field in the argocd-rbac-cm ConfigMap is deprecated, use %q instead", rbac.ConfigMapScopesKey, rbac.ConfigMapClaimsKey)
+				scopesStr, ok = legacyStr, true
+			}
+		}
+		if ok && scopesStr != "" {
 			scopes = make([]string, 0)
-			err := yaml.Unmarshal([]byte(scopesStr), &scopes)
-			if err != nil {
+			if err := yaml.Unmarshal([]byte(scopesStr), &scopes); err != nil {
 				return fmt.Errorf("error unmarshalling scopes: %w", err)
 			}
 		}

--- a/util/rbac/rbac.go
+++ b/util/rbac/rbac.go
@@ -35,7 +35,8 @@ import (
 const (
 	ConfigMapPolicyCSVKey     = "policy.csv"
 	ConfigMapPolicyDefaultKey = "policy.default"
-	ConfigMapScopesKey        = "scopes"
+	ConfigMapClaimsKey        = "claims"
+	ConfigMapScopesKey        = "scopes" // Deprecated: use ConfigMapClaimsKey ("claims") instead.
 	ConfigMapMatchModeKey     = "policy.matchMode"
 	GlobMatchMode             = "glob"
 	RegexMatchMode            = "regex"


### PR DESCRIPTION
## Summary

Fixes #23772.

The `argocd-rbac-cm` `scopes` key controls which OIDC **claims** (`sub`, `groups`, …) are examined during RBAC enforcement — it is not about OAuth scopes, so the name is misleading.

Per @agaudreault's guidance on the issue ("create the necessary code to rename the configuration and update the docs, but preserve backward compatibility"), this:

- adds a `claims` key to `argocd-rbac-cm`, read preferentially;
- keeps `scopes` working as a **deprecated alias** (logged with a deprecation warning when used), so nothing breaks for existing installs;
- updates `docs/operator-manual/rbac.md` and the example `argocd-rbac-cm.yaml`.

The eventual removal of the deprecated `scopes` key can follow in the v4.0 breaking-changes milestone.

## Checklist

- [x] Backwards compatibility preserved (the `scopes` key still works).
- [x] Documentation updated.
- [x] `go build ./util/rbac/ ./server/` and `go vet` pass; DCO signed.
