### PR TITLE
fix: honor project-scoped repositories during project updates (#13914)

### DIFF
--- a/server/project/project.go
+++ b/server/project/project.go
@@ -410,13 +410,30 @@ func (s *Server) Update(ctx context.Context, q *project.ProjectUpdateRequest) (*
 	getProjectClusters := func(project string) ([]*v1alpha1.Cluster, error) {
 		return s.db.GetProjectClusters(ctx, project)
 	}
+	projectRepos, err := s.db.GetProjectRepositories(q.Project.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get project repositories: %w", err)
+	}
+	oldProjWithScopedRepos := oldProj.DeepCopy()
+	updatedProjWithScopedRepos := q.Project.DeepCopy()
+	for _, repo := range projectRepos {
+		oldProjWithScopedRepos.Spec.SourceRepos = append(oldProjWithScopedRepos.Spec.SourceRepos, repo.Repo)
+		updatedProjWithScopedRepos.Spec.SourceRepos = append(updatedProjWithScopedRepos.Spec.SourceRepos, repo.Repo)
+	}
 
 	invalidSrcCount := 0
 	invalidDstCount := 0
 
 	for _, a := range argo.FilterByProjects(appsList.Items, []string{q.Project.Name}) {
-		if oldProj.IsSourcePermitted(a.Spec.GetSource()) && !q.Project.IsSourcePermitted(a.Spec.GetSource()) {
-			invalidSrcCount++
+		sources := a.Spec.GetSources()
+		if a.Spec.SourceHydrator != nil {
+			sources = append(sources, a.Spec.SourceHydrator.GetDrySource())
+		}
+		for _, source := range sources {
+			if oldProjWithScopedRepos.IsSourcePermitted(source) && !updatedProjWithScopedRepos.IsSourcePermitted(source) {
+				invalidSrcCount++
+				break
+			}
 		}
 
 		destCluster, err := argo.GetDestinationCluster(ctx, a.Spec.Destination, s.db)

--- a/server/project/project_test.go
+++ b/server/project/project_test.go
@@ -59,6 +59,19 @@ func TestProjectServer(t *testing.T) {
 		},
 	}, &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
+			Name:      "scoped-repository",
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				common.LabelKeySecretType: common.LabelValueSecretTypeRepository,
+			},
+		},
+		Data: map[string][]byte{
+			"type":    []byte("git"),
+			"url":     []byte("https://github.com/argoproj/argo-cd.git"),
+			"project": []byte("scoped-test"),
+		},
+	}, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cluster-1",
 			Namespace: testNamespace,
 			Labels: map[string]string{
@@ -288,6 +301,106 @@ func TestProjectServer(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.ElementsMatch(t, res.Spec.SourceRepos, updatedProj.Spec.SourceRepos)
+	})
+
+	t.Run("TestRemoveSourceUsedByAppSuccessfulIfRepositoryIsProjectScoped", func(t *testing.T) {
+		proj := existingProj.DeepCopy()
+		proj.Name = "scoped-test"
+		proj.Spec.SourceRepos = []string{"*"}
+		existingApp := v1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec:       v1alpha1.ApplicationSpec{Destination: v1alpha1.ApplicationDestination{Server: "https://server1", Namespace: "ns1"}, Project: proj.Name, Source: &v1alpha1.ApplicationSource{RepoURL: "https://github.com/argoproj/argo-cd.git"}},
+		}
+		argoDB := db.NewDB("default", settingsMgr, kubeclientset)
+		projectServer := NewServer("default", fake.NewSimpleClientset(), apps.NewSimpleClientset(proj, &existingApp), enforcer, sync.NewKeyLock(), nil, nil, projInformer, settingsMgr, argoDB, testEnableEventList)
+
+		updatedProj := proj.DeepCopy()
+		updatedProj.Spec.SourceRepos = nil
+
+		res, err := projectServer.Update(t.Context(), &project.ProjectUpdateRequest{Project: updatedProj})
+
+		require.NoError(t, err)
+		assert.Empty(t, res.Spec.SourceRepos)
+	})
+
+	t.Run("TestRemoveSourceUsedByMultiSourceAppFailsIfOnlyOneRepositoryIsProjectScoped", func(t *testing.T) {
+		proj := existingProj.DeepCopy()
+		proj.Name = "scoped-test"
+		proj.Spec.SourceRepos = []string{"*"}
+		existingApp := v1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: v1alpha1.ApplicationSpec{
+				Destination: v1alpha1.ApplicationDestination{Server: "https://server1", Namespace: "ns1"},
+				Project:     proj.Name,
+				Sources: []v1alpha1.ApplicationSource{
+					{RepoURL: "https://github.com/argoproj/argo-cd.git"},
+					{RepoURL: "https://example.com/unscoped.git"},
+				},
+			},
+		}
+		argoDB := db.NewDB("default", settingsMgr, kubeclientset)
+		projectServer := NewServer("default", fake.NewSimpleClientset(), apps.NewSimpleClientset(proj, &existingApp), enforcer, sync.NewKeyLock(), nil, nil, projInformer, settingsMgr, argoDB, testEnableEventList)
+
+		updatedProj := proj.DeepCopy()
+		updatedProj.Spec.SourceRepos = nil
+
+		_, err := projectServer.Update(t.Context(), &project.ProjectUpdateRequest{Project: updatedProj})
+
+		require.Error(t, err)
+		statusCode, _ := status.FromError(err)
+		assert.Equal(t, codes.InvalidArgument, statusCode.Code())
+		assert.Equal(t, "as a result of project update 1 applications source became invalid", statusCode.Message())
+	})
+
+	t.Run("TestRemoveSourceUsedByHydratorAppFailsIfOnlySyncRepositoryIsProjectScoped", func(t *testing.T) {
+		proj := existingProj.DeepCopy()
+		proj.Name = "scoped-test"
+		proj.Spec.SourceRepos = []string{"*"}
+		existingApp := v1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: v1alpha1.ApplicationSpec{
+				Destination: v1alpha1.ApplicationDestination{Server: "https://server1", Namespace: "ns1"},
+				Project:     proj.Name,
+				SourceHydrator: &v1alpha1.SourceHydrator{
+					DrySource:  v1alpha1.DrySource{RepoURL: "https://example.com/unscoped.git"},
+					SyncSource: v1alpha1.SyncSource{RepoURL: "https://github.com/argoproj/argo-cd.git"},
+				},
+			},
+		}
+		argoDB := db.NewDB("default", settingsMgr, kubeclientset)
+		projectServer := NewServer("default", fake.NewSimpleClientset(), apps.NewSimpleClientset(proj, &existingApp), enforcer, sync.NewKeyLock(), nil, nil, projInformer, settingsMgr, argoDB, testEnableEventList)
+
+		updatedProj := proj.DeepCopy()
+		updatedProj.Spec.SourceRepos = nil
+
+		_, err := projectServer.Update(t.Context(), &project.ProjectUpdateRequest{Project: updatedProj})
+
+		require.Error(t, err)
+		statusCode, _ := status.FromError(err)
+		assert.Equal(t, codes.InvalidArgument, statusCode.Code())
+		assert.Equal(t, "as a result of project update 1 applications source became invalid", statusCode.Message())
+	})
+
+	t.Run("TestProjectScopedRepositoryDoesNotOverrideSourceDenyPattern", func(t *testing.T) {
+		proj := existingProj.DeepCopy()
+		proj.Name = "scoped-test"
+		proj.Spec.SourceRepos = []string{"*"}
+		existingApp := v1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec:       v1alpha1.ApplicationSpec{Destination: v1alpha1.ApplicationDestination{Server: "https://server1", Namespace: "ns1"}, Project: proj.Name, Source: &v1alpha1.ApplicationSource{RepoURL: "https://github.com/argoproj/argo-cd.git"}},
+		}
+		argoDB := db.NewDB("default", settingsMgr, kubeclientset)
+		projectServer := NewServer("default", fake.NewSimpleClientset(), apps.NewSimpleClientset(proj, &existingApp), enforcer, sync.NewKeyLock(), nil, nil, projInformer, settingsMgr, argoDB, testEnableEventList)
+
+		updatedProj := proj.DeepCopy()
+		updatedProj.Spec.SourceRepos = []string{"!https://github.com/argoproj/argo-cd.git"}
+
+		_, err := projectServer.Update(t.Context(), &project.ProjectUpdateRequest{Project: updatedProj})
+
+		require.Error(t, err)
+		statusCode, _ := status.FromError(err)
+		assert.Equal(t, codes.InvalidArgument, statusCode.Code())
+		assert.Equal(t, "as a result of project update 1 applications source became invalid", statusCode.Message())
 	})
 
 	t.Run("TestRemoveDestinationUsedByAppSuccessfulIfPermittedByAnotherDestination", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- include project-scoped repository URLs when validating an `AppProject` update
- keep those URLs on temporary project copies so they are never persisted into `spec.sourceRepos`
- evaluate every effective application source, including multi-source entries and source-hydrator dry/sync repositories
- preserve explicit source deny rules and count each invalid application once

Project-scoped repositories are already treated as automatically permitted during normal application validation. The project update safety check did not include them, so removing a broader source rule such as `*` could incorrectly reject a valid update. This change makes the update check use the same effective repository permissions.

Fixes #13914

## Testing

- `go test ./server/project -run 'TestProjectServer/(TestRemoveSourceUsedByAppSuccessfulIfRepositoryIsProjectScoped|TestRemoveSourceUsedByMultiSourceAppFailsIfOnlyOneRepositoryIsProjectScoped|TestRemoveSourceUsedByHydratorAppFailsIfOnlySyncRepositoryIsProjectScoped|TestProjectScopedRepositoryDoesNotOverrideSourceDenyPattern)$' -count=20`
- focused race run, full `server/project` package, full package race run, and `go vet ./server/project`
- `make build`
- `make cli`
- `make lint-ui` (passes with 11 pre-existing warnings)
- `make lint` reached the repository-wide analysis phase but was killed by Docker Desktop's memory limit; the same pinned linter and configuration passed with `--concurrency 1` and reported zero issues
- `make codegen` completed all generators with no tracked diff, then stopped because the official test image lacks `gh`; `make gh-aw-compile` passed separately with the repository-pinned extension
- `make test` ran 8,025 tests; the macOS bind mount caused the two known permission-sensitive cases to fail. The same final tree passed all 8,025 tests (5 skipped) with `make test-local` from a Linux-native container filesystem
- GitHub CI completed with 27 passing checks, 0 failures, and 3 expected conditional skips

Manual production-path validation on exact head `ab5d018bbdce0d4abf2bc7ea8f05b30e881290f3`:

- built the exact-head CLI and server/repo-server image, then ran them against a disposable kind v1.36.1 cluster;
- with an `AppProject` and Application but no project-scoped repository, `argocd proj remove-source <project> '*'` exited 20, the real server returned `InvalidArgument`, and persisted `sourceRepos` remained `["*"]`;
- added a real public project-scoped repository through `argocd repo add`, then repeated the same project update; it exited 0 and the server returned `OK`;
- verified the persisted project had `sourceRepos=[]`, while the Application still referenced its repository and exactly one separate project-scoped repository secret remained; and
- confirmed the exact commit from both the CLI and live server and removed the cluster, images, network, listener, kubeconfig, and CLI token configuration afterward.

## Documentation and compatibility

No documentation update is needed because this restores the already-documented behavior of project-scoped repositories. No API types, manifests, CLI, or UI behavior changed, and code generation produced no tracked changes.

No backport is requested. Maintainers may evaluate supported branches because this fix intentionally tightens update validation for multi-source and source-hydrator applications.


Checklist:

* [x] Either (a) I've created an enhancement proposal and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes. (This is a bug fix.)
* [x] The title of the PR states what changed and the related issue number.
* [x] The title of the PR conforms to the project title guidelines.
* [x] I've included `Fixes #13914` in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. (N/A: this is server-side validation behavior with no CLI or UI surface.)
* [x] Does this PR require documentation updates? (No; it restores existing documented behavior.)
* [x] I've updated documentation as required by this PR. (N/A: no documentation change is required.)
* [x] I have signed off all my commits as required by DCO.
* [x] I have written unit and/or e2e tests for my change.
* [x] My build is green. (GitHub CI completed with 27 passing checks, 0 failures, and 3 expected conditional skips.)
* [x] My new feature complies with the feature status guidelines. (N/A: bug fix, not a new feature.)
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md. (N/A.)
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into. (No backport requested; maintainers may evaluate supported branches.)
