### PR TITLE
test(e2e): fix github's failure to show complete results of e2e test (#28727)

### DIFF
--- a/test/e2e/fixture/fixture.go
+++ b/test/e2e/fixture/fixture.go
@@ -200,7 +200,7 @@ func init() {
 	// ensure we log all shell execs
 	log.SetLevel(log.DebugLevel)
 	// truncate eccessively long entries
-	log.SetFormatter(MakeTruncatingFormatter(env.ParseNumFromEnv(EnvLogLineMaxLen, 4096, 0, math.MaxInt32)))
+	log.SetFormatter(MakeTruncatingFormatter(env.ParseNumFromEnv(EnvLogLineMaxLen, defaultLogLineMaxLen, 0, math.MaxInt32)))
 	// set-up variables
 	config := getKubeConfig("", clientcmd.ConfigOverrides{})
 	AppClientset = appclientset.NewForConfigOrDie(config)

--- a/test/e2e/fixture/fixture.go
+++ b/test/e2e/fixture/fixture.go
@@ -194,6 +194,8 @@ func IsLocal() bool {
 func init() {
 	// ensure we log all shell execs
 	log.SetLevel(log.DebugLevel)
+	// truncate eccessively long entries
+	log.SetFormatter(MakeTruncatingFormatter())
 	// set-up variables
 	config := getKubeConfig("", clientcmd.ConfigOverrides{})
 	AppClientset = appclientset.NewForConfigOrDie(config)

--- a/test/e2e/fixture/fixture.go
+++ b/test/e2e/fixture/fixture.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
+	"math"
 	"os"
 	"path"
 	"path/filepath"
@@ -76,6 +77,9 @@ const (
 
 	// Account for batch events processing (set to 1ms in e2e tests)
 	WhenThenSleepInterval = 5 * time.Millisecond
+
+	// maximum length of log line
+	defaultLogLineMaxLen = 4096
 )
 
 const (
@@ -86,6 +90,7 @@ const (
 	EnvArgoCDRedisName         = "ARGOCD_E2E_REDIS_NAME"
 	EnvArgoCDRepoServerName    = "ARGOCD_E2E_REPO_SERVER_NAME"
 	EnvArgoCDAppControllerName = "ARGOCD_E2E_APPLICATION_CONTROLLER_NAME"
+	EnvLogLineMaxLen           = "ARGOCD_E2E_LOG_LINE_MAX_LEN"
 )
 
 var (
@@ -195,7 +200,7 @@ func init() {
 	// ensure we log all shell execs
 	log.SetLevel(log.DebugLevel)
 	// truncate eccessively long entries
-	log.SetFormatter(MakeTruncatingFormatter())
+	log.SetFormatter(MakeTruncatingFormatter(env.ParseNumFromEnv(EnvLogLineMaxLen, 4096, 0, math.MaxInt32)))
 	// set-up variables
 	config := getKubeConfig("", clientcmd.ConfigOverrides{})
 	AppClientset = appclientset.NewForConfigOrDie(config)

--- a/test/e2e/fixture/logging.go
+++ b/test/e2e/fixture/logging.go
@@ -1,0 +1,43 @@
+package fixture
+
+import (
+	"unicode/utf8"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// Custom formatter that truncates excessively long messages
+type truncatingFormatter struct {
+	inner log.Formatter
+	// maximum length (bytes)
+	maxLen int
+}
+
+func (f truncatingFormatter) Format(e *log.Entry) ([]byte, error) {
+	b, err := f.inner.Format(e)
+	numBytes := len(b)
+	if numBytes <= f.maxLen {
+		return b, err
+	}
+	for i := 0; i < numBytes; {
+		// parse characters to avoid producing invalid non-UTF8 compliant text
+		_, size := utf8.DecodeRune(b[i:])
+		newLen := i + size
+		// truncate until current byte if next character exceeds the limit
+		if newLen > f.maxLen {
+			b = b[:i]
+			b = append(b, []byte("...[truncated]...\n")...)
+			break
+		}
+		i = newLen
+	}
+	return b, err
+}
+
+func MakeTruncatingFormatter() log.Formatter {
+	formatter := truncatingFormatter{
+		log.StandardLogger().Formatter,
+		60,
+	}
+	return formatter
+}

--- a/test/e2e/fixture/logging.go
+++ b/test/e2e/fixture/logging.go
@@ -34,10 +34,10 @@ func (f truncatingFormatter) Format(e *log.Entry) ([]byte, error) {
 	return b, err
 }
 
-func MakeTruncatingFormatter() log.Formatter {
+func MakeTruncatingFormatter(maxLineLen int) log.Formatter {
 	formatter := truncatingFormatter{
 		log.StandardLogger().Formatter,
-		60,
+		maxLineLen,
 	}
 	return formatter
 }


### PR DESCRIPTION
Fixes: #28727

It looks like the problem is caused by excessively long lines in output from e2e tests,
it started to happen since #28440 😳  

This PR makes the e2e test fixture truncate excessively long lines in the e2e log output. 

The length limit is set using the ARGOCD_E2E_LOG_LINE_MAX_LEN env variable, 
the default is 4096 bytes

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
