### PR TITLE
ci: harden gitops-engine tag step to use GITHUB_REF_NAME

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -353,11 +353,11 @@ jobs:
           # Create a path-prefixed tag for gitops-engine
           # so downstream consumers can resolve github.com/argoproj/argo-cd/gitops-engine/v3
           # https://go.dev/doc/modules/managing-source#multiple-module-source
-          GE_TAG="gitops-engine/${{ github.ref_name }}"
+          GE_TAG="gitops-engine/${GITHUB_REF_NAME}"
           if git ls-remote --exit-code --tags origin "refs/tags/${GE_TAG}" >/dev/null 2>&1; then
             echo "Tag ${GE_TAG} already exists on origin; skipping"
           else
-            git tag "${GE_TAG}" "${{ github.ref_name }}^{}"
+            git tag "${GE_TAG}" "${GITHUB_REF_NAME}^{}"
             git push origin "${GE_TAG}"
           fi
 


### PR DESCRIPTION
Finishing off @crenshaw-dev's hardening from #27304 — the `post-release` "Tag gitops-engine submodule" step (added in #27740) still interpolated `${{ github.ref_name }}` directly, so this swaps both to `${GITHUB_REF_NAME}` to match the rest of the file.

Not externally exploitable (release.yaml only runs on pushed `v*` tags), so this is defense-in-depth / consistency, not a fix for a live hole.

Checklist:

- [x] This is a bug fix / CI hardening; does not need a release note.
- [x] The title conforms to the Title-of-the-PR guidelines (`ci:` prefix).
- [x] I have signed off all my commits as required by DCO.
- [ ] Unit/e2e tests — N/A (CI workflow change; no application code paths affected).
