### PR TITLE
docs: clarify namespaceResourceWhitelist affects UI resource tree visibility

### DIFF
--- a/docs/operator-manual/declarative-setup.md
+++ b/docs/operator-manual/declarative-setup.md
@@ -169,6 +169,12 @@ spec:
     jwtTokens:
     - iat: 1535390316
 ```
+> [!NOTE]
+> `namespaceResourceWhitelist` and `namespaceResourceBlacklist` do more than
+> control what is allowed to sync into the cluster. They also determine which
+> child resource kinds (for example `Pod` or `ReplicaSet` under a `Deployment`)
+> are shown in the Application's resource tree in the Argo CD UI. See
+> [Managing Projects](../user-guide/projects.md#managing-projects) for details.
 
 ## Repositories
 

--- a/docs/user-guide/projects.md
+++ b/docs/user-guide/projects.md
@@ -132,6 +132,14 @@ argocd proj allow-namespace-resource <PROJECT> <GROUP> <KIND> [<NAME>]
 argocd proj deny-cluster-resource <PROJECT> <GROUP> <KIND>
 argocd proj deny-namespace-resource <PROJECT> <GROUP> <KIND> [<NAME>]
 ```
+!!! note
+    `namespaceResourceWhitelist` (and `namespaceResourceBlacklist`) do not only
+    control what is allowed to sync into the cluster. They also determine which
+    resource kinds are displayed in the Application's resource tree in the Argo CD
+    UI. If a child resource's `Group/Kind` (for example `Pod` or `ReplicaSet`) is
+    not permitted by the project, that resource will still exist and run normally
+    in the cluster, but it will be hidden from the resource tree until its
+    `Group/Kind` is added to the whitelist.
 
 #### Restrict Cluster-Scoped Resources by Name
 


### PR DESCRIPTION
Fixes #28564

## Description

This is a docs-only change. `namespaceResourceWhitelist` (and
`namespaceResourceBlacklist`) are documented purely as deploy-time
sync restrictions, but they also silently filter which resource
kinds show up in the Application's resource tree in the UI. If a
child resource's Group/Kind isn't whitelisted, it's hidden from the
tree even though it exists and is running fine in the cluster —
which looks like a bug but isn't.

Added a note explaining this in `docs/user-guide/projects.md`, and
cross-referenced it from `docs/operator-manual/declarative-setup.md`
so both places point to the same explanation.

## Checklist
- [x] Either (a) I've created an [enhancement proposal] and discussed
  it with the community, (b) this is a bug fix, or (c) this does not
  need to be discussed
- [x] The title of the PR states what changed and the related issues
  number
- [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the
  description
- [x] I've updated both the CLI and UI to expose my feature (n/a — docs only)
- [x] I've made sure tests are passing and test coverage is added if
  needed (n/a — docs only)