### PR TITLE
chore(ci): dependabot groups for golang.org/x and codeql

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,11 +14,18 @@ updates:
       otel:
         patterns:
           - "go.opentelemetry.io/*"
+      golang-x:
+        patterns:
+          - "golang.org/x/*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      codeql:
+        patterns:
+          - "github/codeql-action*"
 
   - package-ecosystem: "npm"
     directory: "/ui/"


### PR DESCRIPTION
Dependabot opens a flurry of PRs any time the x or codeql dependencies get bumped. This groups them for easier review/merge.