### PR TITLE
fix(gitops-engine): hooks requiring name generation should use existing api-server logic to avoid invalid characters

### DIFF
--- a/gitops-engine/pkg/sync/sync_context.go
+++ b/gitops-engine/pkg/sync/sync_context.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"k8s.io/apiserver/pkg/storage/names"
+
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -950,6 +952,11 @@ func (sc *syncContext) containsResource(resource reconciledResource) bool {
 	return sc.resourcesFilter == nil || sc.resourcesFilter(resource.key(), resource.Target, resource.Live)
 }
 
+func generateHookName(generateName string) string {
+	baseName := strings.TrimSuffix(generateName, "-")
+	return names.SimpleNameGenerator.GenerateName(baseName)
+}
+
 // generates the list of sync tasks we will be performing during this sync.
 func (sc *syncContext) getSyncTasks(ctx context.Context) (_ syncTasks, successful bool) {
 	resourceTasks := syncTasks{}
@@ -985,15 +992,7 @@ func (sc *syncContext) getSyncTasks(ctx context.Context) (_ syncTasks, successfu
 				// metadata.generateName, then we will generate a formulated metadata.name before submission.
 				targetObj := obj.DeepCopy()
 				if targetObj.GetName() == "" {
-					var syncRevision string
-					if len(sc.revision) >= 8 {
-						syncRevision = sc.revision[0:7]
-					} else {
-						syncRevision = sc.revision
-					}
-					postfix := strings.ToLower(fmt.Sprintf("%s-%s-%d", syncRevision, phase, sc.startedAt.UTC().Unix()))
-					generateName := obj.GetGenerateName()
-					targetObj.SetName(fmt.Sprintf("%s%s", generateName, postfix))
+					targetObj.SetName(generateHookName(targetObj.GetGenerateName()))
 				}
 				if !hook.HasHookFinalizer(targetObj) {
 					targetObj.SetFinalizers(append(targetObj.GetFinalizers(), hook.HookFinalizer))

--- a/gitops-engine/pkg/sync/sync_context.go
+++ b/gitops-engine/pkg/sync/sync_context.go
@@ -953,8 +953,7 @@ func (sc *syncContext) containsResource(resource reconciledResource) bool {
 }
 
 func generateHookName(generateName string) string {
-	baseName := strings.TrimSuffix(generateName, "-")
-	return names.SimpleNameGenerator.GenerateName(baseName)
+	return names.SimpleNameGenerator.GenerateName(generateName)
 }
 
 // generates the list of sync tasks we will be performing during this sync.

--- a/gitops-engine/pkg/sync/sync_context_test.go
+++ b/gitops-engine/pkg/sync/sync_context_test.go
@@ -1349,7 +1349,7 @@ func TestSelectiveSyncOnly(t *testing.T) {
 }
 
 func TestUnnamedHooksGetUniqueNames(t *testing.T) {
-	t.Run("revision", func(t *testing.T) {
+	t.Run("generateName not set", func(t *testing.T) {
 		syncCtx := newTestSyncCtx(nil)
 
 		pod := testingutils.NewPod()
@@ -1366,7 +1366,7 @@ func TestUnnamedHooksGetUniqueNames(t *testing.T) {
 		assert.Empty(t, pod.GetName())
 	})
 
-	t.Run("revision", func(t *testing.T) {
+	t.Run("generateName set", func(t *testing.T) {
 		syncCtx := newTestSyncCtx(nil)
 
 		pod := testingutils.NewPod()

--- a/gitops-engine/pkg/sync/sync_context_test.go
+++ b/gitops-engine/pkg/sync/sync_context_test.go
@@ -1349,7 +1349,7 @@ func TestSelectiveSyncOnly(t *testing.T) {
 }
 
 func TestUnnamedHooksGetUniqueNames(t *testing.T) {
-	t.Run("Truncated revision", func(t *testing.T) {
+	t.Run("revision", func(t *testing.T) {
 		syncCtx := newTestSyncCtx(nil)
 
 		pod := testingutils.NewPod()
@@ -1361,24 +1361,28 @@ func TestUnnamedHooksGetUniqueNames(t *testing.T) {
 
 		assert.True(t, successful)
 		assert.Len(t, tasks, 2)
-		assert.Contains(t, tasks[0].name(), "foobarb-presync-")
-		assert.Contains(t, tasks[1].name(), "foobarb-postsync-")
+		assert.Equal(t, len(tasks[0].name()), 5)
+		assert.Equal(t, len(tasks[1].name()), 5)
 		assert.Empty(t, pod.GetName())
 	})
 
-	t.Run("Short revision", func(t *testing.T) {
+	t.Run("revision", func(t *testing.T) {
 		syncCtx := newTestSyncCtx(nil)
+
 		pod := testingutils.NewPod()
 		pod.SetName("")
+		pod.SetGenerateName("foo-")
 		pod.SetAnnotations(map[string]string{synccommon.AnnotationKeyHook: "PreSync,PostSync"})
 		syncCtx.hooks = []*unstructured.Unstructured{pod}
-		syncCtx.revision = "foobar"
+
 		tasks, successful := syncCtx.getSyncTasks(context.Background())
 
 		assert.True(t, successful)
 		assert.Len(t, tasks, 2)
-		assert.Contains(t, tasks[0].name(), "foobar-presync-")
-		assert.Contains(t, tasks[1].name(), "foobar-postsync-")
+		assert.Contains(t, tasks[0].name(), "foo-")
+		assert.Equal(t, len(tasks[0].name()), 9)
+		assert.Contains(t, tasks[1].name(), "foo-")
+		assert.Equal(t, len(tasks[1].name()), 9)
 		assert.Empty(t, pod.GetName())
 	})
 }


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->

## What this PR does
Fixes https://github.com/argoproj/argo-cd/issues/9184 and https://github.com/argoproj/argo-cd/issues/28588.

Updates the name generation logic for hooks where `metadata.name` is not set on the target object.

## Why?

ArgoCD requires that the name of the resource is known before it gets applied. Kubernetes `jobs` and resources that generate names at apply time using the `metadata.generateName` field do not conform to this constraint, so there is logic in the gitops-engine to generate a name and set this on the resource.

However, this logic does not sanitise input and there is no length check which introduces two new failure modes, both of which violate the rules around RFC 1123 subdomain naming conventions:
1. the generated name exceeds the 63 character limit (bug filed [here](https://github.com/argoproj/argo-cd/issues/9184#issuecomment-3007650845)).
2. the first 8 characters of the `revision` contains an invalid character. This is the behaviour we noticed when we moved to using OCI images, as the `revision` contains the prefix `sha256:<SHA>` and the colon is invalid.

```
Job.batch "<job-name>-sha256:-sync-1783086592" is invalid: [metadata.name: Invalid value: "<job-name>-sha256:-sync-1783086592": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'), spec.template.labels: Invalid value: "<job-name>-sha256:-sync-1783086592": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue', or 'my_value', or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')]
```
