### PR TITLE
feat: make summary chart segments and legend items clickable to filter views

### DIFF
--- a/ui/src/app/applications/components/applications-list/application-sets-list.tsx
+++ b/ui/src/app/applications/components/applications-list/application-sets-list.tsx
@@ -348,7 +348,8 @@ export const ApplicationSetsList = (props: RouteComponentProps<any>) => {
             {
                 health: newPref.healthFilter.join(','),
                 labels: newPref.labelsFilter.map(encodeURIComponent).join(','),
-                showFavorites: newPref.showFavorites ? 'true' : null
+                showFavorites: newPref.showFavorites ? 'true' : null,
+                view: newPref.view
             },
             {replace: true}
         );
@@ -429,7 +430,17 @@ export const ApplicationSetsList = (props: RouteComponentProps<any>) => {
                                                             )}
 
                                                             {pref.view === Summary ? (
-                                                                <ApplicationSetsSummary appSets={filteredApps} />
+                                                                <ApplicationSetsSummary
+                                                                    appSets={filteredApps}
+                                                                    onFilterClick={(type, value) => {
+                                                                        const newPref = {...appSetPref};
+                                                                        if (type === 'Health') {
+                                                                            newPref.healthFilter = [value];
+                                                                        }
+                                                                        newPref.view = AppsListViewKey.Tiles;
+                                                                        onAppSetFilterPrefChanged(ctx, newPref);
+                                                                    }}
+                                                                />
                                                             ) : (
                                                                 <Paginate
                                                                     header={filteredApps.length > 1 && <AppSetsStatusBar appSets={filteredApps} />}

--- a/ui/src/app/applications/components/applications-list/application-sets-summary.tsx
+++ b/ui/src/app/applications/components/applications-list/application-sets-summary.tsx
@@ -12,7 +12,15 @@ appSetHealthColors.set('Healthy', COLORS.health.healthy);
 appSetHealthColors.set('Degraded', COLORS.health.degraded);
 appSetHealthColors.set('Progressing', COLORS.health.progressing);
 
-export const ApplicationSetsSummary = ({appSets}: {appSets: models.ApplicationSet[]}) => {
+export const ApplicationSetsSummary = ({
+    appSets,
+    onFilterClick
+}: {
+    appSets: models.ApplicationSet[];
+    onFilterClick?: (type: 'Health', value: string) => void;
+}) => {
+    const [hoveredSector, setHoveredSector] = React.useState<{title: string; value: number; color: string} | null>(null);
+
     const health = new Map<string, number>();
 
     appSets.forEach(appSet => {
@@ -62,12 +70,31 @@ export const ApplicationSetsSummary = ({appSets}: {appSets: models.ApplicationSe
                                         <div className='row chart'>
                                             <div className='large-8 small-6'>
                                                 <h4 style={{textAlign: 'center'}}>{chart.title}</h4>
-                                                <PieChart data={chart.data} />
+                                                <div
+                                                    onClick={() => {
+                                                        if (onFilterClick && hoveredSector) {
+                                                            onFilterClick(chart.title as 'Health', hoveredSector.title);
+                                                        }
+                                                    }}
+                                                    style={{cursor: 'pointer'}}
+                                                    title='Click to filter application sets'
+                                                >
+                                                    <PieChart data={chart.data} onSectorHover={(d: any) => setHoveredSector(d)} expandOnHover={true} />
+                                                </div>
                                             </div>
                                             <div className='large-3 small-1'>
                                                 <ul>
                                                     {Array.from(chart.legend.keys()).map(key => (
-                                                        <li style={{listStyle: 'none', whiteSpace: 'nowrap'}} key={key}>
+                                                        <li
+                                                            style={{listStyle: 'none', whiteSpace: 'nowrap', cursor: 'pointer'}}
+                                                            key={key}
+                                                            onClick={() => {
+                                                                if (onFilterClick) {
+                                                                    onFilterClick(chart.title as 'Health', key);
+                                                                }
+                                                            }}
+                                                            title={`Filter by ${key}`}
+                                                        >
                                                             <HealthStatusIcon state={{status: key as HealthStatusCode, message: ''}} noSpin={true} />
                                                             {` ${key} (${getLegendValue(key)})`}
                                                         </li>

--- a/ui/src/app/applications/components/applications-list/application-sets-summary.tsx
+++ b/ui/src/app/applications/components/applications-list/application-sets-summary.tsx
@@ -12,14 +12,15 @@ appSetHealthColors.set('Healthy', COLORS.health.healthy);
 appSetHealthColors.set('Degraded', COLORS.health.degraded);
 appSetHealthColors.set('Progressing', COLORS.health.progressing);
 
-export const ApplicationSetsSummary = ({
-    appSets,
-    onFilterClick
-}: {
-    appSets: models.ApplicationSet[];
-    onFilterClick?: (type: 'Health', value: string) => void;
-}) => {
-    const [hoveredSector, setHoveredSector] = React.useState<{title: string; value: number; color: string} | null>(null);
+const handleKeyDown = (e: React.KeyboardEvent, action: () => void) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        action();
+    }
+};
+
+export const ApplicationSetsSummary = ({appSets, onFilterClick}: {appSets: models.ApplicationSet[]; onFilterClick?: (type: 'Health', value: string) => void}) => {
+    const [hoveredSector, setHoveredSector] = React.useState<{chartTitle: string; title: string} | null>(null);
 
     const health = new Map<string, number>();
 
@@ -72,31 +73,50 @@ export const ApplicationSetsSummary = ({
                                                 <h4 style={{textAlign: 'center'}}>{chart.title}</h4>
                                                 <div
                                                     onClick={() => {
-                                                        if (onFilterClick && hoveredSector) {
+                                                        if (onFilterClick && hoveredSector && hoveredSector.chartTitle === chart.title) {
                                                             onFilterClick(chart.title as 'Health', hoveredSector.title);
+                                                        }
+                                                    }}
+                                                    onKeyDown={e => {
+                                                        if (onFilterClick && hoveredSector && hoveredSector.chartTitle === chart.title) {
+                                                            handleKeyDown(e, () => onFilterClick(chart.title as 'Health', hoveredSector.title));
                                                         }
                                                     }}
                                                     style={{cursor: 'pointer'}}
                                                     title='Click to filter application sets'
-                                                >
-                                                    <PieChart data={chart.data} onSectorHover={(d: any) => setHoveredSector(d)} expandOnHover={true} />
+                                                    role='button'
+                                                    tabIndex={0}>
+                                                    <PieChart
+                                                        data={chart.data}
+                                                        onSectorHover={(d: any) => setHoveredSector(d ? {chartTitle: chart.title, title: d.title} : null)}
+                                                        expandOnHover={true}
+                                                    />
                                                 </div>
                                             </div>
                                             <div className='large-3 small-1'>
                                                 <ul>
                                                     {Array.from(chart.legend.keys()).map(key => (
-                                                        <li
-                                                            style={{listStyle: 'none', whiteSpace: 'nowrap', cursor: 'pointer'}}
-                                                            key={key}
-                                                            onClick={() => {
-                                                                if (onFilterClick) {
-                                                                    onFilterClick(chart.title as 'Health', key);
-                                                                }
-                                                            }}
-                                                            title={`Filter by ${key}`}
-                                                        >
-                                                            <HealthStatusIcon state={{status: key as HealthStatusCode, message: ''}} noSpin={true} />
-                                                            {` ${key} (${getLegendValue(key)})`}
+                                                        <li style={{listStyle: 'none', whiteSpace: 'nowrap'}} key={key}>
+                                                            <button
+                                                                type='button'
+                                                                onClick={() => {
+                                                                    if (onFilterClick) {
+                                                                        onFilterClick(chart.title as 'Health', key);
+                                                                    }
+                                                                }}
+                                                                title={`Filter by ${key}`}
+                                                                style={{
+                                                                    background: 'none',
+                                                                    border: 'none',
+                                                                    padding: 0,
+                                                                    cursor: 'pointer',
+                                                                    textAlign: 'left',
+                                                                    font: 'inherit',
+                                                                    color: 'inherit'
+                                                                }}>
+                                                                <HealthStatusIcon state={{status: key as HealthStatusCode, message: ''}} noSpin={true} />
+                                                                {` ${key} (${getLegendValue(key)})`}
+                                                            </button>
                                                         </li>
                                                     ))}
                                                 </ul>

--- a/ui/src/app/applications/components/applications-list/applications-list.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-list.tsx
@@ -467,8 +467,6 @@ export const ApplicationsList = (props: RouteComponentProps<any>) => {
                                                                                 newPref.healthFilter = [value];
                                                                             } else if (type === 'Sync') {
                                                                                 newPref.syncFilter = [value];
-                                                                            } else if (type === 'Hydrator') {
-                                                                                newPref.operationFilter = [value];
                                                                             }
                                                                             newPref.view = AppsListViewKey.Tiles;
                                                                             onAppFilterPrefChanged(ctx, newPref);

--- a/ui/src/app/applications/components/applications-list/applications-list.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-list.tsx
@@ -333,7 +333,8 @@ export const ApplicationsList = (props: RouteComponentProps<any>) => {
                 annotations: newPref.annotationsFilter.map(encodeURIComponent).join(','),
                 operation: newPref.operationFilter.join(','),
                 // Keep URL and preferences consistent. When false, remove the param entirely.
-                showFavorites: newPref.showFavorites ? 'true' : null
+                showFavorites: newPref.showFavorites ? 'true' : null,
+                view: newPref.view
             },
             {replace: true}
         );
@@ -457,7 +458,23 @@ export const ApplicationsList = (props: RouteComponentProps<any>) => {
                                                                     sidebarTarget?.current
                                                                 )}
 
-                                                                {(pref.view === 'summary' && <ApplicationsSummary applications={filteredApps} />) || (
+                                                                {(pref.view === 'summary' && (
+                                                                    <ApplicationsSummary
+                                                                        applications={filteredApps}
+                                                                        onFilterClick={(type, value) => {
+                                                                            const newPref = {...pref};
+                                                                            if (type === 'Health') {
+                                                                                newPref.healthFilter = [value];
+                                                                            } else if (type === 'Sync') {
+                                                                                newPref.syncFilter = [value];
+                                                                            } else if (type === 'Hydrator') {
+                                                                                newPref.operationFilter = [value];
+                                                                            }
+                                                                            newPref.view = AppsListViewKey.Tiles;
+                                                                            onAppFilterPrefChanged(ctx, newPref);
+                                                                        }}
+                                                                    />
+                                                                )) || (
                                                                     <Paginate
                                                                         header={filteredApps.length > 1 && <AppsStatusBar applications={filteredApps} />}
                                                                         showHeader={healthBarPrefs.showHealthStatusBar}

--- a/ui/src/app/applications/components/applications-list/applications-list.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-list.tsx
@@ -458,7 +458,7 @@ export const ApplicationsList = (props: RouteComponentProps<any>) => {
                                                                     sidebarTarget?.current
                                                                 )}
 
-                                                                {(pref.view === 'summary' && (
+                                                                {(pref.view === Summary && (
                                                                     <ApplicationsSummary
                                                                         applications={filteredApps}
                                                                         onFilterClick={(type, value) => {

--- a/ui/src/app/applications/components/applications-list/applications-summary.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-summary.tsx
@@ -25,7 +25,15 @@ hydratorColors.set('Hydrated', COLORS.operation.success);
 hydratorColors.set('Failed', COLORS.operation.failed);
 hydratorColors.set('None', COLORS.sync.unknown);
 
-export const ApplicationsSummary = ({applications}: {applications: models.Application[]}) => {
+export const ApplicationsSummary = ({
+    applications,
+    onFilterClick
+}: {
+    applications: models.Application[];
+    onFilterClick?: (type: 'Health' | 'Sync' | 'Hydrator', value: string) => void;
+}) => {
+    const [hoveredSector, setHoveredSector] = React.useState<{title: string; value: number; color: string} | null>(null);
+
     const sync = new Map<string, number>();
     applications.forEach(app => sync.set(app.status.sync.status, (sync.get(app.status.sync.status) || 0) + 1));
     const health = new Map<string, number>();
@@ -92,12 +100,31 @@ export const ApplicationsSummary = ({applications}: {applications: models.Applic
                                         <div className='row chart'>
                                             <div className='large-8 small-6'>
                                                 <h4 style={{textAlign: 'center'}}>{chart.title}</h4>
-                                                <PieChart data={chart.data} />
+                                                <div
+                                                    onClick={() => {
+                                                        if (onFilterClick && hoveredSector) {
+                                                            onFilterClick(chart.title as 'Health' | 'Sync' | 'Hydrator', hoveredSector.title);
+                                                        }
+                                                    }}
+                                                    style={{cursor: 'pointer'}}
+                                                    title='Click to filter applications'
+                                                >
+                                                    <PieChart data={chart.data} onSectorHover={(d: any) => setHoveredSector(d)} expandOnHover={true} />
+                                                </div>
                                             </div>
                                             <div className='large-3 small-1'>
                                                 <ul>
                                                     {Array.from(chart.legend.keys()).map(key => (
-                                                        <li style={{listStyle: 'none', whiteSpace: 'nowrap'}} key={key}>
+                                                        <li
+                                                            style={{listStyle: 'none', whiteSpace: 'nowrap', cursor: 'pointer'}}
+                                                            key={key}
+                                                            onClick={() => {
+                                                                if (onFilterClick) {
+                                                                    onFilterClick(chart.title as 'Health' | 'Sync' | 'Hydrator', key);
+                                                                }
+                                                            }}
+                                                            title={`Filter by ${key}`}
+                                                        >
                                                             {chart.title === 'Health' && <HealthStatusIcon state={{status: key as HealthStatusCode, message: ''}} noSpin={true} />}
                                                             {chart.title === 'Sync' && <ComparisonStatusIcon status={key as SyncStatusCode} noSpin={true} />}
                                                             {chart.title === 'Hydrator' && key !== 'None' && (

--- a/ui/src/app/applications/components/applications-list/applications-summary.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-summary.tsx
@@ -25,6 +25,13 @@ hydratorColors.set('Hydrated', COLORS.operation.success);
 hydratorColors.set('Failed', COLORS.operation.failed);
 hydratorColors.set('None', COLORS.sync.unknown);
 
+const handleKeyDown = (e: React.KeyboardEvent, action: () => void) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        action();
+    }
+};
+
 export const ApplicationsSummary = ({
     applications,
     onFilterClick
@@ -102,51 +109,73 @@ export const ApplicationsSummary = ({
                                                 <h4 style={{textAlign: 'center'}}>{chart.title}</h4>
                                                 <div
                                                     onClick={() => {
-                                                        if (onFilterClick && hoveredSector && hoveredSector.chartTitle === chart.title) {
-                                                            onFilterClick(chart.title as 'Health' | 'Sync' | 'Hydrator', hoveredSector.title);
+                                                        if (chart.title !== 'Hydrator' && onFilterClick && hoveredSector && hoveredSector.chartTitle === chart.title) {
+                                                            onFilterClick(chart.title as 'Health' | 'Sync', hoveredSector.title);
                                                         }
                                                     }}
-                                                    style={{cursor: 'pointer'}}
-                                                    title='Click to filter applications'
-                                                >
+                                                    onKeyDown={e => {
+                                                        if (chart.title !== 'Hydrator' && onFilterClick && hoveredSector && hoveredSector.chartTitle === chart.title) {
+                                                            handleKeyDown(e, () => onFilterClick(chart.title as 'Health' | 'Sync', hoveredSector.title));
+                                                        }
+                                                    }}
+                                                    style={{cursor: chart.title === 'Hydrator' ? 'default' : 'pointer'}}
+                                                    title={chart.title === 'Hydrator' ? undefined : 'Click to filter applications'}
+                                                    role={chart.title === 'Hydrator' ? undefined : 'button'}
+                                                    tabIndex={chart.title === 'Hydrator' ? undefined : 0}>
                                                     <PieChart
                                                         data={chart.data}
-                                                        onSectorHover={(d: any) => setHoveredSector(d ? {chartTitle: chart.title, title: d.title} : null)}
-                                                        expandOnHover={true}
+                                                        onSectorHover={
+                                                            chart.title === 'Hydrator'
+                                                                ? undefined
+                                                                : (d: any) => setHoveredSector(d ? {chartTitle: chart.title, title: d.title} : null)
+                                                        }
+                                                        expandOnHover={chart.title !== 'Hydrator'}
                                                     />
                                                 </div>
                                             </div>
                                             <div className='large-3 small-1'>
                                                 <ul>
                                                     {Array.from(chart.legend.keys()).map(key => (
-                                                        <li
-                                                            style={{listStyle: 'none', whiteSpace: 'nowrap', cursor: 'pointer'}}
-                                                            key={key}
-                                                            onClick={() => {
-                                                                if (onFilterClick) {
-                                                                    onFilterClick(chart.title as 'Health' | 'Sync' | 'Hydrator', key);
-                                                                }
-                                                            }}
-                                                            title={`Filter by ${key}`}
-                                                        >
-                                                            {chart.title === 'Health' && <HealthStatusIcon state={{status: key as HealthStatusCode, message: ''}} noSpin={true} />}
-                                                            {chart.title === 'Sync' && <ComparisonStatusIcon status={key as SyncStatusCode} noSpin={true} />}
-                                                            {chart.title === 'Hydrator' && key !== 'None' && (
-                                                                <HydrateOperationPhaseIcon
-                                                                    operationState={{
-                                                                        phase: key as any,
-                                                                        startedAt: '',
-                                                                        message: '',
-                                                                        drySHA: '',
-                                                                        hydratedSHA: '',
-                                                                        sourceHydrator: {} as any
-                                                                    }}
-                                                                />
-                                                            )}
-                                                            {chart.title === 'Hydrator' && key === 'None' && (
-                                                                <i className='fa fa-minus-circle' style={{color: hydratorColors.get(key)}} />
-                                                            )}
-                                                            {` ${key} (${getLegendValue(key)})`}
+                                                        <li style={{listStyle: 'none', whiteSpace: 'nowrap'}} key={key}>
+                                                            <button
+                                                                type='button'
+                                                                onClick={() => {
+                                                                    if (chart.title !== 'Hydrator' && onFilterClick) {
+                                                                        onFilterClick(chart.title as 'Health' | 'Sync', key);
+                                                                    }
+                                                                }}
+                                                                title={chart.title === 'Hydrator' ? undefined : `Filter by ${key}`}
+                                                                disabled={chart.title === 'Hydrator'}
+                                                                style={{
+                                                                    background: 'none',
+                                                                    border: 'none',
+                                                                    padding: 0,
+                                                                    cursor: chart.title === 'Hydrator' ? 'default' : 'pointer',
+                                                                    textAlign: 'left',
+                                                                    font: 'inherit',
+                                                                    color: 'inherit'
+                                                                }}>
+                                                                {chart.title === 'Health' && (
+                                                                    <HealthStatusIcon state={{status: key as HealthStatusCode, message: ''}} noSpin={true} />
+                                                                )}
+                                                                {chart.title === 'Sync' && <ComparisonStatusIcon status={key as SyncStatusCode} noSpin={true} />}
+                                                                {chart.title === 'Hydrator' && key !== 'None' && (
+                                                                    <HydrateOperationPhaseIcon
+                                                                        operationState={{
+                                                                            phase: key as any,
+                                                                            startedAt: '',
+                                                                            message: '',
+                                                                            drySHA: '',
+                                                                            hydratedSHA: '',
+                                                                            sourceHydrator: {} as any
+                                                                        }}
+                                                                    />
+                                                                )}
+                                                                {chart.title === 'Hydrator' && key === 'None' && (
+                                                                    <i className='fa fa-minus-circle' style={{color: hydratorColors.get(key)}} />
+                                                                )}
+                                                                {` ${key} (${getLegendValue(key)})`}
+                                                            </button>
                                                         </li>
                                                     ))}
                                                 </ul>

--- a/ui/src/app/applications/components/applications-list/applications-summary.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-summary.tsx
@@ -32,7 +32,7 @@ export const ApplicationsSummary = ({
     applications: models.Application[];
     onFilterClick?: (type: 'Health' | 'Sync' | 'Hydrator', value: string) => void;
 }) => {
-    const [hoveredSector, setHoveredSector] = React.useState<{title: string; value: number; color: string} | null>(null);
+    const [hoveredSector, setHoveredSector] = React.useState<{chartTitle: string; title: string} | null>(null);
 
     const sync = new Map<string, number>();
     applications.forEach(app => sync.set(app.status.sync.status, (sync.get(app.status.sync.status) || 0) + 1));
@@ -102,14 +102,18 @@ export const ApplicationsSummary = ({
                                                 <h4 style={{textAlign: 'center'}}>{chart.title}</h4>
                                                 <div
                                                     onClick={() => {
-                                                        if (onFilterClick && hoveredSector) {
+                                                        if (onFilterClick && hoveredSector && hoveredSector.chartTitle === chart.title) {
                                                             onFilterClick(chart.title as 'Health' | 'Sync' | 'Hydrator', hoveredSector.title);
                                                         }
                                                     }}
                                                     style={{cursor: 'pointer'}}
                                                     title='Click to filter applications'
                                                 >
-                                                    <PieChart data={chart.data} onSectorHover={(d: any) => setHoveredSector(d)} expandOnHover={true} />
+                                                    <PieChart
+                                                        data={chart.data}
+                                                        onSectorHover={(d: any) => setHoveredSector(d ? {chartTitle: chart.title, title: d.title} : null)}
+                                                        expandOnHover={true}
+                                                    />
                                                 </div>
                                             </div>
                                             <div className='large-3 small-1'>


### PR DESCRIPTION
Implements a click-to-filter drill-down capability to the summary pie charts and legend items on the Argo CD Applications and ApplicationSets dashboard pages.

Clicking on a specific status slice (e.g., Degraded on the Health chart or OutOfSync on the Sync chart) or its corresponding legend list item now automatically applies the filter and transitions the user from the Summary view to the Tiles view. This creates a fast, direct shortcut to inspect affected applications during incident triage or routine monitoring.

Fixes- #28508

## Additional Details

- Addresses key edge cases regarding micro-interaction bugs, system accessibility (A11y), and unfilterable charts (Hydrator).

## Implementation Details

### 1. Interactive Pie Slices and Legend Items

- Implemented `onFilterClick` callback props across `ApplicationsSummary` and `ApplicationSetsSummary`.
- Mapped hover events using `onSectorHover` to track the currently hovered slice.
- Wrapped the `PieChart` in a clickable container that delegates clicks to the callback based on the hovered sector status.
- Added `expandOnHover` to the `PieChart` so users get clear visual feedback that slices are interactive.
- Refactored legend list items into semantic `<button>` elements with reset styles, making them easier and more accessible click targets.

### 2. Parent Container and State Handlers

- Updated `onAppFilterPrefChanged` and `onAppSetFilterPrefChanged` in the parent list components, `applications-list.tsx` and `application-sets-list.tsx`, to keep the `view` URL parameter synchronized with local user preferences.
- When a slice or legend button is clicked:
  - The corresponding filter, such as `healthFilter` or `syncFilter`, is set to the selected value.
  - The view type is switched to `Tiles`, the default visual list.
  - A redirect is triggered so the filtered parameters are applied immediately.

### 3. Edge Cases Addressed

#### Hydrator Chart Guard

- The Hydrator operation phase values, such as `Hydrated`, `Hydrating`, `Failed`, and `None`, are not filterable in Argo CD.
- Allowing clicks on those values would result in zero matching applications and create a misleading empty state.
- To prevent this, hover expansion, cursor styling, tab index, and click and keyboard event hooks were explicitly disabled for the Hydrator chart and its legend items.

#### Shared Hover State Fix

- The `hoveredSector` state was updated to track `{chartTitle: string, title: string}` instead of a generic sector object.
- This prevents misfired click events when a user hovers over a slice in one chart and then clicks in a different chart area.

#### Keyboard Accessibility

- Chart containers now use `role="button"` and `tabIndex={0}`.
- They also listen for `Enter` and `Space` through `onKeyDown`, enabling keyboard-based interaction.
- Legend items are implemented as standard focusable `<button>` elements for better accessibility.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->

