### PR TITLE
fix(appset): fall back to create when patch returns NotFound (#17312) (cherry-pick #28645 for 3.4)

### DIFF
--- a/applicationset/utils/client.go
+++ b/applicationset/utils/client.go
@@ -9,6 +9,7 @@ import (
 	"unsafe"
 
 	log "github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	k8scache "k8s.io/client-go/tools/cache"
 	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -86,13 +87,25 @@ func (c *cacheSyncingClient) retrieveStore(ctx context.Context, obj client.Objec
 }
 
 func (c *cacheSyncingClient) execAndSyncCache(ctx context.Context, op func() error, obj client.Object, deleteObj bool) error {
-	// execute the operation first and only sync cache if it succeeds
+	// Execute the operation first; on success sync the informer cache. If it returns NotFound, also attempt to evict any stale entry from the cache.
+	var opErr error
 	if err := op(); err != nil {
-		return err
+		// A NotFound means the object is already gone from the API server. Fall through to
+		// evict any stale entry from the informer cache below, otherwise a lingering
+		// (already-deleted) object keeps being read back and callers can never converge.
+		// Delete callers already expected deletion, so we swallow the error (idempotent).
+		// Update/Patch callers still need to know the object is gone, so we return NotFound.
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+		if !deleteObj {
+			opErr = err
+		}
+		deleteObj = true
 	}
 	// sync cache for applications only
 	if _, ok := obj.(*application.Application); !ok {
-		return nil
+		return opErr
 	}
 
 	logger := log.WithField("namespace", obj.GetNamespace()).WithField("name", obj.GetName())
@@ -109,7 +122,7 @@ func (c *cacheSyncingClient) execAndSyncCache(ctx context.Context, op func() err
 	if err != nil {
 		logger.Errorf("failed to sync cache for object: %v", err)
 	}
-	return nil
+	return opErr
 }
 
 func (c *cacheSyncingClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {

--- a/applicationset/utils/client_test.go
+++ b/applicationset/utils/client_test.go
@@ -2,9 +2,12 @@ package utils
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -34,33 +37,62 @@ func (f *fakeMultiNamespaceCache) GetStore() k8scache.Store {
 	return f.Store
 }
 
-func newClient(objs ...client.Object) (*cacheSyncingClient, k8scache.Store, error) {
-	scheme := runtime.NewScheme()
-	if err := application.AddToScheme(scheme); err != nil {
-		return nil, nil, err
+type clientOptions struct {
+	objects    []client.Object
+	getNSCache func(context.Context, client.Object) (ctrlcache.Cache, error)
+	storesByNs map[string]k8scache.Store
+}
+
+type clientOption func(*clientOptions)
+
+func withObjects(objs ...client.Object) clientOption {
+	return func(o *clientOptions) { o.objects = objs }
+}
+
+func withGetNSCache(fn func(context.Context, client.Object) (ctrlcache.Cache, error)) clientOption {
+	return func(o *clientOptions) { o.getNSCache = fn }
+}
+
+func withStoresByNs(m map[string]k8scache.Store) clientOption {
+	return func(o *clientOptions) { o.storesByNs = m }
+}
+
+func newClient(t *testing.T, opts ...clientOption) (*cacheSyncingClient, k8scache.Store) {
+	t.Helper()
+	o := &clientOptions{}
+	for _, opt := range opts {
+		opt(o)
 	}
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, application.AddToScheme(scheme))
 
 	store := k8scache.NewStore(func(obj any) (string, error) {
 		return obj.(client.Object).GetName(), nil
 	})
-	for _, obj := range objs {
-		if err := store.Add(obj); err != nil {
-			return nil, nil, err
-		}
+	for _, obj := range o.objects {
+		require.NoError(t, store.Add(obj))
 	}
+
 	c := &cacheSyncingClient{
-		Client:     fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build(),
+		Client:     fake.NewClientBuilder().WithScheme(scheme).WithObjects(o.objects...).Build(),
 		storesByNs: map[string]k8scache.Store{},
 		getNSCache: func(_ context.Context, _ client.Object) (ctrlcache.Cache, error) {
 			return &fakeMultiNamespaceCache{Store: store}, nil
 		},
 	}
-	return c, store, nil
+	if o.getNSCache != nil {
+		c.getNSCache = o.getNSCache
+	}
+	if o.storesByNs != nil {
+		c.storesByNs = o.storesByNs
+	}
+	return c, store
 }
 
 func TestCreateSyncsCache(t *testing.T) {
-	c, store, err := newClient()
-	require.NoError(t, err)
+	t.Parallel()
+	c, store := newClient(t)
 
 	app := &application.Application{
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "argocd"},
@@ -78,8 +110,7 @@ func TestUpdateSyncsCache(t *testing.T) {
 			Labels:    map[string]string{"foo": "bar"},
 		},
 	}
-	c, store, err := newClient(app)
-	require.NoError(t, err)
+	c, store := newClient(t, withObjects(app))
 
 	updatedApp := app.DeepCopy()
 	updatedApp.Labels["foo"] = "bar-UPDATED"
@@ -98,14 +129,106 @@ func TestDeleteSyncsCache(t *testing.T) {
 			Labels:    map[string]string{"foo": "bar"},
 		},
 	}
-	c, store, err := newClient(app)
-	require.NoError(t, err)
+	c, store := newClient(t, withObjects(app))
 
 	require.NoError(t, c.Delete(context.Background(), app))
 
 	require.Empty(t, store.List())
 }
 
+// TestDeleteEvictsStaleCacheOnNotFound covers the "ApplicationSet stuck in Deleting" root cause.
+// The informer store still holds an Application that has already been removed from the API server
+// (a missed delete watch event). Deleting it returns NotFound. The stale entry must still be
+// evicted from the store, otherwise cache-backed reads keep returning the ghost object forever and
+// callers such as reverse deletion never converge, only a controller restart clears it.
+func TestDeleteEvictsStaleCacheOnNotFound(t *testing.T) {
+	t.Parallel()
+
+	// Seed the store with a ghost app, but leave the fake API client empty so Delete 404s.
+	app := &application.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "argocd"},
+	}
+	c, store := newClient(t)
+	require.NoError(t, store.Add(app))
+	require.NotEmpty(t, store.List(), "precondition: store holds the stale entry")
+
+	require.NoError(t, c.Delete(t.Context(), app), "a NotFound delete must be swallowed, not surfaced")
+
+	require.Empty(t, store.List(), "stale cache entry should be evicted even though the API returned NotFound")
+}
+
 func TestNewClientDoesNotCrashWithMultiNamespaceCache(_ *testing.T) {
 	_ = NewCacheSyncingClient(nil, &fakeMultiNamespaceCache{})
+}
+
+func TestPatchNotFoundEvictsFromCache(t *testing.T) {
+	t.Parallel()
+	app := &application.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "argocd"},
+	}
+	c, store := newClient(t, withObjects(app))
+
+	require.NoError(t, c.Client.Delete(t.Context(), app))
+	require.Contains(t, store.List(), app)
+
+	patchErr := c.Patch(t.Context(), app.DeepCopy(), client.MergeFrom(app))
+	require.Error(t, patchErr)
+	require.True(t, apierrors.IsNotFound(patchErr))
+	require.Empty(t, store.List())
+}
+
+func TestUpdateNotFoundEvictsFromCache(t *testing.T) {
+	t.Parallel()
+	app := &application.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "argocd"},
+	}
+	c, store := newClient(t, withObjects(app))
+
+	require.NoError(t, c.Client.Delete(t.Context(), app))
+	require.Contains(t, store.List(), app)
+
+	updateErr := c.Update(t.Context(), app.DeepCopy())
+	require.Error(t, updateErr)
+	require.True(t, apierrors.IsNotFound(updateErr))
+	require.Empty(t, store.List())
+}
+
+func TestExecAndSyncCacheNotFoundSkipsNonApplication(t *testing.T) {
+	t.Parallel()
+	c, store := newClient(t)
+	notFound := apierrors.NewNotFound(schema.GroupResource{}, "x")
+	got := c.execAndSyncCache(t.Context(), func() error { return notFound }, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "x", Namespace: "argocd"}}, false)
+	require.Error(t, got)
+	require.True(t, apierrors.IsNotFound(got))
+	require.Empty(t, store.List())
+}
+
+func TestExecAndSyncCacheNotFoundHandlesGetStoreError(t *testing.T) {
+	t.Parallel()
+	c, _ := newClient(t, withGetNSCache(func(_ context.Context, _ client.Object) (ctrlcache.Cache, error) {
+		return nil, errors.New("no cache")
+	}))
+	app := &application.Application{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "argocd"}}
+	notFound := apierrors.NewNotFound(schema.GroupResource{}, "test")
+	require.NotPanics(t, func() {
+		_ = c.execAndSyncCache(t.Context(), func() error { return notFound }, app, false)
+	})
+}
+
+type errDeleteStore struct {
+	k8scache.Store
+}
+
+func (e *errDeleteStore) Delete(_ any) error {
+	return errors.New("delete failed")
+}
+
+func TestExecAndSyncCacheNotFoundHandlesDeleteError(t *testing.T) {
+	t.Parallel()
+	c, _ := newClient(t, withStoresByNs(map[string]k8scache.Store{"argocd": &errDeleteStore{}}))
+	app := &application.Application{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "argocd"}}
+	notFound := apierrors.NewNotFound(schema.GroupResource{}, "test")
+	require.NotPanics(t, func() {
+		_ = c.execAndSyncCache(t.Context(), func() error { return notFound }, app, false)
+	})
 }

--- a/applicationset/utils/createOrUpdate.go
+++ b/applicationset/utils/createOrUpdate.go
@@ -95,6 +95,10 @@ func CreateOrUpdate(ctx context.Context, logCtx *log.Entry, c client.Client, ign
 		},
 	)
 
+	// Note: if the informer cache holds a stale entry for an application that no longer exists on
+	// the API server, DeepEqual may match against that stale entry and we skip Patch here. The
+	// eviction in cacheSyncingClient only runs on NotFound from a write operation, so this edge
+	// case is not covered and relies on Kubernetes propagating the delete event to the informer.
 	if equality.DeepEqual(normalizedLive, obj) {
 		return controllerutil.OperationResultNone, nil
 	}


### PR DESCRIPTION
Cherry-picked fix(appset): fall back to create when patch returns NotFound (https://github.com/argoproj/argo-cd/issues/17312) (https://github.com/argoproj/argo-cd/pull/28645)

Signed-off-by: Rick Brouwer [rickbrouwer@gmail.com](mailto:rickbrouwer@gmail.com)