### PR TITLE
fix: admin cluster shards command does not display shards if there are no clusters assigned to them

### DIFF
--- a/cmd/argocd/commands/admin/cluster.go
+++ b/cmd/argocd/commands/admin/cluster.go
@@ -90,6 +90,18 @@ func loadClusters(ctx context.Context, kubeClient kubernetes.Interface, appClien
 	if err != nil {
 		return nil, err
 	}
+
+	if shardingAlgorithm == "" {
+		cm, err := settingsMgr.GetConfigMapByName(common.ArgoCDCmdParamsConfigMapName)
+		if err != nil {
+			return nil, err
+		}
+		var exists bool
+		shardingAlgorithm, exists = cm.Data["controller.sharding.algorithm"]
+		if !exists {
+			shardingAlgorithm = common.DefaultShardingAlgorithm
+		}
+	}
 	clusterShardingCache := sharding.NewClusterSharding(argoDB, shard, replicas, shardingAlgorithm)
 	clusterShardingCache.Init(clustersList, appItems)
 	clusterShards := clusterShardingCache.GetDistribution()
@@ -213,13 +225,13 @@ func NewClusterShardsCommand(clientOpts *argocdclient.ClientOptions) *cobra.Comm
 				return
 			}
 
-			printStatsSummary(clusters)
+			printStatsSummary(clusters, replicas)
 		},
 	}
 	clientConfig = cli.AddKubectlFlagsToCmd(&command)
 	command.Flags().IntVar(&shard, "shard", -1, "Cluster shard filter")
 	command.Flags().IntVar(&replicas, "replicas", 0, "Application controller replicas count. Inferred from number of running controller pods if not specified")
-	command.Flags().StringVar(&shardingAlgorithm, "sharding-method", common.DefaultShardingAlgorithm, "Sharding method. Defaults: legacy. Supported sharding methods are : [legacy, round-robin, consistent-hashing] ")
+	command.Flags().StringVar(&shardingAlgorithm, "sharding-method", "", "Sharding method. Defaults to what is set for sharding algorithm in argocd-cmd-params (legacy if not provided). Supported sharding methods are : [legacy, round-robin, consistent-hashing] ")
 	command.Flags().BoolVar(&portForwardRedis, "port-forward-redis", true, "Automatically port-forward ha proxy redis from current namespace?")
 
 	cacheSrc = appstatecache.AddCacheFlagsToCmd(&command)
@@ -231,7 +243,7 @@ func NewClusterShardsCommand(clientOpts *argocdclient.ClientOptions) *cobra.Comm
 	return &command
 }
 
-func printStatsSummary(clusters []ClusterWithInfo) {
+func printStatsSummary(clusters []ClusterWithInfo, replicas int) {
 	totalResourcesCount := int64(0)
 	resourcesCountByShard := map[int]int64{}
 	for _, c := range clusters {
@@ -239,13 +251,21 @@ func printStatsSummary(clusters []ClusterWithInfo) {
 		resourcesCountByShard[c.Shard] += c.Info.CacheInfo.ResourcesCount
 	}
 
-	avgResourcesByShard := totalResourcesCount / int64(len(resourcesCountByShard))
+	for replica := range replicas {
+		_, exists := resourcesCountByShard[replica]
+		if !exists {
+			resourcesCountByShard[replica] = 0
+		}
+	}
+
+	avgResourcesByShard := totalResourcesCount / int64(replicas)
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	_, _ = fmt.Fprint(w, "SHARD\tRESOURCES COUNT\n")
+	_, _ = fmt.Fprintf(w, "SHARD\tRESOURCES COUNT\t%% OF TOTAL\t%% OF AVG PER SHARD (%d)\n", avgResourcesByShard)
 	for shard := 0; shard < len(resourcesCountByShard); shard++ {
 		cnt := resourcesCountByShard[shard]
-		percent := (float64(cnt) / float64(avgResourcesByShard)) * 100.0
-		_, _ = fmt.Fprintf(w, "%d\t%s\n", shard, fmt.Sprintf("%d (%.0f%%)", cnt, percent))
+		totalPercent := (float64(cnt) / float64(totalResourcesCount)) * 100.0
+		avgPercent := (float64(cnt) / float64(avgResourcesByShard)) * 100.0
+		_, _ = fmt.Fprintf(w, "%d\t%d\t%.0f%%\t%.0f%%\n", shard, cnt, totalPercent, avgPercent)
 	}
 	_ = w.Flush()
 }
@@ -506,7 +526,7 @@ argocd admin cluster stats target-cluster`,
 	clientConfig = cli.AddKubectlFlagsToCmd(&command)
 	command.Flags().IntVar(&shard, "shard", -1, "Cluster shard filter")
 	command.Flags().IntVar(&replicas, "replicas", 0, "Application controller replicas count. Inferred from number of running controller pods if not specified")
-	command.Flags().StringVar(&shardingAlgorithm, "sharding-method", common.DefaultShardingAlgorithm, "Sharding method. Defaults: legacy. Supported sharding methods are : [legacy, round-robin, consistent-hashing] ")
+	command.Flags().StringVar(&shardingAlgorithm, "sharding-method", "", "Sharding method. Defaults to what is set for sharding algorithm in argocd-cmd-params (legacy if not provided). Supported sharding methods are : [legacy, round-robin, consistent-hashing] ")
 	command.Flags().BoolVar(&portForwardRedis, "port-forward-redis", true, "Automatically port-forward ha proxy redis from current namespace?")
 	cacheSrc = appstatecache.AddCacheFlagsToCmd(&command)
 

--- a/cmd/argocd/commands/admin/cluster.go
+++ b/cmd/argocd/commands/admin/cluster.go
@@ -93,12 +93,14 @@ func loadClusters(ctx context.Context, kubeClient kubernetes.Interface, appClien
 
 	if shardingAlgorithm == "" {
 		cm, err := settingsMgr.GetConfigMapByName(common.ArgoCDCmdParamsConfigMapName)
-		if err != nil {
-			return nil, err
-		}
-		var exists bool
-		shardingAlgorithm, exists = cm.Data["controller.sharding.algorithm"]
-		if !exists {
+		if err == nil {
+			var exists bool
+			shardingAlgorithm, exists = cm.Data["controller.sharding.algorithm"]
+			if !exists {
+				shardingAlgorithm = common.DefaultShardingAlgorithm
+			}
+		} else {
+			log.Warnf("%s was not found in namespace %s, using default sharding algorithm of legacy", common.ArgoCDCmdParamsConfigMapName, namespace)
 			shardingAlgorithm = common.DefaultShardingAlgorithm
 		}
 	}
@@ -212,7 +214,7 @@ func NewClusterShardsCommand(clientOpts *argocdclient.ClientOptions) *cobra.Comm
 			kubeClient := kubernetes.NewForConfigOrDie(clientCfg)
 			appClient := versioned.NewForConfigOrDie(clientCfg)
 
-			if replicas == 0 {
+			if replicas <= 0 {
 				replicas, err = getControllerReplicas(ctx, kubeClient, namespace, clientOpts.AppControllerName)
 				errors.CheckError(err)
 			}
@@ -508,7 +510,7 @@ argocd admin cluster stats target-cluster`,
 
 			kubeClient := kubernetes.NewForConfigOrDie(clientCfg)
 			appClient := versioned.NewForConfigOrDie(clientCfg)
-			if replicas == 0 {
+			if replicas <= 0 {
 				replicas, err = getControllerReplicas(ctx, kubeClient, namespace, clientOpts.AppControllerName)
 				errors.CheckError(err)
 			}

--- a/cmd/argocd/commands/admin/cluster_test.go
+++ b/cmd/argocd/commands/admin/cluster_test.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 	"time"
@@ -90,7 +91,6 @@ func Test_loadClustersSkipsApplicationWithRemovedCluster(t *testing.T) {
 		// This changes, nil it to avoid testing it.
 		clusters[i].Info.ConnectionState.ModifiedAt = nil
 	}
-
 	expected := []ClusterWithInfo{{
 		Cluster: v1alpha1.Cluster{
 			ID:     "",
@@ -107,4 +107,97 @@ func Test_loadClustersSkipsApplicationWithRemovedCluster(t *testing.T) {
 		Namespaces: []string{"test"},
 	}}
 	assert.Equal(t, expected, clusters)
+}
+
+func Test_loadClusters_ShardingAlgorithm(t *testing.T) {
+	var logOutput bytes.Buffer
+	originalOutput := log.StandardLogger().Out
+	log.SetOutput(&logOutput)
+	defer log.SetOutput(originalOutput)
+
+	originalLevel := log.GetLevel()
+	log.SetLevel(log.DebugLevel)
+	defer log.SetLevel(originalLevel)
+
+	argoCDCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "argocd-cm",
+			Namespace: "argocd",
+			Labels: map[string]string{
+				"app.kubernetes.io/part-of": "argocd",
+			},
+		},
+		Data: map[string]string{},
+	}
+	argoCDCmdCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "argocd-cmd-params-cm",
+			Namespace: "argocd",
+			Labels: map[string]string{
+				"app.kubernetes.io/part-of": "argocd",
+			},
+		},
+		Data: map[string]string{},
+	}
+	argoCDSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "argocd-secret",
+			Namespace: "argocd",
+		},
+		Data: map[string][]byte{
+			"server.secretkey": []byte("test"),
+		},
+	}
+	app := &v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "argocd",
+		},
+		Spec: v1alpha1.ApplicationSpec{
+			Project: "default",
+			Destination: v1alpha1.ApplicationDestination{
+				Server:    "https://kubernetes.default.svc",
+				Namespace: "test",
+			},
+		},
+	}
+
+	t.Run("argocd-cmd-params-cm is missing", func(t *testing.T) {
+		ctx := t.Context()
+		kubeClient := fake.NewClientset(argoCDCM, argoCDSecret)
+		appClient := fakeapps.NewSimpleClientset(app)
+		cacheSrc := func() (*appstate.Cache, error) {
+			return appstate.NewCache(cacheutil.NewCache(cacheutil.NewInMemoryCache(time.Minute)), time.Minute), nil
+		}
+		_, err := loadClusters(ctx, kubeClient, appClient, 3, "", "argocd", false, cacheSrc, 0, "", "", "")
+		require.NoError(t, err)
+		require.True(t, strings.Contains(logOutput.String(), "Using filter function:  legacy"))
+	})
+
+	t.Run("argocd-cmd-params-cm has non-default value", func(t *testing.T) {
+		cmdParamsCopy := argoCDCmdCM.DeepCopy()
+		cmdParamsCopy.Data["controller.sharding.algorithm"] = "round-robin"
+
+		ctx := t.Context()
+		kubeClient := fake.NewClientset(argoCDCM, cmdParamsCopy, argoCDSecret)
+		appClient := fakeapps.NewSimpleClientset(app)
+		cacheSrc := func() (*appstate.Cache, error) {
+			return appstate.NewCache(cacheutil.NewCache(cacheutil.NewInMemoryCache(time.Minute)), time.Minute), nil
+		}
+		_, err := loadClusters(ctx, kubeClient, appClient, 3, "", "argocd", false, cacheSrc, 0, "", "", "")
+		require.NoError(t, err)
+		require.True(t, strings.Contains(logOutput.String(), "Using filter function:  round-robin"))
+	})
+
+	t.Run("argocd-cmd-params-cm does not contain controller.sharding.algorithm key", func(t *testing.T) {
+		ctx := t.Context()
+		kubeClient := fake.NewClientset(argoCDCM, argoCDCmdCM, argoCDSecret)
+		appClient := fakeapps.NewSimpleClientset(app)
+		cacheSrc := func() (*appstate.Cache, error) {
+			return appstate.NewCache(cacheutil.NewCache(cacheutil.NewInMemoryCache(time.Minute)), time.Minute), nil
+		}
+		_, err := loadClusters(ctx, kubeClient, appClient, 3, "", "argocd", false, cacheSrc, 0, "", "", "")
+		require.NoError(t, err)
+		require.True(t, strings.Contains(logOutput.String(), "Using filter function:  legacy"))
+	})
 }

--- a/cmd/argocd/commands/admin/cluster_test.go
+++ b/cmd/argocd/commands/admin/cluster_test.go
@@ -2,7 +2,6 @@ package admin
 
 import (
 	"bytes"
-	"strings"
 	"testing"
 	"time"
 
@@ -171,7 +170,7 @@ func Test_loadClusters_ShardingAlgorithm(t *testing.T) {
 		}
 		_, err := loadClusters(ctx, kubeClient, appClient, 3, "", "argocd", false, cacheSrc, 0, "", "", "")
 		require.NoError(t, err)
-		require.True(t, strings.Contains(logOutput.String(), "Using filter function:  legacy"))
+		require.Contains(t, logOutput.String(), "Using filter function:  legacy")
 	})
 
 	t.Run("argocd-cmd-params-cm has non-default value", func(t *testing.T) {
@@ -186,7 +185,7 @@ func Test_loadClusters_ShardingAlgorithm(t *testing.T) {
 		}
 		_, err := loadClusters(ctx, kubeClient, appClient, 3, "", "argocd", false, cacheSrc, 0, "", "", "")
 		require.NoError(t, err)
-		require.True(t, strings.Contains(logOutput.String(), "Using filter function:  round-robin"))
+		require.Contains(t, logOutput.String(), "Using filter function:  round-robin")
 	})
 
 	t.Run("argocd-cmd-params-cm does not contain controller.sharding.algorithm key", func(t *testing.T) {
@@ -198,6 +197,6 @@ func Test_loadClusters_ShardingAlgorithm(t *testing.T) {
 		}
 		_, err := loadClusters(ctx, kubeClient, appClient, 3, "", "argocd", false, cacheSrc, 0, "", "", "")
 		require.NoError(t, err)
-		require.True(t, strings.Contains(logOutput.String(), "Using filter function:  legacy"))
+		require.Contains(t, logOutput.String(), "Using filter function:  legacy")
 	})
 }

--- a/cmd/argocd/commands/admin/cluster_test.go
+++ b/cmd/argocd/commands/admin/cluster_test.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 	"time"
 

--- a/cmd/argocd/commands/admin/cluster_test.go
+++ b/cmd/argocd/commands/admin/cluster_test.go
@@ -30,6 +30,16 @@ func Test_loadClustersSkipsApplicationWithRemovedCluster(t *testing.T) {
 		},
 		Data: map[string]string{},
 	}
+	argoCDCmdCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "argocd-cmd-params-cm",
+			Namespace: "argocd",
+			Labels: map[string]string{
+				"app.kubernetes.io/part-of": "argocd",
+			},
+		},
+		Data: map[string]string{},
+	}
 	argoCDSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "argocd-secret",
@@ -58,7 +68,7 @@ func Test_loadClustersSkipsApplicationWithRemovedCluster(t *testing.T) {
 	staleApp.Spec.Destination.Server = "https://removed-cluster.example.com"
 	staleApp.Spec.Destination.Namespace = "stale"
 	ctx := t.Context()
-	kubeClient := fake.NewClientset(argoCDCM, argoCDSecret)
+	kubeClient := fake.NewClientset(argoCDCM, argoCDCmdCM, argoCDSecret)
 	appClient := fakeapps.NewSimpleClientset(app, staleApp)
 	oldHooks := log.StandardLogger().ReplaceHooks(log.LevelHooks{})
 	t.Cleanup(func() { log.StandardLogger().ReplaceHooks(oldHooks) })

--- a/docs/user-guide/commands/argocd_admin_cluster_shards.md
+++ b/docs/user-guide/commands/argocd_admin_cluster_shards.md
@@ -43,7 +43,7 @@ argocd admin cluster shards [flags]
       --sentinelmaster string                 Redis sentinel master group name. (default "master")
       --server string                         The address and port of the Kubernetes API server
       --shard int                             Cluster shard filter (default -1)
-      --sharding-method string                Sharding method. Defaults: legacy. Supported sharding methods are : [legacy, round-robin, consistent-hashing]  (default "legacy")
+      --sharding-method string                Sharding method. Defaults to what is set for sharding algorithm in argocd-cmd-params (legacy if not provided). Supported sharding methods are : [legacy, round-robin, consistent-hashing] 
       --tls-server-name string                If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                          Bearer token for authentication to the API server
       --user string                           The name of the kubeconfig user to use

--- a/docs/user-guide/commands/argocd_admin_cluster_stats.md
+++ b/docs/user-guide/commands/argocd_admin_cluster_stats.md
@@ -57,7 +57,7 @@ argocd admin cluster stats target-cluster
       --sentinelmaster string                 Redis sentinel master group name. (default "master")
       --server string                         The address and port of the Kubernetes API server
       --shard int                             Cluster shard filter (default -1)
-      --sharding-method string                Sharding method. Defaults: legacy. Supported sharding methods are : [legacy, round-robin, consistent-hashing]  (default "legacy")
+      --sharding-method string                Sharding method. Defaults to what is set for sharding algorithm in argocd-cmd-params (legacy if not provided). Supported sharding methods are : [legacy, round-robin, consistent-hashing] 
       --tls-server-name string                If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                          Bearer token for authentication to the API server
       --user string                           The name of the kubeconfig user to use


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [N/A] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [N/A] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [N/A] Does this PR require documentation updates?
* [X] I've updated documentation as required by this PR.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [X] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [X] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [X] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->

This PR fixes a small issue with the `admin cluster shards` command. If a shard was not assigned any clusters by the distribution algorithm it will not show up in the output of the command. This could lead to misleading information and confusion from users. 

There are two other small improvements made in this PR as well. First is in the formatting in the output of the command. Instead of the `RESOURCE COUNT` column having the total resources per shard and comparison percentage of that total to what should be the average number of total resources per shard I split that into a new column so that number is apparent at first. I also added another column that is the percent of total resources on that shard.

The other small improvement is that the `admin cluster stats` and `admin cluster shards` commands both now look at the `argocd-cmd-params-cm` ConfigMap to get the sharding algorithm that is set if there is none provided for a better user experience. If that is empty it will fallback to the default.