### PR TITLE
feat(health): add health check for Longhorn Volume

### DIFF
--- a/resource_customizations/longhorn.io/Volume/health.lua
+++ b/resource_customizations/longhorn.io/Volume/health.lua
@@ -1,0 +1,42 @@
+-- Health check for the Longhorn Volume CRD.
+-- See https://argo-cd.readthedocs.io/en/stable/operator-manual/health/ for how
+-- custom health checks work and what each status means.
+-- Maps the Volume status.state and status.robustness to an Argo CD health status:
+--   Degraded    - robustness is "faulted" (the volume's data is unavailable).
+--   Progressing - the volume is being created/attached/detached, or is attached
+--                 but rebuilding replicas ("degraded" robustness).
+--   Healthy     - the volume is attached and healthy, or cleanly detached (idle).
+local hs = { status = "Progressing", message = "Waiting for volume" }
+if obj.status ~= nil then
+  local state = obj.status.state
+  local robustness = obj.status.robustness
+
+  if robustness == "faulted" then
+    hs.status = "Degraded"
+    hs.message = "Volume is faulted"
+    return hs
+  end
+
+  if state == "attached" then
+    if robustness == "healthy" then
+      hs.status = "Healthy"
+      hs.message = "Volume is attached and healthy"
+    elseif robustness == "degraded" then
+      hs.status = "Progressing"
+      hs.message = "Volume is degraded (rebuilding replicas)"
+    else
+      hs.status = "Progressing"
+      hs.message = "Volume is attached"
+    end
+    return hs
+  elseif state == "detached" then
+    hs.status = "Healthy"
+    hs.message = "Volume is detached"
+    return hs
+  elseif state ~= nil and state ~= "" then
+    hs.status = "Progressing"
+    hs.message = "Volume is " .. state
+    return hs
+  end
+end
+return hs

--- a/resource_customizations/longhorn.io/Volume/health_test.yaml
+++ b/resource_customizations/longhorn.io/Volume/health_test.yaml
@@ -1,0 +1,21 @@
+tests:
+  - healthStatus:
+      status: Healthy
+      message: "Volume is attached and healthy"
+    inputPath: testdata/attached_healthy.yaml
+  - healthStatus:
+      status: Healthy
+      message: "Volume is detached"
+    inputPath: testdata/detached.yaml
+  - healthStatus:
+      status: Progressing
+      message: "Volume is degraded (rebuilding replicas)"
+    inputPath: testdata/degraded.yaml
+  - healthStatus:
+      status: Degraded
+      message: "Volume is faulted"
+    inputPath: testdata/faulted.yaml
+  - healthStatus:
+      status: Progressing
+      message: "Volume is attaching"
+    inputPath: testdata/attaching.yaml

--- a/resource_customizations/longhorn.io/Volume/testdata/attached_healthy.yaml
+++ b/resource_customizations/longhorn.io/Volume/testdata/attached_healthy.yaml
@@ -1,0 +1,12 @@
+apiVersion: longhorn.io/v1beta2
+kind: Volume
+metadata:
+  name: pvc-abc123
+  namespace: longhorn-system
+spec:
+  numberOfReplicas: 3
+  size: "10737418240"
+status:
+  state: attached
+  robustness: healthy
+  currentNodeID: node-1

--- a/resource_customizations/longhorn.io/Volume/testdata/attaching.yaml
+++ b/resource_customizations/longhorn.io/Volume/testdata/attaching.yaml
@@ -1,0 +1,11 @@
+apiVersion: longhorn.io/v1beta2
+kind: Volume
+metadata:
+  name: pvc-abc123
+  namespace: longhorn-system
+spec:
+  numberOfReplicas: 3
+  size: "10737418240"
+status:
+  state: attaching
+  robustness: unknown

--- a/resource_customizations/longhorn.io/Volume/testdata/degraded.yaml
+++ b/resource_customizations/longhorn.io/Volume/testdata/degraded.yaml
@@ -1,0 +1,12 @@
+apiVersion: longhorn.io/v1beta2
+kind: Volume
+metadata:
+  name: pvc-abc123
+  namespace: longhorn-system
+spec:
+  numberOfReplicas: 3
+  size: "10737418240"
+status:
+  state: attached
+  robustness: degraded
+  currentNodeID: node-1

--- a/resource_customizations/longhorn.io/Volume/testdata/detached.yaml
+++ b/resource_customizations/longhorn.io/Volume/testdata/detached.yaml
@@ -1,0 +1,11 @@
+apiVersion: longhorn.io/v1beta2
+kind: Volume
+metadata:
+  name: pvc-abc123
+  namespace: longhorn-system
+spec:
+  numberOfReplicas: 3
+  size: "10737418240"
+status:
+  state: detached
+  robustness: unknown

--- a/resource_customizations/longhorn.io/Volume/testdata/faulted.yaml
+++ b/resource_customizations/longhorn.io/Volume/testdata/faulted.yaml
@@ -1,0 +1,11 @@
+apiVersion: longhorn.io/v1beta2
+kind: Volume
+metadata:
+  name: pvc-abc123
+  namespace: longhorn-system
+spec:
+  numberOfReplicas: 3
+  size: "10737418240"
+status:
+  state: detached
+  robustness: faulted


### PR DESCRIPTION
## What
Adds a health check for the `longhorn.io/Volume` CRD, which had no health check.

## Behavior
Maps `status.state` + `status.robustness`:
- **Degraded** — `robustness: faulted` (data unavailable).
- **Progressing** — `attached` + `robustness: degraded` (rebuilding replicas), or a transitional `state` (`creating`/`attaching`/`detaching`/`deleting`).
- **Healthy** — `attached` + `robustness: healthy`, or cleanly `detached` (idle).

Values verified against the Longhorn v1beta2 API (`VolumeRobustness` healthy/degraded/faulted/unknown; `VolumeState` creating/attached/detached/attaching/detaching/deleting).

## Tests
`attached_healthy` / `detached` / `degraded` / `faulted` / `attaching` fixtures; `TestLuaHealthScript` passes.