### PR TITLE
chore(ci): fix Renovate PR attribution

### DIFF
--- a/.github/configs/renovate-config.js
+++ b/.github/configs/renovate-config.js
@@ -1,6 +1,5 @@
 module.exports = {
     platform: 'github',
-    gitAuthor: 'renovate[bot] <renovate[bot]@users.noreply.github.com>',
     autodiscover: false,
     allowPostUpgradeCommandTemplating: true,
     allowedPostUpgradeCommands: ["make mockgen"],


### PR DESCRIPTION
Removes the hardcoded `gitAuthor` from the self-hosted Renovate config. The value still pointed at Mend's hosted bot (`renovate[bot]`), but commits are made by the self-hosted GitHub App (`argoproj-renovate[bot]`). That mismatch caused Renovate to treat every open PR as manually edited, [posting "Edited/Blocked Notification" comments](https://github.com/argoproj/argo-cd/pull/28423#issuecomment-4791599665) and listing PRs under "PR Edited (Blocked)" on the dependency dashboard.

With `gitAuthor` removed, Renovate auto-detects the correct author from the GitHub App token.