### PR TITLE
fix: return InvalidArgument for unresolved revision in GetAppDetails

### DIFF
--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -2482,7 +2482,7 @@ func toUserInputStatusError(err error) error {
 	if _, ok := status.FromError(err); ok && status.Code(err) != codes.Unknown {
 		return err
 	}
-	if errors.Is(err, apppathutil.ErrAppPathDoesNotExist) {
+	if errors.Is(err, apppathutil.ErrAppPathDoesNotExist) || errors.Is(err, git.ErrRevisionNotFound) {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
 	return err

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -1791,6 +1791,25 @@ func TestGetAppDetails_NonExistentPath(t *testing.T) {
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
+func TestGetAppDetails_NonExistentRevision(t *testing.T) {
+	service, _, _ := newServiceWithOpt(t, func(gitClient *gitmocks.Client, _ *helmmocks.Client, _ *ocimocks.Client, paths *iomocks.TempPaths) {
+		gitClient.EXPECT().LsRemote("does-not-exist").Return("", fmt.Errorf("unable to resolve 'does-not-exist' to a commit SHA: %w", git.ErrRevisionNotFound))
+		gitClient.EXPECT().Root().Return(".")
+		paths.EXPECT().GetPath(mock.Anything).Return(".", nil)
+	}, ".")
+
+	_, err := service.GetAppDetails(t.Context(), &apiclient.RepoServerAppDetailsQuery{
+		Repo: &v1alpha1.Repository{},
+		Source: &v1alpha1.ApplicationSource{
+			Path:           ".",
+			TargetRevision: "does-not-exist",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
 func TestGetAppDetailsHelm(t *testing.T) {
 	service := newService(t, "../../util/helm/testdata/dependency")
 

--- a/util/git/client.go
+++ b/util/git/client.go
@@ -49,8 +49,9 @@ import (
 )
 
 var (
-	ErrInvalidRepoURL = errors.New("repo URL is invalid")
-	ErrNoNoteFound    = errors.New("no note found")
+	ErrInvalidRepoURL   = errors.New("repo URL is invalid")
+	ErrNoNoteFound      = errors.New("no note found")
+	ErrRevisionNotFound = errors.New("revision not found")
 )
 
 // builtinGitConfig configuration contains statements that are needed
@@ -1000,7 +1001,7 @@ func (m *nativeGitClient) lsRemote(revision string) (string, error) {
 
 	// If we get here, revision string had non hexadecimal characters (indicating its a branch, tag,
 	// or symbolic ref) and we were unable to resolve it to a commit SHA.
-	return "", fmt.Errorf("unable to resolve '%s' to a commit SHA", revision)
+	return "", fmt.Errorf("unable to resolve '%s' to a commit SHA: %w", revision, ErrRevisionNotFound)
 }
 
 // CommitSHA returns current commit sha from `git rev-parse HEAD`

--- a/util/git/git_test.go
+++ b/util/git/git_test.go
@@ -347,8 +347,8 @@ func TestLsRemote(t *testing.T) {
 
 		for _, revision := range xfail {
 			_, err := clnt.LsRemote(revision)
-			assert.ErrorContains(t, err, "unable to resolve")
-			assert.ErrorIs(t, err, ErrRevisionNotFound)
+			require.ErrorContains(t, err, "unable to resolve")
+			require.ErrorIs(t, err, ErrRevisionNotFound)
 		}
 	})
 }

--- a/util/git/git_test.go
+++ b/util/git/git_test.go
@@ -348,6 +348,7 @@ func TestLsRemote(t *testing.T) {
 		for _, revision := range xfail {
 			_, err := clnt.LsRemote(revision)
 			assert.ErrorContains(t, err, "unable to resolve")
+			assert.ErrorIs(t, err, ErrRevisionNotFound)
 		}
 	})
 }


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

`GetAppDetails` returns `codes.Unknown` (HTTP 500) when the requested Git branch or tag cannot be resolved, even though this is a user input error.
This PR adds an `ErrRevisionNotFound` sentinel error and maps it to `codes.InvalidArgument` (HTTP 400) at the repo-server gRPC boundary.

I tested `GetAppDetails` with three cases. A valid revision still returns HTTP 200, and a repository access failure still returns HTTP 500 as before. Only an unresolved revision now returns HTTP 400 (`InvalidArgument`) via `ErrRevisionNotFound`.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
