### PR TITLE
chore: auto-update e2e k3s version matrix via Renovate (#28431)

### DIFF
--- a/.github/configs/renovate-config.js
+++ b/.github/configs/renovate-config.js
@@ -13,6 +13,7 @@ module.exports = {
         "github>argoproj/argo-cd//renovate-presets/commons.json5",
         "github>argoproj/argo-cd//renovate-presets/custom-managers/shell.json5",
         "github>argoproj/argo-cd//renovate-presets/custom-managers/yaml.json5",
+        "github>argoproj/argo-cd//renovate-presets/custom-managers/k3s-matrix.json5",
         "github>argoproj/argo-cd//renovate-presets/fix/disable-all-updates.json5",
         "github>argoproj/argo-cd//renovate-presets/devtool.json5",
         "github>argoproj/argo-cd//renovate-presets/production-binaries.json5",

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -500,12 +500,16 @@ jobs:
         # latest: true means that this version mush upload the coverage report to codecov.io
         # We designate the latest version because we only collect code coverage for that version.
         k3s:
+          # renovate: datasource=github-releases depName=k3s-e2e-latest packageName=k3s-io/k3s extractVersion=^(?<version>v[0-9.]+)\+k3s.*$
           - version: v1.36.0
             latest: true
+          # renovate: datasource=github-releases depName=k3s-e2e-v1.35 packageName=k3s-io/k3s extractVersion=^(?<version>v[0-9.]+)\+k3s.*$
           - version: v1.35.0
             latest: false
+          # renovate: datasource=github-releases depName=k3s-e2e-v1.34 packageName=k3s-io/k3s extractVersion=^(?<version>v[0-9.]+)\+k3s.*$
           - version: v1.34.2
             latest: false
+          # renovate: datasource=github-releases depName=k3s-e2e-v1.33 packageName=k3s-io/k3s extractVersion=^(?<version>v[0-9.]+)\+k3s.*$
           - version: v1.33.1
             latest: false
     needs:

--- a/renovate-presets/custom-managers/k3s-matrix.json5
+++ b/renovate-presets/custom-managers/k3s-matrix.json5
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Auto-update k3s versions in the e2e test matrix. The latest entry gets full updates; older entries are constrained to patch bumps within their minor version.",
+  "customManagers": [
+    {
+      "description": "Extract k3s version entries from the e2e test matrix in ci-build.yaml",
+      "customType": "regex",
+      "fileMatch": [
+        ".github\\/workflows\\/ci-build\\.ya?ml$"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?)(?: depName=(?<depName>.+?))? packageName=(?<packageName>.+?)(?: versioning=(?<versioning>.*?))?(?: extractVersion=(?<extractVersion>.*?))?\\s*\\n\\s*- version:\\s*(?<currentValue>v[0-9.]+)"
+      ]
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Enable updates for k3s e2e matrix entries",
+      "matchDatasources": [
+        "github-releases"
+      ],
+      "matchDepNames": [
+        "/^k3s-e2e-/"
+      ],
+      "enabled": true
+    },
+    {
+      "description": "Constrain k3s v1.35 entries to patch-only updates within the v1.35 minor line",
+      "matchDepNames": [
+        "k3s-e2e-v1.35"
+      ],
+      "allowedVersions": "/^v1\\.35\\./"
+    },
+    {
+      "description": "Constrain k3s v1.34 entries to patch-only updates within the v1.34 minor line",
+      "matchDepNames": [
+        "k3s-e2e-v1.34"
+      ],
+      "allowedVersions": "/^v1\\.34\\./"
+    },
+    {
+      "description": "Constrain k3s v1.33 entries to patch-only updates within the v1.33 minor line",
+      "matchDepNames": [
+        "k3s-e2e-v1.33"
+      ],
+      "allowedVersions": "/^v1\\.33\\./"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #28431.

The k3s versions in the e2e test matrix are currently updated by hand, which is tedious and doesn't happen often enough. This adds a Renovate custom manager to automate it.

## Changes

**New file: `renovate-presets/custom-managers/k3s-matrix.json5`**

A regex custom manager that scans `ci-build.yaml` for `# renovate:` annotations above `- version:` lines inside the k3s strategy matrix. It uses the `github-releases` datasource with `k3s-io/k3s` — k3s tags like `v1.36.0+k3s1` track Kubernetes versions. The `extractVersion` regex strips the `+k3sX` suffix so the matrix stores just the K8s semver.

Each entry has a distinct `depName` so Renovate tracks them independently:

- `k3s-e2e-latest` — gets full bumps (patch and minor)
- `k3s-e2e-v1.35`, `v1.34`, `v1.33` — constrained to patch-only via `allowedVersions`

A package rule re-enables these deps since `disable-all-updates.json5` disables everything by default.

**Modified: `.github/workflows/ci-build.yaml`**

Added a `# renovate:` annotation above each `- version:` line. No structural changes to the matrix — all existing CI logic (matrix iteration, `INSTALL_K3S_VERSION`, `matrix.k3s.latest`) continues to work. The `hack/update-supported-versions.sh` script is unaffected since `yq` ignores comments.

**Modified: `.github/configs/renovate-config.js`**

Registered the new preset in the `extends` array.

## Maintenance note

When adding or removing a minor version from the matrix, update the `depName` in the annotation and add/remove the corresponding `allowedVersions` package rule.
