### PR TITLE
fix(progressivesync): check if error == notfound

### DIFF
--- a/applicationset/progressivesync/progressive_sync.go
+++ b/applicationset/progressivesync/progressive_sync.go
@@ -142,6 +142,7 @@ func (m *Manager) PerformReverseDeletion(ctx context.Context, logCtx *log.Entry,
 				logCtx.Infof("application %s successfully deleted", step.AppName)
 				continue
 			}
+			return 0, fmt.Errorf("error retrieving application %s: %w", step.AppName, err)
 		}
 		// Check if the application is already being deleted
 		if retrievedApp.DeletionTimestamp != nil {
@@ -150,8 +151,16 @@ func (m *Manager) PerformReverseDeletion(ctx context.Context, logCtx *log.Entry,
 				return 0, errors.New("application has not been deleted in over 2 minutes")
 			}
 		}
-		// The application has not been deleted yet, trigger its deletion
+		// The application has not been deleted yet, trigger its deletion.
+		// A NotFound here means the object is already gone from the API server while our
+		// (cache-backed) Get above still saw it — a stale informer cache. Treat it as
+		// already deleted and move on, otherwise we would error-loop forever and never
+		// remove the ApplicationSet finalizer.
 		if err := m.Client.Delete(ctx, &retrievedApp); err != nil {
+			if apierrors.IsNotFound(err) {
+				logCtx.Infof("application %s already deleted", step.AppName)
+				continue
+			}
 			return 0, err
 		}
 		return requeueTime, nil

--- a/applicationset/progressivesync/progressive_sync_test.go
+++ b/applicationset/progressivesync/progressive_sync_test.go
@@ -1,13 +1,19 @@
 package progressivesync
 
 import (
+	"context"
 	"testing"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 )
@@ -1590,4 +1596,77 @@ func TestIsRollingSyncDeletionReversed(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+// TestPerformReverseDeletionStaleCache reproduces the "ApplicationSet stuck in Deleting" bug.
+//
+// When an ApplicationSet with deletionOrder: Reverse is deleted, the controller reads the child
+// Applications from its (cache-backed) client to decide when they are gone. If the informer cache
+// is stale — it still lists Applications that were already removed from the API server — then the
+// per-app Get returns the ghost object while the subsequent Delete hits the API and returns
+// NotFound. The old code treated that NotFound as a fatal error and returned it, so the reconcile
+// error-looped forever and the ResourcesFinalizer was never removed. The only known recovery was
+// restarting the controller (which rebuilds the cache from a fresh LIST).
+//
+// This test simulates the stale cache with an interceptor: Get succeeds (object present in the
+// fake store) but Delete returns NotFound. PerformReverseDeletion must treat that as
+// "already deleted" and converge to (0, nil) so the finalizer can be removed.
+func TestPerformReverseDeletionStaleCache(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+
+	appSet := v1alpha1.ApplicationSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "appset", Namespace: "argocd"},
+		Spec: v1alpha1.ApplicationSetSpec{
+			Strategy: &v1alpha1.ApplicationSetStrategy{
+				Type:          "RollingSync",
+				DeletionOrder: ReverseDeletionOrder,
+				RollingSync: &v1alpha1.ApplicationSetRolloutStrategy{
+					Steps: []v1alpha1.ApplicationSetRolloutStep{
+						{MatchExpressions: []v1alpha1.ApplicationMatchExpression{{Key: "stage", Operator: "In", Values: []string{"0"}}}},
+						{MatchExpressions: []v1alpha1.ApplicationMatchExpression{{Key: "stage", Operator: "In", Values: []string{"1"}}}},
+					},
+				},
+			},
+		},
+	}
+
+	newApp := func(name, stage string) v1alpha1.Application {
+		return v1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "argocd", Labels: map[string]string{"stage": stage}},
+		}
+	}
+	// currentApps mirrors what getCurrentApplications() returns from the stale cache: both apps
+	// still appear to exist even though they have already been deleted from the API server.
+	app0 := newApp("appset-stage0", "0")
+	app1 := newApp("appset-stage1", "1")
+	currentApps := []v1alpha1.Application{app0, app1}
+
+	deleteAttempts := map[string]int{}
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(&app0, &app1). // Get returns the ghost objects (stale cache)
+		WithInterceptorFuncs(interceptor.Funcs{
+			// The objects are already gone on the API server: every Delete 404s.
+			Delete: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.DeleteOption) error {
+				deleteAttempts[obj.GetName()]++
+				return apierrors.NewNotFound(schema.GroupResource{Group: "argoproj.io", Resource: "applications"}, obj.GetName())
+			},
+		}).
+		Build()
+
+	m := NewManager(fakeClient, nil)
+	logCtx := log.NewEntry(log.New())
+
+	requeue, err := m.PerformReverseDeletion(context.Background(), logCtx, appSet, currentApps)
+
+	// With the fix, an already-deleted Application is treated as success: reverse deletion
+	// converges in a single pass so the caller can remove the finalizer instead of looping.
+	require.NoError(t, err, "already-deleted Application must not surface as a hard error")
+	assert.Zero(t, requeue, "deletion should be complete, not requeued")
+	// Both steps should have been visited and their (already-gone) deletion attempted.
+	assert.Equal(t, 1, deleteAttempts["appset-stage0"])
+	assert.Equal(t, 1, deleteAttempts["appset-stage1"])
 }

--- a/applicationset/utils/client.go
+++ b/applicationset/utils/client.go
@@ -9,6 +9,7 @@ import (
 	"unsafe"
 
 	log "github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	k8scache "k8s.io/client-go/tools/cache"
 	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -88,7 +89,12 @@ func (c *cacheSyncingClient) retrieveStore(ctx context.Context, obj client.Objec
 func (c *cacheSyncingClient) execAndSyncCache(ctx context.Context, op func() error, obj client.Object, deleteObj bool) error {
 	// execute the operation first and only sync cache if it succeeds
 	if err := op(); err != nil {
-		return err
+		// A NotFound on Delete means the object is already gone from the API server. We still
+		// want to evict any stale entry from the informer cache below, otherwise a lingering
+		// (already-deleted) object keeps being read back and callers can never converge.
+		if !(deleteObj && apierrors.IsNotFound(err)) {
+			return err
+		}
 	}
 	// sync cache for applications only
 	if _, ok := obj.(*application.Application); !ok {

--- a/applicationset/utils/client.go
+++ b/applicationset/utils/client.go
@@ -92,7 +92,7 @@ func (c *cacheSyncingClient) execAndSyncCache(ctx context.Context, op func() err
 		// A NotFound on Delete means the object is already gone from the API server. We still
 		// want to evict any stale entry from the informer cache below, otherwise a lingering
 		// (already-deleted) object keeps being read back and callers can never converge.
-		if !(deleteObj && apierrors.IsNotFound(err)) {
+		if !deleteObj || !apierrors.IsNotFound(err) {
 			return err
 		}
 	}

--- a/applicationset/utils/client_test.go
+++ b/applicationset/utils/client_test.go
@@ -109,6 +109,29 @@ func TestDeleteSyncsCache(t *testing.T) {
 	require.Empty(t, store.List())
 }
 
+// TestDeleteEvictsStaleCacheOnNotFound covers the "ApplicationSet stuck in Deleting" root cause.
+// The informer store still holds an Application that has already been removed from the API server
+// (a missed delete watch event). Deleting it returns NotFound. The stale entry must still be
+// evicted from the store, otherwise cache-backed reads keep returning the ghost object forever and
+// callers such as reverse deletion never converge — only a controller restart clears it.
+func TestDeleteEvictsStaleCacheOnNotFound(t *testing.T) {
+	t.Parallel()
+
+	// Seed the store with a ghost app, but leave the fake API client empty so Delete 404s.
+	app := &application.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "argocd"},
+	}
+	c, store, err := newClient()
+	require.NoError(t, err)
+	require.NoError(t, store.Add(app))
+	require.NotEmpty(t, store.List(), "precondition: store holds the stale entry")
+
+	err = c.Delete(t.Context(), app)
+	require.NoError(t, err, "a NotFound delete must be swallowed, not surfaced")
+
+	require.Empty(t, store.List(), "stale cache entry should be evicted even though the API returned NotFound")
+}
+
 func TestNewClientDoesNotCrashWithMultiNamespaceCache(_ *testing.T) {
 	_ = NewCacheSyncingClient(nil, &fakeMultiNamespaceCache{})
 }


### PR DESCRIPTION
An ApplicationSet using `spec.strategy.deletionOrder: Reverse` can permanently get stuck in `Deleting`: it keeps the
`resources-finalizer.argocd.argoproj.io` finalizer, its `status.resources` still lists the generated Applications as `Synced`/`Healthy`, but those Applications are already deleted from the cluster. Restarting `argocd-applicationset-controller` was previously the only known way to fix this.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
