### PR TITLE
fix(ui): update cluster count logic in ApplicationsSummary

### DIFF
--- a/ui/src/app/applications/components/applications-list/applications-summary.test.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-summary.test.tsx
@@ -1,0 +1,51 @@
+import {act, render, screen, waitFor} from '@testing-library/react';
+import * as React from 'react';
+
+import {ClusterCtx} from '../../../shared/components';
+import * as models from '../../../shared/models';
+import {ApplicationsSummary} from './applications-summary';
+
+jest.mock('react-svg-piechart', () => ({default: () => null}));
+jest.mock('../utils', () => ({
+    ComparisonStatusIcon: () => null,
+    HealthStatusIcon: () => null,
+    HydrateOperationPhaseIcon: () => null
+}));
+
+const application = (destination: models.ApplicationDestination) =>
+    ({
+        spec: {destination},
+        status: {sync: {status: 'Synced'}, health: {status: 'Healthy'}}
+    }) as models.Application;
+
+const renderSummary = (clusters: Promise<models.Cluster[]>, applications: models.Application[]) =>
+    render(
+        <ClusterCtx.Provider value={clusters}>
+            <ApplicationsSummary applications={applications} />
+        </ClusterCtx.Provider>
+    );
+
+const expectClusterCount = (count: number) => expect(screen.getByText('CLUSTERS').parentElement).toHaveTextContent(count.toString());
+
+test('counts cluster aliases once and preserves destinations missing from the cluster list', async () => {
+    const cluster = {name: 'prod', server: 'https://prod.example'} as models.Cluster;
+    renderSummary(Promise.resolve([cluster]), [
+        application({name: cluster.name}),
+        application({server: cluster.server}),
+        application({server: 'https://hidden-a.example'}),
+        application({server: 'https://hidden-b.example'})
+    ]);
+
+    await waitFor(() => expectClusterCount(3));
+});
+
+test('falls back to application destinations when loading clusters fails', async () => {
+    const clusters = Promise.reject(new Error('failed to load clusters'));
+    renderSummary(clusters, [application({server: 'https://cluster-a.example'}), application({server: 'https://cluster-b.example'})]);
+
+    await act(async () => {
+        await clusters.catch(() => undefined);
+    });
+
+    expectClusterCount(2);
+});

--- a/ui/src/app/applications/components/applications-list/applications-summary.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-summary.tsx
@@ -1,7 +1,8 @@
+import {useData} from 'argo-ui/v2';
 import * as React from 'react';
 const PieChart = require('react-svg-piechart').default;
 
-import {COLORS} from '../../../shared/components';
+import {ClusterCtx, COLORS} from '../../../shared/components';
 import * as models from '../../../shared/models';
 import {HealthStatusCode, SyncStatusCode} from '../../../shared/models';
 import {ComparisonStatusIcon, HealthStatusIcon, HydrateOperationPhaseIcon} from '../utils';
@@ -36,12 +37,34 @@ export const ApplicationsSummary = ({applications}: {applications: models.Applic
         hydrator.set(phase, (hydrator.get(phase) || 0) + 1);
     });
 
+    const clusterP = React.useContext(ClusterCtx);
+    const [clusters = []] = useData(() => clusterP);
+    const clusterMap = new Map(
+        clusters
+            .map(
+                c =>
+                    [
+                        [c.name, c],
+                        [c.server, c]
+                    ] as const
+            )
+            .flat()
+    );
+
     const attributes = [
         {title: 'APPLICATIONS', value: applications.length},
         {title: 'SYNCED', value: applications.filter(app => app.status.sync.status === 'Synced').length},
         {title: 'HEALTHY', value: applications.filter(app => app.status.health.status === 'Healthy').length},
         {title: 'HYDRATED', value: applications.filter(app => app.status.sourceHydrator?.currentOperation?.phase === 'Hydrated').length},
-        {title: 'CLUSTERS', value: new Set(applications.map(app => app.spec.destination.server || app.spec.destination.name)).size},
+        {
+            title: 'CLUSTERS',
+            value: new Set(
+                applications.map(app => {
+                    const destination = app.spec.destination.server || app.spec.destination.name;
+                    return clusterMap.get(destination) || destination;
+                })
+            ).size
+        },
         {title: 'NAMESPACES', value: new Set(applications.map(app => app.spec.destination.namespace)).size}
     ];
 


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Applications can reference the same cluster by name or API server URL, causing the summary to count one physical cluster multiple times.

Resolve cluster names and server URLs to the same cluster before counting, while falling back to the original destination identifier when cluster data is unavailable.

  Fixes #28745

  Checklist:

- [x] Either (a) I've created an enhancement proposal and discussed it with the community, (b) this is a bug
    fix, or (c) this does not need to be in the release notes.
- [x] The title of the PR states what changed and the related issue number.
- [x] The title of the PR conforms to the project title requirements.
- [x] I've included "Fixes #28745" in the description.
- [x] CLI changes are not applicable because this is a UI-only bug fix.
- [x] This PR does not require documentation updates.
- [x] Documentation updates are not applicable.
- [x] I have signed off all commits as required by DCO.
- [x] I have written unit tests for the change.
- [ ] All required repository build and test checks are green.
- [x] Feature-status requirements are not applicable to this bug fix.
- [x] I have added a description of why this PR is necessary.
- [ ] Updating USERS.md is not applicable.
- [ ] This affects v3.4; cherry-picking is left to the maintainers.
<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
