### PR TITLE
test: Remove t.Parallel() from test checking stderr output

### DIFF
--- a/util/argo/diff/diff_test.go
+++ b/util/argo/diff/diff_test.go
@@ -261,10 +261,8 @@ func TestDiffConfigBuilder(t *testing.T) {
 }
 
 func TestDiffFromCache(t *testing.T) {
-	t.Parallel()
 	t.Run("returns false and logs warning on cache miss", func(t *testing.T) {
 		// given
-		t.Parallel()
 		hook := test.NewLocal(logrus.StandardLogger())
 		defer hook.Reset()
 
@@ -292,7 +290,6 @@ func TestDiffFromCache(t *testing.T) {
 
 	t.Run("returns false and logs error on cache failure", func(t *testing.T) {
 		// given
-		t.Parallel()
 		hook := test.NewLocal(logrus.StandardLogger())
 		defer hook.Reset()
 


### PR DESCRIPTION
Fix race problem in unit test `TestDiffFromCache` where the parallel branches write and check the stderr at the same time expecting only single message.

Both tests attach hooks to the `logrus.StandardLogger()` which is a global stderr logger, the tests expect to only have single message, but both error messages from the subtests are present. Removing the parallel execution fixes the issue.

No need to cherry-pick this to older release as this is a test related fix.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
    - bugfix in tests
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
    - did not find any existing issue for this
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
    - not a new feature
* [ ] Does this PR require documentation updates?
    - no
* [ ] I've updated documentation as required by this PR.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
    - No, this PR fixes existing test
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [X] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->

**Additional info**:

- when i tried it this test consistently failed 20/20 times
- I have tracked this change to #28177
- environment: MacBook Pro (M3 Pro), macOS 26.5.2
- go version go1.26.4 darwin/arm64
- log
```
% go test -count=1 -test.fullpath=true -timeout 30s -run ^TestDiffFromCache$ github.com/argoproj/argo-cd/v3/util/argo/diff
time="2026-07-09T15:58:12+02:00" level=error msg="DiffFromCache: cannot get managed resources for app application-name: cache unavailable"
time="2026-07-09T15:58:12+02:00" level=warning msg="DiffFromCache: cannot get managed resources for app application-name: cache: key is missing"
--- FAIL: TestDiffFromCache (0.00s)
    --- FAIL: TestDiffFromCache/returns_false_and_logs_warning_on_cache_miss (0.00s)
        /Users/jakucera/Documents/argo/argo-cd/util/argo/diff/diff_test.go:287: 
                Error Trace:    /Users/jakucera/Documents/argo/argo-cd/util/argo/diff/diff_test.go:287
                Error:          "[{0x1090ed6e0 map[] 2026-07-09 15:58:12.81506 +0200 CEST m=+0.042654751 error <nil> DiffFromCache: cannot get managed resources for app application-name: cache unavailable <nil> <nil> } {0x1090ed6e0 map[] 2026-07-09 15:58:12.815064 +0200 CEST m=+0.042658626 warning <nil> DiffFromCache: cannot get managed resources for app application-name: cache: key is missing <nil> <nil> }]" should have 1 item(s), but has 2
                Test:           TestDiffFromCache/returns_false_and_logs_warning_on_cache_miss
FAIL
FAIL    github.com/argoproj/argo-cd/v3/util/argo/diff   0.809s
FAIL
```

