### PR TITLE
chore(ci): ignore node for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,7 +32,10 @@ updates:
     ignore:
       # We use consistent go and node versions across a lot of different files, and updating via dependabot would cause
       # drift among those files, instead we let renovate bot handle them.
+      # golang and library/golang are synonyms for the same package. Same for node and library/node. Ignore them both.
+      - dependency-name: "golang"
       - dependency-name: "library/golang"
+      - dependency-name: "node"
       - dependency-name: "library/node"
 
   - package-ecosystem: "docker"

--- a/Dockerfile.ui.tilt
+++ b/Dockerfile.ui.tilt
@@ -1,4 +1,4 @@
-FROM node:24.14.1@sha256:80fc934952c8f1b2b4d39907af7211f8a9fff1a4c2cf673fb49099292c251cec
+FROM docker.io/library/node:24.14.1@sha256:80fc934952c8f1b2b4d39907af7211f8a9fff1a4c2cf673fb49099292c251cec
 
 WORKDIR /app/ui
 


### PR DESCRIPTION
We use Renovate instead of dependabot for node bumps, but the shorthand `node` image reference slips through the ignore list.

Standardize repo name and add both to the ignore list for future-proofing.