### PR TITLE
fix(ci): expand image tag in staging deploy commit message

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -171,7 +171,7 @@ jobs:
           docker run -u $(id -u):$(id -g) -v $(pwd):/src -w /src --rm -t ghcr.io/argoproj/argo-cd/argocd:${NEEDS_SET_VARS_OUTPUTS_IMAGE_TAG} kustomize edit set image quay.io/argoproj/argocd=ghcr.io/argoproj/argo-cd/argocd:${NEEDS_SET_VARS_OUTPUTS_IMAGE_TAG}
           git config --global user.email 'ci@argoproj.com'
           git config --global user.name 'CI'
-          git diff --exit-code && echo 'Already deployed' || (git commit -am 'Upgrade argocd to ${NEEDS_SET_VARS_OUTPUTS_IMAGE_TAG}' && git push)
+          git diff --exit-code && echo 'Already deployed' || (git commit -am "Upgrade argocd to ${NEEDS_SET_VARS_OUTPUTS_IMAGE_TAG}" && git push)
         working-directory: argoproj-deployments/argocd
         env:
           NEEDS_SET_VARS_OUTPUTS_IMAGE_TAG: ${{ needs.set-vars.outputs.image-tag }}


### PR DESCRIPTION
Single quotes prevented shell expansion of NEEDS_SET_VARS_OUTPUTS_IMAGE_TAG after #27304 moved it from a GitHub Actions expression to an env var.

Without this fix, commit messages on the deployment repo look weird: https://github.com/argoproj/argoproj-deployments/commit/9a8fd3a95922f61dcf44449188f67889984b2c5d