### PR TITLE
fix: appset-controller re-syncs deleting Apps in progressive sync causing infinite loop (#28511)

### DIFF
--- a/applicationset/controllers/progressive_sync_dependencies_test.go
+++ b/applicationset/controllers/progressive_sync_dependencies_test.go
@@ -882,6 +882,29 @@ func TestUpdateApplicationSetApplicationStatus(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Regression test for https://github.com/argoproj/argo-cd/issues/28511:
+			// An Application with DeletionTimestamp must not be included in appStatuses so
+			// that the progressive-sync wave logic does not treat it as Waiting/Pending and
+			// trigger a sync operation that fights the ongoing deletion.
+			name: "ignores apps that are being deleted (DeletionTimestamp set)",
+			appSet: newDefaultAppSet(1, []v1alpha1.ApplicationSetApplicationStatus{
+				{
+					Application: "app-deleting",
+					Status:      v1alpha1.ProgressiveSyncHealthy,
+					Step:        "1",
+				},
+			}),
+			apps: func() []v1alpha1.Application {
+				deletionTime := metav1.NewTime(time.Now())
+				app := newApp("app-deleting", health.HealthStatusProgressing, v1alpha1.SyncStatusCodeOutOfSync, "abc123", nil)
+				app.DeletionTimestamp = &deletionTime
+				app.Finalizers = []string{"resources-finalizer.argocd.argoproj.io"}
+				return []v1alpha1.Application{app}
+			}(),
+			appStepMap:        map[string]int{"app-deleting": 0},
+			expectedAppStatus: []v1alpha1.ApplicationSetApplicationStatus{},
+		},
 	} {
 		t.Run(cc.name, func(t *testing.T) {
 			t.Parallel()

--- a/applicationset/progressivesync/progressive_sync.go
+++ b/applicationset/progressivesync/progressive_sync.go
@@ -276,6 +276,12 @@ func (m *Manager) UpdateApplicationSetApplicationStatus(ctx context.Context, log
 	}
 
 	for _, app := range applications {
+		// Skip apps that are being deleted so we don't drive their progressive-sync
+		// status forward and trigger spurious sync operations on a deleting app.
+		if app.DeletionTimestamp != nil {
+			continue
+		}
+
 		appHealthStatus := app.Status.Health.Status
 		appSyncStatus := app.Status.Sync.Status
 

--- a/applicationset/utils/createOrUpdate.go
+++ b/applicationset/utils/createOrUpdate.go
@@ -94,6 +94,14 @@ func CreateOrUpdate(ctx context.Context, logCtx *log.Entry, c client.Client, dif
 		return controllerutil.OperationResultCreated, nil
 	}
 
+	// If the application is already being deleted, do not update it. Patching a deleting app
+	// (e.g. setting an Operation to trigger a sync) fights the finalizer-based deletion and
+	// causes an infinite Deleting↔Syncing loop.
+	if obj.DeletionTimestamp != nil {
+		logCtx.Debugf("skipping update of Application %s/%s: DeletionTimestamp is set", obj.Namespace, obj.Name)
+		return controllerutil.OperationResultNone, nil
+	}
+
 	normalizedLive := obj.DeepCopy()
 
 	// Mutate the live object to match the desired state.

--- a/applicationset/utils/createOrUpdate_test.go
+++ b/applicationset/utils/createOrUpdate_test.go
@@ -1,16 +1,66 @@
 package utils
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v3/util/argo/normalizers"
 )
+
+func TestCreateOrUpdate_SkipsAppWithDeletionTimestamp(t *testing.T) {
+	t.Parallel()
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+
+	deletionTime := metav1.NewTime(time.Now())
+	existingApp := &v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "app-being-deleted",
+			Namespace:         "argocd",
+			DeletionTimestamp: &deletionTime,
+			// Finalizers required for fake client to allow DeletionTimestamp to be set
+			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingApp).Build()
+	logCtx := log.NewEntry(log.StandardLogger())
+
+	obj := &v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "app-being-deleted",
+			Namespace: "argocd",
+		},
+	}
+
+	result, err := CreateOrUpdate(context.Background(), logCtx, fakeClient, nil, obj, func() error {
+		// This mutate would set an Operation, triggering a sync — should never be applied.
+		obj.Operation = &v1alpha1.Operation{
+			Sync: &v1alpha1.SyncOperation{},
+		}
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, controllerutil.OperationResultNone, result, "expected no-op for app with DeletionTimestamp")
+
+	// Verify the app was not patched (Operation should remain nil in cluster).
+	updated := &v1alpha1.Application{}
+	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKeyFromObject(existingApp), updated))
+	assert.Nil(t, updated.Operation, "Operation must not be set on a deleting app")
+}
 
 func Test_applyIgnoreDifferences(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

Fixes #28511

When an Application generated by an ApplicationSet with **Progressive Sync (RollingSync)** is manually deleted (e.g. via the ArgoCD UI) while it is stuck in `Progressing` state (e.g. due to a crashlooping resource), the applicationset-controller enters an infinite **Deleting↔Syncing** loop that prevents the Application from ever being cleaned up.

### Root Cause

Two code paths in the applicationset-controller ignored `DeletionTimestamp`:

1. **`createOrUpdate.go` → `CreateOrUpdate()`**: After fetching the live Application from the cluster, the function proceeded to patch it with a sync `Operation` even when `DeletionTimestamp` was set. This directly fought the ArgoCD app controller's finalizer-based deletion process.

2. **`progressive_sync.go` → `UpdateApplicationSetApplicationStatus()`**: Deleting Applications were included in the progressive-sync wave status computation, advancing them to `Pending` state and triggering further sync operations.

### Fix

- **`applicationset/utils/createOrUpdate.go`**: Return `OperationResultNone` immediately after the `Get` if `obj.DeletionTimestamp != nil`, with a debug log message `"skipping update of Application ... DeletionTimestamp is set"`.
- **`applicationset/progressivesync/progressive_sync.go`**: Skip Applications with `DeletionTimestamp != nil` in `UpdateApplicationSetApplicationStatus()` so they are excluded from wave tracking entirely.

### Testing

**Unit tests added:**
- `TestCreateOrUpdate_SkipsAppWithDeletionTimestamp` — verifies no patch is issued for an app with `DeletionTimestamp`
- `"ignores apps that are being deleted"` case in `TestUpdateApplicationSetApplicationStatus` — verifies deleting apps are excluded from appStatus

**Live cluster verification on k3d (ArgoCD v3.4.4):**

Set up an ApplicationSet with 4 apps and RollingSync strategy. Deleted `app-four` manually while the appset controller was watching.

*Before fix (stable controller):*
```json
{"application":"app-four","msg":"patching application",
 "patch":{"operation":{"initiatedBy":{"username":"applicationset-controller"},
 "sync":{"prune":true}}},"time":"2026-06-30T03:59:30Z"}
```
→ Controller **patched app-four with a sync Operation** at the exact moment of deletion, fighting the finalizer.

*After fix (patched controller):*
```json
{"application":"app-four","msg":"skipping update of Application argocd/app-four: DeletionTimestamp is set","time":"2026-06-30T04:02:20Z"}
{"application":"app-four","msg":"skipping update of Application argocd/app-four: DeletionTimestamp is set","time":"2026-06-30T04:02:20Z"}
{"application":"app-four","msg":"skipping update of Application argocd/app-four: DeletionTimestamp is set","time":"2026-06-30T04:02:20Z"}
```
→ Controller **skipped the patch 3 times** during the deletion window, allowing the finalizer to complete cleanly.

## Checklist

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. *(not applicable — backend fix only)*
* [x] Does this PR require documentation updates? No — this is a bug fix with no behavior change for users beyond the loop being resolved.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines. *(not applicable)*
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity). This fix is a good candidate for backport to recent stable releases given the severity of the infinite loop.