### PR TITLE
feat(ui): select resources from the diff panel to sync (#27578)

### DIFF
--- a/ui/src/app/applications/components/application-resources-diff/application-resources-diff.scss
+++ b/ui/src/app/applications/components/application-resources-diff/application-resources-diff.scss
@@ -12,6 +12,22 @@
             }
         }
     }
+    &__sync {
+        float: left;
+    }
+    &__entry {
+        display: flex;
+        align-items: flex-start;
+        input[type='checkbox'] {
+            margin-top: 0.6em;
+            margin-right: 0.5em;
+            flex-shrink: 0;
+        }
+    }
+    &__entry-diff {
+        flex: 1;
+        min-width: 0;
+    }
     &__diff {
         font-size: 10pt;
         &__title {

--- a/ui/src/app/applications/components/application-resources-diff/application-resources-diff.tsx
+++ b/ui/src/app/applications/components/application-resources-diff/application-resources-diff.tsx
@@ -6,79 +6,116 @@ import 'react-diff-view/style/index.css';
 import {diffLines, formatLines} from 'unidiff';
 import * as models from '../../../shared/models';
 import {services} from '../../../shared/services';
+import {nodeKey} from '../utils';
 import {IndividualDiffSection} from './individual-diff-section';
 
 import './application-resources-diff.scss';
 
 export interface ApplicationResourcesDiffProps {
     states: models.ResourceDiff[];
+    // When set, each diffed resource gets a checkbox and a "Sync selected"
+    // button that opens the sync flyout with those resources pre-selected.
+    onSync?: (resourceKeys: string[]) => void;
 }
 
-export const ApplicationResourcesDiff = (props: ApplicationResourcesDiffProps) => (
-    <DataLoader key='resource-diff' load={() => services.viewPreferences.getPreferences()}>
-        {pref => {
-            const diffText = props.states
-                .map(state => {
-                    return {
+export const ApplicationResourcesDiff = (props: ApplicationResourcesDiffProps) => {
+    const selectable = !!props.onSync;
+    const [selected, setSelected] = React.useState<{[key: string]: boolean}>({});
+
+    return (
+        <DataLoader key='resource-diff' load={() => services.viewPreferences.getPreferences()}>
+            {pref => {
+                const items = props.states
+                    .map(state => ({
                         a: state.normalizedLiveState ? jsYaml.dump(state.normalizedLiveState, {indent: 2}) : '',
                         b: state.predictedLiveState ? jsYaml.dump(state.predictedLiveState, {indent: 2}) : '',
                         hook: state.hook,
                         // doubles as sort order
-                        name: (state.group || '') + '/' + state.kind + '/' + (state.namespace ? state.namespace + '/' : '') + state.name
-                    };
-                })
-                .filter(i => !i.hook)
-                .filter(i => i.a !== i.b)
-                .map(i => {
-                    const context = pref.appDetails.compactDiff ? 2 : Number.MAX_SAFE_INTEGER;
-                    // react-diff-view, awesome as it is, does not accept unidiff format, you must add a git header section
-                    return `diff --git a/${i.name} b/${i.name}
+                        name: (state.group || '') + '/' + state.kind + '/' + (state.namespace ? state.namespace + '/' : '') + state.name,
+                        // canonical key the sync flyout matches on
+                        resourceKey: nodeKey(state)
+                    }))
+                    .filter(i => !i.hook)
+                    .filter(i => i.a !== i.b);
+                const diffText = items
+                    .map(i => {
+                        const context = pref.appDetails.compactDiff ? 2 : Number.MAX_SAFE_INTEGER;
+                        // react-diff-view, awesome as it is, does not accept unidiff format, you must add a git header section
+                        return `diff --git a/${i.name} b/${i.name}
 index 6829b8a2..4c565f1b 100644
-${formatLines(diffLines(i.a, i.b), {context, aname: `a/${name}}`, bname: `b/${i.name}`})}`;
-                })
-                .join('\n');
-            // assume that if you only have one file, we don't need the file path
-            const whiteBox = props.states.length > 1 ? 'white-box' : '';
-            const showPath = props.states.length > 1;
-            const files = parseDiff(diffText);
-            const viewType = pref.appDetails.inlineDiff ? 'unified' : 'split';
-            return (
-                <div className='application-resources-diff'>
-                    <div className={whiteBox + ' application-resources-diff__checkboxes'}>
-                        <Checkbox
-                            id='compactDiff'
-                            checked={pref.appDetails.compactDiff}
-                            onChange={() =>
-                                services.viewPreferences.updatePreferences({
-                                    appDetails: {
-                                        ...pref.appDetails,
-                                        compactDiff: !pref.appDetails.compactDiff
-                                    }
-                                })
-                            }
-                        />
-                        <label htmlFor='compactDiff'>Compact diff</label>
-                        <Checkbox
-                            id='inlineDiff'
-                            checked={pref.appDetails.inlineDiff}
-                            onChange={() =>
-                                services.viewPreferences.updatePreferences({
-                                    appDetails: {
-                                        ...pref.appDetails,
-                                        inlineDiff: !pref.appDetails.inlineDiff
-                                    }
-                                })
-                            }
-                        />
-                        <label htmlFor='inlineDiff'>Inline diff</label>
+${formatLines(diffLines(i.a, i.b), {context, aname: `a/${i.name}`, bname: `b/${i.name}`})}`;
+                    })
+                    .join('\n');
+                // map the diff file path back to the canonical resource key
+                const resourceKeyByName: {[name: string]: string} = {};
+                items.forEach(i => (resourceKeyByName[i.name] = i.resourceKey));
+                // assume that if you only have one file, we don't need the file path
+                const whiteBox = props.states.length > 1 ? 'white-box' : '';
+                const showPath = props.states.length > 1;
+                const files = parseDiff(diffText);
+                const viewType = pref.appDetails.inlineDiff ? 'unified' : 'split';
+                const selectedKeys = Object.keys(selected).filter(key => selected[key]);
+                return (
+                    <div className='application-resources-diff'>
+                        <div className={whiteBox + ' application-resources-diff__checkboxes'}>
+                            {selectable && (
+                                <button
+                                    qe-id='application-resources-diff-button-sync-selected'
+                                    className='argo-button argo-button--base application-resources-diff__sync'
+                                    disabled={selectedKeys.length === 0}
+                                    onClick={() => props.onSync(selectedKeys)}>
+                                    Sync selected{selectedKeys.length > 0 ? ` (${selectedKeys.length})` : ''}
+                                </button>
+                            )}
+                            <Checkbox
+                                id='compactDiff'
+                                checked={pref.appDetails.compactDiff}
+                                onChange={() =>
+                                    services.viewPreferences.updatePreferences({
+                                        appDetails: {
+                                            ...pref.appDetails,
+                                            compactDiff: !pref.appDetails.compactDiff
+                                        }
+                                    })
+                                }
+                            />
+                            <label htmlFor='compactDiff'>Compact diff</label>
+                            <Checkbox
+                                id='inlineDiff'
+                                checked={pref.appDetails.inlineDiff}
+                                onChange={() =>
+                                    services.viewPreferences.updatePreferences({
+                                        appDetails: {
+                                            ...pref.appDetails,
+                                            inlineDiff: !pref.appDetails.inlineDiff
+                                        }
+                                    })
+                                }
+                            />
+                            <label htmlFor='inlineDiff'>Inline diff</label>
+                        </div>
+                        {files
+                            .sort((a: any, b: any) => a.newPath.localeCompare(b.newPath))
+                            .map((file: any) => {
+                                const section = <IndividualDiffSection key={file.newPath} file={file} showPath={showPath} whiteBox={whiteBox} viewType={viewType} />;
+                                const resourceKey = resourceKeyByName[file.newPath];
+                                if (!selectable || !resourceKey) {
+                                    return section;
+                                }
+                                return (
+                                    <div key={file.newPath} className='application-resources-diff__entry'>
+                                        <Checkbox
+                                            id={`diff-select-${resourceKey}`}
+                                            checked={!!selected[resourceKey]}
+                                            onChange={() => setSelected(prev => ({...prev, [resourceKey]: !prev[resourceKey]}))}
+                                        />
+                                        <div className='application-resources-diff__entry-diff'>{section}</div>
+                                    </div>
+                                );
+                            })}
                     </div>
-                    {files
-                        .sort((a: any, b: any) => a.newPath.localeCompare(b.newPath))
-                        .map((file: any) => (
-                            <IndividualDiffSection key={file.newPath} file={file} showPath={showPath} whiteBox={whiteBox} viewType={viewType} />
-                        ))}
-                </div>
-            );
-        }}
-    </DataLoader>
-);
+                );
+            }}
+        </DataLoader>
+    );
+};

--- a/ui/src/app/applications/components/application-sync-panel/application-sync-panel.test.tsx
+++ b/ui/src/app/applications/components/application-sync-panel/application-sync-panel.test.tsx
@@ -1,0 +1,40 @@
+import * as models from '../../../shared/models';
+
+// resources-pre-selection imports nodeKey from applications/components/utils, which
+// pulls in ESM-only deps (lodash-es) that jest does not transform, so mock it with
+// a plain nodeKey.
+jest.mock('../utils', () => ({
+    nodeKey: (n: {group: string; kind: string; namespace: string; name: string}) => [n.group, n.kind, n.namespace, n.name].join('/')
+}));
+
+import {resourcesPreSelection} from './resources-pre-selection';
+
+const res = (group: string, kind: string, namespace: string, name: string): models.ResourceStatus => ({group, kind, namespace, name} as models.ResourceStatus);
+const key = (r: models.ResourceStatus): string => [r.group, r.kind, r.namespace, r.name].join('/');
+
+describe('resourcesPreSelection', () => {
+    const a = res('apps', 'Deployment', 'default', 'a');
+    const b = res('', 'Service', 'default', 'b');
+    const c = res('apps', 'Deployment', 'default', 'c');
+    const resources = [a, b, c];
+
+    it("selects everything for 'all' (top-bar Sync)", () => {
+        expect(resourcesPreSelection(resources, 'all')).toEqual([true, true, true]);
+    });
+
+    it('selects only the matching single resource (per-resource Sync menu)', () => {
+        expect(resourcesPreSelection(resources, key(b))).toEqual([false, true, false]);
+    });
+
+    it('selects exactly the comma-separated subset (Sync selected from the diff)', () => {
+        expect(resourcesPreSelection(resources, `${key(a)},${key(c)}`)).toEqual([true, false, true]);
+    });
+
+    it('keeps the historic fallback: a value matching nothing selects everything', () => {
+        expect(resourcesPreSelection(resources, 'does/not/match/anything')).toEqual([true, true, true]);
+    });
+
+    it('selects everything when the value is empty', () => {
+        expect(resourcesPreSelection(resources, '')).toEqual([true, true, true]);
+    });
+});

--- a/ui/src/app/applications/components/application-sync-panel/application-sync-panel.tsx
+++ b/ui/src/app/applications/components/application-sync-panel/application-sync-panel.tsx
@@ -17,6 +17,7 @@ import {
     PRUNE_SOME_WARNING
 } from '../application-sync-options/application-sync-options';
 import {ComparisonStatusIcon, getAppDefaultSource, nodeKey} from '../utils';
+import {resourcesPreSelection} from './resources-pre-selection';
 
 import './application-sync-panel.scss';
 
@@ -26,7 +27,6 @@ export const ApplicationSyncPanel = ({application, selectedResource, hide}: {app
     const appResources = ((application && selectedResource && application.status && application.status.resources) || [])
         .sort((first, second) => nodeKey(first).localeCompare(nodeKey(second), undefined, {numeric: true}))
         .filter(item => !item.hook);
-    const syncResIndex = appResources.findIndex(item => nodeKey(item) === selectedResource);
     const syncStrategy = {} as models.SyncStrategy;
     const [isPending, setPending] = React.useState(false);
     const source = getAppDefaultSource(application);
@@ -57,7 +57,7 @@ export const ApplicationSyncPanel = ({application, selectedResource, hide}: {app
                         <Form
                             defaultValues={{
                                 revision: new URLSearchParams(ctx.history.location.search).get('revision') || source.targetRevision || 'HEAD',
-                                resources: appResources.map((_, i) => i === syncResIndex || syncResIndex === -1),
+                                resources: resourcesPreSelection(appResources, selectedResource),
                                 syncOptions: application.spec.syncPolicy ? application.spec.syncPolicy.syncOptions : []
                             }}
                             validateError={values => ({

--- a/ui/src/app/applications/components/application-sync-panel/resources-pre-selection.ts
+++ b/ui/src/app/applications/components/application-sync-panel/resources-pre-selection.ts
@@ -1,0 +1,12 @@
+import * as models from '../../../shared/models';
+import {nodeKey} from '../utils';
+
+// selectedResource is the `deploy` query param that opened the sync panel: 'all', a
+// single resource key, or a comma-separated list of keys (from "Sync selected" in the
+// diff panel). Returns the initial checkbox state, keeping the existing rule that a
+// value matching no resource (like 'all') selects everything.
+export function resourcesPreSelection(appResources: models.ResourceStatus[], selectedResource: string): boolean[] {
+    const keys = new Set((selectedResource || '').split(',').filter(key => key !== ''));
+    const anyMatch = appResources.some(item => keys.has(nodeKey(item)));
+    return appResources.map(item => !anyMatch || keys.has(nodeKey(item)));
+}

--- a/ui/src/app/applications/components/resource-details/resource-details.tsx
+++ b/ui/src/app/applications/components/resource-details/resource-details.tsx
@@ -234,7 +234,9 @@ export const ResourceDetails = (props: ResourceDetailsProps) => {
                                 fields: ['items.normalizedLiveState', 'items.predictedLiveState', 'items.group', 'items.kind', 'items.namespace', 'items.name']
                             })
                         }>
-                        {managedResources => <ApplicationResourcesDiff states={managedResources} />}
+                        {managedResources => (
+                            <ApplicationResourcesDiff states={managedResources} onSync={resourceKeys => AppUtils.showDeploy(resourceKeys.join(','), null, props.appCxt.apis)} />
+                        )}
                     </DataLoader>
                 )
             });


### PR DESCRIPTION
Implements proposal 1 from #27578. Thanks @crenshaw-dev for spec'ing it out in the thread.

Each resource in the diff panel gets a checkbox, plus a "Sync selected" button at the top. Tick the ones you want, hit the button, and the sync flyout opens with exactly those pre-selected. Boxes start unchecked, so opening the diff just to read it doesn't queue anything. Easy to flip to checked-by-default if you'd rather.

The sync flyout's `deploy` query param used to take a single resource key or `all`. It now also takes a comma-separated list. I pulled the pre-selection into a small `resourcesPreSelection()` helper and added unit tests for the new list form and the existing single-key / `all` cases, so current callers behave the same. Only the app diff view opts in, through a new optional `onSync` prop, so the single-resource node diff and the ApplicationSet diff stay as they were.

<img width="1600" height="1000" alt="real-1-initial" src="https://github.com/user-attachments/assets/b85ec753-0b77-4e5a-ac1f-35c7ee1a2734" />
<img width="1600" height="1000" alt="real-2-selected" src="https://github.com/user-attachments/assets/bc84900b-3948-4306-9769-11dca022d5de" />
<img width="1600" height="1000" alt="real-3-syncflyout" src="https://github.com/user-attachments/assets/70209bd2-efd9-42d8-b3a3-6385d80c57a4" />

Closes #27578

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).
