### PR TITLE
chore(ci): only bump image if there's a new version

### DIFF
--- a/renovate-presets/devtool.json5
+++ b/renovate-presets/devtool.json5
@@ -57,6 +57,16 @@
       "enabled": true
     },
     {
+      "description": "Disable digest-only docker updates; refresh digests when the image tag changes",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchUpdateTypes": [
+        "digest"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Group golang-version packages",
       "groupName": "group golang",
       "matchDatasources": [


### PR DESCRIPTION
Today Renovate bumps image digests any time there's a new digest, not just if there's a new version.

That's excessively noisy. If we find later on that there are genuine benefits to bumping the digest (maybe to pick up some important security fixes?) we can reevaluate. But for now this change limits bumps to only when there's actually a new version tag.