### PR TITLE
fix(repo-server): honor `ARGOCD_REPO_SERVER_OTLP_HEADERS` in repo-server

### DIFF
--- a/cmd/argocd-repo-server/commands/argocd_repo_server.go
+++ b/cmd/argocd-repo-server/commands/argocd_repo_server.go
@@ -52,18 +52,6 @@ var (
 	helmUserAgent                                = env.StringFromEnv(common.EnvHelmUserAgent, "")
 )
 
-const (
-	// envOTLPHeaders is the environment variable holding the OTLP collector headers. It follows the
-	// ARGOCD_<COMPONENT>_OTLP_HEADERS convention used by every other Argo CD component (e.g.
-	// ARGOCD_SERVER_OTLP_HEADERS, ARGOCD_APPLICATION_CONTROLLER_OTLP_HEADERS) and matches the name
-	// the shipped repo-server Deployment already injects from the otlp.headers config map key.
-	envOTLPHeaders = "ARGOCD_REPO_SERVER_OTLP_HEADERS"
-	// envOTLPHeadersDeprecated is the legacy, inconsistently-named variable that omits the "SERVER"
-	// segment. It is retained only for backward compatibility with existing deployments that set it
-	// directly, and is superseded by envOTLPHeaders.
-	envOTLPHeadersDeprecated = "ARGOCD_REPO_OTLP_HEADERS"
-)
-
 func NewCommand() *cobra.Command {
 	var (
 		parallelismLimit                   int64
@@ -273,7 +261,7 @@ func NewCommand() *cobra.Command {
 	command.Flags().IntVar(&metricsPort, "metrics-port", common.DefaultPortRepoServerMetrics, "Start metrics server on given port")
 	command.Flags().StringVar(&otlpAddress, "otlp-address", env.StringFromEnv("ARGOCD_REPO_SERVER_OTLP_ADDRESS", ""), "OpenTelemetry collector address to send traces to")
 	command.Flags().BoolVar(&otlpInsecure, "otlp-insecure", env.ParseBoolFromEnv("ARGOCD_REPO_SERVER_OTLP_INSECURE", true), "OpenTelemetry collector insecure mode")
-	command.Flags().StringToStringVar(&otlpHeaders, "otlp-headers", otlpHeadersFromEnv(), "List of OpenTelemetry collector extra headers sent with traces, headers are comma-separated key-value pairs(e.g. key1=value1,key2=value2)")
+	command.Flags().StringToStringVar(&otlpHeaders, "otlp-headers", env.ParseStringToStringFromEnv("ARGOCD_REPO_SERVER_OTLP_HEADERS", map[string]string{}, ","), "List of OpenTelemetry collector extra headers sent with traces, headers are comma-separated key-value pairs(e.g. key1=value1,key2=value2)")
 	command.Flags().StringSliceVar(&otlpAttrs, "otlp-attrs", env.StringsFromEnv("ARGOCD_REPO_SERVER_OTLP_ATTRS", []string{}, ","), "List of OpenTelemetry collector extra attrs when send traces, each attribute is separated by a colon(e.g. key:value)")
 	command.Flags().StringVar(&maxCombinedDirectoryManifestsSize, "max-combined-directory-manifests-size", env.StringFromEnv("ARGOCD_REPO_SERVER_MAX_COMBINED_DIRECTORY_MANIFESTS_SIZE", "10M"), "Max combined size of manifest files in a directory-type Application")
 	command.Flags().StringArrayVar(&cmpTarExcludedGlobs, "plugin-tar-exclude", env.StringsFromEnv("ARGOCD_REPO_SERVER_PLUGIN_TAR_EXCLUSIONS", []string{}, ";"), "Globs to filter when sending tarballs to plugins.")
@@ -312,24 +300,4 @@ func buildHealthCheckTLSConfig(healthCheckClientCert *ctls.Certificate, disableT
 		cfg.ClientCertificates = []ctls.Certificate{*healthCheckClientCert}
 	}
 	return cfg
-}
-
-// otlpHeadersFromEnv resolves the OTLP collector headers from the environment, preferring the
-// canonical envOTLPHeaders and falling back to the deprecated envOTLPHeadersDeprecated for backward
-// compatibility. When only the deprecated variable is set, a warning is logged so operators migrate.
-// If the canonical variable is present it always wins, even when the deprecated one is also set.
-// An empty map is returned when neither variable is set.
-func otlpHeadersFromEnv() map[string]string {
-	// The canonical, correctly-named variable takes precedence.
-	if _, ok := os.LookupEnv(envOTLPHeaders); ok {
-		return env.ParseStringToStringFromEnv(envOTLPHeaders, map[string]string{}, ",")
-	}
-
-	// Fall back to the deprecated variable, warning the operator to migrate.
-	if _, ok := os.LookupEnv(envOTLPHeadersDeprecated); ok {
-		log.Warnf("environment variable %q is deprecated, use %q instead", envOTLPHeadersDeprecated, envOTLPHeaders)
-		return env.ParseStringToStringFromEnv(envOTLPHeadersDeprecated, map[string]string{}, ",")
-	}
-
-	return map[string]string{}
 }

--- a/cmd/argocd-repo-server/commands/argocd_repo_server.go
+++ b/cmd/argocd-repo-server/commands/argocd_repo_server.go
@@ -52,6 +52,18 @@ var (
 	helmUserAgent                                = env.StringFromEnv(common.EnvHelmUserAgent, "")
 )
 
+const (
+	// envOTLPHeaders is the environment variable holding the OTLP collector headers. It follows the
+	// ARGOCD_<COMPONENT>_OTLP_HEADERS convention used by every other Argo CD component (e.g.
+	// ARGOCD_SERVER_OTLP_HEADERS, ARGOCD_APPLICATION_CONTROLLER_OTLP_HEADERS) and matches the name
+	// the shipped repo-server Deployment already injects from the otlp.headers config map key.
+	envOTLPHeaders = "ARGOCD_REPO_SERVER_OTLP_HEADERS"
+	// envOTLPHeadersDeprecated is the legacy, inconsistently-named variable that omits the "SERVER"
+	// segment. It is retained only for backward compatibility with existing deployments that set it
+	// directly, and is superseded by envOTLPHeaders.
+	envOTLPHeadersDeprecated = "ARGOCD_REPO_OTLP_HEADERS"
+)
+
 func NewCommand() *cobra.Command {
 	var (
 		parallelismLimit                   int64
@@ -261,7 +273,7 @@ func NewCommand() *cobra.Command {
 	command.Flags().IntVar(&metricsPort, "metrics-port", common.DefaultPortRepoServerMetrics, "Start metrics server on given port")
 	command.Flags().StringVar(&otlpAddress, "otlp-address", env.StringFromEnv("ARGOCD_REPO_SERVER_OTLP_ADDRESS", ""), "OpenTelemetry collector address to send traces to")
 	command.Flags().BoolVar(&otlpInsecure, "otlp-insecure", env.ParseBoolFromEnv("ARGOCD_REPO_SERVER_OTLP_INSECURE", true), "OpenTelemetry collector insecure mode")
-	command.Flags().StringToStringVar(&otlpHeaders, "otlp-headers", env.ParseStringToStringFromEnv("ARGOCD_REPO_OTLP_HEADERS", map[string]string{}, ","), "List of OpenTelemetry collector extra headers sent with traces, headers are comma-separated key-value pairs(e.g. key1=value1,key2=value2)")
+	command.Flags().StringToStringVar(&otlpHeaders, "otlp-headers", otlpHeadersFromEnv(), "List of OpenTelemetry collector extra headers sent with traces, headers are comma-separated key-value pairs(e.g. key1=value1,key2=value2)")
 	command.Flags().StringSliceVar(&otlpAttrs, "otlp-attrs", env.StringsFromEnv("ARGOCD_REPO_SERVER_OTLP_ATTRS", []string{}, ","), "List of OpenTelemetry collector extra attrs when send traces, each attribute is separated by a colon(e.g. key:value)")
 	command.Flags().StringVar(&maxCombinedDirectoryManifestsSize, "max-combined-directory-manifests-size", env.StringFromEnv("ARGOCD_REPO_SERVER_MAX_COMBINED_DIRECTORY_MANIFESTS_SIZE", "10M"), "Max combined size of manifest files in a directory-type Application")
 	command.Flags().StringArrayVar(&cmpTarExcludedGlobs, "plugin-tar-exclude", env.StringsFromEnv("ARGOCD_REPO_SERVER_PLUGIN_TAR_EXCLUSIONS", []string{}, ";"), "Globs to filter when sending tarballs to plugins.")
@@ -300,4 +312,24 @@ func buildHealthCheckTLSConfig(healthCheckClientCert *ctls.Certificate, disableT
 		cfg.ClientCertificates = []ctls.Certificate{*healthCheckClientCert}
 	}
 	return cfg
+}
+
+// otlpHeadersFromEnv resolves the OTLP collector headers from the environment, preferring the
+// canonical envOTLPHeaders and falling back to the deprecated envOTLPHeadersDeprecated for backward
+// compatibility. When only the deprecated variable is set, a warning is logged so operators migrate.
+// If the canonical variable is present it always wins, even when the deprecated one is also set.
+// An empty map is returned when neither variable is set.
+func otlpHeadersFromEnv() map[string]string {
+	// The canonical, correctly-named variable takes precedence.
+	if _, ok := os.LookupEnv(envOTLPHeaders); ok {
+		return env.ParseStringToStringFromEnv(envOTLPHeaders, map[string]string{}, ",")
+	}
+
+	// Fall back to the deprecated variable, warning the operator to migrate.
+	if _, ok := os.LookupEnv(envOTLPHeadersDeprecated); ok {
+		log.Warnf("environment variable %q is deprecated, use %q instead", envOTLPHeadersDeprecated, envOTLPHeaders)
+		return env.ParseStringToStringFromEnv(envOTLPHeadersDeprecated, map[string]string{}, ",")
+	}
+
+	return map[string]string{}
 }

--- a/cmd/argocd-repo-server/commands/argocd_repo_server_test.go
+++ b/cmd/argocd-repo-server/commands/argocd_repo_server_test.go
@@ -2,8 +2,10 @@ package commands
 
 import (
 	ctls "crypto/tls"
+	"os"
 	"testing"
 
+	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -84,4 +86,91 @@ func TestBuildHealthCheckTLSConfig_MutatingReturnedCertDoesNotAffectSource(t *te
 	cfg.ClientCertificates[0] = ctls.Certificate{}
 
 	assert.Equal(t, originalDER, hcCert.Certificate[0], "mutating the returned config must not affect the source certificate")
+}
+
+func TestOtlpHeadersFromEnv(t *testing.T) {
+	tests := []struct {
+		name        string
+		setNew      bool
+		newVal      string
+		setOld      bool
+		oldVal      string
+		want        map[string]string
+		wantWarning bool
+	}{
+		{
+			name: "neither variable set returns an empty map",
+			want: map[string]string{},
+		},
+		{
+			name:   "canonical variable is parsed",
+			setNew: true,
+			newVal: "key1=value1,key2=value2",
+			want:   map[string]string{"key1": "value1", "key2": "value2"},
+		},
+		{
+			name:        "deprecated variable is used with a warning",
+			setOld:      true,
+			oldVal:      "key1=value1",
+			want:        map[string]string{"key1": "value1"},
+			wantWarning: true,
+		},
+		{
+			name:   "canonical variable takes precedence over the deprecated one",
+			setNew: true,
+			newVal: "new=1",
+			setOld: true,
+			oldVal: "old=1",
+			want:   map[string]string{"new": "1"},
+		},
+		{
+			name:        "empty deprecated variable is treated as set and used",
+			setOld:      true,
+			oldVal:      "",
+			want:        map[string]string{},
+			wantWarning: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Register cleanup to restore any ambient values, then clear both variables so
+			// os.LookupEnv reflects exactly what this case sets (unset vs. set-but-empty matter).
+			t.Setenv(envOTLPHeaders, "")
+			t.Setenv(envOTLPHeadersDeprecated, "")
+			require.NoError(t, os.Unsetenv(envOTLPHeaders))
+			require.NoError(t, os.Unsetenv(envOTLPHeadersDeprecated))
+
+			if tt.setNew {
+				t.Setenv(envOTLPHeaders, tt.newVal)
+			}
+			if tt.setOld {
+				t.Setenv(envOTLPHeadersDeprecated, tt.oldVal)
+			}
+
+			hook := logtest.NewGlobal()
+			defer hook.Reset()
+
+			got := otlpHeadersFromEnv()
+			assert.Equal(t, tt.want, got)
+
+			if tt.wantWarning {
+				require.NotNil(t, hook.LastEntry(), "expected a deprecation warning to be logged")
+				assert.Contains(t, hook.LastEntry().Message, "is deprecated")
+			} else {
+				assert.Nil(t, hook.LastEntry(), "no deprecation warning should be logged")
+			}
+		})
+	}
+}
+
+// TestNewCommand_OTLPHeadersFlagUsesEnv proves the otlp-headers flag default is wired to
+// otlpHeadersFromEnv, so the canonical environment variable actually reaches the flag.
+func TestNewCommand_OTLPHeadersFlagUsesEnv(t *testing.T) {
+	t.Setenv(envOTLPHeaders, "traceparent=abc123")
+
+	cmd := NewCommand()
+
+	got, err := cmd.Flags().GetStringToString("otlp-headers")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"traceparent": "abc123"}, got)
 }

--- a/cmd/argocd-repo-server/commands/argocd_repo_server_test.go
+++ b/cmd/argocd-repo-server/commands/argocd_repo_server_test.go
@@ -2,10 +2,8 @@ package commands
 
 import (
 	ctls "crypto/tls"
-	"os"
 	"testing"
 
-	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -88,85 +86,10 @@ func TestBuildHealthCheckTLSConfig_MutatingReturnedCertDoesNotAffectSource(t *te
 	assert.Equal(t, originalDER, hcCert.Certificate[0], "mutating the returned config must not affect the source certificate")
 }
 
-func TestOtlpHeadersFromEnv(t *testing.T) {
-	tests := []struct {
-		name        string
-		setNew      bool
-		newVal      string
-		setOld      bool
-		oldVal      string
-		want        map[string]string
-		wantWarning bool
-	}{
-		{
-			name: "neither variable set returns an empty map",
-			want: map[string]string{},
-		},
-		{
-			name:   "canonical variable is parsed",
-			setNew: true,
-			newVal: "key1=value1,key2=value2",
-			want:   map[string]string{"key1": "value1", "key2": "value2"},
-		},
-		{
-			name:        "deprecated variable is used with a warning",
-			setOld:      true,
-			oldVal:      "key1=value1",
-			want:        map[string]string{"key1": "value1"},
-			wantWarning: true,
-		},
-		{
-			name:   "canonical variable takes precedence over the deprecated one",
-			setNew: true,
-			newVal: "new=1",
-			setOld: true,
-			oldVal: "old=1",
-			want:   map[string]string{"new": "1"},
-		},
-		{
-			name:        "empty deprecated variable is treated as set and used",
-			setOld:      true,
-			oldVal:      "",
-			want:        map[string]string{},
-			wantWarning: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Register cleanup to restore any ambient values, then clear both variables so
-			// os.LookupEnv reflects exactly what this case sets (unset vs. set-but-empty matter).
-			t.Setenv(envOTLPHeaders, "")
-			t.Setenv(envOTLPHeadersDeprecated, "")
-			require.NoError(t, os.Unsetenv(envOTLPHeaders))
-			require.NoError(t, os.Unsetenv(envOTLPHeadersDeprecated))
-
-			if tt.setNew {
-				t.Setenv(envOTLPHeaders, tt.newVal)
-			}
-			if tt.setOld {
-				t.Setenv(envOTLPHeadersDeprecated, tt.oldVal)
-			}
-
-			hook := logtest.NewGlobal()
-			defer hook.Reset()
-
-			got := otlpHeadersFromEnv()
-			assert.Equal(t, tt.want, got)
-
-			if tt.wantWarning {
-				require.NotNil(t, hook.LastEntry(), "expected a deprecation warning to be logged")
-				assert.Contains(t, hook.LastEntry().Message, "is deprecated")
-			} else {
-				assert.Nil(t, hook.LastEntry(), "no deprecation warning should be logged")
-			}
-		})
-	}
-}
-
-// TestNewCommand_OTLPHeadersFlagUsesEnv proves the otlp-headers flag default is wired to
-// otlpHeadersFromEnv, so the canonical environment variable actually reaches the flag.
+// TestNewCommand_OTLPHeadersFlagUsesEnv proves the otlp-headers flag default is wired to the
+// canonical ARGOCD_REPO_SERVER_OTLP_HEADERS environment variable.
 func TestNewCommand_OTLPHeadersFlagUsesEnv(t *testing.T) {
-	t.Setenv(envOTLPHeaders, "traceparent=abc123")
+	t.Setenv("ARGOCD_REPO_SERVER_OTLP_HEADERS", "traceparent=abc123")
 
 	cmd := NewCommand()
 

--- a/docs/operator-manual/upgrading/3.5-3.6.md
+++ b/docs/operator-manual/upgrading/3.5-3.6.md
@@ -5,6 +5,21 @@
 <!-- Any breaking behavior change:
 Any removal or change of default behavior that requires user action -->
 
+### Repo-server OTLP headers environment variable renamed
+
+The repo-server now reads OpenTelemetry collector headers from `ARGOCD_REPO_SERVER_OTLP_HEADERS`
+instead of the inconsistently-named `ARGOCD_REPO_OTLP_HEADERS`. The new name follows the
+`ARGOCD_<COMPONENT>_OTLP_HEADERS` convention used by every other Argo CD component (e.g.
+`ARGOCD_SERVER_OTLP_HEADERS`, `ARGOCD_APPLICATION_CONTROLLER_OTLP_HEADERS`) and matches the name the
+shipped repo-server Deployment already injects from the `otlp.headers` config map key.
+
+**Impact:**
+
+- The default manifests already set `ARGOCD_REPO_SERVER_OTLP_HEADERS`, so most operators are
+  unaffected.
+- If you set `ARGOCD_REPO_OTLP_HEADERS` directly (for example via a custom Deployment patch or Helm
+  values), rename it to `ARGOCD_REPO_SERVER_OTLP_HEADERS`. The old variable is no longer read.
+
 ## Behavioral Improvements / Fixes
 
 ### Health transition events now identify the causing resource(s)


### PR DESCRIPTION
Closes https://github.com/argoproj/argo-cd/issues/18488

Surprisingly, the [manifests](https://github.com/argoproj/argo-cd/blob/master/manifests/base/repo-server/argocd-repo-server-deployment.yaml#L172)  already inject `ARGOCD_REPO_SERVER_OTLP_HEADERS` from the cm key `otlp.headers` but the code is reading `ARGOCD_REPO_OTLP_HEADERS` so OTLP headers configured the standard way were silently ignored on repo-server only.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
