### PR TITLE
fix(ui): guard SSO redirect to stop 401 retry loop

### DIFF
--- a/ui/src/app/app.tsx
+++ b/ui/src/app/app.tsx
@@ -27,6 +27,13 @@ const base = bases.length > 0 ? bases[0].getAttribute('href') || '/' : '/';
 export const history = createBrowserHistory({basename: base});
 requests.setBaseHRef(base);
 
+// Guards the SSO re-authentication redirect below. Multiple watch streams can emit 401s
+// simultaneously when a session expires; without this, each one reassigns
+// window.location.href and cancels the previous in-flight navigation to the identity
+// provider, so the browser never actually leaves the page. Reset happens naturally: the
+// redirect is a full page load, which discards this module's state.
+let ssoRedirectInProgress = false;
+
 type Routes = {[path: string]: {component: React.ComponentType<RouteComponentProps<any>>; noLayout?: boolean}};
 
 const routes: Routes = {
@@ -348,6 +355,10 @@ export class App extends React.Component<
                 // If basehref is the default `/` it will become an empty string.
                 const basehref = document.querySelector('head > base').getAttribute('href').replace(/\/$/, '');
                 if (isSSO) {
+                    if (ssoRedirectInProgress) {
+                        return;
+                    }
+                    ssoRedirectInProgress = true;
                     window.location.href = `${basehref}/auth/login?return_url=${encodeURIComponent(location.href)}`;
                 } else {
                     history.push(`/login?return_url=${encodeURIComponent(location.href)}`);

--- a/ui/src/app/app.tsx
+++ b/ui/src/app/app.tsx
@@ -359,6 +359,11 @@ export class App extends React.Component<
                         return;
                     }
                     ssoRedirectInProgress = true;
+                    // If the redirect fails to navigate away (e.g. network failure), reset the
+                    // flag so a later 401 can retry the redirect instead of being blocked forever.
+                    setTimeout(() => {
+                        ssoRedirectInProgress = false;
+                    }, 5000);
                     window.location.href = `${basehref}/auth/login?return_url=${encodeURIComponent(location.href)}`;
                 } else {
                     history.push(`/login?return_url=${encodeURIComponent(location.href)}`);


### PR DESCRIPTION
Fixes #24807

When an OIDC session expires, each open watch stream emits a 401 into the shared `requests.onError` subject. `subscribeUnauthorized` reassigns `window.location.href` on every one of them, so each 401 cancels the previous in-flight navigation to the identity provider. The browser never finishes leaving the page, and the streams keep reconnecting and re-emitting 401s.

This adds a module-level flag so only the first 401 triggers the redirect.

The check and the assignment are deliberately adjacent, immediately before `window.location.href`. `await isExpiredSSO()` earlier in the handler yields the event loop, so a guard placed at the top of the function would let several handlers past before any of them set the flag, which would leave the race intact.

No explicit reset is needed. The redirect is a full page load, so the module state is discarded on the way back in.

Only the SSO branch is guarded. The local-account branch uses `history.push` and is already covered by the existing pathname checks.

## What I saw

I hit this myself on v3.4.4. A tab I had left open on an application view lost its session at 00:43 UTC. At 01:16 the streams started retrying and did not stop until I completed a fresh login at 01:30, with the last failure logged at 01:36. Over that roughly 20 minute window argocd-server logged 26,522 `Failed to verify session token` warnings and the load balancer in front of it logged 38,649 requests to the argocd-server backend. That works out to somewhere between 1,300 and 1,900 requests per minute from a single browser tab.

Every one of those warnings carried the same token expiry timestamp, which is what pointed at the redirect race rather than at ordinary session churn.

My setup is dex with the Google connector, behind GCP IAP and GKE ingress. The earlier reports on the issue were Okta, so this looks identity-provider agnostic, which matches the code path.

## Not included

`watch()` in `applications-service.ts` still uses argument-less `.pipe(repeat()).pipe(retry())`, so the streams keep reconnecting without backoff until login completes. That is a separate concern and #24807 discusses it as a follow-up.

## Checklist

- [x] Commit message follows the conventional format and is signed off per the DCO.
- [x] `pnpm lint` passes (`tsc --noEmit --project ./src/app && eslint`), 0 errors.
- [ ] No test added. There is no existing test for `app.tsx` which would require setting up mocks for a root React component and an RxJs subject... but if you really want a test just LMK.