### PR TITLE
fix(ui): filter project source repository autocomplete suggestions

### DIFF
--- a/ui/src/app/settings/components/project-details/project-details.tsx
+++ b/ui/src/app/settings/components/project-details/project-details.tsx
@@ -400,7 +400,7 @@ export const ProjectDetails: React.FC<RouteComponentProps<{name: string}> & {obj
                                                     formApi={formApi}
                                                     field={`spec.sourceRepos[${i}]`}
                                                     component={AutocompleteField}
-                                                    componentProps={{items: repos.map(repo => repo.repo)}}
+                                                    componentProps={{items: repos.map(repo => repo.repo), filterSuggestions: true}}
                                                 />
                                                 <i className='fa fa-times' onClick={() => formApi.setValue('spec.sourceRepos', removeEl(formApi.values.spec.sourceRepos, i))} />
                                             </div>


### PR DESCRIPTION
## Summary

- Enable `filterSuggestions` on the Project **Source Repositories** `AutocompleteField` so the suggestion list narrows while typing.
- Matches the Application create form behavior; glob patterns like `*` remain fully typeable.

Fixes #28577

## Test plan

- [ ] Configure two or more repositories under Settings → Repositories
- [ ] Open Settings → Projects → edit Source Repositories → ADD SOURCE
- [ ] Type part of a repo URL and confirm the dropdown filters to matching entries
- [ ] Confirm free-text glob patterns (e.g. `https://github.com/org/*`) still work