### PR TITLE
feat: add option to disable Swagger UI endpoint

### DIFF
--- a/cmd/argocd-server/commands/argocd_server.go
+++ b/cmd/argocd-server/commands/argocd_server.go
@@ -93,6 +93,7 @@ func NewCommand() *cobra.Command {
 		webhookRefreshWorkers    int
 		hydratorEnabled          bool
 		syncWithReplaceAllowed   bool
+		disableSwaggerUI         bool
 
 		// ApplicationSet
 		enableNewGitFileGlobbing bool
@@ -258,6 +259,7 @@ func NewCommand() *cobra.Command {
 				EnableK8sEvent:          enableK8sEvent,
 				HydratorEnabled:         hydratorEnabled,
 				SyncWithReplaceAllowed:  syncWithReplaceAllowed,
+				DisableSwaggerUI:        disableSwaggerUI,
 			}
 
 			appsetOpts := server.ApplicationSetOpts{
@@ -317,6 +319,7 @@ func NewCommand() *cobra.Command {
 	command.Flags().BoolVar(&disableAuth, "disable-auth", env.ParseBoolFromEnv("ARGOCD_SERVER_DISABLE_AUTH", false), "Disable client authentication")
 	command.Flags().StringVar(&contentTypes, "api-content-types", env.StringFromEnv("ARGOCD_API_CONTENT_TYPES", "application/json", env.StringFromEnvOpts{AllowEmpty: true}), "Semicolon separated list of allowed content types for non GET api requests. Any content type is allowed if empty.")
 	command.Flags().BoolVar(&enableGZip, "enable-gzip", env.ParseBoolFromEnv("ARGOCD_SERVER_ENABLE_GZIP", true), "Enable GZIP compression")
+	command.Flags().BoolVar(&disableSwaggerUI, "disable-swagger-ui", env.ParseBoolFromEnv("ARGOCD_SERVER_DISABLE_SWAGGER_UI", false), "Disable the Swagger UI (/swagger-ui) endpoint")
 	command.AddCommand(cli.NewVersionCmd(common.CommandServer))
 	command.Flags().StringVar(&listenHost, "address", env.StringFromEnv("ARGOCD_SERVER_LISTEN_ADDRESS", common.DefaultAddressAPIServer), "Listen on given address")
 	command.Flags().IntVar(&listenPort, "port", common.DefaultPortAPIServer, "Listen on given port")

--- a/cmd/argocd-server/commands/argocd_server_test.go
+++ b/cmd/argocd-server/commands/argocd_server_test.go
@@ -118,6 +118,39 @@ func TestNewCommand_StrictTLSWithoutCACertGuardIsAbsent(t *testing.T) {
 	assert.Equal(t, "true", strictFlag.Value.String())
 }
 
+func TestNewCommand_DisableSwaggerUIFlagDefault(t *testing.T) {
+	cmd := NewCommand()
+
+	f := cmd.Flags().Lookup("disable-swagger-ui")
+	require.NotNil(t, f, "flag \"disable-swagger-ui\" must be registered on argocd-server")
+	assert.Equal(t, "false", f.DefValue, "disable-swagger-ui must default to false to preserve existing behavior")
+
+	disableSwaggerUI, err := cmd.Flags().GetBool("disable-swagger-ui")
+	require.NoError(t, err)
+	assert.False(t, disableSwaggerUI)
+}
+
+func TestNewCommand_DisableSwaggerUIFlagCanBeSetExplicitly(t *testing.T) {
+	cmd := NewCommand()
+
+	require.NoError(t, cmd.Flags().Set("disable-swagger-ui", "true"))
+
+	disableSwaggerUI, err := cmd.Flags().GetBool("disable-swagger-ui")
+	require.NoError(t, err)
+	assert.True(t, disableSwaggerUI)
+}
+
+func TestNewCommand_DisableSwaggerUIEnvVar(t *testing.T) {
+	t.Setenv("ARGOCD_SERVER_DISABLE_SWAGGER_UI", "true")
+
+	// NewCommand reads env vars at flag-definition time.
+	cmd := NewCommand()
+
+	disableSwaggerUI, err := cmd.Flags().GetBool("disable-swagger-ui")
+	require.NoError(t, err)
+	assert.True(t, disableSwaggerUI, "ARGOCD_SERVER_DISABLE_SWAGGER_UI=true must set the disable-swagger-ui flag default")
+}
+
 func TestNewCommand_CACertFlagRegistrationAndDefault(t *testing.T) {
 	cmd := NewCommand()
 

--- a/docs/operator-manual/argocd-cmd-params-cm.yaml
+++ b/docs/operator-manual/argocd-cmd-params-cm.yaml
@@ -202,6 +202,8 @@ data:
   server.dex.server.strict.tls: "false"
   # Disable client authentication
   server.disable.auth: "false"
+  # Disable the Swagger UI (/swagger-ui) endpoint
+  server.disable.swagger.ui: "false"
   # Toggle GZIP compression
   server.enable.gzip: "true"
   # Set X-Frame-Options header in HTTP responses to value. To disable, set to "". (default "sameorigin")

--- a/docs/operator-manual/security.md
+++ b/docs/operator-manual/security.md
@@ -40,6 +40,30 @@ the three components (argocd-server, argocd-repo-server, argocd-application-cont
 API server can enforce the use of TLS 1.2 using the flag: `--tlsminversion 1.2`.
 Communication with Redis is performed over plain HTTP by default. TLS can be setup with command line arguments.
 
+## Swagger UI / OpenAPI Documentation
+
+Argo CD's API server exposes its OpenAPI specification and an interactive Swagger UI at
+`/swagger-ui`. This endpoint is unauthenticated by design: the documentation is static and
+identical across Argo CD instances, so it does not expose any instance-specific or sensitive
+information. However, some organizations still prefer to reduce their unauthenticated attack
+surface, or run in environments (e.g. OpenShift Routes) where blocking specific paths at the
+network/ingress layer isn't straightforward.
+
+To disable the `/swagger-ui` endpoint, set the `server.disable.swagger.ui` config option in
+[argocd-cmd-params-cm](argocd-cmd-params-cm.yaml):
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cmd-params-cm
+data:
+  server.disable.swagger.ui: "true"
+```
+
+This can also be set via the `--disable-swagger-ui` flag or `ARGOCD_SERVER_DISABLE_SWAGGER_UI`
+environment variable on `argocd-server`. It defaults to `false`, preserving existing behavior.
+
 ## Git & Helm Repositories
 
 Git and helm repositories are managed by a stand-alone service, called the repo-server. The

--- a/docs/operator-manual/server-commands/argocd-server.md
+++ b/docs/operator-manual/server-commands/argocd-server.md
@@ -51,6 +51,7 @@ argocd-server [flags]
       --dex-server-strict-tls                           Perform strict validation of TLS certificates when connecting to dex server
       --disable-auth                                    Disable client authentication
       --disable-compression                             If true, opt-out of response compression for all requests to the server
+      --disable-swagger-ui                              Disable the Swagger UI (/swagger-ui) endpoint
       --enable-gzip                                     Enable GZIP compression (default true)
       --enable-k8s-event none                           Enable ArgoCD to use k8s event. For disabling all events, set the value as none. (e.g --enable-k8s-event=none), For enabling specific events, set the value as `event reason`. (e.g --enable-k8s-event=StatusRefreshed,ResourceCreated) (default [all])
       --enable-proxy-extension                          Enable Proxy Extension feature

--- a/manifests/base/server/argocd-server-deployment.yaml
+++ b/manifests/base/server/argocd-server-deployment.yaml
@@ -124,6 +124,12 @@ spec:
                   name: argocd-cmd-params-cm
                   key: server.disable.auth
                   optional: true
+            - name: ARGOCD_SERVER_DISABLE_SWAGGER_UI
+              valueFrom:
+                configMapKeyRef:
+                  name: argocd-cmd-params-cm
+                  key: server.disable.swagger.ui
+                  optional: true
             - name: ARGOCD_SERVER_ENABLE_GZIP
               valueFrom:
                 configMapKeyRef:

--- a/manifests/ha/install-with-hydrator.yaml
+++ b/manifests/ha/install-with-hydrator.yaml
@@ -34300,6 +34300,12 @@ spec:
               key: server.disable.auth
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_SERVER_DISABLE_SWAGGER_UI
+          valueFrom:
+            configMapKeyRef:
+              key: server.disable.swagger.ui
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_SERVER_ENABLE_GZIP
           valueFrom:
             configMapKeyRef:

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -34130,6 +34130,12 @@ spec:
               key: server.disable.auth
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_SERVER_DISABLE_SWAGGER_UI
+          valueFrom:
+            configMapKeyRef:
+              key: server.disable.swagger.ui
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_SERVER_ENABLE_GZIP
           valueFrom:
             configMapKeyRef:

--- a/manifests/ha/namespace-install-with-hydrator.yaml
+++ b/manifests/ha/namespace-install-with-hydrator.yaml
@@ -3214,6 +3214,12 @@ spec:
               key: server.disable.auth
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_SERVER_DISABLE_SWAGGER_UI
+          valueFrom:
+            configMapKeyRef:
+              key: server.disable.swagger.ui
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_SERVER_ENABLE_GZIP
           valueFrom:
             configMapKeyRef:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -3044,6 +3044,12 @@ spec:
               key: server.disable.auth
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_SERVER_DISABLE_SWAGGER_UI
+          valueFrom:
+            configMapKeyRef:
+              key: server.disable.swagger.ui
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_SERVER_ENABLE_GZIP
           valueFrom:
             configMapKeyRef:

--- a/manifests/install-with-hydrator.yaml
+++ b/manifests/install-with-hydrator.yaml
@@ -33268,6 +33268,12 @@ spec:
               key: server.disable.auth
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_SERVER_DISABLE_SWAGGER_UI
+          valueFrom:
+            configMapKeyRef:
+              key: server.disable.swagger.ui
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_SERVER_ENABLE_GZIP
           valueFrom:
             configMapKeyRef:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -33096,6 +33096,12 @@ spec:
               key: server.disable.auth
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_SERVER_DISABLE_SWAGGER_UI
+          valueFrom:
+            configMapKeyRef:
+              key: server.disable.swagger.ui
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_SERVER_ENABLE_GZIP
           valueFrom:
             configMapKeyRef:

--- a/manifests/namespace-install-with-hydrator.yaml
+++ b/manifests/namespace-install-with-hydrator.yaml
@@ -2182,6 +2182,12 @@ spec:
               key: server.disable.auth
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_SERVER_DISABLE_SWAGGER_UI
+          valueFrom:
+            configMapKeyRef:
+              key: server.disable.swagger.ui
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_SERVER_ENABLE_GZIP
           valueFrom:
             configMapKeyRef:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -2010,6 +2010,12 @@ spec:
               key: server.disable.auth
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_SERVER_DISABLE_SWAGGER_UI
+          valueFrom:
+            configMapKeyRef:
+              key: server.disable.swagger.ui
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_SERVER_ENABLE_GZIP
           valueFrom:
             configMapKeyRef:

--- a/server/server.go
+++ b/server/server.go
@@ -253,6 +253,7 @@ type ArgoCDServerOpts struct {
 	EnableK8sEvent          []string
 	HydratorEnabled         bool
 	SyncWithReplaceAllowed  bool
+	DisableSwaggerUI        bool
 }
 
 type ApplicationSetOpts struct {
@@ -1166,6 +1167,17 @@ func compressHandler(handler http.Handler) http.Handler {
 	})
 }
 
+// registerSwaggerUI registers the Swagger UI and OpenAPI spec handlers on mux, unless disableSwaggerUI
+// is set. The endpoint serves API documentation and is unauthenticated by design, since the docs are
+// static and identical across Argo CD instances. Some environments (e.g. those fronted by OpenShift
+// Routes, which unlike Ingress cannot block specific paths via annotations) still want the ability to
+// disable it. See https://github.com/argoproj/argo-cd/issues/19780.
+func registerSwaggerUI(mux *http.ServeMux, rootPath string, disableSwaggerUI bool) {
+	if !disableSwaggerUI {
+		swagger.ServeSwaggerUI(mux, assets.SwaggerJSON, "/swagger-ui", rootPath)
+	}
+}
+
 // newHTTPServer returns the HTTP server to serve HTTP/HTTPS requests. This is implemented
 // using grpc-gateway as a proxy to the gRPC server.
 func (server *ArgoCDServer) newHTTPServer(ctx context.Context, port int, grpcWebHandler http.Handler, appResourceTreeFn application.AppResourceTreeFn, conn *grpc.ClientConn, metricsReg HTTPMetricsRegistry) *http.Server {
@@ -1247,8 +1259,7 @@ func (server *ArgoCDServer) newHTTPServer(ctx context.Context, port int, grpcWeb
 	mustRegisterGWHandler(ctx, certificatepkg.RegisterCertificateServiceHandler, gwmux, conn)
 	mustRegisterGWHandler(ctx, gpgkeypkg.RegisterGPGKeyServiceHandler, gwmux, conn)
 
-	// Swagger UI
-	swagger.ServeSwaggerUI(mux, assets.SwaggerJSON, "/swagger-ui", server.RootPath)
+	registerSwaggerUI(mux, server.RootPath, server.DisableSwaggerUI)
 	healthz.ServeHealthCheck(mux, server.healthCheck)
 
 	// Dex reverse proxy and OAuth2 login/callback

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1812,6 +1812,34 @@ func TestReplaceBaseHRef(t *testing.T) {
 	}
 }
 
+func TestRegisterSwaggerUI(t *testing.T) {
+	t.Run("registers /swagger-ui when not disabled", func(t *testing.T) {
+		mux := http.NewServeMux()
+		registerSwaggerUI(mux, "", false)
+
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/swagger-ui", http.NoBody)
+		_, pattern := mux.Handler(req)
+		assert.Equal(t, "/swagger-ui", pattern, "expected /swagger-ui to be registered on the mux when swagger UI is not disabled")
+
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		assert.NotEqual(t, http.StatusNotFound, w.Result().StatusCode, "expected the swagger UI handler to actually serve the request")
+	})
+
+	t.Run("skips registering /swagger-ui when disabled", func(t *testing.T) {
+		mux := http.NewServeMux()
+		registerSwaggerUI(mux, "", true)
+
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/swagger-ui", http.NoBody)
+		_, pattern := mux.Handler(req)
+		assert.Empty(t, pattern, "expected /swagger-ui to not be registered on the mux when swagger UI is disabled")
+
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusNotFound, w.Result().StatusCode, "expected requests to /swagger-ui to 404 when swagger UI is disabled")
+	})
+}
+
 func Test_enforceContentTypes(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Adds a `--disable-swagger-ui` flag (env var: `ARGOCD_SERVER_DISABLE_SWAGGER_UI`) to `argocd-server`, which gates registration of the unauthenticated `/swagger-ui` handler. Defaults to `false`, so current behavior is unchanged for everyone who doesn't opt in.

## Motivation

This revisits #19780 ("Option to disable swagger-ui endpoint"), which was closed as `not_planned`. The reasoning at the time was:

> If there's no pressing need, and if network rules can generally solve the problem, I'd rather avoid adding Argo CD code for this relative edge case. — @crenshaw-dev

That reasoning holds for Ingress-fronted deployments, where a path can be blocked via ingress annotations/rules without touching Argo CD. It does **not** hold for OpenShift Route-based deployments, since Routes have no equivalent path-blocking/annotation mechanism (this was raised on the closed issue by @hariyedlapalli):

> we are running on OpenShift using Routes, not Ingress. Since Ingress is not used in our setup, this cannot be blocked at the Ingress level.

For those users, the only workaround today is a manually maintained second Route pointed at a dead-end service for the `/swagger-ui` path — fragile and easy to lose across upgrades. A first-class, opt-in flag avoids that.

The change is intentionally minimal and disabled by default:
- No new dependencies.
- No behavior change unless explicitly enabled.
- Follows the exact same pattern as existing server flags like `--disable-auth` / `ARGOCD_SERVER_DISABLE_AUTH`.

## Changes

- `server/server.go`: add `DisableSwaggerUI` to `ArgoCDServerOpts`; skip `swagger.ServeSwaggerUI(...)` registration when set.
- `cmd/argocd-server/commands/argocd_server.go`: add `--disable-swagger-ui` flag, defaulting from `ARGOCD_SERVER_DISABLE_SWAGGER_UI`.
- `cmd/argocd-server/commands/argocd_server_test.go`: flag registration/default, explicit set, and env var tests.
- `docs/operator-manual/server-commands/argocd-server.md`: regenerated via `go run ./tools/cmd-docs`.

Addresses #19780

## Test plan

- [x] `go build ./server/... ./cmd/argocd-server/...`
- [x] `go vet ./server/... ./cmd/argocd-server/...`
- [x] `go test ./cmd/argocd-server/...` (new tests pass)
- [x] `go test ./server/...` (full existing suite still passes)
- [x] Docs regenerated with `go run ./tools/cmd-docs`, diff limited to the new flag line

Made with [Cursor](https://cursor.com)