### PR TITLE
fix: resolve stale ComparisonError and operationState patch deadlock

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -1604,6 +1604,9 @@ func (ctrl *ApplicationController) setOperationState(ctx context.Context, app *a
 		now := metav1.Now()
 		state.FinishedAt = &now
 	}
+	if state.Operation.Sync != nil {
+		state.Operation.Sync.Manifests = nil
+	}
 	patch := map[string]any{
 		"status": map[string]any{
 			"operationState": state,
@@ -1822,7 +1825,9 @@ func (ctrl *ApplicationController) processAppRefreshQueueItem() (processNext boo
 	}
 
 	var localManifests []string
-	if opState := app.Status.OperationState; opState != nil && opState.Operation.Sync != nil {
+	if app.Operation != nil && app.Operation.Sync != nil {
+		localManifests = app.Operation.Sync.Manifests
+	} else if opState := app.Status.OperationState; opState != nil && opState.Operation.Sync != nil {
 		localManifests = opState.Operation.Sync.Manifests
 	}
 

--- a/controller/state.go
+++ b/controller/state.go
@@ -696,6 +696,11 @@ func (m *appStateManager) CompareAppState(ctx context.Context, app *v1alpha1.App
 			targetObjs = make([]*unstructured.Unstructured, 0)
 			msg := "Failed to load target state: " + err.Error()
 			conditions = append(conditions, v1alpha1.ApplicationCondition{Type: v1alpha1.ApplicationConditionComparisonError, Message: msg, LastTransitionTime: &now})
+			if hasMultipleSources {
+				syncStatus.Revisions = revisions
+			} else if len(revisions) > 0 {
+				syncStatus.Revision = revisions[0]
+			}
 			if firstSeen, ok := m.repoErrorCache.Load(app.Name); ok {
 				if time.Since(firstSeen.(time.Time)) <= m.repoErrorGracePeriod && !noRevisionCache {
 					// if first seen is less than grace period and it's not a Level 3 comparison,

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -113,7 +113,12 @@ func (m *appStateManager) SyncAppState(ctx context.Context, app *v1alpha1.Applic
 		return
 	}
 
-	syncOp := *state.Operation.Sync
+	var syncOp v1alpha1.SyncOperation
+	if app.Operation != nil && app.Operation.Sync != nil {
+		syncOp = *app.Operation.Sync
+	} else {
+		syncOp = *state.Operation.Sync
+	}
 
 	if state.SyncResult == nil {
 		state.SyncResult = newSyncOperationResult(app, syncOp)


### PR DESCRIPTION
## Summary
## Fixing stale ComparisonError and operationState patch deadlock

1. When manifest generation fails on a target branch (e.g. directory missing), the unresolved revision name (branch name) was left in `app.Status.Sync.Revision`. This caused `UpdateRevisionForPaths` to incorrectly return `Changes: false` on future runs since the synced revision and target revision were string-identical, blocking the detection of new commits.
2. Sync operations with local/dry-run manifests serialized the entire manifests array into `status.operationState`, exceeding the Kubernetes API server / webhook payload limits (3MB) and deadlocking the operation queue.

## Changes Made

- **controller/state.go**: Update `CompareAppState` to populate `syncStatus` with resolved revisions on comparison failure.
- **controller/appcontroller.go**: Exclude `Manifests` from the persisted `status.operationState` in `setOperationState`. Fallback to `spec.operation` to read active local manifests in `processAppRefreshQueueItem`.
- **controller/sync.go**: Retrieve active local manifests from `spec.operation` in `SyncAppState`.

## Verification Results

### Go Build
The codebase builds cleanly with no compilation issues:
```bash
go build ./...
```

### Unit Tests
The controller package tests run successfully:
```bash
go test -v ./controller/... -run "(TestAppStateManager_SyncAppState|TestCompareAppState)"
```
