### PR TITLE
feat(diff): support built-in ignoreDifferences customizations (#28724)

### DIFF
--- a/docs/operator-manual/argocd-cm.yaml
+++ b/docs/operator-manual/argocd-cm.yaml
@@ -90,6 +90,10 @@ data:
   # Keys are in the form: resource.customizations.ignoreDifferences.<group_kind>, resource.customizations.health.<group_kind>
   # resource.customizations.actions.<group_kind>, resource.customizations.knownTypeFields.<group_kind>
   # resource.customizations.ignoreResourceUpdates.<group_kind>
+  #
+  # Note: Argo CD ships built-in ignoreDifferences for some resources (e.g.
+  # postgresql.cnpg.io/Cluster). A ConfigMap entry for the same group/kind takes
+  # precedence and replaces the built-in. See the diffing guide for the full list.
   resource.customizations.ignoreDifferences.admissionregistration.k8s.io_MutatingWebhookConfiguration: |
     jsonPointers:
     - /webhooks/0/clientConfig/caBundle

--- a/docs/user-guide/diffing.md
+++ b/docs/user-guide/diffing.md
@@ -114,6 +114,16 @@ data:
     - /spec/replicas
 ```
 
+### Built-in ignoreDifferences
+
+Argo CD ships built-in `ignoreDifferences` customizations for some resources, alongside the built-in health checks and resource actions. These are loaded from the [`resource_customizations`](https://github.com/argoproj/argo-cd/tree/master/resource_customizations) directory and apply automatically — no ConfigMap entry is required.
+
+A ConfigMap entry for the same group/kind takes precedence and replaces the built-in (consistent with how built-in health checks are overridden).
+
+| Group / Kind | Ignored fields | Reason |
+| --- | --- | --- |
+| `postgresql.cnpg.io/Cluster` | `spec.managed.roles[].connectionLimit` (when `-1`), `.inherit` (when `true`), `.ensure` (when `"present"`) | The CloudNativePG CRD declares these as [kubebuilder defaults](https://github.com/cloudnative-pg/cloudnative-pg/blob/main/api/v1/cluster_types.go), so the Kubernetes API server injects them at admission. Only the default values are stripped, so user-set values (e.g. `connectionLimit: 10`) still produce drift. |
+
 The `status` field of many resources is often stored in Git/Helm manifest and should be ignored during diffing. The `status` field is used by
 Kubernetes controller to persist the current state of the resource and therefore cannot be applied as a desired configuration.
 

--- a/resource_customizations/postgresql.cnpg.io/Cluster/ignoreDifferences.yaml
+++ b/resource_customizations/postgresql.cnpg.io/Cluster/ignoreDifferences.yaml
@@ -1,0 +1,17 @@
+# Built-in ignoreDifferences for CloudNativePG (CNPG) Cluster.
+#
+# The CNPG CRD declares kubebuilder defaults for managed roles which the
+# Kubernetes API server injects at admission time. When users omit these
+# fields from their manifests, the live object contains the defaults while
+# the desired (Git) manifest does not, causing perpetual OutOfSync status.
+#
+# The jqPathExpressions below are wrapped in del(...) by Argo CD's diff
+# normalizer and only strip the fields when they equal the API server
+# default, so legitimate user-set values (e.g. connectionLimit: 10) still
+# produce drift.
+#
+# Reference: https://github.com/cloudnative-pg/cloudnative-pg/blob/main/api/v1/cluster_types.go
+jqPathExpressions:
+  - '.spec.managed.roles[]? | select(.connectionLimit == -1) | .connectionLimit'
+  - '.spec.managed.roles[]? | select(.inherit == true) | .inherit'
+  - '.spec.managed.roles[]? | select(.ensure == "present") | .ensure'

--- a/util/argo/normalizers/builtin_ignore.go
+++ b/util/argo/normalizers/builtin_ignore.go
@@ -1,0 +1,95 @@
+package normalizers
+
+import (
+	"fmt"
+	"io/fs"
+	"path"
+	"strings"
+	"sync"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v3/resource_customizations"
+)
+
+// ignoreDifferencesFileName is the name of the file shipped inside a resource
+// customization directory that declares built-in ignoreDifferences rules.
+const ignoreDifferencesFileName = "ignoreDifferences.yaml"
+
+var (
+	builtinIgnoreDifferencesOnce sync.Once
+	builtinIgnoreDifferences     map[string]v1alpha1.OverrideIgnoreDiff
+	builtinIgnoreDifferencesErr  error
+)
+
+// loadBuiltinIgnoreDifferences parses ignoreDifferences.yaml files shipped in
+// the embedded resource_customizations filesystem. The returned map is keyed by
+// "<group>/<Kind>", matching the ResourceOverrides key format.
+//
+// The embedded filesystem is static, so the result is parsed once and cached.
+// This mirrors how built-in health.lua scripts are loaded on demand by their
+// consumer (see util/lua/lua.go).
+func loadBuiltinIgnoreDifferences() (map[string]v1alpha1.OverrideIgnoreDiff, error) {
+	builtinIgnoreDifferencesOnce.Do(func() {
+		result := make(map[string]v1alpha1.OverrideIgnoreDiff)
+		builtinIgnoreDifferencesErr = fs.WalkDir(resource_customizations.Embedded, ".", func(p string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() || d.Name() != ignoreDifferencesFileName {
+				return nil
+			}
+			// p is "<group>/<Kind>/ignoreDifferences.yaml"; path.Dir is the override key.
+			data, err := resource_customizations.Embedded.ReadFile(p)
+			if err != nil {
+				return fmt.Errorf("error reading built-in ignoreDifferences %q: %w", p, err)
+			}
+			var ignoreDiff v1alpha1.OverrideIgnoreDiff
+			if err := yaml.Unmarshal(data, &ignoreDiff); err != nil {
+				return fmt.Errorf("error parsing built-in ignoreDifferences %q: %w", p, err)
+			}
+			result[path.Dir(p)] = ignoreDiff
+			return nil
+		})
+		builtinIgnoreDifferences = result
+	})
+	return builtinIgnoreDifferences, builtinIgnoreDifferencesErr
+}
+
+// getBuiltinResourceIgnoreDifferences returns built-in ignoreDifferences as
+// ResourceIgnoreDifferences entries, skipping any group/kind already configured
+// by ConfigMap overrides (ConfigMap takes precedence, consistent with built-in
+// health.lua).
+func getBuiltinResourceIgnoreDifferences(overrides map[string]v1alpha1.ResourceOverride) ([]v1alpha1.ResourceIgnoreDifferences, error) {
+	builtins, err := loadBuiltinIgnoreDifferences()
+	if err != nil {
+		return nil, err
+	}
+	result := make([]v1alpha1.ResourceIgnoreDifferences, 0, len(builtins))
+	for key, ignoreDiff := range builtins {
+		// Convert wildcard markers ("_") to glob patterns ("*"), matching how built-in
+		// health.lua wildcard overrides are resolved (see util/lua/lua.go). The normalizer
+		// matches group/kind via glob, where "*" spans "." (e.g. "*.crossplane.io").
+		globKey := strings.ReplaceAll(key, "_", "*")
+		if override, ok := overrides[globKey]; ok && hasIgnoreDifferences(override.IgnoreDifferences) {
+			continue
+		}
+		group, kind, err := getGroupKindForOverrideKey(globKey)
+		if err != nil {
+			continue
+		}
+		result = append(result, v1alpha1.ResourceIgnoreDifferences{
+			Group:                 group,
+			Kind:                  kind,
+			JSONPointers:          ignoreDiff.JSONPointers,
+			JQPathExpressions:     ignoreDiff.JQPathExpressions,
+			ManagedFieldsManagers: ignoreDiff.ManagedFieldsManagers,
+		})
+	}
+	return result, nil
+}
+
+func hasIgnoreDifferences(d v1alpha1.OverrideIgnoreDiff) bool {
+	return len(d.JSONPointers) > 0 || len(d.JQPathExpressions) > 0 || len(d.ManagedFieldsManagers) > 0
+}

--- a/util/argo/normalizers/builtin_ignore_test.go
+++ b/util/argo/normalizers/builtin_ignore_test.go
@@ -1,0 +1,158 @@
+package normalizers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+
+	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+)
+
+const cnpgClusterManagedRolesYAML = `
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: example
+spec:
+  managed:
+    roles:
+      - connectionLimit: -1
+        ensure: present
+        inherit: true
+        login: true
+        name: dev_knowledge_graph
+        passwordSecret:
+          name: cnpg-dev-knowledge-graph-role
+      - connectionLimit: 10
+        ensure: absent
+        inherit: false
+        login: true
+        name: custom_role
+`
+
+func mustUnstructured(t *testing.T, manifest string) *unstructured.Unstructured {
+	t.Helper()
+	obj := &unstructured.Unstructured{}
+	require.NoError(t, yaml.Unmarshal([]byte(manifest), obj))
+	return obj
+}
+
+func roleByName(t *testing.T, obj *unstructured.Unstructured, name string) map[string]any {
+	t.Helper()
+	roles, has, err := unstructured.NestedSlice(obj.Object, "spec", "managed", "roles")
+	require.NoError(t, err)
+	require.True(t, has)
+	for _, r := range roles {
+		role, ok := r.(map[string]any)
+		require.True(t, ok)
+		if role["name"] == name {
+			return role
+		}
+	}
+	t.Fatalf("role %q not found", name)
+	return nil
+}
+
+// TestLoadBuiltinIgnoreDifferences verifies the embedded CNPG Cluster
+// ignoreDifferences.yaml is discovered and parsed.
+func TestLoadBuiltinIgnoreDifferences(t *testing.T) {
+	builtins, err := loadBuiltinIgnoreDifferences()
+	require.NoError(t, err)
+
+	cnpg, ok := builtins["postgresql.cnpg.io/Cluster"]
+	require.True(t, ok, "expected built-in ignoreDifferences for postgresql.cnpg.io/Cluster")
+	assert.ElementsMatch(t, []string{
+		`.spec.managed.roles[]? | select(.connectionLimit == -1) | .connectionLimit`,
+		`.spec.managed.roles[]? | select(.inherit == true) | .inherit`,
+		`.spec.managed.roles[]? | select(.ensure == "present") | .ensure`,
+	}, cnpg.JQPathExpressions)
+}
+
+// TestBuiltinIgnoreDifferencesCNPGCluster verifies the normalizer strips
+// API-server-defaulted fields from managed roles while preserving user-set
+// values that differ from the defaults.
+func TestBuiltinIgnoreDifferencesCNPGCluster(t *testing.T) {
+	normalizer, err := NewIgnoreNormalizer(nil, map[string]v1alpha1.ResourceOverride{}, IgnoreNormalizerOpts{})
+	require.NoError(t, err)
+
+	obj := mustUnstructured(t, cnpgClusterManagedRolesYAML)
+	require.NoError(t, normalizer.Normalize(obj))
+
+	// Role with default values: connectionLimit/inherit/ensure should be stripped.
+	defaulted := roleByName(t, obj, "dev_knowledge_graph")
+	assert.NotContains(t, defaulted, "connectionLimit", "default connectionLimit should be stripped")
+	assert.NotContains(t, defaulted, "inherit", "default inherit should be stripped")
+	assert.NotContains(t, defaulted, "ensure", "default ensure should be stripped")
+	assert.Equal(t, true, defaulted["login"])
+	assert.Equal(t, "cnpg-dev-knowledge-graph-role", defaulted["passwordSecret"].(map[string]any)["name"])
+
+	// Role with non-default values: nothing should be stripped.
+	custom := roleByName(t, obj, "custom_role")
+	assert.Equal(t, int64(10), custom["connectionLimit"], "user-set connectionLimit must be preserved")
+	assert.Equal(t, false, custom["inherit"], "user-set inherit must be preserved")
+	assert.Equal(t, "absent", custom["ensure"], "user-set ensure must be preserved")
+}
+
+// TestBuiltinIgnoreDifferencesConfigMapPrecedence verifies that a ConfigMap
+// override for the same group/kind takes precedence over the built-in
+// (replace semantics, consistent with built-in health.lua).
+func TestBuiltinIgnoreDifferencesConfigMapPrecedence(t *testing.T) {
+	overrides := map[string]v1alpha1.ResourceOverride{
+		"postgresql.cnpg.io/Cluster": {
+			IgnoreDifferences: v1alpha1.OverrideIgnoreDiff{JSONPointers: []string{"/spec/example"}},
+		},
+	}
+
+	builtinIgnores, err := getBuiltinResourceIgnoreDifferences(overrides)
+	require.NoError(t, err)
+	for _, item := range builtinIgnores {
+		if item.Group == "postgresql.cnpg.io" && item.Kind == "Cluster" {
+			t.Fatal("built-in CNPG ignoreDifferences should be skipped when ConfigMap overrides it")
+		}
+	}
+
+	// A ConfigMap override without ignoreDifferences must not suppress the built-in.
+	overridesWithoutIgnore := map[string]v1alpha1.ResourceOverride{
+		"postgresql.cnpg.io/Cluster": {HealthLua: "foo"},
+	}
+	builtinIgnores, err = getBuiltinResourceIgnoreDifferences(overridesWithoutIgnore)
+	require.NoError(t, err)
+	found := false
+	for _, item := range builtinIgnores {
+		if item.Group == "postgresql.cnpg.io" && item.Kind == "Cluster" {
+			found = true
+		}
+	}
+	assert.True(t, found, "built-in CNPG ignoreDifferences should apply when ConfigMap has no ignoreDifferences for it")
+}
+
+// TestBuiltinIgnoreDifferencesWildcardMatch verifies that a wildcard built-in
+// entry — the form produced by converting "_"-prefixed dirs to "*" (matching
+// health.lua) — normalizes resources with multi-segment group names. The
+// normalizer calls glob.Match without separators, so "*" spans ".".
+func TestBuiltinIgnoreDifferencesWildcardMatch(t *testing.T) {
+	normalizer, err := NewIgnoreNormalizer([]v1alpha1.ResourceIgnoreDifferences{{
+		Group:        "*.crossplane.io",
+		Kind:         "*",
+		JSONPointers: []string{"/metadata/annotations/toStrip"},
+	}}, map[string]v1alpha1.ResourceOverride{}, IgnoreNormalizerOpts{})
+	require.NoError(t, err)
+
+	obj := mustUnstructured(t, `
+apiVersion: compute.aws.crossplane.io/v1beta1
+kind: Foo
+metadata:
+  name: example
+  annotations:
+    toStrip: value
+    keep: other
+`)
+	require.NoError(t, normalizer.Normalize(obj))
+
+	_, hasStrip := obj.GetAnnotations()["toStrip"]
+	assert.False(t, hasStrip, "wildcard group *.crossplane.io should match compute.aws.crossplane.io")
+	assert.Contains(t, obj.GetAnnotations(), "keep")
+}

--- a/util/argo/normalizers/diff_normalizer.go
+++ b/util/argo/normalizers/diff_normalizer.go
@@ -138,6 +138,13 @@ func NewIgnoreNormalizer(ignore []v1alpha1.ResourceIgnoreDifferences, overrides 
 			ignore = append(ignore, resourceIgnoreDifference)
 		}
 	}
+	// Merge built-in ignoreDifferences shipped in the embedded resource_customizations
+	// filesystem. ConfigMap overrides take precedence (skip already-configured keys).
+	builtinIgnores, err := getBuiltinResourceIgnoreDifferences(overrides)
+	if err != nil {
+		return nil, fmt.Errorf("error loading built-in ignoreDifferences: %w", err)
+	}
+	ignore = append(ignore, builtinIgnores...)
 	patches := make([]normalizerPatch, 0)
 	for i := range ignore {
 		for _, path := range ignore[i].JSONPointers {

--- a/util/argo/normalizers/diff_normalizer_test.go
+++ b/util/argo/normalizers/diff_normalizer_test.go
@@ -243,9 +243,10 @@ func TestNormalizeExpectedErrorAreSilenced(t *testing.T) {
 	require.NoError(t, err)
 
 	ignoreNormalizer := normalizer.(*ignoreNormalizer)
-	assert.Len(t, ignoreNormalizer.patches, 2)
-	jsonPatch := ignoreNormalizer.patches[0]
-	jqPatch := ignoreNormalizer.patches[1]
+	starPatches := patchesForGroupKind(ignoreNormalizer.patches, "*", "*")
+	assert.Len(t, starPatches, 2)
+	jsonPatch := starPatches[0]
+	jqPatch := starPatches[1]
 
 	deployment := test.NewDeployment()
 	deploymentData, err := json.Marshal(deployment)
@@ -274,8 +275,9 @@ func TestJqPathExpressionFailWithTimeout(t *testing.T) {
 	require.NoError(t, err)
 
 	ignoreNormalizer := normalizer.(*ignoreNormalizer)
-	assert.Len(t, ignoreNormalizer.patches, 1)
-	jqPatch := ignoreNormalizer.patches[0]
+	starPatches := patchesForGroupKind(ignoreNormalizer.patches, "*", "*")
+	assert.Len(t, starPatches, 1)
+	jqPatch := starPatches[0]
 
 	deployment := test.NewDeployment()
 	deploymentData, err := json.Marshal(deployment)
@@ -326,4 +328,18 @@ func TestNormalizeFailureLogIncludesResourceContext(t *testing.T) {
 	assert.Contains(t, out, "Failed to apply normalization patch")
 	assert.Contains(t, out, "kind=ConfigMap")
 	assert.Contains(t, out, "name=my-configmap")
+}
+
+// patchesForGroupKind returns the normalizer patches targeting the given
+// group/kind. Built-in ignoreDifferences patches are loaded for every
+// normalizer, so tests that assert on ConfigMap-configured patches filter by
+// group/kind to remain robust against the addition of new built-ins.
+func patchesForGroupKind(patches []normalizerPatch, group, kind string) []normalizerPatch {
+	var matched []normalizerPatch
+	for _, p := range patches {
+		if p.GetGroupKind().Group == group && p.GetGroupKind().Kind == kind {
+			matched = append(matched, p)
+		}
+	}
+	return matched
 }


### PR DESCRIPTION
Closes #28724

## What & why

The CloudNativePG operator's CRD declares kubebuilder defaults (`connectionLimit: -1`, `inherit: true`, `ensure: "present"`) on managed roles. The Kubernetes API server injects them at admission, so `postgresql.cnpg.io/Cluster` resources perpetually show as `OutOfSync` (client-side diff sees the defaulted live fields absent from Git) and Argo CD prunes them on every sync.

This adds support for built-in `ignoreDifferences.yaml` files shipped in the embedded `resource_customizations/` filesystem — loaded and applied by the diff normalizer, mirroring how built-in `health.lua` is loaded. ConfigMap overrides take precedence (replace semantics). Ships a `postgresql.cnpg.io/Cluster/ignoreDifferences.yaml` that strips only the API-server default values via `jqPathExpressions` with `select(...)`, so legitimate user-set values (e.g. `connectionLimit: 10`) still produce drift. Wildcard (`_`-prefixed) directories are supported via `_`→`*` conversion, consistent with `health.lua`.

> **Note on Server-Side Diff:** enabling it is an alternative that also resolves this drift (the dry-run apply defaults both sides), but it is a broad, app/controller-wide setting with operator field-manager conflict risk; the built-in `ignoreDifferences` is surgical and works in both diff modes.

## Checklist

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes #28724" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. *(N/A — built-in diff normalization has no CLI/UI surface)*
* [x] Does this PR require documentation updates? *(yes)*
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).
