### PR TITLE
fix: prevent goroutine leak in session state and panic on malformed auth header

### DIFF
--- a/util/helm/creds.go
+++ b/util/helm/creds.go
@@ -278,7 +278,10 @@ func (creds AzureWorkloadIdentityCreds) challengeAzureContainerRegistry(ctx cont
 	tokenParams := make(map[string]string)
 
 	for token := range strings.SplitSeq(tokens[1], ",") {
-		kvPair := strings.Split(token, "=")
+		kvPair := strings.SplitN(strings.TrimSpace(token), "=", 2)
+		if len(kvPair) != 2 {
+			continue
+		}
 		tokenParams[kvPair[0]] = strings.Trim(kvPair[1], "\"")
 	}
 

--- a/util/session/state.go
+++ b/util/session/state.go
@@ -45,13 +45,15 @@ func (storage *userStateStorage) Init(ctx context.Context) {
 	ticker := time.NewTicker(storage.resyncDuration)
 	go func() {
 		storage.loadRevokedTokensSafe()
-		for range ticker.C {
-			storage.loadRevokedTokensSafe()
+		for {
+			select {
+			case <-ctx.Done():
+				ticker.Stop()
+				return
+			case <-ticker.C:
+				storage.loadRevokedTokensSafe()
+			}
 		}
-	}()
-	go func() {
-		<-ctx.Done()
-		ticker.Stop()
 	}()
 }
 


### PR DESCRIPTION
## Summary

Two fixes:

### 1. Goroutine leak in session state initialization (`util/session/state.go:43`)

The `Init` method spawned two goroutines: one running `for range ticker.C` (the resync loop), and a second that waited for `ctx.Done()` to call `ticker.Stop()`. The resync goroutine had no context awareness and would run forever even after shutdown, leaking the goroutine and keeping the Redis connection alive.

**Fix**: Combined the ticker loop and context cancellation into a single goroutine using `select`, so the goroutine exits cleanly when `ctx` is done. Removed the separate cleanup goroutine.

### 2. Panic on malformed auth header (`util/helm/creds.go:281`)

When parsing the `Www-Authenticate` header from an Azure container registry, the code split each comma-separated token on `=` using `strings.Split`. If a token has no `=` character, `Split` returns a single element, and accessing `kvPair[1]` panics with an index out of range.

**Fix**: Changed to `strings.SplitN(token, "=", 2)` with a length check to safely skip malformed tokens.