### PR TITLE
docs: fix nested matrix generator examples (#26751)

### DIFF
--- a/applicationset/examples/matrix/matrix-and-union-in-matrix-fasttemplate.yaml
+++ b/applicationset/examples/matrix/matrix-and-union-in-matrix-fasttemplate.yaml
@@ -1,12 +1,13 @@
-# The matrix generator can contain other combination-type generators (matrix and union). But nested matrix and union
-# generators cannot contain further-nested matrix or union generators.
+# The matrix generator can contain other combination-type generators (matrix and merge). But nested matrix and merge
+# generators cannot contain further-nested matrix or merge generators.
 #
 # The generators are evaluated from most-nested to least-nested. In this case:
-#  1. The union generator joins two lists to make 3 parameter sets.
-#  2. The inner matrix generator takes the cartesian product of the two lists to make 4 parameters sets.
-#  3. The outer matrix generator takes the cartesian product of the 3 union and the 4 inner matrix parameter sets to
-#     make 3*4=12 final parameter sets.
-#  4. The 12 final parameter sets are evaluated against the top-level template to generate 12 Applications.
+#  1. The merge generator merges two lists based on the 'cluster' merge key to make 2 parameter sets
+#     (engineering-dev and engineering-prod).
+#  2. The inner matrix generator takes the cartesian product of the two lists to make 4 parameter sets.
+#  3. The outer matrix generator takes the cartesian product of the 2 merge and the 4 inner matrix parameter sets to
+#     make 2*4=8 final parameter sets.
+#  4. The 8 final parameter sets are evaluated against the top-level template to generate 8 Applications.
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
@@ -15,7 +16,7 @@ spec:
   generators:
     - matrix:
         generators:
-          - union:
+          - merge:
               mergeKeys:
                 - cluster
               generators:
@@ -61,7 +62,7 @@ spec:
       source:
         repoURL: https://github.com/argoproj/argo-cd.git
         targetRevision: HEAD
-        path: '{{path}}'
+        path: 'applicationset/examples/list-generator/guestbook/{{cluster}}'
       destination:
         server: '{{url}}'
-        namespace: '{{path.basename}}'
+        namespace: '{{values.prefix}}-{{cluster}}-{{values.suffix}}'

--- a/applicationset/examples/matrix/matrix-and-union-in-matrix.yaml
+++ b/applicationset/examples/matrix/matrix-and-union-in-matrix.yaml
@@ -1,12 +1,13 @@
-# The matrix generator can contain other combination-type generators (matrix and union). But nested matrix and union
-# generators cannot contain further-nested matrix or union generators.
+# The matrix generator can contain other combination-type generators (matrix and merge). But nested matrix and merge
+# generators cannot contain further-nested matrix or merge generators.
 #
 # The generators are evaluated from most-nested to least-nested. In this case:
-#  1. The union generator joins two lists to make 3 parameter sets.
-#  2. The inner matrix generator takes the cartesian product of the two lists to make 4 parameters sets.
-#  3. The outer matrix generator takes the cartesian product of the 3 union and the 4 inner matrix parameter sets to
-#     make 3*4=12 final parameter sets.
-#  4. The 12 final parameter sets are evaluated against the top-level template to generate 12 Applications.
+#  1. The merge generator merges two lists based on the 'cluster' merge key to make 2 parameter sets
+#     (engineering-dev and engineering-prod).
+#  2. The inner matrix generator takes the cartesian product of the two lists to make 4 parameter sets.
+#  3. The outer matrix generator takes the cartesian product of the 2 merge and the 4 inner matrix parameter sets to
+#     make 2*4=8 final parameter sets.
+#  4. The 8 final parameter sets are evaluated against the top-level template to generate 8 Applications.
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
@@ -17,7 +18,7 @@ spec:
   generators:
     - matrix:
         generators:
-          - union:
+          - merge:
               mergeKeys:
                 - cluster
               generators:
@@ -63,7 +64,7 @@ spec:
       source:
         repoURL: https://github.com/argoproj/argo-cd.git
         targetRevision: HEAD
-        path: '{{.path.path}}'
+        path: 'applicationset/examples/list-generator/guestbook/{{.cluster}}'
       destination:
         server: '{{.url}}'
-        namespace: '{{.path.basename}}'
+        namespace: '{{.values.prefix}}-{{.cluster}}-{{.values.suffix}}'


### PR DESCRIPTION
## Summary

The nested Matrix examples used an unsupported `union` generator and referenced Git-generator `path` parameters that their List generators never produce. That made the examples fail during generator parsing or template rendering.

This change updates both the Go-template and fast-template examples to:

- use the supported Merge generator with `cluster` as the merge key;
- document the actual generation flow: 2 merged sets × 4 inner-Matrix sets = 8 Applications;
- point each Application at an existing guestbook directory derived from `cluster`;
- give every generated Application a matching, unique destination namespace.

The historical filenames and `metadata.name` are retained to avoid breaking existing links and copied resource identities.

Closes #26751.

## Testing

- `make build`
- `make lint` — zero issues
- `make lint-ui` — zero errors (11 pre-existing warnings)
- `make cli`
- `go test ./applicationset/generators ./applicationset/controllers/template`
- Parsed both YAML files and exercised Argo CD's real List/Merge/Matrix generators and template renderer; each variant produced 8 unique Application names, 8 matching unique namespaces, and existing source directories.
- `make codegen` produced no tracked changes before its final `gh aw compile` step; that final step cannot run because the pinned `argocd-test-tools` image does not contain `gh`.
- `make test` ran 8,020 tests. Its only failures were two permission-sensitive tests on the Docker Desktop bind mount (`TestPluginNoExecutePermission` and `TestFilePermission/Test_config_file_with_permission_0300`); both pass when rerun natively:
  - `go test ./cmd/argocd/commands -run '^TestPluginNoExecutePermission$' -count=1`
  - `go test ./util/localconfig -run '^TestFilePermission$' -count=1`

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes. (Bug fix in documentation examples; no release note required.)
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. (N/A: examples-only documentation fix with no CLI or UI surface.)
* [x] Does this PR require documentation updates? (Yes; the affected files are documentation examples.)
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal).
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged. (N/A: no runtime code changed; both manifests were validated through the real generator/render path and existing test suites.)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). (See the Docker Desktop-only test and codegen environment caveats above.)
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines. (N/A: not a new feature.)
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md. (N/A.)
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity). (N/A: documentation example fix for `master`.)

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
