### PR TITLE
fix: prevent error swallowing, file handle leak, and data loss in cert, helm, and tar utilities

### DIFF
--- a/util/cert/cert.go
+++ b/util/cert/cert.go
@@ -346,7 +346,7 @@ func GetCertBundlePathForRepository(serverName string) (string, error) {
 	certPath := filepath.Join(GetTLSCertificateDataPath(), ServerNameWithoutPort(serverName))
 	certs, err := GetCertificateForConnect(serverName)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 	if len(certs) == 0 {
 		return "", nil

--- a/util/helm/client.go
+++ b/util/helm/client.go
@@ -185,6 +185,7 @@ func untarChart(ctx context.Context, tempDir string, cachedChartPath string, man
 	if err != nil {
 		return fmt.Errorf("error opening cached chart path %s: %w", cachedChartPath, err)
 	}
+	defer reader.Close()
 	return files.Untgz(tempDir, reader, manifestMaxExtractedSize, false)
 }
 

--- a/util/io/files/tar.go
+++ b/util/io/files/tar.go
@@ -178,6 +178,10 @@ func untar(dstPath string, r io.Reader, preserveFileMode bool) error {
 				f.Close()
 				return fmt.Errorf("error writing tgz file: %w", err)
 			}
+			if err := w.Flush(); err != nil {
+				f.Close()
+				return fmt.Errorf("error flushing file %q: %w", target, err)
+			}
 			f.Close()
 		}
 	}


### PR DESCRIPTION
## Summary

This PR fixes three real bugs that can cause data corruption, resource leaks, and silent error handling failures:

### 1. Error silently swallowed in `GetCertBundlePathForRepository` (util/cert/cert.go)
When `GetCertificateForConnect` returns an error (e.g., permission denied, corrupt certificate file), the error was discarded and the function returned `("", nil)` — the same result as "no certificates found." This meant certificate errors were silently ignored, potentially causing repository connections to fall back to no TLS verification when validation was expected.

### 2. File handle leak in `untarChart` (util/helm/client.go)
The `os.File` returned by `os.Open` was passed to `files.Untgz` but never closed. The repo-server extracts charts continuously, so each leaked file descriptor eventually hits the OS ulimit and causes all subsequent operations to fail with "too many open files."

### 3. Data loss from unflushed `bufio.Writer` in `untar` (util/io/files/tar.go)
Data was copied into a `bufio.Writer` which buffers up to 4KB. The file was closed without flushing the writer first, silently losing up to 4KB of trailing data from every extracted file. This could corrupt chart templates, manifests, or Lua scripts.

## Related Issues

<!-- Link to the issue this PR addresses, if applicable -->

## Testing

Verified each fix handles the error/edge case correctly:
- Error path now returns the actual error instead of nil
- File is properly closed via defer after use
- Buffer is flushed before file close

## Checklist

- [x] DCO sign-off included
- [x] Code follows the project's coding style
- [x] Changes are minimal and focused
- [x] No unrelated changes included