### PR TITLE
fix: strip ANSI escape codes from application conditions messages

### DIFF
--- a/ui/src/app/applications/components/application-conditions/application-conditions.tsx
+++ b/ui/src/app/applications/components/application-conditions/application-conditions.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import {Timestamp} from '../../../shared/components';
 import * as models from '../../../shared/models';
+import {stripAnsiEscapeCodes} from '../../../shared/utils';
 import {getAppSetConditionCategory, getConditionCategory} from '../utils';
 
 import './application-conditions.scss';
@@ -27,7 +28,7 @@ export const ApplicationConditions = ({conditions, title = 'Application conditio
                             <div className='row'>
                                 <div className='columns small-2'>{condition.type}</div>
                                 <div className='columns small-7' style={{whiteSpace: 'normal', lineHeight: 'normal'}}>
-                                    {condition.message}
+                                    {stripAnsiEscapeCodes(condition.message)}
                                 </div>
                                 <div className='columns small-3'>
                                     <Timestamp date={condition.lastTransitionTime} />
@@ -57,7 +58,7 @@ export const ApplicationSetConditions = ({conditions, title = 'ApplicationSet co
                                     {condition.status && <span className='application-conditions__status'> ({condition.status})</span>}
                                 </div>
                                 <div className='columns small-7' style={{whiteSpace: 'normal', lineHeight: 'normal'}}>
-                                    {condition.message}
+                                    {stripAnsiEscapeCodes(condition.message)}
                                 </div>
                                 <div className='columns small-3'>
                                     <Timestamp date={condition.lastTransitionTime} />

--- a/ui/src/app/shared/utils.test.ts
+++ b/ui/src/app/shared/utils.test.ts
@@ -4,6 +4,7 @@ declare const expect: any;
 declare const describe: any;
 import {concatMaps} from './utils';
 import {isValidManagedByURL, isValidURL} from './utils';
+import {stripAnsiEscapeCodes} from './utils';
 
 test('map concatenation', () => {
     const map1 = {
@@ -56,5 +57,30 @@ describe('isValidManagedByURL', () => {
     test('rejects invalid URL strings', () => {
         expect(isValidManagedByURL('not-a-url')).toBe(false);
         expect(isValidManagedByURL('')).toBe(false);
+    });
+});
+
+describe('stripAnsiEscapeCodes', () => {
+    test('strips ANSI color codes', () => {
+        expect(stripAnsiEscapeCodes('\x1b[1;31mError\x1b[0m')).toBe('Error');
+        expect(stripAnsiEscapeCodes('\x1b[32mSuccess\x1b[0m')).toBe('Success');
+    });
+
+    test('strips multiple ANSI codes', () => {
+        expect(stripAnsiEscapeCodes('\x1b[1;31mError\x1b[0m: \x1b[33mWarning\x1b[0m')).toBe('Error: Warning');
+    });
+
+    test('leaves plain text unchanged', () => {
+        expect(stripAnsiEscapeCodes('No escape codes here')).toBe('No escape codes here');
+    });
+
+    test('handles empty string', () => {
+        expect(stripAnsiEscapeCodes('')).toBe('');
+    });
+
+    test('strips the example from the issue', () => {
+        expect(stripAnsiEscapeCodes('./missing-file.dhall \x1b[1;31mError\x1b[0m: Missing file ./missing-file.dhall')).toBe(
+            './missing-file.dhall Error: Missing file ./missing-file.dhall'
+        );
     });
 });

--- a/ui/src/app/shared/utils.ts
+++ b/ui/src/app/shared/utils.ts
@@ -142,6 +142,13 @@ export const formatClusterQueryParam = (cluster: Cluster) => {
     return `${cluster.name} (${cluster.server})`;
 };
 
+// ANSI escape code regex pattern
+const ANSI_ESCAPE_REGEX = /\x1b\[[0-9;]*[a-zA-Z]/g;
+
+export function stripAnsiEscapeCodes(str: string): string {
+    return str.replace(ANSI_ESCAPE_REGEX, '');
+}
+
 /**
  * Checks if SSO is configured for authentication usage.
  * @param userInfo - User information from the session


### PR DESCRIPTION
## Summary

Condition messages from external tools (e.g. dhall-to-yaml) may contain ANSI color escape sequences that render as raw escape characters (e.g. `^[[1;31m`) in the web UI. This PR adds a utility function to strip ANSI escape codes and applies it when rendering condition messages in both `ApplicationConditions` and `ApplicationSetConditions` components.

Fixes #4770

## Changes

- Added `stripAnsiEscapeCodes` utility function in `ui/src/app/shared/utils.ts`
- Applied it in `application-conditions.tsx` for both `ApplicationConditions` and `ApplicationSetConditions` components
- Added unit tests for the utility function

## Test plan

- [x] All existing UI tests pass (`pnpm test` - 268 tests passed)
- [x] Added unit tests for `stripAnsiEscapeCodes` covering:
  - Single ANSI color codes
  - Multiple ANSI codes
  - Plain text (no-op)
  - Empty string
  - The exact example from issue #4770
- [ ] Manually verified that condition messages with ANSI codes are now displayed cleanly

## Further comments

The fix is minimal and targeted: it strips ANSI escape sequences from condition messages before rendering them in the UI. This handles the case where external tools output colored text that gets captured in condition messages.