### PR TITLE
fix(ui): editor in ApplicationSet Preview tab renders cut off until Edit is clicked

### DIFF
--- a/ui/src/app/applications/components/resource-details/appset-preview-tab.tsx
+++ b/ui/src/app/applications/components/resource-details/appset-preview-tab.tsx
@@ -101,6 +101,7 @@ export const AppSetPreviewTab = (props: AppSetPreviewTabProps) => {
                     <div style={{marginTop: '10px'}}>
                         <MonacoEditor
                             key={editorKey}
+                            minHeight={800}
                             vScrollBar={false}
                             editor={{
                                 input: {text: initialYaml, language: 'yaml'},


### PR DESCRIPTION
Motivation

In the ApplicationSet details view, opening the Preview tab shows the
"APPLICATIONSET MANIFEST" Monaco editor almost empty/cut off. The manifest
only renders fully after clicking Edit, which forces a re-render.

Approach

The shared MonacoEditor wrapper (ui/src/app/shared/components/monaco-editor.tsx)
sizes its container to `Math.max(props.minHeight || 0, height)`, where `height`
starts at 0 and is only set asynchronously (via setState) once the editor
computes its content height. On first mount, the editor's `.layout()` call runs
against the still-zero-height container (the state update hasn't been committed
yet), so Monaco bakes in a zero-size layout and nothing later re-triggers
`.layout()` on its own. Clicking Edit changes editor options, causing the ref
callback to run again — by then the container already has the correct height
from the prior render, so `.layout()` finally sees real dimensions and the
editor displays correctly.

Every other consumer of MonacoEditor/YamlEditor in this codebase avoids this by
passing a non-zero `minHeight` up front (e.g. the sibling MANIFEST tab in the
same ApplicationSet details view passes `minHeight={800}`), so the container
already has a correct height on the very first render, before `.layout()` ever
runs. The ApplicationSet Preview tab was the one place missing this. This
change adds `minHeight={800}` to the Preview tab's MonacoEditor, matching the
existing convention.

This is a purely cosmetic rendering bug: `readEditorYaml()` reads from the
Monaco model directly, independent of visual layout, so no data is lost and
the Preview/Edit/Cancel behavior is unaffected — only the initial rendering of
the editor is fixed.

Validation

- `pnpm exec tsc --noEmit --project ./src/app` — passed
- `pnpm exec eslint src/app/applications/components/resource-details/appset-preview-tab.tsx` — passed, no warnings
- `pnpm exec jest` (full UI suite) — 23 suites / 271 tests passed, no snapshot changes

Fixes #28790

/kind bug

```release-note
Fix ApplicationSet Preview tab manifest editor rendering cut off/empty until "Edit" is clicked.
```

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
