### PR TITLE
feat(health): add health check for Prometheus Operator PrometheusAgent

### DIFF
--- a/resource_customizations/monitoring.coreos.com/PrometheusAgent/health.lua
+++ b/resource_customizations/monitoring.coreos.com/PrometheusAgent/health.lua
@@ -1,0 +1,23 @@
+local hs={ status = "Progressing", message = "Waiting for initialization" }
+
+if obj.status ~= nil then
+  if obj.status.conditions ~= nil then
+    for i, condition in ipairs(obj.status.conditions) do
+
+      if condition.type == "Available" and condition.status ~= "True" then
+        if condition.reason == "SomePodsNotReady" then
+          hs.status = "Progressing"
+        else
+          hs.status = "Degraded"
+        end
+        hs.message = condition.message or condition.reason
+      end
+      if condition.type == "Available" and condition.status == "True" then
+        hs.status = "Healthy"
+        hs.message = "All instances are available"
+      end
+    end
+  end
+end
+
+return hs

--- a/resource_customizations/monitoring.coreos.com/PrometheusAgent/health_test.yaml
+++ b/resource_customizations/monitoring.coreos.com/PrometheusAgent/health_test.yaml
@@ -1,0 +1,13 @@
+tests:
+  - healthStatus:
+      status: Healthy
+      message: "All instances are available"
+    inputPath: testdata/healthy.yaml
+  - healthStatus:
+      status: Progressing
+      message: "SomePodsNotReady"
+    inputPath: testdata/progressing.yaml
+  - healthStatus:
+      status: Degraded
+      message: "pod prometheus-agent-0: 0/5 nodes are available"
+    inputPath: testdata/degraded.yaml

--- a/resource_customizations/monitoring.coreos.com/PrometheusAgent/testdata/degraded.yaml
+++ b/resource_customizations/monitoring.coreos.com/PrometheusAgent/testdata/degraded.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: PrometheusAgent
+metadata:
+  name: agent
+  namespace: monitoring
+spec:
+  replicas: 1
+status:
+  availableReplicas: 0
+  conditions:
+  - lastTransitionTime: "2025-05-01T10:00:00Z"
+    message: "pod prometheus-agent-0: 0/5 nodes are available"
+    reason: NoPodReady
+    status: "False"
+    type: Available
+  paused: false
+  replicas: 1
+  unavailableReplicas: 1
+  updatedReplicas: 1

--- a/resource_customizations/monitoring.coreos.com/PrometheusAgent/testdata/healthy.yaml
+++ b/resource_customizations/monitoring.coreos.com/PrometheusAgent/testdata/healthy.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: PrometheusAgent
+metadata:
+  name: agent
+  namespace: monitoring
+spec:
+  replicas: 2
+status:
+  availableReplicas: 2
+  conditions:
+  - lastTransitionTime: "2025-05-01T10:00:00Z"
+    status: "True"
+    type: Available
+  - lastTransitionTime: "2025-05-01T10:00:00Z"
+    status: "True"
+    type: Reconciled
+  paused: false
+  replicas: 2
+  unavailableReplicas: 0
+  updatedReplicas: 2

--- a/resource_customizations/monitoring.coreos.com/PrometheusAgent/testdata/progressing.yaml
+++ b/resource_customizations/monitoring.coreos.com/PrometheusAgent/testdata/progressing.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: PrometheusAgent
+metadata:
+  name: agent
+  namespace: monitoring
+spec:
+  replicas: 2
+status:
+  availableReplicas: 1
+  conditions:
+  - lastTransitionTime: "2025-05-01T10:00:00Z"
+    reason: SomePodsNotReady
+    status: "False"
+    type: Available
+  paused: false
+  replicas: 2
+  unavailableReplicas: 1
+  updatedReplicas: 1


### PR DESCRIPTION
## What
Adds a health check for the Prometheus Operator `PrometheusAgent` CRD (`monitoring.coreos.com/v1alpha1`), completing the operator's workload set alongside the existing `Prometheus` check.

## Behavior
`PrometheusAgent` exposes the same `Available` / `Reconciled` status conditions as `Prometheus`, so this mirrors the existing check:
- **Healthy** — `Available` is `True`.
- **Progressing** — `Available` not `True` with reason `SomePodsNotReady`.
- **Degraded** — `Available` not `True` for any other reason.
- **Progressing** (default) — before status is populated.

## Tests
`healthy` / `progressing` / `degraded` fixtures; `TestLuaHealthScript` passes.