### PR TITLE
docs: fix typos in documentation and CI stale workflow

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -37,7 +37,7 @@ jobs:
             This pull request has been marked as stale because it has had no activity for 90 days. Please comment if this is still relevant.
 
           days-before-stale: 90
-          days-before-close: -1   # Auto-close diabled
+          days-before-close: -1   # Auto-close disabled
 
           exempt-issue-labels: >
             bug, security, breaking/high, breaking/medium, breaking/low

--- a/docs/proposals/proxy-extensions.md
+++ b/docs/proposals/proxy-extensions.md
@@ -111,7 +111,7 @@ Example:
 apiVersion: argoproj.io/v1alpha1
 kind: ArgoCDExtension
 metadata:
-  name: my-cool-extention
+  name: my-cool-extension
   finalizers:
     - extensions-finalizer.argocd.argoproj.io
 spec:

--- a/docs/user-guide/helm.md
+++ b/docs/user-guide/helm.md
@@ -640,7 +640,7 @@ RUN helm plugin install ${GCS_PLUGIN_REPO} --version ${GCS_PLUGIN_VERSION}
 ENV HELM_PLUGINS="/home/argocd/.local/share/helm/plugins/"
 ```
 
-The `HELM_PLUGINS` environment property required for ArgoCD to locate plugins correctly.
+The `HELM_PLUGINS` environment variable required for Argo CD to locate plugins correctly.
 
 Once built, use the custom image for ArgoCD installation.
 


### PR DESCRIPTION
Fixes minor typos in documentation and CI configuration:

- Fixed `extention` to `extension` in proxy-extensions.md proposal example
- Fixed `environment property` to `environment variable` and `ArgoCD` to `Argo CD` in helm user guide
- Fixed `diabled` to `disabled` comment in stale workflow

These are cosmetic fixes only with no functional changes.