### PR TITLE
fix: strip managedFields from manifest before apply (fixes SSA "managedFields must be nil")

### DIFF
--- a/gitops-engine/pkg/utils/kube/resource_ops.go
+++ b/gitops-engine/pkg/utils/kube/resource_ops.go
@@ -147,6 +147,18 @@ func maybeLogManifest(manifestBytes []byte, log logr.Logger) error {
 }
 
 func createManifestFile(obj *unstructured.Unstructured, log logr.Logger) (*os.File, error) {
+	// metadata.managedFields is server-managed and must never be part of a
+	// submitted manifest. A server-side apply request that carries it is
+	// rejected by the API server with "metadata.managedFields must be nil"
+	// (client-side apply tolerates it but does not use it). This can happen
+	// when the object handed to an apply path still has managedFields
+	// populated (e.g. sourced from live state), so strip it here — the single
+	// serialization point shared by every apply path. Copy first so the
+	// caller's object is left untouched.
+	if len(obj.GetManagedFields()) > 0 {
+		obj = obj.DeepCopy()
+		obj.SetManagedFields(nil)
+	}
 	manifestBytes, err := json.Marshal(obj)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal object: %w", err)

--- a/gitops-engine/pkg/utils/kube/resource_ops_test.go
+++ b/gitops-engine/pkg/utils/kube/resource_ops_test.go
@@ -2,6 +2,7 @@ package kube
 
 import (
 	"encoding/json"
+	"os"
 	"testing"
 
 	"github.com/argoproj/argo-cd/gitops-engine/pkg/utils/kube/mocks"
@@ -11,6 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/client-go/kubernetes"
@@ -545,5 +548,66 @@ func TestReplaceOptionsConfiguration(t *testing.T) {
 				assert.Equal(t, tc.expected, capturedOpts.DeleteOptions.ForceDeletion)
 			})
 		}
+	})
+}
+
+func TestCreateManifestFile(t *testing.T) {
+	t.Parallel()
+
+	// A server-side apply request that carries metadata.managedFields is
+	// rejected by the API server with "metadata.managedFields must be nil".
+	// managedFields is server-managed and must never reach the applied
+	// manifest, so createManifestFile must strip it from the serialized output
+	// while leaving the caller's object untouched.
+	t.Run("strips managedFields from the serialized manifest", func(t *testing.T) {
+		t.Parallel()
+		obj := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Namespace",
+			"metadata":   map[string]any{"name": "test-ns"},
+		}}
+		obj.SetManagedFields([]metav1.ManagedFieldsEntry{
+			{Manager: "before-first-apply", Operation: metav1.ManagedFieldsOperationUpdate, APIVersion: "v1"},
+			{Manager: "argocd-controller", Operation: metav1.ManagedFieldsOperationApply, APIVersion: "v1"},
+		})
+		require.NotEmpty(t, obj.GetManagedFields(), "precondition: object has managedFields")
+
+		f, err := createManifestFile(obj, logr.Discard())
+		require.NoError(t, err)
+		defer os.Remove(f.Name())
+
+		data, err := os.ReadFile(f.Name())
+		require.NoError(t, err)
+
+		var written unstructured.Unstructured
+		require.NoError(t, json.Unmarshal(data, &written))
+		assert.Empty(t, written.GetManagedFields(), "serialized manifest must not contain managedFields")
+		assert.Equal(t, "test-ns", written.GetName(), "the rest of the object must be preserved")
+
+		assert.NotEmpty(t, obj.GetManagedFields(), "caller's object must not be mutated")
+	})
+
+	t.Run("serializes an object without managedFields unchanged", func(t *testing.T) {
+		t.Parallel()
+		obj := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata":   map[string]any{"name": "cm", "namespace": "default"},
+			"data":       map[string]any{"key": "value"},
+		}}
+
+		f, err := createManifestFile(obj, logr.Discard())
+		require.NoError(t, err)
+		defer os.Remove(f.Name())
+
+		data, err := os.ReadFile(f.Name())
+		require.NoError(t, err)
+
+		var written unstructured.Unstructured
+		require.NoError(t, json.Unmarshal(data, &written))
+		assert.Empty(t, written.GetManagedFields())
+		assert.Equal(t, "cm", written.GetName())
+		val, _, _ := unstructured.NestedString(written.Object, "data", "key")
+		assert.Equal(t, "value", val)
 	})
 }


### PR DESCRIPTION
## Problem

Syncing a resource with `ServerSideApply=true` fails with:

```
Error from server (BadRequest): metadata.managedFields must be nil
```

This happens when the object being applied still carries
`metadata.managedFields` — most commonly a resource that has a
`before-first-apply` field manager after a client-side → server-side apply
migration. Clearing managedFields by hand lets one sync succeed, but they
repopulate and the next sync fails again. Reported in discussion #20749
(Unanswered).

## Root cause

A server-side apply request whose body contains `metadata.managedFields` is
rejected by the API server — SSA requires the field to be nil in the request.
`createManifestFile` (the single serialization point shared by every kubectl
apply path in gitops-engine) marshals the object verbatim, so if it still
carries managedFields they end up in the apply payload and the API server
rejects it.

The server-side **diff** path already strips managedFields
(`pkg/diff/diff.go`); the **apply** path never did.

I verified the trigger directly against a live cluster (kind, k8s v1.36): a
manifest carrying managedFields is accepted by CREATE, REPLACE (PUT) and
client-side apply, and rejected **only** by server-side apply, with exactly
`metadata.managedFields must be nil`.

## Fix

Strip `metadata.managedFields` in `createManifestFile` before serialization.
managedFields is server-managed and must never appear in a submitted manifest.
The object is deep-copied first so the caller's object is left untouched, and
the copy is only taken when managedFields are present (the common case — a
manifest rendered from Git — is unaffected).

## Tests

- New `TestCreateManifestFile`: managedFields are stripped from the serialized
  manifest, the caller's object is not mutated, and objects without
  managedFields are serialized unchanged.
- `go test ./pkg/utils/kube/... ./pkg/sync/... ./pkg/diff/...` all pass;
  `gofmt` / `go vet` clean.

## AI assistance disclosure

Per the argoproj Generative AI contribution policy: this change was developed
with AI assistance. I reviewed the code and tests, ran the test suite and a
live reproduction, and take full responsibility for the contribution.
