### PR TITLE
feat(appset): add ConfigMap generator

### DIFF
--- a/applicationset/generators/configmap.go
+++ b/applicationset/generators/configmap.go
@@ -1,0 +1,78 @@
+package generators
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	argoprojiov1alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+)
+
+var _ Generator = (*ConfigMapGenerator)(nil)
+
+// ConfigMapGenerator generates a single set of parameters from the data of a referenced ConfigMap.
+type ConfigMapGenerator struct {
+	client    client.Client
+	namespace string
+}
+
+func NewConfigMapGenerator(c client.Client, namespace string) Generator {
+	return &ConfigMapGenerator{
+		client:    c,
+		namespace: namespace,
+	}
+}
+
+func (g *ConfigMapGenerator) GetRequeueAfter(_ *argoprojiov1alpha1.ApplicationSetGenerator) time.Duration {
+	return NoRequeueAfter
+}
+
+func (g *ConfigMapGenerator) GetTemplate(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator) *argoprojiov1alpha1.ApplicationSetTemplate {
+	return &appSetGenerator.ConfigMap.Template
+}
+
+func (g *ConfigMapGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator, appSet *argoprojiov1alpha1.ApplicationSet, _ client.Client) ([]map[string]any, error) {
+	if appSetGenerator == nil {
+		return nil, ErrEmptyAppSetGenerator
+	}
+
+	if appSetGenerator.ConfigMap == nil {
+		return nil, ErrEmptyAppSetGenerator
+	}
+
+	if appSetGenerator.ConfigMap.ConfigMapRef == "" {
+		return nil, errors.New("ConfigMap generator requires configMapRef to be set")
+	}
+
+	ctx := context.Background()
+
+	cm := &corev1.ConfigMap{}
+	err := g.client.Get(
+		ctx,
+		client.ObjectKey{
+			Name:      appSetGenerator.ConfigMap.ConfigMapRef,
+			Namespace: g.namespace,
+		},
+		cm)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching ConfigMap %s/%s: %w", g.namespace, appSetGenerator.ConfigMap.ConfigMapRef, err)
+	}
+
+	// The ConfigMap data is a flat map of strings, so each key/value pair is exposed
+	// directly as a parameter. This works for both the goTemplate and fasttemplate
+	// rendering modes.
+	params := map[string]any{}
+	for k, v := range cm.Data {
+		params[k] = v
+	}
+
+	if err := appendTemplatedValues(appSetGenerator.ConfigMap.Values, params, appSet.Spec.GoTemplate, appSet.Spec.GoTemplateOptions); err != nil {
+		return nil, fmt.Errorf("failed to append templated values: %w", err)
+	}
+
+	return []map[string]any{params}, nil
+}

--- a/applicationset/generators/configmap_test.go
+++ b/applicationset/generators/configmap_test.go
@@ -1,0 +1,134 @@
+package generators
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	argoprojiov1alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+)
+
+func TestConfigMapGenerateParams(t *testing.T) {
+	testCases := []struct {
+		name          string
+		configMap     *corev1.ConfigMap
+		generator     *argoprojiov1alpha1.ConfigMapGenerator
+		gotemplate    bool
+		expected      []map[string]any
+		expectedError string
+	}{
+		{
+			name: "exposes ConfigMap data as parameters",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "env-config", Namespace: "argocd"},
+				Data:       map[string]string{"cluster": "prod", "region": "us-east-1"},
+			},
+			generator: &argoprojiov1alpha1.ConfigMapGenerator{ConfigMapRef: "env-config"},
+			expected: []map[string]any{
+				{"cluster": "prod", "region": "us-east-1"},
+			},
+		},
+		{
+			name: "appends values alongside ConfigMap data (fasttemplate)",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "env-config", Namespace: "argocd"},
+				Data:       map[string]string{"cluster": "prod"},
+			},
+			generator: &argoprojiov1alpha1.ConfigMapGenerator{
+				ConfigMapRef: "env-config",
+				Values:       map[string]string{"environment": "production"},
+			},
+			expected: []map[string]any{
+				{"cluster": "prod", "values.environment": "production"},
+			},
+		},
+		{
+			name: "appends values alongside ConfigMap data (goTemplate)",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "env-config", Namespace: "argocd"},
+				Data:       map[string]string{"cluster": "prod"},
+			},
+			generator: &argoprojiov1alpha1.ConfigMapGenerator{
+				ConfigMapRef: "env-config",
+				Values:       map[string]string{"environment": "{{.cluster}}"},
+			},
+			gotemplate: true,
+			expected: []map[string]any{
+				{"cluster": "prod", "values": map[string]string{"environment": "prod"}},
+			},
+		},
+		{
+			name: "empty ConfigMap data yields a single empty parameter set",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "env-config", Namespace: "argocd"},
+			},
+			generator: &argoprojiov1alpha1.ConfigMapGenerator{ConfigMapRef: "env-config"},
+			expected:  []map[string]any{{}},
+		},
+		{
+			name: "missing configMapRef is an error",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "env-config", Namespace: "argocd"},
+			},
+			generator:     &argoprojiov1alpha1.ConfigMapGenerator{},
+			expectedError: "ConfigMap generator requires configMapRef to be set",
+		},
+		{
+			name: "referenced ConfigMap does not exist is an error",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "env-config", Namespace: "argocd"},
+			},
+			generator:     &argoprojiov1alpha1.ConfigMapGenerator{ConfigMapRef: "does-not-exist"},
+			expectedError: "error fetching ConfigMap argocd/does-not-exist",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().WithObjects([]client.Object{tc.configMap}...).Build()
+
+			g := NewConfigMapGenerator(fakeClient, "argocd")
+
+			appSet := &argoprojiov1alpha1.ApplicationSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "set"},
+				Spec:       argoprojiov1alpha1.ApplicationSetSpec{GoTemplate: tc.gotemplate},
+			}
+
+			got, err := g.GenerateParams(&argoprojiov1alpha1.ApplicationSetGenerator{ConfigMap: tc.generator}, appSet, nil)
+
+			if tc.expectedError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectedError)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestConfigMapGenerateParamsNilGuards(t *testing.T) {
+	g := NewConfigMapGenerator(fake.NewClientBuilder().Build(), "argocd")
+
+	_, err := g.GenerateParams(nil, &argoprojiov1alpha1.ApplicationSet{}, nil)
+	require.ErrorIs(t, err, ErrEmptyAppSetGenerator)
+
+	_, err = g.GenerateParams(&argoprojiov1alpha1.ApplicationSetGenerator{}, &argoprojiov1alpha1.ApplicationSet{}, nil)
+	require.ErrorIs(t, err, ErrEmptyAppSetGenerator)
+}
+
+func TestConfigMapGetTemplate(t *testing.T) {
+	g := NewConfigMapGenerator(fake.NewClientBuilder().Build(), "argocd")
+	tmpl := argoprojiov1alpha1.ApplicationSetTemplate{
+		ApplicationSetTemplateMeta: argoprojiov1alpha1.ApplicationSetTemplateMeta{Name: "{{.cluster}}"},
+	}
+	got := g.GetTemplate(&argoprojiov1alpha1.ApplicationSetGenerator{
+		ConfigMap: &argoprojiov1alpha1.ConfigMapGenerator{Template: tmpl},
+	})
+	assert.Equal(t, "{{.cluster}}", got.Name)
+}

--- a/applicationset/generators/utils.go
+++ b/applicationset/generators/utils.go
@@ -20,6 +20,7 @@ func GetGenerators(ctx context.Context, c client.Client, k8sClient kubernetes.In
 		"ClusterDecisionResource": NewDuckTypeGenerator(ctx, dynamicClient, k8sClient, controllerNamespace, clusterInformer),
 		"PullRequest":             NewPullRequestGenerator(c, scmConfig),
 		"Plugin":                  NewPluginGenerator(c, controllerNamespace),
+		"ConfigMap":               NewConfigMapGenerator(c, controllerNamespace),
 	}
 
 	nestedGenerators := map[string]Generator{
@@ -30,6 +31,7 @@ func GetGenerators(ctx context.Context, c client.Client, k8sClient kubernetes.In
 		"ClusterDecisionResource": terminalGenerators["ClusterDecisionResource"],
 		"PullRequest":             terminalGenerators["PullRequest"],
 		"Plugin":                  terminalGenerators["Plugin"],
+		"ConfigMap":               terminalGenerators["ConfigMap"],
 		"Matrix":                  NewMatrixGenerator(terminalGenerators),
 		"Merge":                   NewMergeGenerator(terminalGenerators),
 	}
@@ -42,6 +44,7 @@ func GetGenerators(ctx context.Context, c client.Client, k8sClient kubernetes.In
 		"ClusterDecisionResource": terminalGenerators["ClusterDecisionResource"],
 		"PullRequest":             terminalGenerators["PullRequest"],
 		"Plugin":                  terminalGenerators["Plugin"],
+		"ConfigMap":               terminalGenerators["ConfigMap"],
 		"Matrix":                  NewMatrixGenerator(nestedGenerators),
 		"Merge":                   NewMergeGenerator(nestedGenerators),
 	}

--- a/docs/operator-manual/applicationset/Generators-ConfigMap.md
+++ b/docs/operator-manual/applicationset/Generators-ConfigMap.md
@@ -1,0 +1,70 @@
+# ConfigMap Generator
+
+The ConfigMap generator generates a single set of parameters from the `data` of a referenced `ConfigMap`. Each key/value pair in the ConfigMap's `data` is exposed as a parameter to the template.
+
+This is useful for driving an Application from operator-managed configuration. Tools such as Crossplane, Cluster API, Azure Service Operator, or Pulumi often export information about the resources they provision (bucket names, endpoints, region, etc.) into a ConfigMap; the ConfigMap generator lets you consume those values directly, without an external config-management plugin.
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: guestbook
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+  - configMap:
+      # The name of a ConfigMap in the ApplicationSet controller's namespace.
+      configMapRef: guestbook-config
+  template:
+    metadata:
+      name: '{{.cluster}}-guestbook'
+    spec:
+      project: "my-project"
+      source:
+        repoURL: https://github.com/argoproj/argo-cd.git
+        targetRevision: HEAD
+        path: applicationset/examples/configmap-generator/guestbook/{{.cluster}}
+      destination:
+        server: '{{.url}}'
+        namespace: guestbook
+```
+
+Given the following ConfigMap, the generator passes `cluster` and `url` as parameters into the template:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: guestbook-config
+  namespace: argocd
+data:
+  cluster: engineering-dev
+  url: https://kubernetes.default.svc
+```
+
+The referenced ConfigMap **must exist in the same namespace as the ApplicationSet controller** (the same requirement as the [Plugin generator](Generators-Plugin.md)'s `configMapRef`). Only the ConfigMap's `data` is read; `binaryData` is not exposed.
+
+!!! note
+    The ConfigMap generator only reads ConfigMaps, by design. Argo CD is not built to handle Secrets as a first-class generator input, so Secret data is intentionally out of scope. To template values from a ConfigMap into an Application while keeping secrets in a Secret, combine this generator with a [Matrix](Generators-Matrix.md) or [Merge](Generators-Merge.md) generator and reference the Secret from within the rendered manifests (for example via a `Secret`-backed Helm value or a `cert-manager`/`external-secrets` resource).
+
+## Values
+
+As with other generators, the `configMap` generator supports a `values` field for arbitrary key/value pairs that are added to the generated parameters (and may themselves reference the ConfigMap data when `goTemplate: true`):
+
+```yaml
+spec:
+  goTemplate: true
+  generators:
+  - configMap:
+      configMapRef: guestbook-config
+      values:
+        prefix: "infra"
+        clusterName: "{{.cluster}}"
+  template:
+    metadata:
+      name: '{{.values.prefix}}-{{.values.clusterName}}'
+```
+
+In `goTemplate: true` mode the values are available under `{{.values.<key>}}`. When `goTemplate` is not set, they are available as `{{values.<key>}}`, matching the behaviour of the other generators.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -122,6 +122,7 @@ nav:
       - operator-manual/applicationset/Generators-Pull-Request.md
       - operator-manual/applicationset/Generators-Post-Selector.md
       - operator-manual/applicationset/Generators-Plugin.md
+      - operator-manual/applicationset/Generators-ConfigMap.md
     - Template fields:
       - operator-manual/applicationset/Template.md
       - operator-manual/applicationset/GoTemplate.md

--- a/pkg/apis/application/v1alpha1/applicationset_types.go
+++ b/pkg/apis/application/v1alpha1/applicationset_types.go
@@ -208,6 +208,9 @@ type ApplicationSetGenerator struct {
 	Selector *metav1.LabelSelector `json:"selector,omitempty" protobuf:"bytes,9,name=selector"`
 
 	Plugin *PluginGenerator `json:"plugin,omitempty" protobuf:"bytes,10,name=plugin"`
+
+	// ConfigMap generates a single set of parameters from the data of a referenced ConfigMap.
+	ConfigMap *ConfigMapGenerator `json:"configMap,omitempty" protobuf:"bytes,11,name=configMap"`
 }
 
 // ApplicationSetNestedGenerator represents a generator nested within a combination-type generator (MatrixGenerator or
@@ -230,6 +233,9 @@ type ApplicationSetNestedGenerator struct {
 	Selector *metav1.LabelSelector `json:"selector,omitempty" protobuf:"bytes,9,name=selector"`
 
 	Plugin *PluginGenerator `json:"plugin,omitempty" protobuf:"bytes,10,name=plugin"`
+
+	// ConfigMap generates a single set of parameters from the data of a referenced ConfigMap.
+	ConfigMap *ConfigMapGenerator `json:"configMap,omitempty" protobuf:"bytes,11,name=configMap"`
 }
 
 type ApplicationSetNestedGenerators []ApplicationSetNestedGenerator
@@ -249,6 +255,9 @@ type ApplicationSetTerminalGenerator struct {
 
 	// Selector allows to post-filter all generator.
 	Selector *metav1.LabelSelector `json:"selector,omitempty" protobuf:"bytes,8,name=selector"`
+
+	// ConfigMap generates a single set of parameters from the data of a referenced ConfigMap.
+	ConfigMap *ConfigMapGenerator `json:"configMap,omitempty" protobuf:"bytes,9,name=configMap"`
 }
 
 type ApplicationSetTerminalGenerators []ApplicationSetTerminalGenerator
@@ -267,6 +276,7 @@ func (g ApplicationSetTerminalGenerators) toApplicationSetNestedGenerators() []A
 			ClusterDecisionResource: terminalGenerator.ClusterDecisionResource,
 			PullRequest:             terminalGenerator.PullRequest,
 			Plugin:                  terminalGenerator.Plugin,
+			ConfigMap:               terminalGenerator.ConfigMap,
 			Selector:                terminalGenerator.Selector,
 		}
 	}
@@ -807,6 +817,20 @@ type PluginGenerator struct {
 	// Values contains key/value pairs which are passed directly as parameters to the template. These values will not be
 	// sent as parameters to the plugin.
 	Values map[string]string `json:"values,omitempty" protobuf:"bytes,5,name=values"`
+}
+
+// ConfigMapGenerator generates a single set of parameters from the data of a referenced ConfigMap. Each key/value pair
+// in the ConfigMap's data is exposed as a parameter to the template. The ConfigMap must exist in the same namespace as
+// the ApplicationSet controller. This is useful for driving Applications from operator-managed configuration (for
+// example values exported into a ConfigMap by Crossplane, Cluster API, or other provisioning tools).
+type ConfigMapGenerator struct {
+	// ConfigMapRef is the name of the ConfigMap to read parameters from.
+	ConfigMapRef string `json:"configMapRef" protobuf:"bytes,1,name=configMapRef"`
+	// Template is an optional override for the ApplicationSet template, applied for this generator only.
+	Template ApplicationSetTemplate `json:"template,omitempty" protobuf:"bytes,2,name=template"`
+	// Values contains key/value pairs which are passed directly as parameters to the template, in addition to the
+	// ConfigMap data.
+	Values map[string]string `json:"values,omitempty" protobuf:"bytes,3,name=values"`
 }
 
 // ApplicationSetStatus defines the observed state of ApplicationSet


### PR DESCRIPTION
Closes #14882

> **Draft** — implementation + unit tests + docs are complete; opening for design confirmation. The generated artifacts (deepcopy, protobuf, CRD, OpenAPI) still need a `make codegen` pass, which I'll push before marking ready.

## What

Adds a first-class `ConfigMap` ApplicationSet generator that reads the `data` of a referenced ConfigMap and exposes each key/value pair as a template parameter (honoring `goTemplate`).

This implements the ConfigMap-as-first-class-generator scope @crenshaw-dev endorsed in #14882 (*"I'd like the ConfigMap feature as first-class. Argo CD really isn't designed to handle secrets, so I don't think I'd want that as a first-class feature."*) — so this is **ConfigMap only; Secrets are intentionally out of scope**.

It's useful for driving Applications from operator-managed config (Crossplane / Cluster API / Azure Service Operator / Pulumi commonly export values into a ConfigMap), without an external config-management plugin.

```yaml
generators:
- configMap:
    configMapRef: guestbook-config   # ConfigMap in the controller's namespace
```

## Implementation

- `applicationset/generators/configmap.go` — implements the `Generator` interface, modeled on the existing Plugin generator (reads the ConfigMap from the controller namespace, exposes `data` as params, supports `values` via `appendTemplatedValues`).
- Registered in `GetGenerators` (terminal / nested / top-level).
- `ConfigMapGenerator` type + `ConfigMap` field added to the generator API structs (`ApplicationSetGenerator`, `…NestedGenerator`, `…TerminalGenerator`) and wired through the terminal→nested conversion.
- Docs: `Generators-ConfigMap.md` + mkdocs nav.

## Tests

`applicationset/generators/configmap_test.go` — 8 cases, all passing: data→params, `values` in both `goTemplate` and fasttemplate modes, empty data, missing `configMapRef`, missing ConfigMap, nil guards, and `GetTemplate`. `go build ./applicationset/...` and the full generators suite are green.

## Open question for maintainers

Does this match the shape you had in mind (@crenshaw-dev)? Happy to add a short `docs/proposals/` doc if preferred before finalizing. Once the design is confirmed I'll run `make codegen` and push the generated files.