### PR TITLE
fix: make install-gh-aw-local gracefully skip if gh CLI is not available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -645,7 +645,11 @@ install-tools-local: install-test-tools-local install-codegen-tools-local instal
 # Installs the gh aw CLI extension for managing GitHub Agentics workflows
 .PHONY: install-gh-aw-local
 install-gh-aw-local:
-	. hack/tool-versions.sh && gh extension install --pin v$${GH_AW_VERSION} --force github/gh-aw
+	@if command -v gh >/dev/null 2>&1; then \
+		. hack/tool-versions.sh && gh extension install --pin v$${GH_AW_VERSION} --force github/gh-aw; \
+	else \
+		echo "WARNING: gh CLI not found — skipping gh-aw extension install (not required for building Argo CD)"; \
+	fi
 
 # Installs all tools required for running unit & end-to-end tests (Linux packages)
 .PHONY: install-test-tools-local


### PR DESCRIPTION
Fixes #28796

`make install-tools-local` requires `gh` CLI to be installed and authenticated even when the user only wants to build/test Argo CD. The `install-gh-aw-local` target now checks for `gh` availability before installing the extension, printing a warning and skipping gracefully if it's not found.