### PR TITLE
fix(ci): gitkeep so go builds work

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -42,13 +42,18 @@ jobs:
       - uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         id: filter
         with:
-          # Any file which is not under docs/, ui/ or is not a markdown file is counted as a backend file
+          # Any file which is not under docs/, ui/ or is not a markdown file is counted as a backend file.
+          # ui/embed.go and ui/dist/app placeholder files are Go embed inputs; changes must run make build-local.
           files_yaml: |
             backend:
+              - '**'
               - '!ui/**'
               - '!**.md'
               - '!**/*.md'
               - '!docs/**'
+              - 'ui/embed.go'
+              - 'ui/dist/app/gitkeep'
+              - 'ui/dist/app/assets/images/resources/.gitkeep'
             frontend:
               - 'ui/**'
               - Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -352,7 +352,7 @@ controller:
 .PHONY: build-ui
 build-ui:
 	DOCKER_BUILDKIT=1 $(DOCKER) build -t argocd-ui --platform=$(TARGET_ARCH) --target argocd-ui .
-	find ./ui/dist -type f -not -name .gitkeep -delete
+	find ./ui/dist -type f -not -name gitkeep -not -name .gitkeep -delete
 	$(DOCKER) run $(PODMAN_ARGS) -v ${CURRENT_DIR}/ui/dist/app:/tmp/app:Z --rm -t argocd-ui sh -c 'cp -r ./dist/app/* /tmp/app/'
 
 .PHONY: image

--- a/ui/dist/app/gitkeep
+++ b/ui/dist/app/gitkeep
@@ -1,0 +1,14 @@
+This directory holds the compiled Argo CD UI assets produced by `make build-ui`.
+
+Built artifacts (JavaScript bundles, index.html, and so on) are gitignored. This file is
+tracked in git so that:
+
+- go:embed dist/app in ui/embed.go has a non-hidden file to embed when the UI has not
+  been built yet (for example, backend-only CI jobs that run make build-local).
+- The directory exists in a fresh clone before the first UI build.
+
+This file is named "gitkeep" (not ".gitkeep") on purpose. Go's embed directive ignores
+files and directories whose names begin with a dot, so a hidden .gitkeep would not satisfy
+the dist/app embed pattern and backend-only CI would fail to compile ui/embed.go.
+
+Do not delete this file. Run make build-ui locally when you need the full UI output.


### PR DESCRIPTION
In March, @choejwoo [fixed a bug](https://github.com/argoproj/argo-cd/pull/26589) where `go:embed` was skipping _-prefixed directories and leaving icon files out of the released artifact. He fixed the problem by using a `go:embed all:` for the specific directory we needed.

Unfortunately, that change broke CI because the embedded directory is generated during the release build, but not during PR builds. So @blakepettersson  fixed it by adding a `gitkeep` file in the embedded directory. The actual resources wouldn't be embedded, but it would be enough for the PR build to work. He used `gitkeep` instead of `.gitkeep`, because `go:embed` ignores dot-prefixed files and directories.

Unfortunately, the `make build-ui` target contains a cleanup step that deletes anything not named `.gitkeep`, so today @dudinea [removed the file](https://github.com/argoproj/argo-cd/pull/28447), believing it was unnecessary. Since the go image build doesn't run on PRs where only files in the ui directory changed, CI passed, and I merged.

This PR attempts to get the best of all worlds. It:

1. restores the necessary `gitkeep` file so that go build passes
2. adds information to that file explaining why it exists and is not called `.gitkeep`
3. updates the make target so that the file doesn't get erroneously deleted
4. updates the CI directories filter so that changes to embed files trigger a go build

I considered making a change to avoid the convoluted mess. But enabling `go:embed all:` for a broader context was already rejected since it introduces the risk of unintentionally embedding irrelevant or sensitive files. So I left the solution as-is and just tried to improve the build setup around it.