### PR TITLE
chore: fix typos in code comments and documentation

### DIFF
--- a/docs/proposals/attach-debug-containers.md
+++ b/docs/proposals/attach-debug-containers.md
@@ -99,7 +99,7 @@ see [PR](https://github.com/argoproj/argo-cd/pull/27124/changes)
 
 ## Drawbacks
 
-ArgoCD might consider limiting attack surface that can be presented with with debug container (which are more powerful then exec'ing into a pod)
+ArgoCD might consider limiting attack surface that can be presented with debug container (which are more powerful than exec'ing into a pod)
 
 ## Alternatives
 

--- a/docs/proposals/attach-debug-containers.md
+++ b/docs/proposals/attach-debug-containers.md
@@ -99,7 +99,7 @@ see [PR](https://github.com/argoproj/argo-cd/pull/27124/changes)
 
 ## Drawbacks
 
-ArgoCD might consider limiting attack surface that can be presented with debug container (which are more powerful than exec'ing into a pod)
+Argo CD might consider limiting the attack surface that can be presented with the debug container (which is more powerful than exec'ing into a pod)
 
 ## Alternatives
 

--- a/hack/gen-resources/generators/cluster_generator.go
+++ b/hack/gen-resources/generators/cluster_generator.go
@@ -233,7 +233,7 @@ func (cg *ClusterGenerator) generate(i int, opts *util.GenerateOpts) error {
 }
 
 func (cg *ClusterGenerator) Generate(opts *util.GenerateOpts) error {
-	log.Printf("Excute in parallel with %v", opts.ClusterOpts.Concurrency)
+	log.Printf("Execute in parallel with %v", opts.ClusterOpts.Concurrency)
 
 	wg := util.New(opts.ClusterOpts.Concurrency)
 	for l := 1; l <= opts.ClusterOpts.Samples; l++ {

--- a/test/e2e/fixture/applicationsets/expectation.go
+++ b/test/e2e/fixture/applicationsets/expectation.go
@@ -25,7 +25,7 @@ const (
 	succeeded = "succeeded"
 )
 
-// Expectation returns succeeded on succes condition, or pending/failed on failure, along with
+// Expectation returns succeeded on success condition, or pending/failed on failure, along with
 // a message to describe the success/failure condition.
 type Expectation func(c *Consequences) (state state, message string)
 

--- a/util/git/creds_test.go
+++ b/util/git/creds_test.go
@@ -909,7 +909,7 @@ func TestGitHubAppGetAccessToken_CustomTimeout(t *testing.T) {
 		gitClientTimeout = 15 * time.Second
 	})
 
-	t.Run("gitClientTimeout must be honoured for for token requests as well", func(t *testing.T) {
+	t.Run("gitClientTimeout must be honoured for token requests as well", func(t *testing.T) {
 		gitClientTimeout = 1 * time.Second // Very short — should cause timeout but won't
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/util/oidc/oidc.go
+++ b/util/oidc/oidc.go
@@ -632,7 +632,7 @@ func (a *ClientApp) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// GetValueFromEncryptedCache is a convenience method for retreiving a value from cache and decrypting it.  If the cache
+// GetValueFromEncryptedCache is a convenience method for retrieving a value from cache and decrypting it.  If the cache
 // does not contain a value for the given key, a nil value is returned.  Return handling should check for error and then
 // check for nil.
 func (a *ClientApp) GetValueFromEncryptedCache(ctx context.Context, key string) (value []byte, err error) {

--- a/util/settings/settings_test.go
+++ b/util/settings/settings_test.go
@@ -1497,7 +1497,7 @@ func Test_GetTLSConfiguration(t *testing.T) {
 		_, err = kubeClient.CoreV1().Secrets("default").Update(t.Context(), tlsSecret, metav1.UpdateOptions{})
 		require.NoError(t, err)
 
-		// allow time for the udpate to resolve to avoid timing issues below
+		// allow time for the update to resolve to avoid timing issues below
 		time.Sleep(250 * time.Millisecond)
 
 		// should be called again after secret update resolves


### PR DESCRIPTION
## Summary

Fix several typos found across the codebase in code comments and documentation.

## Changes

- `udpate` → `update` in `util/settings/settings_test.go`
- `retreiving` → `retrieving` in `util/oidc/oidc.go`
- `Excute` → `Execute` in `hack/gen-resources/generators/cluster_generator.go`
- `succes` → `success` in `test/e2e/fixture/applicationsets/expectation.go`
- `for for` → `for` in `util/git/creds_test.go`
- `with with` → `with` and `then` → `than` in `docs/proposals/attach-debug-containers.md`

## Checklist

- [x] Signed off all commits (DCO)
- [x] PR title follows conventional commit format