### PR TITLE
fix(hydrator): retry notes push on cannot lock ref errors

### DIFF
--- a/util/git/client.go
+++ b/util/git/client.go
@@ -1693,13 +1693,7 @@ func (m *nativeGitClient) AddAndPushNote(ctx context.Context, sha string, namesp
 		log.Debugf("AddAndPushNote push failed (attempt %d): %v", attempt, err)
 
 		// Check if this is a retryable error
-		errStr := err.Error()
-		isRetryable := strings.Contains(errStr, "fetch first") || // Remote updated after our fetch (concurrent push completed between our fetch and push)
-			strings.Contains(errStr, "reference already exists") || // Concurrent push is holding the lock (git server-side lock)
-			strings.Contains(errStr, "incorrect old value") || // Git detected our local ref is stale (concurrent update)
-			strings.Contains(errStr, "failed to update ref") // Generic ref update failure that may include transient issues
-
-		if !isRetryable {
+		if !isRetryableNotePushError(err.Error()) {
 			return struct{}{}, backoff.Permanent(fmt.Errorf("failed to push note: %w", err))
 		}
 
@@ -1714,6 +1708,20 @@ func (m *nativeGitClient) AddAndPushNote(ctx context.Context, sha string, namesp
 		return fmt.Errorf("failed to push note after retries: %w", err)
 	}
 	return nil
+}
+
+// isRetryableNotePushError reports whether a failed git notes push is caused by a
+// concurrent update to the same notes ref and is therefore safe to retry after
+// re-fetching the remote ref. Multiple application controller shards can hydrate
+// and push to the same refs/notes ref at once, and git reports the resulting
+// collision through several different messages depending on the git version and
+// server, including "cannot lock ref" when the server already holds the ref lock.
+func isRetryableNotePushError(errStr string) bool {
+	return strings.Contains(errStr, "fetch first") || // Remote updated after our fetch (concurrent push completed between our fetch and push)
+		strings.Contains(errStr, "reference already exists") || // Concurrent push is holding the lock (git server-side lock)
+		strings.Contains(errStr, "incorrect old value") || // Git detected our local ref is stale (concurrent update)
+		strings.Contains(errStr, "failed to update ref") || // Generic ref update failure that may include transient issues
+		strings.Contains(errStr, "cannot lock ref") // Server could not lock the notes ref because a concurrent push from another shard holds it
 }
 
 // HasFileChanged returns the outout of git diff considering whether it is tracked or un-tracked

--- a/util/git/client_test.go
+++ b/util/git/client_test.go
@@ -1805,6 +1805,53 @@ func Test_nativeGitClient_AddAndPushNote(t *testing.T) {
 	})
 }
 
+func Test_isRetryableNotePushError(t *testing.T) {
+	tests := []struct {
+		name   string
+		errStr string
+		want   bool
+	}{
+		{
+			name:   "fetch first",
+			errStr: "Updates were rejected because the remote contains work that you do not have locally. fetch first",
+			want:   true,
+		},
+		{
+			name:   "reference already exists",
+			errStr: "failed to push some refs: reference already exists",
+			want:   true,
+		},
+		{
+			name:   "incorrect old value",
+			errStr: "update_ref failed for ref 'refs/notes/hydrator.metadata': cannot update the ref: incorrect old value",
+			want:   true,
+		},
+		{
+			name:   "failed to update ref",
+			errStr: "error: failed to update ref",
+			want:   true,
+		},
+		{
+			name: "cannot lock ref from concurrent shard",
+			errStr: " ! [remote rejected]     refs/notes/hydrator.metadata -> refs/notes/hydrator.metadata " +
+				"(cannot lock ref 'refs/notes/hydrator.metadata': is at 477134654bdd5531fc0f76bf026be86515e8685f " +
+				"but expected 30b2c9044a27f1b853fee454ab9bfef183fb9e0d)\n" +
+				"error: failed to push some refs to 'https://github.example.com/org/deployments.git'",
+			want: true,
+		},
+		{
+			name:   "non-retryable error",
+			errStr: "fatal: Authentication failed for 'https://github.example.com/org/deployments.git'",
+			want:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isRetryableNotePushError(tt.errStr))
+		})
+	}
+}
+
 func Test_nativeGitClient_HasFileChanged(t *testing.T) {
 	ctx := t.Context()
 	tempDir, err := _createEmptyGitRepo(ctx)


### PR DESCRIPTION
Fixes #27835

## What this fixes

When several application controller shards run the source hydrator at the same time, they can push to the same refs/notes/hydrator.metadata ref concurrently. AddAndPushNote already has a fetch-then-push retry loop for exactly this case, but it only treats a fixed set of error strings as retryable.

The collision git reports in practice looks like this:

```
 ! [remote rejected]     refs/notes/hydrator.metadata -> refs/notes/hydrator.metadata (cannot lock ref 'refs/notes/hydrator.metadata': is at X but expected Y)
error: failed to push some refs to '...'
```

That message does not contain any of the four substrings the retry check looks for (fetch first, reference already exists, incorrect old value, failed to update ref), so the push is classified as a permanent failure and the hydration fails instead of retrying.

## The change

Pull the retryable check out into a small helper and add cannot lock ref to the set of errors that are safe to retry after re-fetching the notes ref. This is the standard server-side message for a concurrent push holding the ref lock, which is the same race the existing retry loop was built to handle.

I kept the addition narrow on purpose. The wrapper lines remote rejected and failed to push some refs also show up here, but they are generic and also wrap permanent failures like protected branches or pre-receive hook denials, so retrying on those would waste the backoff window and hide real errors. cannot lock ref is the specific signal for the lock collision.

## Testing

Added a table-driven unit test for the helper that covers all four existing signals, the new cannot lock ref case using the real error text from the issue, and a non-retryable auth error. I confirmed the new case fails before the change and passes after it.

Checklist:

* [x] This is a bug fix.
* [x] The title of the PR states what changed and the related issue number.
* [x] The title of the PR conforms to the Title of the PR guidelines.
* [x] I've included Fixes #27835 in the description.
* [x] I have signed off all my commits as required by DCO.
* [x] I have written unit tests for my change.
* [x] I have added a brief description of why this PR is necessary and what it solves.