### PR TITLE
feat(ui): preserve application search bar content across navigation (#5655)

### DIFF
--- a/ui/src/app/applications/components/applications-list/applications-list.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-list.tsx
@@ -186,11 +186,10 @@ const ViewPref = ({children}: {children: (pref: AppsListPreferences & {page: num
                                 .map(decodeURIComponent)
                                 .filter(item => !!item);
                         }
-                        return {
-                            ...viewPref,
-                            page: parseInt(params.get('page') || '0', 10),
-                            search: params.get('search') || ''
-                        };
+                        // Search precedence: URL query param (if present) wins, otherwise fall back to the
+                        // persisted preference so the search text survives navigating into an app and back.
+                        const search = params.get('search') != null ? params.get('search') : viewPref.search || '';
+                        return {...viewPref, page: parseInt(params.get('page') || '0', 10), search};
                     })
                 )
             }>
@@ -229,8 +228,14 @@ function tryJsonParse(input: string) {
     }
 }
 
-const ApplicationsListSearchBar = (props: {content: string; searchRegex: boolean; ctx: ContextApis; apps: models.Application[]}) => {
-    const {content, searchRegex, ctx, apps} = props;
+const ApplicationsListSearchBar = (props: {
+    content: string;
+    searchRegex: boolean;
+    ctx: ContextApis;
+    apps: models.Application[];
+    pref: AppsListPreferences & {page: number; search: string};
+}) => {
+    const {content, searchRegex, ctx, apps, pref} = props;
     const useAuthSettingsCtx = React.useContext(AuthSettingsCtx);
 
     const query = new URLSearchParams(window.location.search);
@@ -239,7 +244,11 @@ const ApplicationsListSearchBar = (props: {content: string; searchRegex: boolean
     return (
         <SearchBar
             value={content || ''}
-            onChange={value => ctx.navigation.goto('.', {search: value}, {replace: true})}
+            onChange={value => {
+                ctx.navigation.goto('.', {search: value}, {replace: true});
+                // Persist the search text like filters so it survives navigating into an app and back.
+                services.viewPreferences.updatePreferences({appList: {...pref, search: value}});
+            }}
             placeholder={searchRegex ? 'Regex search (e.g. ^foo-.*-prod$)' : 'Search applications...'}
             disableKeyboardShortcuts={!!appInput}
             regexEnabled={searchRegex}
@@ -281,7 +290,7 @@ const ApplicationsToolbar: React.FC<ApplicationsToolbarProps> = ({applications, 
 
     return (
         <div className='applications-list__toolbar-controls' key='app-list-tools'>
-            <ApplicationsListSearchBar content={pref.search} searchRegex={pref.searchRegex} apps={applications} ctx={ctx} />
+            <ApplicationsListSearchBar content={pref.search} searchRegex={pref.searchRegex} apps={applications} ctx={ctx} pref={pref} />
             <Tooltip content={pref.searchRegex ? (regexInvalid ? 'Invalid regex pattern' : 'Regex search enabled, click to switch to plain text') : 'Click to enable regex search'}>
                 <button
                     type='button'

--- a/ui/src/app/shared/services/view-preferences-service.test.ts
+++ b/ui/src/app/shared/services/view-preferences-service.test.ts
@@ -1,0 +1,51 @@
+import {AppsListPreferences, ViewPreferences, ViewPreferencesService} from './view-preferences-service';
+
+const VIEW_PREFERENCES_KEY = 'view_preferences';
+
+function readPreferences(service: ViewPreferencesService): ViewPreferences {
+    let current: ViewPreferences;
+    service
+        .getPreferences()
+        .subscribe(prefs => (current = prefs))
+        .unsubscribe();
+    return current;
+}
+
+beforeEach(() => {
+    window.localStorage.clear();
+});
+
+test('appList.search defaults to an empty string when nothing is persisted', () => {
+    const service = new ViewPreferencesService();
+    service.init();
+
+    expect(readPreferences(service).appList.search).toBe('');
+});
+
+test('appList.search is persisted and restored across reloads', () => {
+    const service = new ViewPreferencesService();
+    service.init();
+
+    const appList = {...readPreferences(service).appList, search: 'guestbook'} as AppsListPreferences;
+    service.updatePreferences({appList});
+
+    expect(readPreferences(service).appList.search).toBe('guestbook');
+
+    // A fresh service reads the same backing store, simulating a page reload.
+    const reloaded = new ViewPreferencesService();
+    reloaded.init();
+    expect(readPreferences(reloaded).appList.search).toBe('guestbook');
+});
+
+test('appList.search is normalized to an empty string when missing from stored preferences', () => {
+    const stored = {
+        version: 5,
+        appList: {view: 'tiles'}
+    };
+    window.localStorage.setItem(VIEW_PREFERENCES_KEY, JSON.stringify(stored));
+
+    const service = new ViewPreferencesService();
+    service.init();
+
+    expect(readPreferences(service).appList.search).toBe('');
+});

--- a/ui/src/app/shared/services/view-preferences-service.ts
+++ b/ui/src/app/shared/services/view-preferences-service.ts
@@ -109,6 +109,7 @@ export class AppsListPreferences extends AbstractAppsListPreferences {
     public clustersFilter: string[];
     public targetRevisionFilter: string[];
     public operationFilter: string[];
+    public search: string;
 }
 
 export class AppSetsListPreferences extends AbstractAppsListPreferences {
@@ -173,6 +174,7 @@ const DEFAULT_PREFERENCES: ViewPreferences = {
         autoSyncFilter: new Array<string>(),
         healthFilter: new Array<string>(),
         operationFilter: new Array<string>(),
+        search: '',
         hideFilters: false,
         showFavorites: false,
         favoritesAppList: new Array<string>(),
@@ -250,5 +252,6 @@ export class ViewPreferencesService {
         appList.healthFilter = appList.healthFilter || [];
         appList.operationFilter = appList.operationFilter || [];
         appList.favoritesAppList = appList.favoritesAppList || [];
+        appList.search = appList.search || '';
     }
 }


### PR DESCRIPTION
Closes #5655

## What

On the Applications list page, structured filters are persisted to view
preferences (localStorage), but the free-text search bar is only kept in the
URL query string. Navigating into an app and back via in-app navigation drops
the `?search=` param, so the search box comes back empty while the filters
survive. The original issue asks for the search bar to be preserved the same
way the filters are.

## Changes

- Add a `search` field to `AppsListPreferences` (default `''`, normalized on load).
- Persist the search text in `ApplicationsListSearchBar.onChange` alongside the
  existing URL update, mirroring how filters are stored.
- Seed the search bar from the resolved value, with precedence: URL query param
  (if present) > persisted preference > empty.

## Validation

- `pnpm lint` (tsc --noEmit + eslint): clean.
- `pnpm test` (jest): 23 suites / 266 tests pass, including 3 new tests in
  `view-preferences-service.test.ts` covering the default, a persist + reload
  round-trip, and normalization of older stored preferences without `search`.

This is a UI-only change (the search box has no CLI equivalent).

---

Checklist:

* [x] (c) this does not need to be in the release notes / tracked by existing issue #5655 (`good first issue`, `enhancement`).
* [x] The title states what changed and the related issue number.
* [x] The title conforms to the PR title guidelines.
* [x] I've included "Closes #5655" in the description.
* [ ] CLI/UI parity — UI-only change; the search box has no CLI equivalent.
* [x] I have signed off all my commits (DCO).
* [x] I have written unit tests for my change.
* [x] My build is green locally (lint + unit tests).
* [x] I've added a description of why this PR is necessary.