### PR TITLE
docs: clarify namespaceResourceWhitelist affects UI resource tree

### DIFF
--- a/docs/operator-manual/declarative-setup.md
+++ b/docs/operator-manual/declarative-setup.md
@@ -170,6 +170,8 @@ spec:
     - iat: 1535390316
 ```
 
+`namespaceResourceWhitelist` also determines which child resources are visible in the Application resource tree in the UI. To observe workload children such as `Pod` and `apps/ReplicaSet` under a `Deployment`, those GroupKinds must be included in the whitelist. See [Projects](../user-guide/projects.md) for details.
+
 ## Repositories
 
 > [!NOTE]

--- a/docs/user-guide/projects.md
+++ b/docs/user-guide/projects.md
@@ -133,6 +133,8 @@ argocd proj deny-cluster-resource <PROJECT> <GROUP> <KIND>
 argocd proj deny-namespace-resource <PROJECT> <GROUP> <KIND> [<NAME>]
 ```
 
+When a project uses `namespaceResourceWhitelist`, the whitelist also controls which child resources appear in the Application resource tree in the UI. Any child resource whose GroupKind is not permitted by the project is omitted from the tree, even if it exists and is healthy in the cluster. For example, if the whitelist includes only `apps/Deployment` and `Service`, the Deployment node is shown but its `ReplicaSet` and `Pod` children are hidden until `apps/ReplicaSet` and `Pod` are added to the whitelist. This filtering does not affect sync permissions for resources already deployed; it only affects observability in the resource tree.
+
 #### Restrict Cluster-Scoped Resources by Name
 
 Since the names of certain cluster-scoped resources such as Namespaces and CustomResourceDefinitions (CRDs) have special


### PR DESCRIPTION
## Summary
- Document that `namespaceResourceWhitelist` also controls which child resources are visible in the Application resource tree in the UI
- Cross-reference the behavior from `declarative-setup.md`

Fixes #28564

## Test plan
- [x] Verified documentation renders correctly
- [x] Confirmed wording matches the behavior described in the issue


Made with [Cursor](https://cursor.com)