### PR TITLE
feat(ui): add option to group applications list by project

### DIFF
--- a/ui/src/app/applications/components/applications-list/applications-list.scss
+++ b/ui/src/app/applications/components/applications-list/applications-list.scss
@@ -200,3 +200,58 @@ i.menu_icon {
         display: none !important;
     }
 }
+
+.project-group {
+    margin-bottom: 24px;
+
+    &__header {
+        display: flex;
+        align-items: center;
+        padding: 12px 16px;
+        font-size: 16px;
+        font-weight: 600;
+        cursor: pointer;
+        user-select: none;
+        border-radius: 4px;
+        margin-bottom: 12px;
+        transition: background-color 0.2s ease, color 0.2s ease;
+
+        @include themify($themes) {
+            background-color: themed('background-2');
+            color: themed('text-1');
+            border: 1px solid themed('border');
+        }
+
+        &:hover {
+            @include themify($themes) {
+                background-color: themed('light-argo-gray-2');
+            }
+        }
+
+        i {
+            font-size: 18px;
+            width: 20px;
+            text-align: center;
+            margin-right: 8px;
+            @include themify($themes) {
+                color: themed('text-2');
+            }
+        }
+
+        &__title {
+            flex-grow: 1;
+        }
+
+        &__count {
+            font-size: 12px;
+            padding: 2px 8px;
+            border-radius: 12px;
+            font-weight: normal;
+            @include themify($themes) {
+                background-color: themed('background-1');
+                color: themed('text-2');
+            }
+        }
+    }
+}
+

--- a/ui/src/app/applications/components/applications-list/applications-table.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-table.tsx
@@ -18,6 +18,24 @@ export const ApplicationsTable = (props: {
     deleteApplication: (appName: string, appNamespace: string) => any;
 }) => {
     const [selectedApp, navApp, reset] = useNav(props.applications.length);
+    const [collapsedProjects, setCollapsedProjects] = React.useState<Record<string, boolean>>({});
+
+    const getProjName = (app: models.AbstractApplication) => {
+        return isApp(app) ? app.spec?.project || 'default' : 'default';
+    };
+
+    const groupedApps = React.useMemo(() => {
+        const groupsMap = new Map<string, {app: models.AbstractApplication; index: number}[]>();
+        props.applications.forEach((app, i) => {
+            const proj = getProjName(app);
+            if (!groupsMap.has(proj)) {
+                groupsMap.set(proj, []);
+            }
+            groupsMap.get(proj).push({app, index: i});
+        });
+        return Array.from(groupsMap.entries()).sort((a, b) => a[0].localeCompare(b[0]));
+    }, [props.applications]);
+
     const ctxh = React.useContext(Context);
 
     const {registerKeybinding} = React.useContext(KeybindingContext);
@@ -47,22 +65,71 @@ export const ApplicationsTable = (props: {
             {ctx => (
                 <DataLoader load={() => services.viewPreferences.getPreferences()}>
                     {pref => (
-                        <div className='applications-table argo-table-list argo-table-list--clickable'>
-                            {props.applications.map((app, i) =>
-                                isApp(app) ? (
-                                    <ApplicationTableRow
-                                        key={AppUtils.appInstanceName(app)}
-                                        app={app as models.Application}
-                                        selected={selectedApp === i}
-                                        pref={pref}
-                                        ctx={ctx}
-                                        syncApplication={props.syncApplication}
-                                        refreshApplication={props.refreshApplication}
-                                        deleteApplication={props.deleteApplication}
-                                    />
-                                ) : (
-                                    <AppSetTableRow key={AppUtils.appInstanceName(app)} appSet={app as models.ApplicationSet} selected={selectedApp === i} pref={pref} ctx={ctx} />
-                                )
+                        <div>
+                            {pref.appList.groupByProject ? (
+                                groupedApps.map(([project, appsInGroup]) => {
+                                    const isCollapsed = !!collapsedProjects[project];
+                                    return (
+                                        <div key={project} className='project-group'>
+                                            <div className='project-group__header' onClick={() => setCollapsedProjects({...collapsedProjects, [project]: !isCollapsed})}>
+                                                <i className={`fa fa-angle-${isCollapsed ? 'right' : 'down'}`} />
+                                                <span className='project-group__header__title'>{project}</span>
+                                                <span className='project-group__header__count'>{appsInGroup.length}</span>
+                                            </div>
+                                            {!isCollapsed && (
+                                                <div className='applications-table argo-table-list argo-table-list--clickable'>
+                                                    {appsInGroup.map(({app, index}) =>
+                                                        isApp(app) ? (
+                                                            <ApplicationTableRow
+                                                                key={AppUtils.appInstanceName(app)}
+                                                                app={app as models.Application}
+                                                                selected={selectedApp === index}
+                                                                pref={pref}
+                                                                ctx={ctx}
+                                                                syncApplication={props.syncApplication}
+                                                                refreshApplication={props.refreshApplication}
+                                                                deleteApplication={props.deleteApplication}
+                                                            />
+                                                        ) : (
+                                                            <AppSetTableRow
+                                                                key={AppUtils.appInstanceName(app)}
+                                                                appSet={app as models.ApplicationSet}
+                                                                selected={selectedApp === index}
+                                                                pref={pref}
+                                                                ctx={ctx}
+                                                            />
+                                                        )
+                                                    )}
+                                                </div>
+                                            )}
+                                        </div>
+                                    );
+                                })
+                            ) : (
+                                <div className='applications-table argo-table-list argo-table-list--clickable'>
+                                    {props.applications.map((app, i) =>
+                                        isApp(app) ? (
+                                            <ApplicationTableRow
+                                                key={AppUtils.appInstanceName(app)}
+                                                app={app as models.Application}
+                                                selected={selectedApp === i}
+                                                pref={pref}
+                                                ctx={ctx}
+                                                syncApplication={props.syncApplication}
+                                                refreshApplication={props.refreshApplication}
+                                                deleteApplication={props.deleteApplication}
+                                            />
+                                        ) : (
+                                            <AppSetTableRow
+                                                key={AppUtils.appInstanceName(app)}
+                                                appSet={app as models.ApplicationSet}
+                                                selected={selectedApp === i}
+                                                pref={pref}
+                                                ctx={ctx}
+                                            />
+                                        )
+                                    )}
+                                </div>
                             )}
                         </div>
                     )}

--- a/ui/src/app/applications/components/applications-list/applications-tiles.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-tiles.tsx
@@ -47,6 +47,23 @@ const useItemsPerContainer = (itemRef: any, containerRef: any): number => {
 
 export const ApplicationTiles = ({applications, syncApplication, refreshApplication, deleteApplication}: ApplicationTilesProps) => {
     const [selectedApp, navApp, reset] = useNav(applications.length);
+    const [collapsedProjects, setCollapsedProjects] = React.useState<Record<string, boolean>>({});
+
+    const getProjName = (app: models.AbstractApplication) => {
+        return isApp(app) ? app.spec?.project || 'default' : 'default';
+    };
+
+    const groupedApps = React.useMemo(() => {
+        const groupsMap = new Map<string, {app: models.AbstractApplication; index: number}[]>();
+        applications.forEach((app, i) => {
+            const proj = getProjName(app);
+            if (!groupsMap.has(proj)) {
+                groupsMap.set(proj, []);
+            }
+            groupsMap.get(proj).push({app, index: i});
+        });
+        return Array.from(groupsMap.entries()).sort((a, b) => a[0].localeCompare(b[0]));
+    }, [applications]);
 
     const ctxh = React.useContext(Context);
     const firstTileRef = React.useRef<HTMLDivElement>(null);
@@ -101,34 +118,93 @@ export const ApplicationTiles = ({applications, syncApplication, refreshApplicat
         <Consumer>
             {ctx => (
                 <DataLoader load={() => services.viewPreferences.getPreferences()}>
-                    {pref => (
-                        <div className='applications-tiles argo-table-list argo-table-list--clickable' ref={appContainerRef}>
-                            {applications.map((app, i) =>
-                                isApp(app) ? (
-                                    <ApplicationTile
-                                        key={AppUtils.appInstanceName(app)}
-                                        app={app as models.Application}
-                                        selected={selectedApp === i}
-                                        pref={pref}
-                                        ctx={ctx}
-                                        tileRef={i === 0 ? firstTileRef : undefined}
-                                        syncApplication={syncApplication}
-                                        refreshApplication={refreshApplication}
-                                        deleteApplication={deleteApplication}
-                                    />
+                    {pref => {
+                        let firstVisibleIndex = -1;
+                        if (pref.appList.groupByProject) {
+                            for (const [project, appsInGroup] of groupedApps) {
+                                if (!collapsedProjects[project] && appsInGroup.length > 0) {
+                                    firstVisibleIndex = appsInGroup[0].index;
+                                    break;
+                                }
+                            }
+                        } else {
+                            firstVisibleIndex = 0;
+                        }
+
+                        return (
+                            <div ref={appContainerRef}>
+                                {pref.appList.groupByProject ? (
+                                    groupedApps.map(([project, appsInGroup]) => {
+                                        const isCollapsed = !!collapsedProjects[project];
+                                        return (
+                                            <div key={project} className='project-group'>
+                                                <div className='project-group__header' onClick={() => setCollapsedProjects({...collapsedProjects, [project]: !isCollapsed})}>
+                                                    <i className={`fa fa-angle-${isCollapsed ? 'right' : 'down'}`} />
+                                                    <span className='project-group__header__title'>{project}</span>
+                                                    <span className='project-group__header__count'>{appsInGroup.length}</span>
+                                                </div>
+                                                {!isCollapsed && (
+                                                    <div className='applications-tiles argo-table-list argo-table-list--clickable'>
+                                                        {appsInGroup.map(({app, index}) =>
+                                                            isApp(app) ? (
+                                                                <ApplicationTile
+                                                                    key={AppUtils.appInstanceName(app)}
+                                                                    app={app as models.Application}
+                                                                    selected={selectedApp === index}
+                                                                    pref={pref}
+                                                                    ctx={ctx}
+                                                                    tileRef={index === firstVisibleIndex ? firstTileRef : undefined}
+                                                                    syncApplication={syncApplication}
+                                                                    refreshApplication={refreshApplication}
+                                                                    deleteApplication={deleteApplication}
+                                                                />
+                                                            ) : (
+                                                                <AppSetTile
+                                                                    key={AppUtils.appInstanceName(app)}
+                                                                    appSet={app as models.ApplicationSet}
+                                                                    selected={selectedApp === index}
+                                                                    pref={pref}
+                                                                    ctx={ctx}
+                                                                    tileRef={index === firstVisibleIndex ? firstTileRef : undefined}
+                                                                />
+                                                            )
+                                                        )}
+                                                    </div>
+                                                )}
+                                            </div>
+                                        );
+                                    })
                                 ) : (
-                                    <AppSetTile
-                                        key={AppUtils.appInstanceName(app)}
-                                        appSet={app as models.ApplicationSet}
-                                        selected={selectedApp === i}
-                                        pref={pref}
-                                        ctx={ctx}
-                                        tileRef={i === 0 ? firstTileRef : undefined}
-                                    />
-                                )
-                            )}
-                        </div>
-                    )}
+                                    <div className='applications-tiles argo-table-list argo-table-list--clickable'>
+                                        {applications.map((app, i) =>
+                                            isApp(app) ? (
+                                                <ApplicationTile
+                                                    key={AppUtils.appInstanceName(app)}
+                                                    app={app as models.Application}
+                                                    selected={selectedApp === i}
+                                                    pref={pref}
+                                                    ctx={ctx}
+                                                    tileRef={i === 0 ? firstTileRef : undefined}
+                                                    syncApplication={syncApplication}
+                                                    refreshApplication={refreshApplication}
+                                                    deleteApplication={deleteApplication}
+                                                />
+                                            ) : (
+                                                <AppSetTile
+                                                    key={AppUtils.appInstanceName(app)}
+                                                    appSet={app as models.ApplicationSet}
+                                                    selected={selectedApp === i}
+                                                    pref={pref}
+                                                    ctx={ctx}
+                                                    tileRef={i === 0 ? firstTileRef : undefined}
+                                                />
+                                            )
+                                        )}
+                                    </div>
+                                )}
+                            </div>
+                        );
+                    }}
                 </DataLoader>
             )}
         </Consumer>

--- a/ui/src/app/applications/components/applications-list/applications-tiles.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-tiles.tsx
@@ -40,6 +40,7 @@ const useItemsPerContainer = (itemRef: any, containerRef: any): number => {
         return () => {
             window.removeEventListener('resize', handleResize);
         };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     return itemsPer || 1;

--- a/ui/src/app/applications/components/applications-list/view-type-switcher.tsx
+++ b/ui/src/app/applications/components/applications-list/view-type-switcher.tsx
@@ -7,9 +7,10 @@ import {AppsListPreferences, AppsListViewKey, services} from '../../../shared/se
 interface ViewTypeSwitcherProps {
     pref: AppsListPreferences & {page: number; search: string};
     ctx: ContextApis;
+    onGroupByProjectChange?: (val: boolean) => void;
 }
 
-export const ViewTypeSwitcher: React.FC<ViewTypeSwitcherProps> = ({pref, ctx}) => {
+export const ViewTypeSwitcher: React.FC<ViewTypeSwitcherProps> = ({pref, ctx, onGroupByProjectChange}) => {
     const {List, Summary, Tiles} = AppsListViewKey;
 
     // 1. Add local state to ensure the checkbox updates visually the millisecond it is clicked
@@ -27,28 +28,36 @@ export const ViewTypeSwitcher: React.FC<ViewTypeSwitcherProps> = ({pref, ctx}) =
     const {page, search, ...cleanPrefWithoutGroup} = pref;
     const cleanPref: AppsListPreferences = {...cleanPrefWithoutGroup, groupByProject: isGrouped};
 
+    const isAppsetsView = window.location.pathname.includes('/applicationsets');
+    const showCheckbox = (cleanPref.view === Tiles || cleanPref.view === List) && !isAppsetsView;
+
     return (
         <div className='applications-list__view-type' style={{display: 'flex', alignItems: 'center'}}>
-            <div style={{marginRight: '15px', display: 'flex', alignItems: 'center'}}>
-                <Checkbox
-                    id='group-by-project-checkbox'
-                    checked={isGrouped}
-                    onChange={val => {
-                        // 4. Update the local checkbox instantly
-                        setIsGrouped(val);
-                        // 5. Update the persistent backend preferences in the background
-                        services.viewPreferences.updatePreferences({
-                            appList: {
-                                ...cleanPref,
-                                groupByProject: val
+            {showCheckbox && (
+                <div style={{marginRight: '15px', display: 'flex', alignItems: 'center'}}>
+                    <Checkbox
+                        id='group-by-project-checkbox'
+                        checked={isGrouped}
+                        onChange={val => {
+                            // 4. Update the local checkbox instantly
+                            setIsGrouped(val);
+                            // 5. Update the persistent backend preferences in the background
+                            services.viewPreferences.updatePreferences({
+                                appList: {
+                                    ...cleanPref,
+                                    groupByProject: val
+                                }
+                            });
+                            if (onGroupByProjectChange) {
+                                onGroupByProjectChange(val);
                             }
-                        });
-                    }}
-                />
-                <label htmlFor='group-by-project-checkbox' style={{marginLeft: '6px', cursor: 'pointer', marginBottom: 0}}>
-                    Group by Project
-                </label>
-            </div>
+                        }}
+                    />
+                    <label htmlFor='group-by-project-checkbox' style={{marginLeft: '6px', cursor: 'pointer', marginBottom: 0}}>
+                        Group by Project
+                    </label>
+                </div>
+            )}
             <i
                 className={classNames('fa fa-th', {selected: cleanPref.view === Tiles}, 'menu_icon')}
                 title='Tiles'

--- a/ui/src/app/applications/components/applications-list/view-type-switcher.tsx
+++ b/ui/src/app/applications/components/applications-list/view-type-switcher.tsx
@@ -12,14 +12,37 @@ interface ViewTypeSwitcherProps {
 export const ViewTypeSwitcher: React.FC<ViewTypeSwitcherProps> = ({pref, ctx}) => {
     const {List, Summary, Tiles} = AppsListViewKey;
 
+    // 1. Add local state to ensure the checkbox updates visually the millisecond it is clicked
+    const [isGrouped, setIsGrouped] = React.useState(!!pref.groupByProject);
+    const [prevGroupByProject, setPrevGroupByProject] = React.useState(!!pref.groupByProject);
+
+    // 2. Synchronize the local state if the pref prop changes externally during rendering
+    if (!!pref.groupByProject !== prevGroupByProject) {
+        setIsGrouped(!!pref.groupByProject);
+        setPrevGroupByProject(!!pref.groupByProject);
+    }
+
+    // Extract clean preferences using rest syntax to prevent type pollution and avoid non-existent fields
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const {page, search, ...cleanPrefWithoutGroup} = pref;
+    const cleanPref: AppsListPreferences = {...cleanPrefWithoutGroup, groupByProject: isGrouped};
+
     return (
         <div className='applications-list__view-type' style={{display: 'flex', alignItems: 'center'}}>
             <div style={{marginRight: '15px', display: 'flex', alignItems: 'center'}}>
                 <Checkbox
                     id='group-by-project-checkbox'
-                    checked={!!pref.groupByProject}
+                    checked={isGrouped}
                     onChange={val => {
-                        services.viewPreferences.updatePreferences({appList: {...pref, groupByProject: val}});
+                        // 4. Update the local checkbox instantly
+                        setIsGrouped(val);
+                        // 5. Update the persistent backend preferences in the background
+                        services.viewPreferences.updatePreferences({
+                            appList: {
+                                ...cleanPref,
+                                groupByProject: val
+                            }
+                        });
                     }}
                 />
                 <label htmlFor='group-by-project-checkbox' style={{marginLeft: '6px', cursor: 'pointer', marginBottom: 0}}>
@@ -27,27 +50,33 @@ export const ViewTypeSwitcher: React.FC<ViewTypeSwitcherProps> = ({pref, ctx}) =
                 </label>
             </div>
             <i
-                className={classNames('fa fa-th', {selected: pref.view === Tiles}, 'menu_icon')}
+                className={classNames('fa fa-th', {selected: cleanPref.view === Tiles}, 'menu_icon')}
                 title='Tiles'
                 onClick={() => {
                     ctx.navigation.goto('.', {view: Tiles});
-                    services.viewPreferences.updatePreferences({appList: {...pref, view: Tiles}});
+                    services.viewPreferences.updatePreferences({
+                        appList: {...cleanPref, view: Tiles}
+                    });
                 }}
             />
             <i
-                className={classNames('fa fa-th-list', {selected: pref.view === List}, 'menu_icon')}
+                className={classNames('fa fa-th-list', {selected: cleanPref.view === List}, 'menu_icon')}
                 title='List'
                 onClick={() => {
                     ctx.navigation.goto('.', {view: List});
-                    services.viewPreferences.updatePreferences({appList: {...pref, view: List}});
+                    services.viewPreferences.updatePreferences({
+                        appList: {...cleanPref, view: List}
+                    });
                 }}
             />
             <i
-                className={classNames('fa fa-chart-pie', {selected: pref.view === Summary}, 'menu_icon')}
+                className={classNames('fa fa-chart-pie', {selected: cleanPref.view === Summary}, 'menu_icon')}
                 title='Summary'
                 onClick={() => {
                     ctx.navigation.goto('.', {view: Summary});
-                    services.viewPreferences.updatePreferences({appList: {...pref, view: Summary}});
+                    services.viewPreferences.updatePreferences({
+                        appList: {...cleanPref, view: Summary}
+                    });
                 }}
             />
         </div>

--- a/ui/src/app/applications/components/applications-list/view-type-switcher.tsx
+++ b/ui/src/app/applications/components/applications-list/view-type-switcher.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import * as React from 'react';
+import {Checkbox} from 'argo-ui';
 import {ContextApis} from '../../../shared/context';
 import {AppsListPreferences, AppsListViewKey, services} from '../../../shared/services';
 
@@ -12,7 +13,19 @@ export const ViewTypeSwitcher: React.FC<ViewTypeSwitcherProps> = ({pref, ctx}) =
     const {List, Summary, Tiles} = AppsListViewKey;
 
     return (
-        <div className='applications-list__view-type'>
+        <div className='applications-list__view-type' style={{display: 'flex', alignItems: 'center'}}>
+            <div style={{marginRight: '15px', display: 'flex', alignItems: 'center'}}>
+                <Checkbox
+                    id='group-by-project-checkbox'
+                    checked={!!pref.groupByProject}
+                    onChange={val => {
+                        services.viewPreferences.updatePreferences({appList: {...pref, groupByProject: val}});
+                    }}
+                />
+                <label htmlFor='group-by-project-checkbox' style={{marginLeft: '6px', cursor: 'pointer', marginBottom: 0}}>
+                    Group by Project
+                </label>
+            </div>
             <i
                 className={classNames('fa fa-th', {selected: pref.view === Tiles}, 'menu_icon')}
                 title='Tiles'

--- a/ui/src/app/shared/services/view-preferences-service.ts
+++ b/ui/src/app/shared/services/view-preferences-service.ts
@@ -109,6 +109,7 @@ export class AppsListPreferences extends AbstractAppsListPreferences {
     public clustersFilter: string[];
     public targetRevisionFilter: string[];
     public operationFilter: string[];
+    public groupByProject: boolean;
 }
 
 export class AppSetsListPreferences extends AbstractAppsListPreferences {
@@ -177,6 +178,7 @@ const DEFAULT_PREFERENCES: ViewPreferences = {
         showFavorites: false,
         favoritesAppList: new Array<string>(),
         searchRegex: false,
+        groupByProject: false,
         statusBarView: {
             showHealthStatusBar: true
         }
@@ -250,5 +252,6 @@ export class ViewPreferencesService {
         appList.healthFilter = appList.healthFilter || [];
         appList.operationFilter = appList.operationFilter || [];
         appList.favoritesAppList = appList.favoritesAppList || [];
+        appList.groupByProject = !!appList.groupByProject;
     }
 }


### PR DESCRIPTION
1-)-A checkbox toggle element and the text label "Group by Project" right next to it.

-Look at the top-right corner of the main dark dashboard area. Your checkbox sits directly between the blue application     filter icon and the layout mode selector buttons (Grid/List/Summary icons).

-It gives users a clear, accessible opt-in toggle right where they naturally manage their layout views, satisfying the requirement to let users control when they want to see grouped content.

2-)-The structural rendering arrangement of the application cards.

-The lower 80% of the viewport area containing the card layout block grid (team-frontend/api, team-backend/api, etc.).

-When the user selects your checkbox, this entire main space shifts from a flat, unorganized grid of cards into sections separated by clean, bold project headers. This prevents applications from multiple tenants or teams from getting confusingly mixed together.

video-)
https://github.com/user-attachments/assets/ddaaa414-860f-4771-8ab5-5d31badec4d9


Closes https://github.com/argoproj/argo-cd/issues/28605

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
