### PR TITLE
fix: correct variable expansion in Makefile and typo in .snyk

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -22,7 +22,7 @@ ignore:
     - '*':
         reason: >-
           Argo CD uses go-restful as a transitive dependency of kube-openapi. kube-openapi is used to generate openapi
-          specs. We do not use go-restul at runtime and are therefore not vulnerable to this CORS misconfiguration
+          specs. We do not use go-restful at runtime and are therefore not vulnerable to this CORS misconfiguration
           issue in go-restful.
   SNYK-JS-FORMIDABLE-2838956:
     - '*':

--- a/Makefile
+++ b/Makefile
@@ -379,7 +379,7 @@ endif
 
 .PHONY: armimage
 armimage:
-	$(DOCKER) build -t $(IMAGE_PREFIX)(IMAGE_REPOSITORY):$(IMAGE_TAG)-arm .
+	$(DOCKER) build -t $(IMAGE_PREFIX)$(IMAGE_REPOSITORY):$(IMAGE_TAG)-arm .
 
 .PHONY: builder-image
 builder-image:


### PR DESCRIPTION
What: Fix missing $ in Makefile armimage target so IMAGE_REPOSITORY is properly expanded, and fix typo go-restul to go-restful in .snyk.\nWhy: The Makefile bug causes incorrect image tagging for ARM builds. The .snyk typo is a minor documentation fix.