### PR TITLE
feat(server): set X-Robots-Tag to prevent indexing of the UI

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1480,6 +1480,8 @@ func (server *ArgoCDServer) newStaticAssetsHandler() func(http.ResponseWriter, *
 			w.Header().Set("Content-Security-Policy", server.ContentSecurityPolicy)
 		}
 		w.Header().Set("X-XSS-Protection", "1")
+		// Prevent search engines from indexing the Argo CD UI.
+		w.Header().Set("X-Robots-Tag", "noindex, nofollow")
 
 		// serve index.html for non file requests to support HTML5 History API
 		if acceptHTML && !fileRequest && (r.Method == http.MethodGet || r.Method == http.MethodHead) {

--- a/server/server_norace_test.go
+++ b/server/server_norace_test.go
@@ -115,6 +115,7 @@ func Test_StaticHeaders(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "sameorigin", resp.Header.Get("X-Frame-Options"))
 		assert.Equal(t, "frame-ancestors 'self';", resp.Header.Get("Content-Security-Policy"))
+		assert.Equal(t, "noindex, nofollow", resp.Header.Get("X-Robots-Tag"))
 		require.NoError(t, resp.Body.Close())
 	}
 


### PR DESCRIPTION
Closes #25034

Adds an always-on `X-Robots-Tag: noindex, nofollow` response header to the static asset handler (`newStaticAssetsHandler`), alongside the existing `X-Frame-Options` / `Content-Security-Policy` / `X-XSS-Protection` headers, so a publicly-exposed Argo CD UI is not indexed by search engines.

@crenshaw-dev — you asked on the issue whether to "just Send It", so this is the minimal always-on version. Happy to make it configurable instead (an `ArgoCDServerOpts` field + `--x-robots-tag` flag / `ARGOCD_SERVER_X_ROBOTS_TAG` env, mirroring `--x-frame-options`) if you'd prefer — just say the word.

Extended `Test_StaticHeaders` to assert the header; `go test ./server/ -run Test_StaticHeaders` passes.
