### PR TITLE
fix(argo): sanitize application destination server and name strings with TrimSpace

### DIFF
--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -1087,19 +1087,22 @@ type ClusterGetter interface {
 // directly (normalized). For name based destinations GetClusterServersByName is called.
 // An error is returned if the name is ambiguous or missing.
 func GetDestinationServer(ctx context.Context, destination argoappv1.ApplicationDestination, db ClusterGetter) (string, error) {
-	if destination.Name != "" && destination.Server != "" {
-		return "", fmt.Errorf("application destination can't have both name and server defined: %s %s", destination.Name, destination.Server)
+	name := strings.TrimSpace(destination.Name)
+	server := strings.TrimSpace(destination.Server)
+
+	if name != "" && server != "" {
+		return "", fmt.Errorf("application destination can't have both name and server defined: %s %s", name, server)
 	}
-	if destination.Server != "" {
-		return strings.TrimRight(destination.Server, "/"), nil
+	if server != "" {
+		return strings.TrimRight(server, "/"), nil
 	}
-	if destination.Name != "" {
-		clusterURLs, err := db.GetClusterServersByName(ctx, destination.Name)
+	if name != "" {
+		clusterURLs, err := db.GetClusterServersByName(ctx, name)
 		if err != nil {
-			return "", fmt.Errorf("error getting cluster by name %q: %w", destination.Name, err)
+			return "", fmt.Errorf("error getting cluster by name %q: %w", name, err)
 		}
 		if len(clusterURLs) == 0 {
-			return "", fmt.Errorf("there are no clusters with this name: %s", destination.Name)
+			return "", fmt.Errorf("there are no clusters with this name: %s", name)
 		}
 		if len(clusterURLs) > 1 {
 			return "", fmt.Errorf("there are %d clusters with the same name: [%s]", len(clusterURLs), strings.Join(clusterURLs, " "))


### PR DESCRIPTION
### Description
This PR addresses a configuration validation bypass within the Application destination routing resolution layer (`GetDestinationServer`). By enforcing early whitespace-trimming checks on incoming string inputs, we guarantee that hollow target configurations (e.g., destinations declared with purely empty white space blocks) are caught immediately instead of triggering false-positive matches or propagating un-routable contexts downstream.

### Technical Context
In the standard GitOps application manifest spec, a destination must point explicitly to either a cluster `server` or a cluster `name`. 
The original check evaluated raw string parameters using a simple binary non-empty check (`destination.Name != ""`). Because this logic ignores whitespace density, strings containing only whitespace characters (such as `"    "`) successfully bypassed the validation gate. This allowed conflicting or broken target strings to proceed straight into internal cluster routing loops, leading to database mapping failures or blank configuration allocations.

### Resolution Strategy
* **Local Input Isolation:** Added a dedicated string normalization step at the entry point of `GetDestinationServer` utilizing standard library `strings.TrimSpace`.
* **Sanitized Target Validation:** Diverted downstream check logic and error formats to evaluate the cleaned local variables (`name` and `server`) instead of un-sanitized raw structure inputs.
* **Non-Mutating Security:** This approach keeps the global state clean by performing evaluations within isolated local variable contexts, catching the edge case before reaching `db.GetClusterServersByName()`.

---

### Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).