### PR TITLE
feat(ui): add sibling Applications to search dropdown for quick navigation

### DIFF
--- a/ui/src/app/applications/components/application-details/application-details-app-dropdown.tsx
+++ b/ui/src/app/applications/components/application-details/application-details-app-dropdown.tsx
@@ -49,9 +49,7 @@ export const ApplicationsDetailsAppDropdown = (props: {appName: string; objectLi
                         load={async () => {
                             const [appsResult, appSetResult] = await Promise.allSettled([
                                 services.applications.list([], props.objectListKind, {fields: ['items.metadata.name', 'items.metadata.namespace']}),
-                                appSetRef
-                                    ? services.applications.getApplicationSet(appSetRef.name, props.application.metadata.namespace)
-                                    : Promise.reject(new Error('no appset'))
+                                appSetRef ? services.applications.getApplicationSet(appSetRef.name, props.application.metadata.namespace) : Promise.reject(new Error('no appset'))
                             ]);
                             const apps = appsResult.status === 'fulfilled' ? appsResult.value : ({items: []} as models.AbstractApplicationList);
                             const appSet = appSetResult.status === 'fulfilled' ? appSetResult.value : null;
@@ -60,9 +58,7 @@ export const ApplicationsDetailsAppDropdown = (props: {appName: string; objectLi
                         }}>
                         {({apps, siblings}: {apps: models.AbstractApplicationList; siblings: models.ApplicationSetResource[]}) => {
                             const filteredSiblings =
-                                appSetRef && siblings.length > 0
-                                    ? siblings.filter(s => appFilter.length === 0 || s.name.toLowerCase().includes(appFilter.toLowerCase()))
-                                    : [];
+                                appSetRef && siblings.length > 0 ? siblings.filter(s => appFilter.length === 0 || s.name.toLowerCase().includes(appFilter.toLowerCase())) : [];
                             return (
                                 <>
                                     {filteredSiblings.length > 0 && (
@@ -91,7 +87,9 @@ export const ApplicationsDetailsAppDropdown = (props: {appName: string; objectLi
                                                 className='application-details-app-dropdown__item'
                                                 key={app.metadata.name}
                                                 onClick={() => ctx.navigation.goto(`/${getAppUrl(app)}`)}>
-                                                <i className={`icon ${resourceIconClass(props.objectListKind)} resource-icon__font-icon application-details-app-dropdown__resource-icon`} />
+                                                <i
+                                                    className={`icon ${resourceIconClass(props.objectListKind)} resource-icon__font-icon application-details-app-dropdown__resource-icon`}
+                                                />
                                                 <span>
                                                     {app.metadata.name}
                                                     {app.metadata.name === props.appName && ' (current)'}

--- a/ui/src/app/applications/components/application-details/application-details-app-dropdown.tsx
+++ b/ui/src/app/applications/components/application-details/application-details-app-dropdown.tsx
@@ -53,7 +53,7 @@ export const ApplicationsDetailsAppDropdown = (props: {appName: string; objectLi
                                     ? services.applications.getApplicationSet(appSetRef.name, props.application.metadata.namespace)
                                     : Promise.reject(new Error('no appset'))
                             ]);
-                            const apps = appsResult.status === 'fulfilled' ? appsResult.value : {items: []};
+                            const apps = appsResult.status === 'fulfilled' ? appsResult.value : ({items: []} as models.AbstractApplicationList);
                             const appSet = appSetResult.status === 'fulfilled' ? appSetResult.value : null;
                             const siblings = appSet?.status?.resources?.filter(r => r.kind === 'Application') ?? [];
                             return {apps, siblings};

--- a/ui/src/app/applications/components/application-details/application-details-app-dropdown.tsx
+++ b/ui/src/app/applications/components/application-details/application-details-app-dropdown.tsx
@@ -2,17 +2,21 @@ import {DataLoader, DropDown} from 'argo-ui';
 import * as React from 'react';
 
 import {Context} from '../../../shared/context';
+import * as models from '../../../shared/models';
 import {services} from '../../../shared/services';
-import {getAppUrl} from '../utils';
+import {getAppUrl, getApplicationSetOwnerRef} from '../utils';
 
 function resourceIconClass(objectListKind: string): string {
     return objectListKind === 'applicationset' ? 'argo-icon-applicationset' : 'argo-icon-application';
 }
 
-export const ApplicationsDetailsAppDropdown = (props: {appName: string; objectListKind: string}) => {
+export const ApplicationsDetailsAppDropdown = (props: {appName: string; objectListKind: string; application?: models.Application}) => {
     const [opened, setOpened] = React.useState(false);
     const [appFilter, setAppFilter] = React.useState('');
     const ctx = React.useContext(Context);
+
+    const appSetRef = props.application ? getApplicationSetOwnerRef(props.application) : null;
+
     return (
         <DropDown
             onOpenStateChange={setOpened}
@@ -41,23 +45,62 @@ export const ApplicationsDetailsAppDropdown = (props: {appName: string; objectLi
                             }}
                         />
                     </li>
-                    <DataLoader load={() => services.applications.list([], props.objectListKind, {fields: ['items.metadata.name', 'items.metadata.namespace']})}>
-                        {apps =>
-                            apps.items
-                                .filter(app => {
-                                    return appFilter.length === 0 || app.metadata.name.toLowerCase().includes(appFilter.toLowerCase());
-                                })
-                                .slice(0, 100) // take top 100 results after filtering to avoid performance issues
-                                .map(app => (
-                                    <li className='application-details-app-dropdown__item' key={app.metadata.name} onClick={() => ctx.navigation.goto(`/${getAppUrl(app)}`)}>
-                                        <i className={`icon ${resourceIconClass(props.objectListKind)} resource-icon__font-icon application-details-app-dropdown__resource-icon`} />
-                                        <span>
-                                            {app.metadata.name}
-                                            {app.metadata.name === props.appName && ' (current)'}
-                                        </span>
-                                    </li>
-                                ))
-                        }
+                    <DataLoader
+                        load={async () => {
+                            const [appsResult, appSetResult] = await Promise.allSettled([
+                                services.applications.list([], props.objectListKind, {fields: ['items.metadata.name', 'items.metadata.namespace']}),
+                                appSetRef
+                                    ? services.applications.getApplicationSet(appSetRef.name, props.application.metadata.namespace)
+                                    : Promise.reject(new Error('no appset'))
+                            ]);
+                            const apps = appsResult.status === 'fulfilled' ? appsResult.value : {items: []};
+                            const appSet = appSetResult.status === 'fulfilled' ? appSetResult.value : null;
+                            const siblings = appSet?.status?.resources?.filter(r => r.kind === 'Application') ?? [];
+                            return {apps, siblings};
+                        }}>
+                        {({apps, siblings}: {apps: models.AbstractApplicationList; siblings: models.ApplicationSetResource[]}) => {
+                            const filteredSiblings =
+                                appSetRef && siblings.length > 0
+                                    ? siblings.filter(s => appFilter.length === 0 || s.name.toLowerCase().includes(appFilter.toLowerCase()))
+                                    : [];
+                            return (
+                                <>
+                                    {filteredSiblings.length > 0 && (
+                                        <>
+                                            <li className='application-details-app-dropdown__section-header'>IN SET: {appSetRef.name}</li>
+                                            {filteredSiblings.map(sibling => (
+                                                <li
+                                                    className='application-details-app-dropdown__item'
+                                                    key={`sibling-${sibling.name}`}
+                                                    onClick={() => ctx.navigation.goto(`/applications/${sibling.namespace}/${sibling.name}`)}>
+                                                    <i className='icon argo-icon-application resource-icon__font-icon application-details-app-dropdown__resource-icon' />
+                                                    <span>
+                                                        {sibling.name}
+                                                        {sibling.name === props.appName && ' (current)'}
+                                                    </span>
+                                                </li>
+                                            ))}
+                                            <li className='application-details-app-dropdown__divider' role='separator' />
+                                        </>
+                                    )}
+                                    {apps.items
+                                        .filter(app => appFilter.length === 0 || app.metadata.name.toLowerCase().includes(appFilter.toLowerCase()))
+                                        .slice(0, 100)
+                                        .map(app => (
+                                            <li
+                                                className='application-details-app-dropdown__item'
+                                                key={app.metadata.name}
+                                                onClick={() => ctx.navigation.goto(`/${getAppUrl(app)}`)}>
+                                                <i className={`icon ${resourceIconClass(props.objectListKind)} resource-icon__font-icon application-details-app-dropdown__resource-icon`} />
+                                                <span>
+                                                    {app.metadata.name}
+                                                    {app.metadata.name === props.appName && ' (current)'}
+                                                </span>
+                                            </li>
+                                        ))}
+                                </>
+                            );
+                        }}
                     </DataLoader>
                 </ul>
             )}

--- a/ui/src/app/applications/components/application-details/application-details-app-dropdown.tsx
+++ b/ui/src/app/applications/components/application-details/application-details-app-dropdown.tsx
@@ -57,6 +57,7 @@ export const ApplicationsDetailsAppDropdown = (props: {appName: string; objectLi
                             return {apps, siblings};
                         }}>
                         {({apps, siblings}: {apps: models.AbstractApplicationList; siblings: models.ApplicationSetResource[]}) => {
+                            const siblingKeys = new Set(siblings.map(s => `${s.namespace}/${s.name}`));
                             const filteredSiblings =
                                 appSetRef && siblings.length > 0 ? siblings.filter(s => appFilter.length === 0 || s.name.toLowerCase().includes(appFilter.toLowerCase())) : [];
                             return (
@@ -80,6 +81,7 @@ export const ApplicationsDetailsAppDropdown = (props: {appName: string; objectLi
                                         </>
                                     )}
                                     {apps.items
+                                        .filter(app => !siblingKeys.has(`${app.metadata.namespace}/${app.metadata.name}`))
                                         .filter(app => appFilter.length === 0 || app.metadata.name.toLowerCase().includes(appFilter.toLowerCase()))
                                         .slice(0, 100)
                                         .map(app => (

--- a/ui/src/app/applications/components/application-details/application-details.scss
+++ b/ui/src/app/applications/components/application-details/application-details.scss
@@ -396,7 +396,7 @@ $header: 120px;
         font-size: 11px;
         font-weight: 600;
         letter-spacing: 0.05em;
-        color: $argo-color-teal-5;
+        color: #00a2b3;
         border-bottom: none;
         cursor: default;
     }
@@ -404,7 +404,7 @@ $header: 120px;
     ul li.application-details-app-dropdown__divider {
         padding: 0;
         margin: 4px 0;
-        border-top: 2px solid $argo-color-teal-5;
+        border-top: 2px solid #00a2b3;
         border-bottom: none;
         list-style: none;
     }

--- a/ui/src/app/applications/components/application-details/application-details.scss
+++ b/ui/src/app/applications/components/application-details/application-details.scss
@@ -396,7 +396,7 @@ $header: 120px;
         font-size: 11px;
         font-weight: 600;
         letter-spacing: 0.05em;
-        color: $argo-color-gray-4;
+        color: $argo-color-teal-5;
         border-bottom: none;
         cursor: default;
     }
@@ -404,7 +404,7 @@ $header: 120px;
     ul li.application-details-app-dropdown__divider {
         padding: 0;
         margin: 4px 0;
-        border-top: 1px solid $argo-color-gray-2;
+        border-top: 2px solid $argo-color-teal-5;
         border-bottom: none;
         list-style: none;
     }

--- a/ui/src/app/applications/components/application-details/application-details.scss
+++ b/ui/src/app/applications/components/application-details/application-details.scss
@@ -391,6 +391,24 @@ $header: 120px;
         }
     }
 
+    ul li.application-details-app-dropdown__section-header {
+        padding: 6px 10px 2px;
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.05em;
+        color: $argo-color-gray-4;
+        border-bottom: none;
+        cursor: default;
+    }
+
+    ul li.application-details-app-dropdown__divider {
+        padding: 0;
+        margin: 4px 0;
+        border-top: 1px solid $argo-color-gray-2;
+        border-bottom: none;
+        list-style: none;
+    }
+
     ul li.application-details-app-dropdown__item {
         display: flex;
         align-items: center;

--- a/ui/src/app/applications/components/application-details/application-details.tsx
+++ b/ui/src/app/applications/components/application-details/application-details.tsx
@@ -903,7 +903,7 @@ Are you sure you want to disable auto-sync and rollback application '${props.mat
                                                     title: isApplication ? 'Applications' : 'ApplicationSets',
                                                     path: isApplication ? '/applications' : '/applicationsets'
                                                 },
-                                                {title: <ApplicationsDetailsAppDropdown appName={props.match.params.name} objectListKind={objectListKind} />}
+                                                {title: <ApplicationsDetailsAppDropdown appName={props.match.params.name} objectListKind={objectListKind} application={isApplication ? (application as appModels.Application) : undefined} />}
                                             ],
                                             actionMenu: {
                                                 items: isApplication

--- a/ui/src/app/applications/components/application-details/application-details.tsx
+++ b/ui/src/app/applications/components/application-details/application-details.tsx
@@ -903,7 +903,15 @@ Are you sure you want to disable auto-sync and rollback application '${props.mat
                                                     title: isApplication ? 'Applications' : 'ApplicationSets',
                                                     path: isApplication ? '/applications' : '/applicationsets'
                                                 },
-                                                {title: <ApplicationsDetailsAppDropdown appName={props.match.params.name} objectListKind={objectListKind} application={isApplication ? (application as appModels.Application) : undefined} />}
+                                                {
+                                                    title: (
+                                                        <ApplicationsDetailsAppDropdown
+                                                            appName={props.match.params.name}
+                                                            objectListKind={objectListKind}
+                                                            application={isApplication ? (application as appModels.Application) : undefined}
+                                                        />
+                                                    )
+                                                }
                                             ],
                                             actionMenu: {
                                                 items: isApplication


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Closes #25496

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] ~I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.~ UI change
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.

## Summary

When an Application is managed by an ApplicationSet, navigating between sibling Applications (e.g. staging and production environments in the same set) required going back to the application list and searching again. This PR adds a pinned "IN SET: \<name\>" section at the top of the existing app-name breadcrumb dropdown that lists all sibling Applications from the same ApplicationSet, filtered in sync with the existing search input. The feature degrades gracefully when the ApplicationSet cannot be fetched (RBAC restrictions, transient status, etc.) by simply omitting the siblings section and showing the standard all-apps list as before.

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->

### Before

#### ApplicationSet
<img width="552" height="440" alt="image" src="https://github.com/user-attachments/assets/3c843370-b69c-4dbb-adff-1d8305b32f8d" />

#### Application without parent ApplicationSet

<img width="552" height="440" alt="image" src="https://github.com/user-attachments/assets/02f1d719-1105-43bf-9a5b-68e5668f0206" />

### After

#### ApplicationSet

<img width="552" height="440" alt="image" src="https://github.com/user-attachments/assets/0ec87908-a278-4fff-b17f-1bc52517dca7" />
<img width="552" height="440" alt="image" src="https://github.com/user-attachments/assets/a7d8fa0c-756e-49ea-939f-3d5b9983f562" />
<img width="552" height="440" alt="image" src="https://github.com/user-attachments/assets/84777c46-d2db-4f8a-bdee-e0f295d9a0bd" />

#### Application without parent ApplicationSet

<img width="552" height="440" alt="image" src="https://github.com/user-attachments/assets/2c0bbcf0-d194-4303-a263-85b57281640f" />
