### PR TITLE
feat(ui): advanced settings view 

### DIFF
--- a/ui/src/app/settings/components/advanced-settings/advanced-settings.scss
+++ b/ui/src/app/settings/components/advanced-settings/advanced-settings.scss
@@ -1,0 +1,11 @@
+@import 'node_modules/argo-ui/src/styles/config';
+
+.advanced-settings {
+    &__panels {
+        padding: 1em;
+        
+        > * {
+            margin-bottom: 1em;
+        }
+    }
+}

--- a/ui/src/app/settings/components/advanced-settings/advanced-settings.tsx
+++ b/ui/src/app/settings/components/advanced-settings/advanced-settings.tsx
@@ -11,19 +11,30 @@ require('./advanced-settings.scss');
 
 const NOT_CONFIGURED = '';
 
-const isConfiguredItem = (item: EditablePanelItem): boolean => {
-    const viewString = typeof item.view === 'string' ? item.view : String(item.view);
-    return viewString !== NOT_CONFIGURED && viewString !== 'false';
-};
+type AdvancedItem = EditablePanelItem & {configured: boolean};
+
+// A boolean is considered configured whenever it is present in the payload, even when false.
+const boolItem = (title: string, value?: boolean): AdvancedItem => ({
+    title,
+    view: value ? 'true' : 'false',
+    configured: value !== undefined && value !== null
+});
+
+// A text/list value is considered configured only when it is non-empty.
+const textItem = (title: string, value?: string): AdvancedItem => ({
+    title,
+    view: value || NOT_CONFIGURED,
+    configured: !!value
+});
 
 export const AdvancedSettings = () => {
     const authSettings = React.useContext(AuthSettingsCtx);
     const ctx = React.useContext(Context);
     const [showAll, setShowAll] = React.useState(false);
 
-    const renderPanel = (title: string, settings: AuthSettings, allItems: EditablePanelItem[]) => {
-        const configuredItems = allItems.filter(isConfiguredItem);
-        const unconfiguredItems = allItems.filter(item => !isConfiguredItem(item));
+    const renderPanel = (title: string, settings: AuthSettings, allItems: AdvancedItem[]) => {
+        const configuredItems = allItems.filter(item => item.configured);
+        const unconfiguredItems = allItems.filter(item => !item.configured);
         const itemsToShow = showAll ? [...configuredItems, ...unconfiguredItems] : configuredItems;
 
         if (itemsToShow.length === 0) {
@@ -34,111 +45,61 @@ export const AdvancedSettings = () => {
     };
 
     const configurationTab = (settings: AuthSettings) => {
-        const generalItems: EditablePanelItem[] = [
-            {
-                title: 'Status Badge Enabled',
-                view: settings.statusBadgeEnabled ? 'true' : 'false'
-            },
-            {
-                title: 'Status Badge Root URL',
-                view: settings.statusBadgeRootUrl || NOT_CONFIGURED
-            },
-            {
-                title: 'UI CSS URL',
-                view: settings.uiCssURL || NOT_CONFIGURED
-            },
-            {
-                title: 'UI Banner Content',
-                view: settings.uiBannerContent || NOT_CONFIGURED
-            },
-            {
-                title: 'UI Banner URL',
-                view: settings.uiBannerURL || NOT_CONFIGURED
-            },
-            {
-                title: 'UI Banner Position',
-                view: settings.uiBannerPosition || NOT_CONFIGURED
-            },
-            {
-                title: 'UI Banner Permanent',
-                view: settings.uiBannerPermanent ? 'true' : 'false'
-            }
+        const generalItems: AdvancedItem[] = [
+            textItem('App Label Key', settings.appLabelKey),
+            textItem('Tracking Method', settings.trackingMethod),
+            textItem('Additional URLs', settings.additionalUrls && settings.additionalUrls.length > 0 ? settings.additionalUrls.join(', ') : ''),
+            boolItem('Status Badge Enabled', settings.statusBadgeEnabled),
+            textItem('Status Badge Root URL', settings.statusBadgeRootUrl),
+            textItem('UI CSS URL', settings.uiCssURL),
+            textItem('UI Banner Content', settings.uiBannerContent),
+            textItem('UI Banner URL', settings.uiBannerURL),
+            textItem('UI Banner Position', settings.uiBannerPosition),
+            boolItem('UI Banner Permanent', settings.uiBannerPermanent)
         ];
 
-        const authenticationItems: EditablePanelItem[] = [
-            {
-                title: 'User Logins Disabled',
-                view: settings.userLoginsDisabled ? 'true' : 'false'
-            },
-            {
-                title: 'Dex Connectors',
-                view: settings.dexConfig?.connectors ? settings.dexConfig.connectors.map(c => `${c.name} (${c.type})`).join(', ') : NOT_CONFIGURED
-            },
-            {
-                title: 'OIDC Provider',
-                view: settings.oidcConfig?.name || NOT_CONFIGURED
-            }
+        const instanceItems: AdvancedItem[] = [textItem('Controller Namespace', settings.controllerNamespace), textItem('Installation ID', settings.installationID)];
+
+        const authenticationItems: AdvancedItem[] = [
+            boolItem('User Logins Disabled', settings.userLoginsDisabled),
+            textItem('Dex Connectors', settings.dexConfig?.connectors ? settings.dexConfig.connectors.map(c => `${c.name} (${c.type})`).join(', ') : ''),
+            textItem('OIDC Provider', settings.oidcConfig?.name)
         ];
 
-        const featuresItems: EditablePanelItem[] = [
-            {
-                title: 'Exec Enabled',
-                view: settings.execEnabled ? 'true' : 'false'
-            },
-            {
-                title: 'Apps in Any Namespace Enabled',
-                view: settings.appsInAnyNamespaceEnabled ? 'true' : 'false'
-            },
-            {
-                title: 'Hydrator Enabled',
-                view: settings.hydratorEnabled ? 'true' : 'false'
-            },
-            {
-                title: 'Sync with Replace Allowed',
-                view: settings.syncWithReplaceAllowed ? 'true' : 'false'
-            }
+        const featuresItems: AdvancedItem[] = [
+            boolItem('Exec Enabled', settings.execEnabled),
+            boolItem('Apps in Any Namespace Enabled', settings.appsInAnyNamespaceEnabled),
+            boolItem('Hydrator Enabled', settings.hydratorEnabled),
+            boolItem('Sync with Replace Allowed', settings.syncWithReplaceAllowed),
+            boolItem('Impersonation Enabled', settings.impersonationEnabled)
         ];
 
-        const helpAnalyticsItems: EditablePanelItem[] = [
-            {
-                title: 'Google Analytics Tracking ID',
-                view: settings.googleAnalytics?.trackingID || NOT_CONFIGURED
-            },
-            {
-                title: 'Google Analytics Anonymize Users',
-                view: settings.googleAnalytics?.anonymizeUsers ? 'true' : 'false'
-            },
-            {
-                title: 'Help Chat URL',
-                view: settings.help?.chatUrl || NOT_CONFIGURED
-            },
-            {
-                title: 'Help Chat Text',
-                view: settings.help?.chatText || NOT_CONFIGURED
-            },
-            {
-                title: 'Binary URLs',
-                view: settings.help?.binaryUrls
+        const helpAnalyticsItems: AdvancedItem[] = [
+            textItem('Google Analytics Tracking ID', settings.googleAnalytics?.trackingID),
+            boolItem('Google Analytics Anonymize Users', settings.googleAnalytics?.anonymizeUsers),
+            textItem('Help Chat URL', settings.help?.chatUrl),
+            textItem('Help Chat Text', settings.help?.chatText),
+            textItem(
+                'Binary URLs',
+                settings.help?.binaryUrls
                     ? Object.entries(settings.help.binaryUrls)
                           .map(([k, v]) => `${k}: ${v}`)
                           .join(', ')
-                    : NOT_CONFIGURED
-            }
+                    : ''
+            )
         ];
 
-        const kustomizeItems: EditablePanelItem[] = [
-            {
-                title: 'Kustomize Versions',
-                view: settings.kustomizeVersions && settings.kustomizeVersions.length > 0 ? settings.kustomizeVersions.join(', ') : NOT_CONFIGURED
-            }
+        const kustomizeItems: AdvancedItem[] = [
+            textItem('Kustomize Versions', settings.kustomizeVersions && settings.kustomizeVersions.length > 0 ? settings.kustomizeVersions.join(', ') : '')
         ];
 
         return (
             <div className='argo-container'>
                 <div className='advanced-settings__panels'>
                     {renderPanel('GENERAL', settings, generalItems)}
-                    {renderPanel('AUTHENTICATION', settings, authenticationItems)}
                     {renderPanel('FEATURES', settings, featuresItems)}
+                    {renderPanel('INSTANCE', settings, instanceItems)}
+                    {renderPanel('AUTHENTICATION', settings, authenticationItems)}
                     {renderPanel('HELP & ANALYTICS', settings, helpAnalyticsItems)}
                     {renderPanel('KUSTOMIZE', settings, kustomizeItems)}
                 </div>

--- a/ui/src/app/settings/components/advanced-settings/advanced-settings.tsx
+++ b/ui/src/app/settings/components/advanced-settings/advanced-settings.tsx
@@ -1,0 +1,215 @@
+import {Tabs} from 'argo-ui';
+import * as React from 'react';
+
+import {AuthOption, EditablePanel, Page, Query} from '../../../shared/components';
+import {EditablePanelItem} from '../../../shared/components/editable-panel/editable-panel';
+import {AuthSettingsCtx, Context} from '../../../shared/context';
+import {AuthSettings} from '../../../shared/models';
+import {MonacoEditor} from '../../../shared/components/monaco-editor';
+
+require('./advanced-settings.scss');
+
+const NOT_CONFIGURED = '';
+
+const isConfiguredItem = (item: EditablePanelItem): boolean => {
+    const viewString = typeof item.view === 'string' ? item.view : String(item.view);
+    return viewString !== NOT_CONFIGURED && viewString !== 'false';
+};
+
+export const AdvancedSettings = () => {
+    const authSettings = React.useContext(AuthSettingsCtx);
+    const ctx = React.useContext(Context);
+    const [showAll, setShowAll] = React.useState(false);
+
+    const renderPanel = (title: string, settings: AuthSettings, allItems: EditablePanelItem[]) => {
+        const configuredItems = allItems.filter(isConfiguredItem);
+        const unconfiguredItems = allItems.filter(item => !isConfiguredItem(item));
+        const itemsToShow = showAll ? [...configuredItems, ...unconfiguredItems] : configuredItems;
+
+        if (itemsToShow.length === 0) {
+            return null;
+        }
+
+        return <EditablePanel title={title} values={settings} noReadonlyMode={true} items={itemsToShow} />;
+    };
+
+    const configurationTab = (settings: AuthSettings) => {
+        const generalItems: EditablePanelItem[] = [
+            {
+                title: 'Status Badge Enabled',
+                view: settings.statusBadgeEnabled ? 'true' : 'false'
+            },
+            {
+                title: 'Status Badge Root URL',
+                view: settings.statusBadgeRootUrl || NOT_CONFIGURED
+            },
+            {
+                title: 'UI CSS URL',
+                view: settings.uiCssURL || NOT_CONFIGURED
+            },
+            {
+                title: 'UI Banner Content',
+                view: settings.uiBannerContent || NOT_CONFIGURED
+            },
+            {
+                title: 'UI Banner URL',
+                view: settings.uiBannerURL || NOT_CONFIGURED
+            },
+            {
+                title: 'UI Banner Position',
+                view: settings.uiBannerPosition || NOT_CONFIGURED
+            },
+            {
+                title: 'UI Banner Permanent',
+                view: settings.uiBannerPermanent ? 'true' : 'false'
+            }
+        ];
+
+        const authenticationItems: EditablePanelItem[] = [
+            {
+                title: 'User Logins Disabled',
+                view: settings.userLoginsDisabled ? 'true' : 'false'
+            },
+            {
+                title: 'Dex Connectors',
+                view: settings.dexConfig?.connectors ? settings.dexConfig.connectors.map(c => `${c.name} (${c.type})`).join(', ') : NOT_CONFIGURED
+            },
+            {
+                title: 'OIDC Provider',
+                view: settings.oidcConfig?.name || NOT_CONFIGURED
+            }
+        ];
+
+        const featuresItems: EditablePanelItem[] = [
+            {
+                title: 'Exec Enabled',
+                view: settings.execEnabled ? 'true' : 'false'
+            },
+            {
+                title: 'Apps in Any Namespace Enabled',
+                view: settings.appsInAnyNamespaceEnabled ? 'true' : 'false'
+            },
+            {
+                title: 'Hydrator Enabled',
+                view: settings.hydratorEnabled ? 'true' : 'false'
+            },
+            {
+                title: 'Sync with Replace Allowed',
+                view: settings.syncWithReplaceAllowed ? 'true' : 'false'
+            }
+        ];
+
+        const helpAnalyticsItems: EditablePanelItem[] = [
+            {
+                title: 'Google Analytics Tracking ID',
+                view: settings.googleAnalytics?.trackingID || NOT_CONFIGURED
+            },
+            {
+                title: 'Google Analytics Anonymize Users',
+                view: settings.googleAnalytics?.anonymizeUsers ? 'true' : 'false'
+            },
+            {
+                title: 'Help Chat URL',
+                view: settings.help?.chatUrl || NOT_CONFIGURED
+            },
+            {
+                title: 'Help Chat Text',
+                view: settings.help?.chatText || NOT_CONFIGURED
+            },
+            {
+                title: 'Binary URLs',
+                view: settings.help?.binaryUrls
+                    ? Object.entries(settings.help.binaryUrls)
+                          .map(([k, v]) => `${k}: ${v}`)
+                          .join(', ')
+                    : NOT_CONFIGURED
+            }
+        ];
+
+        const kustomizeItems: EditablePanelItem[] = [
+            {
+                title: 'Kustomize Versions',
+                view: settings.kustomizeVersions && settings.kustomizeVersions.length > 0 ? settings.kustomizeVersions.join(', ') : NOT_CONFIGURED
+            }
+        ];
+
+        return (
+            <div className='argo-container'>
+                <div className='advanced-settings__panels'>
+                    {renderPanel('GENERAL', settings, generalItems)}
+                    {renderPanel('AUTHENTICATION', settings, authenticationItems)}
+                    {renderPanel('FEATURES', settings, featuresItems)}
+                    {renderPanel('HELP & ANALYTICS', settings, helpAnalyticsItems)}
+                    {renderPanel('KUSTOMIZE', settings, kustomizeItems)}
+                </div>
+            </div>
+        );
+    };
+
+    const jsonTab = (settings: AuthSettings) => {
+        return (
+            <div className='argo-container advanced-settings__json'>
+                <MonacoEditor
+                    minHeight={600}
+                    vScrollBar={true}
+                    editor={{
+                        input: {
+                            text: JSON.stringify(settings, null, 2),
+                            language: 'json'
+                        },
+                        options: {
+                            readOnly: true,
+                            minimap: {enabled: false}
+                        }
+                    }}
+                />
+            </div>
+        );
+    };
+
+    return (
+        <Query>
+            {params => {
+                const selectedTab = params.get('tab') || 'configuration';
+                return (
+                    <Page
+                        title='Advanced'
+                        toolbar={{
+                            breadcrumbs: [{title: 'Settings', path: '/settings'}, {title: 'Advanced'}],
+                            actionMenu:
+                                selectedTab === 'configuration'
+                                    ? {
+                                          items: [
+                                              {
+                                                  title: showAll ? 'Show Configured Only' : 'Show All Options',
+                                                  iconClassName: 'fa fa-filter',
+                                                  action: () => setShowAll(prev => !prev)
+                                              }
+                                          ]
+                                      }
+                                    : undefined,
+                            tools: <AuthOption />
+                        }}>
+                        <Tabs
+                            selectedTabKey={selectedTab}
+                            onTabSelected={tab => ctx.navigation.goto('.', {tab}, {replace: true})}
+                            navCenter={true}
+                            tabs={[
+                                {
+                                    key: 'configuration',
+                                    title: 'Configuration',
+                                    content: configurationTab(authSettings)
+                                },
+                                {
+                                    key: 'json',
+                                    title: 'JSON',
+                                    content: jsonTab(authSettings)
+                                }
+                            ].map(tab => ({...tab, isOnlyContentScrollable: true, extraVerticalScrollPadding: 160}))}
+                        />
+                    </Page>
+                );
+            }}
+        </Query>
+    );
+};

--- a/ui/src/app/settings/components/settings-container.tsx
+++ b/ui/src/app/settings/components/settings-container.tsx
@@ -4,6 +4,7 @@ import {KeybindingProvider} from 'argo-ui/v2';
 
 import {AccountDetails} from './account-details/account-details';
 import {AccountsList} from './accounts-list/accounts-list';
+import {AdvancedSettings} from './advanced-settings/advanced-settings';
 import {CertsList} from './certs-list/certs-list';
 import {ClusterDetails} from './cluster-details/cluster-details';
 import {ClustersList} from './clusters-list/clusters-list';
@@ -28,6 +29,7 @@ export const SettingsContainer = (props: RouteComponentProps<any>) => (
             <Route exact={true} path={`${props.match.path}/accounts`} component={AccountsList} />
             <Route exact={true} path={`${props.match.path}/accounts/:name`} component={AccountDetails} />
             <Route exact={true} path={`${props.match.path}/appearance`} component={AppearanceList} />
+            <Route exact={true} path={`${props.match.path}/advanced`} component={AdvancedSettings} />
             <Redirect path='*' to={`${props.match.path}`} />
         </Switch>
     </KeybindingProvider>

--- a/ui/src/app/settings/components/settings-overview/settings-overview.tsx
+++ b/ui/src/app/settings/components/settings-overview/settings-overview.tsx
@@ -7,6 +7,26 @@ require('./settings-overview.scss');
 
 const settings = [
     {
+        title: 'Accounts',
+        description: 'Configure Accounts',
+        path: './accounts'
+    },
+    {
+        title: 'Clusters',
+        description: 'Configure connected Kubernetes clusters',
+        path: './clusters'
+    },
+    {
+        title: 'GnuPG keys',
+        description: 'Configure GnuPG public keys for commit verification',
+        path: './gpgkeys'
+    },
+    {
+        title: 'Projects',
+        description: 'Configure Argo CD projects',
+        path: './projects'
+    },
+    {
         title: 'Repositories',
         description: 'Configure connected repositories',
         path: './repos'
@@ -17,29 +37,14 @@ const settings = [
         path: './certs'
     },
     {
-        title: 'GnuPG keys',
-        description: 'Configure GnuPG public keys for commit verification',
-        path: './gpgkeys'
-    },
-    {
-        title: 'Clusters',
-        description: 'Configure connected Kubernetes clusters',
-        path: './clusters'
-    },
-    {
-        title: 'Projects',
-        description: 'Configure Argo CD projects',
-        path: './projects'
-    },
-    {
-        title: 'Accounts',
-        description: 'Configure Accounts',
-        path: './accounts'
-    },
-    {
         title: 'Appearance',
         description: 'Configure themes in UI',
         path: './appearance'
+    },
+    {
+        title: 'Advanced',
+        description: 'View Argo CD instance configuration',
+        path: './advanced'
     }
 ];
 

--- a/ui/src/app/shared/components/monaco-editor.tsx
+++ b/ui/src/app/shared/components/monaco-editor.tsx
@@ -85,7 +85,7 @@ const MonacoEditorLazy = React.lazy(() =>
                                         scrollBeyondLastLine: props.vScrollBar,
                                         scrollbar: {
                                             alwaysConsumeMouseWheel: false,
-                                            vertical: props.vScrollBar ? 'visible' : 'hidden'
+                                            vertical: props.vScrollBar ? 'auto' : 'hidden'
                                         }
                                     });
 

--- a/ui/src/app/shared/models.ts
+++ b/ui/src/app/shared/models.ts
@@ -627,6 +627,12 @@ export interface AuthSettings {
     appsInAnyNamespaceEnabled: boolean;
     hydratorEnabled: boolean;
     syncWithReplaceAllowed: boolean;
+    appLabelKey: string;
+    trackingMethod: string;
+    additionalUrls: string[];
+    impersonationEnabled: boolean;
+    controllerNamespace: string;
+    installationID: string;
 }
 
 export interface UserInfo {

--- a/ui/src/app/webpack.config.js
+++ b/ui/src/app/webpack.config.js
@@ -127,7 +127,7 @@ const config = {
         }),
         new MonacoWebpackPlugin({
             // https://github.com/microsoft/monaco-editor-webpack-plugin#options
-            languages: ['yaml']
+            languages: ['yaml', 'json']
         }),
         codecovWebpackPlugin({
             enableBundleAnalysis: process.env.CODECOV_TOKEN !== undefined,


### PR DESCRIPTION
The information is available already by calling api/v1/settings and does not require any special authentication. If the user is not authenticated, the information will not be present. When the user is authenticated, it is possible that the server sends more information that will be populated in the response. 

The UI simply display the settings response in a nicer format for human consumption. The JSON editor allow any user to quickly view the full payload, without the need to inspect the network calls.

This change also makes the ordering a little more consistent with the configurations resources sections ordered alphabetically, the user preference and the advanced section at the end.

https://github.com/user-attachments/assets/d1af163a-654a-4f25-97dd-20725c4a97b7

