### PR TITLE
fix(ui): show namespace/name in app dropdown when same-name apps exist in multiple namespaces

### DIFF
--- a/ui/src/app/applications/components/application-details/application-details-app-dropdown.tsx
+++ b/ui/src/app/applications/components/application-details/application-details-app-dropdown.tsx
@@ -9,7 +9,7 @@ function resourceIconClass(objectListKind: string): string {
     return objectListKind === 'applicationset' ? 'argo-icon-applicationset' : 'argo-icon-application';
 }
 
-export const ApplicationsDetailsAppDropdown = (props: {appName: string; objectListKind: string}) => {
+export const ApplicationsDetailsAppDropdown = (props: {appName: string; appNamespace: string; objectListKind: string}) => {
     const [opened, setOpened] = React.useState(false);
     const [appFilter, setAppFilter] = React.useState('');
     const ctx = React.useContext(Context);
@@ -42,22 +42,39 @@ export const ApplicationsDetailsAppDropdown = (props: {appName: string; objectLi
                         />
                     </li>
                     <DataLoader load={() => services.applications.list([], props.objectListKind, {fields: ['items.metadata.name', 'items.metadata.namespace']})}>
-                        {apps =>
-                            apps.items
+                        {apps => {
+                            const filtered = apps.items
                                 .filter(app => {
                                     return appFilter.length === 0 || app.metadata.name.toLowerCase().includes(appFilter.toLowerCase());
                                 })
-                                .slice(0, 100) // take top 100 results after filtering to avoid performance issues
-                                .map(app => (
-                                    <li className='application-details-app-dropdown__item' key={app.metadata.name} onClick={() => ctx.navigation.goto(`/${getAppUrl(app)}`)}>
+                                .slice(0, 100); // take top 100 results after filtering to avoid performance issues
+
+                            // Determine which names appear in more than one namespace so we can show
+                            // the namespace prefix only when disambiguation is needed.
+                            const nameCounts = new Map<string, number>();
+                            for (const app of filtered) {
+                                nameCounts.set(app.metadata.name, (nameCounts.get(app.metadata.name) ?? 0) + 1);
+                            }
+
+                            return filtered.map(app => {
+                                const isCurrent = app.metadata.name === props.appName && app.metadata.namespace === props.appNamespace;
+                                const needsNamespace = app.metadata.namespace && nameCounts.get(app.metadata.name) > 1;
+                                const label = needsNamespace ? `${app.metadata.namespace}/${app.metadata.name}` : app.metadata.name;
+                                const key = app.metadata.namespace ? `${app.metadata.namespace}/${app.metadata.name}` : app.metadata.name;
+                                return (
+                                    <li
+                                        className='application-details-app-dropdown__item'
+                                        key={key}
+                                        onClick={() => ctx.navigation.goto(`/${getAppUrl(app)}`)}>
                                         <i className={`icon ${resourceIconClass(props.objectListKind)} resource-icon__font-icon application-details-app-dropdown__resource-icon`} />
                                         <span>
-                                            {app.metadata.name}
-                                            {app.metadata.name === props.appName && ' (current)'}
+                                            {label}
+                                            {isCurrent && ' (current)'}
                                         </span>
                                     </li>
-                                ))
-                        }
+                                );
+                            });
+                        }}
                     </DataLoader>
                 </ul>
             )}

--- a/ui/src/app/applications/components/application-details/application-details-app-dropdown.tsx
+++ b/ui/src/app/applications/components/application-details/application-details-app-dropdown.tsx
@@ -62,10 +62,7 @@ export const ApplicationsDetailsAppDropdown = (props: {appName: string; appNames
                                 const label = needsNamespace ? `${app.metadata.namespace}/${app.metadata.name}` : app.metadata.name;
                                 const key = app.metadata.namespace ? `${app.metadata.namespace}/${app.metadata.name}` : app.metadata.name;
                                 return (
-                                    <li
-                                        className='application-details-app-dropdown__item'
-                                        key={key}
-                                        onClick={() => ctx.navigation.goto(`/${getAppUrl(app)}`)}>
+                                    <li className='application-details-app-dropdown__item' key={key} onClick={() => ctx.navigation.goto(`/${getAppUrl(app)}`)}>
                                         <i className={`icon ${resourceIconClass(props.objectListKind)} resource-icon__font-icon application-details-app-dropdown__resource-icon`} />
                                         <span>
                                             {label}

--- a/ui/src/app/applications/components/application-details/application-details.tsx
+++ b/ui/src/app/applications/components/application-details/application-details.tsx
@@ -908,7 +908,7 @@ Are you sure you want to disable auto-sync and rollback application '${props.mat
                                                     title: isApplication ? 'Applications' : 'ApplicationSets',
                                                     path: isApplication ? '/applications' : '/applicationsets'
                                                 },
-                                                {title: <ApplicationsDetailsAppDropdown appName={props.match.params.name} objectListKind={objectListKind} />}
+                                                {title: <ApplicationsDetailsAppDropdown appName={props.match.params.name} appNamespace={getAppNamespace()} objectListKind={objectListKind} />}
                                             ],
                                             actionMenu: {
                                                 items: isApplication

--- a/ui/src/app/applications/components/application-details/application-details.tsx
+++ b/ui/src/app/applications/components/application-details/application-details.tsx
@@ -908,7 +908,15 @@ Are you sure you want to disable auto-sync and rollback application '${props.mat
                                                     title: isApplication ? 'Applications' : 'ApplicationSets',
                                                     path: isApplication ? '/applications' : '/applicationsets'
                                                 },
-                                                {title: <ApplicationsDetailsAppDropdown appName={props.match.params.name} appNamespace={getAppNamespace()} objectListKind={objectListKind} />}
+                                                {
+                                                    title: (
+                                                        <ApplicationsDetailsAppDropdown
+                                                            appName={props.match.params.name}
+                                                            appNamespace={getAppNamespace()}
+                                                            objectListKind={objectListKind}
+                                                        />
+                                                    )
+                                                }
                                             ],
                                             actionMenu: {
                                                 items: isApplication


### PR DESCRIPTION
## Summary of the change

Fixes #28681

When **apps-in-any-namespace** is enabled and multiple applications share the same name across different namespaces, the breadcrumb app-switcher dropdown (inside the Application details view) had three bugs:

1. **Duplicate React keys** — `key={app.metadata.name}` caused duplicate keys for same-name apps in different namespaces.
2. **Wrong "(current)" marker** — the current-app check compared only `name`, so every app sharing the name was marked `(current)` regardless of namespace.
3. **Indistinguishable labels** — all entries displayed the same `app-name` string with no namespace prefix, making it impossible for users to tell them apart.

### What changed

**`application-details-app-dropdown.tsx`**
- `key` is now `namespace/name` (falls back to `name` when no namespace).
- `(current)` check now compares **both** `name` and `namespace` against the currently-viewed app.
- Labels show `namespace/name` only when the name is **ambiguous** (appears in more than one namespace within the filtered results). Unique-name apps continue to show just the name for a clean, uncluttered display.

**`application-details.tsx`**
- Passes `appNamespace={getAppNamespace()}` to the dropdown so it has the full identity of the currently-viewed application.

### Before / After

| Scenario | Before | After |
|---|---|---|
| `app-1` in `ns-1` and `ns-2`, viewing `ns-1/app-1` | `app-1 (current)` × 2 | `ns-1/app-1 (current)`, `ns-2/app-1` |
| `app-1` only in `ns-1` | `app-1 (current)` | `app-1 (current)` (unchanged) |
| All apps have unique names | unchanged | unchanged |

## Does this PR introduce a user-facing change?

```
Fix: When multiple applications share the same name in different namespaces, the app-switcher dropdown in the Application details breadcrumb now shows namespace/name labels to disambiguate entries, correctly marks only the currently-viewed app as (current), and avoids duplicate React keys.
```

## Which issue(s) does this PR fix?

Fixes #28681

## How was this tested?

TypeScript compilation passes with no new errors in the modified files. The fix was manually verified against the scenario described in the issue using the live k3d cluster.