### PR TITLE
feat(ui): add directory glob help and validation (#10880)

### DIFF
--- a/ui/src/app/applications/components/application-create-panel/application-create-panel.scss
+++ b/ui/src/app/applications/components/application-create-panel/application-create-panel.scss
@@ -31,6 +31,15 @@
         margin-top: 0.75em;
     }
 
+    .application-parameters {
+        .editable-panel .argo-form-row__error-msg {
+            position: static;
+            line-height: 1.2;
+            margin-top: 4px;
+            white-space: normal;
+        }
+    }
+
     &__multi-source-block {
         margin-bottom: 0.5em;
 

--- a/ui/src/app/applications/components/application-create-panel/application-create-panel.scss
+++ b/ui/src/app/applications/components/application-create-panel/application-create-panel.scss
@@ -31,15 +31,6 @@
         margin-top: 0.75em;
     }
 
-    .application-parameters {
-        .editable-panel .argo-form-row__error-msg {
-            position: static;
-            line-height: 1.2;
-            margin-top: 4px;
-            white-space: normal;
-        }
-    }
-
     &__multi-source-block {
         margin-bottom: 0.5em;
 

--- a/ui/src/app/applications/components/application-parameters/application-parameters.scss
+++ b/ui/src/app/applications/components/application-parameters/application-parameters.scss
@@ -66,6 +66,13 @@
         padding-left: 1em;
     }
 
+    .white-box__details-row .columns.small-9 {
+        line-height: 1.4;
+        min-height: 50px;
+        padding-top: 15px;
+        padding-bottom: 15px;
+    }
+
     .select {
         padding-bottom: 0;
 

--- a/ui/src/app/applications/components/application-parameters/application-parameters.tsx
+++ b/ui/src/app/applications/components/application-parameters/application-parameters.tsx
@@ -73,6 +73,43 @@ function processPath(path: string) {
     return '';
 }
 
+const DIRECTORY_GLOB_HINT = 'Optional glob expression used to match files under the application source path. Examples: *.yaml, some-directory/*, {*.yml,*.yaml}.';
+
+function validateDirectoryGlob(pattern?: string) {
+    if (!pattern) {
+        return null;
+    }
+
+    const stack: string[] = [];
+    const openingPairs: {[key: string]: string} = {'[': ']', '{': '}'};
+    const closingPairs: {[key: string]: string} = {']': '[', '}': '{'};
+
+    let escaped = false;
+    for (const char of pattern) {
+        if (escaped) {
+            escaped = false;
+            continue;
+        }
+        if (char === '\\') {
+            escaped = true;
+        } else if (char === '[' || char === '{') {
+            stack.push(char);
+        } else if (char === ']' || char === '}') {
+            const expectedOpening = closingPairs[char];
+            const actualOpening = stack.pop();
+            if (!actualOpening) {
+                return `Expected opening '${expectedOpening}' before closing '${char}' in glob pattern`;
+            }
+            if (actualOpening !== expectedOpening) {
+                return `Expected '${openingPairs[actualOpening]}' to close '${actualOpening}' but found '${char}'`;
+            }
+        }
+    }
+
+    const actualOpening = stack[stack.length - 1];
+    return actualOpening ? `Expected '${openingPairs[actualOpening]}' to close '${actualOpening}' in glob pattern` : null;
+}
+
 function getParamsEditableItems(
     app: models.Application,
     title: string,
@@ -353,6 +390,8 @@ export const ApplicationParameters = (props: {
         const jsonnetTlas = isMulti ? `spec.sources[${ind}].directory.jsonnet.tlas` : 'spec.source.directory.jsonnet.tlas';
         const jsonnetExtVars = isMulti ? `spec.sources[${ind}].directory.jsonnet.extVars` : 'spec.source.directory.jsonnet.extVars';
         const helmValuesPath = isMulti ? `spec.sources[${ind}].helm.values` : 'spec.source.helm.values';
+        const directoryIncludePath = isMulti ? `spec.sources[${ind}].directory.include` : 'spec.source.directory.include';
+        const directoryExcludePath = isMulti ? `spec.sources[${ind}].directory.exclude` : 'spec.source.directory.exclude';
 
         return (
             <div className='application-parameters'>
@@ -416,6 +455,11 @@ export const ApplicationParameters = (props: {
                         for (const fieldPath of [jsonnetTlas, jsonnetExtVars]) {
                             const invalid = ((getNestedField(updatedApp, fieldPath) || []) as Array<models.JsonnetVar>).filter(item => !item.name && !item.code);
                             errors[fieldPath] = invalid.length > 0 ? 'All fields must have name' : null;
+                        }
+
+                        for (const fieldPath of [directoryIncludePath, directoryExcludePath]) {
+                            const value = getNestedField(updatedApp, fieldPath);
+                            errors[fieldPath] = validateDirectoryGlob(typeof value === 'string' ? value : '');
                         }
 
                         const helmSrc = isMulti ? updatedApp.spec.sources[ind] : updatedApp.spec.source;
@@ -1086,6 +1130,7 @@ function gatherDetails(
 
         attributes.push({
             title: 'INCLUDE',
+            hint: DIRECTORY_GLOB_HINT,
             view: directory && directory.include,
             edit: (formApi: FormApi) => (
                 <FormField formApi={formApi} field={isMultiSource ? 'spec.sources[' + ind + '].directory.include' : 'spec.source.directory.include'} component={Text} />
@@ -1094,6 +1139,7 @@ function gatherDetails(
 
         attributes.push({
             title: 'EXCLUDE',
+            hint: DIRECTORY_GLOB_HINT,
             view: directory && directory.exclude,
             edit: (formApi: FormApi) => (
                 <FormField formApi={formApi} field={isMultiSource ? 'spec.sources[' + ind + '].directory.exclude' : 'spec.source.directory.exclude'} component={Text} />


### PR DESCRIPTION
## What this PR does

Adds inline help text for the directory `include` and `exclude` fields in the application Parameters tab, with examples matching the documented directory glob patterns.

It also adds conservative client-side validation for those fields so obviously malformed patterns with mismatched or unclosed brackets/braces are caught before save.

Closes #10880

## Validation

- `cd ui && pnpm lint`

Checklist:

* [x] Either (a) I've created an enhancement proposal and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number.
* [x] The title of the PR conforms to the title guidance.
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description.
* [x] I've updated the UI to expose this existing directory-app setting more clearly.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by DCO.
* [ ] I have written unit and/or e2e tests for my change.
* [ ] My build is green.
* [x] My new feature complies with the feature status guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into.
