### PR TITLE
feat(health): add health check for Kro resources

### DIFF
--- a/resource_customizations/_.services.k8s.aws/_/health.lua
+++ b/resource_customizations/_.services.k8s.aws/_/health.lua
@@ -1,0 +1,29 @@
+-- AWS ACK: https://aws-controllers-k8s.github.io/docs/
+local hs = {}
+
+if obj.status ~= nil and obj.status.conditions ~= nil then
+  for i, condition in ipairs(obj.status.conditions) do
+
+    if condition.type == "ACK.Terminal" and condition.status == "True" then
+      hs.status = "Degraded"
+      hs.message = condition.message
+      return hs
+    end
+    
+    if condition.type == "Ready" then
+      if condition.status == "False" then
+        hs.status = "Progressing"
+        hs.message = condition.message
+        return hs
+      elseif condition.status == "True" then
+        hs.status = "Healthy"
+        hs.message = ""
+        return hs
+      end
+    end
+  end
+end
+
+hs.status = "Progressing"
+hs.message = "Waiting for resource to be ready"
+return hs

--- a/resource_customizations/_.services.k8s.aws/_/health_test.yaml
+++ b/resource_customizations/_.services.k8s.aws/_/health_test.yaml
@@ -1,0 +1,17 @@
+tests:
+  - healthStatus:
+      status: Healthy
+      message: ""
+    inputPath: testdata/healthy.yaml
+  - healthStatus:
+      status: Progressing
+      message: bucket in CREATING state
+    inputPath: testdata/progressing.yaml
+  - healthStatus:
+      status: Progressing
+      message: Waiting for resource to be ready
+    inputPath: testdata/progressing_no_conditions.yaml
+  - healthStatus:
+      status: Degraded
+      message: Resource already exists
+    inputPath: testdata/degraded.yaml

--- a/resource_customizations/_.services.k8s.aws/_/testdata/degraded.yaml
+++ b/resource_customizations/_.services.k8s.aws/_/testdata/degraded.yaml
@@ -1,0 +1,28 @@
+apiVersion: s3.services.k8s.aws/v1alpha1
+kind: Bucket
+metadata:
+  name: test-s3-bucket
+  namespace: default
+spec:
+  name: test-s3-bucket
+status:
+  ackResourceMetadata:
+    arn: arn:aws:s3:::test-s3-bucket
+    ownerAccountID: "111111111111"
+    region: us-west-2
+  conditions:
+  - lastTransitionTime: "2026-04-15T18:20:17Z"
+    message: Resource already exists
+    reason: This resource already exists but is not managed by ACK.
+    status: "True"
+    type: ACK.Terminal
+  - lastTransitionTime: "2026-04-15T18:20:17Z"
+    message: Resource not synced
+    reason: resource is in terminal condition
+    status: "False"
+    type: ACK.ResourceSynced
+  - lastTransitionTime: "2026-04-15T18:20:17Z"
+    message: Resource already exists
+    reason: ACK.Terminal
+    status: "False"
+    type: Ready

--- a/resource_customizations/_.services.k8s.aws/_/testdata/healthy.yaml
+++ b/resource_customizations/_.services.k8s.aws/_/testdata/healthy.yaml
@@ -1,0 +1,24 @@
+apiVersion: s3.services.k8s.aws/v1alpha1
+kind: Bucket
+metadata:
+  name: test-s3-bucket
+  namespace: default
+spec:
+  name: test-s3-bucket
+status:
+  ackResourceMetadata:
+    arn: arn:aws:s3:::test-s3-bucket
+    ownerAccountID: "111111111111"
+    region: us-west-2
+  conditions:
+  - lastTransitionTime: "2026-04-15T18:20:17Z"
+    message: Resource synced successfully
+    reason: ""
+    status: "True"
+    type: ACK.ResourceSynced
+  - lastTransitionTime: "2026-04-15T18:20:17Z"
+    message: Resource synced successfully
+    reason: ""
+    status: "True"
+    type: Ready
+  location: http://test-s3-bucket.s3.amazonaws.com/

--- a/resource_customizations/_.services.k8s.aws/_/testdata/progressing.yaml
+++ b/resource_customizations/_.services.k8s.aws/_/testdata/progressing.yaml
@@ -1,0 +1,23 @@
+apiVersion: s3.services.k8s.aws/v1alpha1
+kind: Bucket
+metadata:
+  name: test-s3-bucket
+  namespace: default
+spec:
+  name: test-s3-bucket
+status:
+  ackResourceMetadata:
+    arn: arn:aws:s3:::test-s3-bucket
+    ownerAccountID: "111111111111"
+    region: us-west-2
+  conditions:
+  - lastTransitionTime: "2026-04-15T18:20:17Z"
+    message: bucket in CREATING state
+    reason: bucket in CREATING state
+    status: "False"
+    type: ACK.ResourceSynced
+  - lastTransitionTime: "2026-04-15T18:20:17Z"
+    message: bucket in CREATING state
+    reason: bucket in CREATING state
+    status: "False"
+    type: Ready

--- a/resource_customizations/_.services.k8s.aws/_/testdata/progressing_no_conditions.yaml
+++ b/resource_customizations/_.services.k8s.aws/_/testdata/progressing_no_conditions.yaml
@@ -1,0 +1,12 @@
+apiVersion: s3.services.k8s.aws/v1alpha1
+kind: Bucket
+metadata:
+  name: test-s3-bucket
+  namespace: default
+spec:
+  name: test-s3-bucket
+status:
+  ackResourceMetadata:
+    arn: arn:aws:s3:::test-s3-bucket
+    ownerAccountID: "111111111111"
+    region: us-west-2

--- a/resource_customizations/kro.run/ResourceGraphDefinition/health.lua
+++ b/resource_customizations/kro.run/ResourceGraphDefinition/health.lua
@@ -1,0 +1,38 @@
+-- KRO ResourceGraphDefinition: https://kro.run/docs/concepts/rgd/overview
+local hs = {}
+
+if obj.status == nil or obj.status.conditions == nil then
+  hs.status = "Progressing"
+  hs.message = "Waiting for KRO to report status"
+  return hs
+end
+
+local defined_conditions = {
+  GraphRevisionsResolved = true,
+  GraphAccepted = true,
+  KindReady = true,
+  ControllerReady = true,
+  Ready = true,
+}
+
+local generation = obj.metadata and obj.metadata.generation
+
+for _, condition in ipairs(obj.status.conditions) do
+  if generation ~= nil and condition.observedGeneration ~= nil and condition.observedGeneration == generation then
+    if condition.type == "Ready" and condition.status == "True" then
+      hs.status = "Healthy"
+      hs.message = "ResourceGraphDefinition is active and serving instances"
+      return hs
+    end
+
+    if defined_conditions[condition.type] and condition.status == "False" then
+      hs.status = "Degraded"
+      hs.message = condition.message or (condition.type .. " is False")
+      return hs
+    end
+  end
+end
+
+hs.status = "Progressing"
+hs.message = "Waiting for ResourceGraphDefinition to become ready"
+return hs

--- a/resource_customizations/kro.run/ResourceGraphDefinition/health_test.yaml
+++ b/resource_customizations/kro.run/ResourceGraphDefinition/health_test.yaml
@@ -1,0 +1,25 @@
+tests:
+  - healthStatus:
+      status: Healthy
+      message: "ResourceGraphDefinition is active and serving instances"
+    inputPath: testdata/active.yaml
+  - healthStatus:
+      status: Degraded
+      message: "graph was rejected: validation failed"
+    inputPath: testdata/inactive_degraded.yaml
+  - healthStatus:
+      status: Progressing
+      message: "Waiting for KRO to report status"
+    inputPath: testdata/no_status.yaml
+  - healthStatus:
+      status: Progressing
+      message: "Waiting for ResourceGraphDefinition to become ready"
+    inputPath: testdata/inactive_progressing.yaml
+  - healthStatus:
+      status: Progressing
+      message: "Waiting for ResourceGraphDefinition to become ready"
+    inputPath: testdata/stale_generation.yaml
+  - healthStatus:
+      status: Progressing
+      message: "Waiting for ResourceGraphDefinition to become ready"
+    inputPath: testdata/missing_generation.yaml

--- a/resource_customizations/kro.run/ResourceGraphDefinition/testdata/active.yaml
+++ b/resource_customizations/kro.run/ResourceGraphDefinition/testdata/active.yaml
@@ -1,0 +1,45 @@
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: application
+  generation: 1
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: Application
+status:
+  state: Active
+  topologicalOrder:
+    - deployment
+    - service
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: Ready
+      message: ""
+      lastTransitionTime: "2025-08-08T00:03:46Z"
+      observedGeneration: 1
+    - type: GraphRevisionsResolved
+      status: "True"
+      reason: Resolved
+      message: "graph revisions resolved"
+      lastTransitionTime: "2025-08-08T00:03:46Z"
+      observedGeneration: 1
+    - type: GraphAccepted
+      status: "True"
+      reason: Accepted
+      message: "graph accepted"
+      lastTransitionTime: "2025-08-08T00:03:46Z"
+      observedGeneration: 1
+    - type: KindReady
+      status: "True"
+      reason: Ready
+      message: "CRD created and accepted"
+      lastTransitionTime: "2025-08-08T00:03:46Z"
+      observedGeneration: 1
+    - type: ControllerReady
+      status: "True"
+      reason: Ready
+      message: "controller registered"
+      lastTransitionTime: "2025-08-08T00:03:46Z"
+      observedGeneration: 1

--- a/resource_customizations/kro.run/ResourceGraphDefinition/testdata/inactive_degraded.yaml
+++ b/resource_customizations/kro.run/ResourceGraphDefinition/testdata/inactive_degraded.yaml
@@ -1,0 +1,24 @@
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: broken-app
+  generation: 1
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: BrokenApp
+status:
+  state: Inactive
+  conditions:
+    - type: Ready
+      status: "False"
+      reason: GraphRejected
+      message: "graph was rejected: validation failed"
+      lastTransitionTime: "2025-08-08T00:05:00Z"
+      observedGeneration: 1
+    - type: GraphAccepted
+      status: "False"
+      reason: Rejected
+      message: "graph was rejected: validation failed"
+      lastTransitionTime: "2025-08-08T00:05:00Z"
+      observedGeneration: 1

--- a/resource_customizations/kro.run/ResourceGraphDefinition/testdata/inactive_progressing.yaml
+++ b/resource_customizations/kro.run/ResourceGraphDefinition/testdata/inactive_progressing.yaml
@@ -1,0 +1,24 @@
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: pending-app
+  generation: 1
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: PendingApp
+status:
+  state: Inactive
+  conditions:
+    - type: Ready
+      status: "Unknown"
+      reason: Pending
+      message: "waiting for graph revision to compile"
+      lastTransitionTime: "2025-08-08T00:04:00Z"
+      observedGeneration: 1
+    - type: GraphRevisionsResolved
+      status: "Unknown"
+      reason: Waiting
+      message: "waiting for revision"
+      lastTransitionTime: "2025-08-08T00:04:00Z"
+      observedGeneration: 1

--- a/resource_customizations/kro.run/ResourceGraphDefinition/testdata/missing_generation.yaml
+++ b/resource_customizations/kro.run/ResourceGraphDefinition/testdata/missing_generation.yaml
@@ -1,0 +1,18 @@
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: application
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: Application
+status:
+  state: Active
+  topologicalOrder:
+    - deployment
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: Ready
+      message: ""
+      lastTransitionTime: "2025-08-08T00:03:46Z"

--- a/resource_customizations/kro.run/ResourceGraphDefinition/testdata/no_status.yaml
+++ b/resource_customizations/kro.run/ResourceGraphDefinition/testdata/no_status.yaml
@@ -1,0 +1,8 @@
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: new-app
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: NewApp

--- a/resource_customizations/kro.run/ResourceGraphDefinition/testdata/stale_generation.yaml
+++ b/resource_customizations/kro.run/ResourceGraphDefinition/testdata/stale_generation.yaml
@@ -1,0 +1,45 @@
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: application
+  generation: 4
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: Application
+status:
+  state: Active
+  lastIssuedRevision: 1
+  topologicalOrder:
+    - deployment
+  conditions:
+    - type: GraphRevisionsResolved
+      status: "True"
+      reason: Resolved
+      message: "revision 1 compiled and active"
+      lastTransitionTime: "2026-07-15T22:57:09Z"
+      observedGeneration: 3
+    - type: KindReady
+      status: "True"
+      reason: Ready
+      message: "kind Application has been accepted and ready"
+      lastTransitionTime: "2026-07-15T22:57:09Z"
+      observedGeneration: 3
+    - type: ControllerReady
+      status: "True"
+      reason: Running
+      message: "controller is running"
+      lastTransitionTime: "2026-07-15T22:57:10Z"
+      observedGeneration: 3
+    - type: GraphAccepted
+      status: "True"
+      reason: Valid
+      message: "resource graph and schema are valid"
+      lastTransitionTime: "2026-07-15T23:01:10Z"
+      observedGeneration: 3
+    - type: Ready
+      status: "True"
+      reason: Ready
+      message: ""
+      lastTransitionTime: "2026-07-15T23:01:10Z"
+      observedGeneration: 3

--- a/resource_customizations/kro.run/_/health.lua
+++ b/resource_customizations/kro.run/_/health.lua
@@ -1,0 +1,46 @@
+-- KRO instance: https://kro.run/docs/concepts/instances/
+local hs = {}
+
+if obj.status == nil or obj.status.conditions == nil then
+  hs.status = "Progressing"
+  hs.message = "Waiting for KRO to report status"
+  return hs
+end
+
+local state = obj.status.state
+local generation = obj.metadata and obj.metadata.generation
+
+local defined_conditions = {
+  InstanceManaged = true,
+  GraphResolved = true,
+  ResourcesReady = true,
+  Ready = true,
+}
+
+for _, condition in ipairs(obj.status.conditions) do
+  if generation ~= nil and condition.observedGeneration ~= nil and condition.observedGeneration == generation then
+    if condition.type == "Ready" and condition.status == "True" then
+      hs.status = "Healthy"
+      hs.message = "Instance is active and running"
+      return hs
+    end
+
+    if defined_conditions[condition.type] and condition.status == "False" then
+      if state == "FAILED" or state == "ERROR" then
+        hs.status = "Degraded"
+        hs.message = condition.message or (condition.type .. " is False")
+        return hs
+      end
+      if state == "IN_PROGRESS" then
+        hs.status = "Progressing"
+        hs.message = condition.message or (condition.type .. " is in progress")
+        return hs
+      end
+    end
+  end
+end
+
+-- No condition is False and Ready is not True yet
+hs.status = "Progressing"
+hs.message = "Waiting for instance to become ready"
+return hs

--- a/resource_customizations/kro.run/_/health_test.yaml
+++ b/resource_customizations/kro.run/_/health_test.yaml
@@ -1,0 +1,33 @@
+tests:
+  - healthStatus:
+      status: Healthy
+      message: "Instance is active and running"
+    inputPath: testdata/active.yaml
+  - healthStatus:
+      status: Progressing
+      message: "Waiting for instance to become ready"
+    inputPath: testdata/in_progress.yaml
+  - healthStatus:
+      status: Progressing
+      message: "instance is being reconciled"
+    inputPath: testdata/in_progress_condition_false.yaml
+  - healthStatus:
+      status: Degraded
+      message: "instance reconciliation failed"
+    inputPath: testdata/failed.yaml
+  - healthStatus:
+      status: Degraded
+      message: "an error occurred during processing"
+    inputPath: testdata/error.yaml
+  - healthStatus:
+      status: Progressing
+      message: "Waiting for KRO to report status"
+    inputPath: testdata/no_status.yaml
+  - healthStatus:
+      status: Progressing
+      message: "Waiting for instance to become ready"
+    inputPath: testdata/stale_generation.yaml
+  - healthStatus:
+      status: Progressing
+      message: "Waiting for instance to become ready"
+    inputPath: testdata/missing_generation.yaml

--- a/resource_customizations/kro.run/_/testdata/active.yaml
+++ b/resource_customizations/kro.run/_/testdata/active.yaml
@@ -1,0 +1,37 @@
+apiVersion: kro.run/v1alpha1
+kind: WebApplication
+metadata:
+  name: my-app
+  namespace: default
+  generation: 1
+spec:
+  name: web-app
+  image: nginx:latest
+status:
+  state: ACTIVE
+  availableReplicas: 3
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: Ready
+      message: ""
+      lastTransitionTime: "2025-08-08T00:03:46Z"
+      observedGeneration: 1
+    - type: InstanceManaged
+      status: "True"
+      reason: Managed
+      message: "instance is properly managed with finalizers and labels"
+      lastTransitionTime: "2025-08-08T00:03:46Z"
+      observedGeneration: 1
+    - type: GraphResolved
+      status: "True"
+      reason: Resolved
+      message: "runtime graph created and all resources resolved"
+      lastTransitionTime: "2025-08-08T00:03:46Z"
+      observedGeneration: 1
+    - type: ResourcesReady
+      status: "True"
+      reason: AllResourcesReady
+      message: "all resources are created and ready"
+      lastTransitionTime: "2025-08-08T00:03:46Z"
+      observedGeneration: 1

--- a/resource_customizations/kro.run/_/testdata/error.yaml
+++ b/resource_customizations/kro.run/_/testdata/error.yaml
@@ -1,0 +1,36 @@
+apiVersion: kro.run/v1alpha1
+kind: WebApplication
+metadata:
+  name: my-app
+  namespace: default
+  generation: 1
+spec:
+  name: web-app
+  image: nginx:latest
+status:
+  state: ERROR
+  conditions:
+    - type: Ready
+      status: "False"
+      reason: Error
+      message: "an error occurred during processing"
+      lastTransitionTime: "2025-08-08T00:05:00Z"
+      observedGeneration: 1
+    - type: InstanceManaged
+      status: "True"
+      reason: Managed
+      message: "instance is properly managed with finalizers and labels"
+      lastTransitionTime: "2025-08-08T00:03:46Z"
+      observedGeneration: 1
+    - type: GraphResolved
+      status: "False"
+      reason: Error
+      message: "failed to resolve runtime graph"
+      lastTransitionTime: "2025-08-08T00:05:00Z"
+      observedGeneration: 1
+    - type: ResourcesReady
+      status: "False"
+      reason: Error
+      message: "resources could not be created"
+      lastTransitionTime: "2025-08-08T00:05:00Z"
+      observedGeneration: 1

--- a/resource_customizations/kro.run/_/testdata/failed.yaml
+++ b/resource_customizations/kro.run/_/testdata/failed.yaml
@@ -1,0 +1,36 @@
+apiVersion: kro.run/v1alpha1
+kind: WebApplication
+metadata:
+  name: my-app
+  namespace: default
+  generation: 1
+spec:
+  name: web-app
+  image: nginx:latest
+status:
+  state: FAILED
+  conditions:
+    - type: Ready
+      status: "False"
+      reason: Failed
+      message: "instance reconciliation failed"
+      lastTransitionTime: "2025-08-08T00:05:00Z"
+      observedGeneration: 1
+    - type: InstanceManaged
+      status: "True"
+      reason: Managed
+      message: "instance is properly managed with finalizers and labels"
+      lastTransitionTime: "2025-08-08T00:03:46Z"
+      observedGeneration: 1
+    - type: GraphResolved
+      status: "True"
+      reason: Resolved
+      message: "runtime graph created and all resources resolved"
+      lastTransitionTime: "2025-08-08T00:03:46Z"
+      observedGeneration: 1
+    - type: ResourcesReady
+      status: "False"
+      reason: ReconcileError
+      message: "all resources are not yet ready"
+      lastTransitionTime: "2025-08-08T00:05:00Z"
+      observedGeneration: 1

--- a/resource_customizations/kro.run/_/testdata/in_progress.yaml
+++ b/resource_customizations/kro.run/_/testdata/in_progress.yaml
@@ -1,0 +1,36 @@
+apiVersion: kro.run/v1alpha1
+kind: WebApplication
+metadata:
+  name: my-app
+  namespace: default
+  generation: 1
+spec:
+  name: web-app
+  image: nginx:latest
+status:
+  state: IN_PROGRESS
+  conditions:
+    - type: Ready
+      status: "Unknown"
+      reason: Pending
+      message: "instance is being reconciled"
+      lastTransitionTime: "2025-08-08T00:03:46Z"
+      observedGeneration: 1
+    - type: InstanceManaged
+      status: "True"
+      reason: Managed
+      message: "instance is properly managed with finalizers and labels"
+      lastTransitionTime: "2025-08-08T00:03:46Z"
+      observedGeneration: 1
+    - type: GraphResolved
+      status: "True"
+      reason: Resolved
+      message: "runtime graph created and all resources resolved"
+      lastTransitionTime: "2025-08-08T00:03:46Z"
+      observedGeneration: 1
+    - type: ResourcesReady
+      status: "Unknown"
+      reason: Pending
+      message: "waiting for resources to be ready"
+      lastTransitionTime: "2025-08-08T00:03:46Z"
+      observedGeneration: 1

--- a/resource_customizations/kro.run/_/testdata/in_progress_condition_false.yaml
+++ b/resource_customizations/kro.run/_/testdata/in_progress_condition_false.yaml
@@ -1,0 +1,36 @@
+apiVersion: kro.run/v1alpha1
+kind: WebApplication
+metadata:
+  name: my-app
+  namespace: default
+  generation: 1
+spec:
+  name: web-app
+  image: nginx:latest
+status:
+  state: IN_PROGRESS
+  conditions:
+    - type: Ready
+      status: "False"
+      reason: Pending
+      message: "instance is being reconciled"
+      lastTransitionTime: "2025-08-08T00:03:46Z"
+      observedGeneration: 1
+    - type: InstanceManaged
+      status: "True"
+      reason: Managed
+      message: "instance is properly managed with finalizers and labels"
+      lastTransitionTime: "2025-08-08T00:03:46Z"
+      observedGeneration: 1
+    - type: GraphResolved
+      status: "True"
+      reason: Resolved
+      message: "runtime graph created and all resources resolved"
+      lastTransitionTime: "2025-08-08T00:03:46Z"
+      observedGeneration: 1
+    - type: ResourcesReady
+      status: "False"
+      reason: Pending
+      message: "waiting for resources to be created"
+      lastTransitionTime: "2025-08-08T00:03:46Z"
+      observedGeneration: 1

--- a/resource_customizations/kro.run/_/testdata/missing_generation.yaml
+++ b/resource_customizations/kro.run/_/testdata/missing_generation.yaml
@@ -1,0 +1,18 @@
+apiVersion: kro.run/v1alpha1
+kind: WebApplication
+metadata:
+  name: my-app
+  namespace: default
+  generation: 1
+spec:
+  name: web-app
+  image: nginx:latest
+status:
+  state: ACTIVE
+  availableReplicas: 3
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: Ready
+      message: ""
+      lastTransitionTime: "2025-08-08T00:03:46Z"

--- a/resource_customizations/kro.run/_/testdata/no_status.yaml
+++ b/resource_customizations/kro.run/_/testdata/no_status.yaml
@@ -1,0 +1,8 @@
+apiVersion: kro.run/v1alpha1
+kind: WebApplication
+metadata:
+  name: my-app
+  namespace: default
+spec:
+  name: web-app
+  image: nginx:latest

--- a/resource_customizations/kro.run/_/testdata/stale_generation.yaml
+++ b/resource_customizations/kro.run/_/testdata/stale_generation.yaml
@@ -1,0 +1,37 @@
+apiVersion: kro.run/v1alpha1
+kind: WebApplication
+metadata:
+  name: my-app
+  namespace: default
+  generation: 2
+spec:
+  name: web-app
+  image: nginx:latest
+status:
+  state: ACTIVE
+  availableReplicas: 3
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: Ready
+      message: ""
+      lastTransitionTime: "2025-08-08T00:03:46Z"
+      observedGeneration: 1
+    - type: InstanceManaged
+      status: "True"
+      reason: Managed
+      message: "instance is properly managed with finalizers and labels"
+      lastTransitionTime: "2025-08-08T00:03:46Z"
+      observedGeneration: 1
+    - type: GraphResolved
+      status: "True"
+      reason: Resolved
+      message: "runtime graph created and all resources resolved"
+      lastTransitionTime: "2025-08-08T00:03:46Z"
+      observedGeneration: 1
+    - type: ResourcesReady
+      status: "True"
+      reason: AllResourcesReady
+      message: "all resources are created and ready"
+      lastTransitionTime: "2025-08-08T00:03:46Z"
+      observedGeneration: 1

--- a/util/lua/lua_test.go
+++ b/util/lua/lua_test.go
@@ -1125,8 +1125,10 @@ func Test_getHealthScriptPaths(t *testing.T) {
 	assert.Equal(t, []string{
 		"_.cnrm.cloud.google.com/_",
 		"_.crossplane.io/_",
+		"_.services.k8s.aws/_",
 		"_.upbound.io/_",
 		"grafana-org-operator.kubitus-project.gitlab.io/_",
+		"kro.run/_",
 		"microgateway.airlock.com/_",
 		"operator.victoriametrics.com/_",
 	}, paths)


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [X] I've updated documentation as required by this PR.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [X] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [X] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [X] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->

---

 ## Summary

  Adds built-in Lua health checks for two families of custom resources:

  **AWS Controllers for Kubernetes ([ACK](https://aws.amazon.com/blogs/containers/aws-controllers-for-kubernetes-ack/))** — CRDs from the `<aws-service>.services.k8s.aws` API groups, handled with a single wildcard
  check (`_.services.k8s.aws`). Some example groups are:
  - `s3.services.k8s.aws`
  - `dynamodb.services.k8s.aws`

  **[KRO](https://docs.aws.amazon.com/eks/latest/userguide/kro.html) (Kube Resource Orchestrator)** — the `ResourceGraphDefinition` CRD plus a wildcard check (`kro.run/_`) that covers the instance CRs generated from any ResourceGraphDefinition.

  ## Health Mapping

  ### ACK (`_.services.k8s.aws`)
  All ACK resources share a common set of conditions, which can be used to determine the state of the resource ([ref](https://docs.aws.amazon.com/eks/latest/userguide/ack-concepts.html#_status_conditions)).

  ACK conditions do not carry an `observedGeneration`, so the check evaluates the conditions as-is rather than gating on the current generation.

  | Condition type and status | Argo CD Health |
  |---|---|
  | `ACK.Terminal` + `True` | Degraded |
  | `Ready` + `False` | Progressing |
  | `Ready` + `True` | Healthy |
  | Any other phase or missing status | Progressing |

  ### KRO `ResourceGraphDefinition` (`kro.run/ResourceGraphDefinition`)
  Unlike ACK, KRO conditions include an `observedGeneration`, so conditions are only evaluated when it matches the resource's current `metadata.generation`. This ensures a stale status never produces a misleading
  result.

  | Condition (for the current generation) | Argo CD Health |
  |---|---|
  | `Ready` + `True` | Healthy |
  | A defined condition + `False` (e.g. `GraphAccepted`, `KindReady`, `ControllerReady`) | Degraded |
  | Any other phase or missing status | Progressing |

  ### KRO instances (`kro.run/_`)
  Instance health combines the `Ready` condition (again, only for the current generation) with the reported `status.state`.

  | Condition / state (for the current generation) | Argo CD Health |
  |---|---|
  | `Ready` + `True` | Healthy |
  | A defined condition + `False` while `state` is `FAILED` or `ERROR` | Degraded |
  | A defined condition + `False` while `state` is `IN_PROGRESS` | Progressing |
  | Any other phase or missing status | Progressing |

  ## Validation

  New health check tests were added and pass for every scenario in each check:
  - **ACK:** healthy, progressing, degraded, and missing/empty status.
  - **KRO ResourceGraphDefinition:** active, inactive/degraded, inactive/progressing, missing generation, stale generation, and no status.
  - **KRO instance:** active, failed, error, in-progress, in-progress with a `False` condition, missing generation, stale generation, and no status.
