### PR TITLE
refactor: compile regex once in SanitizeName

### DIFF
--- a/applicationset/utils/template_functions.go
+++ b/applicationset/utils/template_functions.go
@@ -7,13 +7,14 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+var invalidDNSNameChars = regexp.MustCompile(`[^-a-z0-9.]`)
+
 // SanitizeName sanitizes the name in accordance with the below rules
 // 1. contain no more than 253 characters
 // 2. contain only lowercase alphanumeric characters, '-' or '.'
 // 3. start and end with an alphanumeric character
 func SanitizeName(name string) string {
-	invalidDNSNameChars := regexp.MustCompile("[^-a-z0-9.]")
-	maxDNSNameLength := 253
+	const maxDNSNameLength = 253
 
 	name = strings.ToLower(name)
 	name = invalidDNSNameChars.ReplaceAllString(name, "-")


### PR DESCRIPTION
## Summary

This PR moves the regular expression used by `SanitizeName` to a package-level variable so it is compiled only once during package initialization instead of every time the function is called.

This reduces unnecessary regex compilation overhead while preserving the existing behavior.

## Changes

- Moved `regexp.MustCompile(...)` to a package-level variable.
- Reused the compiled regular expression in `SanitizeName`.
- Kept the sanitization logic unchanged.

## Testing

- Existing tests pass.
- No functional or behavioral changes were introduced.