### PR TITLE
fix(controller): persist operationstate with optimistic concurrency

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -1715,8 +1715,8 @@ func (ctrl *ApplicationController) setOperationState(ctx context.Context, app *a
 	// concurrency alone is not enough, however: a stale writer that refetches would still
 	// overwrite a completed operation with a current resourceVersion. So we also refuse,
 	// semantically, to move a completed operation back to a non-terminal phase. Once an
-	// operation completes, spec.operation is cleared; a non-terminal write for an operation
-	// whose spec.operation is already gone is therefore out of order and is discarded.
+	// operation completes, the top-level operation field is cleared; a non-terminal write for
+	// an operation whose operation field is already gone is therefore out of order and is discarded.
 	written := false
 	kube.RetryUntilSucceed(ctx, updateOperationStateTimeout, "Update application operation state", logutils.NewLogrusLogger(logutils.NewWithCurrentConfig()), func() error {
 		live, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(app.Namespace).Get(ctx, app.Name, metav1.GetOptions{})

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -1693,47 +1693,103 @@ func (ctrl *ApplicationController) setOperationState(ctx context.Context, app *a
 		now := metav1.Now()
 		state.FinishedAt = &now
 	}
-	patch := map[string]any{
-		"status": map[string]any{
-			"operationState": state,
-		},
-	}
-	if state.Phase.Completed() {
-		// If operation is completed, clear the operation field to indicate no operation is
-		// in progress.
-		patch["operation"] = nil
-	}
 	if reflect.DeepEqual(app.Status.OperationState, state) {
 		logCtx.Infof("No operation updates necessary to '%s'. Skipping patch", app.QualifiedName())
 		return
 	}
-	patchJSON, err := json.Marshal(patch)
-	if err != nil {
-		logCtx.WithError(err).Error("error marshaling json")
-		return
-	}
-	if app.Status.OperationState != nil && app.Status.OperationState.FinishedAt != nil && state.FinishedAt == nil {
-		patchJSON, err = jsonpatch.MergeMergePatches(patchJSON, []byte(`{"status": {"operationState": {"finishedAt": null}}}`))
-		if err != nil {
-			logCtx.WithError(err).Error("error merging operation state patch")
-			return
-		}
-	}
 
+	// Persist operationState with optimistic concurrency instead of a blind merge patch.
+	//
+	// A merge patch of status.operationState is unsafe for two reasons that, together, can
+	// strand an application in a perpetual "running" phase (argoproj/argo-cd#18613, #23765):
+	//   1. operationState's fields are `omitempty`, so a patch carrying only a subset of them
+	//      cannot clear the rest — a stale "Running" progress update silently leaves the
+	//      finishedAt recorded by a preceding terminal write in place.
+	//   2. a merge patch has no resourceVersion precondition, so an out-of-order update can
+	//      overwrite a newer one, letting a late progress update clobber the terminal
+	//      "Succeeded"/"Failed" write.
+	//
+	// Reading the live application and patching status.operationState with the live
+	// resourceVersion as a precondition replaces the whole operationState atomically, so a
+	// concurrent writer causes a Conflict + refetch instead of a silent clobber. Optimistic
+	// concurrency alone is not enough, however: a stale writer that refetches would still
+	// overwrite a completed operation with a current resourceVersion. So we also refuse,
+	// semantically, to move a completed operation back to a non-terminal phase. Once an
+	// operation completes, spec.operation is cleared; a non-terminal write for an operation
+	// whose spec.operation is already gone is therefore out of order and is discarded.
+	written := false
 	kube.RetryUntilSucceed(ctx, updateOperationStateTimeout, "Update application operation state", logutils.NewLogrusLogger(logutils.NewWithCurrentConfig()), func() error {
-		_, err := ctrl.PatchAppWithWriteBack(ctx, app.Name, app.Namespace, types.MergePatchType, patchJSON, metav1.PatchOptions{})
+		live, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(app.Namespace).Get(ctx, app.Name, metav1.GetOptions{})
 		if err != nil {
 			// Stop retrying updating deleted application
 			if apierrors.IsNotFound(err) {
 				return nil
 			}
-			// kube.RetryUntilSucceed logs failed attempts at "debug" level, but we want to know if this fails. Log a
-			// warning.
+			return fmt.Errorf("error reading application before operation state update: %w", err)
+		}
+
+		if !state.Phase.Completed() && live.Operation == nil &&
+			live.Status.OperationState != nil && live.Status.OperationState.Phase.Completed() {
+			logCtx.Warnf("Discarding stale operation state update (phase: %s): live operation already completed as %s",
+				state.Phase, live.Status.OperationState.Phase)
+			return nil
+		}
+
+		newOperation := live.Operation
+		if state.Phase.Completed() {
+			// If operation is completed, clear the operation field to indicate no operation is
+			// in progress.
+			newOperation = nil
+		}
+
+		// Build a patch scoped to just status.operationState (and, on completion, operation)
+		// instead of writing back the whole Application. createMergePatch diffs against the live
+		// operationState, so it emits explicit nulls for the fields the new state drops.
+		patch, modified, err := createMergePatch(
+			&appv1.Application{Operation: live.Operation, Status: appv1.ApplicationStatus{OperationState: live.Status.OperationState}},
+			&appv1.Application{Operation: newOperation, Status: appv1.ApplicationStatus{OperationState: state}},
+		)
+		if err != nil {
+			logCtx.WithError(err).Error("error constructing operation state patch")
+			return nil
+		}
+		if !modified {
+			// Live already matches the desired operation state; nothing to persist.
+			return nil
+		}
+
+		// Embed the resourceVersion we just read so the apiserver applies the patch under
+		// optimistic concurrency: if the live object changed since the Get above (for example the
+		// terminal write we must not clobber, or a status refresh), the patch is rejected with a
+		// Conflict and RetryUntilSucceed refetches and re-evaluates the guard.
+		if live.ResourceVersion == "" {
+			return fmt.Errorf("live application %q has no resourceVersion; refusing to patch operation state without an optimistic-concurrency precondition", app.QualifiedName())
+		}
+		patch, err = jsonpatch.MergeMergePatches(patch, fmt.Appendf(nil, `{"metadata":{"resourceVersion":%q}}`, live.ResourceVersion))
+		if err != nil {
+			logCtx.WithError(err).Error("error adding resourceVersion precondition to operation state patch")
+			return nil
+		}
+
+		if _, err := ctrl.PatchAppWithWriteBack(ctx, app.Name, app.Namespace, types.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
+			// Stop retrying updating deleted application
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			// A conflict means the live object changed under us (for example the terminal
+			// write we must not clobber, or a status refresh); refetch and re-evaluate.
+			// kube.RetryUntilSucceed logs failed attempts at "debug" level, but we want to
+			// know if this fails. Log a warning.
 			logCtx.WithError(err).Warn("error patching application with operation state")
 			return fmt.Errorf("error patching application with operation state: %w", err)
 		}
+		written = true
 		return nil
 	})
+
+	if !written {
+		return
+	}
 
 	logCtx.Infof("updated '%s' operation (phase: %s)", app.QualifiedName(), state.Phase)
 	if state.Phase.Completed() {

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -639,6 +639,11 @@ func createFakeApp(testApp string) *v1alpha1.Application {
 	if err != nil {
 		panic(err)
 	}
+	// A real apiserver always returns a resourceVersion on Get; model that so optimistic
+	// concurrency paths (e.g. setOperationState) behave as they do in production.
+	if app.ResourceVersion == "" {
+		app.ResourceVersion = "1"
+	}
 	return &app
 }
 
@@ -1903,13 +1908,13 @@ func TestSetOperationStateOnDeletedApp(t *testing.T) {
 	ctrl := newFakeController(t.Context(), &fakeData{apps: []runtime.Object{}}, nil)
 	fakeAppCs := ctrl.applicationClientset.(*appclientset.Clientset)
 	fakeAppCs.ReactionChain = nil
-	patched := false
-	fakeAppCs.AddReactor("patch", "*", func(_ kubetesting.Action) (handled bool, ret runtime.Object, err error) {
-		patched = true
+	fetched := false
+	fakeAppCs.AddReactor("get", "*", func(_ kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+		fetched = true
 		return true, &v1alpha1.Application{}, apierrors.NewNotFound(schema.GroupResource{}, "my-app")
 	})
 	ctrl.setOperationState(t.Context(), newFakeApp(), &v1alpha1.OperationState{Phase: synccommon.OperationSucceeded})
-	assert.True(t, patched)
+	assert.True(t, fetched)
 }
 
 func TestSetOperationStateLogRetries(t *testing.T) {
@@ -1917,16 +1922,20 @@ func TestSetOperationStateLogRetries(t *testing.T) {
 	logrus.AddHook(&hook)
 	t.Cleanup(hook.CleanupHook)
 
+	app := newFakeApp()
 	ctrl := newFakeController(t.Context(), &fakeData{apps: []runtime.Object{}}, nil)
 	fakeAppCs := ctrl.applicationClientset.(*appclientset.Clientset)
 	fakeAppCs.ReactionChain = nil
+	fakeAppCs.AddReactor("get", "*", func(_ kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, app.DeepCopy(), nil
+	})
 	patched := false
 	fakeAppCs.AddReactor("patch", "*", func(_ kubetesting.Action) (handled bool, ret runtime.Object, err error) {
 		if !patched {
 			patched = true
 			return true, &v1alpha1.Application{}, errors.New("fake error")
 		}
-		return true, &v1alpha1.Application{}, nil
+		return true, app.DeepCopy(), nil
 	})
 	ctrl.setOperationState(t.Context(), newFakeApp(), &v1alpha1.OperationState{Phase: synccommon.OperationSucceeded})
 	assert.True(t, patched)
@@ -1936,6 +1945,166 @@ func TestSetOperationStateLogRetries(t *testing.T) {
 	errorVal, ok := entry.Data["error"].(error)
 	require.True(t, ok, "error field should be of type error")
 	assert.Contains(t, errorVal.Error(), "fake error")
+}
+
+// TestSetOperationStateDoesNotRegressCompletedOperation is a regression test for
+// argoproj/argo-cd#18613 and #23765: a stale, out-of-order non-terminal operation-state
+// update must never resurrect the running phase on an operation that has already completed.
+func TestSetOperationStateDoesNotRegressCompletedOperation(t *testing.T) {
+	t.Run("discards non-terminal update to a completed operation", func(t *testing.T) {
+		app := newFakeApp()
+		app.Operation = nil // spec.operation is cleared once an operation completes
+		finishedAt := metav1.Now()
+		startedAt := metav1.NewTime(finishedAt.Add(-time.Minute))
+		app.Status.OperationState = &v1alpha1.OperationState{
+			Phase:      synccommon.OperationSucceeded,
+			Message:    "successfully synced (all tasks run)",
+			StartedAt:  startedAt,
+			FinishedAt: &finishedAt,
+			SyncResult: &v1alpha1.SyncOperationResult{Revision: "abc123"},
+		}
+		ctrl := newFakeController(t.Context(), &fakeData{apps: []runtime.Object{app}}, nil)
+
+		// A late "waiting for healthy state" progress update belonging to the finished
+		// operation, e.g. delivered out of order by a flaky control-plane connection.
+		stale := &v1alpha1.OperationState{
+			Phase:     synccommon.OperationRunning,
+			Message:   "waiting for healthy state of /ServiceAccount/foo",
+			StartedAt: startedAt,
+		}
+		ctrl.setOperationState(t.Context(), app, stale)
+
+		got, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(test.FakeArgoCDNamespace).Get(t.Context(), app.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, got.Status.OperationState)
+		assert.Equal(t, synccommon.OperationSucceeded, got.Status.OperationState.Phase, "completed phase must be preserved")
+		assert.NotNil(t, got.Status.OperationState.FinishedAt, "finishedAt must be preserved")
+	})
+
+	t.Run("persists a terminal update and clears spec.operation", func(t *testing.T) {
+		app := newFakeApp()
+		app.Operation = &v1alpha1.Operation{Sync: &v1alpha1.SyncOperation{Revision: "abc123"}}
+		app.Status.OperationState = &v1alpha1.OperationState{
+			Phase:     synccommon.OperationRunning,
+			Message:   "waiting for healthy state of /ServiceAccount/foo",
+			StartedAt: metav1.Now(),
+			Operation: *app.Operation,
+		}
+		ctrl := newFakeController(t.Context(), &fakeData{apps: []runtime.Object{app}}, nil)
+
+		done := &v1alpha1.OperationState{
+			Phase:     synccommon.OperationSucceeded,
+			Message:   "successfully synced (all tasks run)",
+			StartedAt: app.Status.OperationState.StartedAt,
+			Operation: *app.Operation,
+		}
+		ctrl.setOperationState(t.Context(), app, done)
+
+		got, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(test.FakeArgoCDNamespace).Get(t.Context(), app.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, got.Status.OperationState)
+		assert.Equal(t, synccommon.OperationSucceeded, got.Status.OperationState.Phase)
+		assert.NotNil(t, got.Status.OperationState.FinishedAt, "finishedAt must be stamped on completion")
+		assert.Nil(t, got.Operation, "spec.operation must be cleared on completion")
+	})
+}
+
+// TestSetOperationStateRetriesOnConflict pins down the optimistic-concurrency contract of
+// setOperationState: when the scoped patch is rejected with a Conflict (the live object changed
+// under us), the controller must refetch the live application and re-evaluate the stale-update
+// guard before writing again, rather than blindly overwriting. This is the core safety
+// mechanism behind argoproj/argo-cd#18613 and #23765, and the fake clientset does not enforce
+// resourceVersion preconditions on its own, so we drive the Conflict explicitly.
+func TestSetOperationStateRetriesOnConflict(t *testing.T) {
+	appConflict := schema.GroupResource{Group: "argoproj.io", Resource: "applications"}
+
+	t.Run("refetches and retries until the patch succeeds", func(t *testing.T) {
+		app := newFakeApp()
+		app.Operation = &v1alpha1.Operation{Sync: &v1alpha1.SyncOperation{Revision: "abc123"}}
+		app.Status.OperationState = &v1alpha1.OperationState{
+			Phase:     synccommon.OperationRunning,
+			StartedAt: metav1.Now(),
+			Operation: *app.Operation,
+		}
+		ctrl := newFakeController(t.Context(), &fakeData{apps: []runtime.Object{}}, nil)
+		fakeAppCs := ctrl.applicationClientset.(*appclientset.Clientset)
+		fakeAppCs.ReactionChain = nil
+
+		gets, patches := 0, 0
+		fakeAppCs.AddReactor("get", "*", func(_ kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+			gets++
+			return true, app.DeepCopy(), nil
+		})
+		fakeAppCs.AddReactor("patch", "*", func(_ kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+			patches++
+			if patches == 1 {
+				return true, &v1alpha1.Application{}, apierrors.NewConflict(appConflict, app.Name, errors.New("the object has been modified"))
+			}
+			return true, app.DeepCopy(), nil
+		})
+
+		done := &v1alpha1.OperationState{
+			Phase:     synccommon.OperationSucceeded,
+			Message:   "successfully synced (all tasks run)",
+			StartedAt: app.Status.OperationState.StartedAt,
+			Operation: *app.Operation,
+		}
+		ctrl.setOperationState(t.Context(), app, done)
+
+		assert.Equal(t, 2, patches, "the conflicting patch must be retried exactly once")
+		assert.GreaterOrEqual(t, gets, 2, "each patch attempt must be preceded by a fresh Get")
+	})
+
+	t.Run("re-evaluates the stale-update guard against the refetched object", func(t *testing.T) {
+		// A non-terminal progress update races a terminal write. The first Get sees the
+		// operation still in progress, so the guard admits the update and the controller
+		// patches — but that patch conflicts because the terminal write landed first. On
+		// refetch the live operation has completed and spec.operation is cleared, so the
+		// guard must now discard the stale progress update instead of resurrecting "Running".
+		running := newFakeApp()
+		running.Operation = &v1alpha1.Operation{Sync: &v1alpha1.SyncOperation{Revision: "abc123"}}
+		running.Status.OperationState = &v1alpha1.OperationState{
+			Phase:     synccommon.OperationRunning,
+			StartedAt: metav1.Now(),
+			Operation: *running.Operation,
+		}
+		completed := running.DeepCopy()
+		completed.Operation = nil // spec.operation is cleared once an operation completes
+		finishedAt := metav1.Now()
+		completed.Status.OperationState = &v1alpha1.OperationState{
+			Phase:      synccommon.OperationSucceeded,
+			Message:    "successfully synced (all tasks run)",
+			StartedAt:  running.Status.OperationState.StartedAt,
+			FinishedAt: &finishedAt,
+		}
+
+		ctrl := newFakeController(t.Context(), &fakeData{apps: []runtime.Object{}}, nil)
+		fakeAppCs := ctrl.applicationClientset.(*appclientset.Clientset)
+		fakeAppCs.ReactionChain = nil
+
+		gets, patches := 0, 0
+		fakeAppCs.AddReactor("get", "*", func(_ kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+			gets++
+			if gets == 1 {
+				return true, running.DeepCopy(), nil // operation still in progress
+			}
+			return true, completed.DeepCopy(), nil // terminal write won the race
+		})
+		fakeAppCs.AddReactor("patch", "*", func(_ kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+			patches++
+			return true, &v1alpha1.Application{}, apierrors.NewConflict(appConflict, running.Name, errors.New("the object has been modified"))
+		})
+
+		stale := &v1alpha1.OperationState{
+			Phase:     synccommon.OperationRunning,
+			Message:   "waiting for healthy state of /ServiceAccount/foo",
+			StartedAt: running.Status.OperationState.StartedAt,
+		}
+		ctrl.setOperationState(t.Context(), running, stale)
+
+		assert.Equal(t, 1, patches, "once the refetch shows the operation completed, the stale update must not be re-patched")
+		assert.GreaterOrEqual(t, gets, 2, "the conflict must trigger a refetch and guard re-evaluation")
+	})
 }
 
 func TestNeedRefreshAppStatus(t *testing.T) {
@@ -3086,6 +3255,9 @@ func TestProcessRequestedAppOperation_Successful(t *testing.T) {
 	app.Operation = &v1alpha1.Operation{
 		Sync: &v1alpha1.SyncOperation{},
 	}
+	// Start from a fresh operation (SetAppOperation clears operationState when a new
+	// operation begins) so the scoped patch carries the Running -> Succeeded transition.
+	app.Status.OperationState = nil
 	ctrl := newFakeController(t.Context(), &fakeData{
 		apps: []runtime.Object{app, &defaultProj},
 		manifestResponses: []*apiclient.ManifestResponse{{
@@ -3121,6 +3293,9 @@ func TestProcessRequestedAppAutomatedOperation_Successful(t *testing.T) {
 			Automated: true,
 		},
 	}
+	// Start from a fresh operation (SetAppOperation clears operationState when a new
+	// operation begins) so the scoped patch carries the Running -> Succeeded transition.
+	app.Status.OperationState = nil
 	ctrl := newFakeController(t.Context(), &fakeData{
 		apps: []runtime.Object{app, &defaultProj},
 		manifestResponses: []*apiclient.ManifestResponse{{

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -1953,7 +1953,7 @@ func TestSetOperationStateLogRetries(t *testing.T) {
 func TestSetOperationStateDoesNotRegressCompletedOperation(t *testing.T) {
 	t.Run("discards non-terminal update to a completed operation", func(t *testing.T) {
 		app := newFakeApp()
-		app.Operation = nil // spec.operation is cleared once an operation completes
+		app.Operation = nil // the operation field is cleared once an operation completes
 		finishedAt := metav1.Now()
 		startedAt := metav1.NewTime(finishedAt.Add(-time.Minute))
 		app.Status.OperationState = &v1alpha1.OperationState{
@@ -1981,7 +1981,7 @@ func TestSetOperationStateDoesNotRegressCompletedOperation(t *testing.T) {
 		assert.NotNil(t, got.Status.OperationState.FinishedAt, "finishedAt must be preserved")
 	})
 
-	t.Run("persists a terminal update and clears spec.operation", func(t *testing.T) {
+	t.Run("persists a terminal update and clears the operation field", func(t *testing.T) {
 		app := newFakeApp()
 		app.Operation = &v1alpha1.Operation{Sync: &v1alpha1.SyncOperation{Revision: "abc123"}}
 		app.Status.OperationState = &v1alpha1.OperationState{
@@ -2005,7 +2005,7 @@ func TestSetOperationStateDoesNotRegressCompletedOperation(t *testing.T) {
 		require.NotNil(t, got.Status.OperationState)
 		assert.Equal(t, synccommon.OperationSucceeded, got.Status.OperationState.Phase)
 		assert.NotNil(t, got.Status.OperationState.FinishedAt, "finishedAt must be stamped on completion")
-		assert.Nil(t, got.Operation, "spec.operation must be cleared on completion")
+		assert.Nil(t, got.Operation, "the operation field must be cleared on completion")
 	})
 }
 
@@ -2031,12 +2031,14 @@ func TestSetOperationStateRetriesOnConflict(t *testing.T) {
 		fakeAppCs.ReactionChain = nil
 
 		gets, patches := 0, 0
+		var patchRVs []string
 		fakeAppCs.AddReactor("get", "*", func(_ kubetesting.Action) (handled bool, ret runtime.Object, err error) {
 			gets++
 			return true, app.DeepCopy(), nil
 		})
-		fakeAppCs.AddReactor("patch", "*", func(_ kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+		fakeAppCs.AddReactor("patch", "*", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
 			patches++
+			patchRVs = append(patchRVs, patchResourceVersion(t, action))
 			if patches == 1 {
 				return true, &v1alpha1.Application{}, apierrors.NewConflict(appConflict, app.Name, errors.New("the object has been modified"))
 			}
@@ -2053,13 +2055,16 @@ func TestSetOperationStateRetriesOnConflict(t *testing.T) {
 
 		assert.Equal(t, 2, patches, "the conflicting patch must be retried exactly once")
 		assert.GreaterOrEqual(t, gets, 2, "each patch attempt must be preceded by a fresh Get")
+		// Every patch must carry the resourceVersion of the Get that preceded it as an
+		// optimistic-concurrency precondition; the fake app's Get always returns "1".
+		assert.Equal(t, []string{"1", "1"}, patchRVs, "each patch must embed the live resourceVersion precondition")
 	})
 
 	t.Run("re-evaluates the stale-update guard against the refetched object", func(t *testing.T) {
 		// A non-terminal progress update races a terminal write. The first Get sees the
 		// operation still in progress, so the guard admits the update and the controller
 		// patches — but that patch conflicts because the terminal write landed first. On
-		// refetch the live operation has completed and spec.operation is cleared, so the
+		// refetch the live operation has completed and the operation field is cleared, so the
 		// guard must now discard the stale progress update instead of resurrecting "Running".
 		running := newFakeApp()
 		running.Operation = &v1alpha1.Operation{Sync: &v1alpha1.SyncOperation{Revision: "abc123"}}
@@ -2069,7 +2074,7 @@ func TestSetOperationStateRetriesOnConflict(t *testing.T) {
 			Operation: *running.Operation,
 		}
 		completed := running.DeepCopy()
-		completed.Operation = nil // spec.operation is cleared once an operation completes
+		completed.Operation = nil // the operation field is cleared once an operation completes
 		finishedAt := metav1.Now()
 		completed.Status.OperationState = &v1alpha1.OperationState{
 			Phase:      synccommon.OperationSucceeded,
@@ -2083,6 +2088,7 @@ func TestSetOperationStateRetriesOnConflict(t *testing.T) {
 		fakeAppCs.ReactionChain = nil
 
 		gets, patches := 0, 0
+		var patchRVs []string
 		fakeAppCs.AddReactor("get", "*", func(_ kubetesting.Action) (handled bool, ret runtime.Object, err error) {
 			gets++
 			if gets == 1 {
@@ -2090,8 +2096,9 @@ func TestSetOperationStateRetriesOnConflict(t *testing.T) {
 			}
 			return true, completed.DeepCopy(), nil // terminal write won the race
 		})
-		fakeAppCs.AddReactor("patch", "*", func(_ kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+		fakeAppCs.AddReactor("patch", "*", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
 			patches++
+			patchRVs = append(patchRVs, patchResourceVersion(t, action))
 			return true, &v1alpha1.Application{}, apierrors.NewConflict(appConflict, running.Name, errors.New("the object has been modified"))
 		})
 
@@ -2104,7 +2111,25 @@ func TestSetOperationStateRetriesOnConflict(t *testing.T) {
 
 		assert.Equal(t, 1, patches, "once the refetch shows the operation completed, the stale update must not be re-patched")
 		assert.GreaterOrEqual(t, gets, 2, "the conflict must trigger a refetch and guard re-evaluation")
+		// The single patch that was attempted must have carried the first Get's resourceVersion
+		// precondition; the fake app's Get always returns "1".
+		assert.Equal(t, []string{"1"}, patchRVs, "the patch must embed the live resourceVersion precondition")
 	})
+}
+
+// patchResourceVersion extracts metadata.resourceVersion from a merge-patch PatchAction payload,
+// so tests can assert that setOperationState embeds the optimistic-concurrency precondition.
+func patchResourceVersion(t *testing.T, action kubetesting.Action) string {
+	t.Helper()
+	patchAction, ok := action.(kubetesting.PatchAction)
+	require.True(t, ok, "expected a PatchAction, got %T", action)
+	var patch struct {
+		Metadata struct {
+			ResourceVersion string `json:"resourceVersion"`
+		} `json:"metadata"`
+	}
+	require.NoError(t, json.Unmarshal(patchAction.GetPatch(), &patch))
+	return patch.Metadata.ResourceVersion
 }
 
 func TestNeedRefreshAppStatus(t *testing.T) {

--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -2066,6 +2066,71 @@ func TestFailedSyncWithRetry(t *testing.T) {
 		Expect(OperationMessageContains("retried 1 times"))
 }
 
+// TestStaleOperationRevisionNotUsedNewSync validates new operations resolve the revision
+// and do not use the existing completed operation state.
+func TestStaleOperationRevisionNotUsedNewSync(t *testing.T) {
+	var revisionX string
+	var revisionY string
+
+	ctx := Given(t)
+	ctx.
+		Path("hook").
+		When().
+		CreateApp().
+		And(func() {
+			sha, err := fixture.Run(fixture.TmpDir()+"/testdata.git", "git", "rev-parse", "HEAD")
+			require.NoError(t, err)
+			revisionX = strings.TrimSpace(sha)
+		}).
+		// 1. Create and sync the app on revision X.
+		Sync("--revision", revisionX).
+		Then().
+		// 2. The app must be synced and healthy on X.
+		Expect(OperationPhaseIs(OperationSucceeded)).
+		Expect(SyncStatusIs(SyncStatusCodeSynced)).
+		Expect(HealthIs(health.HealthStatusHealthy)).
+		And(func(app *Application) {
+			require.NotNil(t, app.Status.OperationState)
+			require.NotNil(t, app.Status.OperationState.SyncResult)
+			require.Equal(t, revisionX, app.Status.OperationState.SyncResult.Revision)
+		}).
+		When().
+		// 3. Push an invalid commit Y (an apply-time failure only present on HEAD).
+		AddFile("failure-during-sync.yaml", `apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: failure-during-sync
+  labels:
+    my-label: has-inva/id-character!
+`).
+		And(func() {
+			sha, err := fixture.Run(fixture.TmpDir()+"/testdata.git", "git", "rev-parse", "HEAD")
+			require.NoError(t, err)
+			revisionY = strings.TrimSpace(sha)
+			require.NotEqual(t, revisionX, revisionY)
+			// 4. Add a sync Operation on HEAD (without any resolved revisions)
+			patch := fmt.Sprintf(`{
+				"operation": {
+					"initiatedBy": {"username": "e2e", "automated": true},
+					"info": [{"name": "Reason", "value": "Syncing latest without resolved revision"}],
+					"sync": {},
+					"retry": {"limit": %d, "backoff": {"duration": %q}}
+				}
+			}`, 1, "1s")
+			_, err = fixture.Run("", "kubectl", "-n", fixture.TestNamespace(), "patch", "application", ctx.AppName(), "--type", "merge", "-p", patch)
+			require.NoError(t, err)
+		}).
+		Then().
+		// 5. The sync resolves the new revision Y and fails on it
+		Expect(OperationRetriedMinimumTimes(1)).
+		Expect(OperationPhaseIs(OperationFailed)).
+		And(func(app *Application) {
+			require.NotNil(t, app.Status.OperationState.SyncResult)
+			// syncResult must record revision Y, the current broken HEAD that failed.
+			assert.Equal(t, revisionY, app.Status.OperationState.SyncResult.Revision)
+		})
+}
+
 func TestCreateDisableValidation(t *testing.T) {
 	ctx := Given(t)
 	ctx.Path("baddir").

--- a/test/e2e/fixture/app/expectation.go
+++ b/test/e2e/fixture/app/expectation.go
@@ -76,8 +76,14 @@ func OperationMessageContains(text string) Expectation {
 func OperationRetriedMinimumTimes(minRetries int64) Expectation {
 	return func(c *Consequences) (state, string) {
 		operationState := c.app().Status.OperationState
+		// operationState is briefly nil while a new operation is being started (SetAppOperation
+		// clears status.operationState when it sets spec.operation), so treat nil as "not retried
+		// yet" and keep polling instead of dereferencing it.
+		if operationState == nil {
+			return pending, fmt.Sprintf("operation state retry count should be at least %d, but no operation state is set yet", minRetries)
+		}
 		actual := operationState.RetryCount
-		message := fmt.Sprintf("operation state retry cound should be at least %d, is %d, message: '%s'", minRetries, actual, operationState.Message)
+		message := fmt.Sprintf("operation state retry count should be at least %d, is %d, message: '%s'", minRetries, actual, operationState.Message)
 		return simple(actual >= minRetries, message)
 	}
 }


### PR DESCRIPTION
`setOperationState` writes `status.operationState` with a blind JSON merge patch, which could cause an app to be in a permanent `Running` phase:

- OperationState fields are `omitempty`, so a merge patch carrying a subset of them can't clear the rest (the old `{"finishedAt": null}` fix worked around that)
- A merge patch has no `resourceVersion` precondition, so an out-of-order write applies unconditionally.

During an ideal sync the controller emits progress writes (`Running`) followed by a final write (`Succeeded`, `finishedAt` set, `spec.operation` cleared). If a delayed `Running` write lands after the final one, e.g under apiserver load, a controller restart, or a flaky client<->apiserver link, it'll revert phase/message to the in-flight values but can't clear the `finishedAt` the terminal write recorded. The result is a `Running` + `finishedAt` + stale message; `spec.operation` is already consumed, so the app is never re-enqueued and never self-heals.

The fix here is to read the live app and write `operationState` back with a scoped merge patch carrying the live `resourceVersion` as a precondition: a concurrent writer now causes a Conflict + refetch instead of a silent clobber, and the scoped diff clears dropped fields (dropping the need for the null `finishedAt`).

Optimistic concurrency alone isn't enough; a stale writer that refetches would still overwrite a completed op, so also refuse moving a completed operation back to a non-terminal phase.

Related: #7890, #18613, #23765


<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
