### PR TITLE
fix: update cluster sharding cache before application ownership check 

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -286,13 +286,16 @@ func NewApplicationController(
 						return err
 					}
 					for _, app := range apps {
+						// Update the sharding cache for all apps before determining
+						// which ones this controller should reconcile.
+						ctrl.clusterSharding.AddApp(app)
+
 						if !ctrl.canProcessApp(app) {
 							continue
 						}
 						key, err := cache.MetaNamespaceKeyFunc(app)
 						if err == nil {
 							ctrl.appRefreshQueue.AddRateLimited(key)
-							ctrl.clusterSharding.AddApp(app)
 						}
 					}
 				}
@@ -2726,30 +2729,40 @@ func (ctrl *ApplicationController) appProjectEventHandlerFuncs() cache.ResourceE
 }
 
 // applicationEventHandlerFuncs returns the informer event handlers for Application
-// objects. Events for applications this controller cannot process (per canProcessApp)
-// are ignored. DeleteFunc unwraps cache.DeletedFinalStateUnknown tombstones and
-// immediately enqueues a refresh, while add/update use the rate-limited queues. The
-// cluster sharding cache is updated to reflect the application's lifecycle.
+// objects. The cluster sharding cache is updated for all application events so every
+// controller replica maintains a consistent view of application distribution. Work
+// queue additions are gated by canProcessApp. DeleteFunc unwraps
+// cache.DeletedFinalStateUnknown tombstones and immediately enqueues a refresh,
+// while add/update use the rate-limited queues.
 func (ctrl *ApplicationController) applicationEventHandlerFuncs() cache.ResourceEventHandlerFuncs {
 	return cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj any) {
+			if newApp, newOK := obj.(*appv1.Application); newOK {
+				// Update the sharding cache for all apps, regardless of whether
+				// this controller processes the app. All replicas must track all
+				// apps so the load-based shard distribution stays consistent
+				// across replicas. Only work queue additions are gated by
+				// canProcessApp.
+				ctrl.clusterSharding.AddApp(newApp)
+			}
 			if !ctrl.canProcessApp(obj) {
 				return
 			}
+
 			key, err := cache.MetaNamespaceKeyFunc(obj)
 			if err == nil {
 				ctrl.appRefreshQueue.AddRateLimited(key)
 			}
-			newApp, newOK := obj.(*appv1.Application)
-			if err == nil && newOK {
-				ctrl.clusterSharding.AddApp(newApp)
-			}
 		},
 		UpdateFunc: func(old, new any) {
+			if updatedApp, updatedOK := new.(*appv1.Application); updatedOK {
+				// Update the sharding cache for all apps regardless of shard
+				// assignment. See the comment in AddFunc.
+				ctrl.clusterSharding.UpdateApp(updatedApp)
+			}
 			if !ctrl.canProcessApp(new) {
 				return
 			}
-
 			key, err := cache.MetaNamespaceKeyFunc(new)
 			if err != nil {
 				return
@@ -2775,6 +2788,7 @@ func (ctrl *ApplicationController) applicationEventHandlerFuncs() cache.Resource
 			if ctrl.hydrator != nil && newOK {
 				ctrl.appHydrateQueue.AddRateLimited(newApp.QualifiedName())
 			}
+
 			if newOK && ctrl.shouldProcessOperation(newApp) {
 				ctrl.appOperationQueue.AddRateLimited(key)
 			}
@@ -2785,6 +2799,11 @@ func (ctrl *ApplicationController) applicationEventHandlerFuncs() cache.Resource
 			if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
 				obj = tombstone.Obj
 			}
+			if delApp, delOK := obj.(*appv1.Application); delOK {
+				// Update the sharding cache for all apps regardless of shard
+				// assignment. See the comment in AddFunc.
+				ctrl.clusterSharding.DeleteApp(delApp)
+			}
 			if !ctrl.canProcessApp(obj) {
 				return
 			}
@@ -2794,10 +2813,6 @@ func (ctrl *ApplicationController) applicationEventHandlerFuncs() cache.Resource
 			if err == nil {
 				// for deletes, we immediately add to the refresh queue
 				ctrl.appRefreshQueue.Add(key)
-			}
-			delApp, delOK := obj.(*appv1.Application)
-			if err == nil && delOK {
-				ctrl.clusterSharding.DeleteApp(delApp)
 			}
 		},
 	}

--- a/controller/appcontroller_informer_test.go
+++ b/controller/appcontroller_informer_test.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
+	"github.com/argoproj/argo-cd/v3/controller/sharding"
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v3/test"
 )
@@ -51,9 +52,7 @@ func TestAppProjectEventHandlerFuncs(t *testing.T) {
 		ctrl := newFakeController(t.Context(), &fakeData{}, nil)
 		ctrl.projByNameCache.Store("my-proj", struct{}{})
 		h := ctrl.appProjectEventHandlerFuncs()
-
 		h.OnAdd(newProject("my-proj"), false)
-
 		assert.Contains(t, assertEnqueued(t, ctrl.projectRefreshQueue), "my-proj")
 		_, ok := ctrl.projByNameCache.Load("my-proj")
 		assert.False(t, ok, "project cache entry should have been invalidated")
@@ -63,9 +62,7 @@ func TestAppProjectEventHandlerFuncs(t *testing.T) {
 		ctrl := newFakeController(t.Context(), &fakeData{}, nil)
 		ctrl.projByNameCache.Store("my-proj", struct{}{})
 		h := ctrl.appProjectEventHandlerFuncs()
-
 		h.OnUpdate(newProject("my-proj"), newProject("my-proj"))
-
 		assert.Contains(t, assertEnqueued(t, ctrl.projectRefreshQueue), "my-proj")
 		_, ok := ctrl.projByNameCache.Load("my-proj")
 		assert.False(t, ok)
@@ -75,9 +72,7 @@ func TestAppProjectEventHandlerFuncs(t *testing.T) {
 		ctrl := newFakeController(t.Context(), &fakeData{}, nil)
 		ctrl.projByNameCache.Store("my-proj", struct{}{})
 		h := ctrl.appProjectEventHandlerFuncs()
-
 		h.OnDelete(newProject("my-proj"))
-
 		assert.Contains(t, assertEnqueued(t, ctrl.projectRefreshQueue), "my-proj")
 		_, ok := ctrl.projByNameCache.Load("my-proj")
 		assert.False(t, ok)
@@ -87,9 +82,7 @@ func TestAppProjectEventHandlerFuncs(t *testing.T) {
 		ctrl := newFakeController(t.Context(), &fakeData{}, nil)
 		ctrl.projByNameCache.Store("my-proj", struct{}{})
 		h := ctrl.appProjectEventHandlerFuncs()
-
 		h.OnDelete(cache.DeletedFinalStateUnknown{Key: test.FakeArgoCDNamespace + "/my-proj", Obj: newProject("my-proj")})
-
 		assert.Contains(t, assertEnqueued(t, ctrl.projectRefreshQueue), "my-proj")
 		_, ok := ctrl.projByNameCache.Load("my-proj")
 		assert.False(t, ok)
@@ -99,7 +92,6 @@ func TestAppProjectEventHandlerFuncs(t *testing.T) {
 		ctrl := newFakeController(t.Context(), &fakeData{}, nil)
 		ctrl.projByNameCache.Store("my-proj", struct{}{})
 		h := ctrl.appProjectEventHandlerFuncs()
-
 		assert.NotPanics(t, func() {
 			h.OnDelete(cache.DeletedFinalStateUnknown{Key: test.FakeArgoCDNamespace + "/gone", Obj: nil})
 		})
@@ -111,7 +103,6 @@ func TestAppProjectEventHandlerFuncs(t *testing.T) {
 	t.Run("unexpected object types are ignored without panicking", func(t *testing.T) {
 		ctrl := newFakeController(t.Context(), &fakeData{}, nil)
 		h := ctrl.appProjectEventHandlerFuncs()
-
 		assert.NotPanics(t, func() {
 			h.OnAdd("not-a-project", false)
 			h.OnUpdate("not-a-project", "not-a-project")
@@ -125,21 +116,17 @@ func TestApplicationEventHandlerFuncs(t *testing.T) {
 	t.Run("add of a processable application requeues a refresh", func(t *testing.T) {
 		ctrl := newFakeController(t.Context(), &fakeData{}, nil)
 		h := ctrl.applicationEventHandlerFuncs()
-
 		h.OnAdd(newFakeApp(), false)
-
 		assert.Contains(t, assertEnqueued(t, ctrl.appRefreshQueue), "my-app")
 	})
 
 	t.Run("update of a processable application requeues a refresh", func(t *testing.T) {
 		ctrl := newFakeController(t.Context(), &fakeData{}, nil)
 		h := ctrl.applicationEventHandlerFuncs()
-
 		old := newFakeApp()
 		updated := newFakeApp()
 		updated.ResourceVersion = "2"
 		h.OnUpdate(old, updated)
-
 		assert.Contains(t, assertEnqueued(t, ctrl.appRefreshQueue), "my-app")
 		assertNotEnqueued(t, ctrl.appOperationQueue)
 	})
@@ -174,26 +161,21 @@ func TestApplicationEventHandlerFuncs(t *testing.T) {
 	t.Run("delete of a processable application requeues a refresh", func(t *testing.T) {
 		ctrl := newFakeController(t.Context(), &fakeData{}, nil)
 		h := ctrl.applicationEventHandlerFuncs()
-
 		h.OnDelete(newFakeApp())
-
 		assert.Contains(t, assertEnqueued(t, ctrl.appRefreshQueue), "my-app")
 	})
 
 	t.Run("delete unwraps a tombstone wrapping an application", func(t *testing.T) {
 		ctrl := newFakeController(t.Context(), &fakeData{}, nil)
 		h := ctrl.applicationEventHandlerFuncs()
-
 		app := newFakeApp()
 		h.OnDelete(cache.DeletedFinalStateUnknown{Key: app.Namespace + "/" + app.Name, Obj: app})
-
 		assert.Contains(t, assertEnqueued(t, ctrl.appRefreshQueue), "my-app")
 	})
 
 	t.Run("delete of a tombstone wrapping nil is ignored without panicking", func(t *testing.T) {
 		ctrl := newFakeController(t.Context(), &fakeData{}, nil)
 		h := ctrl.applicationEventHandlerFuncs()
-
 		assert.NotPanics(t, func() {
 			h.OnDelete(cache.DeletedFinalStateUnknown{Key: "gone", Obj: nil})
 		})
@@ -203,15 +185,61 @@ func TestApplicationEventHandlerFuncs(t *testing.T) {
 	t.Run("an application in a disallowed namespace is ignored", func(t *testing.T) {
 		ctrl := newFakeController(t.Context(), &fakeData{}, nil)
 		h := ctrl.applicationEventHandlerFuncs()
-
 		app := newFakeApp()
 		app.Namespace = "some-other-namespace"
 		h.OnAdd(app, false)
 		h.OnUpdate(app, app)
 		h.OnDelete(app)
-
 		assertNotEnqueued(t, ctrl.appRefreshQueue)
 	})
+
+	makeNonOwningSharding := func(ctrl *ApplicationController) *sharding.ClusterSharding {
+		cs := sharding.NewClusterSharding(nil, 1, 2, "legacy").(*sharding.ClusterSharding)
+		cs.Shards["https://localhost:6443"] = 0
+		ctrl.clusterSharding = cs
+		return cs
+	}
+
+	t.Run("AddFunc: non-processable application still updates cluster sharding cache", func(t *testing.T) {
+		ctrl := newFakeController(t.Context(), &fakeData{}, nil)
+		cs := makeNonOwningSharding(ctrl)
+		h := ctrl.applicationEventHandlerFuncs()
+		app := newFakeApp()
+		_, existsBefore := cs.Apps[app.Name]
+		assert.False(t, existsBefore, "app should not be in the sharding cache before OnAdd")
+		h.OnAdd(app, false)
+		assertNotEnqueued(t, ctrl.appRefreshQueue)
+		_, existsAfter := cs.Apps[app.Name]
+		assert.True(t, existsAfter, "app must be tracked in the sharding cache even when canProcessApp is false")
+	})
+
+	t.Run("UpdateFunc: non-processable application still updates cluster sharding cache", func(t *testing.T) {
+		ctrl := newFakeController(t.Context(), &fakeData{}, nil)
+		cs := makeNonOwningSharding(ctrl)
+		h := ctrl.applicationEventHandlerFuncs()
+		old := newFakeApp()
+		updated := newFakeApp()
+		updated.ResourceVersion = "2"
+		h.OnUpdate(old, updated)
+		assertNotEnqueued(t, ctrl.appRefreshQueue)
+		tracked, exists := cs.Apps[updated.Name]
+		require.True(t, exists, "app must be tracked in the sharding cache even when canProcessApp is false")
+		assert.Equal(t, "2", tracked.ResourceVersion, "sharding cache must hold the latest application version")
+	})
+
+	t.Run("DeleteFunc: non-processable application still updates cluster sharding cache", func(t *testing.T) {
+		ctrl := newFakeController(t.Context(), &fakeData{}, nil)
+		cs := makeNonOwningSharding(ctrl)
+		h := ctrl.applicationEventHandlerFuncs()
+
+		app := newFakeApp()
+		cs.AddApp(app)
+		h.OnDelete(app)
+		assertNotEnqueued(t, ctrl.appRefreshQueue)
+		_, existsAfter := cs.Apps[app.Name]
+		assert.False(t, existsAfter, "deleted app must be removed from the sharding cache even when canProcessApp is false")
+	})
+
 
 	t.Run("unexpected object types are ignored without panicking", func(t *testing.T) {
 		ctrl := newFakeController(t.Context(), &fakeData{}, nil)

--- a/controller/appcontroller_informer_test.go
+++ b/controller/appcontroller_informer_test.go
@@ -240,7 +240,6 @@ func TestApplicationEventHandlerFuncs(t *testing.T) {
 		assert.False(t, existsAfter, "deleted app must be removed from the sharding cache even when canProcessApp is false")
 	})
 
-
 	t.Run("unexpected object types are ignored without panicking", func(t *testing.T) {
 		ctrl := newFakeController(t.Context(), &fakeData{}, nil)
 		h := ctrl.applicationEventHandlerFuncs()


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Fixes  #28558


### Summary

This PR fixes an issue where the cluster sharding cache was not updated for applications that were not owned by the current controller replica.

Previously, the informer handlers returned before updating the cluster sharding cache when `canProcessApp()` returned `false`. This could leave stale cache state after shard redistribution, resulting in incorrect application counts and potential cluster orphaning.

This change updates the cluster sharding cache before checking application ownership, ensuring that all controller replicas maintain an up-to-date view of application-to-cluster mappings while preserving the existing reconciliation behavior for applications not owned by the current controller.

### Changes

- Update the cluster sharding cache before the ownership check in informer handlers.
- Preserve the existing reconciliation behavior for non-owned applications.
- Add regression tests covering add, update, and delete informer events.

### Testing

```bash
go test ./controller/...
go build ./controller/...

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
