### PR TITLE
chore: add logs with timing for cluster sync performance

### DIFF
--- a/gitops-engine/pkg/cache/cluster.go
+++ b/gitops-engine/pkg/cache/cluster.go
@@ -1094,6 +1094,7 @@ func (c *clusterCache) checkPermission(ctx context.Context, reviewInterface auth
 func (c *clusterCache) sync() error {
 	c.log.Info("Start syncing cluster")
 
+	start := time.Now()
 	syncLock := sync.Mutex{}
 
 	for i := range c.apisMeta {
@@ -1152,6 +1153,7 @@ func (c *clusterCache) sync() error {
 		go c.processEvents()
 	}
 
+	discoveryEnd := time.Now()
 	err = kube.RunAllAsync(len(apis), func(i int) error {
 		api := apis[i]
 
@@ -1203,12 +1205,17 @@ func (c *clusterCache) sync() error {
 			return nil
 		})
 	})
+	log := c.log.WithValues(
+		"total_ms", time.Since(start).Milliseconds(),
+		"discovery_ms", discoveryEnd.Sub(start).Milliseconds(),
+		"list_ms", time.Since(discoveryEnd).Milliseconds(),
+	)
 	if err != nil {
-		c.log.Error(err, "Failed to sync cluster")
+		log.Error(err, "Failed to sync cluster")
 		return fmt.Errorf("failed to sync cluster %s: %w", c.config.Host, err)
 	}
 
-	c.log.Info("Cluster successfully synced")
+	log.Info("Cluster successfully synced")
 	return nil
 }
 

--- a/gitops-engine/pkg/cache/cluster.go
+++ b/gitops-engine/pkg/cache/cluster.go
@@ -1091,11 +1091,29 @@ func (c *clusterCache) checkPermission(ctx context.Context, reviewInterface auth
 //
 // When this function exits, the cluster cache is up to date, and the appropriate resources are being watched for
 // changes.
-func (c *clusterCache) sync() error {
+func (c *clusterCache) sync() (err error) {
 	c.log.Info("Start syncing cluster")
 
 	start := time.Now()
 	syncLock := sync.Mutex{}
+
+	var discoveryEnd time.Time
+	defer func() {
+		end := time.Now()
+		if discoveryEnd.IsZero() {
+			discoveryEnd = end
+		}
+		log := c.log.WithValues(
+			"total_ms", end.Sub(start).Milliseconds(),
+			"discovery_ms", discoveryEnd.Sub(start).Milliseconds(),
+			"list_ms", end.Sub(discoveryEnd).Milliseconds(),
+		)
+		if err != nil {
+			log.Error(err, "Failed to sync cluster")
+		} else {
+			log.Info("Cluster successfully synced")
+		}
+	}()
 
 	for i := range c.apisMeta {
 		c.apisMeta[i].watchCancel()
@@ -1153,7 +1171,7 @@ func (c *clusterCache) sync() error {
 		go c.processEvents()
 	}
 
-	discoveryEnd := time.Now()
+	discoveryEnd = time.Now()
 	err = kube.RunAllAsync(len(apis), func(i int) error {
 		api := apis[i]
 
@@ -1205,17 +1223,9 @@ func (c *clusterCache) sync() error {
 			return nil
 		})
 	})
-	log := c.log.WithValues(
-		"total_ms", time.Since(start).Milliseconds(),
-		"discovery_ms", discoveryEnd.Sub(start).Milliseconds(),
-		"list_ms", time.Since(discoveryEnd).Milliseconds(),
-	)
 	if err != nil {
-		log.Error(err, "Failed to sync cluster")
 		return fmt.Errorf("failed to sync cluster %s: %w", c.config.Host, err)
 	}
-
-	log.Info("Cluster successfully synced")
 	return nil
 }
 


### PR DESCRIPTION
To be able to have more insights on the cache sync performance, add timing stats to the log message. 

This will help diagnose performance issues with the cache holding a lock and blocking all reconciliations while a cluster is syncing. 