### PR TITLE
fix(health): configconnectorcontext and configconnector (#26308) (#26309) (3.3)

### DIFF
--- a/resource_customizations/_.cnrm.cloud.google.com/_/health.lua
+++ b/resource_customizations/_.cnrm.cloud.google.com/_/health.lua
@@ -3,6 +3,22 @@ local hs = {
   message = "Update in progress"
 }
 if obj.status ~= nil then
+  -- ConfigConnector and ConfigConnectorContext use status.healthy instead of conditions
+  if (obj.kind == "ConfigConnector" or obj.kind == "ConfigConnectorContext") and obj.status.healthy ~= nil then
+    -- Check if status is stale
+    if obj.status.observedGeneration == nil or obj.status.observedGeneration == obj.metadata.generation then
+      if obj.status.healthy == true then
+        hs.status = "Healthy"
+        hs.message = obj.kind .. " is healthy"
+        return hs
+      else
+        hs.status = "Degraded"
+        hs.message = obj.kind .. " is not healthy"
+        return hs
+      end
+    end
+  end
+
   if obj.status.conditions ~= nil then
     
     -- Progressing health while the resource status is stale, skip if observedGeneration is not set

--- a/resource_customizations/_.cnrm.cloud.google.com/_/health_test.yaml
+++ b/resource_customizations/_.cnrm.cloud.google.com/_/health_test.yaml
@@ -23,3 +23,23 @@ tests:
     status: Progressing
     message: 'Update in progress'
   inputPath: testdata/generation.yaml
+- healthStatus:
+    status: Healthy
+    message: "ConfigConnectorContext is healthy"
+  inputPath: testdata/config-connector-context.yaml
+- healthStatus:
+    status: Degraded
+    message: "ConfigConnectorContext is not healthy"
+  inputPath: testdata/config-connector-context-unhealthy.yaml
+- healthStatus:
+    status: Healthy
+    message: "ConfigConnector is healthy"
+  inputPath: testdata/config-connector-healthy.yaml
+- healthStatus:
+    status: Degraded
+    message: "ConfigConnector is not healthy"
+  inputPath: testdata/config-connector-unhealthy.yaml
+- healthStatus:
+    status: Progressing
+    message: "Update in progress"
+  inputPath: testdata/config-connector-stale.yaml

--- a/resource_customizations/_.cnrm.cloud.google.com/_/testdata/config-connector-context-unhealthy.yaml
+++ b/resource_customizations/_.cnrm.cloud.google.com/_/testdata/config-connector-context-unhealthy.yaml
@@ -1,0 +1,11 @@
+apiVersion: core.cnrm.cloud.google.com/v1beta1
+kind: ConfigConnectorContext
+metadata:
+  generation: 1
+  name: configconnectorcontext.core.cnrm.cloud.google.com
+  namespace: foo
+spec:
+  googleServiceAccount: foo@bar.iam.gserviceaccount.com
+status:
+  healthy: false
+  observedGeneration: 1

--- a/resource_customizations/_.cnrm.cloud.google.com/_/testdata/config-connector-context.yaml
+++ b/resource_customizations/_.cnrm.cloud.google.com/_/testdata/config-connector-context.yaml
@@ -1,0 +1,11 @@
+apiVersion: core.cnrm.cloud.google.com/v1beta1
+kind: ConfigConnectorContext
+metadata:
+  generation: 1
+  name: configconnectorcontext.core.cnrm.cloud.google.com
+  namespace: foo
+spec:
+  googleServiceAccount: foo@bar.iam.gserviceaccount.com
+status:
+  healthy: true
+  observedGeneration: 1

--- a/resource_customizations/_.cnrm.cloud.google.com/_/testdata/config-connector-healthy.yaml
+++ b/resource_customizations/_.cnrm.cloud.google.com/_/testdata/config-connector-healthy.yaml
@@ -1,0 +1,12 @@
+apiVersion: core.cnrm.cloud.google.com/v1beta1
+kind: ConfigConnector
+metadata:
+  finalizers:
+  - configconnector.cnrm.cloud.google.com/finalizer
+  generation: 2
+  name: configconnector.core.cnrm.cloud.google.com
+spec:
+  mode: namespaced
+status:
+  healthy: true
+  observedGeneration: 2

--- a/resource_customizations/_.cnrm.cloud.google.com/_/testdata/config-connector-stale.yaml
+++ b/resource_customizations/_.cnrm.cloud.google.com/_/testdata/config-connector-stale.yaml
@@ -1,0 +1,12 @@
+apiVersion: core.cnrm.cloud.google.com/v1beta1
+kind: ConfigConnector
+metadata:
+  finalizers:
+  - configconnector.cnrm.cloud.google.com/finalizer
+  generation: 3
+  name: configconnector.core.cnrm.cloud.google.com
+spec:
+  mode: namespaced
+status:
+  healthy: true
+  observedGeneration: 2

--- a/resource_customizations/_.cnrm.cloud.google.com/_/testdata/config-connector-unhealthy.yaml
+++ b/resource_customizations/_.cnrm.cloud.google.com/_/testdata/config-connector-unhealthy.yaml
@@ -1,0 +1,12 @@
+apiVersion: core.cnrm.cloud.google.com/v1beta1
+kind: ConfigConnector
+metadata:
+  finalizers:
+  - configconnector.cnrm.cloud.google.com/finalizer
+  generation: 2
+  name: configconnector.core.cnrm.cloud.google.com
+spec:
+  mode: namespaced
+status:
+  healthy: false
+  observedGeneration: 2


### PR DESCRIPTION
Cherry-picking https://github.com/argoproj/argo-cd/pull/26309/ onto 3.3

Closes #26308