### PR TITLE
fix(sync): add state information for sync operation

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -1483,6 +1483,9 @@ func (ctrl *ApplicationController) processRequestedAppOperation(app *appv1.Appli
 	ctx, span := tracer.Start(ctx, "controller.Operation")
 	setAppTraceAttrs(span, app)
 	var state *appv1.OperationState
+	// requeuedForRetry marks the retry-backoff early return, where no sync work is
+	// performed this cycle and the app is only rescheduled for a future retry.
+	requeuedForRetry := false
 	// Registered first so it runs last: after the panic-recovery and timing defers below have
 	// finalized state. The operation reports failure via state.Phase (not a return value), so map
 	// a terminal failed phase onto the span status; panics are handled by the recovery defer.
@@ -1513,7 +1516,29 @@ func (ctrl *ApplicationController) processRequestedAppOperation(app *appv1.Appli
 			logCtx = logCtx.WithField(k, v.Milliseconds())
 		}
 		logCtx = logCtx.WithField("time_ms", time.Since(ts.StartTime).Milliseconds())
-		logCtx.Debug("Finished processing requested app operation")
+		if state != nil {
+			logCtx = logCtx.WithField("phase", state.Phase)
+			logCtx = logCtx.WithField("retryCount", state.RetryCount)
+			logCtx = logCtx.WithField("startedAt", state.StartedAt.Unix())
+			if state.FinishedAt != nil {
+				logCtx = logCtx.WithField("finishedAt", state.FinishedAt.Unix())
+			}
+			// Always publish `revisions` as an array so the field type is stable.
+			revisions := []string{}
+			if state.SyncResult != nil {
+				if len(state.SyncResult.Revisions) > 0 {
+					revisions = state.SyncResult.Revisions
+				} else if state.SyncResult.Revision != "" {
+					revisions = []string{state.SyncResult.Revision}
+				}
+			}
+			logCtx = logCtx.WithField("revisions", revisions)
+		}
+		if requeuedForRetry {
+			logCtx.Debug("Finished processing requested app operation")
+		} else {
+			logCtx.Info("Finished processing requested app operation")
+		}
 	}()
 
 	requeueAfter := appOperationMaxRequeueInterval
@@ -1554,6 +1579,7 @@ func (ctrl *ApplicationController) processRequestedAppOperation(app *appv1.Appli
 			if retryAfter > 0 {
 				logCtx.Infof("Skipping retrying in-progress operation. Attempting again at: %s", retryAt.Format(time.RFC3339))
 				requeueAfter = retryAfter
+				requeuedForRetry = true
 				return
 			}
 
@@ -1633,7 +1659,7 @@ func (ctrl *ApplicationController) processRequestedAppOperation(app *appv1.Appli
 	}
 
 	ctrl.setOperationState(ctx, app, state)
-	ts.AddCheckpoint("final_set_operation_state")
+	ts.AddCheckpoint("final_set_operation_state_ms")
 	if state.Phase.Completed() && (app.Operation.Sync != nil && !app.Operation.Sync.DryRun) {
 		// if we just completed an operation, force a refresh so that UI will report up-to-date
 		// sync/health information


### PR DESCRIPTION
## Summary

Promote the per-operation timing log in `processRequestedAppOperation` (application controller) from `debug` to `info` and enrich it so sync performance can be tracked from logs.

The `Finished processing requested app operation` line now includes:
- `phase` — operation phase (`Succeeded`/`Failed`/`Error`/`Running`/`Terminating`)
- `startedAt` / `finishedAt` — Unix epoch seconds (`finishedAt` only on terminal cycles)
- `retryCount` — number of retries for the operation
- `revisions` — resolved revisions, always emitted as an array (single-source is wrapped in a 1-element array)
- existing per-phase timings, now consistently `_ms`-suffixed (`final_set_operation_state` → `final_set_operation_state_ms`)

## Behavior

- Logged at `info` by default (syncs are infrequent).
- Logged at `debug` only when the cycle is a retry-backoff skip (rescheduled for a future retry without performing sync work), to avoid noise, keeps current behaviour.=

## Why

Enables dashboards/queries for: sync failures per application, stuck in-progress syncs, total sync duration (`finishedAt - startedAt`), and time per sync phase.