### PR TITLE
feat: remove the CMP version field (#16178)

### DIFF
--- a/cmd/argocd-cmp-server/commands/argocd_cmp_server.go
+++ b/cmd/argocd-cmp-server/commands/argocd_cmp_server.go
@@ -52,9 +52,6 @@ func NewCommand() *cobra.Command {
 
 			if !config.Spec.Discover.IsDefined() {
 				name := config.Metadata.Name
-				if config.Spec.Version != "" {
-					name = name + "-" + config.Spec.Version
-				}
 				log.Infof("No discovery configuration is defined for plugin %s. To use this plugin, specify %q in the Application's spec.source.plugin.name field.", config.Metadata.Name, name)
 			}
 

--- a/cmpserver/plugin/config.go
+++ b/cmpserver/plugin/config.go
@@ -16,6 +16,10 @@ const (
 	ConfigManagementPluginKind string = "ConfigManagementPlugin"
 )
 
+// errVersionUnsupported is returned when a plugin configuration still sets the removed spec.version
+// field. Keeping it in one place lets the validator and its tests share a single source of truth.
+var errVersionUnsupported = errors.New("invalid plugin configuration file. spec.version is no longer supported. Remove it and, if you need to distinguish plugin versions, append the version to metadata.name instead (e.g. metadata.name: <name>-<version>)")
+
 type PluginConfig struct {
 	metav1.TypeMeta `json:",inline"`
 	Metadata        metav1.ObjectMeta `json:"metadata"`
@@ -23,6 +27,11 @@ type PluginConfig struct {
 }
 
 type PluginConfigSpec struct {
+	// Version is no longer supported. It is retained only so that the CMP server can
+	// detect a config that still sets it and return an actionable error. Append the
+	// version to metadata.name instead (e.g. metadata.name: <name>-<version>).
+	//
+	// Deprecated: unsupported in Argo CD 4.0.
 	Version          string     `json:"version"`
 	Init             Command    `json:"init,omitempty"`
 	Generate         Command    `json:"generate"`
@@ -89,6 +98,9 @@ func ValidatePluginConfig(config PluginConfig) error {
 	if config.Kind != ConfigManagementPluginKind {
 		return fmt.Errorf("invalid plugin configuration file. kind should be %s, found %s", ConfigManagementPluginKind, config.Kind)
 	}
+	if config.Spec.Version != "" {
+		return errVersionUnsupported
+	}
 	if len(config.Spec.Generate.Command) == 0 {
 		return errors.New("invalid plugin configuration file. spec.generate command should be non-empty")
 	}
@@ -97,12 +109,6 @@ func ValidatePluginConfig(config PluginConfig) error {
 }
 
 func (cfg *PluginConfig) Address() string {
-	var address string
 	pluginSockFilePath := common.GetPluginSockFilePath()
-	if cfg.Spec.Version != "" {
-		address = fmt.Sprintf("%s/%s-%s.sock", pluginSockFilePath, cfg.Metadata.Name, cfg.Spec.Version)
-	} else {
-		address = fmt.Sprintf("%s/%s.sock", pluginSockFilePath, cfg.Metadata.Name)
-	}
-	return address
+	return fmt.Sprintf("%s/%s.sock", pluginSockFilePath, cfg.Metadata.Name)
 }

--- a/cmpserver/plugin/config_test.go
+++ b/cmpserver/plugin/config_test.go
@@ -124,6 +124,20 @@ metadata:
 			expectedErr: "invalid plugin configuration file. spec.generate command should be non-empty",
 		},
 		{
+			// version is reported before the missing spec.generate error so users
+			// migrating off the removed field always see the actionable message first.
+			name: "version is no longer supported",
+			fileContents: `
+kind: ConfigManagementPlugin
+metadata:
+  name: name
+spec:
+  version: v1.0
+`,
+			expected:    nil,
+			expectedErr: errVersionUnsupported.Error(),
+		},
+		{
 			name: "valid config",
 			fileContents: `
 kind: ConfigManagementPlugin
@@ -181,7 +195,7 @@ func Test_PluginConfig_Address(t *testing.T) {
 		expected string
 	}{
 		{
-			name: "no version specified",
+			name: "address is based on metadata.name",
 			config: &PluginConfig{
 				TypeMeta: metav1.TypeMeta{
 					Kind: ConfigManagementPluginKind,
@@ -191,21 +205,6 @@ func Test_PluginConfig_Address(t *testing.T) {
 				},
 			},
 			expected: "name",
-		},
-		{
-			name: "version specified",
-			config: &PluginConfig{
-				TypeMeta: metav1.TypeMeta{
-					Kind: ConfigManagementPluginKind,
-				},
-				Metadata: metav1.ObjectMeta{
-					Name: "name",
-				},
-				Spec: PluginConfigSpec{
-					Version: "version",
-				},
-			},
-			expected: "name-version",
 		},
 	}
 

--- a/cmpserver/plugin/plugin_test.go
+++ b/cmpserver/plugin/plugin_test.go
@@ -64,9 +64,6 @@ func buildPluginConfig(opts ...pluginOpt) *CMPServerInitConstants {
 			Metadata: metav1.ObjectMeta{
 				Name: "some-plugin",
 			},
-			Spec: PluginConfigSpec{
-				Version: "v1.0",
-			},
 		},
 	}
 	for _, opt := range opts {

--- a/cmpserver/plugin/testdata/ksonnet/config/plugin.yaml
+++ b/cmpserver/plugin/testdata/ksonnet/config/plugin.yaml
@@ -3,7 +3,6 @@ kind: ConfigManagementPlugin
 metadata:
   name: ksonnet
 spec:
-  version: v1.0
   init:
     command: [ks, version]
   generate:

--- a/cmpserver/plugin/testdata/kustomize-neg/config/plugin-bad.yaml
+++ b/cmpserver/plugin/testdata/kustomize-neg/config/plugin-bad.yaml
@@ -3,7 +3,6 @@ kind: ConfigManagementPlugin
 metadata:
   name: kustomize
 spec:
-  version: v1.0
   init:
     command: [kustomize, version]
   generate:

--- a/cmpserver/plugin/testdata/kustomize/config/plugin.yaml
+++ b/cmpserver/plugin/testdata/kustomize/config/plugin.yaml
@@ -3,7 +3,6 @@ kind: ConfigManagementPlugin
 metadata:
   name: kustomize
 spec:
-  version: v1.0
   init:
     command: [sh, -c]
     args:

--- a/docs/operator-manual/config-management-plugins.md
+++ b/docs/operator-manual/config-management-plugins.md
@@ -34,9 +34,6 @@ metadata:
   # The name of the plugin must be unique within a given Argo CD instance.
   name: my-plugin
 spec:
-  # The version of your plugin. Optional. If specified, the Application's spec.source.plugin.name field
-  # must be <plugin name>-<plugin version>.
-  version: v1.0
   # The init command runs in the Application source directory at the beginning of each manifest generation. The init
   # command can output anything. A non-zero status code will fail manifest generation.
   init:
@@ -164,7 +161,6 @@ data:
     metadata:
       name: my-plugin
     spec:
-      version: v1.0
       init:
         command: [sh, -c, 'echo "Initializing..."']
       generate:
@@ -288,7 +284,7 @@ Plugin commands have access to
 
 You may leave the `name` field
 empty in the `plugin` section for the plugin to be automatically matched with the Application based on its discovery rules. If you do mention the name make sure 
-it is either `<metadata.name>-<spec.version>` if version is mentioned in the `ConfigManagementPlugin` spec or else just `<metadata.name>`. When name is explicitly 
+it matches the plugin's `metadata.name`. When name is explicitly
 specified only that particular plugin will be used if its discovery pattern/command matches the provided application repo.
 
 ```yaml
@@ -326,8 +322,8 @@ If you don't need to set any environment variables, you can set an empty plugin 
     
 > [!NOTE]
 > Each Application can only have one config management plugin configured at a time. If you're converting an existing
-> plugin configured through the `argocd-cm` ConfigMap to a sidecar, make sure to update the plugin name to either `<metadata.name>-<spec.version>` 
-> if version was mentioned in the `ConfigManagementPlugin` spec or else just use `<metadata.name>`. You can also remove the name altogether 
+> plugin configured through the `argocd-cm` ConfigMap to a sidecar, make sure to update the plugin name to match the plugin's `metadata.name`.
+> You can also remove the name altogether
 > and let the automatic discovery to identify the plugin.
 
 > [!NOTE]
@@ -460,8 +456,7 @@ If you want to use discovery instead of the plugin name to match applications to
 your plugin [using the instructions above](#write-discovery-rules-for-your-plugin) and add them to your configuration 
 file.
 
-To use the name instead of discovery, update the name in your application manifest to `<metadata.name>-<spec.version>` 
-if version was mentioned in the `ConfigManagementPlugin` spec or else just use `<metadata.name>`. For example:
+To use the name instead of discovery, update the name in your application manifest to match the plugin's `metadata.name`. For example:
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1

--- a/docs/operator-manual/upgrading/3.6-4.0.md
+++ b/docs/operator-manual/upgrading/3.6-4.0.md
@@ -1,0 +1,30 @@
+# v3.6 to 4.0
+
+## Breaking Changes
+
+### Config Management Plugin `spec.version` field removed
+
+The `spec.version` field of the Config Management Plugin (CMP) configuration file (`plugin.yaml`) is no longer
+supported. Previously, when `spec.version` was set, the plugin had to be referenced from an Application as
+`<metadata.name>-<spec.version>`. The version was only ever used as a suffix on the plugin name, so it did not provide
+any behavior that appending the version to `metadata.name` does not.
+
+Starting with 4.0, the cmp-server fails to start when a plugin configuration still sets `spec.version`, returning an
+error such as:
+
+```text
+invalid plugin configuration file. spec.version is no longer supported. Remove it and, if you need to distinguish plugin versions, append the version to metadata.name instead (e.g. metadata.name: <name>-<version>)
+```
+
+#### Detection
+
+You are impacted if any of your sidecar plugin `plugin.yaml` files set `spec.version`.
+
+#### Remediation
+
+1. Remove the `spec.version` field from each plugin's `plugin.yaml`.
+2. If you relied on the version to distinguish plugins, append it to `metadata.name` instead
+   (for example, rename `metadata.name: my-plugin` with `spec.version: v1.0` to `metadata.name: my-plugin-v1.0`).
+3. Update each Application's `spec.source.plugin.name` to match the plugin's `metadata.name`. Applications that
+   previously referenced `my-plugin-v1.0` continue to work as long as the plugin's `metadata.name` is set to
+   `my-plugin-v1.0`.

--- a/examples/plugins/helm/plugin.yaml
+++ b/examples/plugins/helm/plugin.yaml
@@ -3,7 +3,6 @@ kind: ConfigManagementPlugin
 metadata:
   name: simple-helm-cmp
 spec:
-  version: v1.0
   generate:
     command: [sh, /var/run/argocd/helm-plugin/generate.sh]
   discover:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -139,6 +139,7 @@ nav:
     - operator-manual/server-commands/additional-configuration-method.md
   - Upgrading:
     - operator-manual/upgrading/overview.md
+    - operator-manual/upgrading/3.6-4.0.md
     - operator-manual/upgrading/3.4-3.5.md
     - operator-manual/upgrading/3.3-3.4.md
     - operator-manual/upgrading/3.2-3.3.md

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -1765,7 +1765,7 @@ func GenerateManifests(ctx context.Context, appPath, repoRoot, revision string, 
 		if q.ApplicationSource.Plugin != nil {
 			pluginName = q.ApplicationSource.Plugin.Name
 		}
-		// if pluginName is provided it has to be `<metadata.name>-<spec.version>` or just `<metadata.name>` if plugin version is empty
+		// if pluginName is provided it has to match the plugin's `metadata.name`
 		targetObjs, err = runConfigManagementPluginSidecars(ctx, appPath, repoRoot, pluginName, env, q, q.Repo.GetGitCreds(gitCredsStore), opt.cmpTarDoneCh, opt.cmpTarExcludedGlobs, opt.cmpUseManifestGeneratePaths)
 		if err != nil {
 			return nil, fmt.Errorf("CMP processing failed for application %q: %w", q.AppName, err)

--- a/test/cmp/plugin.yaml
+++ b/test/cmp/plugin.yaml
@@ -3,7 +3,6 @@ kind: ConfigManagementPlugin
 metadata:
   name: cmp-plugin
 spec:
-  version: v1.0
   init:
     command: [env]
   generate:

--- a/test/e2e/custom_tool_test.go
+++ b/test/e2e/custom_tool_test.go
@@ -217,8 +217,8 @@ func TestCMPDiscoverWithPluginName(t *testing.T) {
 		Path("guestbook").
 		When().
 		CreateFromFile(func(app *Application) {
-			// specifically mention the plugin to use (name is based on <plugin name>-<version>
-			app.Spec.Source.Plugin = &ApplicationSourcePlugin{Name: "cmp-find-glob-v1.0"}
+			// specifically mention the plugin to use (name is based on the plugin's metadata.name)
+			app.Spec.Source.Plugin = &ApplicationSourcePlugin{Name: "cmp-find-glob"}
 		}).
 		Sync().
 		Then().
@@ -292,7 +292,7 @@ func TestPreserveFileModeForCMP(t *testing.T) {
 		Path("cmp-preserve-file-mode").
 		When().
 		CreateFromFile(func(app *Application) {
-			app.Spec.Source.Plugin = &ApplicationSourcePlugin{Name: "cmp-preserve-file-mode-v1.0"}
+			app.Spec.Source.Plugin = &ApplicationSourcePlugin{Name: "cmp-preserve-file-mode"}
 		}).
 		Refresh(RefreshTypeNormal).
 		Then().

--- a/test/e2e/diff_test.go
+++ b/test/e2e/diff_test.go
@@ -298,7 +298,7 @@ func TestCustomToolSyncAndDiffLocal(t *testing.T) {
 		// does not matter what the path is
 		Path("config-map").
 		When().
-		CreateApp("--config-management-plugin", "cmp-kustomize-v1.0").
+		CreateApp("--config-management-plugin", "cmp-kustomize").
 		Sync("--local", appPath, "--local-repo-root", testdataPath).
 		Then().
 		Expect(OperationPhaseIs(synccommon.OperationSucceeded)).

--- a/test/e2e/testdata/cmp-fileName/plugin.yaml
+++ b/test/e2e/testdata/cmp-fileName/plugin.yaml
@@ -3,7 +3,6 @@ kind: ConfigManagementPlugin
 metadata:
   name: cmp-fileName
 spec:
-  version: v1.0
   generate:
     # The -z test is to ensure that environment variables are made available to the plugin, even if they're empty. https://serverfault.com/a/382740/462962
     command: [sh, -c, 'if [ -z "${ARGOCD_ENV_EMPTY+set}" ]; then echo "ARGOCD_ENV_EMPTY should have been set." && exit 1; fi; echo "{\"kind\": \"ConfigMap\", \"apiVersion\": \"v1\", \"metadata\": { \"name\": \"$ARGOCD_APP_NAME\", \"namespace\": \"$ARGOCD_APP_NAMESPACE\", \"annotations\": {\"Foo\": \"$ARGOCD_ENV_FOO\", \"KubeVersion\": \"$KUBE_VERSION\", \"KubeApiVersion\": \"$KUBE_API_VERSIONS\",\"Bar\": \"baz\"}}}"']

--- a/test/e2e/testdata/cmp-find-command/plugin.yaml
+++ b/test/e2e/testdata/cmp-find-command/plugin.yaml
@@ -3,7 +3,6 @@ kind: ConfigManagementPlugin
 metadata:
   name: cmp-find-command
 spec:
-  version: v1.0
   generate:
     command: [sh, -c, 'echo "{\"kind\": \"ConfigMap\", \"apiVersion\": \"v1\", \"metadata\": { \"name\": \"$ARGOCD_APP_NAME\", \"namespace\": \"$ARGOCD_APP_NAMESPACE\", \"annotations\": {\"KubeVersion\": \"$KUBE_VERSION\", \"KubeApiVersion\": \"$KUBE_API_VERSIONS\",\"Bar\": \"baz\"}}}"']
   discover:

--- a/test/e2e/testdata/cmp-find-glob/plugin.yaml
+++ b/test/e2e/testdata/cmp-find-glob/plugin.yaml
@@ -3,7 +3,6 @@ kind: ConfigManagementPlugin
 metadata:
   name: cmp-find-glob
 spec:
-  version: v1.0
   init:
     command: [kustomize, version]
   generate:

--- a/test/e2e/testdata/cmp-gitcreds/plugin.yaml
+++ b/test/e2e/testdata/cmp-gitcreds/plugin.yaml
@@ -3,7 +3,6 @@ kind: ConfigManagementPlugin
 metadata:
   name: cmp-gitcreds
 spec:
-  version: v1.0
   generate:
     command: [sh, -c, 'echo "{\"kind\": \"ConfigMap\", \"apiVersion\": \"v1\", \"metadata\": { \"name\": \"$ARGOCD_APP_NAME\", \"namespace\": \"$ARGOCD_APP_NAMESPACE\", \"annotations\": {\"GitAskpass\": \"$GIT_ASKPASS\"}}}"']
   discover:

--- a/test/e2e/testdata/cmp-gitcredstemplate/plugin.yaml
+++ b/test/e2e/testdata/cmp-gitcredstemplate/plugin.yaml
@@ -3,7 +3,6 @@ kind: ConfigManagementPlugin
 metadata:
   name: cmp-gitcredstemplate
 spec:
-  version: v1.0
   generate:
     command: [sh, -c, 'echo "{\"kind\": \"ConfigMap\", \"apiVersion\": \"v1\", \"metadata\": { \"name\": \"$ARGOCD_APP_NAME\", \"namespace\": \"$ARGOCD_APP_NAMESPACE\", \"annotations\": {\"GitAskpass\": \"$GIT_ASKPASS\", \"GitUsername\": \"$GIT_USERNAME\", \"GitPassword\": \"$GIT_PASSWORD\"}}}"']
   discover:

--- a/test/e2e/testdata/cmp-gitsshcreds-disable-provide/plugin.yaml
+++ b/test/e2e/testdata/cmp-gitsshcreds-disable-provide/plugin.yaml
@@ -3,7 +3,6 @@ kind: ConfigManagementPlugin
 metadata:
   name: cmp-gitsshcreds-disable-sharing
 spec:
-  version: v1.0
   generate:
     command: ["sh", "generate.sh"]
   discover:

--- a/test/e2e/testdata/cmp-gitsshcreds/plugin.yaml
+++ b/test/e2e/testdata/cmp-gitsshcreds/plugin.yaml
@@ -3,7 +3,6 @@ kind: ConfigManagementPlugin
 metadata:
   name: cmp-gitsshcreds
 spec:
-  version: v1.0
   generate:
     command: ["sh", "generate.sh"]
   discover:

--- a/test/e2e/testdata/cmp-kustomize/plugin.yaml
+++ b/test/e2e/testdata/cmp-kustomize/plugin.yaml
@@ -3,7 +3,6 @@ kind: ConfigManagementPlugin
 metadata:
   name: cmp-kustomize
 spec:
-  version: v1.0
   generate:
     command: [kustomize, build, .]
   discover:

--- a/test/e2e/testdata/cmp-preserve-file-mode/plugin.yaml
+++ b/test/e2e/testdata/cmp-preserve-file-mode/plugin.yaml
@@ -3,7 +3,6 @@ kind: ConfigManagementPlugin
 metadata:
   name: cmp-preserve-file-mode
 spec:
-  version: v1.0
   generate:
     command: [sh, -c , "./script.sh"]
   discovery:

--- a/test/e2e/testdata/hydrator-plugin/plugin.yaml
+++ b/test/e2e/testdata/hydrator-plugin/plugin.yaml
@@ -3,7 +3,6 @@ kind: ConfigManagementPlugin
 metadata:
   name: hydrator-plugin
 spec:
-  version: v1.0
   generate:
     command: [sh, -c, 'echo "{\"kind\": \"ConfigMap\", \"apiVersion\": \"v1\", \"metadata\": { \"name\": \"plugin-generated-map\", \"namespace\": \"$ARGOCD_APP_NAMESPACE\" }, \"data\": { \"message\": \"plugin-hydrated\", \"source\": \"hydrator-plugin\", \"content\": \"$(cat data.txt)\", \"plugin-env\": \"$ARGOCD_ENV_PLUGIN_ENV\" }}"']
   discover:

--- a/test/e2e/testdata2/cmp-symlink/plugin.yaml
+++ b/test/e2e/testdata2/cmp-symlink/plugin.yaml
@@ -3,7 +3,6 @@ kind: ConfigManagementPlugin
 metadata:
   name: cmp-symlink
 spec:
-  version: v1.0
   init:
     command: [kustomize, version]
   generate:

--- a/test/manifests/cmp/plugin.yaml
+++ b/test/manifests/cmp/plugin.yaml
@@ -9,7 +9,6 @@ data:
     metadata:
       name: my-plugin
     spec:
-      version: v1.0
       init:
         command: [sh , -c, 'echo "params: $ARGOCD_APP_PARAMETERS"']
       generate:


### PR DESCRIPTION
The `spec.version` field of a Config Management Plugin was only ever used as a suffix on the plugin's socket name, forcing Applications to reference the plugin as `<metadata.name>-<spec.version>`. It provided no behaviour that appending the version to `metadata.name` does not, and was a frequent source of confusion.

This drops the version from the plugin socket/address logic and makes the cmp-server reject any configuration that still sets it, returning an actionable error that directs users to fold the version into `metadata.name`. The struct field is retained (deprecated) solely so the server can detect and report the removed setting, since the plugin config is parsed non-strictly.

Docs, examples, and unit/e2e fixtures are updated to drop `spec.version`, and a v4.0 upgrade note documents the breaking change and migration steps.

Closes #16178

**Notes for reviewers**

- This is a **v4.0 breaking change** (per the issue milestone) and is intended to land in the v4.0 cycle.
- It follows the proposal in #16178: remove the field and hard-error when it is set. No new `application.spec.sources[].plugin.version` field was introduced.
- The `Version` struct field is intentionally retained (marked deprecated) only so the cmp-server can detect a stale `spec.version` and return a clear migration error — the plugin config is parsed non-strictly, so simply deleting the field would cause a stale `version:` to be silently ignored.
- The upgrade note is filed as `docs/operator-manual/upgrading/3.6-4.0.md` based on the current `VERSION` (3.6.0); happy to rename it once the final last-3.x release before 4.0 is known.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).