### PR TITLE
docs: document object format for the clusters RBAC resource

### DIFF
--- a/docs/operator-manual/rbac.md
+++ b/docs/operator-manual/rbac.md
@@ -280,6 +280,55 @@ p, example-user, applications, get, default/*, allow
 p, example-user, extensions, invoke, httpbin, allow
 ```
 
+### The `clusters` resource
+
+The `clusters` resource governs which cluster credentials a user can list, create,
+update, or delete via the Argo CD API/UI/CLI. Cluster credentials are stored as
+Kubernetes `Secret`s in the Argo CD namespace with the
+`argocd.argoproj.io/secret-type: cluster` label. Each such Secret may optionally
+carry a `project` field, which scopes the cluster to a single AppProject.
+
+The `<object>` value in a `clusters` policy is derived from the cluster Secret's
+`server` (its API URL, e.g. `https://kubernetes.default.svc`) and its optional
+`project` field, following [`CreateClusterRBACObject`](https://github.com/argoproj/argo-cd/blob/master/server/cluster/cluster.go):
+
+- **Unscoped cluster** (Secret's `project` is empty): the object is the cluster
+  server URL, e.g. `https://kubernetes.default.svc`.
+- **Project-scoped cluster** (Secret's `project` is set): the object is
+  `<project>/<server-url>`, e.g. `my-project/https://api.example.com:6443`.
+
+Examples:
+
+```csv
+# Grant every authenticated user visibility of the shared in-cluster Secret
+# (which is unscoped).
+p, role:defaultrole, clusters, get, https://kubernetes.default.svc, allow
+
+# Grant a role full access to a project-scoped external cluster.
+p, role:my-role, clusters, *, my-project/https://api.example.com:6443, allow
+```
+
+Because `policy.matchMode` defaults to `glob`, wildcards are supported:
+
+```csv
+# Any authenticated user can get every cluster Secret owned by "my-project".
+p, role:defaultrole, clusters, get, my-project/*, allow
+```
+
+> [!NOTE]
+> **The cluster Secret's `name` is not accepted as an object**
+>
+> The `<object>` for a `clusters` policy must be the server URL (optionally
+> project-prefixed); the cluster Secret's `name` field is **not** an accepted
+> object shape. A policy such as `p, ..., clusters, get, my-cluster, allow`
+> will silently match nothing when `my-cluster` is not a URL. See
+> [issue #13244](https://github.com/argoproj/argo-cd/issues/13244) for tracking
+> of a feature request to also accept cluster names.
+
+For the setup side of project-scoped clusters (how to attach a `project` to a
+cluster Secret and let developers self-register clusters into a project) see
+[Project scoped Repositories and Clusters](../user-guide/projects.md#project-scoped-repositories-and-clusters).
+
 ### The `deny` effect
 
 When `deny` is used as an effect in a policy, it will be effective if the policy matches.

--- a/docs/operator-manual/rbac.md
+++ b/docs/operator-manual/rbac.md
@@ -282,11 +282,7 @@ p, example-user, extensions, invoke, httpbin, allow
 
 ### The `clusters` resource
 
-The `clusters` resource governs which cluster credentials a user can list, create,
-update, or delete via the Argo CD API/UI/CLI. Cluster credentials are stored as
-Kubernetes `Secret`s in the Argo CD namespace with the
-`argocd.argoproj.io/secret-type: cluster` label. Each such Secret may optionally
-carry a `project` field, which scopes the cluster to a single AppProject.
+The clusters resource controls which Argo CD cluster entries a user can list, create, update, or delete via the Argo CD API/UI/CLI. Registered cluster credentials are typically stored as Kubernetes Secrets in the Argo CD namespace with the argocd.argoproj.io/secret-type: cluster label. Such Secrets may optionally carry a project field, which scopes the cluster to a single AppProject.
 
 The `<object>` value in a `clusters` policy is derived from the cluster Secret's
 `server` (its API URL, e.g. `https://kubernetes.default.svc`) and its optional

--- a/docs/operator-manual/rbac.md
+++ b/docs/operator-manual/rbac.md
@@ -311,14 +311,16 @@ p, role:defaultrole, clusters, get, my-project/*, allow
 ```
 
 > [!NOTE]
-> **The cluster Secret's `name` is not accepted as an object**
+> **The cluster name is not accepted as the RBAC object**
 >
-> The `<object>` for a `clusters` policy must be the server URL (optionally
-> project-prefixed); the cluster Secret's `name` field is **not** an accepted
-> object shape. A policy such as `p, ..., clusters, get, my-cluster, allow`
-> will silently match nothing when `my-cluster` is not a URL. See
-> [issue #13244](https://github.com/argoproj/argo-cd/issues/13244) for tracking
-> of a feature request to also accept cluster names.
+> The `<object>` for a `clusters` policy must be the cluster server URL,
+> optionally prefixed with the project. The cluster's logical `name` field
+> (`data.name` / `stringData.name` in a declarative cluster Secret) is not an
+> accepted object format. For example, a policy such as
+> `p, ..., clusters, get, my-cluster, allow` will not match a cluster whose
+> server is a URL such as `https://api.example.com:6443`. See
+> [issue #13244](https://github.com/argoproj/argo-cd/issues/13244) for the
+> feature request to also accept cluster names.
 
 For the setup side of project-scoped clusters (how to attach a `project` to a
 cluster Secret and let developers self-register clusters into a project) see

--- a/docs/operator-manual/rbac.md
+++ b/docs/operator-manual/rbac.md
@@ -296,8 +296,7 @@ The `<object>` value in a `clusters` policy is derived from the cluster Secret's
 Examples:
 
 ```csv
-# Grant every authenticated user visibility of the shared in-cluster Secret
-# (which is unscoped).
+# Grant the default role visibility of the unscoped in-cluster entry
 p, role:defaultrole, clusters, get, https://kubernetes.default.svc, allow
 
 # Grant a role full access to a project-scoped external cluster.


### PR DESCRIPTION
## Summary
Add a `### The clusters resource` subsection to `docs/operator-manual/rbac.md`. Cross-link it to the existing setup-side coverage in `docs/user-guide/projects.md#project-scoped-repositories-and-clusters`.

## What's already documented (and where the gap is)

Being explicit about the existing state before proposing an addition:

- **`docs/operator-manual/rbac.md`** — has per-resource subsections for `applications`, `applicationsets`, `logs`, `exec`, `extensions`. **No section for `clusters`** (or `repositories`, or `projects`).
- **`docs/user-guide/projects.md#project-scoped-repositories-and-clusters`** — shows the URL-based `<project>/<url>` pattern, but:
  - only for the `repositories` resource,
  - only for `create` / `update` / `delete` actions (never `get`),
  - hand-waves the cluster case with *"All the examples above concern Git repositories, but the same principles apply to clusters as well"* — no cluster RBAC example.
- **`docs/user-guide/projects.md`** line 206 (Note 2 under "Project Roles"):
  > "See the [RBAC documentation](../operator-manual/rbac.md) for more details about those resources: `applicationsets`, `repositories`, **`clusters`**, `logs` and `exec`."
  Circular reference — this points to `rbac.md` which does not currently document `clusters`.
- **`docs/proposals/project-repos-and-clusters.md`** (2020) — describes the RBAC pattern as `<projectName>/<name>`. The shipped implementation uses `<projectName>/<server-url>` (per `CreateClusterRBACObject`), not `<name>`. Historical proposal, not user-facing docs, but worth being aware of when reading old design notes.
- **Various user-management examples** (`onelogin.md`, `microsoft.md`, `keycloak.md`, …) — all show `p, role:org-admin, clusters, get, *, allow`. Wildcard object; doesn't demonstrate the actual format.

**Net gap** — nowhere in the docs is the object format for `clusters` spelled out for:
- the **unscoped** case (`data.project == ""` → object is just `<server-url>`), which is the common shape when using the shared `in-cluster` Secret or a globally-usable external cluster;
- the **`get`** action, which is what the "New Application" UI cluster picker enforces;
- and there's no clear signal that the cluster Secret's `name` is **not** an accepted object — a common mistake users make (see #13244, open since 2023).

## Why
Writing a `clusters, get` policy today requires reading `server/cluster/cluster.go`. I hit this personally: guessed `/<cluster-name>` based on how sibling resource sections read in `rbac.md`, deployed, and only found out it never matched by reading source and grep'ing the argocd-server logs. #13244 confirms other users trip on the same edge.

The authoritative source is [`CreateClusterRBACObject`](https://github.com/argoproj/argo-cd/blob/master/server/cluster/cluster.go):

```go
func CreateClusterRBACObject(project string, server string) string {
    if project != "" {
        return project + "/" + server
    }
    return server
}
```

Every call site in `server/cluster/cluster.go` (`List`, `Get`, `Create`, `Update`, `Delete`) uses this helper for the enforce object. There is no `<name>` code path.

## What the PR does
Adds `### The clusters resource` to `docs/operator-manual/rbac.md`, symmetric with the existing per-resource subsections, that:

- describes the two object shapes (unscoped Secret → `<server-url>`; project-scoped Secret → `<project>/<server-url>`);
- cites `CreateClusterRBACObject` for the authoritative behavior;
- gives concrete `csv` examples covering both cases and a glob wildcard;
- adds a `> [!NOTE]` block explicitly warning that the cluster Secret's `name` field is **not** an accepted object, with a link to #13244 for the ongoing feature ask to also accept names;
- **cross-links back to `projects.md#project-scoped-repositories-and-clusters`** for the setup side (how to attach a `project` to a cluster Secret and let developers self-register clusters into a project) — closing the circular-reference loop.

Scope discipline: `clusters` only. `repositories` and `projects` have the same "no dedicated section in `rbac.md`" problem — worth a follow-up PR, but keeping this diff focused for reviewer velocity.

## Type of change
- [x] docs

## Validation

```
$ uv run --with-requirements docs/requirements.txt --no-project --python 3.12 mkdocs build --strict
...
INFO    -  Documentation built in 3.47 seconds
```

No errors; no warnings related to this change. mkdocs also validates the cross-link to `../user-guide/projects.md#project-scoped-repositories-and-clusters` (target anchor exists). Pre-existing INFO messages about broken anchors in unrelated files (`developer-guide/index.md`, `operator-manual/applicationset/Generators-Git.md`, `operator-manual/user-management/keycloak.md`) are not caused by this change.

Rendered site inspection confirms the new nav entry (`The clusters resource` → `#the-clusters-resource`), the heading, the source-citation link, the examples, the #13244 link, and the cross-link all render correctly in `site/operator-manual/rbac/index.html`.

## Checklist

* [x] (c) This does not need to be in the release notes — pure docs addition.
* [x] The title of the PR states what changed.
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr) (`docs:` prefix).
* [x] Does this PR require documentation updates? — this PR *is* the doc update.
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal).
* [ ] I have written unit and/or e2e tests for my change — N/A for a docs-only change.
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.

## Suggested follow-up (not in this PR)
1. Add a `clusters`-flavor RBAC example alongside the `repositories` example in `docs/user-guide/projects.md#project-scoped-repositories-and-clusters`, so the "same principles apply to clusters as well" hand-wave becomes concrete.
2. Add `### The repositories resource` and `### The projects resource` subsections to `rbac.md` for parity (same silent-format problem as `clusters` had).

## Related
- Long-standing feature request tracking a related surprise: #13244 ("policy.csv recognizes cluster server URL but not cluster name")
- Tested against v3.4.4; `server/cluster/cluster.go` `CreateClusterRBACObject` unchanged on `master`.
