### PR TITLE
fix: flush bufio.Writer in tar extraction and close file handle in helm chart untar

### DIFF
--- a/util/helm/client.go
+++ b/util/helm/client.go
@@ -185,6 +185,7 @@ func untarChart(ctx context.Context, tempDir string, cachedChartPath string, man
 	if err != nil {
 		return fmt.Errorf("error opening cached chart path %s: %w", cachedChartPath, err)
 	}
+	defer reader.Close()
 	return files.Untgz(tempDir, reader, manifestMaxExtractedSize, false)
 }
 

--- a/util/io/files/tar.go
+++ b/util/io/files/tar.go
@@ -178,6 +178,10 @@ func untar(dstPath string, r io.Reader, preserveFileMode bool) error {
 				f.Close()
 				return fmt.Errorf("error writing tgz file: %w", err)
 			}
+			if err := w.Flush(); err != nil {
+				f.Close()
+				return fmt.Errorf("error flushing tgz file: %w", err)
+			}
 			f.Close()
 		}
 	}


### PR DESCRIPTION
## Summary

Two resource handling fixes:

### 1. Missing `bufio.Writer.Flush()` in tar extraction (`util/io/files/tar.go:176`)

When extracting tgz archives, a `bufio.Writer` wraps the output file but is never flushed before `f.Close()`. Any data remaining in the buffer is silently lost. This can cause truncated or corrupted files after extraction.

Added `w.Flush()` call before closing the file, returning the error if the flush fails.

### 2. Unclosed file handle in helm chart untar (`util/helm/client.go:184`)

In `untarChart()`, `os.Open(cachedChartPath)` opens a reader that is passed to `files.Untgz()` but never closed. This leaks a file descriptor on every chart extraction. Added `defer reader.Close()` after the error check.