### PR TITLE
fix: support repeated --header flags in ARGOCD_OPTS (#24065)

### DIFF
--- a/util/config/env.go
+++ b/util/config/env.go
@@ -11,7 +11,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var flags map[string]string
+var flags map[string][]string
 
 func init() {
 	err := LoadFlags()
@@ -21,7 +21,7 @@ func init() {
 }
 
 func LoadFlags() error {
-	flags = make(map[string]string)
+	flags = make(map[string][]string)
 
 	opts, err := shellquote.Split(os.Getenv("ARGOCD_OPTS"))
 	if err != nil {
@@ -33,37 +33,35 @@ func LoadFlags() error {
 		switch {
 		case strings.HasPrefix(opt, "--"):
 			if key != "" {
-				flags[key] = "true"
+				flags[key] = append(flags[key], "true")
 			}
 			key = strings.TrimPrefix(opt, "--")
 		case key != "":
-			flags[key] = opt
+			flags[key] = append(flags[key], opt)
 			key = ""
 		default:
 			return errors.New("ARGOCD_OPTS invalid at '" + opt + "'")
 		}
 	}
 	if key != "" {
-		flags[key] = "true"
+		flags[key] = append(flags[key], "true")
 	}
 	// pkg shellquota doesn't recognize `=` so that the opts in format `foo=bar` could not work.
 	// issue ref: https://github.com/argoproj/argo-cd/issues/6822
-	for k, v := range flags {
-		if strings.Contains(k, "=") && v == "true" {
+	for k, vals := range flags {
+		if strings.Contains(k, "=") && len(vals) == 1 && vals[0] == "true" {
 			kv := strings.SplitN(k, "=", 2)
 			actualKey, actualValue := kv[0], kv[1]
-			if _, ok := flags[actualKey]; !ok {
-				flags[actualKey] = actualValue
-			}
+			flags[actualKey] = append(flags[actualKey], actualValue)
 		}
 	}
 	return nil
 }
 
 func GetFlag(key, fallback string) string {
-	val, ok := flags[key]
-	if ok {
-		return val
+	vals, ok := flags[key]
+	if ok && len(vals) > 0 {
+		return vals[0]
 	}
 	return fallback
 }
@@ -73,8 +71,8 @@ func GetBoolFlag(key string) bool {
 }
 
 func GetIntFlag(key string, fallback int) int {
-	val, ok := flags[key]
-	if !ok {
+	val := GetFlag(key, "")
+	if val == "" {
 		return fallback
 	}
 
@@ -86,19 +84,26 @@ func GetIntFlag(key string, fallback int) int {
 }
 
 func GetStringSliceFlag(key string, fallback []string) []string {
-	val, ok := flags[key]
-	if !ok {
+	vals, ok := flags[key]
+	if !ok || len(vals) == 0 {
 		return fallback
 	}
 
-	if val == "" {
+	var result []string
+	for _, val := range vals {
+		if val == "" {
+			continue
+		}
+		stringReader := strings.NewReader(val)
+		csvReader := csv.NewReader(stringReader)
+		v, err := csvReader.Read()
+		if err != nil {
+			log.Fatal(err)
+		}
+		result = append(result, v...)
+	}
+	if result == nil {
 		return []string{}
 	}
-	stringReader := strings.NewReader(val)
-	csvReader := csv.NewReader(stringReader)
-	v, err := csvReader.Read()
-	if err != nil {
-		log.Fatal(err)
-	}
-	return v
+	return result
 }

--- a/util/config/env_test.go
+++ b/util/config/env_test.go
@@ -148,3 +148,21 @@ func TestFlagWithEqualSign(t *testing.T) {
 
 	assert.Equal(t, "bar", GetFlag("foo", ""))
 }
+
+func TestStringSliceFlagMultipleHeaders(t *testing.T) {
+	loadOpts(t, "--header 'Content-Type: application/json' --header 'Authorization: Bearer token'")
+	strings := GetStringSliceFlag("header", []string{})
+
+	assert.Len(t, strings, 2)
+	assert.Equal(t, "Content-Type: application/json", strings[0])
+	assert.Equal(t, "Authorization: Bearer token", strings[1])
+}
+
+func TestStringSliceFlagMultipleHeadersMixed(t *testing.T) {
+	loadOpts(t, "--header 'Content-Type: application/json' --header='Authorization: Bearer token'")
+	strings := GetStringSliceFlag("header", []string{})
+
+	assert.Len(t, strings, 2)
+	assert.Equal(t, "Content-Type: application/json", strings[0])
+	assert.Equal(t, "Authorization: Bearer token", strings[1])
+}


### PR DESCRIPTION
## Summary

Fixes #24065

ARGOCD_OPTS previously overwrote repeated flags because flags were stored in a map[string]string. This meant that using --header multiple times would only keep the last value.

### Changes

- Changed the internal flags storage from map[string]string to map[string][]string
- Updated GetFlag, GetBoolFlag, GetIntFlag, and GetStringSliceFlag to work with the new data structure
- Updated the = sign handling in LoadFlags to append values instead of overwriting
- Added tests for multiple --header flags in both space-separated and = formats

### Example

Before this fix:
export ARGOCD_OPTS='--header Content-Type: application/json --header Authorization: Bearer token'
Only Authorization: Bearer token would be preserved

After this fix:
Both headers are now preserved

The existing comma-separated format continues to work as before.