### PR TITLE
fix: show 'name does not match' error in delete/sync confirmation dialogs

### DIFF
--- a/ui/src/app/applications/components/utils.test.tsx
+++ b/ui/src/app/applications/components/utils.test.tsx
@@ -22,6 +22,7 @@ import {
     getOperationType,
     getPodStateReason,
     HealthStatusIcon,
+    nameConfirmationError,
     OperationState,
     ResourceResultIcon
 } from './utils';
@@ -1041,6 +1042,39 @@ describe('getAppHydratorSyncSource', () => {
             targetRevision: 'env/test',
             path: 'out'
         });
+    });
+});
+
+describe('nameConfirmationError', () => {
+    const emptyMsg = 'Enter the resource name to confirm the deletion';
+    const mismatchMsg = 'Resource name does not match';
+
+    it('returns false when entered value matches expected', () => {
+        expect(nameConfirmationError('my-app', 'my-app', emptyMsg, mismatchMsg)).toBe(false);
+    });
+
+    it('returns empty message when field is empty', () => {
+        expect(nameConfirmationError('', 'my-app', emptyMsg, mismatchMsg)).toBe(emptyMsg);
+    });
+
+    it('returns mismatch message when field has a wrong value', () => {
+        expect(nameConfirmationError('wrong-name', 'my-app', emptyMsg, mismatchMsg)).toBe(mismatchMsg);
+    });
+
+    it('returns mismatch message when field has a partial value', () => {
+        expect(nameConfirmationError('my-ap', 'my-app', emptyMsg, mismatchMsg)).toBe(mismatchMsg);
+    });
+
+    it('returns false when both entered and expected are empty strings', () => {
+        expect(nameConfirmationError('', '', emptyMsg, mismatchMsg)).toBe(false);
+    });
+
+    it('uses the provided message strings (application delete variant)', () => {
+        const appEmpty = 'Enter the application name to confirm the deletion';
+        const appMismatch = 'Application name does not match';
+        expect(nameConfirmationError('', 'guestbook', appEmpty, appMismatch)).toBe(appEmpty);
+        expect(nameConfirmationError('guestbook-typo', 'guestbook', appEmpty, appMismatch)).toBe(appMismatch);
+        expect(nameConfirmationError('guestbook', 'guestbook', appEmpty, appMismatch)).toBe(false);
     });
 });
 

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -88,6 +88,11 @@ export const SpinningIcon = ({color, qeId}: {color: string; qeId: string}) => {
     );
 };
 
+export function nameConfirmationError(entered: string, expected: string, emptyMessage: string, mismatchMessage: string): string | false {
+    if (entered === expected) return false;
+    return !entered ? emptyMessage : mismatchMessage;
+}
+
 export async function deleteApplication(appName: string, appNamespace: string, apis: ContextApis, application?: appModels.Application): Promise<boolean> {
     let confirmed = false;
 
@@ -163,7 +168,7 @@ export async function deleteApplication(appName: string, appNamespace: string, a
         ),
         {
             validate: vals => ({
-                applicationName: vals.applicationName !== appName && 'Enter the application name to confirm the deletion'
+                applicationName: nameConfirmationError(vals.applicationName, appName, 'Enter the application name to confirm the deletion', 'Application name does not match')
             }),
             submit: async (vals, _, close) => {
                 try {
@@ -210,7 +215,7 @@ export async function confirmSyncingAppOfApps(apps: appModels.Application[], api
         ),
         {
             validate: vals => ({
-                applicationName: vals.applicationName !== appNameList && 'Enter the application name(s) to confirm syncing'
+                applicationName: nameConfirmationError(vals.applicationName, appNameList, 'Enter the application name(s) to confirm syncing', 'Application name does not match')
             }),
             submit: async (_vals, _, close) => {
                 try {
@@ -604,7 +609,7 @@ export const deletePopup = async (
         {
             validate: vals =>
                 isManaged && {
-                    resourceName: vals.resourceName !== resource.name && 'Enter the resource name to confirm the deletion'
+                    resourceName: nameConfirmationError(vals.resourceName, resource.name, 'Enter the resource name to confirm the deletion', 'Resource name does not match')
                 },
             submit: async (vals, _, close) => {
                 const force = deleteOptions.option === 'force';


### PR DESCRIPTION
## Summary

Fixes #28751

When a user types the wrong name in the resource delete, application delete, or sync confirmation dialog, the previous error message **\"Enter the resource name to confirm the deletion\"** was misleading — it implies the field is empty rather than that the typed value is incorrect (analogous to a password change form saying \"enter a password\" when the two passwords don't match).

**Before:**
- Empty field → _\"Enter the resource name to confirm the deletion\"_
- Wrong value → _\"Enter the resource name to confirm the deletion\"_ ← same, confusing

**After:**
- Empty field → _\"Enter the resource name to confirm the deletion\"_
- Wrong value → _\"Resource name does not match\"_ ← accurate

## Changes

- `ui/src/app/applications/components/utils.tsx`:
  - Added exported `nameConfirmationError(entered, expected, emptyMessage, mismatchMessage)` helper to separate the two error cases cleanly
  - Applied to all three confirmation dialogs: resource delete, application delete, and sync confirmation
- `ui/src/app/applications/components/utils.test.tsx`:
  - Added 6 unit tests for `nameConfirmationError` covering: match, empty, wrong value, partial value, both-empty, and the application-delete variant

## Test plan

### Unit tests

```
nameConfirmationError
  ✓ returns false when entered value matches expected
  ✓ returns empty message when field is empty
  ✓ returns mismatch message when field has a wrong value
  ✓ returns mismatch message when field has a partial value
  ✓ returns false when both entered and expected are empty strings
  ✓ uses the provided message strings (application delete variant)

Tests: 67 passed, 67 total
```

### Bundle verification

All five message strings confirmed present in the built JS bundle:
- ✅ `Resource name does not match`
- ✅ `Application name does not match`
- ✅ `Enter the resource name to confirm the deletion`
- ✅ `Enter the application name to confirm the deletion`
- ✅ `Enter the application name(s) to confirm syncing`

### Live cluster (k3d + patched ArgoCD v99.99.99)

Manually verified all dialog cases in a live k3d cluster running the patched `argocd-server` binary:

| Dialog | Condition | Expected message | Result |
|--------|-----------|-----------------|--------|
| Application delete | Empty field | \"Enter the application name to confirm the deletion\" | ✅ |
| Application delete | Wrong name typed | \"Application name does not match\" | ✅ |
| Resource delete | Empty field | \"Enter the resource name to confirm the deletion\" | ✅ |
| Resource delete | Wrong name typed | \"Resource name does not match\" | ✅ |

> [!NOTE]
> The sync confirmation dialog name check (`confirmSyncingAppOfApps`) only triggers for App-of-Apps resources with the `Replace=true` sync option selected — a specialized case covered by the unit tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)