### PR TITLE
feat(health): add health checks for Knative Eventing Broker and Trigger

### DIFF
--- a/resource_customizations/eventing.knative.dev/Broker/health.lua
+++ b/resource_customizations/eventing.knative.dev/Broker/health.lua
@@ -1,0 +1,26 @@
+-- Health check for the Knative Eventing Broker CRD.
+-- See https://argo-cd.readthedocs.io/en/stable/operator-manual/health/ for how
+-- custom health checks work and what each status means.
+-- Knative resources expose an aggregate "Ready" status condition (knative duck):
+--   Healthy     - Ready is True.
+--   Degraded    - Ready is False.
+--   Progressing - Ready is Unknown, or status is not populated yet.
+local hs = { status = "Progressing", message = "Waiting for status update." }
+if obj.status ~= nil and obj.status.conditions ~= nil then
+  for i, condition in ipairs(obj.status.conditions) do
+    if condition.type == "Ready" then
+      if condition.status == "True" then
+        hs.status = "Healthy"
+        hs.message = condition.message or "Broker is ready"
+      elseif condition.status == "False" then
+        hs.status = "Degraded"
+        hs.message = condition.message or condition.reason or "Broker is not ready"
+      else
+        hs.status = "Progressing"
+        hs.message = condition.message or condition.reason or "Waiting for status update."
+      end
+      return hs
+    end
+  end
+end
+return hs

--- a/resource_customizations/eventing.knative.dev/Broker/health_test.yaml
+++ b/resource_customizations/eventing.knative.dev/Broker/health_test.yaml
@@ -1,0 +1,13 @@
+tests:
+  - healthStatus:
+      status: Healthy
+      message: "Broker is ready"
+    inputPath: testdata/healthy.yaml
+  - healthStatus:
+      status: Progressing
+      message: "IngressNotConfigured"
+    inputPath: testdata/progressing.yaml
+  - healthStatus:
+      status: Degraded
+      message: "Failed to reconcile Broker ingress deployment"
+    inputPath: testdata/degraded.yaml

--- a/resource_customizations/eventing.knative.dev/Broker/testdata/degraded.yaml
+++ b/resource_customizations/eventing.knative.dev/Broker/testdata/degraded.yaml
@@ -1,0 +1,14 @@
+apiVersion: eventing.knative.dev/v1
+kind: Broker
+metadata:
+  name: default
+  namespace: events
+spec: {}
+status:
+  conditions:
+  - type: IngressReady
+    status: "False"
+  - type: Ready
+    status: "False"
+    reason: IngressFailed
+    message: Failed to reconcile Broker ingress deployment

--- a/resource_customizations/eventing.knative.dev/Broker/testdata/healthy.yaml
+++ b/resource_customizations/eventing.knative.dev/Broker/testdata/healthy.yaml
@@ -1,0 +1,24 @@
+apiVersion: eventing.knative.dev/v1
+kind: Broker
+metadata:
+  name: default
+  namespace: events
+spec:
+  config:
+    apiVersion: v1
+    kind: ConfigMap
+    name: config-br-default-channel
+    namespace: knative-eventing
+status:
+  address:
+    url: http://broker-ingress.knative-eventing.svc.cluster.local/events/default
+  conditions:
+  - type: Addressable
+    status: "True"
+  - type: IngressReady
+    status: "True"
+  - type: Ready
+    status: "True"
+    message: Broker is ready
+  - type: TriggerChannelReady
+    status: "True"

--- a/resource_customizations/eventing.knative.dev/Broker/testdata/progressing.yaml
+++ b/resource_customizations/eventing.knative.dev/Broker/testdata/progressing.yaml
@@ -1,0 +1,13 @@
+apiVersion: eventing.knative.dev/v1
+kind: Broker
+metadata:
+  name: default
+  namespace: events
+spec: {}
+status:
+  conditions:
+  - type: IngressReady
+    status: Unknown
+  - type: Ready
+    status: Unknown
+    reason: IngressNotConfigured

--- a/resource_customizations/eventing.knative.dev/Trigger/health.lua
+++ b/resource_customizations/eventing.knative.dev/Trigger/health.lua
@@ -1,0 +1,26 @@
+-- Health check for the Knative Eventing Trigger CRD.
+-- See https://argo-cd.readthedocs.io/en/stable/operator-manual/health/ for how
+-- custom health checks work and what each status means.
+-- Knative resources expose an aggregate "Ready" status condition (knative duck):
+--   Healthy     - Ready is True.
+--   Degraded    - Ready is False.
+--   Progressing - Ready is Unknown, or status is not populated yet.
+local hs = { status = "Progressing", message = "Waiting for status update." }
+if obj.status ~= nil and obj.status.conditions ~= nil then
+  for i, condition in ipairs(obj.status.conditions) do
+    if condition.type == "Ready" then
+      if condition.status == "True" then
+        hs.status = "Healthy"
+        hs.message = condition.message or "Trigger is ready"
+      elseif condition.status == "False" then
+        hs.status = "Degraded"
+        hs.message = condition.message or condition.reason or "Trigger is not ready"
+      else
+        hs.status = "Progressing"
+        hs.message = condition.message or condition.reason or "Waiting for status update."
+      end
+      return hs
+    end
+  end
+end
+return hs

--- a/resource_customizations/eventing.knative.dev/Trigger/health_test.yaml
+++ b/resource_customizations/eventing.knative.dev/Trigger/health_test.yaml
@@ -1,0 +1,13 @@
+tests:
+  - healthStatus:
+      status: Healthy
+      message: "Trigger is ready"
+    inputPath: testdata/healthy.yaml
+  - healthStatus:
+      status: Progressing
+      message: "BrokerNotReady"
+    inputPath: testdata/progressing.yaml
+  - healthStatus:
+      status: Degraded
+      message: "the status of Dependency Ready is False"
+    inputPath: testdata/degraded.yaml

--- a/resource_customizations/eventing.knative.dev/Trigger/testdata/degraded.yaml
+++ b/resource_customizations/eventing.knative.dev/Trigger/testdata/degraded.yaml
@@ -1,0 +1,15 @@
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: my-service-trigger
+  namespace: events
+spec:
+  broker: default
+status:
+  conditions:
+  - type: DependencyReady
+    status: "False"
+  - type: Ready
+    status: "False"
+    reason: DependencyFailed
+    message: the status of Dependency Ready is False

--- a/resource_customizations/eventing.knative.dev/Trigger/testdata/healthy.yaml
+++ b/resource_customizations/eventing.knative.dev/Trigger/testdata/healthy.yaml
@@ -1,0 +1,23 @@
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: my-service-trigger
+  namespace: events
+spec:
+  broker: default
+  subscriber:
+    ref:
+      apiVersion: v1
+      kind: Service
+      name: my-service
+status:
+  conditions:
+  - type: BrokerReady
+    status: "True"
+  - type: DependencyReady
+    status: "True"
+  - type: Ready
+    status: "True"
+    message: Trigger is ready
+  - type: SubscriberResolved
+    status: "True"

--- a/resource_customizations/eventing.knative.dev/Trigger/testdata/progressing.yaml
+++ b/resource_customizations/eventing.knative.dev/Trigger/testdata/progressing.yaml
@@ -1,0 +1,14 @@
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: my-service-trigger
+  namespace: events
+spec:
+  broker: default
+status:
+  conditions:
+  - type: BrokerReady
+    status: Unknown
+  - type: Ready
+    status: Unknown
+    reason: BrokerNotReady


### PR DESCRIPTION
## What

Adds resource health checks for the Knative Eventing CRDs (`eventing.knative.dev`): `Broker` and `Trigger`. Argo CD already covers `serving.knative.dev/Service`, but not the eventing group, so Brokers and Triggers showed no health status in the UI.

## Behavior

Knative resources expose an aggregate `Ready` status condition (the knative duck type), so each check reads it directly:
- **Healthy** — `Ready` is `True`.
- **Degraded** — `Ready` is `False` (surfaces the condition message/reason).
- **Progressing** — `Ready` is `Unknown`, or status is not yet populated.

## Tests

Added `health_test.yaml` + `healthy` / `progressing` / `degraded` fixtures for each kind. `TestLuaHealthScript` passes all six subtests.