### PR TITLE
fix: use Entra ID uti claim as token id when jti is absent (#28625)

### DIFF
--- a/util/session/sessionmanager.go
+++ b/util/session/sessionmanager.go
@@ -603,7 +603,7 @@ func (mgr *SessionManager) VerifyToken(ctx context.Context, tokenString string) 
 
 		id := tokenUniqueID(claims)
 		if id == "" {
-			log.Warnf("token does not have jti claim")
+			log.Warnf("token does not have jti or uti claim")
 		}
 		// Workaround for Dex token, because does not have jti.
 		if id == "" {

--- a/util/session/sessionmanager.go
+++ b/util/session/sessionmanager.go
@@ -629,8 +629,8 @@ func (mgr *SessionManager) VerifyToken(ctx context.Context, tokenString string) 
 // the equivalent, so fall back to it. Returns an empty string when neither claim
 // is present.
 func tokenUniqueID(claims jwt.MapClaims) string {
-	if id := jwutil.StringField(claims, "jti"); id != "' {
-	          return id
+	if id := jwtutil.StringField(claims, "jti"); id != "" {
+		return id
 	}
 	return jwtutil.StringField(claims, "uti")
 }

--- a/util/session/sessionmanager.go
+++ b/util/session/sessionmanager.go
@@ -629,13 +629,10 @@ func (mgr *SessionManager) VerifyToken(ctx context.Context, tokenString string) 
 // the equivalent, so fall back to it. Returns an empty string when neither claim
 // is present.
 func tokenUniqueID(claims jwt.MapClaims) string {
-	if id, ok := claims["jti"].(string); ok && id != "" {
-		return id
+	if id := jwutil.StringField(claims, "jti"); id != "' {
+	          return id
 	}
-	if id, ok := claims["uti"].(string); ok && id != "" {
-		return id
-	}
-	return ""
+	return jwtutil.StringField(claims, "uti")
 }
 
 func (mgr *SessionManager) provider() (oidcutil.Provider, error) {

--- a/util/session/sessionmanager.go
+++ b/util/session/sessionmanager.go
@@ -601,10 +601,9 @@ func (mgr *SessionManager) VerifyToken(ctx context.Context, tokenString string) 
 			return nil, "", common.ErrTokenVerification
 		}
 
-		id, ok := claims["jti"].(string)
-		if !ok {
+		id := tokenUniqueID(claims)
+		if id == "" {
 			log.Warnf("token does not have jti claim")
-			id = ""
 		}
 		// Workaround for Dex token, because does not have jti.
 		if id == "" {
@@ -622,6 +621,21 @@ func (mgr *SessionManager) VerifyToken(ctx context.Context, tokenString string) 
 		}
 		return claims, "", nil
 	}
+}
+
+// tokenUniqueID returns a unique identifier for the token, used for revocation
+// checks. It prefers the standard "jti" claim. Microsoft Entra ID does not emit
+// "jti"; it emits "uti" (unique token identifier), which Microsoft documents as
+// the equivalent, so fall back to it. Returns an empty string when neither claim
+// is present.
+func tokenUniqueID(claims jwt.MapClaims) string {
+	if id, ok := claims["jti"].(string); ok && id != "" {
+		return id
+	}
+	if id, ok := claims["uti"].(string); ok && id != "" {
+		return id
+	}
+	return ""
 }
 
 func (mgr *SessionManager) provider() (oidcutil.Provider, error) {

--- a/util/session/sessionmanager_test.go
+++ b/util/session/sessionmanager_test.go
@@ -1565,3 +1565,47 @@ func Test_PickFailureAttemptWhenOverflowed(t *testing.T) {
 		}
 	})
 }
+
+func TestTokenUniqueID(t *testing.T) {
+	testCases := []struct {
+		name   string
+		claims jwt.MapClaims
+		want   string
+	}{
+		{
+			name:   "jti present",
+			claims: jwt.MapClaims{"jti": "abc123"},
+			want:   "abc123",
+		},
+		{
+			name:   "uti fallback when jti absent (Entra ID)",
+			claims: jwt.MapClaims{"uti": "xyz789"},
+			want:   "xyz789",
+		},
+		{
+			name:   "jti preferred over uti",
+			claims: jwt.MapClaims{"jti": "abc123", "uti": "xyz789"},
+			want:   "abc123",
+		},
+		{
+			name:   "empty jti falls back to uti",
+			claims: jwt.MapClaims{"jti": "", "uti": "xyz789"},
+			want:   "xyz789",
+		},
+		{
+			name:   "neither present",
+			claims: jwt.MapClaims{"sub": "user"},
+			want:   "",
+		},
+		{
+			name:   "non-string jti ignored, uti used",
+			claims: jwt.MapClaims{"jti": 123, "uti": "xyz789"},
+			want:   "xyz789",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tokenUniqueID(tc.claims))
+		})
+	}
+}


### PR DESCRIPTION
Closes #28625

### What does this PR do?

`SessionManager.VerifyToken` derives a unique token identifier from the
standard JWT `jti` claim to perform revocation checks. Microsoft Entra ID
does not emit `jti`; it emits [`uti`](https://learn.microsoft.com/en-us/entra/identity-platform/id-token-claims-reference)
(unique token identifier), which Microsoft documents as the equivalent.

Because of this, every Entra ID (direct OIDC) token verification logged
`token does not have jti claim` and fell back to the access token hash. On a
busy argocd-server this produces a steady stream of warnings.

This extracts the lookup into a small `tokenUniqueID` helper that prefers
`jti` and falls back to `uti` before giving up, so Entra ID tokens use a real
unique identifier and no longer emit the warning on every verification.

### Notes

- Behavior for existing IdPs is unchanged: `jti` is still preferred, and the
  empty-id fallback to `AccessTokenHash` (the Dex workaround) is preserved.
- Added a table-driven unit test (`TestTokenUniqueID`) covering jti, uti
  fallback, precedence, empty/non-string values, and neither-present.
- The `token does not have jti claim` warning behavior was introduced in #26388.

### Disclosure

This change was prepared with the assistance of an AI coding tool, in line
with the [Argo project Generative AI policy](https://github.com/argoproj/argoproj/blob/main/community/genai.md).
I have reviewed, tested (`go test ./util/session/`), and take responsibility
for the change.

Checklist:

* [x] Either (a) I've created an enhancement proposal and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the Title of the PR
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates? No — no user-facing config or API change.
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by DCO.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
