### PR TITLE
feat: show Application Links for Gateway API HTTPRoute hostnames

### DIFF
--- a/controller/cache/info.go
+++ b/controller/cache/info.go
@@ -584,10 +584,48 @@ func populateGatewayAPIRouteInfo(un *unstructured.Unstructured, res *ResourceInf
 		urls = res.NetworkingInfo.ExternalURLs
 	}
 
+	// Generate ExternalURLs from spec.hostnames for HTTPRoute.
+	// Scheme defaults to http since TLS termination is handled at the Gateway level.
+	if un.GetKind() == "HTTPRoute" {
+		enableDefaultExternalURLs := true
+		if ignoreVal, ok := un.GetAnnotations()[common.AnnotationKeyIgnoreDefaultLinks]; ok {
+			if ignoreDefaultLinks, err := strconv.ParseBool(ignoreVal); err == nil {
+				enableDefaultExternalURLs = !ignoreDefaultLinks
+			}
+		}
+		if enableDefaultExternalURLs {
+			urls = append(urls, generateHTTPRouteURLs(un)...)
+		}
+	}
+
 	res.NetworkingInfo = &v1alpha1.ResourceNetworkingInfo{
 		TargetRefs:   targets,
 		ExternalURLs: urls,
 	}
+}
+
+func generateHTTPRouteURLs(un *unstructured.Unstructured) []string {
+	hostnames, ok, err := unstructured.NestedStringSlice(un.Object, "spec", "hostnames")
+	if !ok || err != nil {
+		return nil
+	}
+	urlsSet := make(map[string]bool)
+	for _, hostname := range hostnames {
+		if hostname == "" || strings.HasPrefix(hostname, "*") {
+			continue
+		}
+		urlStr := fmt.Sprintf("http://%s", hostname)
+		if err := settings.ValidateExternalURL(urlStr); err != nil {
+			log.Warnf("Invalid URL generated for HTTPRoute %s/%s hostname %q: %v", un.GetNamespace(), un.GetName(), hostname, err)
+			continue
+		}
+		urlsSet[urlStr] = true
+	}
+	urls := make([]string, 0, len(urlsSet))
+	for u := range urlsSet {
+		urls = append(urls, u)
+	}
+	return urls
 }
 
 func isPodInitializedConditionTrue(status *corev1.PodStatus) bool {

--- a/controller/cache/info.go
+++ b/controller/cache/info.go
@@ -614,7 +614,7 @@ func generateHTTPRouteURLs(un *unstructured.Unstructured) []string {
 		if hostname == "" || strings.HasPrefix(hostname, "*") {
 			continue
 		}
-		urlStr := fmt.Sprintf("http://%s", hostname)
+		urlStr := "http://" + hostname
 		if err := settings.ValidateExternalURL(urlStr); err != nil {
 			log.Warnf("Invalid URL generated for HTTPRoute %s/%s hostname %q: %v", un.GetNamespace(), un.GetName(), hostname, err)
 			continue

--- a/controller/cache/info_test.go
+++ b/controller/cache/info_test.go
@@ -414,6 +414,59 @@ spec:
       port: 8080
 `)
 
+	testHTTPRouteWithHostnames = strToUnstructured(`
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: hostnames-route
+  namespace: default
+spec:
+  parentRefs:
+  - name: example-gateway
+    namespace: default
+  hostnames:
+  - app.example.com
+  - api.example.com
+  rules:
+  - backendRefs:
+    - name: service-a
+      port: 8080
+`)
+
+	testHTTPRouteWithWildcardHostname = strToUnstructured(`
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: wildcard-route
+  namespace: default
+spec:
+  parentRefs:
+  - name: example-gateway
+  hostnames:
+  - "*.example.com"
+  rules:
+  - backendRefs:
+    - name: service-a
+      port: 8080
+`)
+
+	testHTTPRouteIgnoreDefaultLinks = strToUnstructured(`
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: no-links-route
+  namespace: default
+  annotations:
+    argocd.argoproj.io/ignore-default-links: "true"
+spec:
+  hostnames:
+  - app.example.com
+  rules:
+  - backendRefs:
+    - name: service-a
+      port: 8080
+`)
+
 	testGRPCRoute = strToUnstructured(`
 apiVersion: gateway.networking.k8s.io/v1
 kind: GRPCRoute
@@ -1440,36 +1493,6 @@ func TestGetIstioServiceEntryInfo(t *testing.T) {
 	}, info.NetworkingInfo.TargetLabels)
 }
 
-func TestGetHTTPRouteInfo(t *testing.T) {
-	info := &ResourceInfo{}
-	populateNodeInfo(testHTTPRoute, info, []string{})
-	assert.Empty(t, info.Info)
-	require.NotNil(t, info.NetworkingInfo)
-	// Should have Gateway (parentRef) + 2 Services (backendRefs)
-	assert.Len(t, info.NetworkingInfo.TargetRefs, 3)
-	// Check Gateway ref from parentRefs
-	assert.Contains(t, info.NetworkingInfo.TargetRefs, v1alpha1.ResourceRef{
-		Group:     "gateway.networking.k8s.io",
-		Kind:      "Gateway",
-		Namespace: "default",
-		Name:      "example-gateway",
-	})
-	// Check Service refs from backendRefs
-	assert.Contains(t, info.NetworkingInfo.TargetRefs, v1alpha1.ResourceRef{
-		Group:     "",
-		Kind:      kube.ServiceKind,
-		Namespace: "default",
-		Name:      "service-a",
-	})
-	assert.Contains(t, info.NetworkingInfo.TargetRefs, v1alpha1.ResourceRef{
-		Group:     "",
-		Kind:      kube.ServiceKind,
-		Namespace: "default",
-		Name:      "service-b",
-	})
-	assert.Empty(t, info.NetworkingInfo.Ingress)
-}
-
 func TestGetHTTPRouteCrossNamespaceInfo(t *testing.T) {
 	info := &ResourceInfo{}
 	populateNodeInfo(testHTTPRouteCrossNamespace, info, []string{})
@@ -1523,6 +1546,63 @@ func TestGetHTTPRouteCrossNamespaceParent(t *testing.T) {
 		Namespace: "default",
 		Name:      "my-service",
 	})
+}
+
+func TestGetHTTPRouteWithHostnames(t *testing.T) {
+	info := &ResourceInfo{}
+	populateNodeInfo(testHTTPRouteWithHostnames, info, []string{})
+	require.NotNil(t, info.NetworkingInfo)
+	assert.Contains(t, info.NetworkingInfo.ExternalURLs, "http://app.example.com")
+	assert.Contains(t, info.NetworkingInfo.ExternalURLs, "http://api.example.com")
+	assert.Len(t, info.NetworkingInfo.ExternalURLs, 2)
+}
+
+func TestGetHTTPRouteWildcardHostnameNotLinked(t *testing.T) {
+	info := &ResourceInfo{}
+	populateNodeInfo(testHTTPRouteWithWildcardHostname, info, []string{})
+	require.NotNil(t, info.NetworkingInfo)
+	// Wildcard hostname "*.example.com" should not generate a link
+	assert.Empty(t, info.NetworkingInfo.ExternalURLs)
+}
+
+func TestGetHTTPRouteIgnoreDefaultLinks(t *testing.T) {
+	info := &ResourceInfo{}
+	populateNodeInfo(testHTTPRouteIgnoreDefaultLinks, info, []string{})
+	require.NotNil(t, info.NetworkingInfo)
+	// argocd.argoproj.io/ignore-default-links: "true" suppresses hostname links
+	assert.Empty(t, info.NetworkingInfo.ExternalURLs)
+}
+
+func TestGetHTTPRouteInfo(t *testing.T) {
+	info := &ResourceInfo{}
+	populateNodeInfo(testHTTPRoute, info, []string{})
+	assert.Empty(t, info.Info)
+	require.NotNil(t, info.NetworkingInfo)
+	// Should have Gateway (parentRef) + 2 Services (backendRefs)
+	assert.Len(t, info.NetworkingInfo.TargetRefs, 3)
+	// Check Gateway ref from parentRefs
+	assert.Contains(t, info.NetworkingInfo.TargetRefs, v1alpha1.ResourceRef{
+		Group:     "gateway.networking.k8s.io",
+		Kind:      "Gateway",
+		Namespace: "default",
+		Name:      "example-gateway",
+	})
+	// Check Service refs from backendRefs
+	assert.Contains(t, info.NetworkingInfo.TargetRefs, v1alpha1.ResourceRef{
+		Group:     "",
+		Kind:      kube.ServiceKind,
+		Namespace: "default",
+		Name:      "service-a",
+	})
+	assert.Contains(t, info.NetworkingInfo.TargetRefs, v1alpha1.ResourceRef{
+		Group:     "",
+		Kind:      kube.ServiceKind,
+		Namespace: "default",
+		Name:      "service-b",
+	})
+	assert.Empty(t, info.NetworkingInfo.Ingress)
+	// testHTTPRoute has spec.hostnames: [example.com] — should generate a link
+	assert.Contains(t, info.NetworkingInfo.ExternalURLs, "http://example.com")
 }
 
 func TestGetGRPCRoute(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #28599

- Extracts `spec.hostnames` from `HTTPRoute` objects and generates `http://` links in Application Details → Summary → **LINKS** section
- Wildcard hostnames (e.g. `*.example.com`) are skipped — they don't resolve to a concrete URL
- The `argocd.argoproj.io/ignore-default-links: "true"` annotation suppresses auto-generated links, consistent with `Ingress` and `Gateway` behavior

### Before

HTTPRoute objects with explicit hostnames did not appear in the LINKS section, even though equivalent `Ingress` objects did.

### After

An HTTPRoute with `spec.hostnames: [app.example.com]` generates a clickable `http://app.example.com` link in the Summary tab, matching the Ingress experience.

> [!NOTE]
> The scheme defaults to `http://` because TLS termination is handled at the `Gateway` level. The parent `Gateway` object already generates `https://` links via its listener configuration. Adding annotation-based scheme override is left as a follow-up if needed.

## Changes

- `controller/cache/info.go`: Added `generateHTTPRouteURLs` helper and wired it into `populateGatewayAPIRouteInfo` for `HTTPRoute` kind
- `controller/cache/info_test.go`: Added 3 new test cases + updated `TestGetHTTPRouteInfo` to assert the hostname link is generated

## Test plan

### Unit tests

- [x] `go test ./controller/cache/` — all tests pass
- [x] `TestGetHTTPRouteWithHostnames` — multiple hostnames generate correct links
- [x] `TestGetHTTPRouteWildcardHostnameNotLinked` — `*.example.com` is skipped
- [x] `TestGetHTTPRouteIgnoreDefaultLinks` — annotation suppresses links
- [x] `TestGetHTTPRouteInfo` — existing test updated to assert `http://example.com` link

### Live cluster verification (k3d + ArgoCD v3.4.4)

Gateway API CRDs (`v1.2.0`) installed, a `GatewayClass` + `Gateway` + three `HTTPRoute` variants applied and managed by an ArgoCD Application.

**Bug reproduced** on stock controller — `ExternalURLs` was empty for an HTTPRoute with explicit hostnames:

```
GET /api/v1/applications/test-httproute-28599/resource-tree

Kind:         HTTPRoute
Name:         test-httproute
ExternalURLs: []   ← no links shown in UI
```

**After deploying the patched controller:**

| Route | Hostnames | ExternalURLs | Expected |
|-------|-----------|--------------|----------|
| `test-httproute` | `my-app.example.com`, `api.example.com` | `["http://api.example.com", "http://my-app.example.com"]` | ✅ |
| `test-wildcard-route` | `*.example.com` | `[]` | ✅ skipped |
| `test-ignore-links-route` | `explicit.example.com` + annotation | `[]` | ✅ suppressed |

Application Summary LINKS (the field the issue reports missing):

```
status.summary.externalURLs: ["http://api.example.com", "http://my-app.example.com"]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)