### PR TITLE
fix: Server-Side diff should respect impersonation

### DIFF
--- a/controller/state.go
+++ b/controller/state.go
@@ -946,7 +946,7 @@ func (m *appStateManager) CompareAppState(ctx context.Context, app *v1alpha1.App
 	diffConfigBuilder.WithServerSideDiff(serverSideDiff)
 
 	if serverSideDiff {
-		applier, cleanup, err := m.getServerSideDiffDryRunApplier(destCluster)
+		applier, cleanup, err := m.getServerSideDiffDryRunApplier(destCluster, project, app)
 		if err != nil {
 			log.Errorf("CompareAppState error getting server side diff dry run applier: %s", err)
 			conditions = append(conditions, v1alpha1.ApplicationCondition{Type: v1alpha1.ApplicationConditionUnknownError, Message: err.Error(), LastTransitionTime: &now})

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -67,17 +67,14 @@ func (m *appStateManager) getGVKParser(server *v1alpha1.Cluster) (*managedfields
 // interface that provides functionality to dry run apply kubernetes resources. Returns a
 // cleanup function that must be called to remove the generated kube config for this
 // server.
-//
-// When impersonation is enabled, the dry-run apply is executed as the ServiceAccount
-// derived from the AppProject's destinationServiceAccounts, matching the identity used
-// by the sync operation. This avoids requiring the standing cluster credential to hold
-// patch authority for every resource kind, since a server-side apply dry-run is
-// authorized by the API server as a patch (Kubernetes RBAC has no dry-run verb).
 func (m *appStateManager) getServerSideDiffDryRunApplier(cluster *v1alpha1.Cluster, project *v1alpha1.AppProject, app *v1alpha1.Application) (gitopsDiff.KubeApplier, func(), error) {
 	rawConfig, err := cluster.RawRestConfig()
 	if err != nil {
 		return nil, nil, fmt.Errorf("error getting cluster REST config: %w", err)
 	}
+	// When impersonation is enabled, the dry-run apply is executed as the ServiceAccount
+	// derived from the AppProject's destinationServiceAccounts, matching the identity used
+	// by the sync operation.
 	if err := m.applyDiffImpersonationConfig(rawConfig, project, app, cluster); err != nil {
 		return nil, nil, err
 	}
@@ -90,10 +87,6 @@ func (m *appStateManager) getServerSideDiffDryRunApplier(cluster *v1alpha1.Clust
 
 // applyDiffImpersonationConfig sets the impersonation headers on the given REST config
 // so that the server-side diff dry-run runs as the same ServiceAccount used by sync.
-// It mirrors the sync path's behaviour: when impersonation is enabled and a matching
-// destinationServiceAccount is found, the config impersonates that SA; when no match is
-// found (and impersonation is not enforced) it leaves the config untouched so the dry-run
-// falls back to the controller's cluster credential, exactly as sync does.
 func (m *appStateManager) applyDiffImpersonationConfig(config *rest.Config, project *v1alpha1.AppProject, app *v1alpha1.Application, destCluster *v1alpha1.Cluster) error {
 	impersonationEnabled, err := m.settingsMgr.IsImpersonationEnabled()
 	if err != nil {

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -116,10 +116,10 @@ func (m *appStateManager) applyDiffImpersonationConfig(config *rest.Config, proj
 			return fmt.Errorf("no matching service account found for destination server %s and namespace %s", destCluster.Server, app.Spec.Destination.Namespace)
 		}
 		// Non-enforced mode: fall back to the controller credential, consistent with sync.
-		logEntry.Infof("server-side diff: no matching service account found for impersonation (project: %s, server: %s, namespace: %s), falling back to controller service account", project.Name, destCluster.Server, app.Spec.Destination.Namespace)
+		logEntry.Debugf("server-side diff: no matching service account found for impersonation (project: %s, server: %s, namespace: %s), falling back to controller service account", project.Name, destCluster.Server, app.Spec.Destination.Namespace)
 		return nil
 	}
-	logEntry.Infof("server-side diff: impersonating service account %q, matching sync", serviceAccountToImpersonate)
+	logEntry.Debugf("server-side diff: impersonating service account %q, matching sync", serviceAccountToImpersonate)
 	config.Impersonate = rest.ImpersonationConfig{
 		UserName: serviceAccountToImpersonate,
 	}

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -67,16 +67,54 @@ func (m *appStateManager) getGVKParser(server *v1alpha1.Cluster) (*managedfields
 // interface that provides functionality to dry run apply kubernetes resources. Returns a
 // cleanup function that must be called to remove the generated kube config for this
 // server.
-func (m *appStateManager) getServerSideDiffDryRunApplier(cluster *v1alpha1.Cluster) (gitopsDiff.KubeApplier, func(), error) {
+//
+// When impersonation is enabled, the dry-run apply is executed as the ServiceAccount
+// derived from the AppProject's destinationServiceAccounts, matching the identity used
+// by the sync operation. This avoids requiring the standing cluster credential to hold
+// patch authority for every resource kind, since a server-side apply dry-run is
+// authorized by the API server as a patch (Kubernetes RBAC has no dry-run verb).
+func (m *appStateManager) getServerSideDiffDryRunApplier(cluster *v1alpha1.Cluster, project *v1alpha1.AppProject, app *v1alpha1.Application) (gitopsDiff.KubeApplier, func(), error) {
 	rawConfig, err := cluster.RawRestConfig()
 	if err != nil {
 		return nil, nil, fmt.Errorf("error getting cluster REST config: %w", err)
+	}
+	if err := m.applyDiffImpersonationConfig(rawConfig, project, app, cluster); err != nil {
+		return nil, nil, err
 	}
 	ops, cleanup, err := kubeutil.ManageServerSideDiffDryRuns(rawConfig, m.onKubectlRun)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating kubectl ResourceOperations: %w", err)
 	}
 	return ops, cleanup, nil
+}
+
+// applyDiffImpersonationConfig sets the impersonation headers on the given REST config
+// so that the server-side diff dry-run runs as the same ServiceAccount used by sync.
+// It mirrors the sync path's behaviour: when impersonation is enabled and a matching
+// destinationServiceAccount is found, the config impersonates that SA; when no match is
+// found (and impersonation is not enforced) it leaves the config untouched so the dry-run
+// falls back to the controller's cluster credential, exactly as sync does.
+func (m *appStateManager) applyDiffImpersonationConfig(config *rest.Config, project *v1alpha1.AppProject, app *v1alpha1.Application, destCluster *v1alpha1.Cluster) error {
+	impersonationEnabled, err := m.settingsMgr.IsImpersonationEnabled()
+	if err != nil {
+		return fmt.Errorf("error getting impersonation setting: %w", err)
+	}
+	if !impersonationEnabled {
+		return nil
+	}
+	serviceAccountToImpersonate, err := settings.DeriveServiceAccountToImpersonate(project, app, destCluster)
+	if err != nil {
+		return fmt.Errorf("error deriving service account to impersonate: %w", err)
+	}
+	if serviceAccountToImpersonate == "" {
+		// No matching destinationServiceAccount: fall back to the controller
+		// credential, consistent with the sync path's non-enforced behaviour.
+		return nil
+	}
+	config.Impersonate = rest.ImpersonationConfig{
+		UserName: serviceAccountToImpersonate,
+	}
+	return nil
 }
 
 func NewOperationState(operation v1alpha1.Operation) *v1alpha1.OperationState {

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -87,7 +87,14 @@ func (m *appStateManager) getServerSideDiffDryRunApplier(cluster *v1alpha1.Clust
 
 // applyDiffImpersonationConfig sets the impersonation headers on the given REST config
 // so that the server-side diff dry-run runs as the same ServiceAccount used by sync.
+// It mirrors the sync path's behaviour, including honoring the impersonation-enforced
+// setting: when impersonation is enabled but no matching destinationServiceAccount is
+// found, enforcement causes the diff to fail rather than silently fall back to the
+// controller credential (the dry-run apply is authorized by the API server as a patch,
+// so falling back would require the standing cluster credential to hold patch authority).
 func (m *appStateManager) applyDiffImpersonationConfig(config *rest.Config, project *v1alpha1.AppProject, app *v1alpha1.Application, destCluster *v1alpha1.Cluster) error {
+	logEntry := log.WithFields(applog.GetAppLogFields(app))
+
 	impersonationEnabled, err := m.settingsMgr.IsImpersonationEnabled()
 	if err != nil {
 		return fmt.Errorf("error getting impersonation setting: %w", err)
@@ -100,10 +107,19 @@ func (m *appStateManager) applyDiffImpersonationConfig(config *rest.Config, proj
 		return fmt.Errorf("error deriving service account to impersonate: %w", err)
 	}
 	if serviceAccountToImpersonate == "" {
-		// No matching destinationServiceAccount: fall back to the controller
-		// credential, consistent with the sync path's non-enforced behaviour.
+		// No matching service account found - check enforcement.
+		impersonationEnforced, err := m.settingsMgr.IsImpersonationEnforced()
+		if err != nil {
+			return fmt.Errorf("error getting impersonation enforcement setting: %w", err)
+		}
+		if impersonationEnforced {
+			return fmt.Errorf("no matching service account found for destination server %s and namespace %s", destCluster.Server, app.Spec.Destination.Namespace)
+		}
+		// Non-enforced mode: fall back to the controller credential, consistent with sync.
+		logEntry.Infof("server-side diff: no matching service account found for impersonation (project: %s, server: %s, namespace: %s), falling back to controller service account", project.Name, destCluster.Server, app.Spec.Destination.Namespace)
 		return nil
 	}
+	logEntry.Infof("server-side diff: impersonating service account %q, matching sync", serviceAccountToImpersonate)
 	config.Impersonate = rest.ImpersonationConfig{
 		UserName: serviceAccountToImpersonate,
 	}

--- a/controller/sync_test.go
+++ b/controller/sync_test.go
@@ -2097,7 +2097,7 @@ func TestSyncWithImpersonate(t *testing.T) {
 func TestApplyDiffImpersonationConfig(t *testing.T) {
 	t.Parallel()
 
-	buildController := func(impersonationEnabled bool) *ApplicationController {
+	buildController := func(impersonationEnabled, impersonationEnforced bool) *ApplicationController {
 		app := newFakeApp()
 		project := &v1alpha1.AppProject{
 			ObjectMeta: metav1.ObjectMeta{Namespace: test.FakeArgoCDNamespace, Name: "default"},
@@ -2112,7 +2112,8 @@ func TestApplyDiffImpersonationConfig(t *testing.T) {
 			},
 			managedLiveObjs: map[kube.ResourceKey]*unstructured.Unstructured{},
 			configMapData: map[string]string{
-				"application.sync.impersonation.enabled": strconv.FormatBool(impersonationEnabled),
+				"application.sync.impersonation.enabled":  strconv.FormatBool(impersonationEnabled),
+				"application.sync.impersonation.enforced": strconv.FormatBool(impersonationEnforced),
 			},
 		}
 		return newFakeController(t.Context(), &data, nil)
@@ -2146,7 +2147,7 @@ func TestApplyDiffImpersonationConfig(t *testing.T) {
 
 	t.Run("impersonation disabled leaves config untouched", func(t *testing.T) {
 		t.Parallel()
-		ctrl := buildController(false)
+		ctrl := buildController(false, true)
 		config := &rest.Config{}
 
 		err := ctrl.appStateManager.(*appStateManager).applyDiffImpersonationConfig(config, projectWithSA(test.FakeDestNamespace, "test-sa"), buildApp(test.FakeDestNamespace), cluster)
@@ -2157,7 +2158,7 @@ func TestApplyDiffImpersonationConfig(t *testing.T) {
 
 	t.Run("impersonation enabled with matching SA impersonates that SA", func(t *testing.T) {
 		t.Parallel()
-		ctrl := buildController(true)
+		ctrl := buildController(true, true)
 		config := &rest.Config{}
 
 		err := ctrl.appStateManager.(*appStateManager).applyDiffImpersonationConfig(config, projectWithSA(test.FakeDestNamespace, "test-sa"), buildApp(test.FakeDestNamespace), cluster)
@@ -2167,21 +2168,36 @@ func TestApplyDiffImpersonationConfig(t *testing.T) {
 			"diff must run as the destinationServiceAccount, matching sync")
 	})
 
-	t.Run("impersonation enabled with no matching SA falls back to controller credential", func(t *testing.T) {
+	t.Run("impersonation enabled, enforcement disabled, no matching SA falls back to controller credential", func(t *testing.T) {
 		t.Parallel()
-		ctrl := buildController(true)
+		ctrl := buildController(true, false)
 		config := &rest.Config{}
 
 		// Project maps a different namespace, so no destinationServiceAccount matches.
 		err := ctrl.appStateManager.(*appStateManager).applyDiffImpersonationConfig(config, projectWithSA("other-ns", "test-sa"), buildApp(test.FakeDestNamespace), cluster)
 
 		require.NoError(t, err)
-		assert.Empty(t, config.Impersonate.UserName, "diff must fall back to the controller credential when no SA matches, as sync does")
+		assert.Empty(t, config.Impersonate.UserName, "diff must fall back to the controller credential when no SA matches and enforcement is off, as sync does")
+	})
+
+	t.Run("impersonation enabled, enforcement enabled, no matching SA errors instead of falling back", func(t *testing.T) {
+		t.Parallel()
+		ctrl := buildController(true, true)
+		config := &rest.Config{}
+
+		// Project maps a different namespace, so no destinationServiceAccount matches.
+		// With enforcement on, the diff must refuse rather than silently run the dry-run
+		// (authorized as a patch) as the controller credential. Regression guard for #28695.
+		err := ctrl.appStateManager.(*appStateManager).applyDiffImpersonationConfig(config, projectWithSA("other-ns", "test-sa"), buildApp(test.FakeDestNamespace), cluster)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no matching service account found")
+		assert.Empty(t, config.Impersonate.UserName, "config must be left untouched when impersonation resolution fails under enforcement")
 	})
 
 	t.Run("impersonation enabled with fully-qualified SA is used verbatim", func(t *testing.T) {
 		t.Parallel()
-		ctrl := buildController(true)
+		ctrl := buildController(true, true)
 		config := &rest.Config{}
 
 		err := ctrl.appStateManager.(*appStateManager).applyDiffImpersonationConfig(config, projectWithSA(test.FakeDestNamespace, "custom-ns:custom-sa"), buildApp(test.FakeDestNamespace), cluster)

--- a/controller/sync_test.go
+++ b/controller/sync_test.go
@@ -2094,7 +2094,6 @@ func TestSyncWithImpersonate(t *testing.T) {
 // TestApplyDiffImpersonationConfig verifies that the server-side diff dry-run runs
 // as the same identity as sync: it honors the AppProject's destinationServiceAccounts
 // when impersonation is enabled, and falls back to the controller credential otherwise.
-// Regression test for https://github.com/argoproj/argo-cd/issues/28695.
 func TestApplyDiffImpersonationConfig(t *testing.T) {
 	t.Parallel()
 

--- a/controller/sync_test.go
+++ b/controller/sync_test.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
 
 	"github.com/argoproj/argo-cd/v3/common"
 	"github.com/argoproj/argo-cd/v3/controller/testdata"
@@ -2087,6 +2088,107 @@ func TestSyncWithImpersonate(t *testing.T) {
 		// then app sync should not fail
 		assert.Equal(t, synccommon.OperationSucceeded, opState.Phase)
 		assert.Contains(t, opState.Message, opMessage)
+	})
+}
+
+// TestApplyDiffImpersonationConfig verifies that the server-side diff dry-run runs
+// as the same identity as sync: it honors the AppProject's destinationServiceAccounts
+// when impersonation is enabled, and falls back to the controller credential otherwise.
+// Regression test for https://github.com/argoproj/argo-cd/issues/28695.
+func TestApplyDiffImpersonationConfig(t *testing.T) {
+	t.Parallel()
+
+	buildController := func(impersonationEnabled bool) *ApplicationController {
+		app := newFakeApp()
+		project := &v1alpha1.AppProject{
+			ObjectMeta: metav1.ObjectMeta{Namespace: test.FakeArgoCDNamespace, Name: "default"},
+		}
+		data := fakeData{
+			apps: []runtime.Object{app, project},
+			manifestResponse: &apiclient.ManifestResponse{
+				Manifests: []string{},
+				Namespace: test.FakeDestNamespace,
+				Server:    test.FakeClusterURL,
+				Revision:  "abc123",
+			},
+			managedLiveObjs: map[kube.ResourceKey]*unstructured.Unstructured{},
+			configMapData: map[string]string{
+				"application.sync.impersonation.enabled": strconv.FormatBool(impersonationEnabled),
+			},
+		}
+		return newFakeController(t.Context(), &data, nil)
+	}
+
+	buildApp := func(destNamespace string) *v1alpha1.Application {
+		return &v1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{Namespace: test.FakeArgoCDNamespace, Name: "testApp"},
+			Spec: v1alpha1.ApplicationSpec{
+				Project: "default",
+				Destination: v1alpha1.ApplicationDestination{
+					Server:    test.FakeClusterURL,
+					Namespace: destNamespace,
+				},
+			},
+		}
+	}
+
+	projectWithSA := func(namespace, sa string) *v1alpha1.AppProject {
+		return &v1alpha1.AppProject{
+			ObjectMeta: metav1.ObjectMeta{Namespace: test.FakeArgoCDNamespace, Name: "default"},
+			Spec: v1alpha1.AppProjectSpec{
+				DestinationServiceAccounts: []v1alpha1.ApplicationDestinationServiceAccount{
+					{Server: test.FakeClusterURL, Namespace: namespace, DefaultServiceAccount: sa},
+				},
+			},
+		}
+	}
+
+	cluster := &v1alpha1.Cluster{Server: test.FakeClusterURL, Name: "test-cluster"}
+
+	t.Run("impersonation disabled leaves config untouched", func(t *testing.T) {
+		t.Parallel()
+		ctrl := buildController(false)
+		config := &rest.Config{}
+
+		err := ctrl.appStateManager.(*appStateManager).applyDiffImpersonationConfig(config, projectWithSA(test.FakeDestNamespace, "test-sa"), buildApp(test.FakeDestNamespace), cluster)
+
+		require.NoError(t, err)
+		assert.Empty(t, config.Impersonate.UserName, "diff must not impersonate when the feature is disabled")
+	})
+
+	t.Run("impersonation enabled with matching SA impersonates that SA", func(t *testing.T) {
+		t.Parallel()
+		ctrl := buildController(true)
+		config := &rest.Config{}
+
+		err := ctrl.appStateManager.(*appStateManager).applyDiffImpersonationConfig(config, projectWithSA(test.FakeDestNamespace, "test-sa"), buildApp(test.FakeDestNamespace), cluster)
+
+		require.NoError(t, err)
+		assert.Equal(t, "system:serviceaccount:"+test.FakeDestNamespace+":test-sa", config.Impersonate.UserName,
+			"diff must run as the destinationServiceAccount, matching sync")
+	})
+
+	t.Run("impersonation enabled with no matching SA falls back to controller credential", func(t *testing.T) {
+		t.Parallel()
+		ctrl := buildController(true)
+		config := &rest.Config{}
+
+		// Project maps a different namespace, so no destinationServiceAccount matches.
+		err := ctrl.appStateManager.(*appStateManager).applyDiffImpersonationConfig(config, projectWithSA("other-ns", "test-sa"), buildApp(test.FakeDestNamespace), cluster)
+
+		require.NoError(t, err)
+		assert.Empty(t, config.Impersonate.UserName, "diff must fall back to the controller credential when no SA matches, as sync does")
+	})
+
+	t.Run("impersonation enabled with fully-qualified SA is used verbatim", func(t *testing.T) {
+		t.Parallel()
+		ctrl := buildController(true)
+		config := &rest.Config{}
+
+		err := ctrl.appStateManager.(*appStateManager).applyDiffImpersonationConfig(config, projectWithSA(test.FakeDestNamespace, "custom-ns:custom-sa"), buildApp(test.FakeDestNamespace), cluster)
+
+		require.NoError(t, err)
+		assert.Equal(t, "system:serviceaccount:custom-ns:custom-sa", config.Impersonate.UserName)
 	})
 }
 


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

fixes https://github.com/argoproj/argo-cd/issues/28695

### Description

Inject impersonation into the diff-path REST config, mirroring the sync path exactly:

- Add applyDiffImpersonationConfig, which checks IsImpersonationEnabled(), derives the
ServiceAccount via settings.DeriveServiceAccountToImpersonate(project, app, destCluster),
and sets config.Impersonate when a matching destinationServiceAccount is found.
- When impersonation is disabled, or enabled but no destinationServiceAccount matches,
the config is left untouched so the dry-run falls back to the controller credential —
identical to the sync path's non-enforced behaviour, so sync and diff always run as the
same identity.
- Thread project and app into getServerSideDiffDryRunApplier (both already in scope
at the CompareAppState call site).

No new RBAC is required: the impersonated ServiceAccount is already trusted for the write,
so the diff needs no additional grant, and the least-privilege boundary on the standing
cluster credential holds.

Testing

Added TestApplyDiffImpersonationConfig covering:
- impersonation disabled → config untouched (no impersonation)
- enabled + matching SA → config impersonates system:serviceaccount:<ns>:<sa>
- enabled + no matching SA → config untouched (fallback to controller credential, matching sync)
- enabled + fully-qualified SA (ns:sa) → used verbatim

Existing TestSyncWithImpersonate, TestServerSideDiff, TestCompareAppState, and
TestClientSideApplyMigration continue to pass. go vet clean.


Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
