### PR TITLE
fix(ui): use groupedResources local variable in parent ref panel

### DIFF
--- a/ui/src/app/applications/components/application-details/application-details.tsx
+++ b/ui/src/app/applications/components/application-details/application-details.tsx
@@ -1170,9 +1170,7 @@ Are you sure you want to disable auto-sync and rollback application '${props.mat
                                         {isApplication && (
                                             <SlidingPanel isShown={groupedResources.length > 0} onClose={() => closeGroupedNodesPanel()}>
                                                 <div className='application-details__sliding-panel-pagination-wrap'>
-                                                    {(pref.view === 'tree' || pref.view === 'network') && (
-                                                        <ApplicationResourceParentRef resources={state.groupedResources} tree={tree} />
-                                                    )}
+                                                    {(pref.view === 'tree' || pref.view === 'network') && <ApplicationResourceParentRef resources={groupedResources} tree={tree} />}
                                                     <Paginate
                                                         page={state.slidingPanelPage}
                                                         data={groupedResources}


### PR DESCRIPTION
Fixes a TypeScript/ESLint regression from #28385 where `ApplicationResourceParentRef` referenced `state.groupedResources`, which does not exist on `ApplicationDetailsState`. The component already computes a local `groupedResources` array from `groupedResourceIds`; this PR uses that instead.

This was a rare case of the master branch changing in an important way that didn't trigger a conflict with the change in the PR. Preventing cases like this would mean requiring PR branches to be up-to-date with master, which is must more costly than an occasional missed conflict.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

## Test plan

- [x] `pnpm exec eslint src/app/applications/components/application-details/application-details.tsx` passes locally
- [ ] CI `Build, test & lint UI code` passes