### PR TITLE
feat(ui): add skip schema validation toggle to Application parameters editor (#5111)

### DIFF
--- a/ui/src/app/applications/components/application-parameters/application-parameters.tsx
+++ b/ui/src/app/applications/components/application-parameters/application-parameters.tsx
@@ -346,7 +346,7 @@ export const ApplicationParameters = (props: {
                 <EditablePanel
                     save={
                         props.save &&
-                        (async (input: models.Application) => {
+                        (async (input: models.Application, query: {validate?: boolean}) => {
                             const updatedSrc = isMulti ? input.spec.sources[ind] : input.spec.source;
 
                             function isDefined(item: any) {
@@ -392,7 +392,7 @@ export const ApplicationParameters = (props: {
                                 updatedSrc.helm.valuesObject = jsYaml.load(updatedSrc.helm.values); // Deserialize json
                                 updatedSrc.helm.values = '';
                             }
-                            await props.save(input, {});
+                            await props.save(input, query);
                             setRemovedOverrides(new Array<boolean>());
                         })
                     }
@@ -423,6 +423,7 @@ export const ApplicationParameters = (props: {
                     items={items as EditablePanelItem[]}
                     noReadonlyMode={props.noReadonlyMode}
                     hasMultipleSources={false}
+                    showValidationToggle={true}
                 />
             </div>
         );

--- a/ui/src/app/applications/components/application-parameters/application-parameters.tsx
+++ b/ui/src/app/applications/components/application-parameters/application-parameters.tsx
@@ -359,7 +359,7 @@ export const ApplicationParameters = (props: {
                 <EditablePanel
                     save={
                         props.save &&
-                        (async (input: models.Application) => {
+                        (async (input: models.Application, query: {validate?: boolean}) => {
                             const updatedSrc = isMulti ? input.spec.sources[ind] : input.spec.source;
 
                             function isDefined(item: any) {
@@ -405,7 +405,7 @@ export const ApplicationParameters = (props: {
                                 updatedSrc.helm.valuesObject = jsYaml.load(updatedSrc.helm.values); // Deserialize json
                                 updatedSrc.helm.values = '';
                             }
-                            await props.save(input, {});
+                            await props.save(input, query);
                             setRemovedOverrides(new Array<boolean>());
                         })
                     }
@@ -436,6 +436,7 @@ export const ApplicationParameters = (props: {
                     items={items as EditablePanelItem[]}
                     noReadonlyMode={props.noReadonlyMode}
                     hasMultipleSources={false}
+                    showValidationToggle={true}
                 />
             </div>
         );

--- a/ui/src/app/shared/components/editable-panel/__tests__/editable-panel.test.tsx
+++ b/ui/src/app/shared/components/editable-panel/__tests__/editable-panel.test.tsx
@@ -345,3 +345,46 @@ describe('EditablePanel – collapsible behavior', () => {
         expect(editButton.disabled).toBe(true);
     });
 });
+
+// ===========================================================================
+// 2f. Skip Schema Validation toggle
+// ===========================================================================
+
+describe('EditablePanel – skip schema validation toggle', () => {
+    test('toggle is not rendered by default in edit mode', () => {
+        renderPanel(
+            <EditablePanel values={{name: 'alice'}} items={basicItems} save={jest.fn().mockResolvedValue(undefined)} />
+        );
+        act(() => { fireEvent.click(screen.getByRole('button', {name: /Edit/i})); });
+        expect(screen.queryByLabelText('Skip Schema Validation')).toBeFalsy();
+    });
+
+    test('toggle is rendered in edit mode when showValidationToggle=true', () => {
+        renderPanel(
+            <EditablePanel values={{name: 'alice'}} items={basicItems} save={jest.fn().mockResolvedValue(undefined)} showValidationToggle={true} />
+        );
+        act(() => { fireEvent.click(screen.getByRole('button', {name: /Edit/i})); });
+        expect(screen.queryByLabelText('Skip Schema Validation')).toBeTruthy();
+    });
+
+    test('save passes {validate: true} when toggle is left unchecked', async () => {
+        const save = jest.fn().mockResolvedValue(undefined);
+        renderPanel(
+            <EditablePanel values={{name: 'alice'}} items={basicItems} save={save} showValidationToggle={true} />
+        );
+        act(() => { fireEvent.click(screen.getByRole('button', {name: /Edit/i})); });
+        await act(async () => { fireEvent.click(screen.getByRole('button', {name: /Save/i})); });
+        expect(save).toHaveBeenCalledWith(expect.anything(), {validate: true});
+    });
+
+    test('save passes {validate: false} after checking the toggle', async () => {
+        const save = jest.fn().mockResolvedValue(undefined);
+        renderPanel(
+            <EditablePanel values={{name: 'alice'}} items={basicItems} save={save} showValidationToggle={true} />
+        );
+        act(() => { fireEvent.click(screen.getByRole('button', {name: /Edit/i})); });
+        act(() => { fireEvent.click(screen.getByLabelText('Skip Schema Validation')); });
+        await act(async () => { fireEvent.click(screen.getByRole('button', {name: /Save/i})); });
+        expect(save).toHaveBeenCalledWith(expect.anything(), {validate: false});
+    });
+});

--- a/ui/src/app/shared/components/editable-panel/__tests__/editable-panel.test.tsx
+++ b/ui/src/app/shared/components/editable-panel/__tests__/editable-panel.test.tsx
@@ -343,3 +343,46 @@ describe('EditablePanel – collapsible behavior', () => {
         expect(editButton.disabled).toBe(true);
     });
 });
+
+// ===========================================================================
+// 2f. Skip Schema Validation toggle
+// ===========================================================================
+
+describe('EditablePanel – skip schema validation toggle', () => {
+    test('toggle is not rendered by default in edit mode', () => {
+        renderPanel(
+            <EditablePanel values={{name: 'alice'}} items={basicItems} save={jest.fn().mockResolvedValue(undefined)} />
+        );
+        act(() => { fireEvent.click(screen.getByRole('button', {name: /Edit/i})); });
+        expect(screen.queryByLabelText('Skip Schema Validation')).toBeFalsy();
+    });
+
+    test('toggle is rendered in edit mode when showValidationToggle=true', () => {
+        renderPanel(
+            <EditablePanel values={{name: 'alice'}} items={basicItems} save={jest.fn().mockResolvedValue(undefined)} showValidationToggle={true} />
+        );
+        act(() => { fireEvent.click(screen.getByRole('button', {name: /Edit/i})); });
+        expect(screen.queryByLabelText('Skip Schema Validation')).toBeTruthy();
+    });
+
+    test('save passes {validate: true} when toggle is left unchecked', async () => {
+        const save = jest.fn().mockResolvedValue(undefined);
+        renderPanel(
+            <EditablePanel values={{name: 'alice'}} items={basicItems} save={save} showValidationToggle={true} />
+        );
+        act(() => { fireEvent.click(screen.getByRole('button', {name: /Edit/i})); });
+        await act(async () => { fireEvent.click(screen.getByRole('button', {name: /Save/i})); });
+        expect(save).toHaveBeenCalledWith(expect.anything(), {validate: true});
+    });
+
+    test('save passes {validate: false} after checking the toggle', async () => {
+        const save = jest.fn().mockResolvedValue(undefined);
+        renderPanel(
+            <EditablePanel values={{name: 'alice'}} items={basicItems} save={save} showValidationToggle={true} />
+        );
+        act(() => { fireEvent.click(screen.getByRole('button', {name: /Edit/i})); });
+        act(() => { fireEvent.click(screen.getByLabelText('Skip Schema Validation')); });
+        await act(async () => { fireEvent.click(screen.getByRole('button', {name: /Save/i})); });
+        expect(save).toHaveBeenCalledWith(expect.anything(), {validate: false});
+    });
+});

--- a/ui/src/app/shared/components/editable-panel/editable-panel.scss
+++ b/ui/src/app/shared/components/editable-panel/editable-panel.scss
@@ -12,6 +12,16 @@
         position: absolute;
         top: 30px;
         right: 3em;
+        white-space: nowrap;
+    }
+
+    &__validation-toggle {
+        margin-right: 1em;
+        white-space: nowrap;
+
+        label {
+            margin-left: 0.3em;
+        }
     }
 
     &__divider {

--- a/ui/src/app/shared/components/editable-panel/editable-panel.scss
+++ b/ui/src/app/shared/components/editable-panel/editable-panel.scss
@@ -13,6 +13,16 @@
         top: 30px;
         right: 3em;
         z-index: 12; // above the sticky title
+        white-space: nowrap;
+    }
+
+    &__validation-toggle {
+        margin-right: 1em;
+        white-space: nowrap;
+
+        label {
+            margin-left: 0.3em;
+        }
     }
 
     &__divider {

--- a/ui/src/app/shared/components/editable-panel/editable-panel.tsx
+++ b/ui/src/app/shared/components/editable-panel/editable-panel.tsx
@@ -1,4 +1,4 @@
-import {ErrorNotification, HelpIcon, NotificationType} from 'argo-ui';
+import {Checkbox, ErrorNotification, HelpIcon, NotificationType} from 'argo-ui';
 import classNames from 'classnames';
 import * as React from 'react';
 import {type ReactNode, useCallback, useContext, useEffect, useRef, useState, Fragment} from 'react';
@@ -47,6 +47,7 @@ export interface EditablePanelProps<T> {
     collapsible?: boolean;
     collapsed?: boolean;
     collapsedDescription?: string;
+    showValidationToggle?: boolean;
 }
 
 function EditablePanel<T extends {} = {}>({
@@ -64,10 +65,12 @@ function EditablePanel<T extends {} = {}>({
     hasMultipleSources,
     collapsible,
     collapsed: collapsedProp = false,
-    collapsedDescription
+    collapsedDescription,
+    showValidationToggle
 }: EditablePanelProps<T>) {
     const [isEditing, setIsEditing] = useState<boolean>(!!noReadonlyMode);
     const [isSaving, setIsSaving] = useState<boolean>(false);
+    const [skipValidation, setSkipValidation] = useState<boolean>(false);
     const [isCollapsed, setIsCollapsed] = useState<boolean>(collapsedProp);
     const ctx = useContext(Context);
     const formApiRef = useRef<FormApi | null>(null);
@@ -102,8 +105,9 @@ function EditablePanel<T extends {} = {}>({
             if (!save) return;
             try {
                 setIsSaving(true);
-                await save(input, {});
+                await save(input, showValidationToggle ? {validate: !skipValidation} : {});
                 setIsEditing(false);
+                setSkipValidation(false);
                 setIsSaving(false);
                 onModeSwitch();
             } catch (e) {
@@ -115,11 +119,12 @@ function EditablePanel<T extends {} = {}>({
                 setIsSaving(false);
             }
         },
-        [save, onModeSwitch, ctx.notifications]
+        [save, onModeSwitch, ctx.notifications, showValidationToggle, skipValidation]
     );
 
     const handleCancel = useCallback(() => {
         setIsEditing(false);
+        setSkipValidation(false);
         onModeSwitch();
     }, [onModeSwitch]);
 
@@ -195,6 +200,12 @@ function EditablePanel<T extends {} = {}>({
                                 )}
                                 {isEditing && (
                                     <>
+                                        {showValidationToggle && (
+                                            <span className='editable-panel__validation-toggle'>
+                                                <Checkbox id='editable-panel-skip-validation' checked={skipValidation} onChange={setSkipValidation} />
+                                                <label htmlFor='editable-panel-skip-validation'>Skip Schema Validation</label>{' '}
+                                            </span>
+                                        )}
                                         <button disabled={isSaving} onClick={() => !isSaving && formApiRef.current?.submitForm(null)} className='argo-button argo-button--base'>
                                             <Spinner show={isSaving} style={{marginRight: '5px'}} />
                                             Save

--- a/ui/src/app/shared/components/editable-panel/editable-panel.tsx
+++ b/ui/src/app/shared/components/editable-panel/editable-panel.tsx
@@ -1,4 +1,4 @@
-import {ErrorNotification, HelpIcon, NotificationType} from 'argo-ui';
+import {Checkbox, ErrorNotification, HelpIcon, NotificationType} from 'argo-ui';
 import classNames from 'classnames';
 import * as React from 'react';
 import {type ReactNode, useCallback, useContext, useEffect, useRef, useState, Fragment} from 'react';
@@ -47,6 +47,7 @@ export interface EditablePanelProps<T> {
     collapsible?: boolean;
     collapsed?: boolean;
     collapsedDescription?: string;
+    showValidationToggle?: boolean;
 }
 
 function EditablePanel<T extends {} = {}>({
@@ -64,10 +65,12 @@ function EditablePanel<T extends {} = {}>({
     hasMultipleSources,
     collapsible,
     collapsed: collapsedProp = false,
-    collapsedDescription
+    collapsedDescription,
+    showValidationToggle
 }: EditablePanelProps<T>) {
     const [isEditing, setIsEditing] = useState<boolean>(!!noReadonlyMode);
     const [isSaving, setIsSaving] = useState<boolean>(false);
+    const [skipValidation, setSkipValidation] = useState<boolean>(false);
     const [isCollapsed, setIsCollapsed] = useState<boolean>(collapsedProp);
     const [prevCollapsedProp, setPrevCollapsedProp] = useState<boolean>(collapsedProp);
     const ctx = useContext(Context);
@@ -106,8 +109,9 @@ function EditablePanel<T extends {} = {}>({
             if (!save) return;
             try {
                 setIsSaving(true);
-                await save(input, {});
+                await save(input, showValidationToggle ? {validate: !skipValidation} : {});
                 setIsEditing(false);
+                setSkipValidation(false);
                 setIsSaving(false);
                 onModeSwitch();
             } catch (e) {
@@ -119,11 +123,12 @@ function EditablePanel<T extends {} = {}>({
                 setIsSaving(false);
             }
         },
-        [save, onModeSwitch, ctx.notifications]
+        [save, onModeSwitch, ctx.notifications, showValidationToggle, skipValidation]
     );
 
     const handleCancel = useCallback(() => {
         setIsEditing(false);
+        setSkipValidation(false);
         onModeSwitch();
     }, [onModeSwitch]);
 
@@ -199,6 +204,12 @@ function EditablePanel<T extends {} = {}>({
                                 )}
                                 {isEditing && (
                                     <>
+                                        {showValidationToggle && (
+                                            <span className='editable-panel__validation-toggle'>
+                                                <Checkbox id='editable-panel-skip-validation' checked={skipValidation} onChange={setSkipValidation} />
+                                                <label htmlFor='editable-panel-skip-validation'>Skip Schema Validation</label>{' '}
+                                            </span>
+                                        )}
                                         <button disabled={isSaving} onClick={() => !isSaving && formApiRef.current?.submitForm(null)} className='argo-button argo-button--base'>
                                             <Spinner show={isSaving} style={{marginRight: '5px'}} />
                                             Save


### PR DESCRIPTION
## What / Why

Adds a **Skip Schema Validation** checkbox to the Application **Parameters** tab editor. When checked, saving parameter changes sends `validate=false` to the update API, skipping server-side schema validation — matching the existing `argocd app set --validate=false` CLI capability, which previously had no UI equivalent.

This speeds up common edits (e.g. bumping an image tag) as requested in #5111, where a maintainer confirmed the intent is a skip-validation toggle when editing parameters in the Parameters/Manifest tab (distinct from the sync-operation "Skip Schema Validation" option).

Scope: the single-source Parameters editor (the default for most apps). The multi-source source editor and the Manifest tab are left as follow-ups to keep this PR focused.

## How

- `EditablePanel` gains an opt-in `showValidationToggle` prop; when set it renders the checkbox in edit mode and forwards `{validate: !skipValidation}` to its `save` handler. All other consumers are unchanged (still send `{}`).
- `application-parameters.tsx` enables the toggle on the parameters panel and forwards the query to the update call. The unchecked default sends `validate=true`, which the server treats identically to the previous no-param behavior (`server/application/application.go` defaults `validate := true`).

Closes #5111

## Checklist

- [x] The title of the PR states what changed and the related issue number (used for the release note).
- [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr) convention.
- [x] I've included "Closes #5111" in the description to automatically close the associated issue.
- [x] I've updated the UI to expose my feature; the CLI already supports `--validate=false` on `argocd app set`.
- [ ] Does this PR require documentation updates? — UI-only toggle, no docs change needed.
- [x] I have signed off all my commits as required by DCO.
- [x] I have written unit tests for my change (`editable-panel.test.tsx`: toggle visibility + `validate` true/false forwarded on save).
- [x] My build is green — `pnpm lint`, `pnpm test`, and `pnpm build` all pass locally.
- [x] I have added a brief description of why this PR is necessary and what it solves.
