### PR TITLE
feat: display event source/component in events list (#25684)

### DIFF
--- a/ui/src/app/shared/components/events-list/events-list.tsx
+++ b/ui/src/app/shared/components/events-list/events-list.tsx
@@ -38,8 +38,9 @@ export const EventsList = (props: {events: models.Event[]}) => {
                     <div className='argo-table-list__head'>
                         <div className='row'>
                             <div className='columns small-2 xxlarge-2'>REASON</div>
-                            <div className='columns small-4 xxlarge-5'>MESSAGE</div>
-                            <div className='columns small-2 xxlarge-1'>COUNT</div>
+                            <div className='columns small-3 xxlarge-4'>MESSAGE</div>
+                            <div className='columns small-1 xxlarge-1'>COUNT</div>
+                            <div className='columns small-2 xxlarge-2'>SOURCE</div>
                             <div className='columns small-2 xxlarge-2'>FIRST OCCURRED</div>
                             <div className='columns small-2 xxlarge-2'>LAST OCCURRED</div>
                         </div>
@@ -48,10 +49,13 @@ export const EventsList = (props: {events: models.Event[]}) => {
                         <div className={`argo-table-list__row events-list__event events-list__event--${event.type}`} key={event.metadata.uid}>
                             <div className='row'>
                                 <div className='columns small-2 xxlarge-2'>{event.reason}</div>
-                                <div className='columns small-4 xxlarge-5' style={{whiteSpace: 'normal', lineHeight: 'normal'}}>
+                                <div className='columns small-3 xxlarge-4' style={{whiteSpace: 'normal', lineHeight: 'normal'}}>
                                     {event.message}
                                 </div>
-                                <div className='columns small-2 xxlarge-1'>{event.count}</div>
+                                <div className='columns small-1 xxlarge-1'>{event.count}</div>
+                                <div className='columns small-2 xxlarge-2' title={event.reportingInstance || ''}>
+                                    {event.source.component || event.reportingController || '-'}
+                                </div>
                                 <div className='columns small-2 xxlarge-2'>{event.firstTimestamp ? getTimeElements(event.firstTimestamp) : getTimeElements(event.eventTime)}</div>
                                 <div className='columns small-2 xxlarge-2'>{event.lastTimestamp ? getTimeElements(event.lastTimestamp) : getTimeElements(event.eventTime)}</div>
                             </div>


### PR DESCRIPTION
## Summary

Fixes #25684

Adds a SOURCE column to the EventsList component that displays which component or controller issued an event. This information was already available in the Event model (source.component, reportingController, reportingInstance) but was not being rendered in the UI.

### Changes

- Added a new SOURCE column to the events table header
- Renders event.source.component with a fallback to event.reportingController
- Shows reportingInstance in a tooltip on hover
- Adjusted column widths to accommodate the new column

### Impact

This change applies to all event display contexts since EventsList is a shared component used for:
- Application events tab
- Resource-level events tab
- ApplicationSet events tab
- Project events tab

The source data was already present in the API response, so no backend changes are needed.