### PR TITLE
docs: fix typos and grammar in documentation

### DIFF
--- a/docs/proposals/proxy-extensions.md
+++ b/docs/proposals/proxy-extensions.md
@@ -50,7 +50,7 @@ backend code will live outside Argo CD main repository.
 
 The initiative to implement the anomaly detection capability in Argo CD
 highlighted the need to improve the existing UI extensions feature. The
-new capability will required the UI to have access to data that isn't
+new capability will require the UI to have access to data that isn't
 available as part of Application's owned resources. It is necessary to
 access an API defined by the extension's development team so the proper
 information can be displayed.

--- a/docs/security_considerations.md
+++ b/docs/security_considerations.md
@@ -9,7 +9,7 @@
 > [published security advisories](https://github.com/argoproj/argo-cd/security/advisories).
 
 As a deployment tool, Argo CD needs to have production access which makes security a very important topic.
-The Argoproj team takes security very seriously and continuously working on improving it. Learn more about security
+The Argoproj team takes security very seriously and is continuously working on improving it. Learn more about security
 related features in [Security](./operator-manual/security.md) section.
 
 ## Overview of past and current issues
@@ -115,7 +115,7 @@ Argo CD uses the `argocd-server` pod name (ex: `argocd-server-55594fbdb9-ptsf5`)
 
 Kubernetes users able to list pods in the argo namespace are able to retrieve the default password.
 
-Additionally, In most installations, [the Pod name contains a random "trail" of characters](https://github.com/kubernetes/kubernetes/blob/dda530cfb74b157f1d17b97818aa128a9db8e711/staging/src/k8s.io/apiserver/pkg/storage/names/generate.go#L37).
+Additionally, in most installations, [the Pod name contains a random "trail" of characters](https://github.com/kubernetes/kubernetes/blob/dda530cfb74b157f1d17b97818aa128a9db8e711/staging/src/k8s.io/apiserver/pkg/storage/names/generate.go#L37).
 These characters are generated using [a time-seeded PRNG](https://github.com/kubernetes/apimachinery/blob/master/pkg/util/rand/rand.go#L26) and not a CSPRNG.
 An attacker could use this information in an attempt to deduce the state of the internal PRNG, aiding bruteforce attacks.
 


### PR DESCRIPTION
What: Fix typo ('will required' → 'will require') in proxy-extensions proposal, add missing auxiliary verb in security_considerations, and fix capitalization after comma.\nWhy: Improves documentation quality and correctness.