### PR TITLE
fix: reap the whole process group when an exec command times out

### DIFF
--- a/util/exec/exec.go
+++ b/util/exec/exec.go
@@ -189,6 +189,11 @@ func RunCommandExt(cmd *exec.Cmd, opts CmdOpts) (string, error) {
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
+	// Run the command in its own process group so a timeout can reap the whole
+	// group (the command plus any grandchildren it spawned), not just the
+	// direct child. See signalProcessGroup.
+	setChildProcessGroup(cmd)
+
 	start := time.Now()
 	err = cmd.Start()
 	if err != nil {
@@ -229,15 +234,15 @@ func RunCommandExt(cmd *exec.Cmd, opts CmdOpts) (string, error) {
 	select {
 	// noinspection ALL
 	case <-timoutCh:
-		// send timeout signal
-		_ = cmd.Process.Signal(timeoutBehavior.Signal)
+		// send timeout signal to the whole process group
+		_ = signalProcessGroup(cmd, timeoutBehavior.Signal)
 		// wait on timeout signal and fallback to fatal timeout signal
 		if timeoutBehavior.ShouldWait {
 			select {
 			case <-done:
 			case <-fatalTimeoutCh:
 				// upgrades to SIGKILL if cmd does not respect SIGTERM
-				_ = cmd.Process.Signal(fatalTimeoutBehaviour)
+				_ = signalProcessGroup(cmd, fatalTimeoutBehaviour)
 				// now original cmd should exit immediately after SIGKILL
 				<-done
 				// return error with a marker indicating that cmd exited only after fatal SIGKILL

--- a/util/exec/exec_test.go
+++ b/util/exec/exec_test.go
@@ -226,3 +226,36 @@ func TestRunWithExecRunOptsCaptureStderr(t *testing.T) {
 	assert.Equal(t, "hello world\nmy-error", output)
 	assert.NoError(t, err)
 }
+
+// TestRunCommandExtTimeoutReapsProcessGroup verifies that a timed-out command is
+// torn down along with any grandchild processes it spawned.
+//
+// The shell backgrounds a long-lived `sleep` that inherits the command's stdout
+// pipe and then waits on it. When the timeout fires, signalling only the direct
+// child (the shell) is not enough: the orphaned `sleep` keeps the inherited
+// stdout pipe open, so cmd.Wait() — and therefore RunCommandExt — blocks until
+// `sleep` exits on its own, far past timeout+fatalTimeout. This is the same
+// failure mode that lets a single hung `git fetch` (whose `git-remote-https`
+// child holds a dead TCP connection) keep the argocd-repo-server per-repo lock
+// held for many minutes. Killing the whole process group fixes it.
+func TestRunCommandExtTimeoutReapsProcessGroup(t *testing.T) {
+	// `sleep 15` outlives timeout+fatalTimeout (500ms) by ~30x, so if the
+	// process group is not reaped the call blocks for ~15s instead of ~0.5s.
+	cmd := exec.CommandContext(t.Context(), "sh", "-c", "sleep 15 & wait")
+	opts := CmdOpts{
+		Timeout:      250 * time.Millisecond,
+		FatalTimeout: 250 * time.Millisecond,
+		TimeoutBehavior: TimeoutBehavior{
+			Signal:     syscall.SIGTERM,
+			ShouldWait: true,
+		},
+	}
+
+	start := time.Now()
+	_, err := RunCommandExt(cmd, opts)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Lessf(t, elapsed, 5*time.Second,
+		"RunCommandExt blocked for %s waiting on an orphaned grandchild; the process group was not reaped", elapsed)
+}

--- a/util/exec/exec_unix.go
+++ b/util/exec/exec_unix.go
@@ -1,0 +1,39 @@
+//go:build !windows
+
+package exec
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setChildProcessGroup puts the command into its own process group so that the
+// timeout handler can signal the entire group — the command plus any
+// grandchildren it spawned — rather than only the direct child.
+//
+// Without this, a grandchild that inherited the command's stdout/stderr pipes
+// (for example git's git-remote-https helper, which can block on a dead TCP
+// connection) keeps those pipes open after the direct child is killed. That
+// stalls cmd.Wait() until the grandchild exits on its own, long past the
+// configured timeout.
+func setChildProcessGroup(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+}
+
+// signalProcessGroup sends sig to the command's whole process group. It relies
+// on setChildProcessGroup having made the command a process-group leader, so
+// the group ID equals the process ID. If the group signal fails it falls back
+// to signalling just the process.
+func signalProcessGroup(cmd *exec.Cmd, sig syscall.Signal) error {
+	if cmd.Process == nil {
+		return nil
+	}
+	// A negative PID signals the whole process group. See kill(2).
+	if err := syscall.Kill(-cmd.Process.Pid, sig); err != nil {
+		return cmd.Process.Signal(sig)
+	}
+	return nil
+}

--- a/util/exec/exec_windows.go
+++ b/util/exec/exec_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package exec
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setChildProcessGroup is a no-op on Windows, which has no POSIX process
+// groups. Timeout handling falls back to signalling the process directly.
+func setChildProcessGroup(_ *exec.Cmd) {}
+
+// signalProcessGroup signals the process directly on Windows, preserving the
+// previous best-effort behaviour (os.Process.Signal only meaningfully supports
+// Kill on Windows).
+func signalProcessGroup(cmd *exec.Cmd, sig syscall.Signal) error {
+	if cmd.Process == nil {
+		return nil
+	}
+	return cmd.Process.Signal(sig)
+}


### PR DESCRIPTION
Fixes #28394

### What does this PR do?

As described in #28394, `ARGOCD_EXEC_TIMEOUT` does not reliably bound how long a command runs. `util/exec.RunCommandExt` sends the timeout signal (SIGTERM, then SIGKILL after the fatal timeout) to the **direct** child process only, but `cmd.Wait()` does not return until the command's stdout/stderr pipes are closed. A grandchild that inherited those pipes keeps `RunCommandExt` blocked long past the configured timeout — until the grandchild exits on its own.

In production this surfaces in **argocd-repo-server**: a `git fetch` whose `git-remote-https` child holds a dead TCP connection (reaped by the kernel only after its retransmission timeout) keeps the per-repo lock for many minutes, serializing all manifest generation for that repository. See #28394 for the full symptoms and metrics.

### How does it fix it?

Run each command in its own process group (`Setpgid`) and signal the **whole group** on timeout instead of just the direct child. This reaps grandchildren (e.g. `git-remote-https`) along with the command, so the inherited pipes close and `cmd.Wait()` returns promptly when the timeout fires.

This mirrors the existing process-group pattern already used in `cmpserver/plugin` (`plugin_unix.go` / `plugin_windows.go`). The process-group behavior is implemented in build-tagged files: `exec_unix.go` does the real `Setpgid` + group-signal, and `exec_windows.go` keeps the prior best-effort per-process behavior (Windows has no POSIX process groups).

### Testing

Added `TestRunCommandExtTimeoutReapsProcessGroup`, which backgrounds a long-lived `sleep` that inherits the command's stdout pipe. Against the old code the test blocks for ~15s (the orphaned grandchild keeps the pipe open); with the fix it returns in well under a second once the timeout fires. The assertion fails if the call takes longer than 5s, so it is a true regression test for this bug. All existing `util/exec` tests continue to pass; `go vet` and the Windows cross-compile are clean.

---

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes. — **(b) bug fix**
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue. — **Fixes #28394**
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. — *N/A: internal exec/timeout behavior, no CLI/UI surface*
* [x] Does this PR require documentation updates? — **No**; behavior is internal, no config/flags changed
* [x] I've updated documentation as required by this PR. — *none required*
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines. — *N/A: not a new feature*
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity). — **candidate for cherry-pick into active release branches (e.g. release-3.3)**; low risk, no API/behavior change beyond timeout teardown
