### PR TITLE
fix: tooltips that are cut in half when the window is to small in the health bar

### DIFF
--- a/ui/src/app/applications/components/applications-list/applications-status-bar.scss
+++ b/ui/src/app/applications/components/applications-list/applications-status-bar.scss
@@ -29,4 +29,9 @@
     &__segment:not(:first-child) {
         border-left: 3px solid white;
     }
+
+    &__segment:nth-last-child(-n + 2) .tooltip {
+        left: auto;
+        right: 0;
+    }
 }

--- a/util/argo/diff/diff_test.go
+++ b/util/argo/diff/diff_test.go
@@ -261,10 +261,8 @@ func TestDiffConfigBuilder(t *testing.T) {
 }
 
 func TestDiffFromCache(t *testing.T) {
-	t.Parallel()
 	t.Run("returns false and logs warning on cache miss", func(t *testing.T) {
 		// given
-		t.Parallel()
 		hook := test.NewLocal(logrus.StandardLogger())
 		defer hook.Reset()
 
@@ -292,7 +290,6 @@ func TestDiffFromCache(t *testing.T) {
 
 	t.Run("returns false and logs error on cache failure", func(t *testing.T) {
 		// given
-		t.Parallel()
 		hook := test.NewLocal(logrus.StandardLogger())
 		defer hook.Reset()
 


### PR DESCRIPTION
In the applications page, when the `Toggle Health Status Bar` is activated and the proportions of the health bar is +95% Healthy and the user has the mouse over the remaining 5% (approximately) and the window is not big enough, it will cut the tool tips in half and it will not be visible, sometimes the content will not even be visible. This pr enables users to be able to read the whole tool tip even if the window is small.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).
