### PR TITLE
fix(helm): resolve extracted chart dir from archive contents (#28779)

### DIFF
--- a/util/helm/client.go
+++ b/util/helm/client.go
@@ -302,12 +302,9 @@ func (c *nativeHelmChart) ExtractChart(ctx context.Context, chart string, versio
 		_ = os.RemoveAll(tempDir)
 		return "", nil, fmt.Errorf("error untarring chart: %w", err)
 	}
-	// A well-formed Helm chart archive extracts into a single top-level directory named after
-	// the chart's Chart.yaml `name`. That name is authoritative and is not guaranteed to equal
-	// the last path segment of the chart reference: an OCI chart may be published to a repository
-	// path whose basename differs from the chart name (Helm itself resolves the chart from the
-	// packaged contents, not from the reference path). Locate the extracted directory by reading
-	// it back rather than deriving it from the reference.
+	// The extracted directory is named after the chart's Chart.yaml name, which an OCI chart
+	// may publish under a repository path with a different basename; read it back rather than
+	// deriving the name from the reference.
 	chartDir, err := extractedChartDir(tempDir)
 	if err != nil {
 		_ = os.RemoveAll(tempDir)
@@ -463,11 +460,9 @@ func newTLSConfig(creds Creds) (*tls.Config, error) {
 	return tlsConfig, nil
 }
 
-// extractedChartDir returns the path to the chart directory extracted into dir. A Helm chart
-// archive produced by `helm package` always contains exactly one top-level directory, named
-// after the chart's Chart.yaml `name`. We read that directory back rather than deriving it from
-// the chart reference, because an OCI chart may be published to a repository path whose basename
-// differs from the chart name; Helm resolves the chart from its packaged contents, not the path.
+// extractedChartDir returns the single chart directory extracted into dir. A packaged Helm chart
+// has exactly one top-level directory, named after its Chart.yaml name — which need not match the
+// reference's last path segment (e.g. an OCI chart under a differently-named repository path).
 func extractedChartDir(dir string) (string, error) {
 	infos, err := os.ReadDir(dir)
 	if err != nil {

--- a/util/helm/client.go
+++ b/util/helm/client.go
@@ -302,7 +302,18 @@ func (c *nativeHelmChart) ExtractChart(ctx context.Context, chart string, versio
 		_ = os.RemoveAll(tempDir)
 		return "", nil, fmt.Errorf("error untarring chart: %w", err)
 	}
-	return path.Join(tempDir, normalizeChartName(chart)), utilio.NewCloser(func() error {
+	// A well-formed Helm chart archive extracts into a single top-level directory named after
+	// the chart's Chart.yaml `name`. That name is authoritative and is not guaranteed to equal
+	// the last path segment of the chart reference: an OCI chart may be published to a repository
+	// path whose basename differs from the chart name (Helm itself resolves the chart from the
+	// packaged contents, not from the reference path). Locate the extracted directory by reading
+	// it back rather than deriving it from the reference.
+	chartDir, err := extractedChartDir(tempDir)
+	if err != nil {
+		_ = os.RemoveAll(tempDir)
+		return "", nil, err
+	}
+	return chartDir, utilio.NewCloser(func() error {
 		return os.RemoveAll(tempDir)
 	}), nil
 }
@@ -452,16 +463,20 @@ func newTLSConfig(creds Creds) (*tls.Config, error) {
 	return tlsConfig, nil
 }
 
-// Normalize a chart name for file system use, that is, if chart name is foo/bar/baz, returns the last component as chart name.
-func normalizeChartName(chart string) string {
-	strings.Join(strings.Split(chart, "/"), "_")
-	_, nc := path.Split(chart)
-	// We do not want to return the empty string or something else related to filesystem access
-	// Instead, return original string
-	if nc == "" || nc == "." || nc == ".." {
-		return chart
+// extractedChartDir returns the path to the chart directory extracted into dir. A Helm chart
+// archive produced by `helm package` always contains exactly one top-level directory, named
+// after the chart's Chart.yaml `name`. We read that directory back rather than deriving it from
+// the chart reference, because an OCI chart may be published to a repository path whose basename
+// differs from the chart name; Helm resolves the chart from its packaged contents, not the path.
+func extractedChartDir(dir string) (string, error) {
+	infos, err := os.ReadDir(dir)
+	if err != nil {
+		return "", fmt.Errorf("error reading extracted chart directory %s: %w", dir, err)
 	}
-	return nc
+	if len(infos) != 1 || !infos[0].IsDir() {
+		return "", fmt.Errorf("expected a single chart directory after extraction, found %d entries in %s", len(infos), dir)
+	}
+	return filepath.Join(dir, infos[0].Name()), nil
 }
 
 func (c *nativeHelmChart) getCachedChartPath(chart string, version string) (string, error) {

--- a/util/helm/client_test.go
+++ b/util/helm/client_test.go
@@ -145,6 +145,45 @@ func Test_extractedChartDir(t *testing.T) {
 	})
 }
 
+// legacyNormalizeChartName reproduces the chart-directory derivation ExtractChart
+// used before this change (the removed normalizeChartName): the reference's last
+// path segment, falling back to the whole reference for a degenerate segment.
+func legacyNormalizeChartName(chart string) string {
+	nc := chart
+	if i := strings.LastIndex(chart, "/"); i >= 0 {
+		nc = chart[i+1:]
+	}
+	if nc == "" || nc == "." || nc == ".." {
+		return chart
+	}
+	return nc
+}
+
+// Test_extractedChartDir_matchesLegacyDerivationForExistingCharts is a regression
+// guard: any chart reference that resolved before this change extracted into a
+// directory named legacyNormalizeChartName(chart) — otherwise ExtractChart could not
+// have located Chart.yaml under path.Join(tempDir, normalizeChartName(chart)). So for
+// every previously working reference the archive-driven lookup must return that exact
+// same path; only references whose extracted directory differed (the bug) change from
+// failing to succeeding.
+func Test_extractedChartDir_matchesLegacyDerivationForExistingCharts(t *testing.T) {
+	for _, chartRef := range []string{
+		"grafana",
+		"myrepo/grafana",
+		"registry.example.com/team/charts/grafana",
+	} {
+		t.Run(chartRef, func(t *testing.T) {
+			legacyName := legacyNormalizeChartName(chartRef)
+			tempDir := t.TempDir()
+			require.NoError(t, os.Mkdir(filepath.Join(tempDir, legacyName), 0o755))
+
+			dir, err := extractedChartDir(tempDir)
+			require.NoError(t, err)
+			assert.Equal(t, filepath.Join(tempDir, legacyName), dir)
+		})
+	}
+}
+
 func TestIsHelmOciRepo(t *testing.T) {
 	assert.True(t, IsHelmOciRepo("demo.goharbor.io"))
 	assert.True(t, IsHelmOciRepo("demo.goharbor.io:8080"))

--- a/util/helm/client_test.go
+++ b/util/helm/client_test.go
@@ -115,34 +115,33 @@ func Test_nativeHelmChart_ExtractChart_insecure(t *testing.T) {
 	assert.True(t, info.IsDir())
 }
 
-func Test_normalizeChartName(t *testing.T) {
-	t.Run("Test non-slashed name", func(t *testing.T) {
-		n := normalizeChartName("mychart")
-		assert.Equal(t, "mychart", n)
+func Test_extractedChartDir(t *testing.T) {
+	t.Run("returns the extracted directory regardless of its name", func(t *testing.T) {
+		// Simulates an OCI chart whose Chart.yaml name ("foo") differs from the
+		// repository-path basename used as the chart reference ("bar"): the
+		// extracted directory is named after the chart, not the reference.
+		tempDir := t.TempDir()
+		require.NoError(t, os.Mkdir(filepath.Join(tempDir, "foo"), 0o755))
+		dir, err := extractedChartDir(tempDir)
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(tempDir, "foo"), dir)
 	})
-	t.Run("Test single-slashed name", func(t *testing.T) {
-		n := normalizeChartName("myorg/mychart")
-		assert.Equal(t, "mychart", n)
+	t.Run("errors when no directory was extracted", func(t *testing.T) {
+		_, err := extractedChartDir(t.TempDir())
+		require.Error(t, err)
 	})
-	t.Run("Test chart name with suborg", func(t *testing.T) {
-		n := normalizeChartName("myorg/mysuborg/mychart")
-		assert.Equal(t, "mychart", n)
+	t.Run("errors when the top-level entry is a file", func(t *testing.T) {
+		tempDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(tempDir, "Chart.yaml"), []byte("name: x\n"), 0o644))
+		_, err := extractedChartDir(tempDir)
+		require.Error(t, err)
 	})
-	t.Run("Test double-slashed name", func(t *testing.T) {
-		n := normalizeChartName("myorg//mychart")
-		assert.Equal(t, "mychart", n)
-	})
-	t.Run("Test invalid chart name - ends with slash", func(t *testing.T) {
-		n := normalizeChartName("myorg/")
-		assert.Equal(t, "myorg/", n)
-	})
-	t.Run("Test invalid chart name - is dot", func(t *testing.T) {
-		n := normalizeChartName("myorg/.")
-		assert.Equal(t, "myorg/.", n)
-	})
-	t.Run("Test invalid chart name - is two dots", func(t *testing.T) {
-		n := normalizeChartName("myorg/..")
-		assert.Equal(t, "myorg/..", n)
+	t.Run("errors when multiple top-level entries were extracted", func(t *testing.T) {
+		tempDir := t.TempDir()
+		require.NoError(t, os.Mkdir(filepath.Join(tempDir, "a"), 0o755))
+		require.NoError(t, os.Mkdir(filepath.Join(tempDir, "b"), 0o755))
+		_, err := extractedChartDir(tempDir)
+		require.Error(t, err)
 	})
 }
 


### PR DESCRIPTION
Argo CD's Helm client derived the extracted chart directory from the last path segment of the chart reference (`normalizeChartName`). When an OCI chart is published to a repository path whose basename differs from the chart's `Chart.yaml` `name` — e.g. a chart named `foo` pushed to `.../charts/bar` — the derived path does not exist and `ExtractChart` fails with `Chart.yaml: no such file or directory`.

`helm pull` / `helm install` resolve the chart from its packaged contents rather than from the reference path, so these charts install fine outside Argo CD. This reads the single extracted top-level directory back instead of deriving it from the reference, aligning Argo CD with Helm's own behavior. HTTP charts are unaffected (their reference basename already equals the chart name).

Fixes #28779

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. — N/A (internal repo-server extraction logic; no CLI/UI surface)
* [x] Does this PR require documentation updates? — No.
* [x] I've updated documentation as required by this PR. — N/A.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged. — `Test_extractedChartDir` added; existing `ExtractChart` tests unchanged and passing.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into: **`release-3.5`, `release-3.4`** (low risk — the behavior change is confined to reading the extracted directory).

## Why

An OCI chart may be published to a repository path whose basename differs from its `Chart.yaml` `name` (e.g. pushed via `oras` rather than `helm push`). The Helm CLI installs such charts fine, but Argo CD cannot, because it reconstructs the extracted directory name from the reference rather than reading what was actually extracted. See #28779 for a self-contained reproduction.

## What changed

- `ExtractChart` now resolves the chart directory by reading the single top-level directory produced by extraction, rather than `path.Join(tempDir, normalizeChartName(chart))`.
- Removed the now-unused `normalizeChartName` (and its test).
- Added `extractedChartDir` with unit coverage (`Test_extractedChartDir`).
