### PR TITLE
fix: return explicit error for missing helm value files

### DIFF
--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -1541,17 +1541,21 @@ func getResolvedValueFiles(
 		}
 		if !isRemote {
 			_, err = os.Stat(string(resolvedPath))
-			if os.IsNotExist(err) {
-				if ignoreMissingValueFiles {
-					log.Debugf(" %s values file does not exist", resolvedPath)
-					continue
+			if err != nil {
+				if os.IsNotExist(err) {
+					if ignoreMissingValueFiles {
+						log.Debugf(" %s values file does not exist", resolvedPath)
+						continue
+					}
+					return nil, fmt.Errorf("value file %s does not exist", rawValueFile)
 				}
+				return nil, fmt.Errorf("error checking value file %s: %w", rawValueFile, err)
 			}
 		}
 
 		appendUnique(resolvedPath)
 	}
-	log.Infof("resolved value files: %v", resolvedValueFiles)
+	log.Debugf("resolved value files: %v", resolvedValueFiles)
 	return resolvedValueFiles, nil
 }
 

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -1307,7 +1307,7 @@ func TestHelmWithMissingValueFiles(t *testing.T) {
 
 	// Should fail since we're passing a non-existent values file, and error should indicate that
 	_, err := service.GenerateManifest(t.Context(), req)
-	require.ErrorContains(t, err, missingValuesFile+": no such file or directory")
+	require.ErrorContains(t, err, "value file "+missingValuesFile+" does not exist")
 
 	// Should template without error even if defining a non-existent values file
 	req.ApplicationSource.Helm.IgnoreMissingValueFiles = true
@@ -3922,6 +3922,14 @@ func Test_getResolvedValueFiles(t *testing.T) {
 
 	paths.Add(git.NormalizeGitURL("https://github.com/org/repo1"), path.Join(tempDir, "repo1"))
 
+	// Create files required by test cases that expect successful resolution.
+	require.NoError(t, os.MkdirAll(path.Join(tempDir, "main-repo", "app-path"), 0o755))
+	require.NoError(t, os.MkdirAll(path.Join(tempDir, "repo1", "app-path"), 0o755))
+	require.NoError(t, os.WriteFile(path.Join(tempDir, "main-repo", "values.yaml"), []byte{}, 0o644))
+	require.NoError(t, os.WriteFile(path.Join(tempDir, "main-repo", "app-path", "values.yaml"), []byte{}, 0o644))
+	require.NoError(t, os.WriteFile(path.Join(tempDir, "repo1", "values.yaml"), []byte{}, 0o644))
+	require.NoError(t, os.WriteFile(path.Join(tempDir, "repo1", "app-path", "values.yaml"), []byte{}, 0o644))
+
 	testCases := []struct {
 		name         string
 		rawPath      string
@@ -4071,6 +4079,68 @@ func Test_getResolvedValueFiles(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_getResolvedValueFiles_missingFile(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	paths := utilio.NewRandomizedTempPaths(tempDir)
+	require.NoError(t, os.MkdirAll(path.Join(tempDir, "repo"), 0o755))
+	require.NoError(t, os.WriteFile(path.Join(tempDir, "repo", "existing.yaml"), []byte{}, 0o644))
+
+	repoPath := path.Join(tempDir, "repo")
+
+	t.Run("missing file with ignoreMissingValueFiles=false returns error", func(t *testing.T) {
+		t.Parallel()
+		_, err := getResolvedValueFiles(repoPath, repoPath, &v1alpha1.Env{}, []string{},
+			[]string{"nonexistent.yaml"}, map[string]*v1alpha1.RefTarget{}, paths, false)
+		require.ErrorContains(t, err, "does not exist")
+	})
+
+	t.Run("missing file with ignoreMissingValueFiles=true is silently skipped", func(t *testing.T) {
+		t.Parallel()
+		resolved, err := getResolvedValueFiles(repoPath, repoPath, &v1alpha1.Env{}, []string{},
+			[]string{"nonexistent.yaml"}, map[string]*v1alpha1.RefTarget{}, paths, true)
+		require.NoError(t, err)
+		assert.Empty(t, resolved)
+	})
+
+	t.Run("existing file is included", func(t *testing.T) {
+		t.Parallel()
+		resolved, err := getResolvedValueFiles(repoPath, repoPath, &v1alpha1.Env{}, []string{},
+			[]string{"existing.yaml"}, map[string]*v1alpha1.RefTarget{}, paths, false)
+		require.NoError(t, err)
+		require.Len(t, resolved, 1)
+		assert.Equal(t, path.Join(repoPath, "existing.yaml"), string(resolved[0]))
+	})
+
+	t.Run("mix of existing and missing with ignoreMissingValueFiles=false errors on missing", func(t *testing.T) {
+		t.Parallel()
+		_, err := getResolvedValueFiles(repoPath, repoPath, &v1alpha1.Env{}, []string{},
+			[]string{"existing.yaml", "missing.yaml"}, map[string]*v1alpha1.RefTarget{}, paths, false)
+		require.ErrorContains(t, err, "does not exist")
+	})
+
+	t.Run("mix of existing and missing with ignoreMissingValueFiles=true only includes existing", func(t *testing.T) {
+		t.Parallel()
+		resolved, err := getResolvedValueFiles(repoPath, repoPath, &v1alpha1.Env{}, []string{},
+			[]string{"existing.yaml", "missing.yaml"}, map[string]*v1alpha1.RefTarget{}, paths, true)
+		require.NoError(t, err)
+		require.Len(t, resolved, 1)
+		assert.Equal(t, path.Join(repoPath, "existing.yaml"), string(resolved[0]))
+	})
+
+	t.Run("multiple existing files are all included", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, os.WriteFile(path.Join(tempDir, "repo", "second.yaml"), []byte{}, 0o644))
+		resolved, err := getResolvedValueFiles(repoPath, repoPath, &v1alpha1.Env{}, []string{},
+			[]string{"existing.yaml", "second.yaml"}, map[string]*v1alpha1.RefTarget{}, paths, false)
+		require.NoError(t, err)
+		require.Len(t, resolved, 2)
+		assert.Equal(t, path.Join(repoPath, "existing.yaml"), string(resolved[0]))
+		assert.Equal(t, path.Join(repoPath, "second.yaml"), string(resolved[1]))
+	})
 }
 
 func Test_getResolvedValueFiles_glob(t *testing.T) {

--- a/test/e2e/helm_test.go
+++ b/test/e2e/helm_test.go
@@ -86,7 +86,7 @@ func TestDeclarativeHelmInvalidValuesFile(t *testing.T) {
 		Then().
 		Expect(HealthIs(health.HealthStatusHealthy)).
 		Expect(SyncStatusIs(SyncStatusCodeUnknown)).
-		Expect(Condition(ApplicationConditionComparisonError, "does-not-exist-values.yaml: no such file or directory"))
+		Expect(Condition(ApplicationConditionComparisonError, "value file does-not-exist-values.yaml does not exist"))
 }
 
 func TestHelmRepo(t *testing.T) {
@@ -153,7 +153,7 @@ func TestHelmIgnoreMissingValueFiles(t *testing.T) {
 		IgnoreErrors().
 		Sync().
 		Then().
-		Expect(ErrorRegex("Error: open .*does-not-exist-values.yaml: no such file or directory", ""))
+		Expect(ErrorRegex("value file does-not-exist-values.yaml does not exist", ""))
 }
 
 // TestHelmGlobValueFiles verifies that a glob pattern in valueFiles expands to all matching


### PR DESCRIPTION
## Summary of the change

Fixes #28376

When a Helm value file does not exist and `ignoreMissingValueFiles` is `false`, the `os.Stat` error was silently discarded and the non-existent path was forwarded to `helm template`. This caused a cryptic, hard-to-diagnose downstream error from helm rather than a clear message pointing at the missing file.

This PR:

1. **Returns an explicit error** from `getResolvedValueFiles` when `os.Stat` reports the file does not exist and `ignoreMissingValueFiles=false`:
   ```
   value file <path> does not exist
   ```
2. **Wraps unexpected stat errors** (e.g. permission denied) so they are also surfaced with context rather than silently ignored.
3. **Demotes the "resolved value files" log line** from `Info` to `Debug` to reduce noise in production logs.

## Does this PR introduce a user-facing change?

```
Fix: Helm applications that reference a missing value file with ignoreMissingValueFiles=false now return a clear error immediately instead of producing a cryptic helm template failure.
```

## Which issue(s) does this PR fix?

Fixes #28376

## How was this tested?

### Unit tests

- **`TestHelmWithMissingValueFiles`** — existing integration test updated to assert the new, clearer error message.
- **`Test_getResolvedValueFiles_missingFile`** — new unit test with 6 sub-cases covering:
  - Missing file with `ignoreMissingValueFiles=false` → returns error
  - Missing file with `ignoreMissingValueFiles=true` → silently skipped
  - Existing file → included in result
  - Mix of existing + missing with `ignoreMissingValueFiles=false` → errors on missing
  - Mix of existing + missing with `ignoreMissingValueFiles=true` → only includes existing
  - Multiple existing files → all included
- **`Test_getResolvedValueFiles`** and **`Test_getResolvedValueFiles_glob`** — all pre-existing sub-tests continue to pass.

```
--- PASS: TestHelmWithMissingValueFiles (0.11s)
--- PASS: Test_getResolvedValueFiles (0.00s)
--- PASS: Test_getResolvedValueFiles_missingFile (0.00s)
--- PASS: Test_getResolvedValueFiles_glob (0.00s)
```

### Live cluster verification (k3d / ArgoCD v3.4.4 → patched)

The fix was built and deployed into a live k3d cluster to reproduce the bug and confirm the fix end-to-end.

**Bug reproduced on v3.4.4 (before fix):**

Attempted to create an Application pointing at `helm-guestbook` with `helm.valueFiles: [missing-values.yaml]` and `ignoreMissingValueFiles: false`. The error from the unpatched repo-server:

```
rpc error: code = InvalidArgument desc = application spec is invalid:
Unable to generate manifests in helm-guestbook:
failed running helm: `helm template . --values <path to cached source>/helm-guestbook/missing-values.yaml ...`
Error: open <path to cached source>/helm-guestbook/missing-values.yaml: no such file or directory
```

The error came from inside `helm template`, leaked an internal temp-dir path, and gave no indication that the problem was a misconfigured spec rather than an infrastructure failure.

**After deploying the patched repo-server:**

Same Application creation attempt produced:

```
rpc error: code = InvalidArgument desc = application spec is invalid:
error resolving helm value files: value file missing-values.yaml does not exist
```

The error is caught in `getResolvedValueFiles` before helm is invoked. No temp-dir path, no helm subprocess error — the message uses only the name the user wrote in their spec and clearly identifies it as a value file problem.

**Additional probes on the patched server:**

| Scenario | Result |
|---|---|
| `ignoreMissingValueFiles: false` + missing file | ✅ Returns `value file missing-values.yaml does not exist` immediately |
| `ignoreMissingValueFiles: true` + missing file | ✅ Silently skipped, manifests generated cleanly |
| Existing `values.yaml` referenced explicitly | ✅ Manifests generated correctly, no regression |
| `"resolved value files"` at Info log level | ✅ No longer emitted at Info — demoted to Debug as intended |