### PR TITLE
fix(cli): support multiple --header flags in ARGOCD_OPTS

### DIFF
--- a/util/config/env.go
+++ b/util/config/env.go
@@ -11,7 +11,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var flags map[string]string
+var flags map[string][]string
 
 func init() {
 	err := LoadFlags()
@@ -21,7 +21,7 @@ func init() {
 }
 
 func LoadFlags() error {
-	flags = make(map[string]string)
+	flags = make(map[string][]string)
 
 	opts, err := shellquote.Split(os.Getenv("ARGOCD_OPTS"))
 	if err != nil {
@@ -33,27 +33,27 @@ func LoadFlags() error {
 		switch {
 		case strings.HasPrefix(opt, "--"):
 			if key != "" {
-				flags[key] = "true"
+				flags[key] = append(flags[key], "true")
 			}
 			key = strings.TrimPrefix(opt, "--")
 		case key != "":
-			flags[key] = opt
+			flags[key] = append(flags[key], opt)
 			key = ""
 		default:
 			return errors.New("ARGOCD_OPTS invalid at '" + opt + "'")
 		}
 	}
 	if key != "" {
-		flags[key] = "true"
+		flags[key] = append(flags[key], "true")
 	}
 	// pkg shellquota doesn't recognize `=` so that the opts in format `foo=bar` could not work.
 	// issue ref: https://github.com/argoproj/argo-cd/issues/6822
-	for k, v := range flags {
-		if strings.Contains(k, "=") && v == "true" {
+	for k, vals := range flags {
+		if strings.Contains(k, "=") && len(vals) > 0 && vals[len(vals)-1] == "true" {
 			kv := strings.SplitN(k, "=", 2)
 			actualKey, actualValue := kv[0], kv[1]
 			if _, ok := flags[actualKey]; !ok {
-				flags[actualKey] = actualValue
+				flags[actualKey] = []string{actualValue}
 			}
 		}
 	}
@@ -61,11 +61,11 @@ func LoadFlags() error {
 }
 
 func GetFlag(key, fallback string) string {
-	val, ok := flags[key]
-	if ok {
-		return val
+	vals, ok := flags[key]
+	if !ok || len(vals) == 0 {
+		return fallback
 	}
-	return fallback
+	return vals[len(vals)-1]
 }
 
 func GetBoolFlag(key string) bool {
@@ -74,11 +74,11 @@ func GetBoolFlag(key string) bool {
 
 func GetIntFlag(key string, fallback int) int {
 	val, ok := flags[key]
-	if !ok {
+	if !ok || len(val) == 0 {
 		return fallback
 	}
 
-	v, err := strconv.Atoi(val)
+	v, err := strconv.Atoi(val[len(val)-1])
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -86,11 +86,16 @@ func GetIntFlag(key string, fallback int) int {
 }
 
 func GetStringSliceFlag(key string, fallback []string) []string {
-	val, ok := flags[key]
-	if !ok {
+	vals, ok := flags[key]
+	if !ok || len(vals) == 0 {
 		return fallback
 	}
 
+	if len(vals) > 1 {
+		return vals
+	}
+
+	val := vals[0]
 	if val == "" {
 		return []string{}
 	}

--- a/util/config/env_test.go
+++ b/util/config/env_test.go
@@ -113,6 +113,15 @@ func TestStringSliceFlagAtEnd(t *testing.T) {
 	assert.Equal(t, "Strict-Transport-Security: max-age=31536000", strings[0])
 }
 
+func TestStringSliceFlagMultipleHeaders(t *testing.T) {
+	loadOpts(t, `--header "CF-Access-Client-Id: foo" --header "CF-Access-Client-Secret: bar"`)
+	strings := GetStringSliceFlag("header", []string{})
+
+	assert.Len(t, strings, 2)
+	assert.Equal(t, "CF-Access-Client-Id: foo", strings[0])
+	assert.Equal(t, "CF-Access-Client-Secret: bar", strings[1])
+}
+
 func TestFlagAtStart(t *testing.T) {
 	loadOpts(t, "--foo bar")
 


### PR DESCRIPTION
## Summary
- Store `ARGOCD_OPTS` values as slices so repeated flags like `--header` are accumulated instead of overwritten
- Add unit test covering multiple `--header` values via `ARGOCD_OPTS`

Fixes #24065

## Test plan
- [x] Added `TestStringSliceFlagMultipleHeaders` in `util/config/env_test.go`
- [ ] `go test ./util/config/...`


Made with [Cursor](https://cursor.com)