### PR TITLE
docs: fix grammatical error in CI troubleshooting documentation

### DIFF
--- a/docs/developer-guide/ci.md
+++ b/docs/developer-guide/ci.md
@@ -6,7 +6,7 @@ You can click on the "Details" link next to the failed step to get more informat
 
 ![Failed GitHub Action](ci-pipeline-failed.png)
 
-To read more about The GitHub actions are configured in [`ci-build.yaml`](https://github.com/argoproj/argo-cd/blob/master/.github/workflows/ci-build.yaml).
+The GitHub actions are configured in [`ci-build.yaml`](https://github.com/argoproj/argo-cd/blob/master/.github/workflows/ci-build.yaml).
 
 ### Can I retrigger the checks without pushing a new commit?
 


### PR DESCRIPTION
Fix a grammatical issue in docs/developer-guide/ci.md where 'To read more about The GitHub actions are configured...' was not a valid sentence structure.