### PR TITLE
feat: support configurable OTLP trace sampling (#28460)

### DIFF
--- a/cmd/argocd-application-controller/commands/argocd_application_controller.go
+++ b/cmd/argocd-application-controller/commands/argocd_application_controller.go
@@ -86,6 +86,7 @@ func NewCommand() *cobra.Command {
 		otlpInsecure                     bool
 		otlpHeaders                      map[string]string
 		otlpAttrs                        []string
+		otlpSamplingRatio                float64
 		applicationNamespaces            []string
 		persistResourceHealth            bool
 		shardingAlgorithm                string
@@ -229,7 +230,7 @@ func NewCommand() *cobra.Command {
 			stats.RegisterHeapDumper("memprofile")
 
 			if otlpAddress != "" {
-				closeTracer, err := trace.InitTracer(ctx, "argocd-controller", otlpAddress, otlpInsecure, otlpHeaders, otlpAttrs)
+				closeTracer, err := trace.InitTracer(ctx, "argocd-controller", otlpAddress, otlpInsecure, otlpHeaders, otlpAttrs, otlpSamplingRatio)
 				if err != nil {
 					log.Fatalf("failed to initialize tracing: %v", err)
 				}
@@ -289,6 +290,7 @@ func NewCommand() *cobra.Command {
 	command.Flags().BoolVar(&otlpInsecure, "otlp-insecure", env.ParseBoolFromEnv("ARGOCD_APPLICATION_CONTROLLER_OTLP_INSECURE", true), "OpenTelemetry collector insecure mode")
 	command.Flags().StringToStringVar(&otlpHeaders, "otlp-headers", env.ParseStringToStringFromEnv("ARGOCD_APPLICATION_CONTROLLER_OTLP_HEADERS", map[string]string{}, ","), "List of OpenTelemetry collector extra headers sent with traces, headers are comma-separated key-value pairs(e.g. key1=value1,key2=value2)")
 	command.Flags().StringSliceVar(&otlpAttrs, "otlp-attrs", env.StringsFromEnv("ARGOCD_APPLICATION_CONTROLLER_OTLP_ATTRS", []string{}, ","), "List of OpenTelemetry collector extra attrs when send traces, each attribute is separated by a colon(e.g. key:value)")
+	command.Flags().Float64Var(&otlpSamplingRatio, "otlp-sampling-ratio", env.ParseFloat64FromEnv("ARGOCD_APPLICATION_CONTROLLER_OTLP_SAMPLING_RATIO", 1.0, 0.0, 1.0), "Fraction of traces to sample, between 0.0 and 1.0. 1.0 samples every trace (default), 0.0 disables sampling")
 	command.Flags().StringSliceVar(&applicationNamespaces, "application-namespaces", env.StringsFromEnv("ARGOCD_APPLICATION_NAMESPACES", []string{}, ","), "List of additional namespaces that applications are allowed to be reconciled from")
 	command.Flags().BoolVar(&persistResourceHealth, "persist-resource-health", env.ParseBoolFromEnv("ARGOCD_APPLICATION_CONTROLLER_PERSIST_RESOURCE_HEALTH", false), "Enables storing the managed resources health in the Application CRD")
 	command.Flags().StringVar(&shardingAlgorithm, "sharding-method", env.StringFromEnv(common.EnvControllerShardingAlgorithm, common.DefaultShardingAlgorithm), "Enables choice of sharding method. Supported sharding methods are : [legacy, round-robin, consistent-hashing] ")

--- a/cmd/argocd-cmp-server/commands/argocd_cmp_server.go
+++ b/cmd/argocd-cmp-server/commands/argocd_cmp_server.go
@@ -20,11 +20,12 @@ import (
 
 func NewCommand() *cobra.Command {
 	var (
-		configFilePath string
-		otlpAddress    string
-		otlpInsecure   bool
-		otlpHeaders    map[string]string
-		otlpAttrs      []string
+		configFilePath    string
+		otlpAddress       string
+		otlpInsecure      bool
+		otlpHeaders       map[string]string
+		otlpAttrs         []string
+		otlpSamplingRatio float64
 	)
 	command := cobra.Command{
 		Use:               common.CommandCMPServer,
@@ -61,7 +62,7 @@ func NewCommand() *cobra.Command {
 			if otlpAddress != "" {
 				var closer func()
 				var err error
-				closer, err = traceutil.InitTracer(ctx, "argocd-cmp-server", otlpAddress, otlpInsecure, otlpHeaders, otlpAttrs)
+				closer, err = traceutil.InitTracer(ctx, "argocd-cmp-server", otlpAddress, otlpInsecure, otlpHeaders, otlpAttrs, otlpSamplingRatio)
 				if err != nil {
 					log.Fatalf("failed to initialize tracing: %v", err)
 				}
@@ -91,5 +92,6 @@ func NewCommand() *cobra.Command {
 	command.Flags().BoolVar(&otlpInsecure, "otlp-insecure", env.ParseBoolFromEnv("ARGOCD_CMP_SERVER_OTLP_INSECURE", true), "OpenTelemetry collector insecure mode")
 	command.Flags().StringToStringVar(&otlpHeaders, "otlp-headers", env.ParseStringToStringFromEnv("ARGOCD_CMP_SERVER_OTLP_HEADERS", map[string]string{}, ","), "List of OpenTelemetry collector extra headers sent with traces, headers are comma-separated key-value pairs(e.g. key1=value1,key2=value2)")
 	command.Flags().StringSliceVar(&otlpAttrs, "otlp-attrs", env.StringsFromEnv("ARGOCD_CMP_SERVER_OTLP_ATTRS", []string{}, ","), "List of OpenTelemetry collector extra attrs when send traces, each attribute is separated by a colon(e.g. key:value)")
+	command.Flags().Float64Var(&otlpSamplingRatio, "otlp-sampling-ratio", env.ParseFloat64FromEnv("ARGOCD_CMP_SERVER_OTLP_SAMPLING_RATIO", 1.0, 0.0, 1.0), "Fraction of traces to sample, between 0.0 and 1.0. 1.0 samples every trace (default), 0.0 disables sampling")
 	return &command
 }

--- a/cmd/argocd-repo-server/commands/argocd_repo_server.go
+++ b/cmd/argocd-repo-server/commands/argocd_repo_server.go
@@ -63,6 +63,7 @@ func NewCommand() *cobra.Command {
 		otlpInsecure                       bool
 		otlpHeaders                        map[string]string
 		otlpAttrs                          []string
+		otlpSamplingRatio                  float64
 		cacheSrc                           func() (*reposervercache.Cache, error)
 		tlsConfigCustomizer                tls.ConfigCustomizer
 		tlsConfigCustomizerSrc             func() (tls.ConfigCustomizer, error)
@@ -171,7 +172,7 @@ func NewCommand() *cobra.Command {
 			if otlpAddress != "" {
 				var closer func()
 				var err error
-				closer, err = traceutil.InitTracer(ctx, "argocd-repo-server", otlpAddress, otlpInsecure, otlpHeaders, otlpAttrs)
+				closer, err = traceutil.InitTracer(ctx, "argocd-repo-server", otlpAddress, otlpInsecure, otlpHeaders, otlpAttrs, otlpSamplingRatio)
 				if err != nil {
 					log.Fatalf("failed to initialize tracing: %v", err)
 				}
@@ -263,6 +264,7 @@ func NewCommand() *cobra.Command {
 	command.Flags().BoolVar(&otlpInsecure, "otlp-insecure", env.ParseBoolFromEnv("ARGOCD_REPO_SERVER_OTLP_INSECURE", true), "OpenTelemetry collector insecure mode")
 	command.Flags().StringToStringVar(&otlpHeaders, "otlp-headers", env.ParseStringToStringFromEnv("ARGOCD_REPO_OTLP_HEADERS", map[string]string{}, ","), "List of OpenTelemetry collector extra headers sent with traces, headers are comma-separated key-value pairs(e.g. key1=value1,key2=value2)")
 	command.Flags().StringSliceVar(&otlpAttrs, "otlp-attrs", env.StringsFromEnv("ARGOCD_REPO_SERVER_OTLP_ATTRS", []string{}, ","), "List of OpenTelemetry collector extra attrs when send traces, each attribute is separated by a colon(e.g. key:value)")
+	command.Flags().Float64Var(&otlpSamplingRatio, "otlp-sampling-ratio", env.ParseFloat64FromEnv("ARGOCD_REPO_SERVER_OTLP_SAMPLING_RATIO", 1.0, 0.0, 1.0), "Fraction of traces to sample, between 0.0 and 1.0. 1.0 samples every trace (default), 0.0 disables sampling")
 	command.Flags().StringVar(&maxCombinedDirectoryManifestsSize, "max-combined-directory-manifests-size", env.StringFromEnv("ARGOCD_REPO_SERVER_MAX_COMBINED_DIRECTORY_MANIFESTS_SIZE", "10M"), "Max combined size of manifest files in a directory-type Application")
 	command.Flags().StringArrayVar(&cmpTarExcludedGlobs, "plugin-tar-exclude", env.StringsFromEnv("ARGOCD_REPO_SERVER_PLUGIN_TAR_EXCLUSIONS", []string{}, ";"), "Globs to filter when sending tarballs to plugins.")
 	command.Flags().BoolVar(&allowOutOfBoundsSymlinks, "allow-oob-symlinks", env.ParseBoolFromEnv("ARGOCD_REPO_SERVER_ALLOW_OUT_OF_BOUNDS_SYMLINKS", false), "Allow out-of-bounds symlinks in repositories (not recommended)")

--- a/cmd/argocd-server/commands/argocd_server.go
+++ b/cmd/argocd-server/commands/argocd_server.go
@@ -65,6 +65,7 @@ func NewCommand() *cobra.Command {
 		otlpInsecure             bool
 		otlpHeaders              map[string]string
 		otlpAttrs                []string
+		otlpSamplingRatio        float64
 		glogLevel                int
 		clientConfig             clientcmd.ClientConfig
 		repoServerTimeoutSeconds int
@@ -279,7 +280,7 @@ func NewCommand() *cobra.Command {
 				lns, err := argocd.Listen()
 				errors.CheckError(err)
 				if otlpAddress != "" {
-					closer, err = traceutil.InitTracer(serverCtx, "argocd-server", otlpAddress, otlpInsecure, otlpHeaders, otlpAttrs)
+					closer, err = traceutil.InitTracer(serverCtx, "argocd-server", otlpAddress, otlpInsecure, otlpHeaders, otlpAttrs, otlpSamplingRatio)
 					if err != nil {
 						log.Fatalf("failed to initialize tracing: %v", err)
 					}
@@ -325,6 +326,7 @@ func NewCommand() *cobra.Command {
 	command.Flags().BoolVar(&otlpInsecure, "otlp-insecure", env.ParseBoolFromEnv("ARGOCD_SERVER_OTLP_INSECURE", true), "OpenTelemetry collector insecure mode")
 	command.Flags().StringToStringVar(&otlpHeaders, "otlp-headers", env.ParseStringToStringFromEnv("ARGOCD_SERVER_OTLP_HEADERS", map[string]string{}, ","), "List of OpenTelemetry collector extra headers sent with traces, headers are comma-separated key-value pairs(e.g. key1=value1,key2=value2)")
 	command.Flags().StringSliceVar(&otlpAttrs, "otlp-attrs", env.StringsFromEnv("ARGOCD_SERVER_OTLP_ATTRS", []string{}, ","), "List of OpenTelemetry collector extra attrs when send traces, each attribute is separated by a colon(e.g. key:value)")
+	command.Flags().Float64Var(&otlpSamplingRatio, "otlp-sampling-ratio", env.ParseFloat64FromEnv("ARGOCD_SERVER_OTLP_SAMPLING_RATIO", 1.0, 0.0, 1.0), "Fraction of traces to sample, between 0.0 and 1.0. 1.0 samples every trace (default), 0.0 disables sampling")
 	command.Flags().IntVar(&repoServerTimeoutSeconds, "repo-server-timeout-seconds", env.ParseNumFromEnv("ARGOCD_SERVER_REPO_SERVER_TIMEOUT_SECONDS", 60, 0, math.MaxInt64), "Repo server RPC call timeout seconds.")
 	command.Flags().StringVar(&frameOptions, "x-frame-options", env.StringFromEnv("ARGOCD_SERVER_X_FRAME_OPTIONS", "sameorigin"), "Set X-Frame-Options header in HTTP responses to `value`. To disable, set to \"\".")
 	command.Flags().StringVar(&contentSecurityPolicy, "content-security-policy", env.StringFromEnv("ARGOCD_SERVER_CONTENT_SECURITY_POLICY", "frame-ancestors 'self';"), "Set Content-Security-Policy header in HTTP responses to `value`. To disable, set to \"\".")

--- a/docs/operator-manual/argocd-cmd-params-cm.yaml
+++ b/docs/operator-manual/argocd-cmd-params-cm.yaml
@@ -30,6 +30,8 @@ data:
   otlp.headers: ""
   # Open-Telemetry collector attrs: (e.g. "key1:value1,key2:value2")
   otlp.attrs: ""
+  # Open-Telemetry trace sampling ratio between 0.0 and 1.0: (e.g. "0.1")
+  otlp.sampling.ratio: "1.0"
 
   # List of additional namespaces where applications may be created in and
   # reconciled from. The namespace where Argo CD is installed to will always

--- a/docs/operator-manual/server-commands/argocd-application-controller.md
+++ b/docs/operator-manual/server-commands/argocd-application-controller.md
@@ -54,6 +54,7 @@ argocd-application-controller [flags]
       --otlp-attrs strings                                        List of OpenTelemetry collector extra attrs when send traces, each attribute is separated by a colon(e.g. key:value)
       --otlp-headers stringToString                               List of OpenTelemetry collector extra headers sent with traces, headers are comma-separated key-value pairs(e.g. key1=value1,key2=value2) (default [])
       --otlp-insecure                                             OpenTelemetry collector insecure mode (default true)
+      --otlp-sampling-ratio float                                 Fraction of traces to sample, between 0.0 and 1.0. 1.0 samples every trace (default), 0.0 disables sampling (default 1)
       --password string                                           Password for basic authentication to the API server
       --persist-resource-health                                   Enables storing the managed resources health in the Application CRD
       --proxy-url string                                          If provided, this URL will be used to connect via proxy

--- a/docs/operator-manual/server-commands/argocd-repo-server.md
+++ b/docs/operator-manual/server-commands/argocd-repo-server.md
@@ -38,6 +38,7 @@ argocd-repo-server [flags]
       --otlp-attrs strings                             List of OpenTelemetry collector extra attrs when send traces, each attribute is separated by a colon(e.g. key:value)
       --otlp-headers stringToString                    List of OpenTelemetry collector extra headers sent with traces, headers are comma-separated key-value pairs(e.g. key1=value1,key2=value2) (default [])
       --otlp-insecure                                  OpenTelemetry collector insecure mode (default true)
+      --otlp-sampling-ratio float                      Fraction of traces to sample, between 0.0 and 1.0. 1.0 samples every trace (default), 0.0 disables sampling (default 1)
       --parallelismlimit int                           Limit on number of concurrent manifests generate requests. Any value less the 1 means no limit.
       --plugin-tar-exclude stringArray                 Globs to filter when sending tarballs to plugins.
       --plugin-use-manifest-generate-paths             Pass the resources described in argocd.argoproj.io/manifest-generate-paths value to the cmpserver to generate the application manifests.

--- a/docs/operator-manual/server-commands/argocd-server.md
+++ b/docs/operator-manual/server-commands/argocd-server.md
@@ -72,6 +72,7 @@ argocd-server [flags]
       --otlp-attrs strings                              List of OpenTelemetry collector extra attrs when send traces, each attribute is separated by a colon(e.g. key:value)
       --otlp-headers stringToString                     List of OpenTelemetry collector extra headers sent with traces, headers are comma-separated key-value pairs(e.g. key1=value1,key2=value2) (default [])
       --otlp-insecure                                   OpenTelemetry collector insecure mode (default true)
+      --otlp-sampling-ratio float                       Fraction of traces to sample, between 0.0 and 1.0. 1.0 samples every trace (default), 0.0 disables sampling (default 1)
       --password string                                 Password for basic authentication to the API server
       --port int                                        Listen on given port (default 8080)
       --proxy-url string                                If provided, this URL will be used to connect via proxy

--- a/manifests/base/application-controller/argocd-application-controller-statefulset.yaml
+++ b/manifests/base/application-controller/argocd-application-controller-statefulset.yaml
@@ -310,6 +310,12 @@ spec:
               name: argocd-cmd-params-cm
               key: otlp.attrs
               optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_OTLP_SAMPLING_RATIO
+          valueFrom:
+            configMapKeyRef:
+              name: argocd-cmd-params-cm
+              key: otlp.sampling.ratio
+              optional: true
         - name: ARGOCD_APPLICATION_NAMESPACES
           valueFrom:
             configMapKeyRef:

--- a/manifests/base/repo-server/argocd-repo-server-deployment.yaml
+++ b/manifests/base/repo-server/argocd-repo-server-deployment.yaml
@@ -167,6 +167,12 @@ spec:
                   name: argocd-cmd-params-cm
                   key: otlp.attrs
                   optional: true
+          - name: ARGOCD_REPO_SERVER_OTLP_SAMPLING_RATIO
+            valueFrom:
+                configMapKeyRef:
+                  name: argocd-cmd-params-cm
+                  key: otlp.sampling.ratio
+                  optional: true
           - name: ARGOCD_REPO_SERVER_MAX_COMBINED_DIRECTORY_MANIFESTS_SIZE
             valueFrom:
               configMapKeyRef:

--- a/manifests/base/server/argocd-server-deployment.yaml
+++ b/manifests/base/server/argocd-server-deployment.yaml
@@ -304,6 +304,12 @@ spec:
                   name: argocd-cmd-params-cm
                   key: otlp.attrs
                   optional: true
+            - name: ARGOCD_SERVER_OTLP_SAMPLING_RATIO
+              valueFrom:
+                configMapKeyRef:
+                  name: argocd-cmd-params-cm
+                  key: otlp.sampling.ratio
+                  optional: true
             - name: ARGOCD_APPLICATION_NAMESPACES
               valueFrom:
                 configMapKeyRef:

--- a/manifests/core-install-with-hydrator.yaml
+++ b/manifests/core-install-with-hydrator.yaml
@@ -32162,6 +32162,12 @@ spec:
               key: otlp.attrs
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_REPO_SERVER_OTLP_SAMPLING_RATIO
+          valueFrom:
+            configMapKeyRef:
+              key: otlp.sampling.ratio
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_REPO_SERVER_MAX_COMBINED_DIRECTORY_MANIFESTS_SIZE
           valueFrom:
             configMapKeyRef:
@@ -32725,6 +32731,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: otlp.attrs
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_OTLP_SAMPLING_RATIO
+          valueFrom:
+            configMapKeyRef:
+              key: otlp.sampling.ratio
               name: argocd-cmd-params-cm
               optional: true
         - name: ARGOCD_APPLICATION_NAMESPACES

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -31990,6 +31990,12 @@ spec:
               key: otlp.attrs
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_REPO_SERVER_OTLP_SAMPLING_RATIO
+          valueFrom:
+            configMapKeyRef:
+              key: otlp.sampling.ratio
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_REPO_SERVER_MAX_COMBINED_DIRECTORY_MANIFESTS_SIZE
           valueFrom:
             configMapKeyRef:
@@ -32553,6 +32559,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: otlp.attrs
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_OTLP_SAMPLING_RATIO
+          valueFrom:
+            configMapKeyRef:
+              key: otlp.sampling.ratio
               name: argocd-cmd-params-cm
               optional: true
         - name: ARGOCD_APPLICATION_NAMESPACES

--- a/manifests/ha/install-with-hydrator.yaml
+++ b/manifests/ha/install-with-hydrator.yaml
@@ -33907,6 +33907,12 @@ spec:
               key: otlp.attrs
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_REPO_SERVER_OTLP_SAMPLING_RATIO
+          valueFrom:
+            configMapKeyRef:
+              key: otlp.sampling.ratio
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_REPO_SERVER_MAX_COMBINED_DIRECTORY_MANIFESTS_SIZE
           valueFrom:
             configMapKeyRef:
@@ -34464,6 +34470,12 @@ spec:
               key: otlp.attrs
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_SERVER_OTLP_SAMPLING_RATIO
+          valueFrom:
+            configMapKeyRef:
+              key: otlp.sampling.ratio
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_APPLICATION_NAMESPACES
           valueFrom:
             configMapKeyRef:
@@ -34977,6 +34989,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: otlp.attrs
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_OTLP_SAMPLING_RATIO
+          valueFrom:
+            configMapKeyRef:
+              key: otlp.sampling.ratio
               name: argocd-cmd-params-cm
               optional: true
         - name: ARGOCD_APPLICATION_NAMESPACES

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -33737,6 +33737,12 @@ spec:
               key: otlp.attrs
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_REPO_SERVER_OTLP_SAMPLING_RATIO
+          valueFrom:
+            configMapKeyRef:
+              key: otlp.sampling.ratio
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_REPO_SERVER_MAX_COMBINED_DIRECTORY_MANIFESTS_SIZE
           valueFrom:
             configMapKeyRef:
@@ -34294,6 +34300,12 @@ spec:
               key: otlp.attrs
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_SERVER_OTLP_SAMPLING_RATIO
+          valueFrom:
+            configMapKeyRef:
+              key: otlp.sampling.ratio
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_APPLICATION_NAMESPACES
           valueFrom:
             configMapKeyRef:
@@ -34807,6 +34819,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: otlp.attrs
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_OTLP_SAMPLING_RATIO
+          valueFrom:
+            configMapKeyRef:
+              key: otlp.sampling.ratio
               name: argocd-cmd-params-cm
               optional: true
         - name: ARGOCD_APPLICATION_NAMESPACES

--- a/manifests/ha/namespace-install-with-hydrator.yaml
+++ b/manifests/ha/namespace-install-with-hydrator.yaml
@@ -2819,6 +2819,12 @@ spec:
               key: otlp.attrs
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_REPO_SERVER_OTLP_SAMPLING_RATIO
+          valueFrom:
+            configMapKeyRef:
+              key: otlp.sampling.ratio
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_REPO_SERVER_MAX_COMBINED_DIRECTORY_MANIFESTS_SIZE
           valueFrom:
             configMapKeyRef:
@@ -3376,6 +3382,12 @@ spec:
               key: otlp.attrs
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_SERVER_OTLP_SAMPLING_RATIO
+          valueFrom:
+            configMapKeyRef:
+              key: otlp.sampling.ratio
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_APPLICATION_NAMESPACES
           valueFrom:
             configMapKeyRef:
@@ -3889,6 +3901,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: otlp.attrs
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_OTLP_SAMPLING_RATIO
+          valueFrom:
+            configMapKeyRef:
+              key: otlp.sampling.ratio
               name: argocd-cmd-params-cm
               optional: true
         - name: ARGOCD_APPLICATION_NAMESPACES

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -2649,6 +2649,12 @@ spec:
               key: otlp.attrs
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_REPO_SERVER_OTLP_SAMPLING_RATIO
+          valueFrom:
+            configMapKeyRef:
+              key: otlp.sampling.ratio
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_REPO_SERVER_MAX_COMBINED_DIRECTORY_MANIFESTS_SIZE
           valueFrom:
             configMapKeyRef:
@@ -3206,6 +3212,12 @@ spec:
               key: otlp.attrs
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_SERVER_OTLP_SAMPLING_RATIO
+          valueFrom:
+            configMapKeyRef:
+              key: otlp.sampling.ratio
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_APPLICATION_NAMESPACES
           valueFrom:
             configMapKeyRef:
@@ -3719,6 +3731,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: otlp.attrs
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_OTLP_SAMPLING_RATIO
+          valueFrom:
+            configMapKeyRef:
+              key: otlp.sampling.ratio
               name: argocd-cmd-params-cm
               optional: true
         - name: ARGOCD_APPLICATION_NAMESPACES

--- a/manifests/install-with-hydrator.yaml
+++ b/manifests/install-with-hydrator.yaml
@@ -32877,6 +32877,12 @@ spec:
               key: otlp.attrs
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_REPO_SERVER_OTLP_SAMPLING_RATIO
+          valueFrom:
+            configMapKeyRef:
+              key: otlp.sampling.ratio
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_REPO_SERVER_MAX_COMBINED_DIRECTORY_MANIFESTS_SIZE
           valueFrom:
             configMapKeyRef:
@@ -33432,6 +33438,12 @@ spec:
               key: otlp.attrs
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_SERVER_OTLP_SAMPLING_RATIO
+          valueFrom:
+            configMapKeyRef:
+              key: otlp.sampling.ratio
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_APPLICATION_NAMESPACES
           valueFrom:
             configMapKeyRef:
@@ -33945,6 +33957,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: otlp.attrs
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_OTLP_SAMPLING_RATIO
+          valueFrom:
+            configMapKeyRef:
+              key: otlp.sampling.ratio
               name: argocd-cmd-params-cm
               optional: true
         - name: ARGOCD_APPLICATION_NAMESPACES

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -32705,6 +32705,12 @@ spec:
               key: otlp.attrs
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_REPO_SERVER_OTLP_SAMPLING_RATIO
+          valueFrom:
+            configMapKeyRef:
+              key: otlp.sampling.ratio
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_REPO_SERVER_MAX_COMBINED_DIRECTORY_MANIFESTS_SIZE
           valueFrom:
             configMapKeyRef:
@@ -33260,6 +33266,12 @@ spec:
               key: otlp.attrs
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_SERVER_OTLP_SAMPLING_RATIO
+          valueFrom:
+            configMapKeyRef:
+              key: otlp.sampling.ratio
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_APPLICATION_NAMESPACES
           valueFrom:
             configMapKeyRef:
@@ -33773,6 +33785,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: otlp.attrs
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_OTLP_SAMPLING_RATIO
+          valueFrom:
+            configMapKeyRef:
+              key: otlp.sampling.ratio
               name: argocd-cmd-params-cm
               optional: true
         - name: ARGOCD_APPLICATION_NAMESPACES

--- a/manifests/namespace-install-with-hydrator.yaml
+++ b/manifests/namespace-install-with-hydrator.yaml
@@ -1789,6 +1789,12 @@ spec:
               key: otlp.attrs
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_REPO_SERVER_OTLP_SAMPLING_RATIO
+          valueFrom:
+            configMapKeyRef:
+              key: otlp.sampling.ratio
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_REPO_SERVER_MAX_COMBINED_DIRECTORY_MANIFESTS_SIZE
           valueFrom:
             configMapKeyRef:
@@ -2344,6 +2350,12 @@ spec:
               key: otlp.attrs
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_SERVER_OTLP_SAMPLING_RATIO
+          valueFrom:
+            configMapKeyRef:
+              key: otlp.sampling.ratio
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_APPLICATION_NAMESPACES
           valueFrom:
             configMapKeyRef:
@@ -2857,6 +2869,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: otlp.attrs
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_OTLP_SAMPLING_RATIO
+          valueFrom:
+            configMapKeyRef:
+              key: otlp.sampling.ratio
               name: argocd-cmd-params-cm
               optional: true
         - name: ARGOCD_APPLICATION_NAMESPACES

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -1617,6 +1617,12 @@ spec:
               key: otlp.attrs
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_REPO_SERVER_OTLP_SAMPLING_RATIO
+          valueFrom:
+            configMapKeyRef:
+              key: otlp.sampling.ratio
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_REPO_SERVER_MAX_COMBINED_DIRECTORY_MANIFESTS_SIZE
           valueFrom:
             configMapKeyRef:
@@ -2172,6 +2178,12 @@ spec:
               key: otlp.attrs
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_SERVER_OTLP_SAMPLING_RATIO
+          valueFrom:
+            configMapKeyRef:
+              key: otlp.sampling.ratio
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_APPLICATION_NAMESPACES
           valueFrom:
             configMapKeyRef:
@@ -2685,6 +2697,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: otlp.attrs
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_APPLICATION_CONTROLLER_OTLP_SAMPLING_RATIO
+          valueFrom:
+            configMapKeyRef:
+              key: otlp.sampling.ratio
               name: argocd-cmd-params-cm
               optional: true
         - name: ARGOCD_APPLICATION_NAMESPACES

--- a/util/trace/trace.go
+++ b/util/trace/trace.go
@@ -17,7 +17,11 @@ import (
 )
 
 // InitTracer initializes the trace provider and the otel grpc exporter.
-func InitTracer(ctx context.Context, serviceName, otlpAddress string, otlpInsecure bool, otlpHeaders map[string]string, otlpAttrs []string) (func(), error) {
+//
+// otlpSamplingRatio controls the fraction of traces that are sampled. A value
+// >= 1.0 samples every trace (the historical default), <= 0.0 samples none, and
+// any value in between is applied as a parent-based TraceIDRatioBased sampler.
+func InitTracer(ctx context.Context, serviceName, otlpAddress string, otlpInsecure bool, otlpHeaders map[string]string, otlpAttrs []string, otlpSamplingRatio float64) (func(), error) {
 	attrs := make([]attribute.KeyValue, 0, len(otlpAttrs))
 	for i := range otlpAttrs {
 		attr := otlpAttrs[i]
@@ -61,7 +65,7 @@ func InitTracer(ctx context.Context, serviceName, otlpAddress string, otlpInsecu
 	// span processor to aggregate spans before export.
 	bsp := sdktrace.NewBatchSpanProcessor(exporter)
 	provider := sdktrace.NewTracerProvider(
-		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+		sdktrace.WithSampler(newSampler(otlpSamplingRatio)),
 		sdktrace.WithResource(res),
 		sdktrace.WithSpanProcessor(bsp),
 	)
@@ -75,4 +79,19 @@ func InitTracer(ctx context.Context, serviceName, otlpAddress string, otlpInsecu
 			log.Errorf("failed to stop exporter: %v", err)
 		}
 	}, nil
+}
+
+// newSampler returns a trace sampler for the given ratio. A ratio >= 1.0 keeps
+// the historical always-sample behavior, <= 0.0 disables sampling entirely, and
+// anything in between is wrapped in a parent-based TraceIDRatioBased sampler so
+// that sampling decisions made upstream are respected.
+func newSampler(ratio float64) sdktrace.Sampler {
+	switch {
+	case ratio >= 1.0:
+		return sdktrace.AlwaysSample()
+	case ratio <= 0.0:
+		return sdktrace.NeverSample()
+	default:
+		return sdktrace.ParentBased(sdktrace.TraceIDRatioBased(ratio))
+	}
 }

--- a/util/trace/trace_test.go
+++ b/util/trace/trace_test.go
@@ -1,0 +1,48 @@
+package trace
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+func TestNewSampler(t *testing.T) {
+	tests := []struct {
+		name        string
+		ratio       float64
+		description string
+	}{
+		{
+			name:        "ratio of 1.0 always samples",
+			ratio:       1.0,
+			description: sdktrace.AlwaysSample().Description(),
+		},
+		{
+			name:        "ratio above 1.0 always samples",
+			ratio:       2.0,
+			description: sdktrace.AlwaysSample().Description(),
+		},
+		{
+			name:        "ratio of 0.0 never samples",
+			ratio:       0.0,
+			description: sdktrace.NeverSample().Description(),
+		},
+		{
+			name:        "negative ratio never samples",
+			ratio:       -1.0,
+			description: sdktrace.NeverSample().Description(),
+		},
+		{
+			name:        "fractional ratio uses parent-based ratio sampler",
+			ratio:       0.5,
+			description: sdktrace.ParentBased(sdktrace.TraceIDRatioBased(0.5)).Description(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sampler := newSampler(tt.ratio)
+			assert.Equal(t, tt.description, sampler.Description())
+		})
+	}
+}


### PR DESCRIPTION
Closes #28460

## What does this PR do / why we need it

The OpenTelemetry tracer provider in `util/trace/trace.go` hardcoded `sdktrace.AlwaysSample()`, so every component that enables OTLP (`argocd-server`, `argocd-repo-server`, `argocd-application-controller`, `argocd-cmp-server`) exported **100% of spans** with no way to reduce volume. On large installs this drives collector and tracing-backend cost and noise, and operators had no middle ground between full tracing and disabling it entirely.

This PR makes the sampling rate configurable while keeping the current always-sample behavior as the default.

## How it works

- `InitTracer` gains an `otlpSamplingRatio float64` parameter, applied via a new `newSampler` helper:
  - `ratio >= 1.0` → `AlwaysSample()` (default, fully backward compatible)
  - `ratio <= 0.0` → `NeverSample()`
  - otherwise → `ParentBased(TraceIDRatioBased(ratio))`, so upstream parent sampling decisions are respected
- Exposed on all four components as `--otlp-sampling-ratio`, consistent with the existing `--otlp-*` flags, backed by:
  - env var `ARGOCD_<COMPONENT>_OTLP_SAMPLING_RATIO`
  - `argocd-cmd-params-cm` key `otlp.sampling.ratio`
- Manifests (`base` sources + regenerated aggregates) wire the new config key into each component.

## Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. <!-- This is a server-side flag with no UI surface; the UI does not expose tracing config. -->
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)