### PR TITLE
fix: only do annotation backfill if live unset

### DIFF
--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -2447,6 +2447,91 @@ func TestSwitchTrackingMethod(t *testing.T) {
 		Expect(HealthIs(health.HealthStatusHealthy))
 }
 
+// TestTrackingMethodAnnotationMovedResource verifies that a resource previously
+// tracked by another application surfaces as OutOfSync and that syncing updates
+// its tracking annotation. The manifest deliberately carries a chart-rendered
+// app.kubernetes.io/instance label, which used to hide the stale tracking
+// annotation from the diff (issue #17965).
+func TestTrackingMethodAnnotationMovedResource(t *testing.T) {
+	ctx := Given(t)
+
+	ctx.
+		SetTrackingMethod(string(TrackingMethodAnnotation)).
+		Path("tracking-instance-label").
+		When().
+		CreateApp().
+		Sync().
+		Refresh(RefreshTypeNormal).
+		Then().
+		Expect(OperationPhaseIs(OperationSucceeded)).
+		Expect(SyncStatusIs(SyncStatusCodeSynced)).
+		When().
+		And(func() {
+			// Rewrite the tracking annotation to the value a previous application
+			// (e.g. one replaced by an ApplicationSet-generated app) left behind.
+			patch := fmt.Sprintf(`{"metadata":{"annotations":{%q:%q}}}`,
+				common.AnnotationKeyAppInstance,
+				fmt.Sprintf("old-app:/ConfigMap:%s/my-map", ctx.DeploymentNamespace()))
+			errors.NewHandler(t).FailOnErr(fixture.KubeClientset.CoreV1().ConfigMaps(ctx.DeploymentNamespace()).Patch(
+				t.Context(), "my-map", types.MergePatchType, []byte(patch), metav1.PatchOptions{}))
+		}).
+		Refresh(RefreshTypeNormal).
+		Then().
+		// The stale tracking annotation is a real difference and must show up.
+		Expect(SyncStatusIs(SyncStatusCodeOutOfSync)).
+		When().
+		Sync().
+		Then().
+		Expect(OperationPhaseIs(OperationSucceeded)).
+		Expect(SyncStatusIs(SyncStatusCodeSynced)).
+		And(func(app *Application) {
+			// Syncing must repair the tracking annotation.
+			cm, err := fixture.KubeClientset.CoreV1().ConfigMaps(ctx.DeploymentNamespace()).Get(t.Context(), "my-map", metav1.GetOptions{})
+			require.NoError(t, err)
+			assert.Equal(t, fmt.Sprintf("%s:/ConfigMap:%s/my-map", app.Name, ctx.DeploymentNamespace()), cm.Annotations[common.AnnotationKeyAppInstance])
+			// The chart-rendered instance label is not owned by tracking and stays.
+			assert.Equal(t, "my-release", cm.Labels["app.kubernetes.io/instance"])
+		})
+}
+
+// TestTrackingMethodAnnotationMovedResourceSSA is the server-side apply variant
+// of TestTrackingMethodAnnotationMovedResource.
+func TestTrackingMethodAnnotationMovedResourceSSA(t *testing.T) {
+	ctx := Given(t)
+
+	ctx.
+		SetTrackingMethod(string(TrackingMethodAnnotation)).
+		Path("tracking-instance-label").
+		When().
+		CreateApp("--sync-option", "ServerSideApply=true").
+		Sync().
+		Refresh(RefreshTypeNormal).
+		Then().
+		Expect(OperationPhaseIs(OperationSucceeded)).
+		Expect(SyncStatusIs(SyncStatusCodeSynced)).
+		When().
+		And(func() {
+			patch := fmt.Sprintf(`{"metadata":{"annotations":{%q:%q}}}`,
+				common.AnnotationKeyAppInstance,
+				fmt.Sprintf("old-app:/ConfigMap:%s/my-map", ctx.DeploymentNamespace()))
+			errors.NewHandler(t).FailOnErr(fixture.KubeClientset.CoreV1().ConfigMaps(ctx.DeploymentNamespace()).Patch(
+				t.Context(), "my-map", types.MergePatchType, []byte(patch), metav1.PatchOptions{}))
+		}).
+		Refresh(RefreshTypeNormal).
+		Then().
+		Expect(SyncStatusIs(SyncStatusCodeOutOfSync)).
+		When().
+		Sync().
+		Then().
+		Expect(OperationPhaseIs(OperationSucceeded)).
+		Expect(SyncStatusIs(SyncStatusCodeSynced)).
+		And(func(app *Application) {
+			cm, err := fixture.KubeClientset.CoreV1().ConfigMaps(ctx.DeploymentNamespace()).Get(t.Context(), "my-map", metav1.GetOptions{})
+			require.NoError(t, err)
+			assert.Equal(t, fmt.Sprintf("%s:/ConfigMap:%s/my-map", app.Name, ctx.DeploymentNamespace()), cm.Annotations[common.AnnotationKeyAppInstance])
+		})
+}
+
 func TestSwitchTrackingLabel(t *testing.T) {
 	ctx := Given(t)
 

--- a/test/e2e/testdata/tracking-instance-label/config-map.yaml
+++ b/test/e2e/testdata/tracking-instance-label/config-map.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-map
+  labels:
+    # Charts commonly render the instance label themselves (e.g. Helm's
+    # standard app.kubernetes.io/instance label set to the release name).
+    app.kubernetes.io/instance: my-release
+data:
+  foo: bar

--- a/util/argo/resource_tracking.go
+++ b/util/argo/resource_tracking.go
@@ -281,13 +281,31 @@ func (rt *resourceTracking) Normalize(config, live *unstructured.Unstructured, l
 		return nil
 	}
 
-	annotation, err := kube.GetAppInstanceAnnotation(config, common.AnnotationKeyAppInstance)
+	liveAnnotation, err := kube.GetAppInstanceAnnotation(live, common.AnnotationKeyAppInstance)
 	if err != nil {
 		return err
 	}
-	err = kube.SetAppInstanceAnnotation(live, common.AnnotationKeyAppInstance, annotation)
-	if err != nil {
-		return err
+	if liveAnnotation == "" {
+		// The live resource carries the instance label but no tracking annotation,
+		// which happens when it was last synced under label-based tracking.
+		// Backfill the desired annotation so that migrating to annotation-based
+		// tracking does not mark every resource OutOfSync.
+		//
+		// Note that the label is not necessarily owned by Argo CD: charts commonly
+		// render app.kubernetes.io/instance themselves (e.g. Helm's standard
+		// instance label). That is why the backfill must only happen when the
+		// tracking annotation is absent: if the live resource already has one,
+		// leave it untouched — a mismatch (e.g. the resource moved to another
+		// application) is a real difference that must surface in the diff so a
+		// sync can repair it (see issue #17965).
+		annotation, err := kube.GetAppInstanceAnnotation(config, common.AnnotationKeyAppInstance)
+		if err != nil {
+			return err
+		}
+		err = kube.SetAppInstanceAnnotation(live, common.AnnotationKeyAppInstance, annotation)
+		if err != nil {
+			return err
+		}
 	}
 
 	label, err = kube.GetAppInstanceLabel(config, labelKey)

--- a/util/argo/resource_tracking_test.go
+++ b/util/argo/resource_tracking_test.go
@@ -445,6 +445,103 @@ func TestResourceIdNormalizer_Normalize_ConfigHasOldLabel(t *testing.T) {
 	assert.True(t, hasOldLabel)
 }
 
+// movedResource returns a ConfigMap as used in the moved-between-apps scenario
+// of issue #17965.
+func movedResource() *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]any{
+			"name":      "my-cm",
+			"namespace": "default",
+		},
+	}}
+}
+
+func TestResourceIdNormalizer_Normalize_ResourceMovedToAnotherApp(t *testing.T) {
+	t.Parallel()
+	rt := NewResourceTracking()
+
+	// live object is tracked by app-a with annotation+label tracking
+	liveObj := movedResource()
+	err := rt.SetAppInstance(liveObj, common.LabelKeyAppInstance, "app-a", "", v1alpha1.TrackingMethodAnnotationAndLabel, "")
+	require.NoError(t, err)
+
+	// config object is the same resource, now managed by app-b
+	configObj := movedResource()
+	err = rt.SetAppInstance(configObj, common.LabelKeyAppInstance, "app-b", "", v1alpha1.TrackingMethodAnnotationAndLabel, "")
+	require.NoError(t, err)
+
+	err = rt.Normalize(configObj, liveObj, common.LabelKeyAppInstance, string(v1alpha1.TrackingMethodAnnotationAndLabel))
+	require.NoError(t, err)
+
+	// the stale tracking annotation on the live object must be preserved so that
+	// the diff surfaces and a sync can update it (issue #17965)
+	assert.Equal(t, "app-a:/ConfigMap:default/my-cm", liveObj.GetAnnotations()[common.AnnotationKeyAppInstance])
+	assert.Equal(t, "app-b:/ConfigMap:default/my-cm", configObj.GetAnnotations()[common.AnnotationKeyAppInstance])
+}
+
+func TestResourceIdNormalizer_Normalize_ResourceMovedToAnotherApp_AnnotationTracking(t *testing.T) {
+	t.Parallel()
+	rt := NewResourceTracking()
+
+	// live object was previously synced with annotation+label tracking by app-a,
+	// so it still carries the instance label
+	liveObj := movedResource()
+	err := rt.SetAppInstance(liveObj, common.LabelKeyAppInstance, "app-a", "", v1alpha1.TrackingMethodAnnotationAndLabel, "")
+	require.NoError(t, err)
+
+	// config object is the same resource, now managed by app-b with annotation tracking
+	configObj := movedResource()
+	err = rt.SetAppInstance(configObj, common.LabelKeyAppInstance, "app-b", "", v1alpha1.TrackingMethodAnnotation, "")
+	require.NoError(t, err)
+
+	err = rt.Normalize(configObj, liveObj, common.LabelKeyAppInstance, string(v1alpha1.TrackingMethodAnnotation))
+	require.NoError(t, err)
+
+	// the stale tracking annotation must be preserved so the diff surfaces (issue #17965),
+	// while the stale label is still dropped to smooth the label->annotation migration
+	assert.Equal(t, "app-a:/ConfigMap:default/my-cm", liveObj.GetAnnotations()[common.AnnotationKeyAppInstance])
+	_, hasOldLabel := liveObj.GetLabels()[common.LabelKeyAppInstance]
+	assert.False(t, hasOldLabel)
+}
+
+func TestResourceIdNormalizer_Normalize_ResourceMovedToAnotherApp_HelmInstanceLabel(t *testing.T) {
+	t.Parallel()
+	rt := NewResourceTracking()
+
+	// Both apps use annotation-only tracking, but the manifest itself bakes in
+	// the app.kubernetes.io/instance label (as Helm charts commonly do). The
+	// label alone must not cause the stale tracking annotation to be hidden.
+	withHelmLabel := func(un *unstructured.Unstructured) *unstructured.Unstructured {
+		labels := un.GetLabels()
+		if labels == nil {
+			labels = map[string]string{}
+		}
+		labels[common.LabelKeyAppInstance] = "my-release"
+		un.SetLabels(labels)
+		return un
+	}
+
+	// live object is tracked by the old standalone app
+	liveObj := withHelmLabel(movedResource())
+	err := rt.SetAppInstance(liveObj, common.LabelKeyAppInstance, "standalone-app", "", v1alpha1.TrackingMethodAnnotation, "")
+	require.NoError(t, err)
+
+	// config object is the same resource, now rendered for the appset-generated app
+	configObj := withHelmLabel(movedResource())
+	err = rt.SetAppInstance(configObj, common.LabelKeyAppInstance, "appset-app", "", v1alpha1.TrackingMethodAnnotation, "")
+	require.NoError(t, err)
+
+	err = rt.Normalize(configObj, liveObj, common.LabelKeyAppInstance, string(v1alpha1.TrackingMethodAnnotation))
+	require.NoError(t, err)
+
+	// the stale tracking annotation must be preserved so the diff surfaces (issue #17965)
+	assert.Equal(t, "standalone-app:/ConfigMap:default/my-cm", liveObj.GetAnnotations()[common.AnnotationKeyAppInstance])
+	// the manifest-defined helm instance label is untouched
+	assert.Equal(t, "my-release", liveObj.GetLabels()[common.LabelKeyAppInstance])
+}
+
 func TestIsOldTrackingMethod(t *testing.T) {
 	t.Parallel()
 	assert.True(t, IsOldTrackingMethod(string(v1alpha1.TrackingMethodLabel)))


### PR DESCRIPTION
In the resource tracking normalization logic, there is conversion logic when migrating from label tracking to annotation tracking. All good, but this happens when there is _any_ `app.kubernetes.io/instance` label set (as is typically the case with e.g. Helm charts).

This has an impact when migrating resources between a new and an old app, since the stale tracking-id never appears in the diff, the app remains Synced and the annotation will never change, which leads to ~suffering~ `SharedResourceWarning`s that don't go away without either manually editing `tracking-id`, or doing a full manual sync without `ApplyOutOfSyncOnly` (although there might not be anything obvious that needs syncing)

So let's only perform the label migration logic when the live tracking-id annotation is unset. Fixes #17965.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
