### PR TITLE
fix: prevent three-dots menu from clipping offscreen when items load async

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,7 +102,8 @@ WORKDIR /home/argocd
 FROM --platform=$BUILDPLATFORM docker.io/library/node:24.17.0@sha256:032e78d7e54e352129831743737e3a83171d9cc5b5896f411649c597ce0b11ea AS argocd-ui
 
 WORKDIR /src
-COPY ["ui/package.json", "ui/pnpm-lock.yaml", "./"]
+COPY ["ui/package.json", "ui/pnpm-lock.yaml", "ui/pnpm-workspace.yaml", "./"]
+COPY ui/patches/ ./patches/
 
 RUN npm install -g corepack@0.34.6 && corepack enable && pnpm install --frozen-lockfile
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -65,6 +65,9 @@
       "rxjs": "6.6.7",
       "formidable": "2.1.3",
       "dompurify": "3.4.0"
+    },
+    "patchedDependencies": {
+      "argo-ui@1.0.0": "patches/argo-ui@1.0.0.patch"
     }
   },
   "devDependencies": {

--- a/ui/patches/argo-ui@1.0.0.patch
+++ b/ui/patches/argo-ui@1.0.0.patch
@@ -1,0 +1,92 @@
+diff --git a/src/components/dropdown/dropdown.tsx b/src/components/dropdown/dropdown.tsx
+index d99da792155d4f02d30604b4be3bba6e77ebe91d..94466d223d2086f627277f60ab69bad39975f631 100644
+--- a/src/components/dropdown/dropdown.tsx
++++ b/src/components/dropdown/dropdown.tsx
+@@ -26,7 +26,7 @@ export class DropDown extends React.Component<DropDownProps, DropDownState> {
+     private el: HTMLDivElement;
+     private content: HTMLDivElement;
+     private subscriptions: Subscription[];
+-    private isFirstOpen = true;
++    private resizeObserver: ResizeObserver | null = null;
+ 
+     constructor(props: DropDownProps) {
+         super(props);
+@@ -52,7 +52,26 @@ export class DropDown extends React.Component<DropDownProps, DropDownState> {
+                 {ReactDOM.createPortal((
+                     <div className={classNames('argo-dropdown__content', { 'opened': this.state.opened, 'is-menu': this.props.isMenu })}
+                         style={{top: this.state.top, left: this.state.left}}
+-                        ref={(el) => { this.content = el; }}>
++                        ref={(el) => {
++                            this.content = el;
++                            // Re-attach ResizeObserver whenever the content element changes.
++                            if (this.resizeObserver) {
++                                this.resizeObserver.disconnect();
++                                this.resizeObserver = null;
++                            }
++                            if (el && typeof ResizeObserver !== 'undefined') {
++                                this.resizeObserver = new ResizeObserver(() => {
++                                    // Reposition when content grows (e.g. async DataLoader items).
++                                    if (this.state.opened && this.content && this.el) {
++                                        const newState = this.refreshState();
++                                        if (newState.left !== this.state.left || newState.top !== this.state.top) {
++                                            this.setState(newState);
++                                        }
++                                    }
++                                });
++                                this.resizeObserver.observe(el);
++                            }
++                        }}>
+                         {children}
+                     </div>
+                 ), document.body)}
+@@ -81,6 +100,10 @@ export class DropDown extends React.Component<DropDownProps, DropDownState> {
+     public componentWillUnmount() {
+         (this.subscriptions || []).forEach((s) => s.unsubscribe());
+         this.subscriptions = [];
++        if (this.resizeObserver) {
++            this.resizeObserver.disconnect();
++            this.resizeObserver = null;
++        }
+     }
+ 
+     public close() {
+@@ -128,28 +151,11 @@ export class DropDown extends React.Component<DropDownProps, DropDownState> {
+     }
+ 
+     public componentDidUpdate(_prevProps: DropDownProps, prevState: DropDownState) {
+-        // When menu changes from closed to open state
++        // When menu changes from closed to open state, recalculate position once
++        // children have been rendered (offsetHeight was 0 before open).
+         if (!prevState.opened && this.state.opened) {
+-            // Mark as first open
+-            this.isFirstOpen = true;
+-            // Use setTimeout to ensure content has been rendered
+             setTimeout(() => {
+                 if (this.state.opened && this.content && this.el) {
+-                    const newState = this.refreshState();
+-                    // Only update state if calculated position differs from current position
+-                    if (newState.left !== this.state.left || newState.top !== this.state.top) {
+-                        this.setState(newState);
+-                    }
+-                    this.isFirstOpen = false;
+-                }
+-            }, 0);
+-        }
+-        
+-        // If content changes and it's not the first open, recalculate position
+-        if (this.state.opened && !this.isFirstOpen && this.content && this.el) {
+-            // Use setTimeout to ensure calculation happens after DOM updates
+-            setTimeout(() => {
+-                if (this.state.opened) {
+                     const newState = this.refreshState();
+                     if (newState.left !== this.state.left || newState.top !== this.state.top) {
+                         this.setState(newState);
+@@ -157,6 +163,8 @@ export class DropDown extends React.Component<DropDownProps, DropDownState> {
+                 }
+             }, 0);
+         }
++        // Note: subsequent repositioning (e.g. async DataLoader content) is handled
++        // by the ResizeObserver attached to the content element.
+     }
+ 
+     private open() {

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -12,6 +12,11 @@ overrides:
   formidable: 2.1.3
   dompurify: 3.4.0
 
+patchedDependencies:
+  argo-ui@1.0.0:
+    hash: 307387bf6d0730beb4468fe0c54fef28ab73dfc9630877193f6313aed413266f
+    path: patches/argo-ui@1.0.0.patch
+
 importers:
 
   .:
@@ -30,7 +35,7 @@ importers:
         version: 6.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       argo-ui:
         specifier: git+https://github.com/argoproj/argo-ui.git#ad616de862f60d5348fe41ccaa72d7b74f9c3a13
-        version: https://codeload.github.com/argoproj/argo-ui/tar.gz/ad616de862f60d5348fe41ccaa72d7b74f9c3a13(@types/react@19.2.14)(jquery@4.0.0)(react-dom@19.2.6(react@19.2.6))(react-router-dom@5.3.4(react@19.2.6))(react@19.2.6)(what-input@5.2.12)
+        version: https://codeload.github.com/argoproj/argo-ui/tar.gz/ad616de862f60d5348fe41ccaa72d7b74f9c3a13(patch_hash=307387bf6d0730beb4468fe0c54fef28ab73dfc9630877193f6313aed413266f)(@types/react@19.2.14)(jquery@4.0.0)(react-dom@19.2.6(react@19.2.6))(react-router-dom@5.3.4(react@19.2.6))(react@19.2.6)(what-input@5.2.12)
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
@@ -8547,7 +8552,7 @@ snapshots:
 
   arg@4.1.3: {}
 
-  argo-ui@https://codeload.github.com/argoproj/argo-ui/tar.gz/ad616de862f60d5348fe41ccaa72d7b74f9c3a13(@types/react@19.2.14)(jquery@4.0.0)(react-dom@19.2.6(react@19.2.6))(react-router-dom@5.3.4(react@19.2.6))(react@19.2.6)(what-input@5.2.12):
+  argo-ui@https://codeload.github.com/argoproj/argo-ui/tar.gz/ad616de862f60d5348fe41ccaa72d7b74f9c3a13(patch_hash=307387bf6d0730beb4468fe0c54fef28ab73dfc9630877193f6313aed413266f)(@types/react@19.2.14)(jquery@4.0.0)(react-dom@19.2.6(react@19.2.6))(react-router-dom@5.3.4(react@19.2.6))(react@19.2.6)(what-input@5.2.12):
     dependencies:
       '@fortawesome/fontawesome-free': 6.7.2
       '@tippy.js/react': 3.1.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)

--- a/ui/pnpm-workspace.yaml
+++ b/ui/pnpm-workspace.yaml
@@ -1,0 +1,10 @@
+overrides:
+  '@types/react': ^19.0.0
+  '@types/react-dom': ^19.0.0
+  normalize-url: 4.5.1
+  rxjs: 6.6.7
+  formidable: 2.1.3
+  dompurify: 3.4.0
+
+patchedDependencies:
+  argo-ui@1.0.0: patches/argo-ui@1.0.0.patch


### PR DESCRIPTION
## Summary

Fixes #28753

The three-dots (⋮) context menu on resource tree nodes was regularly appearing with items clipped below the bottom of the viewport, making options like **Restart**, **Pause**, or **Scale** invisible or unreachable.

### Root cause

`argo-ui`'s `DropDown` component already has logic to flip the menu above the anchor when the content would overflow the viewport. However, this logic only runs in `componentDidUpdate` — which only fires when the **DropDown's own state changes**.

The resource node menu uses `renderResourceMenu` → `DataLoader` → an RxJS `combineLatest` observable. The observable emits multiple times as async API calls resolve (RBAC check for logs, resource actions like Restart/Pause, exec permission, custom links). Each emission re-renders `DataLoader` and grows the menu, but **`DropDown.componentDidUpdate` is never triggered by child re-renders**, so the menu never gets repositioned after async items arrive.

Timeline (before fix):
1. Menu opens — content height is ~0 (not yet rendered) → positioned below anchor
2. `DataLoader` initial sync items render (~70px) → `setTimeout(0)` recalculates — still fits below
3. Async items load (resource actions, logs, etc.) — menu grows to ~200px
4. **No repositioning happens** — menu extends 130px below viewport, items are invisible

### Fix

Patch `argo-ui@1.0.0` (via pnpm) to attach a `ResizeObserver` to the portal content div. Whenever the content size changes for any reason — including async `DataLoader` emissions — the observer fires `refreshState()`, which flips the menu above the anchor if it would otherwise overflow:

```
if (content.offsetHeight + anchorTop + anchorHeight > window.innerHeight) {
    // flip above
} else {
    // keep below
}
```

The `ResizeObserver` replaces the flawed `isFirstOpen`-gated `componentDidUpdate` second block, which could never observe child-driven size changes.

### Changes

- `ui/patches/argo-ui@1.0.0.patch` — adds `ResizeObserver` to `DropDown`; removes unused `isFirstOpen` tracking and the dead second block in `componentDidUpdate`
- `ui/pnpm-workspace.yaml` — new file; migrates `overrides` and `patchedDependencies` from `package.json`'s deprecated `"pnpm"` field to the pnpm v10 location
- `ui/package.json` — adds `patchedDependencies` entry (for pnpm < 10 compatibility, pnpm v10 reads from `pnpm-workspace.yaml`)
- `ui/pnpm-lock.yaml` — records patch hash for reproducible installs

## Test plan

- [ ] `pnpm run lint` — 0 errors ✅
- [ ] `pnpm run test` — 269/269 pass ✅
- [ ] `pnpm run build` — webpack compiles with 0 errors ✅
- [ ] `pnpm install` (fresh) re-applies patch automatically via `pnpm-workspace.yaml`

### Manual verification

Open the resource tree for any application with a Deployment. Click the ⋮ button on a node near the bottom of the viewport. Before the fix, async items (Restart, Scale, Pause) were clipped offscreen. After the fix, the `ResizeObserver` fires as each batch of async items loads and repositions the menu above the anchor when needed — all items are visible without scrolling.

> [!NOTE]
> `ResizeObserver` is supported in all modern browsers (Chrome 64+, Firefox 69+, Safari 13.1+, Edge 79+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)