### PR TITLE
feat(health): add health check for VerticalPodAutoscaler

### DIFF
--- a/resource_customizations/autoscaling.k8s.io/VerticalPodAutoscaler/health.lua
+++ b/resource_customizations/autoscaling.k8s.io/VerticalPodAutoscaler/health.lua
@@ -1,0 +1,26 @@
+-- Health check for the VerticalPodAutoscaler CRD.
+-- See https://argo-cd.readthedocs.io/en/stable/operator-manual/health/ for how
+-- custom health checks work and what each status means.
+-- Maps the VPA status conditions to an Argo CD health status:
+--   Degraded    - NoPodsMatched is True (the selector matches no pods).
+--   Healthy     - RecommendationProvided is True (a recommendation is available).
+--   Progressing - the recommender has not produced a recommendation yet, or
+--                 status is not populated yet.
+local hs = { status = "Progressing", message = "Waiting for VPA recommendation" }
+if obj.status ~= nil and obj.status.conditions ~= nil then
+  for _, condition in ipairs(obj.status.conditions) do
+    if condition.type == "NoPodsMatched" and condition.status == "True" then
+      hs.status = "Degraded"
+      hs.message = condition.message or condition.reason or "No pods match the VPA selector"
+      return hs
+    end
+  end
+  for _, condition in ipairs(obj.status.conditions) do
+    if condition.type == "RecommendationProvided" and condition.status == "True" then
+      hs.status = "Healthy"
+      hs.message = "VPA recommendation provided"
+      return hs
+    end
+  end
+end
+return hs

--- a/resource_customizations/autoscaling.k8s.io/VerticalPodAutoscaler/health_test.yaml
+++ b/resource_customizations/autoscaling.k8s.io/VerticalPodAutoscaler/health_test.yaml
@@ -1,0 +1,13 @@
+tests:
+  - healthStatus:
+      status: Healthy
+      message: "VPA recommendation provided"
+    inputPath: testdata/healthy.yaml
+  - healthStatus:
+      status: Degraded
+      message: "No pods match the VPA selector"
+    inputPath: testdata/nopods.yaml
+  - healthStatus:
+      status: Progressing
+      message: "Waiting for VPA recommendation"
+    inputPath: testdata/progressing.yaml

--- a/resource_customizations/autoscaling.k8s.io/VerticalPodAutoscaler/testdata/healthy.yaml
+++ b/resource_customizations/autoscaling.k8s.io/VerticalPodAutoscaler/testdata/healthy.yaml
@@ -1,0 +1,23 @@
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: app-vpa
+  namespace: default
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: app
+  updatePolicy:
+    updateMode: "Auto"
+status:
+  conditions:
+  - lastTransitionTime: "2025-05-01T10:00:00Z"
+    status: "True"
+    type: RecommendationProvided
+  recommendation:
+    containerRecommendations:
+    - containerName: app
+      target:
+        cpu: 100m
+        memory: 262144k

--- a/resource_customizations/autoscaling.k8s.io/VerticalPodAutoscaler/testdata/nopods.yaml
+++ b/resource_customizations/autoscaling.k8s.io/VerticalPodAutoscaler/testdata/nopods.yaml
@@ -1,0 +1,17 @@
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: app-vpa
+  namespace: default
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: missing-app
+status:
+  conditions:
+  - lastTransitionTime: "2025-05-01T10:00:00Z"
+    message: No pods match the VPA selector
+    reason: NoPodsMatched
+    status: "True"
+    type: NoPodsMatched

--- a/resource_customizations/autoscaling.k8s.io/VerticalPodAutoscaler/testdata/progressing.yaml
+++ b/resource_customizations/autoscaling.k8s.io/VerticalPodAutoscaler/testdata/progressing.yaml
@@ -1,0 +1,10 @@
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: app-vpa
+  namespace: default
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: app


### PR DESCRIPTION
## What
Adds a health check for the `autoscaling.k8s.io/VerticalPodAutoscaler` (VPA) CRD, which had no health check.

## Behavior
Reads the VPA status conditions:
- **Degraded** — `NoPodsMatched` is `True` (the target selector matches no pods — a misconfiguration).
- **Healthy** — `RecommendationProvided` is `True` (the recommender produced a recommendation).
- **Progressing** — no recommendation yet, or status not populated.

Condition types verified against the VPA v1 API (`RecommendationProvided`, `NoPodsMatched`).

## Tests
`healthy` / `nopods` / `progressing` fixtures; `TestLuaHealthScript` passes.