### PR TITLE
fix: support ref-only sources in New App panel (#20964)

### DIFF
--- a/ui/src/app/applications/components/application-create-panel/application-create-panel-validation.test.ts
+++ b/ui/src/app/applications/components/application-create-panel/application-create-panel-validation.test.ts
@@ -1,0 +1,57 @@
+import * as models from '../../../shared/models';
+import {validateApplicationCreate} from './application-create-panel-validation';
+
+function multiSourceApplication(valuesSource: models.ApplicationSource): models.Application {
+    return {
+        metadata: {name: 'sandbox'},
+        spec: {
+            project: 'default',
+            destination: {server: 'https://kubernetes.default.svc', namespace: 'sandbox'},
+            sources: [
+                {
+                    repoURL: 'https://example.com/helm-charts',
+                    chart: 'application',
+                    targetRevision: '1.0.0',
+                    helm: {valueFiles: ['$values/sandboxes/test-123/values.yaml'], parameters: [], fileParameters: []}
+                },
+                valuesSource
+            ]
+        }
+    } as models.Application;
+}
+
+describe('validateApplicationCreate', () => {
+    test('accepts a ref-only source for Helm value files', () => {
+        const app = multiSourceApplication({
+            repoURL: 'https://git.example.com/infrastructure/values.git',
+            targetRevision: 'main',
+            ref: 'values'
+        } as models.ApplicationSource);
+
+        const errors = validateApplicationCreate(app, true);
+
+        expect(errors['spec.sources[1].path']).toBeUndefined();
+        expect(errors['spec.sources[1].chart']).toBeUndefined();
+        expect(Object.values(errors).filter(Boolean)).toEqual([]);
+    });
+
+    test('rejects a source without a path, chart, or ref', () => {
+        const app = multiSourceApplication({
+            repoURL: 'https://git.example.com/infrastructure/values.git',
+            targetRevision: 'main'
+        } as models.ApplicationSource);
+
+        const errors = validateApplicationCreate(app, true);
+
+        expect(errors['spec.sources[1].path']).toBe('Path or Ref is required');
+        expect(errors['spec.sources[1].chart']).toBe('Chart is required');
+    });
+
+    test('still requires a repository URL for a ref-only source', () => {
+        const app = multiSourceApplication({targetRevision: 'main', ref: 'values'} as models.ApplicationSource);
+
+        const errors = validateApplicationCreate(app, true);
+
+        expect(errors['spec.sources[1].repoURL']).toBe('Repository URL is required');
+    });
+});

--- a/ui/src/app/applications/components/application-create-panel/application-create-panel-validation.ts
+++ b/ui/src/app/applications/components/application-create-panel/application-create-panel-validation.ts
@@ -1,0 +1,44 @@
+import * as models from '../../../shared/models';
+
+function hasOwnProperty(value: object | null | undefined, field: PropertyKey): boolean {
+    return value != null && Object.prototype.hasOwnProperty.call(value, field);
+}
+
+export function validateApplicationCreate(app: models.Application, multiSourceMode: boolean): Record<string, string | undefined> {
+    const hasHydrator = !!app.spec.sourceHydrator;
+    const source = app.spec.source;
+
+    const destinationErrors = {
+        'spec.destination.server':
+            !app.spec.destination.server && (!hasOwnProperty(app.spec.destination, 'name') || app.spec.destination.name === '') ? 'Cluster URL is required' : undefined,
+        'spec.destination.name':
+            !app.spec.destination.name && (!hasOwnProperty(app.spec.destination, 'server') || app.spec.destination.server === '') ? 'Cluster name is required' : undefined
+    };
+
+    if (multiSourceMode && !hasHydrator) {
+        const errors: Record<string, string | undefined> = {
+            'metadata.name': !app.metadata.name ? 'Application Name is required' : undefined,
+            'spec.project': !app.spec.project ? 'Project Name is required' : undefined,
+            ...destinationErrors
+        };
+        const sources = app.spec.sources || [];
+        for (let i = 0; i < sources.length; i++) {
+            const currentSource = sources[i];
+            errors[`spec.sources[${i}].repoURL`] = !currentSource?.repoURL ? 'Repository URL is required' : undefined;
+            errors[`spec.sources[${i}].targetRevision`] = !currentSource?.targetRevision && hasOwnProperty(currentSource, 'chart') ? 'Version is required' : undefined;
+            errors[`spec.sources[${i}].path`] = !currentSource?.path && !currentSource?.chart && !currentSource?.ref ? 'Path or Ref is required' : undefined;
+            errors[`spec.sources[${i}].chart`] = !currentSource?.path && !currentSource?.chart && !currentSource?.ref ? 'Chart is required' : undefined;
+        }
+        return errors;
+    }
+
+    return {
+        'metadata.name': !app.metadata.name ? 'Application Name is required' : undefined,
+        'spec.project': !app.spec.project ? 'Project Name is required' : undefined,
+        'spec.source.repoURL': !hasHydrator && !source?.repoURL ? 'Repository URL is required' : undefined,
+        'spec.source.targetRevision': !hasHydrator && !source?.targetRevision && hasOwnProperty(source, 'chart') ? 'Version is required' : undefined,
+        'spec.source.path': !hasHydrator && !source?.path && !source?.chart ? 'Path is required' : undefined,
+        'spec.source.chart': !hasHydrator && !source?.path && !source?.chart ? 'Chart is required' : undefined,
+        ...destinationErrors
+    };
+}

--- a/ui/src/app/applications/components/application-create-panel/application-create-panel.tsx
+++ b/ui/src/app/applications/components/application-create-panel/application-create-panel.tsx
@@ -18,6 +18,7 @@ import {SourcePanel} from './source-panel';
 import './application-create-panel.scss';
 import {getAppDefaultSource} from '../utils';
 import {APP_SOURCE_TYPES, normalizeTypeFieldsForSource} from '../shared/app-source-edit';
+import {validateApplicationCreate} from './application-create-panel-validation';
 
 const jsonMergePatch = require('json-merge-patch');
 
@@ -253,49 +254,7 @@ export const ApplicationCreatePanel = (props: {
                             />
                         )) || (
                             <Form
-                                validateError={(a: models.Application) => {
-                                    const hasHydrator = !!a.spec.sourceHydrator;
-                                    const source = a.spec.source;
-
-                                    const destinationErrors = {
-                                        'spec.destination.server':
-                                            !a.spec.destination.server && (!a.spec.destination.hasOwnProperty('name') || a.spec.destination.name === '')
-                                                ? 'Cluster URL is required'
-                                                : undefined,
-                                        'spec.destination.name':
-                                            !a.spec.destination.name && (!a.spec.destination.hasOwnProperty('server') || a.spec.destination.server === '')
-                                                ? 'Cluster name is required'
-                                                : undefined
-                                    };
-
-                                    if (multiSourceMode && !hasHydrator) {
-                                        const errs: Record<string, string | undefined> = {
-                                            'metadata.name': !a.metadata.name ? 'Application Name is required' : undefined,
-                                            'spec.project': !a.spec.project ? 'Project Name is required' : undefined,
-                                            ...destinationErrors
-                                        };
-                                        const sources = a.spec.sources || [];
-                                        for (let i = 0; i < sources.length; i++) {
-                                            const s = sources[i];
-                                            errs[`spec.sources[${i}].repoURL`] = !s?.repoURL ? 'Repository URL is required' : undefined;
-                                            errs[`spec.sources[${i}].targetRevision`] = !s?.targetRevision && s?.hasOwnProperty('chart') ? 'Version is required' : undefined;
-                                            errs[`spec.sources[${i}].path`] = !s?.path && !s?.chart ? 'Path is required' : undefined;
-                                            errs[`spec.sources[${i}].chart`] = !s?.path && !s?.chart ? 'Chart is required' : undefined;
-                                        }
-                                        return errs;
-                                    }
-
-                                    return {
-                                        'metadata.name': !a.metadata.name ? 'Application Name is required' : undefined,
-                                        'spec.project': !a.spec.project ? 'Project Name is required' : undefined,
-                                        'spec.source.repoURL': !hasHydrator && !source?.repoURL ? 'Repository URL is required' : undefined,
-                                        'spec.source.targetRevision':
-                                            !hasHydrator && !source?.targetRevision && source?.hasOwnProperty('chart') ? 'Version is required' : undefined,
-                                        'spec.source.path': !hasHydrator && !source?.path && !source?.chart ? 'Path is required' : undefined,
-                                        'spec.source.chart': !hasHydrator && !source?.path && !source?.chart ? 'Chart is required' : undefined,
-                                        ...destinationErrors
-                                    };
-                                }}
+                                validateError={(a: models.Application) => validateApplicationCreate(a, multiSourceMode)}
                                 defaultValues={app}
                                 formDidUpdate={state => debouncedOnAppChanged(state.values as any)}
                                 onSubmit={onCreateApp}

--- a/ui/src/app/applications/components/application-create-panel/application-create-panel.tsx
+++ b/ui/src/app/applications/components/application-create-panel/application-create-panel.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-prototype-builtins */
 import {AutocompleteField, Checkbox, DataLoader, DropDownMenu, FormField, HelpIcon, Select} from 'argo-ui';
 import * as deepMerge from 'deepmerge';
 import * as React from 'react';
@@ -16,8 +15,7 @@ import {HydratorSourcePanel} from './hydrator-source-panel';
 import {CollapsibleMultiSourceSection} from './collapsible-multi-source-section';
 import {SourcePanel} from './source-panel';
 import './application-create-panel.scss';
-import {getAppDefaultSource} from '../utils';
-import {APP_SOURCE_TYPES, normalizeTypeFieldsForSource} from '../shared/app-source-edit';
+import {APP_SOURCE_TYPES, normalizeTypeFieldsForSource, sourceDiscoveryKey, sourceKeyForTypeOverride} from '../shared/app-source-edit';
 import {validateApplicationCreate} from './application-create-panel-validation';
 
 const jsonMergePatch = require('json-merge-patch');
@@ -84,24 +82,6 @@ const AutoSyncFormField = ReactFormField((props: {fieldApi: FieldApi; className:
     );
 });
 
-function normalizeAppSource(app: models.Application, type: string): boolean {
-    const source = getAppDefaultSource(app);
-    const repoType = source.repoURL.startsWith('oci://') ? 'oci' : (source.hasOwnProperty('chart') && 'helm') || 'git';
-    if (repoType !== type) {
-        if (type === 'git' || type === 'oci') {
-            source.path = source.chart;
-            delete source.chart;
-            source.targetRevision = 'HEAD';
-        } else {
-            source.chart = source.path;
-            delete source.path;
-            source.targetRevision = '';
-        }
-        return true;
-    }
-    return false;
-}
-
 export const ApplicationCreatePanel = (props: {
     app: models.Application;
     onAppChanged: (app: models.Application) => any;
@@ -109,13 +89,12 @@ export const ApplicationCreatePanel = (props: {
     getFormApi: (api: FormApi) => any;
 }) => {
     const [yamlMode, setYamlMode] = React.useState(false);
-    const [explicitPathType, setExplicitPathType] = React.useState<{path: string; type: models.AppSourceType}>(null);
+    const [explicitPathType, setExplicitPathType] = React.useState<{sourceKey: string; type: models.AppSourceType}>(null);
     const [retry, setRetry] = React.useState(false);
     const app = deepMerge(DEFAULT_APP, props.app || {});
     const debouncedOnAppChanged = debounce(props.onAppChanged, 800);
     const [destinationFieldChanges, setDestinationFieldChanges] = React.useState({destFormat: 'URL', destFormatChanged: null});
     const [comboSwitchedFromPanel, setComboSwitchedFromPanel] = React.useState(false);
-    const currentRepoType = React.useRef(undefined);
     const lastGitOrHelmUrl = React.useRef('');
     const lastOciUrl = React.useRef('');
     const [isHydratorEnabled, setIsHydratorEnabled] = React.useState(!!app.spec.sourceHydrator);
@@ -232,10 +211,6 @@ export const ApplicationCreatePanel = (props: {
             }>
             {({projects, clusters, reposInfo}) => {
                 const repos = reposInfo.map(info => info.repo).sort();
-                const repoInfo = reposInfo.find(info => info.repo === app.spec.source?.repoURL);
-                if (repoInfo) {
-                    normalizeAppSource(app, repoInfo.type || currentRepoType.current || 'git');
-                }
                 return (
                     <div className='application-create-panel'>
                         {(yamlMode && (
@@ -261,6 +236,7 @@ export const ApplicationCreatePanel = (props: {
                                 getApi={props.getFormApi}>
                                 {api => {
                                     const formApp = api.getFormState().values as models.Application;
+                                    const repoInfo = reposInfo.find(info => info.repo === formApp.spec.source?.repoURL);
 
                                     const generalPanel = () => (
                                         <div className='white-box'>
@@ -392,14 +368,7 @@ export const ApplicationCreatePanel = (props: {
                                                     <HydratorSourcePanel formApi={api} repos={repos} />
                                                 ) : (
                                                     <React.Fragment>
-                                                        <SourcePanel
-                                                            formApi={api}
-                                                            repos={repos}
-                                                            repoInfo={repoInfo}
-                                                            currentRepoType={currentRepoType}
-                                                            lastGitOrHelmUrl={lastGitOrHelmUrl}
-                                                            lastOciUrl={lastOciUrl}
-                                                        />
+                                                        <SourcePanel formApi={api} repos={repos} repoInfo={repoInfo} lastGitOrHelmUrl={lastGitOrHelmUrl} lastOciUrl={lastOciUrl} />
                                                         <div className='application-create-panel__add-source'>
                                                             <button type='button' className='argo-button argo-button--base' onClick={() => handleAddSource(api)}>
                                                                 <i className='fa fa-plus' style={{marginLeft: '-5px', marginRight: '5px'}} />
@@ -484,6 +453,7 @@ export const ApplicationCreatePanel = (props: {
                                         const liveSrc = liveApp.spec.source;
                                         return (
                                             <DataLoader
+                                                key={sourceDiscoveryKey(liveSrc, liveApp.metadata.name, liveApp.spec.project)}
                                                 input={{
                                                     repoURL: liveSrc?.repoURL,
                                                     path: liveSrc?.path,
@@ -505,8 +475,8 @@ export const ApplicationCreatePanel = (props: {
                                                     };
                                                 }}>
                                                 {(details: models.RepoAppDetails) => {
-                                                    const pathKey = (liveSrc?.chart || liveSrc?.path || '') as string;
-                                                    const type = (explicitPathType && explicitPathType.path === pathKey && explicitPathType.type) || details.type;
+                                                    const sourceKey = sourceKeyForTypeOverride(liveSrc);
+                                                    const type = (explicitPathType && explicitPathType.sourceKey === sourceKey && explicitPathType.type) || details.type;
                                                     let d = details;
                                                     if (d.type !== type) {
                                                         switch (type) {
@@ -540,7 +510,7 @@ export const ApplicationCreatePanel = (props: {
                                                                 items={APP_SOURCE_TYPES.map(item => ({
                                                                     title: item.type,
                                                                     action: () => {
-                                                                        setExplicitPathType({type: item.type, path: pathKey});
+                                                                        setExplicitPathType({type: item.type, sourceKey});
                                                                         normalizeTypeFieldsForSource(api, item.type, undefined);
                                                                     }
                                                                 }))}

--- a/ui/src/app/applications/components/application-create-panel/collapsible-multi-source-section.tsx
+++ b/ui/src/app/applications/components/application-create-panel/collapsible-multi-source-section.tsx
@@ -17,7 +17,9 @@ export function CollapsibleMultiSourceSection(props: {
     const src = props.formApp.spec.sources?.[props.index];
     const repoInfoFor = props.reposInfo.find(r => r.repo === src?.repoURL);
     const title = `Source ${props.index + 1}${src?.name ? ` — ${src.name}` : ''}: ${src?.repoURL || ''}`;
-    const desc = [src?.path && `PATH=${src.path}`, src?.chart && `CHART=${src.chart}`, src?.targetRevision && `REVISION=${src.targetRevision}`].filter(Boolean).join(', ');
+    const desc = [src?.path && `PATH=${src.path}`, src?.chart && `CHART=${src.chart}`, src?.ref && `REF=${src.ref}`, src?.targetRevision && `REVISION=${src.targetRevision}`]
+        .filter(Boolean)
+        .join(', ');
 
     if (!expanded) {
         return (

--- a/ui/src/app/applications/components/application-create-panel/create-panel-source-type-parameters.test.tsx
+++ b/ui/src/app/applications/components/application-create-panel/create-panel-source-type-parameters.test.tsx
@@ -1,5 +1,6 @@
-import {Form, FormApi} from 'argo-ui';
-import {act, fireEvent, render, screen, waitFor} from '@testing-library/react';
+import {Form} from 'argo-ui';
+import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 import * as models from '../../../shared/models';
 import {Context} from '../../../shared/context';
@@ -36,7 +37,7 @@ describe('CreatePanelSourceTypeParameters', () => {
         appDetails.mockReset();
     });
 
-    test('stores an external Helm value file on the chart source', async () => {
+    test('stores a typed external Helm value file when Create is clicked without pressing Enter', async () => {
         const app = applicationWithSources([
             {repoURL: 'https://prometheus-community.github.io/helm-charts', chart: 'prometheus', targetRevision: '15.7.1'} as models.ApplicationSource,
             {repoURL: 'https://git.example.com/org/value-files.git', targetRevision: 'main', ref: 'values'} as models.ApplicationSource
@@ -46,37 +47,36 @@ describe('CreatePanelSourceTypeParameters', () => {
             path: '',
             helm: {name: 'prometheus', valueFiles: ['values.yaml'], parameters: [], fileParameters: []}
         } as models.RepoAppDetails);
-        let formApi: FormApi | undefined;
         const onSubmit = jest.fn();
+        const user = userEvent.setup();
 
         render(
             <Context.Provider value={{notifications: {show: jest.fn()}} as any}>
-                <Form defaultValues={app} getApi={api => (formApi = api)} onSubmit={onSubmit}>
-                    {api => <CreatePanelSourceTypeParameters formApi={api} sourceIndex={0} />}
+                <Form defaultValues={app} onSubmit={onSubmit}>
+                    {api => (
+                        <>
+                            <CreatePanelSourceTypeParameters formApi={api} sourceIndex={0} />
+                            <button type='button' onClick={api.submitForm}>
+                                Create
+                            </button>
+                        </>
+                    )}
                 </Form>
             </Context.Provider>
         );
 
         await screen.findByText('VALUES FILES');
         const valueFilesInput = document.querySelector('.tags-input input') as HTMLInputElement;
+        expect(valueFilesInput).toHaveAttribute('placeholder', '$<ref>/path/to/values.yaml');
         const valueFile = '$values/charts/prometheus/values.yaml';
         fireEvent.change(valueFilesInput, {target: {value: valueFile}});
-        fireEvent.keyUp(valueFilesInput, {key: 'Enter', keyCode: 13});
+        await user.click(screen.getByRole('button', {name: 'Create'}));
 
-        await waitFor(() => expect(formApi?.values.spec.sources[0].helm.valueFiles).toEqual([valueFile]));
-        expect(formApi?.values.spec.sources[1].helm).toBeUndefined();
-        expect(formApi?.values.spec.sources[1].ref).toBe('values');
-
-        act(() => formApi?.submitForm(null));
-        expect(onSubmit).toHaveBeenCalledWith(
-            expect.objectContaining({
-                spec: expect.objectContaining({
-                    sources: expect.arrayContaining([expect.objectContaining({helm: expect.objectContaining({valueFiles: [valueFile]})})])
-                })
-            }),
-            null,
-            expect.anything()
-        );
+        await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+        const submittedApp = onSubmit.mock.calls[0][0] as models.Application;
+        expect(submittedApp.spec.sources?.[0].helm?.valueFiles).toEqual([valueFile]);
+        expect(submittedApp.spec.sources?.[1].ref).toBe('values');
+        expect(submittedApp.spec.sources?.[1].helm).toBeUndefined();
     });
 
     test('does not show generator parameters or discover a ref-only source', () => {

--- a/ui/src/app/applications/components/application-create-panel/create-panel-source-type-parameters.test.tsx
+++ b/ui/src/app/applications/components/application-create-panel/create-panel-source-type-parameters.test.tsx
@@ -1,0 +1,97 @@
+import {Form, FormApi} from 'argo-ui';
+import {act, fireEvent, render, screen, waitFor} from '@testing-library/react';
+import * as React from 'react';
+import * as models from '../../../shared/models';
+import {Context} from '../../../shared/context';
+import {services} from '../../../shared/services';
+import {CreatePanelSourceTypeParameters} from './create-panel-source-type-parameters';
+
+jest.mock('../../../shared/services', () => ({
+    services: {
+        repos: {
+            appDetails: jest.fn()
+        }
+    }
+}));
+
+jest.mock('lodash-es', () => ({
+    cloneDeep: (value: unknown) => JSON.parse(JSON.stringify(value))
+}));
+
+function applicationWithSources(sources: models.ApplicationSource[]): models.Application {
+    return {
+        metadata: {name: 'sandbox'},
+        spec: {
+            project: 'default',
+            destination: {server: 'https://kubernetes.default.svc', namespace: 'sandbox'},
+            sources
+        }
+    } as models.Application;
+}
+
+describe('CreatePanelSourceTypeParameters', () => {
+    const appDetails = services.repos.appDetails as jest.Mock;
+
+    beforeEach(() => {
+        appDetails.mockReset();
+    });
+
+    test('stores an external Helm value file on the chart source', async () => {
+        const app = applicationWithSources([
+            {repoURL: 'https://prometheus-community.github.io/helm-charts', chart: 'prometheus', targetRevision: '15.7.1'} as models.ApplicationSource,
+            {repoURL: 'https://git.example.com/org/value-files.git', targetRevision: 'main', ref: 'values'} as models.ApplicationSource
+        ]);
+        appDetails.mockResolvedValue({
+            type: 'Helm',
+            path: '',
+            helm: {name: 'prometheus', valueFiles: ['values.yaml'], parameters: [], fileParameters: []}
+        } as models.RepoAppDetails);
+        let formApi: FormApi | undefined;
+        const onSubmit = jest.fn();
+
+        render(
+            <Context.Provider value={{notifications: {show: jest.fn()}} as any}>
+                <Form defaultValues={app} getApi={api => (formApi = api)} onSubmit={onSubmit}>
+                    {api => <CreatePanelSourceTypeParameters formApi={api} sourceIndex={0} />}
+                </Form>
+            </Context.Provider>
+        );
+
+        await screen.findByText('VALUES FILES');
+        const valueFilesInput = document.querySelector('.tags-input input') as HTMLInputElement;
+        const valueFile = '$values/charts/prometheus/values.yaml';
+        fireEvent.change(valueFilesInput, {target: {value: valueFile}});
+        fireEvent.keyUp(valueFilesInput, {key: 'Enter', keyCode: 13});
+
+        await waitFor(() => expect(formApi?.values.spec.sources[0].helm.valueFiles).toEqual([valueFile]));
+        expect(formApi?.values.spec.sources[1].helm).toBeUndefined();
+        expect(formApi?.values.spec.sources[1].ref).toBe('values');
+
+        act(() => formApi?.submitForm(null));
+        expect(onSubmit).toHaveBeenCalledWith(
+            expect.objectContaining({
+                spec: expect.objectContaining({
+                    sources: expect.arrayContaining([expect.objectContaining({helm: expect.objectContaining({valueFiles: [valueFile]})})])
+                })
+            }),
+            null,
+            expect.anything()
+        );
+    });
+
+    test('does not show generator parameters or discover a ref-only source', () => {
+        const app = applicationWithSources([
+            {repoURL: 'https://prometheus-community.github.io/helm-charts', chart: 'prometheus', targetRevision: '15.7.1'} as models.ApplicationSource,
+            {repoURL: 'https://git.example.com/org/value-files.git', targetRevision: 'main', ref: 'values'} as models.ApplicationSource
+        ]);
+
+        const {container} = render(
+            <Context.Provider value={{notifications: {show: jest.fn()}} as any}>
+                <Form defaultValues={app}>{api => <CreatePanelSourceTypeParameters formApi={api} sourceIndex={1} />}</Form>
+            </Context.Provider>
+        );
+
+        expect(container).toBeEmptyDOMElement();
+        expect(appDetails).not.toHaveBeenCalled();
+    });
+});

--- a/ui/src/app/applications/components/application-create-panel/create-panel-source-type-parameters.test.tsx
+++ b/ui/src/app/applications/components/application-create-panel/create-panel-source-type-parameters.test.tsx
@@ -1,5 +1,5 @@
-import {Form} from 'argo-ui';
-import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+import {Form, FormApi} from 'argo-ui';
+import {act, fireEvent, render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 import * as models from '../../../shared/models';
@@ -9,6 +9,9 @@ import {CreatePanelSourceTypeParameters} from './create-panel-source-type-parame
 
 jest.mock('../../../shared/services', () => ({
     services: {
+        authService: {
+            settings: jest.fn().mockResolvedValue({kustomizeVersions: []})
+        },
         repos: {
             appDetails: jest.fn()
         }
@@ -28,6 +31,12 @@ function applicationWithSources(sources: models.ApplicationSource[]): models.App
             sources
         }
     } as models.Application;
+}
+
+function deferred<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>(res => (resolve = res));
+    return {promise, resolve};
 }
 
 describe('CreatePanelSourceTypeParameters', () => {
@@ -93,5 +102,99 @@ describe('CreatePanelSourceTypeParameters', () => {
 
         expect(container).toBeEmptyDOMElement();
         expect(appDetails).not.toHaveBeenCalled();
+    });
+
+    test('does not carry an explicit generator type to another repository with the same path', async () => {
+        const firstRepo = 'https://git.example.com/first.git';
+        const secondRepo = 'https://git.example.com/second.git';
+        const app = applicationWithSources([{repoURL: firstRepo, targetRevision: 'main', path: 'manifests'} as models.ApplicationSource]);
+        appDetails.mockImplementation((source: models.ApplicationSource) =>
+            Promise.resolve(
+                source.repoURL === firstRepo
+                    ? ({type: 'Directory', path: 'manifests', directory: {}} as models.RepoAppDetails)
+                    : ({type: 'Directory', path: 'manifests', directory: {}} as models.RepoAppDetails)
+            )
+        );
+        let formApi: FormApi | undefined;
+
+        render(
+            <Context.Provider value={{notifications: {show: jest.fn()}} as any}>
+                <Form defaultValues={app} getApi={api => (formApi = api)}>
+                    {api => <CreatePanelSourceTypeParameters formApi={api} sourceIndex={0} />}
+                </Form>
+            </Context.Provider>
+        );
+
+        await screen.findByText('DIRECTORY');
+        fireEvent.click(document.querySelector('[qe-id="application-create-dropdown-source-1-Kustomize"]') as HTMLElement);
+        await screen.findByText('KUSTOMIZE');
+
+        act(() => formApi!.setValue('spec.sources[0].repoURL', secondRepo));
+
+        await screen.findByText('DIRECTORY');
+        expect(screen.queryByText('KUSTOMIZE')).not.toBeInTheDocument();
+    });
+
+    test('does not carry an explicit generator type from a path source to a chart source', async () => {
+        const repoURL = 'https://example.com/repository';
+        const app = applicationWithSources([{repoURL, targetRevision: 'main', path: 'manifests'} as models.ApplicationSource]);
+        appDetails.mockResolvedValue({type: 'Directory', path: 'manifests', directory: {}} as models.RepoAppDetails);
+        let formApi: FormApi | undefined;
+
+        render(
+            <Context.Provider value={{notifications: {show: jest.fn()}} as any}>
+                <Form defaultValues={app} getApi={api => (formApi = api)}>
+                    {api => <CreatePanelSourceTypeParameters formApi={api} sourceIndex={0} />}
+                </Form>
+            </Context.Provider>
+        );
+
+        await screen.findByText('DIRECTORY');
+        fireEvent.click(document.querySelector('[qe-id="application-create-dropdown-source-1-Kustomize"]') as HTMLElement);
+        await screen.findByText('KUSTOMIZE');
+
+        const {path, ...sourceWithoutPath} = formApi!.values.spec.sources[0] as models.ApplicationSource;
+        act(() => formApi!.setValue('spec.sources[0]', {...sourceWithoutPath, chart: path, targetRevision: '1.0.0'}));
+
+        await screen.findByText('DIRECTORY');
+        expect(screen.queryByText('KUSTOMIZE')).not.toBeInTheDocument();
+    });
+
+    test('ignores a stale discovery response from an intermediate repository shape', async () => {
+        const helmRepo = 'https://charts.example.com';
+        const gitRepo = 'https://git.example.com/application.git';
+        const app = applicationWithSources([{repoURL: helmRepo, chart: 'application', targetRevision: '1.0.0'} as models.ApplicationSource]);
+        const stale = deferred<models.RepoAppDetails>();
+        const current = deferred<models.RepoAppDetails>();
+        appDetails.mockImplementation((source: models.ApplicationSource) => {
+            if (source.repoURL === helmRepo) {
+                return Promise.resolve({type: 'Helm', path: '', helm: {name: 'application', valueFiles: [], parameters: [], fileParameters: []}} as models.RepoAppDetails);
+            }
+            return source.chart ? stale.promise : current.promise;
+        });
+        let formApi: FormApi | undefined;
+
+        render(
+            <Context.Provider value={{notifications: {show: jest.fn()}} as any}>
+                <Form defaultValues={app} getApi={api => (formApi = api)}>
+                    {api => <CreatePanelSourceTypeParameters formApi={api} sourceIndex={0} />}
+                </Form>
+            </Context.Provider>
+        );
+
+        await screen.findByText('VALUES FILES');
+        act(() => formApi!.setValue('spec.sources[0].repoURL', gitRepo));
+        await waitFor(() => expect(appDetails.mock.calls.some(([source]) => source.repoURL === gitRepo && source.chart === 'application')).toBe(true));
+
+        const {chart, ...sourceWithoutChart} = formApi!.values.spec.sources[0] as models.ApplicationSource;
+        act(() => formApi!.setValue('spec.sources[0]', {...sourceWithoutChart, path: chart, targetRevision: 'HEAD'}));
+        await waitFor(() => expect(appDetails.mock.calls.some(([source]) => source.repoURL === gitRepo && source.path === 'application')).toBe(true));
+
+        await act(async () => current.resolve({type: 'Kustomize', path: 'application', kustomize: {path: 'application'}} as models.RepoAppDetails));
+        await screen.findByText('KUSTOMIZE');
+        await act(async () => stale.resolve({type: 'Directory', path: 'application', directory: {}} as models.RepoAppDetails));
+
+        expect(screen.getByText('KUSTOMIZE')).toBeInTheDocument();
+        expect(screen.queryByText('DIRECTORY')).not.toBeInTheDocument();
     });
 });

--- a/ui/src/app/applications/components/application-create-panel/create-panel-source-type-parameters.tsx
+++ b/ui/src/app/applications/components/application-create-panel/create-panel-source-type-parameters.tsx
@@ -4,7 +4,7 @@ import {FormApi} from 'argo-ui';
 import * as models from '../../../shared/models';
 import {services} from '../../../shared/services';
 import {ApplicationParameters} from '../application-parameters/application-parameters';
-import {APP_SOURCE_TYPES, normalizeTypeFieldsForSource} from '../shared/app-source-edit';
+import {APP_SOURCE_TYPES, isRefOnlySource, normalizeTypeFieldsForSource} from '../shared/app-source-edit';
 
 function pathKeyForSource(src: models.ApplicationSource | undefined): string {
     if (!src) {
@@ -18,6 +18,10 @@ export const CreatePanelSourceTypeParameters = (props: {formApi: FormApi; source
     const formApp = props.formApi.getFormState().values as models.Application;
     const src = formApp.spec.sources?.[props.sourceIndex];
     const qeN = props.sourceIndex + 1;
+
+    if (isRefOnlySource(src)) {
+        return null;
+    }
 
     return (
         <DataLoader

--- a/ui/src/app/applications/components/application-create-panel/create-panel-source-type-parameters.tsx
+++ b/ui/src/app/applications/components/application-create-panel/create-panel-source-type-parameters.tsx
@@ -4,7 +4,7 @@ import {FormApi} from 'argo-ui';
 import * as models from '../../../shared/models';
 import {services} from '../../../shared/services';
 import {ApplicationParameters} from '../application-parameters/application-parameters';
-import {APP_SOURCE_TYPES, isRefOnlySource, normalizeTypeFieldsForSource} from '../shared/app-source-edit';
+import {APP_SOURCE_TYPES, isRefOnlySource, normalizeTypeFieldsForSource, sourceDiscoveryKey, sourceKeyForTypeOverride} from '../shared/app-source-edit';
 
 function pathKeyForSource(src: models.ApplicationSource | undefined): string {
     if (!src) {
@@ -14,7 +14,7 @@ function pathKeyForSource(src: models.ApplicationSource | undefined): string {
 }
 
 export const CreatePanelSourceTypeParameters = (props: {formApi: FormApi; sourceIndex: number}) => {
-    const [explicitPathType, setExplicitPathType] = React.useState<{path: string; type: models.AppSourceType}>(null);
+    const [explicitPathType, setExplicitPathType] = React.useState<{sourceKey: string; type: models.AppSourceType}>(null);
     const formApp = props.formApi.getFormState().values as models.Application;
     const src = formApp.spec.sources?.[props.sourceIndex];
     const qeN = props.sourceIndex + 1;
@@ -25,6 +25,7 @@ export const CreatePanelSourceTypeParameters = (props: {formApi: FormApi; source
 
     return (
         <DataLoader
+            key={sourceDiscoveryKey(src, formApp.metadata.name, formApp.spec.project)}
             input={{
                 repoURL: src?.repoURL,
                 path: src?.path,
@@ -47,8 +48,8 @@ export const CreatePanelSourceTypeParameters = (props: {formApi: FormApi; source
                 };
             }}>
             {(details: models.RepoAppDetails) => {
-                const key = pathKeyForSource(src);
-                const type = (explicitPathType && explicitPathType.path === key && explicitPathType.type) || details.type;
+                const sourceKey = sourceKeyForTypeOverride(src);
+                const type = (explicitPathType && explicitPathType.sourceKey === sourceKey && explicitPathType.type) || details.type;
                 let d = details;
                 if (d.type !== type) {
                     switch (type) {
@@ -82,7 +83,7 @@ export const CreatePanelSourceTypeParameters = (props: {formApi: FormApi; source
                             items={APP_SOURCE_TYPES.map(item => ({
                                 title: item.type,
                                 action: () => {
-                                    setExplicitPathType({type: item.type, path: key});
+                                    setExplicitPathType({type: item.type, sourceKey});
                                     normalizeTypeFieldsForSource(props.formApi, item.type, props.sourceIndex);
                                 }
                             }))}

--- a/ui/src/app/applications/components/application-create-panel/source-panel.test.tsx
+++ b/ui/src/app/applications/components/application-create-panel/source-panel.test.tsx
@@ -1,0 +1,103 @@
+import {Form, FormApi} from 'argo-ui';
+import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+import * as React from 'react';
+import * as models from '../../../shared/models';
+import {SourcePanel} from './source-panel';
+
+jest.mock('../../../shared/services', () => ({
+    services: {
+        repos: {
+            apps: jest.fn().mockResolvedValue([]),
+            charts: jest.fn().mockResolvedValue([])
+        }
+    }
+}));
+
+jest.mock('../revision-form-field/revision-form-field', () => ({
+    RevisionFormField: () => null
+}));
+
+jest.mock('../../../shared/components', () => ({
+    RevisionHelpIcon: () => null
+}));
+
+function applicationWithSources(sources: models.ApplicationSource[]): models.Application {
+    return {
+        metadata: {name: 'sandbox'},
+        spec: {
+            project: 'default',
+            destination: {server: 'https://kubernetes.default.svc', namespace: 'sandbox'},
+            sources
+        }
+    } as models.Application;
+}
+
+describe('SourcePanel', () => {
+    test('binds Ref to the selected Git source in a multi-source application', async () => {
+        const app = applicationWithSources([
+            {repoURL: 'https://example.com/helm-charts', chart: 'application', targetRevision: '1.0.0'} as models.ApplicationSource,
+            {repoURL: 'https://git.example.com/infrastructure/values.git', targetRevision: 'main'} as models.ApplicationSource
+        ]);
+        let formApi: FormApi | undefined;
+
+        render(
+            <Form defaultValues={app} getApi={api => (formApi = api)}>
+                {api => (
+                    <SourcePanel
+                        formApi={api}
+                        repos={[]}
+                        repoInfo={{repo: 'https://git.example.com/infrastructure/values.git', type: 'git'} as models.Repository}
+                        sourceIndex={1}
+                    />
+                )}
+            </Form>
+        );
+
+        await waitFor(() => expect(document.querySelector('[qe-id="application-create-source-2-field-path"]')).not.toBeNull());
+        const refInput = screen.getByRole('textbox', {name: 'Ref'});
+        fireEvent.change(refInput, {target: {value: 'values'}});
+
+        expect(formApi?.values.spec.sources[1].ref).toBe('values');
+        expect(formApi?.values.spec.sources[0].ref).toBeUndefined();
+    });
+
+    test('does not offer Ref for a Helm source', async () => {
+        const app = applicationWithSources([{repoURL: 'https://example.com/helm-charts', chart: 'application', targetRevision: '1.0.0'} as models.ApplicationSource]);
+
+        render(
+            <Form defaultValues={app}>
+                {api => <SourcePanel formApi={api} repos={[]} repoInfo={{repo: 'https://example.com/helm-charts', type: 'helm'} as models.Repository} sourceIndex={0} />}
+            </Form>
+        );
+
+        await screen.findByDisplayValue('application');
+        expect(screen.queryByRole('textbox', {name: 'Ref'})).toBeNull();
+    });
+
+    test.each([
+        ['HELM', ''],
+        ['OCI', undefined]
+    ])('clears Ref when changing a ref-only Git source to %s', async (targetType, expectedChart) => {
+        const app = applicationWithSources([
+            {
+                repoURL: 'https://git.example.com/infrastructure/values.git',
+                targetRevision: 'main',
+                ref: 'values'
+            } as models.ApplicationSource
+        ]);
+        let formApi: FormApi | undefined;
+
+        render(
+            <Form defaultValues={app} getApi={api => (formApi = api)}>
+                {api => <SourcePanel formApi={api} repos={[]} sourceIndex={0} />}
+            </Form>
+        );
+
+        await screen.findByRole('textbox', {name: 'Ref'});
+        fireEvent.click(document.querySelector(`[qe-id="application-create-dropdown-source-repository-1-${targetType}"]`) as HTMLElement);
+
+        await waitFor(() => expect(formApi?.values.spec.sources[0].ref).toBeUndefined());
+        expect(formApi?.values.spec.sources[0].chart).toBe(expectedChart);
+        expect(formApi?.values.spec.sources[0].repoURL).toBe(targetType === 'OCI' ? 'oci://' : 'https://git.example.com/infrastructure/values.git');
+    });
+});

--- a/ui/src/app/applications/components/application-create-panel/source-panel.test.tsx
+++ b/ui/src/app/applications/components/application-create-panel/source-panel.test.tsx
@@ -100,4 +100,72 @@ describe('SourcePanel', () => {
         expect(formApi?.values.spec.sources[0].chart).toBe(expectedChart);
         expect(formApi?.values.spec.sources[0].repoURL).toBe(targetType === 'OCI' ? 'oci://' : 'https://git.example.com/infrastructure/values.git');
     });
+
+    test.each([
+        ['Helm', 'https://charts.example.com', 'helm', '', ''],
+        ['OCI', 'oci://registry.example.com/application', 'oci', undefined, 'main']
+    ])('normalizes a ref-only Git source when a registered %s repository URL is selected', async (_name, repoURL, type, expectedChart, expectedRevision) => {
+        const app = applicationWithSources([
+            {
+                repoURL: 'https://git.example.com/infrastructure/values.git',
+                targetRevision: 'main',
+                ref: 'values',
+                plugin: {name: 'stale'}
+            } as models.ApplicationSource
+        ]);
+        const registeredRepo = {repo: repoURL, type} as models.Repository;
+        let formApi: FormApi | undefined;
+
+        render(
+            <Form defaultValues={app} getApi={api => (formApi = api)}>
+                {api => {
+                    const selectedURL = (api.values as models.Application).spec.sources?.[0]?.repoURL;
+                    return <SourcePanel formApi={api} repos={[repoURL]} repoInfo={selectedURL === repoURL ? registeredRepo : undefined} sourceIndex={0} />;
+                }}
+            </Form>
+        );
+
+        fireEvent.change(document.querySelector('[qe-id="application-create-source-1-field-repository-url"]') as HTMLInputElement, {target: {value: repoURL}});
+
+        await waitFor(() => expect(formApi?.values.spec.sources[0].ref).toBeUndefined());
+        expect(formApi?.values.spec.sources[0].chart).toBe(expectedChart);
+        expect(formApi?.values.spec.sources[0].targetRevision).toBe(expectedRevision);
+        expect(formApi?.values.spec.sources[0].plugin).toBeUndefined();
+        expect(screen.queryByRole('textbox', {name: 'Ref'})).toBeNull();
+    });
+
+    test('normalizes a registered Helm source when a registered Git repository URL is selected', async () => {
+        const helmRepoURL = 'https://charts.example.com';
+        const gitRepoURL = 'https://git.example.com/application.git';
+        const app = applicationWithSources([
+            {
+                repoURL: helmRepoURL,
+                chart: 'application',
+                targetRevision: '1.0.0',
+                helm: {valueFiles: ['values.yaml']}
+            } as models.ApplicationSource
+        ]);
+        const repositories = [
+            {repo: helmRepoURL, type: 'helm'},
+            {repo: gitRepoURL, type: 'git'}
+        ] as models.Repository[];
+        let formApi: FormApi | undefined;
+
+        render(
+            <Form defaultValues={app} getApi={api => (formApi = api)}>
+                {api => {
+                    const selectedURL = (api.values as models.Application).spec.sources?.[0]?.repoURL;
+                    return <SourcePanel formApi={api} repos={repositories.map(repo => repo.repo)} repoInfo={repositories.find(repo => repo.repo === selectedURL)} sourceIndex={0} />;
+                }}
+            </Form>
+        );
+
+        fireEvent.change(document.querySelector('[qe-id="application-create-source-1-field-repository-url"]') as HTMLInputElement, {target: {value: gitRepoURL}});
+
+        await waitFor(() => expect(formApi?.values.spec.sources[0].path).toBe('application'));
+        expect(formApi?.values.spec.sources[0].chart).toBeUndefined();
+        expect(formApi?.values.spec.sources[0].targetRevision).toBe('HEAD');
+        expect(formApi?.values.spec.sources[0].helm?.valueFiles).toEqual(['values.yaml']);
+        expect(screen.getByRole('textbox', {name: 'Ref'})).toBeInTheDocument();
+    });
 });

--- a/ui/src/app/applications/components/application-create-panel/source-panel.tsx
+++ b/ui/src/app/applications/components/application-create-panel/source-panel.tsx
@@ -1,4 +1,4 @@
-import {AutocompleteField, DataLoader, DropDownMenu, FormField} from 'argo-ui';
+import {AutocompleteField, DataLoader, DropDownMenu, FormField, Text} from 'argo-ui';
 import * as React from 'react';
 import {FormApi} from 'argo-ui';
 import {RevisionHelpIcon} from '../../../shared/components';
@@ -103,6 +103,9 @@ export const SourcePanel = (props: SourcePanelProps) => {
                                             }
                                             currentRepoType.current = type;
                                             /* eslint-enable react-hooks/refs */
+                                            if (type !== 'git') {
+                                                delete source.ref;
+                                            }
                                             switch (type) {
                                                 case 'git':
                                                 case 'oci':
@@ -117,6 +120,8 @@ export const SourcePanel = (props: SourcePanelProps) => {
                                                     if (Object.prototype.hasOwnProperty.call(source, 'path')) {
                                                         source.chart = source.path;
                                                         delete source.path;
+                                                    } else if (!Object.prototype.hasOwnProperty.call(source, 'chart')) {
+                                                        source.chart = '';
                                                     }
                                                     source.targetRevision = '';
                                                     source.repoURL = lastGitOrHelmUrl.current;
@@ -241,6 +246,11 @@ export const SourcePanel = (props: SourcePanelProps) => {
                         }}
                     </DataLoader>
                 )}
+            {isMulti && repoType === 'git' && (
+                <div className='argo-form-row'>
+                    <FormField formApi={props.formApi} label='Ref' qeId={`application-create-source-${qeSourceN}-field-ref`} field={fieldPath(idx, 'ref')} component={Text} />
+                </div>
+            )}
         </React.Fragment>
     );
 };

--- a/ui/src/app/applications/components/application-create-panel/source-panel.tsx
+++ b/ui/src/app/applications/components/application-create-panel/source-panel.tsx
@@ -6,6 +6,7 @@ import * as models from '../../../shared/models';
 import {services} from '../../../shared/services';
 import {RevisionFormField} from '../revision-form-field/revision-form-field';
 import {getAppDefaultSource} from '../utils';
+import {inferSourceRepositoryType, isRefOnlySource, normalizeRefOnlySource, normalizeSourceForRepositoryType, SourceRepositoryType} from '../shared/app-source-edit';
 
 function getSourceForPanel(app: models.Application, sourceIndex?: number): models.ApplicationSource | null {
     if (sourceIndex !== undefined) {
@@ -21,29 +22,64 @@ function fieldPath(sourceIndex: number | undefined, field: string): string {
     return `spec.source.${field}`;
 }
 
+function registeredRepositoryType(repoInfo: models.Repository | undefined, source: models.ApplicationSource | null): SourceRepositoryType {
+    if (!repoInfo) {
+        return inferSourceRepositoryType(source ?? undefined);
+    }
+    const type = repoInfo.type?.toLowerCase();
+    return type === 'helm' || type === 'oci' ? type : 'git';
+}
+
+function updateSource(formApi: FormApi, sourceIndex: number | undefined, transform: (source: models.ApplicationSource) => models.ApplicationSource): void {
+    const app = formApi.getFormState().values as models.Application;
+    const source = getSourceForPanel(app, sourceIndex);
+    if (!source) {
+        return;
+    }
+    const updatedSource = transform(source);
+    if (updatedSource === source) {
+        return;
+    }
+
+    if (sourceIndex === undefined) {
+        formApi.setAllValues({...app, spec: {...app.spec, source: updatedSource}});
+        return;
+    }
+
+    const sources = [...(app.spec.sources || [])];
+    if (!sources[sourceIndex]) {
+        return;
+    }
+    sources[sourceIndex] = updatedSource;
+    formApi.setAllValues({...app, spec: {...app.spec, sources}});
+}
+
 export interface SourcePanelProps {
     formApi: FormApi;
     repos: string[];
     repoInfo?: models.Repository;
     sourceIndex?: number;
     suppressMultiSourceHeading?: boolean;
-    currentRepoType?: React.MutableRefObject<string | undefined>;
     lastGitOrHelmUrl?: React.MutableRefObject<string>;
     lastOciUrl?: React.MutableRefObject<string>;
 }
 
 export const SourcePanel = (props: SourcePanelProps) => {
-    const internalRepoType = React.useRef<string | undefined>(undefined);
     const internalLastGit = React.useRef('');
     const internalLastOci = React.useRef('');
     const isMulti = props.sourceIndex !== undefined;
-    const lastGitOrHelmUrl = isMulti ? internalLastGit : props.lastGitOrHelmUrl;
-    const lastOciUrl = isMulti ? internalLastOci : props.lastOciUrl;
-    const currentRepoType = isMulti ? internalRepoType : props.currentRepoType;
+    const lastGitOrHelmUrl = isMulti ? internalLastGit : props.lastGitOrHelmUrl || internalLastGit;
+    const lastOciUrl = isMulti ? internalLastOci : props.lastOciUrl || internalLastOci;
 
     const currentApp = props.formApi.getFormState().values as models.Application;
     const currentSource = getSourceForPanel(currentApp, props.sourceIndex);
-    const repoType = currentSource?.repoURL?.startsWith('oci://') ? 'oci' : (currentSource && Object.prototype.hasOwnProperty.call(currentSource, 'chart') && 'helm') || 'git';
+    const repoType = registeredRepositoryType(props.repoInfo, currentSource);
+    const currentRepoURL = currentSource?.repoURL;
+    const refOnly = isRefOnlySource(currentSource ?? undefined);
+
+    React.useEffect(() => {
+        updateSource(props.formApi, props.sourceIndex, source => normalizeSourceForRepositoryType(normalizeRefOnlySource(source), repoType));
+    }, [props.formApi, props.sourceIndex, repoType, currentRepoURL, refOnly]);
 
     const idx = props.sourceIndex;
     const qeSourceN = isMulti && idx !== undefined ? idx + 1 : 0;
@@ -101,33 +137,13 @@ export const SourcePanel = (props: SourcePanelProps) => {
                                             } else {
                                                 lastOciUrl.current = source.repoURL;
                                             }
-                                            currentRepoType.current = type;
                                             /* eslint-enable react-hooks/refs */
-                                            if (type !== 'git') {
-                                                delete source.ref;
-                                            }
-                                            switch (type) {
-                                                case 'git':
-                                                case 'oci':
-                                                    if (Object.prototype.hasOwnProperty.call(source, 'chart')) {
-                                                        source.path = source.chart;
-                                                        delete source.chart;
-                                                    }
-                                                    source.targetRevision = 'HEAD';
-                                                    source.repoURL = type === 'git' ? lastGitOrHelmUrl.current : lastOciUrl.current === '' ? 'oci://' : lastOciUrl.current;
-                                                    break;
-                                                case 'helm':
-                                                    if (Object.prototype.hasOwnProperty.call(source, 'path')) {
-                                                        source.chart = source.path;
-                                                        delete source.path;
-                                                    } else if (!Object.prototype.hasOwnProperty.call(source, 'chart')) {
-                                                        source.chart = '';
-                                                    }
-                                                    source.targetRevision = '';
-                                                    source.repoURL = lastGitOrHelmUrl.current;
-                                                    break;
-                                            }
-                                            props.formApi.setAllValues(updatedApp);
+                                            const targetRepoURL = type === 'oci' ? (lastOciUrl.current === '' ? 'oci://' : lastOciUrl.current) : lastGitOrHelmUrl.current;
+                                            updateSource(props.formApi, props.sourceIndex, current => ({
+                                                ...normalizeSourceForRepositoryType(current, type),
+                                                repoURL: targetRepoURL,
+                                                targetRevision: type === 'helm' ? '' : 'HEAD'
+                                            }));
                                         }
                                     }
                                 }))}

--- a/ui/src/app/applications/components/application-parameters/application-parameters-source.tsx
+++ b/ui/src/app/applications/components/application-parameters/application-parameters-source.tsx
@@ -28,6 +28,7 @@ export interface ApplicationParametersPanelProps<T> {
     numberOfSources?: number;
     noReadonlyMode?: boolean;
     collapsible?: boolean;
+    hideBottom?: boolean;
     deleteSource: () => void;
 }
 
@@ -68,7 +69,7 @@ export function ApplicationParametersSource<T = {}>(props: ApplicationParameters
                 }}
                 deleteSource={props.deleteSource}
             />
-            {props.itemsTop && (
+            {props.itemsTop && !props.hideBottom && (
                 <>
                     <div className='row white-box__details-row'>
                         <p>&nbsp;</p>
@@ -76,25 +77,27 @@ export function ApplicationParametersSource<T = {}>(props: ApplicationParameters
                     <div className='white-box--no-padding editable-panel__divider' />
                 </>
             )}
-            <EditableSection
-                uniqueId={'bottom_' + props.index}
-                title={props.titleBottom}
-                view={props.viewBottom}
-                values={props.valuesBottom}
-                items={props.itemsBottom}
-                validate={props.validateBottom}
-                save={props.saveBottom}
-                onModeSwitch={() => onModeSwitch()}
-                noReadonlyMode={props.noReadonlyMode}
-                edit={props.editBottom}
-                collapsible={props.collapsible}
-                ctx={ctx}
-                isTopSection={false}
-                disabledState={editBottom || editBottom === null}
-                updateButtons={editClicked => {
-                    setEditTop(editClicked);
-                }}
-            />
+            {!props.hideBottom && (
+                <EditableSection
+                    uniqueId={'bottom_' + props.index}
+                    title={props.titleBottom}
+                    view={props.viewBottom}
+                    values={props.valuesBottom}
+                    items={props.itemsBottom}
+                    validate={props.validateBottom}
+                    save={props.saveBottom}
+                    onModeSwitch={() => onModeSwitch()}
+                    noReadonlyMode={props.noReadonlyMode}
+                    edit={props.editBottom}
+                    collapsible={props.collapsible}
+                    ctx={ctx}
+                    isTopSection={false}
+                    disabledState={editBottom || editBottom === null}
+                    updateButtons={editClicked => {
+                        setEditTop(editClicked);
+                    }}
+                />
+            )}
         </div>
     );
 }

--- a/ui/src/app/applications/components/application-parameters/application-parameters.test.tsx
+++ b/ui/src/app/applications/components/application-parameters/application-parameters.test.tsx
@@ -1,0 +1,93 @@
+import {render, screen, waitFor} from '@testing-library/react';
+import * as React from 'react';
+import * as models from '../../../shared/models';
+import {services} from '../../../shared/services';
+import {Context} from '../../../shared/context';
+import {ApplicationParameters} from './application-parameters';
+
+jest.mock('../../../shared/services', () => ({
+    services: {
+        repos: {
+            appDetails: jest.fn()
+        },
+        viewPreferences: {
+            getPreferences: jest.fn().mockResolvedValue({pageSizes: {'5': 10}, sortOptions: {}}),
+            updatePreferences: jest.fn()
+        }
+    }
+}));
+
+jest.mock('lodash-es', () => ({
+    cloneDeep: (value: unknown) => JSON.parse(JSON.stringify(value))
+}));
+
+jest.mock('./source-panel', () => ({
+    SourcePanel: () => null
+}));
+
+jest.mock('../utils', () => ({
+    deleteSourceAction: jest.fn(),
+    getAppDefaultSource: (app: models.Application) => app.spec.source || app.spec.sources?.[0],
+    getAppDrySource: (app: models.Application) => app.spec.source,
+    helpTip: () => null
+}));
+
+function applicationWithValuesSource(valuesSource: models.ApplicationSource): models.Application {
+    return {
+        metadata: {name: 'sandbox'},
+        spec: {
+            project: 'default',
+            destination: {server: 'https://kubernetes.default.svc', namespace: 'sandbox'},
+            sources: [{repoURL: 'https://prometheus-community.github.io/helm-charts', chart: 'prometheus', targetRevision: '15.7.1'} as models.ApplicationSource, valuesSource]
+        }
+    } as models.Application;
+}
+
+function renderParameters(app: models.Application) {
+    return render(
+        <Context.Provider value={{notifications: {show: jest.fn()}} as any}>
+            <ApplicationParameters application={app} pageNumber={0} setPageNumber={jest.fn()} collapsedSources={[true, false]} handleCollapse={jest.fn()} appContext={{} as any} />
+        </Context.Provider>
+    );
+}
+
+describe('ApplicationParameters ref-only sources', () => {
+    const appDetails = services.repos.appDetails as jest.Mock;
+
+    beforeEach(() => {
+        appDetails.mockReset();
+    });
+
+    test('shows only core fields without running source discovery', async () => {
+        renderParameters(
+            applicationWithValuesSource({
+                repoURL: 'https://git.example.com/org/value-files.git',
+                targetRevision: 'main',
+                ref: 'values'
+            } as models.ApplicationSource)
+        );
+
+        expect(await screen.findByText('Source 2: REF=values, URL=https://git.example.com/org/value-files.git, TARGET REVISION=main')).toBeInTheDocument();
+        expect(screen.getByText('REF')).toBeInTheDocument();
+        expect(screen.getByText('values')).toBeInTheDocument();
+        expect(screen.queryByText('PLUGIN')).not.toBeInTheDocument();
+        expect(screen.queryByText('DIRECTORY')).not.toBeInTheDocument();
+        expect(appDetails).not.toHaveBeenCalled();
+    });
+
+    test('still discovers a source that has both ref and path', async () => {
+        appDetails.mockResolvedValue({type: 'Plugin', path: 'manifests', plugin: {name: 'example', env: []}} as models.RepoAppDetails);
+        const source = {
+            repoURL: 'https://git.example.com/org/value-files.git',
+            targetRevision: 'main',
+            path: 'manifests',
+            ref: 'values'
+        } as models.ApplicationSource;
+
+        renderParameters(applicationWithValuesSource(source));
+
+        await waitFor(() => expect(appDetails).toHaveBeenCalledWith(source, 'sandbox', 'default', 1, 0));
+        expect(await screen.findByText('PLUGIN')).toBeInTheDocument();
+        expect(screen.getByText(/Source 2: TYPE=Plugin/)).toBeInTheDocument();
+    });
+});

--- a/ui/src/app/applications/components/application-parameters/application-parameters.test.tsx
+++ b/ui/src/app/applications/components/application-parameters/application-parameters.test.tsx
@@ -127,4 +127,41 @@ describe('ApplicationParameters ref-only sources', () => {
 
         await waitFor(() => expect(screen.getByText('VALUES FILES').closest('.columns.small-3')?.querySelector('.help-tip')).not.toBeNull());
     });
+
+    test.each([
+        ['repository details cannot be loaded', () => appDetails.mockRejectedValue(new Error('failed to load application details'))],
+        ['repository details report a different type', () => appDetails.mockResolvedValue({type: 'Directory', path: 'charts/web-app'} as models.RepoAppDetails)]
+    ])('uses the explicit Helm source when %s', async (_name, arrangeAppDetails) => {
+        arrangeAppDetails();
+        const app = applicationWithValuesSource({
+            repoURL: 'https://git.example.com/org/value-files.git',
+            targetRevision: 'main',
+            ref: 'values'
+        } as models.ApplicationSource);
+        app.spec.sources[0] = {
+            repoURL: 'https://git.example.com/org/charts.git',
+            targetRevision: 'main',
+            path: 'charts/web-app',
+            helm: {valueFiles: ['$values/sandboxes/multisource-ui-test/values.yaml']}
+        } as models.ApplicationSource;
+
+        render(
+            <Context.Provider value={{notifications: {show: jest.fn()}} as any}>
+                <ApplicationParameters
+                    application={app}
+                    pageNumber={0}
+                    setPageNumber={jest.fn()}
+                    collapsedSources={[false, true]}
+                    handleCollapse={jest.fn()}
+                    appContext={{} as any}
+                />
+            </Context.Provider>
+        );
+
+        expect(await screen.findByText(/Source 1: TYPE=Helm/)).toBeInTheDocument();
+        expect(screen.getByText('HELM')).toBeInTheDocument();
+        expect(screen.getByText('$values/sandboxes/multisource-ui-test/values.yaml')).toBeInTheDocument();
+        expect(screen.getByText('VALUES FILES').closest('.columns.small-3')?.querySelector('.help-tip')).not.toBeNull();
+        expect(screen.queryByText('DIRECTORY')).not.toBeInTheDocument();
+    });
 });

--- a/ui/src/app/applications/components/application-parameters/application-parameters.test.tsx
+++ b/ui/src/app/applications/components/application-parameters/application-parameters.test.tsx
@@ -1,4 +1,5 @@
 import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 import * as models from '../../../shared/models';
 import {services} from '../../../shared/services';
@@ -89,5 +90,41 @@ describe('ApplicationParameters ref-only sources', () => {
         await waitFor(() => expect(appDetails).toHaveBeenCalledWith(source, 'sandbox', 'default', 1, 0));
         expect(await screen.findByText('PLUGIN')).toBeInTheDocument();
         expect(screen.getByText(/Source 2: TYPE=Plugin/)).toBeInTheDocument();
+    });
+
+    test('shows the external values hint while viewing and editing an existing multi-source application', async () => {
+        const app = applicationWithValuesSource({
+            repoURL: 'https://git.example.com/org/value-files.git',
+            targetRevision: 'main',
+            ref: 'values'
+        } as models.ApplicationSource);
+        app.spec.sources[0].helm = {valueFiles: ['$values/charts/prometheus/values.yaml']} as models.ApplicationSourceHelm;
+        appDetails.mockResolvedValue({
+            type: 'Helm',
+            helm: {name: 'prometheus', valueFiles: ['values.yaml'], parameters: [], fileParameters: []}
+        } as models.RepoAppDetails);
+        const user = userEvent.setup();
+
+        render(
+            <Context.Provider value={{notifications: {show: jest.fn()}} as any}>
+                <ApplicationParameters
+                    application={app}
+                    save={jest.fn().mockResolvedValue(undefined)}
+                    pageNumber={0}
+                    setPageNumber={jest.fn()}
+                    collapsedSources={[false, true]}
+                    handleCollapse={jest.fn()}
+                    appContext={{} as any}
+                />
+            </Context.Provider>
+        );
+
+        const viewTitle = await screen.findByText('VALUES FILES');
+        expect(viewTitle.closest('.columns.small-3')?.querySelector('.help-tip')).not.toBeNull();
+
+        const editButtons = screen.getAllByRole('button', {name: 'Edit'});
+        await user.click(editButtons[1]);
+
+        await waitFor(() => expect(screen.getByText('VALUES FILES').closest('.columns.small-3')?.querySelector('.help-tip')).not.toBeNull());
     });
 });

--- a/ui/src/app/applications/components/application-parameters/application-parameters.tsx
+++ b/ui/src/app/applications/components/application-parameters/application-parameters.tsx
@@ -33,6 +33,7 @@ import * as jsYaml from 'js-yaml';
 import {RevisionFormField} from '../revision-form-field/revision-form-field';
 import classNames from 'classnames';
 import {ApplicationParametersSource} from './application-parameters-source';
+import {isRefOnlySource} from '../shared/app-source-edit';
 
 import './application-parameters.scss';
 import {AppContext} from '../../../shared/context';
@@ -323,12 +324,16 @@ export const ApplicationParameters = (props: {
                             />
                         </div>
                     )}
-                    <DataLoader
-                        key={'app_params_source_' + index}
-                        input={app.spec.sources[index]}
-                        load={src => getSourceFromAppSources(src, app.metadata.name, app.spec.project, index, 0)}>
-                        {(details: models.RepoAppDetails) => getEditablePanelForOneSource(details, index, app.spec.sources[index])}
-                    </DataLoader>
+                    {isRefOnlySource(app.spec.sources[index]) ? (
+                        getEditablePanelForOneSource(undefined, index, app.spec.sources[index])
+                    ) : (
+                        <DataLoader
+                            key={'app_params_source_' + index}
+                            input={app.spec.sources[index]}
+                            load={src => getSourceFromAppSources(src, app.metadata.name, app.spec.project, index, 0)}>
+                            {(details: models.RepoAppDetails) => getEditablePanelForOneSource(details, index, app.spec.sources[index])}
+                        </DataLoader>
+                    )}
                 </div>
             </div>
         );
@@ -428,26 +433,32 @@ export const ApplicationParameters = (props: {
         );
     }
 
-    function getEditablePanelForOneSource(repoAppDetails: models.RepoAppDetails, ind: number, src: models.ApplicationSource): any {
+    function getEditablePanelForOneSource(repoAppDetails: models.RepoAppDetails | undefined, ind: number, src: models.ApplicationSource): any {
         let floatingTitle: string;
         const lowerPanelAttributes: EditablePanelItem[] = [];
         const upperPanelAttributes: EditablePanelItem[] = [];
+        const refOnly = isRefOnlySource(src);
 
         const upperPanel = gatherCoreSourceDetails(ind, upperPanelAttributes, appSources[ind], app);
-        const lowerPanel = gatherDetails(
-            ind,
-            repoAppDetails,
-            lowerPanelAttributes,
-            appSources[ind],
-            app,
-            setRemovedOverrides,
-            removedOverrides,
-            appParamsDeletedState,
-            setAppParamsDeletedState,
-            true
-        );
+        const lowerPanel =
+            refOnly || !repoAppDetails
+                ? []
+                : gatherDetails(
+                      ind,
+                      repoAppDetails,
+                      lowerPanelAttributes,
+                      appSources[ind],
+                      app,
+                      setRemovedOverrides,
+                      removedOverrides,
+                      appParamsDeletedState,
+                      setAppParamsDeletedState,
+                      true
+                  );
 
-        if (repoAppDetails.type === 'Directory') {
+        if (refOnly) {
+            floatingTitle = 'Source ' + (ind + 1) + ': REF=' + src.ref + ', URL=' + src.repoURL + (src.targetRevision ? ', TARGET REVISION=' + src.targetRevision : '');
+        } else if (repoAppDetails?.type === 'Directory') {
             floatingTitle =
                 'Source ' +
                 (ind + 1) +
@@ -457,7 +468,7 @@ export const ApplicationParameters = (props: {
                 src.repoURL +
                 (repoAppDetails.path ? ', PATH=' + repoAppDetails.path : '') +
                 (src.targetRevision ? ', TARGET REVISION=' + src.targetRevision : '');
-        } else if (repoAppDetails.type === 'Helm') {
+        } else if (repoAppDetails?.type === 'Helm') {
             floatingTitle =
                 'Source ' +
                 (ind + 1) +
@@ -468,7 +479,7 @@ export const ApplicationParameters = (props: {
                 (src.chart ? ', CHART=' + src.chart + ':' + src.targetRevision : '') +
                 (src.path ? ', PATH=' + src.path : '') +
                 (src.targetRevision ? ', REVISION=' + src.targetRevision : '');
-        } else if (repoAppDetails.type === 'Kustomize') {
+        } else if (repoAppDetails?.type === 'Kustomize') {
             floatingTitle =
                 'Source ' +
                 (ind + 1) +
@@ -478,7 +489,7 @@ export const ApplicationParameters = (props: {
                 src.repoURL +
                 (repoAppDetails.path ? ', PATH=' + repoAppDetails.path : '') +
                 (src.targetRevision ? ', TARGET REVISION=' + src.targetRevision : '');
-        } else if (repoAppDetails.type === 'Plugin') {
+        } else if (repoAppDetails?.type === 'Plugin') {
             floatingTitle =
                 'Source ' +
                 (ind + 1) +
@@ -540,8 +551,8 @@ export const ApplicationParameters = (props: {
                         setRemovedOverrides(new Array<boolean>());
                     })
                 }
-                valuesTop={(app?.spec?.sources && (repoAppDetails.plugin || app?.spec?.sources[ind]?.plugin) && cloneDeep(app)) || app}
-                valuesBottom={(app?.spec?.sources && (repoAppDetails.plugin || app?.spec?.sources[ind]?.plugin) && cloneDeep(app)) || app}
+                valuesTop={(app?.spec?.sources && (repoAppDetails?.plugin || app?.spec?.sources[ind]?.plugin) && cloneDeep(app)) || app}
+                valuesBottom={(app?.spec?.sources && (repoAppDetails?.plugin || app?.spec?.sources[ind]?.plugin) && cloneDeep(app)) || app}
                 validateTop={updatedApp => {
                     const errors = [] as any;
                     const repoURL = updatedApp.spec.sources[ind].repoURL;
@@ -568,18 +579,19 @@ export const ApplicationParameters = (props: {
                     return errors;
                 }}
                 onModeSwitch={
-                    repoAppDetails.plugin &&
+                    repoAppDetails?.plugin &&
                     (() => {
                         setAppParamsDeletedState([]);
                     })
                 }
-                titleBottom={repoAppDetails.type.toLocaleUpperCase()}
+                titleBottom={repoAppDetails?.type?.toLocaleUpperCase()}
                 titleTop={'SOURCE ' + (ind + 1)}
                 floatingTitle={floatingTitle ? floatingTitle : null}
                 itemsBottom={lowerPanel as EditablePanelItem[]}
                 itemsTop={upperPanel as EditablePanelItem[]}
                 noReadonlyMode={props.noReadonlyMode}
                 collapsible={collapsible}
+                hideBottom={refOnly}
                 numberOfSources={app?.spec?.sources.length}
                 deleteSource={() => {
                     deleteSourceAction(app, app.spec.sources.at(ind), props.appContext);

--- a/ui/src/app/applications/components/application-parameters/application-parameters.tsx
+++ b/ui/src/app/applications/components/application-parameters/application-parameters.tsx
@@ -789,6 +789,9 @@ function gatherDetails(
         const helmValues = isValuesObject ? jsYaml.dump(source.helm.valuesObject) : source?.helm?.values;
         attributes.push({
             title: 'VALUES FILES',
+            hint: isMultiSource
+                ? 'To use a file from another Git source, set its Ref and enter $<ref>/path/to/values.yaml. The path is relative to that repository root.'
+                : undefined,
             view: (source.helm && (source.helm.valueFiles || []).join(', ')) || 'No values files selected',
             edit: (formApi: FormApi) => (
                 <FormField
@@ -797,7 +800,8 @@ function gatherDetails(
                     component={TagsInputField}
                     componentProps={{
                         options: repoDetails.helm.valueFiles,
-                        noTagsLabel: 'No values files selected'
+                        noTagsLabel: 'No values files selected',
+                        placeholder: isMultiSource ? '$<ref>/path/to/values.yaml' : 'path/to/values.yaml'
                     }}
                 />
             )

--- a/ui/src/app/applications/components/application-parameters/application-parameters.tsx
+++ b/ui/src/app/applications/components/application-parameters/application-parameters.tsx
@@ -1108,21 +1108,46 @@ function gatherDetails(
 
 // For Sources field. Get one source with index i from the list
 async function getSourceFromAppSources(aSource: models.ApplicationSource, name: string, project: string, index: number, version: number) {
-    const repoDetail = await services.repos.appDetails(aSource, name, project, index, version).catch(() => ({
-        type: 'Directory' as models.AppSourceType,
-        path: aSource.path
-    }));
-    return repoDetail;
+    const repoDetail = await services.repos.appDetails(aSource, name, project, index, version).catch(() => getExplicitSourceDetails(aSource));
+    return applyExplicitSourceType(aSource, repoDetail);
 }
 
 // Delete when source field is removed
 async function getSingleSource(app: models.Application) {
     if (app.spec.source || app.spec.sourceHydrator) {
-        const repoDetail = await services.repos.appDetails(getAppDrySource(app), app.metadata.name, app.spec.project, 0, 0).catch(() => ({
-            type: 'Directory' as models.AppSourceType,
-            path: getAppDrySource(app).path
-        }));
-        return repoDetail;
+        const source = getAppDrySource(app);
+        const repoDetail = await services.repos.appDetails(source, app.metadata.name, app.spec.project, 0, 0).catch(() => getExplicitSourceDetails(source));
+        return applyExplicitSourceType(source, repoDetail);
     }
     return null;
+}
+
+function applyExplicitSourceType(source: models.ApplicationSource, details: models.RepoAppDetails): models.RepoAppDetails {
+    const explicitDetails = getExplicitSourceDetails(source);
+    if (!hasExplicitSourceType(source) || details.type === explicitDetails.type) {
+        return details;
+    }
+    return {...details, ...explicitDetails};
+}
+
+function hasExplicitSourceType(source: models.ApplicationSource): boolean {
+    return !!(source.chart || source.helm || source.kustomize || source.directory || source.plugin);
+}
+
+function getExplicitSourceDetails(source: models.ApplicationSource): models.RepoAppDetails {
+    const path = source.path || '';
+    if (source.chart || source.helm) {
+        return {
+            type: 'Helm',
+            path,
+            helm: {name: source.chart || '', path, valueFiles: [], parameters: [], fileParameters: []}
+        };
+    }
+    if (source.kustomize) {
+        return {type: 'Kustomize', path, kustomize: {path}};
+    }
+    if (source.plugin) {
+        return {type: 'Plugin', path, plugin: {name: source.plugin.name || '', env: source.plugin.env || []}};
+    }
+    return {type: 'Directory', path, directory: {}};
 }

--- a/ui/src/app/applications/components/shared/app-source-edit.test.ts
+++ b/ui/src/app/applications/components/shared/app-source-edit.test.ts
@@ -1,0 +1,13 @@
+import * as models from '../../../shared/models';
+import {isRefOnlySource} from './app-source-edit';
+
+describe('isRefOnlySource', () => {
+    test.each([
+        ['Git source with ref only', {repoURL: 'https://git.example.com/values.git', ref: 'values'}, true],
+        ['Git source with ref and path', {repoURL: 'https://git.example.com/values.git', ref: 'values', path: 'manifests'}, false],
+        ['Helm source with ref', {repoURL: 'https://charts.example.com', ref: 'values', chart: 'application'}, false],
+        ['OCI source with ref', {repoURL: 'oci://registry.example.com/application', ref: 'values'}, false]
+    ])('%s', (_name, source, expected) => {
+        expect(isRefOnlySource(source as models.ApplicationSource)).toBe(expected);
+    });
+});

--- a/ui/src/app/applications/components/shared/app-source-edit.test.ts
+++ b/ui/src/app/applications/components/shared/app-source-edit.test.ts
@@ -1,5 +1,15 @@
 import * as models from '../../../shared/models';
-import {isRefOnlySource} from './app-source-edit';
+import {
+    APP_SOURCE_TYPES,
+    inferSourceRepositoryType,
+    isRefOnlySource,
+    normalizeRefOnlySource,
+    normalizeSourceForRepositoryType,
+    normalizeSourceTypeFields,
+    sourceDiscoveryKey,
+    sourceKeyForTypeOverride,
+    SourceRepositoryType
+} from './app-source-edit';
 
 describe('isRefOnlySource', () => {
     test.each([
@@ -9,5 +19,143 @@ describe('isRefOnlySource', () => {
         ['OCI source with ref', {repoURL: 'oci://registry.example.com/application', ref: 'values'}, false]
     ])('%s', (_name, source, expected) => {
         expect(isRefOnlySource(source as models.ApplicationSource)).toBe(expected);
+    });
+});
+
+describe('inferSourceRepositoryType', () => {
+    test.each([
+        ['Git', {repoURL: 'https://git.example.com/app.git', path: 'manifests'}, 'git'],
+        ['Helm', {repoURL: 'https://charts.example.com', chart: 'application'}, 'helm'],
+        ['OCI', {repoURL: 'oci://registry.example.com/application', path: '.'}, 'oci']
+    ])('infers %s sources', (_name, source, expected) => {
+        expect(inferSourceRepositoryType(source as models.ApplicationSource)).toBe(expected);
+    });
+});
+
+describe('normalizeSourceForRepositoryType', () => {
+    test('normalizes a ref-only Git source selected as a Helm repository', () => {
+        const source = {
+            repoURL: 'https://charts.example.com',
+            targetRevision: 'main',
+            ref: 'values',
+            kustomize: {namePrefix: 'stale-'}
+        } as models.ApplicationSource;
+
+        const normalized = normalizeSourceForRepositoryType(source, 'helm');
+
+        expect(normalized).toEqual({repoURL: 'https://charts.example.com', targetRevision: '', chart: ''});
+        expect(source).toHaveProperty('ref', 'values');
+        expect(source).toHaveProperty('kustomize');
+    });
+
+    test.each<{
+        name: string;
+        source: models.ApplicationSource;
+        type: SourceRepositoryType;
+        expected: models.ApplicationSource;
+    }>([
+        {
+            name: 'Git path to Helm chart',
+            source: {repoURL: 'https://charts.example.com', path: 'application', targetRevision: 'main', directory: {recurse: true}} as models.ApplicationSource,
+            type: 'helm',
+            expected: {repoURL: 'https://charts.example.com', chart: 'application', targetRevision: ''} as models.ApplicationSource
+        },
+        {
+            name: 'Helm chart to Git path',
+            source: {
+                repoURL: 'https://git.example.com/app.git',
+                chart: 'application',
+                targetRevision: '1.0.0',
+                helm: {valueFiles: ['values.yaml']}
+            } as models.ApplicationSource,
+            type: 'git',
+            expected: {
+                repoURL: 'https://git.example.com/app.git',
+                path: 'application',
+                targetRevision: 'HEAD',
+                helm: {valueFiles: ['values.yaml']}
+            } as models.ApplicationSource
+        },
+        {
+            name: 'Helm chart to OCI path',
+            source: {repoURL: 'oci://registry.example.com/app', chart: 'application', targetRevision: '1.0.0'} as models.ApplicationSource,
+            type: 'oci',
+            expected: {repoURL: 'oci://registry.example.com/app', path: 'application', targetRevision: 'HEAD'} as models.ApplicationSource
+        },
+        {
+            name: 'Git path with ref to OCI path',
+            source: {repoURL: 'oci://registry.example.com/app', path: 'manifests', targetRevision: 'main', ref: 'values'} as models.ApplicationSource,
+            type: 'oci',
+            expected: {repoURL: 'oci://registry.example.com/app', path: 'manifests', targetRevision: 'main'} as models.ApplicationSource
+        },
+        {
+            name: 'OCI path to Git path',
+            source: {repoURL: 'https://git.example.com/app.git', path: 'manifests', targetRevision: '1.2.3'} as models.ApplicationSource,
+            type: 'git',
+            expected: {repoURL: 'https://git.example.com/app.git', path: 'manifests', targetRevision: '1.2.3'} as models.ApplicationSource
+        }
+    ])('$name', ({source, type, expected}) => {
+        expect(normalizeSourceForRepositoryType(source, type)).toEqual(expected);
+    });
+
+    test('is idempotent for an already normalized source', () => {
+        const source = {repoURL: 'https://charts.example.com', chart: 'application', targetRevision: '1.0.0', helm: {valueFiles: []}} as models.ApplicationSource;
+
+        expect(normalizeSourceForRepositoryType(source, 'helm')).toBe(source);
+    });
+});
+
+describe('source identity keys', () => {
+    const pathSource = {repoURL: 'https://git.example.com/app.git', path: 'manifests', targetRevision: 'main'} as models.ApplicationSource;
+
+    test('separates explicit generator choices by repository and path/chart shape', () => {
+        expect(sourceKeyForTypeOverride({...pathSource, repoURL: 'https://git.example.com/other.git'})).not.toBe(sourceKeyForTypeOverride(pathSource));
+        expect(sourceKeyForTypeOverride({repoURL: pathSource.repoURL, chart: pathSource.path, targetRevision: 'main'} as models.ApplicationSource)).not.toBe(
+            sourceKeyForTypeOverride(pathSource)
+        );
+    });
+
+    test('keeps a generator choice across revisions but remounts discovery', () => {
+        const nextRevision = {...pathSource, targetRevision: 'release'};
+
+        expect(sourceKeyForTypeOverride(nextRevision)).toBe(sourceKeyForTypeOverride(pathSource));
+        expect(sourceDiscoveryKey(nextRevision)).not.toBe(sourceDiscoveryKey(pathSource));
+    });
+
+    test('remounts discovery when the application name or project changes', () => {
+        expect(sourceDiscoveryKey(pathSource, 'app-a', 'default')).not.toBe(sourceDiscoveryKey(pathSource, 'app-b', 'default'));
+        expect(sourceDiscoveryKey(pathSource, 'app-a', 'default')).not.toBe(sourceDiscoveryKey(pathSource, 'app-a', 'other-project'));
+    });
+});
+
+describe('source generator normalization', () => {
+    const sourceWithEveryGenerator = {
+        repoURL: 'https://git.example.com/app.git',
+        path: 'manifests',
+        targetRevision: 'main',
+        helm: {valueFiles: []},
+        kustomize: {namePrefix: 'test-'},
+        directory: {recurse: true},
+        plugin: {name: 'example'}
+    } as models.ApplicationSource;
+
+    test.each(APP_SOURCE_TYPES)('keeps only the $type generator block', ({type, field}) => {
+        const normalized = normalizeSourceTypeFields(sourceWithEveryGenerator, type) as unknown as Record<string, unknown>;
+
+        for (const sourceType of APP_SOURCE_TYPES) {
+            expect(Object.prototype.hasOwnProperty.call(normalized, sourceType.field)).toBe(sourceType.field === field);
+        }
+    });
+
+    test('clears every generator block when a source becomes ref-only', () => {
+        const source = {...sourceWithEveryGenerator, path: '', ref: 'values'} as models.ApplicationSource;
+        delete source.path;
+
+        const normalized = normalizeRefOnlySource(source) as unknown as Record<string, unknown>;
+
+        for (const sourceType of APP_SOURCE_TYPES) {
+            expect(normalized).not.toHaveProperty(sourceType.field);
+        }
+        expect(normalized).toMatchObject({repoURL: source.repoURL, targetRevision: 'main', ref: 'values'});
     });
 });

--- a/ui/src/app/applications/components/shared/app-source-edit.ts
+++ b/ui/src/app/applications/components/shared/app-source-edit.ts
@@ -10,6 +10,14 @@ export const APP_SOURCE_TYPES = new Array<{field: string; type: models.AppSource
 );
 
 /**
+ * A ref-only source is checked out solely so another source can reference files from it.
+ * It does not generate manifests and therefore has no application source type to configure.
+ */
+export function isRefOnlySource(source: models.ApplicationSource | undefined): boolean {
+    return !!source?.ref && !source.path && !source.chart && !source.repoURL?.startsWith('oci://');
+}
+
+/**
  * Clears sibling source-type blocks (helm/kustomize/directory/plugin) when the user picks a type.
  * @param sourceIndex — when set, edits `spec.sources[index]`; otherwise `spec.source`.
  */

--- a/ui/src/app/applications/components/shared/app-source-edit.ts
+++ b/ui/src/app/applications/components/shared/app-source-edit.ts
@@ -1,6 +1,8 @@
 import {FormApi} from 'argo-ui';
 import * as models from '../../../shared/models';
 
+export type SourceRepositoryType = 'git' | 'helm' | 'oci';
+
 /** Shared with application-create-panel and application-parameters/source-panel. */
 export const APP_SOURCE_TYPES = new Array<{field: string; type: models.AppSourceType}>(
     {type: 'Helm', field: 'helm'},
@@ -17,30 +19,131 @@ export function isRefOnlySource(source: models.ApplicationSource | undefined): b
     return !!source?.ref && !source.path && !source.chart && !source.repoURL?.startsWith('oci://');
 }
 
+export function inferSourceRepositoryType(source: models.ApplicationSource | undefined): SourceRepositoryType {
+    if (source?.repoURL?.startsWith('oci://')) {
+        return 'oci';
+    }
+    if (source && Object.prototype.hasOwnProperty.call(source, 'chart')) {
+        return 'helm';
+    }
+    return 'git';
+}
+
+/** Identifies the repository location for which the user explicitly selected a generator type. */
+export function sourceKeyForTypeOverride(source: models.ApplicationSource | undefined): string {
+    const usesChart = !!source && Object.prototype.hasOwnProperty.call(source, 'chart');
+    return `${source?.repoURL || ''}\n${usesChart ? 'chart' : 'path'}\n${(usesChart ? source?.chart : source?.path) || ''}`;
+}
+
+/** Remounts source discovery whenever any field that identifies its request changes. */
+export function sourceDiscoveryKey(source: models.ApplicationSource | undefined, appName = '', project = ''): string {
+    return `${sourceKeyForTypeOverride(source)}\n${source?.targetRevision || ''}\n${appName}\n${project}`;
+}
+
+/**
+ * Returns a source whose path/chart/ref fields match the selected repository type.
+ * The original object is returned when it is already normalized.
+ */
+export function normalizeSourceForRepositoryType(source: models.ApplicationSource, type: SourceRepositoryType): models.ApplicationSource {
+    const normalized = {...source};
+    const normalizedRecord = normalized as unknown as Record<string, unknown>;
+    let changed = false;
+
+    const remove = (field: string) => {
+        if (Object.prototype.hasOwnProperty.call(normalizedRecord, field)) {
+            delete normalizedRecord[field];
+            changed = true;
+        }
+    };
+    const set = (field: string, value: unknown) => {
+        if (normalizedRecord[field] !== value || !Object.prototype.hasOwnProperty.call(normalizedRecord, field)) {
+            normalizedRecord[field] = value;
+            changed = true;
+        }
+    };
+
+    if (type !== 'git') {
+        remove('ref');
+    }
+
+    if (type === 'helm') {
+        const hasChart = Object.prototype.hasOwnProperty.call(normalizedRecord, 'chart');
+        const hasPath = Object.prototype.hasOwnProperty.call(normalizedRecord, 'path');
+        if (!hasChart) {
+            set('chart', hasPath ? normalized.path : '');
+            set('targetRevision', '');
+        }
+        remove('path');
+
+        // A chart repository cannot render Kustomize, Directory, or Plugin sources.
+        remove('kustomize');
+        remove('directory');
+        remove('plugin');
+    } else if (Object.prototype.hasOwnProperty.call(normalizedRecord, 'chart')) {
+        if (!Object.prototype.hasOwnProperty.call(normalizedRecord, 'path')) {
+            set('path', normalized.chart);
+            set('targetRevision', 'HEAD');
+        }
+        remove('chart');
+    }
+
+    return changed ? normalized : source;
+}
+
+/** Clears generator settings that cannot be used by a ref-only source. */
+export function normalizeRefOnlySource(source: models.ApplicationSource): models.ApplicationSource {
+    if (!isRefOnlySource(source)) {
+        return source;
+    }
+    return clearSourceTypeFields(source);
+}
+
+/** Keeps only the generator block selected by the user. */
+export function normalizeSourceTypeFields(source: models.ApplicationSource, type: models.AppSourceType): models.ApplicationSource {
+    return clearSourceTypeFields(source, type);
+}
+
+function clearSourceTypeFields(source: models.ApplicationSource, keep?: models.AppSourceType): models.ApplicationSource {
+    const normalized = {...source};
+    const normalizedRecord = normalized as unknown as Record<string, unknown>;
+    let changed = false;
+    for (const item of APP_SOURCE_TYPES) {
+        if (item.type !== keep && Object.prototype.hasOwnProperty.call(normalizedRecord, item.field)) {
+            delete normalizedRecord[item.field];
+            changed = true;
+        }
+    }
+    return changed ? normalized : source;
+}
+
 /**
  * Clears sibling source-type blocks (helm/kustomize/directory/plugin) when the user picks a type.
  * @param sourceIndex — when set, edits `spec.sources[index]`; otherwise `spec.source`.
  */
 export function normalizeTypeFieldsForSource(formApi: FormApi, type: models.AppSourceType, sourceIndex?: number): void {
     const appToNormalize = formApi.getFormState().values as models.Application;
+    let normalizedSource: models.ApplicationSource;
     if (sourceIndex === undefined) {
-        const single = appToNormalize.spec.source as unknown as Record<string, unknown>;
-        for (const item of APP_SOURCE_TYPES) {
-            if (item.type !== type) {
-                delete single[item.field];
-            }
+        const source = appToNormalize.spec.source;
+        if (!source) {
+            return;
         }
+        normalizedSource = normalizeSourceTypeFields(source, type);
+        if (normalizedSource === source) {
+            return;
+        }
+        formApi.setAllValues({...appToNormalize, spec: {...appToNormalize.spec, source: normalizedSource}});
     } else {
-        const src = appToNormalize.spec.sources[sourceIndex];
+        const src = appToNormalize.spec.sources?.[sourceIndex];
         if (!src) {
             return;
         }
-        const srcRec = src as unknown as Record<string, unknown>;
-        for (const item of APP_SOURCE_TYPES) {
-            if (item.type !== type) {
-                delete srcRec[item.field];
-            }
+        normalizedSource = normalizeSourceTypeFields(src, type);
+        if (normalizedSource === src) {
+            return;
         }
+        const sources = [...appToNormalize.spec.sources];
+        sources[sourceIndex] = normalizedSource;
+        formApi.setAllValues({...appToNormalize, spec: {...appToNormalize.spec, sources}});
     }
-    formApi.setAllValues(appToNormalize);
 }

--- a/ui/src/app/shared/components/editable-panel/editable-panel.tsx
+++ b/ui/src/app/shared/components/editable-panel/editable-panel.tsx
@@ -20,6 +20,22 @@ export interface EditablePanelItem {
     titleEdit?: (formApi: FormApi) => ReactNode;
 }
 
+export function EditablePanelItemTitle({item, formApi}: {item: EditablePanelItem; formApi?: FormApi}) {
+    if (formApi && item.titleEdit) {
+        return <>{item.titleEdit(formApi)}</>;
+    }
+    return (
+        <>
+            {item.customTitle || item.title}
+            {item.hint && (
+                <span style={{marginLeft: '0.25em'}}>
+                    <HelpIcon title={item.hint} />
+                </span>
+            )}
+        </>
+    );
+}
+
 export interface EditablePanelSubsection {
     sectionName: string;
     items: EditablePanelItem[];
@@ -132,18 +148,7 @@ function EditablePanel<T extends {} = {}>({
             {item.before}
             <div className='row white-box__details-row'>
                 <div className='columns small-3' style={isIndented ? {paddingLeft: '2em'} : undefined}>
-                    {api && item.titleEdit ? (
-                        item.titleEdit(api)
-                    ) : (
-                        <>
-                            {item.customTitle || item.title}
-                            {item.hint && (
-                                <span style={{marginLeft: '0.25em'}}>
-                                    <HelpIcon title={item.hint} />
-                                </span>
-                            )}
-                        </>
-                    )}
+                    <EditablePanelItemTitle item={item} formApi={api} />
                 </div>
                 <div className='columns small-9'>{api && item.edit ? item.edit(api) : item.view}</div>
             </div>

--- a/ui/src/app/shared/components/editable-panel/editable-section.tsx
+++ b/ui/src/app/shared/components/editable-panel/editable-section.tsx
@@ -4,7 +4,7 @@ import {useState, useRef, useEffect, Fragment, useCallback} from 'react';
 import type {FormApi, FormState} from 'argo-ui';
 import {Form} from 'argo-ui';
 import {ContextApis} from '../../context';
-import {EditablePanelItem} from './editable-panel';
+import {EditablePanelItem, EditablePanelItemTitle} from './editable-panel';
 import {Spinner} from '../spinner';
 import {helpTip} from '../../../applications/components/utils';
 
@@ -165,7 +165,9 @@ function EditableSection<T extends {} = {}>({
                             <Fragment key={'read_' + uniqueId + '_' + (item.key || item.title)}>
                                 {item.before}
                                 <div className='row white-box__details-row'>
-                                    <div className='columns small-3'>{item.customTitle || item.title}</div>
+                                    <div className='columns small-3'>
+                                        <EditablePanelItemTitle item={item} />
+                                    </div>
                                     <div className='columns small-9'>{item.view}</div>
                                 </div>
                             </Fragment>
@@ -180,7 +182,9 @@ function EditableSection<T extends {} = {}>({
                                 <Fragment key={'edit_' + uniqueId + '_' + (item.key || item.title)}>
                                     {item.before}
                                     <div className='row white-box__details-row'>
-                                        <div className='columns small-3'>{(item.titleEdit && item.titleEdit(api)) || item.customTitle || item.title}</div>
+                                        <div className='columns small-3'>
+                                            <EditablePanelItemTitle item={item} formApi={api} />
+                                        </div>
                                         <div className='columns small-9'>{(item.edit && item.edit(api)) || item.view}</div>
                                     </div>
                                 </Fragment>

--- a/ui/src/app/shared/components/tags-input/tags-input-field.tsx
+++ b/ui/src/app/shared/components/tags-input/tags-input-field.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {ReactForm} from 'argo-ui';
 import {TagsInput} from './tags-input';
 
-export const TagsInputField = ReactForm.FormField((props: {options: string[]; noTagsLabel?: string; fieldApi: ReactForm.FieldApi; className: string}) => {
+export const TagsInputField = ReactForm.FormField((props: {options: string[]; noTagsLabel?: string; placeholder?: string; fieldApi: ReactForm.FieldApi; className: string}) => {
     const {
         fieldApi: {getValue, setValue}
     } = props;
@@ -10,7 +10,7 @@ export const TagsInputField = ReactForm.FormField((props: {options: string[]; no
 
     return (
         <div className='argo-has-value argo-field' style={{border: 'none'}}>
-            <TagsInput tags={tags} autocomplete={props.options || []} onChange={vals => setValue(vals)} />
+            <TagsInput tags={tags} autocomplete={props.options || []} placeholder={props.placeholder} onChange={vals => setValue(vals)} />
         </div>
     );
 });

--- a/ui/src/app/shared/components/tags-input/tags-input.test.tsx
+++ b/ui/src/app/shared/components/tags-input/tags-input.test.tsx
@@ -1,0 +1,41 @@
+import {fireEvent, render, screen} from '@testing-library/react';
+import * as React from 'react';
+import {TagsInput} from './tags-input';
+
+describe('TagsInput', () => {
+    test('commits typed input as a tag on Enter', () => {
+        const onChange = jest.fn();
+        render(<TagsInput tags={[]} onChange={onChange} />);
+
+        const input = screen.getByRole('combobox');
+        fireEvent.change(input, {target: {value: 'values.yaml'}});
+        fireEvent.keyUp(input, {key: 'Enter', keyCode: 13});
+
+        expect(onChange).toHaveBeenCalledWith(['values.yaml']);
+        expect(screen.getByText('values.yaml')).toBeInTheDocument();
+    });
+
+    test('commits typed input as a tag on blur', () => {
+        const onChange = jest.fn();
+        render(<TagsInput tags={[]} placeholder='Add value' onChange={onChange} />);
+
+        const input = screen.getByRole('combobox');
+        fireEvent.change(input, {target: {value: '$values/path/to/values.yaml'}});
+        fireEvent.blur(input);
+
+        expect(onChange).toHaveBeenCalledWith(['$values/path/to/values.yaml']);
+        expect(screen.getByText('$values/path/to/values.yaml')).toBeInTheDocument();
+    });
+
+    test('does not add a duplicate tag on blur', () => {
+        const onChange = jest.fn();
+        render(<TagsInput tags={['values.yaml']} onChange={onChange} />);
+
+        const input = screen.getByRole('combobox');
+        fireEvent.change(input, {target: {value: 'values.yaml'}});
+        fireEvent.blur(input);
+
+        expect(onChange).not.toHaveBeenCalled();
+        expect(screen.getAllByText('values.yaml')).toHaveLength(1);
+    });
+});

--- a/ui/src/app/shared/components/tags-input/tags-input.tsx
+++ b/ui/src/app/shared/components/tags-input/tags-input.tsx
@@ -34,6 +34,16 @@ export function TagsInput(props: TagsInputProps) {
         }
     };
 
+    const addTag = (tag: string, focused = state.focused) => {
+        if (state.tags.includes(tag)) {
+            setState({...state, input: '', focused});
+            return;
+        }
+        const newTags = state.tags.concat(tag);
+        setState({...state, input: '', focused, tags: newTags});
+        onTagsChange(newTags);
+    };
+
     return (
         <div className={classNames('tags-input argo-field', {'tags-input--focused': state.focused || !!state.input})} onClick={() => inputEl.current && inputEl.current.focus()}>
             {state.tags.map((tag, i) => (
@@ -57,33 +67,33 @@ export function TagsInput(props: TagsInputProps) {
                 items={props.autocomplete}
                 onChange={e => setState({...state, input: e.target.value})}
                 onSelect={value => {
-                    if (state.tags.indexOf(value) === -1) {
-                        const newTags = state.tags.concat(value);
-                        setState(prevState => ({...prevState, input: '', tags: newTags}));
-                        onTagsChange(newTags);
-                    }
+                    addTag(value);
                 }}
-                renderInput={props => (
+                renderInput={inputProps => (
                     <input
-                        {...props}
+                        {...inputProps}
                         placeholder={props.placeholder}
                         ref={el => {
                             inputEl.current = el;
-                            if (props.ref) {
-                                (props.ref as any)(el);
+                            if (inputProps.ref) {
+                                (inputProps.ref as any)(el);
                             }
                         }}
                         onFocus={e => {
-                            if (props.onFocus) {
-                                props.onFocus(e);
+                            if (inputProps.onFocus) {
+                                inputProps.onFocus(e);
                             }
                             setState({...state, focused: true});
                         }}
                         onBlur={e => {
-                            if (props.onBlur) {
-                                props.onBlur(e);
+                            if (inputProps.onBlur) {
+                                inputProps.onBlur(e);
                             }
-                            setState({...state, focused: false});
+                            if (state.input) {
+                                addTag(state.input, false);
+                            } else {
+                                setState({...state, focused: false});
+                            }
                         }}
                         onKeyDown={e => {
                             if (e.keyCode === 8 && state.tags.length > 0 && state.input === '') {
@@ -91,18 +101,16 @@ export function TagsInput(props: TagsInputProps) {
                                 setState(prevState => ({...prevState, tags: newTags}));
                                 onTagsChange(newTags);
                             }
-                            if (props.onKeyDown) {
-                                props.onKeyDown(e);
+                            if (inputProps.onKeyDown) {
+                                inputProps.onKeyDown(e);
                             }
                         }}
                         onKeyUp={e => {
-                            if (e.keyCode === 13 && state.input && state.tags.indexOf(state.input) === -1) {
-                                const newTags = state.tags.concat(state.input);
-                                setState(prevState => ({...prevState, input: '', tags: newTags}));
-                                onTagsChange(newTags);
+                            if (e.keyCode === 13 && state.input) {
+                                addTag(state.input);
                             }
-                            if (props.onKeyUp) {
-                                props.onKeyUp(e);
+                            if (inputProps.onKeyUp) {
+                                inputProps.onKeyUp(e);
                             }
                         }}
                     />


### PR DESCRIPTION
## Summary

The New App panel now supports ref-only Git sources in multi-source Applications.

This change:

* adds a `Ref` field for each Git source in multi-source mode;
* aligns UI validation with the API contract of `repoURL` plus one of `path`, `chart`, or `ref`;
* clears stale `ref` state when changing a source to Helm or OCI;
* includes `REF` in collapsed source summaries; and
* adds regression coverage for external Helm value files and source type changes.

## Why

Argo CD already accepts a multi-source Application where one source provides a Helm chart and a ref-only Git source provides external value files. The New App panel rejected that same configuration because it required every source to have a path or chart and did not expose `spec.sources[].ref`.

This left the UI inconsistent with the Application API and prevented users from creating the documented external-values configuration through the form.

Closes #20964.

## User impact

Users can create a multi-source Application in the New App panel with a Helm source such as `$values/sandboxes/test/values.yaml` and a second Git source containing `ref: values`, without adding an artificial path or editing YAML manually.

## Validation

* Targeted regression tests: 2 suites, 7 tests passed.
* Full UI unit suite: 24 suites, 270 tests, and 32 snapshots passed.
* Production UI build completed successfully.
* `make build` passed.
* `make lint` passed.
* `make lint-ui` passed with no errors.
* `make test` passed.
* `make cli` passed.
* Manual verification created and synced a multi-source Application using a Helm chart from one Git repository and external values from a ref-only second Git repository.
* `make codegen` was not required because no API types, CRDs, or generated manifests changed.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes. This bug fix is tracked in #20964.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. This is a UI consistency fix; the API and CLI already support ref-only sources.
* [x] Does this PR require documentation updates? No. The external-values configuration is already documented; this change makes the form support it.
* [x] I've updated documentation as required by this PR. No documentation changes are required.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal).
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines. Not applicable: this is a bug fix for an existing API capability.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md. Not applicable; no organization entry is being requested.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity). No specific backport is requested.

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
