### PR TITLE
feat: add hibernate/rehydrate resource actions for CloudNativePG Cluster

### DIFF
--- a/resource_customizations/postgresql.cnpg.io/Cluster/actions/action_test.yaml
+++ b/resource_customizations/postgresql.cnpg.io/Cluster/actions/action_test.yaml
@@ -31,3 +31,9 @@ actionTests:
   - action: resume
     inputPath: testdata/cluster_reconcile_suspended.yaml
     expectedOutputPath: testdata/cluster_healthy.yaml
+  - action: hibernate
+    inputPath: testdata/cluster_healthy.yaml
+    expectedOutputPath: testdata/cluster_hibernation_on.yaml
+  - action: rehydrate
+    inputPath: testdata/cluster_hibernation_on.yaml
+    expectedOutputPath: testdata/cluster_hibernation_off.yaml

--- a/resource_customizations/postgresql.cnpg.io/Cluster/actions/discovery.lua
+++ b/resource_customizations/postgresql.cnpg.io/Cluster/actions/discovery.lua
@@ -45,4 +45,24 @@ else
     }
 end
 
+-- Declarative hibernation for a cluster
+-- https://cloudnative-pg.io/docs/current/declarative_hibernation/
+local isHibernated = false
+if obj.metadata and obj.metadata.annotations and obj.metadata.annotations["cnpg.io/hibernation"] == "on" then
+    isHibernated = true
+end
+
+-- Add hibernate/rehydrate actions based on current state
+if isHibernated then
+    actions["rehydrate"] = {
+        ["iconClass"] = "fa fa-fw fa-sun-o",
+        ["displayName"] = "Rehydrate (exit hibernation)"
+    }
+else
+    actions["hibernate"] = {
+        ["iconClass"] = "fa fa-fw fa-moon-o",
+        ["displayName"] = "Hibernate Cluster"
+    }
+end
+
 return actions

--- a/resource_customizations/postgresql.cnpg.io/Cluster/actions/hibernate/action.lua
+++ b/resource_customizations/postgresql.cnpg.io/Cluster/actions/hibernate/action.lua
@@ -1,0 +1,12 @@
+-- Enter CloudNativePG declarative hibernation by setting the hibernation annotation to "on".
+-- https://cloudnative-pg.io/docs/current/declarative_hibernation/
+if obj.metadata == nil then
+    obj.metadata = {}
+end
+
+if obj.metadata.annotations == nil then
+    obj.metadata.annotations = {}
+end
+
+obj.metadata.annotations["cnpg.io/hibernation"] = "on"
+return obj

--- a/resource_customizations/postgresql.cnpg.io/Cluster/actions/rehydrate/action.lua
+++ b/resource_customizations/postgresql.cnpg.io/Cluster/actions/rehydrate/action.lua
@@ -1,0 +1,12 @@
+-- Exit CloudNativePG declarative hibernation by setting the hibernation annotation to "off".
+-- https://cloudnative-pg.io/docs/current/declarative_hibernation/
+if obj.metadata == nil then
+    obj.metadata = {}
+end
+
+if obj.metadata.annotations == nil then
+    obj.metadata.annotations = {}
+end
+
+obj.metadata.annotations["cnpg.io/hibernation"] = "off"
+return obj

--- a/resource_customizations/postgresql.cnpg.io/Cluster/actions/testdata/cluster_hibernation_off.yaml
+++ b/resource_customizations/postgresql.cnpg.io/Cluster/actions/testdata/cluster_hibernation_off.yaml
@@ -1,0 +1,25 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  annotations:
+    cnpg.io/hibernation: "off"
+  creationTimestamp: "2025-04-25T20:44:24Z"
+  generation: 1
+  name: cluster-example
+  namespace: default
+  resourceVersion: "20230"
+  uid: 987fe1ba-bba7-4021-9d25-f06ca9a8c0d2
+spec:
+  imageName: ghcr.io/cloudnative-pg/postgresql:13
+  instances: 3
+status:
+  currentPrimary: cluster-example-1
+  currentPrimaryTimestamp: "2025-04-25T20:44:38.190232Z"
+  instancesStatus:
+    healthy:
+    - cluster-example-1
+    - cluster-example-2
+    - cluster-example-3
+  phase: Cluster in healthy state
+  targetPrimary: cluster-example-1
+  targetPrimaryTimestamp: "2025-04-25T20:44:26.214164Z"

--- a/resource_customizations/postgresql.cnpg.io/Cluster/actions/testdata/cluster_hibernation_on.yaml
+++ b/resource_customizations/postgresql.cnpg.io/Cluster/actions/testdata/cluster_hibernation_on.yaml
@@ -1,0 +1,25 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  annotations:
+    cnpg.io/hibernation: "on"
+  creationTimestamp: "2025-04-25T20:44:24Z"
+  generation: 1
+  name: cluster-example
+  namespace: default
+  resourceVersion: "20230"
+  uid: 987fe1ba-bba7-4021-9d25-f06ca9a8c0d2
+spec:
+  imageName: ghcr.io/cloudnative-pg/postgresql:13
+  instances: 3
+status:
+  currentPrimary: cluster-example-1
+  currentPrimaryTimestamp: "2025-04-25T20:44:38.190232Z"
+  instancesStatus:
+    healthy:
+    - cluster-example-1
+    - cluster-example-2
+    - cluster-example-3
+  phase: Cluster in healthy state
+  targetPrimary: cluster-example-1
+  targetPrimaryTimestamp: "2025-04-25T20:44:26.214164Z"


### PR DESCRIPTION
Closes #28477

## What

Adds two resource actions for `postgresql.cnpg.io/Cluster` to enter and exit CloudNativePG [declarative hibernation](https://cloudnative-pg.io/docs/current/declarative_hibernation/) via the `cnpg.io/hibernation` annotation:

- **hibernate** — sets `cnpg.io/hibernation: "on"`
- **rehydrate** — sets `cnpg.io/hibernation: "off"`

`discovery.lua` offers **hibernate** when the cluster is running and **rehydrate** when it is hibernated (based on the current annotation), mirroring the existing conditional `suspend`/`resume` actions in the same resource.

This is a follow-up to #26421 / #26711, which corrected the `suspend`/`resume` reconciliation annotation but did not add the hibernation actions.

## Tests

Added `hibernate` and `rehydrate` cases to `action_test.yaml` with fixtures (`cluster_hibernation_on.yaml` / `cluster_hibernation_off.yaml`). `TestLuaResourceActionsScript` passes.