### PR TITLE
fix: lua script for Pipeline not to use strings library

### DIFF
--- a/resource_customizations/numaflow.numaproj.io/Pipeline/actions/discovery.lua
+++ b/resource_customizations/numaflow.numaproj.io/Pipeline/actions/discovery.lua
@@ -94,7 +94,7 @@ end
 local recyclable = false
 if obj.metadata.labels ~= nil then
   local upgradeState = obj.metadata.labels["numaplane.numaproj.io/upgrade-state"]
-  if upgradeState ~= nil and string.find(upgradeState, "^recyclable") then
+  if upgradeState == "recyclable" or upgradeState == "recyclable-expired" then
     recyclable = true
   end
 end


### PR DESCRIPTION
The lua `strings` library isn't available, which causes the script to not load. Replacing with a simpler check which looks for equality between the two values instead of trying to use a "starts with" expression.
