### PR TITLE
fix: detect OCI repo type from URL prefix in Normalize() (#28517)

### DIFF
--- a/pkg/apis/application/v1alpha1/repository_types.go
+++ b/pkg/apis/application/v1alpha1/repository_types.go
@@ -424,7 +424,11 @@ func (repo *Repository) Sanitized() *Repository {
 
 func (repo *Repository) Normalize() *Repository {
 	if repo.Type == "" {
-		repo.Type = common.DefaultRepoType
+		if strings.HasPrefix(repo.Repo, "oci://") {
+			repo.Type = "oci"
+		} else {
+			repo.Type = common.DefaultRepoType
+		}
 	}
 	return repo
 }

--- a/pkg/apis/application/v1alpha1/repository_types_test.go
+++ b/pkg/apis/application/v1alpha1/repository_types_test.go
@@ -236,3 +236,53 @@ func TestGetGitCreds_GitHubApp_OrgExtractionFails(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to extract organization")
 	assert.Contains(t, err.Error(), "invalid-url-format")
 }
+
+func TestRepository_Normalize(t *testing.T) {
+	tests := []struct {
+		name     string
+		repo     Repository
+		wantType string
+	}{
+		{
+			name:     "OCI URL with empty type defaults to oci",
+			repo:     Repository{Repo: "oci://example.com/foo"},
+			wantType: "oci",
+		},
+		{
+			name:     "HTTPS URL with empty type defaults to git",
+			repo:     Repository{Repo: "https://example.com/foo/bar.git"},
+			wantType: "git",
+		},
+		{
+			name:     "SSH URL with empty type defaults to git",
+			repo:     Repository{Repo: "ssh://git@example.com/foo.git"},
+			wantType: "git",
+		},
+		{
+			name:     "Explicit git type is preserved on HTTPS URL",
+			repo:     Repository{Repo: "https://example.com/foo/bar.git", Type: "git"},
+			wantType: "git",
+		},
+		{
+			name:     "Explicit git type is preserved on SSH URL",
+			repo:     Repository{Repo: "ssh://git@example.com/foo.git", Type: "git"},
+			wantType: "git",
+		},
+		{
+			name:     "Explicit helm type is preserved on HTTPS URL",
+			repo:     Repository{Repo: "https://charts.example.com", Type: "helm"},
+			wantType: "helm",
+		},
+		{
+			name:     "Explicit oci type is preserved on OCI URL",
+			repo:     Repository{Repo: "oci://example.com/foo", Type: "oci"},
+			wantType: "oci",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.repo.Normalize()
+			assert.Equal(t, tt.wantType, got.Type)
+		})
+	}
+}

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -4995,6 +4995,25 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 				Paths:          []string{},
 			},
 		}, want: &apiclient.UpdateRevisionForPathsResponse{Changes: true}, wantErr: assert.NoError},
+		{name: "OCIRepoWithEmptyTypeShortCircuits", fields: func() fields {
+			// Regression test: empty Type on an oci:// repo URL must not be normalized to "git",
+			// otherwise the call falls through to git LsRemote and fails with
+			// "unsupported scheme oci".
+			s, _, c := newServiceWithOpt(t, func(_ *gitmocks.Client, _ *helmmocks.Client, _ *ocimocks.Client, _ *iomocks.TempPaths) {
+			}, ".")
+			return fields{
+				service: s,
+				cache:   c,
+			}
+		}(), args: args{
+			ctx: t.Context(),
+			request: &apiclient.UpdateRevisionForPathsRequest{
+				Repo:           &v1alpha1.Repository{Repo: "oci://example.com/foo"},
+				Revision:       "1.0.0",
+				SyncedRevision: "0.9.0",
+				Paths:          []string{"."},
+			},
+		}, want: &apiclient.UpdateRevisionForPathsResponse{}, wantErr: assert.NoError},
 		{name: "SameResolvedRevisionAbort", fields: func() fields {
 			s, _, c := newServiceWithOpt(t, func(gitClient *gitmocks.Client, _ *helmmocks.Client, _ *ocimocks.Client, paths *iomocks.TempPaths) {
 				gitClient.EXPECT().Checkout(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

With ArgoCD v3.4.4, after repository type normalization was added in https://github.com/argoproj/argo-cd/pull/28113, `oci://...` app sources result in the following error if there is no explicit repository credentials secret for the OCI registry:

```
ComparisonError: Failed to load target state: failed to compare revisions for source 1 of 2: rpc error: code = Internal desc = unable to resolve git revision : failed to list refs: unsupported scheme "oci"
```

This is because `type` is initially unset in this case, and is set to `git` after normalization, when it should have been set to `oci` instead based on the URL.

This fix sets the type to `oci` during normalization if the URL starts with `oci://`.

Closes #28517.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
