### PR TITLE
fix: respect manifest-generate-paths annotation on empty-commit webhook events

### DIFF
--- a/util/app/path/path.go
+++ b/util/app/path/path.go
@@ -150,12 +150,14 @@ func GetSourceRefreshPaths(app *v1alpha1.Application, source v1alpha1.Applicatio
 	return paths
 }
 
-// AppFilesHaveChanged returns true if any of the changed files are under the given refresh paths
-// If refreshPaths or changedFiles are empty, it will always return true
+// AppFilesHaveChanged returns true if any of the changed files are under the given refresh paths.
+// A nil changedFiles means the source did not provide a file list (unknown changes) and always
+// returns true. A non-nil but empty changedFiles means the source confirmed no files changed;
+// in that case only refreshPaths emptiness can still force a refresh.
 func AppFilesHaveChanged(refreshPaths []string, changedFiles []string) bool {
-	// an empty slice of changed files means that the payload didn't include a list
-	// of changed files and we have to assume that a refresh is required
-	if len(changedFiles) == 0 {
+	// nil means the webhook payload did not include a file list (e.g. Azure DevOps, Bitbucket
+	// Server), so we must assume something changed and trigger a refresh.
+	if changedFiles == nil {
 		return true
 	}
 

--- a/util/app/path/path_test.go
+++ b/util/app/path/path_test.go
@@ -256,3 +256,59 @@ func Test_GetAppRefreshPaths(t *testing.T) {
 		})
 	}
 }
+
+func TestAppFilesHaveChanged(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		refreshPaths []string
+		changedFiles []string
+		expected     bool
+	}{
+		{
+			name:         "nil changedFiles means unknown file list - always refresh",
+			refreshPaths: []string{"manifests"},
+			changedFiles: nil,
+			expected:     true,
+		},
+		{
+			name:         "nil changedFiles with no refresh paths - always refresh",
+			refreshPaths: nil,
+			changedFiles: nil,
+			expected:     true,
+		},
+		{
+			name:         "empty commit (non-nil empty changedFiles) with matching refresh path - no refresh",
+			refreshPaths: []string{"manifests"},
+			changedFiles: []string{},
+			expected:     false,
+		},
+		{
+			name:         "empty commit with no refresh paths - always refresh",
+			refreshPaths: nil,
+			changedFiles: []string{},
+			expected:     true,
+		},
+		{
+			name:         "changed file matches refresh path - refresh",
+			refreshPaths: []string{"manifests"},
+			changedFiles: []string{"manifests/app.yaml"},
+			expected:     true,
+		},
+		{
+			name:         "changed file does not match refresh path - no refresh",
+			refreshPaths: []string{"manifests"},
+			changedFiles: []string{"docs/readme.md"},
+			expected:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		ttc := tt
+		t.Run(ttc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, ttc.expected, AppFilesHaveChanged(ttc.refreshPaths, ttc.changedFiles))
+		})
+	}
+}

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -259,6 +259,9 @@ func (a *ArgoCDWebhookHandler) affectedRevisionInfo(payloadIf any) (webURLs []st
 		change.shaAfter = ParseRevision(payload.After)
 		change.shaBefore = ParseRevision(payload.Before)
 		touchedHead = bool(payload.Repository.DefaultBranch == revision)
+		// Initialize to non-nil so an empty commit (no files changed) is distinguishable
+		// from SCMs that do not provide file lists at all (which remain nil).
+		changedFiles = []string{}
 		for _, commit := range payload.Commits {
 			changedFiles = append(changedFiles, commit.Added...)
 			changedFiles = append(changedFiles, commit.Modified...)
@@ -271,6 +274,7 @@ func (a *ArgoCDWebhookHandler) affectedRevisionInfo(payloadIf any) (webURLs []st
 		change.shaAfter = ParseRevision(payload.After)
 		change.shaBefore = ParseRevision(payload.Before)
 		touchedHead = bool(payload.Project.DefaultBranch == revision)
+		changedFiles = []string{}
 		for _, commit := range payload.Commits {
 			changedFiles = append(changedFiles, commit.Added...)
 			changedFiles = append(changedFiles, commit.Modified...)
@@ -284,6 +288,7 @@ func (a *ArgoCDWebhookHandler) affectedRevisionInfo(payloadIf any) (webURLs []st
 		change.shaAfter = ParseRevision(payload.After)
 		change.shaBefore = ParseRevision(payload.Before)
 		touchedHead = bool(payload.Project.DefaultBranch == revision)
+		changedFiles = []string{}
 		for _, commit := range payload.Commits {
 			changedFiles = append(changedFiles, commit.Added...)
 			changedFiles = append(changedFiles, commit.Modified...)
@@ -336,8 +341,12 @@ func (a *ArgoCDWebhookHandler) affectedRevisionInfo(payloadIf any) (webURLs []st
 			diffStatChangedFiles, err := fetchDiffStatFromBitbucket(ctx, bbClient, owner, repoSlug, spec)
 			if err != nil {
 				log.Warnf("error fetching changed files using bitbucket diffstat api: %v", err)
+			} else {
+				// Assign directly so a non-nil empty slice from the diffstat API
+				// is preserved (signals "we know no files changed"), distinguishing
+				// it from nil which means "file list unavailable".
+				changedFiles = diffStatChangedFiles
 			}
-			changedFiles = append(changedFiles, diffStatChangedFiles...)
 			touchedHead, err = isHeadTouched(ctx, bbClient, owner, repoSlug, revision)
 			if err != nil {
 				log.Warnf("error fetching bitbucket repo details: %v", err)
@@ -386,6 +395,7 @@ func (a *ArgoCDWebhookHandler) affectedRevisionInfo(payloadIf any) (webURLs []st
 			webURLs = append(webURLs, payload.Repo.HTMLURL)
 			touchedHead = payload.Repo.DefaultBranch == revision
 		}
+		changedFiles = []string{}
 		for _, commit := range payload.Commits {
 			changedFiles = append(changedFiles, commit.Added...)
 			changedFiles = append(changedFiles, commit.Modified...)

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -1237,6 +1237,184 @@ func createTestPayload(changedFile string) []byte {
 	return []byte(payload)
 }
 
+// createEmptyCommitPayload creates a GitHub push event payload where the commit has no file changes.
+func createEmptyCommitPayload() []byte {
+	payload := fmt.Sprintf(`{
+		"ref": "refs/heads/master",
+		"before": "%s",
+		"after": "%s",
+		"repository": {
+			"html_url": "https://github.com/jessesuen/test-repo",
+			"default_branch": "master"
+		},
+		"commits": [
+			{
+				"added": [],
+				"modified": [],
+				"removed": []
+			}
+		]
+	}`, testBeforeSHA, testAfterSHA)
+	return []byte(payload)
+}
+
+// Test_affectedRevisionInfo_EmptyCommit verifies that pushes from SCMs that provide file
+// lists always return a non-nil changedFiles slice (even when no files changed), while SCMs
+// that do not provide file lists return nil (triggering an unconditional refresh).
+func Test_affectedRevisionInfo_EmptyCommit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                 string
+		hookPayload          any
+		expectedChangedFiles []string
+	}{
+		{
+			// GitHub provides file lists: even with no commits, changedFiles must be non-nil.
+			// A zero-value PushPayload simulates a push with an empty commit (no file changes).
+			name:                 "github push with no file changes produces non-nil empty changedFiles",
+			hookPayload:          github.PushPayload{},
+			expectedChangedFiles: []string{},
+		},
+		{
+			// GitLab provides file lists: a commit with no files must produce non-nil empty slice.
+			name: "gitlab push with no file changes produces non-nil empty changedFiles",
+			hookPayload: gitlab.PushEventPayload{
+				Commits: []gitlab.Commit{{Added: []string{}, Modified: []string{}, Removed: []string{}}},
+			},
+			expectedChangedFiles: []string{},
+		},
+		{
+			// Gogs provides file lists: a commit with no files must produce non-nil empty slice.
+			name: "gogs push with no file changes produces non-nil empty changedFiles",
+			hookPayload: gogsclient.PushPayload{
+				Commits: []*gogsclient.PayloadCommit{{Added: []string{}, Modified: []string{}, Removed: []string{}}},
+			},
+			expectedChangedFiles: []string{},
+		},
+		{
+			// Azure DevOps does not include changed files in its payload: must produce nil.
+			name: "azure devops payload produces nil changedFiles (file list unavailable)",
+			hookPayload: azuredevops.GitPushEvent{
+				Resource: azuredevops.Resource{
+					RefUpdates: []azuredevops.RefUpdate{{Name: "refs/heads/master"}},
+				},
+			},
+			expectedChangedFiles: nil,
+		},
+		{
+			// Bitbucket Server does not include changed files in its payload: must produce nil.
+			name: "bitbucket server payload produces nil changedFiles (file list unavailable)",
+			hookPayload: bitbucketserver.RepositoryReferenceChangedPayload{
+				Changes: []bitbucketserver.RepositoryChange{
+					{Reference: bitbucketserver.RepositoryReference{ID: "refs/heads/master"}},
+				},
+				Repository: bitbucketserver.Repository{Links: map[string]any{"clone": []any{}}},
+			},
+			expectedChangedFiles: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		ttc := tt
+		t.Run(ttc.name, func(t *testing.T) {
+			t.Parallel()
+			h := NewMockHandler(nil, []string{})
+			_, _, _, _, changedFiles := h.affectedRevisionInfo(ttc.hookPayload)
+			require.Equal(t, ttc.expectedChangedFiles, changedFiles)
+		})
+	}
+}
+
+// TestHandleEvent_EmptyCommit verifies that an empty commit from GitHub (no file changes)
+// does not trigger a refresh for apps that use manifest-generate-paths annotation.
+func TestHandleEvent_EmptyCommit(t *testing.T) {
+	t.Parallel()
+
+	app := &v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-app",
+			Namespace: "argocd",
+			Annotations: map[string]string{
+				"argocd.argoproj.io/manifest-generate-paths": "manifests",
+			},
+		},
+		Spec: v1alpha1.ApplicationSpec{
+			Sources: v1alpha1.ApplicationSources{
+				{
+					RepoURL:        "https://github.com/jessesuen/test-repo",
+					Path:           "source/path",
+					TargetRevision: "HEAD",
+				},
+			},
+			Destination: v1alpha1.ApplicationDestination{Server: testClusterURL},
+		},
+	}
+
+	var patched bool
+	reaction := func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+		if action.GetVerb() == "patch" {
+			patched = true
+		}
+		return true, nil, nil
+	}
+
+	appClientset := appclientset.NewSimpleClientset(app)
+	defaultReactor := appClientset.ReactionChain[0]
+	appClientset.ReactionChain = nil
+	appClientset.AddReactor("list", "*", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+		return defaultReactor.React(action)
+	})
+	appClientset.AddReactor("patch", "applications", reaction)
+
+	inMemoryCache := cacheutil.NewInMemoryCache(1 * time.Hour)
+	cacheClient := cacheutil.NewCache(inMemoryCache)
+	repoCache := cache.NewCache(cacheClient, 1*time.Minute, 1*time.Minute, 10*time.Second)
+	serverCache := servercache.NewCache(appstate.NewCache(cacheClient, time.Minute), time.Minute, time.Minute)
+	mockDB := &mocks.ArgoDB{}
+	mockDB.EXPECT().GetCluster(mock.Anything, testClusterURL).Return(&v1alpha1.Cluster{
+		Server: testClusterURL,
+		Info: v1alpha1.ClusterInfo{
+			ServerVersion:   "1.28.0",
+			ConnectionState: v1alpha1.ConnectionState{Status: v1alpha1.ConnectionStatusSuccessful},
+		},
+	}, nil).Maybe()
+	mockDB.EXPECT().ListRepositories(mock.Anything).Return([]*v1alpha1.Repository{}, nil).Maybe()
+	require.NoError(t, serverCache.SetClusterInfo(testClusterURL, &v1alpha1.ClusterInfo{
+		ServerVersion:   "1.28.0",
+		ConnectionState: v1alpha1.ConnectionState{Status: v1alpha1.ConnectionStatusSuccessful},
+	}))
+
+	h := NewHandler(
+		"argocd",
+		[]string{},
+		10,
+		1,
+		appClientset,
+		&fakeAppsLister{clientset: appClientset},
+		&settings.ArgoCDSettings{},
+		&fakeSettingsSrc{},
+		repoCache,
+		serverCache,
+		mockDB,
+		int64(50)*1024*1024,
+		0,
+		10,
+	)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/webhook", http.NoBody)
+	req.Header.Set("X-GitHub-Event", "push")
+	req.Body = io.NopCloser(bytes.NewReader(createEmptyCommitPayload()))
+
+	w := httptest.NewRecorder()
+	h.Handler(w, req)
+	time.Sleep(50 * time.Millisecond)
+	h.Shutdown()
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.False(t, patched, "app with manifest-generate-paths annotation must not be refreshed on empty commit")
+}
+
 func Test_affectedRevisionInfo_bitbucket_changed_files(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()


### PR DESCRIPTION
## What this PR does

Fixes #28545

The `manifest-generate-paths` annotation (`argocd.argoproj.io/manifest-generate-paths`) was ignored when a GitHub (or GitLab / Gogs) webhook fired for an **empty commit** (e.g. `git commit --allow-empty`). The app would refresh unconditionally even though no files changed.

## Root cause

`AppFilesHaveChanged` in `util/app/path/path.go` used `len(changedFiles) == 0` as a guard to handle SCMs that don't include file lists (Azure DevOps, Bitbucket Server) — in that case we must assume something changed and always refresh.

But this couldn't distinguish between two very different situations:

| Situation | `changedFiles` (old) | Correct behavior |
|-----------|---------------------|-----------------|
| Azure DevOps / Bitbucket Server — no file list in payload | `nil` | always refresh |
| GitHub / GitLab / Gogs — empty commit (zero files changed) | also `nil` | respect annotation, skip refresh |

Both produced a `nil` slice, so ArgoCD treated an empty commit the same as "we have no idea what changed."

## Fix

Use Go's **nil vs non-nil empty slice** distinction as a semantic signal:

- **`nil`** → file list not provided by SCM → always refresh (existing behavior preserved for Azure DevOps, Bitbucket Server)
- **`[]string{}`** → file list provided, zero files changed → respect `manifest-generate-paths` annotation

**`util/webhook/webhook.go`**: Initialize `changedFiles = []string{}` before the commit loop for SCMs that do provide file lists (GitHub, GitLab push, GitLab tag, Gogs). For Bitbucket Cloud with auth (diffstat API), assign the result directly instead of appending, so a successful empty response stays non-nil.

**`util/app/path/path.go`**: Change the early-return guard from `len(changedFiles) == 0` to `changedFiles == nil`.

The call site in `reposerver/repository/repository.go` already guards with `if len(files) != 0` before calling `AppFilesHaveChanged`, so it is unaffected.

## How the bug was reproduced

Deployed **argocd-server v3.3.12** (the exact version from the issue report) into a local k3d cluster. Created an ArgoCD app with `manifest-generate-paths: /guestbook` pointing to `https://github.com/argoproj/argocd-example-apps`. Sent a GitHub webhook payload simulating an empty commit via curl:

```json
{
  "ref": "refs/heads/main",
  "repository": { "html_url": "https://github.com/argoproj/argocd-example-apps", "default_branch": "main" },
  "commits": [{ "added": [], "modified": [], "removed": [] }]
}
```

**argocd-server log confirmed the bug:**
```
{"msg":"Received push event repo: https://github.com/argoproj/argocd-example-apps, revision: main, touchedHead: true"}
{"msg":"refreshing app 'test-app-28545' from webhook"}   ← BUG: annotation bypassed
{"msg":"Requested app 'test-app-28545' refresh"}
```

## How the fix was tested

Built the fixed `argocd-server` binary from this branch, loaded it into the same k3d cluster, and ran three webhook scenarios:

**Test A — Empty commit → no refresh (the bug scenario)**
```
{"msg":"Received push event repo: https://github.com/argoproj/argocd-example-apps ..."}
{"msg":"Webhook handler completed in 12ms"}
// no "refreshing app" log — annotation respected ✓
```

**Test B — File inside `/guestbook` → refresh triggered (normal flow)**
```
{"msg":"Received push event repo: https://github.com/argoproj/argocd-example-apps ..."}
{"msg":"refreshing app 'test-app-28545' from webhook"}   ✓
```

**Test C — File outside `/guestbook` (README.md) → no refresh**
```
{"msg":"Received push event repo: https://github.com/argoproj/argocd-example-apps ..."}
{"msg":"Webhook handler completed in 2ms"}
// no "refreshing app" log ✓
```

## Unit tests added

- `Test_affectedRevisionInfo_EmptyCommit` — verifies `affectedRevisionInfo` returns `[]string{}` (non-nil) for GitHub/GitLab/Gogs and `nil` for Azure DevOps/Bitbucket Server
- `TestHandleEvent_EmptyCommit` — end-to-end webhook handler test: empty GitHub commit does **not** patch an app that has `manifest-generate-paths` set
- `TestAppFilesHaveChanged` — unit tests covering nil vs non-nil empty `changedFiles` behaviour

## Test plan

- [x] `go test ./util/app/path/...` — all pass
- [x] `go test ./util/webhook/...` — all pass
- [x] `go test ./reposerver/repository/... -run TestUpdateRevisionForPaths` — all pass
- [x] `golangci-lint run ./util/app/path/... ./util/webhook/...` — 0 issues
- [x] Bug reproduced live on k3d with argocd-server v3.3.12
- [x] Fix verified live on k3d with binary built from this branch