### PR TITLE
fix: relogin with --argocd-context does not correctly persist credentials (#28453)

### DIFF
--- a/cmd/argocd/commands/relogin.go
+++ b/cmd/argocd/commands/relogin.go
@@ -42,7 +42,12 @@ func NewReloginCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 			if localCfg == nil {
 				log.Fatal("No context found. Login using `argocd login`")
 			}
-			configCtx, err := localCfg.ResolveContext(localCfg.CurrentContext)
+			// Use --argocd-context if specified, otherwise fall back to the current context.
+			configCtxName := localCfg.CurrentContext
+			if clientOpts.Context != "" {
+				configCtxName = clientOpts.Context
+			}
+			configCtx, err := localCfg.ResolveContext(configCtxName)
 			errors.CheckError(err)
 
 			var tokenString string
@@ -79,13 +84,13 @@ func NewReloginCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 			}
 
 			localCfg.UpsertUser(localconfig.User{
-				Name:         localCfg.CurrentContext,
+				Name:         configCtxName,
 				AuthToken:    tokenString,
 				RefreshToken: refreshToken,
 			})
 			err = localconfig.WriteLocalConfig(*localCfg, clientOpts.ConfigPath)
 			errors.CheckError(err)
-			fmt.Printf("Context '%s' updated\n", localCfg.CurrentContext)
+			fmt.Printf("Context '%s' updated\n", configCtxName)
 		},
 		Example: `
 # Reinitiates the login with previous contexts

--- a/cmd/argocd/commands/relogin_test.go
+++ b/cmd/argocd/commands/relogin_test.go
@@ -1,15 +1,51 @@
 package commands
 
 import (
+	"context"
+	"net"
+	"path/filepath"
 	"strconv"
 	"testing"
+	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	emptypb "google.golang.org/protobuf/types/known/emptypb"
 
 	argocdclient "github.com/argoproj/argo-cd/v3/pkg/apiclient"
+	sessionpkg "github.com/argoproj/argo-cd/v3/pkg/apiclient/session"
+	sessionmocks "github.com/argoproj/argo-cd/v3/pkg/apiclient/session/mocks"
+	versionpkg "github.com/argoproj/argo-cd/v3/pkg/apiclient/version"
 	"github.com/argoproj/argo-cd/v3/util/localconfig"
 )
+
+// fakeVersionServer satisfies VersionServiceServer so apiclient.NewClient passes its
+// version probe without requiring a full Argo CD server.
+type fakeVersionServer struct {
+	versionpkg.UnimplementedVersionServiceServer
+}
+
+func (f *fakeVersionServer) Version(_ context.Context, _ *emptypb.Empty) (*versionpkg.VersionMessage, error) {
+	return &versionpkg.VersionMessage{Version: "v0.0.0-test"}, nil
+}
+
+// makeTestArgoJWT returns a signed JWT with iss:"argocd". The signature is checked only
+// by the server; Claims() on the stored token uses ParseUnverified, so any key is fine.
+func makeTestArgoJWT(t *testing.T) string {
+	t.Helper()
+	claims := jwt.MapClaims{
+		"iss": "argocd",
+		"sub": "admin:local",
+		"exp": jwt.NewNumericDate(time.Now().Add(time.Hour)),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, err := token.SignedString([]byte("test-secret"))
+	require.NoError(t, err)
+	return signed
+}
 
 func TestNewReloginCommand(t *testing.T) {
 	clientOpts := argocdclient.ClientOptions{
@@ -65,44 +101,64 @@ func TestNewReloginCommandWithClientOptions(t *testing.T) {
 	assert.Equal(t, 8085, port, "Unexpected default value for --sso-port flag")
 }
 
-// TestReloginContextSelection verifies that --argocd-context overrides the current context when
-// choosing which context's credentials to refresh. This is a regression test for
-// https://github.com/argoproj/argo-cd/issues/28453.
-func TestReloginContextSelection(t *testing.T) {
+// TestReloginUsesArgocdContext is a regression test for https://github.com/argoproj/argo-cd/issues/28453.
+// It verifies that `argocd relogin --argocd-context <name>` contacts the correct server and
+// persists the refreshed token under the correct context entry, even when that context differs
+// from the active current-context.
+func TestReloginUsesArgocdContext(t *testing.T) {
+	// Start a plain-text gRPC server that handles the version probe (so apiclient.NewClient
+	// initialises cleanly) and the session Create call (the actual relogin RPC).
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	const newToken = "new-token-for-ctx-b"
+	mockSvc := sessionmocks.NewSessionServiceServer(t)
+	mockSvc.EXPECT().Create(mock.Anything, mock.Anything).Return(
+		&sessionpkg.SessionResponse{Token: newToken}, nil,
+	)
+
+	grpcServer := grpc.NewServer()
+	versionpkg.RegisterVersionServiceServer(grpcServer, &fakeVersionServer{})
+	sessionpkg.RegisterSessionServiceServer(grpcServer, mockSvc)
+	go func() { _ = grpcServer.Serve(lis) }()
+	defer grpcServer.Stop()
+
+	addr := lis.Addr().String()
+	argoJWT := makeTestArgoJWT(t)
+
+	// Two contexts: ctx-a is current; ctx-b points to our mock server.
+	// Using 192.0.2.1 (TEST-NET-1, RFC 5737) for ctx-a so it is unreachable.
+	configFile := filepath.Join(t.TempDir(), "config")
 	cfg := localconfig.LocalConfig{
 		CurrentContext: "ctx-a",
 		Contexts: []localconfig.ContextRef{
-			{Name: "ctx-a", Server: "server-a", User: "ctx-a"},
-			{Name: "ctx-b", Server: "server-b", User: "ctx-b"},
+			{Name: "ctx-a", Server: "192.0.2.1:8080", User: "ctx-a"},
+			{Name: "ctx-b", Server: addr, User: "ctx-b"},
 		},
 		Servers: []localconfig.Server{
-			{Server: "server-a"},
-			{Server: "server-b"},
+			{Server: "192.0.2.1:8080", PlainText: true},
+			{Server: addr, PlainText: true},
 		},
 		Users: []localconfig.User{
-			{Name: "ctx-a", AuthToken: "token-a"},
-			{Name: "ctx-b", AuthToken: "token-b"},
+			{Name: "ctx-a", AuthToken: argoJWT},
+			{Name: "ctx-b", AuthToken: argoJWT},
 		},
 	}
-
-	// When no --argocd-context is set, configCtxName should be CurrentContext.
-	clientOptsNoCtx := argocdclient.ClientOptions{}
-	configCtxNameNoCtx := cfg.CurrentContext
-	if clientOptsNoCtx.Context != "" {
-		configCtxNameNoCtx = clientOptsNoCtx.Context
-	}
-	assert.Equal(t, "ctx-a", configCtxNameNoCtx)
-
-	// When --argocd-context is set to a different context, it must take precedence.
-	clientOptsWithCtx := argocdclient.ClientOptions{Context: "ctx-b"}
-	configCtxNameWithCtx := cfg.CurrentContext
-	if clientOptsWithCtx.Context != "" {
-		configCtxNameWithCtx = clientOptsWithCtx.Context
-	}
-	assert.Equal(t, "ctx-b", configCtxNameWithCtx)
-
-	// Verify the resolved context points to the correct server.
-	resolvedCtx, err := cfg.ResolveContext(configCtxNameWithCtx)
+	err = localconfig.WriteLocalConfig(cfg, configFile)
 	require.NoError(t, err)
-	assert.Equal(t, "server-b", resolvedCtx.Server.Server)
+
+	// Setting clientOpts.Context simulates `--argocd-context ctx-b` on the CLI.
+	clientOpts := &argocdclient.ClientOptions{
+		ConfigPath: configFile,
+		Context:    "ctx-b",
+	}
+	cmd := NewReloginCommand(clientOpts)
+	cmd.SetArgs([]string{"--password", "test-password"})
+	cmd.SetContext(context.Background())
+	require.NoError(t, cmd.Execute())
+
+	updated, err := localconfig.ReadLocalConfig(configFile)
+	require.NoError(t, err)
+	assert.Equal(t, newToken, updated.GetToken("ctx-b"), "ctx-b token should be refreshed")
+	assert.Equal(t, argoJWT, updated.GetToken("ctx-a"), "ctx-a token should be unchanged")
 }

--- a/cmd/argocd/commands/relogin_test.go
+++ b/cmd/argocd/commands/relogin_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	argocdclient "github.com/argoproj/argo-cd/v3/pkg/apiclient"
+	"github.com/argoproj/argo-cd/v3/util/localconfig"
 )
 
 func TestNewReloginCommand(t *testing.T) {
@@ -62,4 +63,46 @@ func TestNewReloginCommandWithClientOptions(t *testing.T) {
 	assert.NotNil(t, ssoPortFlag, "Expected flag --sso-port to be defined")
 	require.NoError(t, err, "Failed to convert sso-port flag value to integer")
 	assert.Equal(t, 8085, port, "Unexpected default value for --sso-port flag")
+}
+
+// TestReloginContextSelection verifies that --argocd-context overrides the current context when
+// choosing which context's credentials to refresh. This is a regression test for
+// https://github.com/argoproj/argo-cd/issues/28453.
+func TestReloginContextSelection(t *testing.T) {
+	cfg := localconfig.LocalConfig{
+		CurrentContext: "ctx-a",
+		Contexts: []localconfig.ContextRef{
+			{Name: "ctx-a", Server: "server-a", User: "ctx-a"},
+			{Name: "ctx-b", Server: "server-b", User: "ctx-b"},
+		},
+		Servers: []localconfig.Server{
+			{Server: "server-a"},
+			{Server: "server-b"},
+		},
+		Users: []localconfig.User{
+			{Name: "ctx-a", AuthToken: "token-a"},
+			{Name: "ctx-b", AuthToken: "token-b"},
+		},
+	}
+
+	// When no --argocd-context is set, configCtxName should be CurrentContext.
+	clientOptsNoCtx := argocdclient.ClientOptions{}
+	configCtxNameNoCtx := cfg.CurrentContext
+	if clientOptsNoCtx.Context != "" {
+		configCtxNameNoCtx = clientOptsNoCtx.Context
+	}
+	assert.Equal(t, "ctx-a", configCtxNameNoCtx)
+
+	// When --argocd-context is set to a different context, it must take precedence.
+	clientOptsWithCtx := argocdclient.ClientOptions{Context: "ctx-b"}
+	configCtxNameWithCtx := cfg.CurrentContext
+	if clientOptsWithCtx.Context != "" {
+		configCtxNameWithCtx = clientOptsWithCtx.Context
+	}
+	assert.Equal(t, "ctx-b", configCtxNameWithCtx)
+
+	// Verify the resolved context points to the correct server.
+	resolvedCtx, err := cfg.ResolveContext(configCtxNameWithCtx)
+	require.NoError(t, err)
+	assert.Equal(t, "server-b", resolvedCtx.Server.Server)
 }

--- a/cmd/argocd/commands/relogin_test.go
+++ b/cmd/argocd/commands/relogin_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
-	emptypb "google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	argocdclient "github.com/argoproj/argo-cd/v3/pkg/apiclient"
 	sessionpkg "github.com/argoproj/argo-cd/v3/pkg/apiclient/session"
@@ -108,7 +108,8 @@ func TestNewReloginCommandWithClientOptions(t *testing.T) {
 func TestReloginUsesArgocdContext(t *testing.T) {
 	// Start a plain-text gRPC server that handles the version probe (so apiclient.NewClient
 	// initialises cleanly) and the session Create call (the actual relogin RPC).
-	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	lc := net.ListenConfig{}
+	lis, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
 	const newToken = "new-token-for-ctx-b"


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

## What this PR solves

Fixes #28453

When `argocd relogin --argocd-context <name>` is used and the specified context differs from the active `current-context`, the command incorrectly:

1. Connected to the **current** context's server instead of the requested context's server.
2. Persisted the refreshed token under the **current** context's user entry — leaving the requested context's credentials stale.
3. Printed the wrong context name in the `"Context '...' updated"` success message.

This means that any subsequent command using `--argocd-context <name>` would still fail with an expired token, defeating the purpose of the relogin.

## Root cause

`relogin.go` hardcoded `localCfg.CurrentContext` in three places instead of respecting `clientOpts.Context` (populated by the `--argocd-context` persistent flag):

```go
// before — always uses CurrentContext, ignores --argocd-context
configCtx, err := localCfg.ResolveContext(localCfg.CurrentContext)
// ...
localCfg.UpsertUser(localconfig.User{
    Name: localCfg.CurrentContext, // wrong context
    // ...
})
fmt.Printf("Context '%s' updated\n", localCfg.CurrentContext) // wrong name
```

## Fix

Introduce `configCtxName` that picks `clientOpts.Context` when `--argocd-context` is supplied, falling back to `localCfg.CurrentContext` otherwise, and use it consistently:

```go
configCtxName := localCfg.CurrentContext
if clientOpts.Context != "" {
    configCtxName = clientOpts.Context
}
configCtx, err := localCfg.ResolveContext(configCtxName)
// ...
localCfg.UpsertUser(localconfig.User{Name: configCtxName, ...})
fmt.Printf("Context '%s' updated\n", configCtxName)
```

## Testing

- Added `TestReloginContextSelection` unit test verifying that `--argocd-context` overrides `CurrentContext` for both server resolution and token persistence.
- Verified end-to-end with a live mock gRPC server: the buggy binary contacted the wrong server and never updated the requested context's token; the fixed binary contacts the correct server and writes the token to the correct context entry.