### PR TITLE
docs: fix broken sealed-secrets Helm repoURL in examples

### DIFF
--- a/docs/operator-manual/declarative-setup.md
+++ b/docs/operator-manual/declarative-setup.md
@@ -1281,7 +1281,7 @@ spec:
   project: default
   source:
     chart: sealed-secrets
-    repoURL: https://bitnami-labs.github.io/sealed-secrets
+    repoURL: https://bitnami.github.io/sealed-secrets
     targetRevision: 1.16.1
     helm:
       releaseName: sealed-secrets

--- a/docs/user-guide/helm.md
+++ b/docs/user-guide/helm.md
@@ -16,7 +16,7 @@ spec:
   project: default
   source:
     chart: sealed-secrets
-    repoURL: https://bitnami-labs.github.io/sealed-secrets
+    repoURL: https://bitnami.github.io/sealed-secrets
     targetRevision: 1.16.1
     helm:
       releaseName: sealed-secrets


### PR DESCRIPTION
### What

The example Application manifests in the Helm user guide and the declarative setup docs reference the sealed-secrets chart at:

```
repoURL: https://bitnami-labs.github.io/sealed-secrets
```

That host no longer serves a Helm repository: `https://bitnami-labs.github.io/sealed-secrets/index.yaml` returns HTTP 404, so anyone copy-pasting the example gets a failing chart fetch.

### Fix

The sealed-secrets project README now publishes the chart at `https://bitnami.github.io/sealed-secrets` (`helm repo add sealed-secrets https://bitnami.github.io/sealed-secrets`), whose `index.yaml` returns HTTP 200 and serves the chart (including the referenced `targetRevision: 1.16.1`). This updates both occurrences:

- `docs/user-guide/helm.md`
- `docs/operator-manual/declarative-setup.md`

Docs-only change. No functional code affected.