### PR TITLE
fix: fix flaky tests

### DIFF
--- a/controller/sync_test.go
+++ b/controller/sync_test.go
@@ -1997,7 +1997,7 @@ func TestSyncWithImpersonate(t *testing.T) {
 			Phase: synccommon.OperationRunning,
 		}
 		// when
-		ctrl.appStateManager.SyncAppState(app, project, opState)
+		ctrl.appStateManager.SyncAppState(t.Context(), app, project, opState)
 
 		// then app sync should succeed with fallback to controller SA
 		assert.Equal(t, synccommon.OperationSucceeded, opState.Phase)
@@ -2057,7 +2057,7 @@ func TestSyncWithImpersonate(t *testing.T) {
 			Phase: synccommon.OperationRunning,
 		}
 		// when
-		ctrl.appStateManager.SyncAppState(app, project, opState)
+		ctrl.appStateManager.SyncAppState(t.Context(), app, project, opState)
 
 		// then app sync should succeed using impersonation
 		assert.Equal(t, synccommon.OperationSucceeded, opState.Phase)


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->
Error logs:
```
run golangci-lint
  Running [/home/runner/golangci-lint-2.12.2-linux-amd64/golangci-lint config path] in [/home/runner/work/argo-cd/argo-cd] ...
  Running [/home/runner/golangci-lint-2.12.2-linux-amd64/golangci-lint config verify] in [/home/runner/work/argo-cd/argo-cd] ...
  Running [/home/runner/golangci-lint-2.12.2-linux-amd64/golangci-lint run  --verbose] in [/home/runner/work/argo-cd/argo-cd] ...
  controller/appcontroller.go:1: : # github.com/argoproj/argo-cd/v3/controller [github.com/argoproj/argo-cd/v3/controller.test]
  Error: controller/sync_test.go:2000:51: not enough arguments in call to ctrl.appStateManager.SyncAppState
  	have (*"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1".Application, *"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1".AppProject, *"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1".OperationState)
  	want ("context".Context, *"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1".Application, *"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1".AppProject, *"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1".OperationState)
  Error: controller/sync_test.go:2060:51: not enough arguments in call to ctrl.appStateManager.SyncAppState
  	have (*"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1".Application, *"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1".AppProject, *"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1".OperationState)
  	want ("context".Context, *"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1".Application, *"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1".AppProject, *"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1".OperationState) (typecheck)
  package controller
  1 issues:
  * typecheck: 1
  
```

It's caused by the https://github.com/argoproj/argo-cd/pull/28353/ , 
Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
