### PR TITLE
fix: require watch permission for respectRBAC resource checks (#28744)

### DIFF
--- a/docs/operator-manual/declarative-setup.md
+++ b/docs/operator-manual/declarative-setup.md
@@ -1434,7 +1434,7 @@ Users who are comfortable with an increase in kube api-server calls can opt for 
 Notes:
 
 * When set to use `strict` mode controller must have RBAC permission to `create` a `SelfSubjectAccessReview` resource 
-* The `SelfSubjectAccessReview` request will be only made for the `list` verb, it is assumed that if `list` is allowed for a resource then all other permissions are also available to the controller.
+* The `SelfSubjectAccessReview` request is made for both the `list` and `watch` verbs. The cache always establishes a watch after the initial list, so `list` alone is not treated as sufficient (some platforms grant `list` without `watch`, which would otherwise cause repeated watch failures).
 
 Example argocd cm with `resource.respectRBAC` set to `strict`:
 

--- a/docs/operator-manual/declarative-setup.md
+++ b/docs/operator-manual/declarative-setup.md
@@ -1466,7 +1466,7 @@ Users who are comfortable with an increase in kube api-server calls can opt for 
 Notes:
 
 * When set to use `strict` mode controller must have RBAC permission to `create` a `SelfSubjectAccessReview` resource 
-* The `SelfSubjectAccessReview` request is made for both the `list` and `watch` verbs. The cache always establishes a watch after the initial list, so `list` alone is not treated as sufficient (some platforms grant `list` without `watch`, which would otherwise cause repeated watch failures).
+* `strict` mode issues reviews as follows: if the initial list is forbidden/unauthorized it reviews `list` first and stops if that verb is denied; if the list succeeds it only reviews `watch` before starting the informer. `list` alone is not treated as sufficient (some platforms grant `list` without `watch`, which would otherwise cause repeated watch failures). Namespaced reviews are scoped to the namespace being listed or watched.
 
 Example `argocd-cm` ConfigMap with `resource.respectRBAC` set to `strict`:
 

--- a/docs/operator-manual/declarative-setup.md
+++ b/docs/operator-manual/declarative-setup.md
@@ -1466,7 +1466,7 @@ Users who are comfortable with an increase in kube api-server calls can opt for 
 Notes:
 
 * When set to use `strict` mode controller must have RBAC permission to `create` a `SelfSubjectAccessReview` resource 
-* The `SelfSubjectAccessReview` request will be only made for the `list` verb, it is assumed that if `list` is allowed for a resource then all other permissions are also available to the controller.
+* The `SelfSubjectAccessReview` request is made for both the `list` and `watch` verbs. The cache always establishes a watch after the initial list, so `list` alone is not treated as sufficient (some platforms grant `list` without `watch`, which would otherwise cause repeated watch failures).
 
 Example `argocd-cm` ConfigMap with `resource.respectRBAC` set to `strict`:
 

--- a/gitops-engine/pkg/cache/cluster.go
+++ b/gitops-engine/pkg/cache/cluster.go
@@ -693,6 +693,20 @@ func (c *clusterCache) startMissingWatches() error {
 						return nil
 					}
 				}
+				// List may succeed while watch is denied (e.g. OpenShift basic-user
+				// grants get/list on storageclasses but not watch). In strict mode,
+				// confirm watch via SSAR before starting the informer.
+				if err == nil && c.respectRBAC == RespectRbacStrict {
+					allowed, permErr := c.isAllowed(ctx, clientset.AuthorizationV1().SelfSubjectAccessReviews(), api, "watch")
+					if permErr != nil {
+						return fmt.Errorf("failed to check watch permission for resource %s: %w", api.GroupKind.String(), permErr)
+					}
+					if !allowed {
+						delete(c.apisMeta, api.GroupKind)
+						delete(namespacedResources, api.GroupKind)
+						return nil
+					}
+				}
 				go c.watchEvents(ctx, api, resClient, ns, resourceVersion)
 				return nil
 			})
@@ -816,6 +830,29 @@ func (c *clusterCache) watchEvents(ctx context.Context, api kube.APIResourceInfo
 			},
 		})
 		if err != nil {
+			// When respectRBAC is enabled, a forbidden/unauthorized watch must not
+			// be retried forever. list can be allowed while watch is not (OpenShift
+			// basic-user on storageclasses is a common case); drop the resource
+			// from the watch list instead of spamming errors.
+			if c.isRestrictedResource(err) {
+				keep := false
+				if c.respectRBAC == RespectRbacStrict {
+					clientset, csErr := kubernetes.NewForConfig(c.config)
+					if csErr != nil {
+						return fmt.Errorf("failed to create clientset while checking watch permission for %s: %w", api.GroupKind.String(), csErr)
+					}
+					k, permErr := c.isAllowed(ctx, clientset.AuthorizationV1().SelfSubjectAccessReviews(), api, "watch")
+					if permErr != nil {
+						return fmt.Errorf("failed to check watch permission for resource %s: %w, original error=%v", api.GroupKind.String(), permErr, err.Error())
+					}
+					keep = k
+				}
+				if !keep {
+					c.stopWatching(api.GroupKind, ns)
+					c.log.Info(fmt.Sprintf("Stop watching %s: watch not permitted", api.GroupKind))
+					return nil
+				}
+			}
 			return fmt.Errorf("failed to create resource watcher: %w", err)
 		}
 
@@ -1036,13 +1073,40 @@ func (c *clusterCache) isRestrictedResource(err error) bool {
 	return c.respectRBAC != RespectRbacDisabled && (apierrors.IsForbidden(err) || apierrors.IsUnauthorized(err))
 }
 
-// checkPermission runs a self subject access review to check if the controller has permissions to list the resource
+// verbsRequiredForWatch are the RBAC verbs the controller needs in order to
+// maintain a cache informer for a resource. list alone is not enough: without
+// watch the informer fails and retries forever (see #28744).
+var verbsRequiredForWatch = []string{"list", "watch"}
+
+// checkPermission runs self subject access reviews to check if the controller
+// has permissions to list and watch the resource. Both verbs are required
+// because the cache always establishes a watch after the initial list; having
+// list without watch (common on OpenShift via the basic-user ClusterRole for
+// resources like storageclasses) would otherwise leave the informer retrying
+// a forbidden watch indefinitely.
 func (c *clusterCache) checkPermission(ctx context.Context, reviewInterface authType1.SelfSubjectAccessReviewInterface, api kube.APIResourceInfo) (keep bool, err error) {
+	for _, verb := range verbsRequiredForWatch {
+		allowed, err := c.isAllowed(ctx, reviewInterface, api, verb)
+		if err != nil {
+			return false, err
+		}
+		if !allowed {
+			// unsupported, remove from watch list
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// isAllowed reports whether the controller is allowed to perform verb on api
+// for the scopes this cache manages.
+func (c *clusterCache) isAllowed(ctx context.Context, reviewInterface authType1.SelfSubjectAccessReviewInterface, api kube.APIResourceInfo, verb string) (bool, error) {
 	sar := &authorizationv1.SelfSubjectAccessReview{
 		Spec: authorizationv1.SelfSubjectAccessReviewSpec{
 			ResourceAttributes: &authorizationv1.ResourceAttributes{
 				Namespace: "*",
-				Verb:      "list", // uses list verb to check for permissions
+				Verb:      verb,
+				Group:     api.GroupVersionResource.Group,
 				Resource:  api.GroupVersionResource.Resource,
 			},
 		},
@@ -1058,7 +1122,6 @@ func (c *clusterCache) checkPermission(ctx context.Context, reviewInterface auth
 		if resp != nil && resp.Status.Allowed {
 			return true, nil
 		}
-		// unsupported, remove from watch list
 		return false, nil
 	// if manage some namespaces and resource is namespaced
 	case len(c.namespaces) != 0 && api.Meta.Namespaced:
@@ -1072,10 +1135,9 @@ func (c *clusterCache) checkPermission(ctx context.Context, reviewInterface auth
 				return true, nil
 			}
 		}
-		// unsupported, remove from watch list
 		return false, nil
 	}
-	// checkPermission follows the same logic of determining namespace/cluster resource as the processApi function
+	// isAllowed follows the same logic of determining namespace/cluster resource as the processApi function
 	// so if neither of the cases match it means the controller will not watch for it so it is safe to return true.
 	return true, nil
 }
@@ -1196,6 +1258,25 @@ func (c *clusterCache) sync() error {
 					}
 				}
 				return fmt.Errorf("failed to load initial state of resource %s: %w", api.GroupKind.String(), err)
+			}
+
+			// List may succeed while watch is denied (e.g. OpenShift basic-user
+			// grants get/list on storageclasses but not watch). In strict mode,
+			// confirm watch via SSAR before starting the informer so we don't
+			// spam "cannot watch" retries. Normal mode relies on the watch path
+			// handling a forbidden response (see watchEvents).
+			if c.respectRBAC == RespectRbacStrict {
+				allowed, permErr := c.isAllowed(ctx, clientset.AuthorizationV1().SelfSubjectAccessReviews(), api, "watch")
+				if permErr != nil {
+					return fmt.Errorf("failed to check watch permission for resource %s: %w", api.GroupKind.String(), permErr)
+				}
+				if !allowed {
+					syncLock.Lock()
+					delete(c.apisMeta, api.GroupKind)
+					delete(c.namespacedResources, api.GroupKind)
+					syncLock.Unlock()
+					return nil
+				}
 			}
 
 			go c.watchEvents(ctx, api, resClient, ns, resourceVersion)

--- a/gitops-engine/pkg/cache/cluster.go
+++ b/gitops-engine/pkg/cache/cluster.go
@@ -1073,10 +1073,13 @@ func (c *clusterCache) isRestrictedResource(err error) bool {
 	return c.respectRBAC != RespectRbacDisabled && (apierrors.IsForbidden(err) || apierrors.IsUnauthorized(err))
 }
 
-// verbsRequiredForWatch are the RBAC verbs the controller needs in order to
-// maintain a cache informer for a resource. list alone is not enough: without
-// watch the informer fails and retries forever (see #28744).
-var verbsRequiredForWatch = []string{"list", "watch"}
+// verbsRequiredForWatch returns the RBAC verbs the controller needs in order
+// to maintain a cache informer for a resource. list alone is not enough:
+// without watch the informer fails and retries forever (see #28744).
+// Returned as a fresh slice so callers cannot mutate shared package state.
+func verbsRequiredForWatch() []string {
+	return []string{"list", "watch"}
+}
 
 // checkPermission runs self subject access reviews to check if the controller
 // has permissions to list and watch the resource. Both verbs are required
@@ -1085,7 +1088,7 @@ var verbsRequiredForWatch = []string{"list", "watch"}
 // resources like storageclasses) would otherwise leave the informer retrying
 // a forbidden watch indefinitely.
 func (c *clusterCache) checkPermission(ctx context.Context, reviewInterface authType1.SelfSubjectAccessReviewInterface, api kube.APIResourceInfo) (keep bool, err error) {
-	for _, verb := range verbsRequiredForWatch {
+	for _, verb := range verbsRequiredForWatch() {
 		allowed, err := c.isAllowed(ctx, reviewInterface, api, verb)
 		if err != nil {
 			return false, err

--- a/gitops-engine/pkg/cache/cluster.go
+++ b/gitops-engine/pkg/cache/cluster.go
@@ -1078,10 +1078,13 @@ func (c *clusterCache) isRestrictedResource(err error) bool {
 	return c.respectRBAC != RespectRbacDisabled && (apierrors.IsForbidden(err) || apierrors.IsUnauthorized(err))
 }
 
-// verbsRequiredForWatch are the RBAC verbs the controller needs in order to
-// maintain a cache informer for a resource. list alone is not enough: without
-// watch the informer fails and retries forever (see #28744).
-var verbsRequiredForWatch = []string{"list", "watch"}
+// verbsRequiredForWatch returns the RBAC verbs the controller needs in order
+// to maintain a cache informer for a resource. list alone is not enough:
+// without watch the informer fails and retries forever (see #28744).
+// Returned as a fresh slice so callers cannot mutate shared package state.
+func verbsRequiredForWatch() []string {
+	return []string{"list", "watch"}
+}
 
 // checkPermission runs self subject access reviews to check if the controller
 // has permissions to list and watch the resource. Both verbs are required
@@ -1090,7 +1093,7 @@ var verbsRequiredForWatch = []string{"list", "watch"}
 // resources like storageclasses) would otherwise leave the informer retrying
 // a forbidden watch indefinitely.
 func (c *clusterCache) checkPermission(ctx context.Context, reviewInterface authType1.SelfSubjectAccessReviewInterface, api kube.APIResourceInfo) (keep bool, err error) {
-	for _, verb := range verbsRequiredForWatch {
+	for _, verb := range verbsRequiredForWatch() {
 		allowed, err := c.isAllowed(ctx, reviewInterface, api, verb)
 		if err != nil {
 			return false, err

--- a/gitops-engine/pkg/cache/cluster.go
+++ b/gitops-engine/pkg/cache/cluster.go
@@ -693,6 +693,20 @@ func (c *clusterCache) startMissingWatches() error {
 						return nil
 					}
 				}
+				// List may succeed while watch is denied (e.g. OpenShift basic-user
+				// grants get/list on storageclasses but not watch). In strict mode,
+				// confirm watch via SSAR before starting the informer.
+				if err == nil && c.respectRBAC == RespectRbacStrict {
+					allowed, permErr := c.isAllowed(ctx, clientset.AuthorizationV1().SelfSubjectAccessReviews(), api, "watch")
+					if permErr != nil {
+						return fmt.Errorf("failed to check watch permission for resource %s: %w", api.GroupKind.String(), permErr)
+					}
+					if !allowed {
+						delete(c.apisMeta, api.GroupKind)
+						delete(namespacedResources, api.GroupKind)
+						return nil
+					}
+				}
 				go c.watchEvents(ctx, api, resClient, ns, resourceVersion)
 				return nil
 			})
@@ -820,6 +834,29 @@ func (c *clusterCache) watchEvents(ctx context.Context, api kube.APIResourceInfo
 			},
 		})
 		if err != nil {
+			// When respectRBAC is enabled, a forbidden/unauthorized watch must not
+			// be retried forever. list can be allowed while watch is not (OpenShift
+			// basic-user on storageclasses is a common case); drop the resource
+			// from the watch list instead of spamming errors.
+			if c.isRestrictedResource(err) {
+				keep := false
+				if c.respectRBAC == RespectRbacStrict {
+					clientset, csErr := kubernetes.NewForConfig(c.config)
+					if csErr != nil {
+						return fmt.Errorf("failed to create clientset while checking watch permission for %s: %w", api.GroupKind.String(), csErr)
+					}
+					k, permErr := c.isAllowed(ctx, clientset.AuthorizationV1().SelfSubjectAccessReviews(), api, "watch")
+					if permErr != nil {
+						return fmt.Errorf("failed to check watch permission for resource %s: %w, original error=%v", api.GroupKind.String(), permErr, err.Error())
+					}
+					keep = k
+				}
+				if !keep {
+					c.stopWatching(api.GroupKind, ns)
+					c.log.Info(fmt.Sprintf("Stop watching %s: watch not permitted", api.GroupKind))
+					return nil
+				}
+			}
 			return fmt.Errorf("failed to create resource watcher: %w", err)
 		}
 
@@ -1041,13 +1078,40 @@ func (c *clusterCache) isRestrictedResource(err error) bool {
 	return c.respectRBAC != RespectRbacDisabled && (apierrors.IsForbidden(err) || apierrors.IsUnauthorized(err))
 }
 
-// checkPermission runs a self subject access review to check if the controller has permissions to list the resource
+// verbsRequiredForWatch are the RBAC verbs the controller needs in order to
+// maintain a cache informer for a resource. list alone is not enough: without
+// watch the informer fails and retries forever (see #28744).
+var verbsRequiredForWatch = []string{"list", "watch"}
+
+// checkPermission runs self subject access reviews to check if the controller
+// has permissions to list and watch the resource. Both verbs are required
+// because the cache always establishes a watch after the initial list; having
+// list without watch (common on OpenShift via the basic-user ClusterRole for
+// resources like storageclasses) would otherwise leave the informer retrying
+// a forbidden watch indefinitely.
 func (c *clusterCache) checkPermission(ctx context.Context, reviewInterface authType1.SelfSubjectAccessReviewInterface, api kube.APIResourceInfo) (keep bool, err error) {
+	for _, verb := range verbsRequiredForWatch {
+		allowed, err := c.isAllowed(ctx, reviewInterface, api, verb)
+		if err != nil {
+			return false, err
+		}
+		if !allowed {
+			// unsupported, remove from watch list
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// isAllowed reports whether the controller is allowed to perform verb on api
+// for the scopes this cache manages.
+func (c *clusterCache) isAllowed(ctx context.Context, reviewInterface authType1.SelfSubjectAccessReviewInterface, api kube.APIResourceInfo, verb string) (bool, error) {
 	sar := &authorizationv1.SelfSubjectAccessReview{
 		Spec: authorizationv1.SelfSubjectAccessReviewSpec{
 			ResourceAttributes: &authorizationv1.ResourceAttributes{
 				Namespace: "*",
-				Verb:      "list", // uses list verb to check for permissions
+				Verb:      verb,
+				Group:     api.GroupVersionResource.Group,
 				Resource:  api.GroupVersionResource.Resource,
 			},
 		},
@@ -1063,7 +1127,6 @@ func (c *clusterCache) checkPermission(ctx context.Context, reviewInterface auth
 		if resp != nil && resp.Status.Allowed {
 			return true, nil
 		}
-		// unsupported, remove from watch list
 		return false, nil
 	// if manage some namespaces and resource is namespaced
 	case len(c.namespaces) != 0 && api.Meta.Namespaced:
@@ -1077,10 +1140,9 @@ func (c *clusterCache) checkPermission(ctx context.Context, reviewInterface auth
 				return true, nil
 			}
 		}
-		// unsupported, remove from watch list
 		return false, nil
 	}
-	// checkPermission follows the same logic of determining namespace/cluster resource as the processApi function
+	// isAllowed follows the same logic of determining namespace/cluster resource as the processApi function
 	// so if neither of the cases match it means the controller will not watch for it so it is safe to return true.
 	return true, nil
 }
@@ -1224,6 +1286,25 @@ func (c *clusterCache) sync() (err error) {
 					}
 				}
 				return fmt.Errorf("failed to load initial state of resource %s: %w", api.GroupKind.String(), err)
+			}
+
+			// List may succeed while watch is denied (e.g. OpenShift basic-user
+			// grants get/list on storageclasses but not watch). In strict mode,
+			// confirm watch via SSAR before starting the informer so we don't
+			// spam "cannot watch" retries. Normal mode relies on the watch path
+			// handling a forbidden response (see watchEvents).
+			if c.respectRBAC == RespectRbacStrict {
+				allowed, permErr := c.isAllowed(ctx, clientset.AuthorizationV1().SelfSubjectAccessReviews(), api, "watch")
+				if permErr != nil {
+					return fmt.Errorf("failed to check watch permission for resource %s: %w", api.GroupKind.String(), permErr)
+				}
+				if !allowed {
+					syncLock.Lock()
+					delete(c.apisMeta, api.GroupKind)
+					delete(c.namespacedResources, api.GroupKind)
+					syncLock.Unlock()
+					return nil
+				}
 			}
 
 			go c.watchEvents(ctx, api, resClient, ns, resourceVersion)

--- a/gitops-engine/pkg/cache/cluster.go
+++ b/gitops-engine/pkg/cache/cluster.go
@@ -680,7 +680,7 @@ func (c *clusterCache) startMissingWatches() error {
 				if err != nil && c.isRestrictedResource(err) {
 					keep := false
 					if c.respectRBAC == RespectRbacStrict {
-						k, permErr := c.checkPermission(ctx, clientset.AuthorizationV1().SelfSubjectAccessReviews(), api)
+						k, permErr := c.checkPermission(ctx, clientset.AuthorizationV1().SelfSubjectAccessReviews(), api, ns)
 						if permErr != nil {
 							return fmt.Errorf("failed to check permissions for resource %s: %w, original error=%v", api.GroupKind.String(), permErr, err.Error())
 						}
@@ -697,7 +697,7 @@ func (c *clusterCache) startMissingWatches() error {
 				// grants get/list on storageclasses but not watch). In strict mode,
 				// confirm watch via SSAR before starting the informer.
 				if err == nil && c.respectRBAC == RespectRbacStrict {
-					allowed, permErr := c.isAllowed(ctx, clientset.AuthorizationV1().SelfSubjectAccessReviews(), api, "watch")
+					allowed, permErr := c.isAllowed(ctx, clientset.AuthorizationV1().SelfSubjectAccessReviews(), api, "watch", ns)
 					if permErr != nil {
 						return fmt.Errorf("failed to check watch permission for resource %s: %w", api.GroupKind.String(), permErr)
 					}
@@ -829,33 +829,22 @@ func (c *clusterCache) watchEvents(ctx context.Context, api kube.APIResourceInfo
 				if apierrors.IsNotFound(err) {
 					c.stopWatching(api.GroupKind, ns)
 				}
+				if stopped, stopErr := c.stopIfWatchForbidden(ctx, api, ns, err); stopErr != nil {
+					return res, stopErr
+				} else if stopped {
+					// Cancelled via stopWatching; still return err so RetryWatcher
+					// does not treat a nil watcher as success.
+					return res, err
+				}
 				//nolint:wrapcheck // wrap outside the retry
 				return res, err
 			},
 		})
 		if err != nil {
-			// When respectRBAC is enabled, a forbidden/unauthorized watch must not
-			// be retried forever. list can be allowed while watch is not (OpenShift
-			// basic-user on storageclasses is a common case); drop the resource
-			// from the watch list instead of spamming errors.
-			if c.isRestrictedResource(err) {
-				keep := false
-				if c.respectRBAC == RespectRbacStrict {
-					clientset, csErr := kubernetes.NewForConfig(c.config)
-					if csErr != nil {
-						return fmt.Errorf("failed to create clientset while checking watch permission for %s: %w", api.GroupKind.String(), csErr)
-					}
-					k, permErr := c.isAllowed(ctx, clientset.AuthorizationV1().SelfSubjectAccessReviews(), api, "watch")
-					if permErr != nil {
-						return fmt.Errorf("failed to check watch permission for resource %s: %w, original error=%v", api.GroupKind.String(), permErr, err.Error())
-					}
-					keep = k
-				}
-				if !keep {
-					c.stopWatching(api.GroupKind, ns)
-					c.log.Info(fmt.Sprintf("Stop watching %s: watch not permitted", api.GroupKind))
-					return nil
-				}
+			if stopped, stopErr := c.stopIfWatchForbidden(ctx, api, ns, err); stopErr != nil {
+				return stopErr
+			} else if stopped {
+				return nil
 			}
 			return fmt.Errorf("failed to create resource watcher: %w", err)
 		}
@@ -891,8 +880,25 @@ func (c *clusterCache) watchEvents(ctx context.Context, api kube.APIResourceInfo
 					return fmt.Errorf("watch %s on %s has closed", api.GroupKind, c.config.Host)
 				}
 
+				if event.Type == watch.Error {
+					werr := apierrors.FromObject(event.Object)
+					if stopped, stopErr := c.stopIfWatchForbidden(ctx, api, ns, werr); stopErr != nil {
+						return stopErr
+					} else if stopped {
+						return nil
+					}
+					return fmt.Errorf("watch error for %s: %v", api.GroupKind, event.Object)
+				}
+
 				obj, ok := event.Object.(*unstructured.Unstructured)
 				if !ok {
+					if werr := apierrors.FromObject(event.Object); werr != nil {
+						if stopped, stopErr := c.stopIfWatchForbidden(ctx, api, ns, werr); stopErr != nil {
+							return stopErr
+						} else if stopped {
+							return nil
+						}
+					}
 					return fmt.Errorf("failed to convert to *unstructured.Unstructured: %v", event.Object)
 				}
 
@@ -1078,6 +1084,34 @@ func (c *clusterCache) isRestrictedResource(err error) bool {
 	return c.respectRBAC != RespectRbacDisabled && (apierrors.IsForbidden(err) || apierrors.IsUnauthorized(err))
 }
 
+// stopIfWatchForbidden drops the watch when respectRBAC is on and err is a
+// forbidden/unauthorized watch. RetryWatcher does not surface that as a
+// constructor error (Watch() fails later as watch.Error), so callers must
+// invoke this from WatchFunc and from ResultChan as well.
+func (c *clusterCache) stopIfWatchForbidden(ctx context.Context, api kube.APIResourceInfo, ns string, err error) (stopped bool, retErr error) {
+	if !c.isRestrictedResource(err) {
+		return false, nil
+	}
+	keep := false
+	if c.respectRBAC == RespectRbacStrict {
+		clientset, csErr := kubernetes.NewForConfig(c.config)
+		if csErr != nil {
+			return false, fmt.Errorf("failed to create clientset while checking watch permission for %s: %w", api.GroupKind.String(), csErr)
+		}
+		k, permErr := c.isAllowed(ctx, clientset.AuthorizationV1().SelfSubjectAccessReviews(), api, "watch", ns)
+		if permErr != nil {
+			return false, fmt.Errorf("failed to check watch permission for resource %s: %w, original error=%v", api.GroupKind.String(), permErr, err.Error())
+		}
+		keep = k
+	}
+	if keep {
+		return false, nil
+	}
+	c.stopWatching(api.GroupKind, ns)
+	c.log.Info(fmt.Sprintf("Stop watching %s: watch not permitted", api.GroupKind))
+	return true, nil
+}
+
 // verbsRequiredForWatch returns the RBAC verbs the controller needs in order
 // to maintain a cache informer for a resource. list alone is not enough:
 // without watch the informer fails and retries forever (see #28744).
@@ -1092,9 +1126,9 @@ func verbsRequiredForWatch() []string {
 // list without watch (common on OpenShift via the basic-user ClusterRole for
 // resources like storageclasses) would otherwise leave the informer retrying
 // a forbidden watch indefinitely.
-func (c *clusterCache) checkPermission(ctx context.Context, reviewInterface authType1.SelfSubjectAccessReviewInterface, api kube.APIResourceInfo) (keep bool, err error) {
+func (c *clusterCache) checkPermission(ctx context.Context, reviewInterface authType1.SelfSubjectAccessReviewInterface, api kube.APIResourceInfo, ns string) (keep bool, err error) {
 	for _, verb := range verbsRequiredForWatch() {
-		allowed, err := c.isAllowed(ctx, reviewInterface, api, verb)
+		allowed, err := c.isAllowed(ctx, reviewInterface, api, verb, ns)
 		if err != nil {
 			return false, err
 		}
@@ -1108,7 +1142,7 @@ func (c *clusterCache) checkPermission(ctx context.Context, reviewInterface auth
 
 // isAllowed reports whether the controller is allowed to perform verb on api
 // for the scopes this cache manages.
-func (c *clusterCache) isAllowed(ctx context.Context, reviewInterface authType1.SelfSubjectAccessReviewInterface, api kube.APIResourceInfo, verb string) (bool, error) {
+func (c *clusterCache) isAllowed(ctx context.Context, reviewInterface authType1.SelfSubjectAccessReviewInterface, api kube.APIResourceInfo, verb, ns string) (bool, error) {
 	sar := &authorizationv1.SelfSubjectAccessReview{
 		Spec: authorizationv1.SelfSubjectAccessReviewSpec{
 			ResourceAttributes: &authorizationv1.ResourceAttributes{
@@ -1133,8 +1167,12 @@ func (c *clusterCache) isAllowed(ctx context.Context, reviewInterface authType1.
 		return false, nil
 	// if manage some namespaces and resource is namespaced
 	case len(c.namespaces) != 0 && api.Meta.Namespaced:
-		for _, ns := range c.namespaces {
-			sar.Spec.ResourceAttributes.Namespace = ns
+		nss := c.namespaces
+		if ns != "" {
+			nss = []string{ns}
+		}
+		for _, n := range nss {
+			sar.Spec.ResourceAttributes.Namespace = n
 			resp, err := reviewInterface.Create(ctx, sar, metav1.CreateOptions{})
 			if err != nil {
 				return false, fmt.Errorf("failed to create self subject access review: %w", err)
@@ -1273,7 +1311,7 @@ func (c *clusterCache) sync() (err error) {
 				if c.isRestrictedResource(err) {
 					keep := false
 					if c.respectRBAC == RespectRbacStrict {
-						k, permErr := c.checkPermission(ctx, clientset.AuthorizationV1().SelfSubjectAccessReviews(), api)
+						k, permErr := c.checkPermission(ctx, clientset.AuthorizationV1().SelfSubjectAccessReviews(), api, ns)
 						if permErr != nil {
 							return fmt.Errorf("failed to check permissions for resource %s: %w, original error=%v", api.GroupKind.String(), permErr, err.Error())
 						}
@@ -1297,7 +1335,7 @@ func (c *clusterCache) sync() (err error) {
 			// spam "cannot watch" retries. Normal mode relies on the watch path
 			// handling a forbidden response (see watchEvents).
 			if c.respectRBAC == RespectRbacStrict {
-				allowed, permErr := c.isAllowed(ctx, clientset.AuthorizationV1().SelfSubjectAccessReviews(), api, "watch")
+				allowed, permErr := c.isAllowed(ctx, clientset.AuthorizationV1().SelfSubjectAccessReviews(), api, "watch", ns)
 				if permErr != nil {
 					return fmt.Errorf("failed to check watch permission for resource %s: %w", api.GroupKind.String(), permErr)
 				}

--- a/gitops-engine/pkg/cache/cluster_permission_test.go
+++ b/gitops-engine/pkg/cache/cluster_permission_test.go
@@ -1,0 +1,169 @@
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	authType1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
+
+	"github.com/argoproj/argo-cd/gitops-engine/v3/pkg/utils/kube"
+)
+
+// recordingSSAR answers from a verb -> allowed map and records every verb checked.
+type recordingSSAR struct {
+	allowed map[string]bool
+	verbs   []string
+}
+
+func (r *recordingSSAR) Create(ctx context.Context, sar *authorizationv1.SelfSubjectAccessReview, opts metav1.CreateOptions) (*authorizationv1.SelfSubjectAccessReview, error) {
+	verb := sar.Spec.ResourceAttributes.Verb
+	r.verbs = append(r.verbs, verb)
+	out := sar.DeepCopy()
+	out.Status.Allowed = r.allowed[verb]
+	return out, nil
+}
+
+// compile-time interface check
+var _ authType1.SelfSubjectAccessReviewInterface = (*recordingSSAR)(nil)
+
+func storageClassAPI() kube.APIResourceInfo {
+	return kube.APIResourceInfo{
+		GroupKind: schema.GroupKind{Group: "storage.k8s.io", Kind: "StorageClass"},
+		GroupVersionResource: schema.GroupVersionResource{
+			Group: "storage.k8s.io", Version: "v1", Resource: "storageclasses",
+		},
+		Meta: metav1.APIResource{
+			Name:       "storageclasses",
+			Namespaced: false,
+			Group:      "storage.k8s.io",
+			Kind:       "StorageClass",
+			Version:    "v1",
+		},
+	}
+}
+
+func TestCheckPermission_RequiresListAndWatch(t *testing.T) {
+	// Cluster-wide cache (no namespace restriction).
+	cluster := &clusterCache{}
+
+	t.Run("allowed when both list and watch are permitted", func(t *testing.T) {
+		ssar := &recordingSSAR{allowed: map[string]bool{"list": true, "watch": true}}
+		keep, err := cluster.checkPermission(context.Background(), ssar, storageClassAPI())
+		require.NoError(t, err)
+		assert.True(t, keep)
+		assert.ElementsMatch(t, []string{"list", "watch"}, ssar.verbs)
+	})
+
+	t.Run("denied when only list is permitted (OpenShift basic-user case)", func(t *testing.T) {
+		ssar := &recordingSSAR{allowed: map[string]bool{"list": true, "watch": false}}
+		keep, err := cluster.checkPermission(context.Background(), ssar, storageClassAPI())
+		require.NoError(t, err)
+		assert.False(t, keep, "list without watch must not keep the resource on the watch list")
+		assert.Contains(t, ssar.verbs, "list")
+		assert.Contains(t, ssar.verbs, "watch")
+	})
+
+	t.Run("denied when list is not permitted", func(t *testing.T) {
+		ssar := &recordingSSAR{allowed: map[string]bool{"list": false, "watch": true}}
+		keep, err := cluster.checkPermission(context.Background(), ssar, storageClassAPI())
+		require.NoError(t, err)
+		assert.False(t, keep)
+		assert.Contains(t, ssar.verbs, "list")
+	})
+
+	t.Run("denied when neither verb is permitted", func(t *testing.T) {
+		ssar := &recordingSSAR{allowed: map[string]bool{"list": false, "watch": false}}
+		keep, err := cluster.checkPermission(context.Background(), ssar, storageClassAPI())
+		require.NoError(t, err)
+		assert.False(t, keep)
+	})
+}
+
+func TestIsAllowed_SetsGroupAndVerb(t *testing.T) {
+	cluster := &clusterCache{}
+	var got *authorizationv1.ResourceAttributes
+	ssar := &captureSSAR{onCreate: func(sar *authorizationv1.SelfSubjectAccessReview) {
+		got = sar.Spec.ResourceAttributes.DeepCopy()
+		sar.Status.Allowed = true
+	}}
+
+	allowed, err := cluster.isAllowed(context.Background(), ssar, storageClassAPI(), "watch")
+	require.NoError(t, err)
+	assert.True(t, allowed)
+	require.NotNil(t, got)
+	assert.Equal(t, "watch", got.Verb)
+	assert.Equal(t, "storage.k8s.io", got.Group)
+	assert.Equal(t, "storageclasses", got.Resource)
+}
+
+func TestIsAllowed_Namespaced(t *testing.T) {
+	cluster := &clusterCache{namespaces: []string{"app-ns", "other-ns"}}
+	api := kube.APIResourceInfo{
+		GroupKind: schema.GroupKind{Group: "", Kind: "Secret"},
+		GroupVersionResource: schema.GroupVersionResource{
+			Group: "", Version: "v1", Resource: "secrets",
+		},
+		Meta: metav1.APIResource{Name: "secrets", Namespaced: true, Kind: "Secret", Version: "v1"},
+	}
+
+	t.Run("allowed if any managed namespace permits the verb", func(t *testing.T) {
+		ssar := &nsAwareSSAR{allow: map[string]bool{"app-ns": true, "other-ns": false}}
+		allowed, err := cluster.isAllowed(context.Background(), ssar, api, "watch")
+		require.NoError(t, err)
+		assert.True(t, allowed)
+	})
+
+	t.Run("denied if no managed namespace permits the verb", func(t *testing.T) {
+		ssar := &nsAwareSSAR{allow: map[string]bool{"app-ns": false, "other-ns": false}}
+		allowed, err := cluster.isAllowed(context.Background(), ssar, api, "watch")
+		require.NoError(t, err)
+		assert.False(t, allowed)
+	})
+}
+
+func TestIsRestrictedResource(t *testing.T) {
+	forbidden := apierrors.NewForbidden(schema.GroupResource{Group: "storage.k8s.io", Resource: "storageclasses"}, "", assert.AnError)
+	unauthorized := apierrors.NewUnauthorized("nope")
+
+	disabled := &clusterCache{respectRBAC: RespectRbacDisabled}
+	assert.False(t, disabled.isRestrictedResource(forbidden))
+
+	normal := &clusterCache{respectRBAC: RespectRbacNormal}
+	assert.True(t, normal.isRestrictedResource(forbidden))
+	assert.True(t, normal.isRestrictedResource(unauthorized))
+	assert.False(t, normal.isRestrictedResource(assert.AnError))
+}
+
+// captureSSAR invokes onCreate with the review before returning it.
+type captureSSAR struct {
+	onCreate func(*authorizationv1.SelfSubjectAccessReview)
+}
+
+func (c *captureSSAR) Create(ctx context.Context, sar *authorizationv1.SelfSubjectAccessReview, opts metav1.CreateOptions) (*authorizationv1.SelfSubjectAccessReview, error) {
+	out := sar.DeepCopy()
+	if c.onCreate != nil {
+		c.onCreate(out)
+	}
+	return out, nil
+}
+
+var _ authType1.SelfSubjectAccessReviewInterface = (*captureSSAR)(nil)
+
+// nsAwareSSAR answers based on the namespace on the review request.
+type nsAwareSSAR struct {
+	allow map[string]bool
+}
+
+func (n *nsAwareSSAR) Create(ctx context.Context, sar *authorizationv1.SelfSubjectAccessReview, opts metav1.CreateOptions) (*authorizationv1.SelfSubjectAccessReview, error) {
+	out := sar.DeepCopy()
+	out.Status.Allowed = n.allow[sar.Spec.ResourceAttributes.Namespace]
+	return out, nil
+}
+
+var _ authType1.SelfSubjectAccessReviewInterface = (*nsAwareSSAR)(nil)

--- a/gitops-engine/pkg/cache/cluster_permission_test.go
+++ b/gitops-engine/pkg/cache/cluster_permission_test.go
@@ -167,3 +167,96 @@ func (n *nsAwareSSAR) Create(ctx context.Context, sar *authorizationv1.SelfSubje
 }
 
 var _ authType1.SelfSubjectAccessReviewInterface = (*nsAwareSSAR)(nil)
+
+func TestVerbsRequiredForWatch_ReturnsFreshSlice(t *testing.T) {
+	a := verbsRequiredForWatch()
+	b := verbsRequiredForWatch()
+	require.Equal(t, []string{"list", "watch"}, a)
+	require.Equal(t, []string{"list", "watch"}, b)
+
+	// Mutating one result must not affect a later call.
+	a[0] = "get"
+	c := verbsRequiredForWatch()
+	require.Equal(t, []string{"list", "watch"}, c)
+}
+
+func TestCheckPermission_PropagatesSSARError(t *testing.T) {
+	cluster := &clusterCache{}
+	ssar := &errorSSAR{err: assert.AnError}
+	keep, err := cluster.checkPermission(context.Background(), ssar, storageClassAPI())
+	require.Error(t, err)
+	assert.False(t, keep)
+	assert.ErrorContains(t, err, "failed to create self subject access review")
+}
+
+func TestCheckPermission_StopsAfterFirstDeniedVerb(t *testing.T) {
+	cluster := &clusterCache{}
+	ssar := &recordingSSAR{allowed: map[string]bool{"list": false, "watch": true}}
+	keep, err := cluster.checkPermission(context.Background(), ssar, storageClassAPI())
+	require.NoError(t, err)
+	assert.False(t, keep)
+	// list is checked first; once denied, watch is not required.
+	assert.Equal(t, []string{"list"}, ssar.verbs)
+}
+
+func TestIsAllowed_PropagatesSSARError(t *testing.T) {
+	cluster := &clusterCache{}
+	ssar := &errorSSAR{err: assert.AnError}
+	allowed, err := cluster.isAllowed(context.Background(), ssar, storageClassAPI(), "watch")
+	require.Error(t, err)
+	assert.False(t, allowed)
+}
+
+func TestIsAllowed_ClusterScopedWithClusterResources(t *testing.T) {
+	// namespaces set, but resource is cluster-scoped and clusterResources is on
+	// → still uses the cluster-wide SSAR path (Namespace: "*").
+	cluster := &clusterCache{namespaces: []string{"app-ns"}, clusterResources: true}
+	var got *authorizationv1.ResourceAttributes
+	ssar := &captureSSAR{onCreate: func(sar *authorizationv1.SelfSubjectAccessReview) {
+		got = sar.Spec.ResourceAttributes.DeepCopy()
+		sar.Status.Allowed = true
+	}}
+
+	allowed, err := cluster.isAllowed(context.Background(), ssar, storageClassAPI(), "list")
+	require.NoError(t, err)
+	assert.True(t, allowed)
+	require.NotNil(t, got)
+	assert.Equal(t, "*", got.Namespace)
+}
+
+func TestIsAllowed_NotWatchedScopeReturnsTrue(t *testing.T) {
+	// namespaced=false, namespaces non-empty, clusterResources=false:
+	// processApi would not watch this resource, so isAllowed returns true.
+	cluster := &clusterCache{namespaces: []string{"app-ns"}, clusterResources: false}
+	ssar := &recordingSSAR{allowed: map[string]bool{}}
+	allowed, err := cluster.isAllowed(context.Background(), ssar, storageClassAPI(), "watch")
+	require.NoError(t, err)
+	assert.True(t, allowed)
+	assert.Empty(t, ssar.verbs, "no SSAR should be issued for unwatched scopes")
+}
+
+func TestIsAllowed_NamespacedPropagatesSSARError(t *testing.T) {
+	cluster := &clusterCache{namespaces: []string{"app-ns"}}
+	api := kube.APIResourceInfo{
+		GroupKind: schema.GroupKind{Group: "", Kind: "Secret"},
+		GroupVersionResource: schema.GroupVersionResource{
+			Group: "", Version: "v1", Resource: "secrets",
+		},
+		Meta: metav1.APIResource{Name: "secrets", Namespaced: true, Kind: "Secret", Version: "v1"},
+	}
+	ssar := &errorSSAR{err: assert.AnError}
+	allowed, err := cluster.isAllowed(context.Background(), ssar, api, "watch")
+	require.Error(t, err)
+	assert.False(t, allowed)
+}
+
+// errorSSAR always returns an error from Create.
+type errorSSAR struct {
+	err error
+}
+
+func (e *errorSSAR) Create(ctx context.Context, sar *authorizationv1.SelfSubjectAccessReview, opts metav1.CreateOptions) (*authorizationv1.SelfSubjectAccessReview, error) {
+	return nil, e.err
+}
+
+var _ authType1.SelfSubjectAccessReviewInterface = (*errorSSAR)(nil)

--- a/gitops-engine/pkg/cache/cluster_permission_test.go
+++ b/gitops-engine/pkg/cache/cluster_permission_test.go
@@ -54,7 +54,7 @@ func TestCheckPermission_RequiresListAndWatch(t *testing.T) {
 
 	t.Run("allowed when both list and watch are permitted", func(t *testing.T) {
 		ssar := &recordingSSAR{allowed: map[string]bool{"list": true, "watch": true}}
-		keep, err := cluster.checkPermission(context.Background(), ssar, storageClassAPI())
+		keep, err := cluster.checkPermission(context.Background(), ssar, storageClassAPI(), "")
 		require.NoError(t, err)
 		assert.True(t, keep)
 		assert.ElementsMatch(t, []string{"list", "watch"}, ssar.verbs)
@@ -62,7 +62,7 @@ func TestCheckPermission_RequiresListAndWatch(t *testing.T) {
 
 	t.Run("denied when only list is permitted (OpenShift basic-user case)", func(t *testing.T) {
 		ssar := &recordingSSAR{allowed: map[string]bool{"list": true, "watch": false}}
-		keep, err := cluster.checkPermission(context.Background(), ssar, storageClassAPI())
+		keep, err := cluster.checkPermission(context.Background(), ssar, storageClassAPI(), "")
 		require.NoError(t, err)
 		assert.False(t, keep, "list without watch must not keep the resource on the watch list")
 		assert.Contains(t, ssar.verbs, "list")
@@ -71,7 +71,7 @@ func TestCheckPermission_RequiresListAndWatch(t *testing.T) {
 
 	t.Run("denied when list is not permitted", func(t *testing.T) {
 		ssar := &recordingSSAR{allowed: map[string]bool{"list": false, "watch": true}}
-		keep, err := cluster.checkPermission(context.Background(), ssar, storageClassAPI())
+		keep, err := cluster.checkPermission(context.Background(), ssar, storageClassAPI(), "")
 		require.NoError(t, err)
 		assert.False(t, keep)
 		assert.Contains(t, ssar.verbs, "list")
@@ -79,7 +79,7 @@ func TestCheckPermission_RequiresListAndWatch(t *testing.T) {
 
 	t.Run("denied when neither verb is permitted", func(t *testing.T) {
 		ssar := &recordingSSAR{allowed: map[string]bool{"list": false, "watch": false}}
-		keep, err := cluster.checkPermission(context.Background(), ssar, storageClassAPI())
+		keep, err := cluster.checkPermission(context.Background(), ssar, storageClassAPI(), "")
 		require.NoError(t, err)
 		assert.False(t, keep)
 	})
@@ -93,7 +93,7 @@ func TestIsAllowed_SetsGroupAndVerb(t *testing.T) {
 		sar.Status.Allowed = true
 	}}
 
-	allowed, err := cluster.isAllowed(context.Background(), ssar, storageClassAPI(), "watch")
+	allowed, err := cluster.isAllowed(context.Background(), ssar, storageClassAPI(), "watch", "")
 	require.NoError(t, err)
 	assert.True(t, allowed)
 	require.NotNil(t, got)
@@ -114,16 +114,29 @@ func TestIsAllowed_Namespaced(t *testing.T) {
 
 	t.Run("allowed if any managed namespace permits the verb", func(t *testing.T) {
 		ssar := &nsAwareSSAR{allow: map[string]bool{"app-ns": true, "other-ns": false}}
-		allowed, err := cluster.isAllowed(context.Background(), ssar, api, "watch")
+		allowed, err := cluster.isAllowed(context.Background(), ssar, api, "watch", "")
 		require.NoError(t, err)
 		assert.True(t, allowed)
 	})
 
 	t.Run("denied if no managed namespace permits the verb", func(t *testing.T) {
 		ssar := &nsAwareSSAR{allow: map[string]bool{"app-ns": false, "other-ns": false}}
-		allowed, err := cluster.isAllowed(context.Background(), ssar, api, "watch")
+		allowed, err := cluster.isAllowed(context.Background(), ssar, api, "watch", "")
 		require.NoError(t, err)
 		assert.False(t, allowed)
+	})
+
+	t.Run("scoped to the namespace being watched", func(t *testing.T) {
+		ssar := &nsAwareSSAR{allow: map[string]bool{"app-ns": true, "other-ns": false}}
+		allowed, err := cluster.isAllowed(context.Background(), ssar, api, "watch", "other-ns")
+		require.NoError(t, err)
+		assert.False(t, allowed, "must not start a watch in a namespace that denies the verb")
+
+		ssar = &nsAwareSSAR{allow: map[string]bool{"app-ns": true, "other-ns": false}}
+		allowed, err = cluster.isAllowed(context.Background(), ssar, api, "watch", "app-ns")
+		require.NoError(t, err)
+		assert.True(t, allowed)
+		assert.Equal(t, []string{"app-ns"}, ssar.seen)
 	})
 }
 
@@ -158,11 +171,14 @@ var _ authType1.SelfSubjectAccessReviewInterface = (*captureSSAR)(nil)
 // nsAwareSSAR answers based on the namespace on the review request.
 type nsAwareSSAR struct {
 	allow map[string]bool
+	seen  []string
 }
 
 func (n *nsAwareSSAR) Create(ctx context.Context, sar *authorizationv1.SelfSubjectAccessReview, opts metav1.CreateOptions) (*authorizationv1.SelfSubjectAccessReview, error) {
+	ns := sar.Spec.ResourceAttributes.Namespace
+	n.seen = append(n.seen, ns)
 	out := sar.DeepCopy()
-	out.Status.Allowed = n.allow[sar.Spec.ResourceAttributes.Namespace]
+	out.Status.Allowed = n.allow[ns]
 	return out, nil
 }
 
@@ -183,7 +199,7 @@ func TestVerbsRequiredForWatch_ReturnsFreshSlice(t *testing.T) {
 func TestCheckPermission_PropagatesSSARError(t *testing.T) {
 	cluster := &clusterCache{}
 	ssar := &errorSSAR{err: assert.AnError}
-	keep, err := cluster.checkPermission(context.Background(), ssar, storageClassAPI())
+	keep, err := cluster.checkPermission(context.Background(), ssar, storageClassAPI(), "")
 	require.Error(t, err)
 	assert.False(t, keep)
 	assert.ErrorContains(t, err, "failed to create self subject access review")
@@ -192,7 +208,7 @@ func TestCheckPermission_PropagatesSSARError(t *testing.T) {
 func TestCheckPermission_StopsAfterFirstDeniedVerb(t *testing.T) {
 	cluster := &clusterCache{}
 	ssar := &recordingSSAR{allowed: map[string]bool{"list": false, "watch": true}}
-	keep, err := cluster.checkPermission(context.Background(), ssar, storageClassAPI())
+	keep, err := cluster.checkPermission(context.Background(), ssar, storageClassAPI(), "")
 	require.NoError(t, err)
 	assert.False(t, keep)
 	// list is checked first; once denied, watch is not required.
@@ -202,7 +218,7 @@ func TestCheckPermission_StopsAfterFirstDeniedVerb(t *testing.T) {
 func TestIsAllowed_PropagatesSSARError(t *testing.T) {
 	cluster := &clusterCache{}
 	ssar := &errorSSAR{err: assert.AnError}
-	allowed, err := cluster.isAllowed(context.Background(), ssar, storageClassAPI(), "watch")
+	allowed, err := cluster.isAllowed(context.Background(), ssar, storageClassAPI(), "watch", "")
 	require.Error(t, err)
 	assert.False(t, allowed)
 }
@@ -217,7 +233,7 @@ func TestIsAllowed_ClusterScopedWithClusterResources(t *testing.T) {
 		sar.Status.Allowed = true
 	}}
 
-	allowed, err := cluster.isAllowed(context.Background(), ssar, storageClassAPI(), "list")
+	allowed, err := cluster.isAllowed(context.Background(), ssar, storageClassAPI(), "list", "")
 	require.NoError(t, err)
 	assert.True(t, allowed)
 	require.NotNil(t, got)
@@ -229,7 +245,7 @@ func TestIsAllowed_NotWatchedScopeReturnsTrue(t *testing.T) {
 	// processApi would not watch this resource, so isAllowed returns true.
 	cluster := &clusterCache{namespaces: []string{"app-ns"}, clusterResources: false}
 	ssar := &recordingSSAR{allowed: map[string]bool{}}
-	allowed, err := cluster.isAllowed(context.Background(), ssar, storageClassAPI(), "watch")
+	allowed, err := cluster.isAllowed(context.Background(), ssar, storageClassAPI(), "watch", "")
 	require.NoError(t, err)
 	assert.True(t, allowed)
 	assert.Empty(t, ssar.verbs, "no SSAR should be issued for unwatched scopes")
@@ -245,7 +261,7 @@ func TestIsAllowed_NamespacedPropagatesSSARError(t *testing.T) {
 		Meta: metav1.APIResource{Name: "secrets", Namespaced: true, Kind: "Secret", Version: "v1"},
 	}
 	ssar := &errorSSAR{err: assert.AnError}
-	allowed, err := cluster.isAllowed(context.Background(), ssar, api, "watch")
+	allowed, err := cluster.isAllowed(context.Background(), ssar, api, "watch", "")
 	require.Error(t, err)
 	assert.False(t, allowed)
 }


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

## Description

When `resource.respectRBAC` is enabled, the controller decided whether to keep watching a resource based on **list** permission only. On OpenShift, the built-in `basic-user` ClusterRole often grants `get`/`list` on cluster resources like `storageclasses` **without** `watch`. The initial list succeeds, the informer starts anyway, and watch fails and retries forever:

```
cannot watch resource "storageclasses" in API group "storage.k8s.io" at the cluster scope
```

### Changes

- `checkPermission` (strict mode SSAR) now requires both `list` and `watch`
- After a successful list in strict mode, confirm `watch` via SSAR before starting the informer
- In normal mode (no SSAR on the happy path): if establishing the watch returns forbidden/unauthorized, drop the resource from the watch list instead of retrying forever
- Docs updated to match
- Unit tests for the permission helpers (including the list-without-watch case)

Fixes #28744