### PR TITLE
fix: correct operator precedence in getAppInstanceValue

### DIFF
--- a/util/argo/resource_tracking.go
+++ b/util/argo/resource_tracking.go
@@ -51,7 +51,7 @@ func IsOldTrackingMethod(trackingMethod string) bool {
 }
 
 func (rt *resourceTracking) getAppInstanceValue(un *unstructured.Unstructured, installationID string) *AppInstanceValue {
-	if installationID != "" && un.GetAnnotations() == nil || un.GetAnnotations()[common.AnnotationInstallationID] != installationID {
+	if installationID != "" && (un.GetAnnotations() == nil || un.GetAnnotations()[common.AnnotationInstallationID] != installationID) {
 		return nil
 	}
 	appInstanceAnnotation, err := kube.GetAppInstanceAnnotation(un, common.AnnotationKeyAppInstance)

--- a/util/argo/resource_tracking_test.go
+++ b/util/argo/resource_tracking_test.go
@@ -50,6 +50,34 @@ func TestSetAppInstanceAnnotation(t *testing.T) {
 	assert.Equal(t, "my-app", app)
 }
 
+func TestGetAppName_AnnotationWithExistingInstallationID(t *testing.T) {
+	t.Parallel()
+	yamlBytes, err := os.ReadFile("testdata/svc.yaml")
+	require.NoError(t, err)
+
+	var obj unstructured.Unstructured
+	err = yaml.Unmarshal(yamlBytes, &obj)
+	require.NoError(t, err)
+
+	resourceTracking := NewResourceTracking()
+
+	err = resourceTracking.SetAppInstance(&obj, common.AnnotationKeyAppInstance, "my-app", "", v1alpha1.TrackingMethodAnnotation, "some-installation-id")
+	require.NoError(t, err)
+
+	// When no installationID filter is provided, the app name should still be returned
+	// even though the resource has an installation ID annotation.
+	app := resourceTracking.GetAppName(&obj, common.AnnotationKeyAppInstance, v1alpha1.TrackingMethodAnnotation, "")
+	assert.Equal(t, "my-app", app)
+
+	// When a different installationID is provided, it should not match.
+	app = resourceTracking.GetAppName(&obj, common.AnnotationKeyAppInstance, v1alpha1.TrackingMethodAnnotation, "different-id")
+	assert.Empty(t, app)
+
+	// When the correct installationID is provided, it should match.
+	app = resourceTracking.GetAppName(&obj, common.AnnotationKeyAppInstance, v1alpha1.TrackingMethodAnnotation, "some-installation-id")
+	assert.Equal(t, "my-app", app)
+}
+
 func TestSetAppInstanceAnnotationAndLabel(t *testing.T) {
 	t.Parallel()
 	yamlBytes, err := os.ReadFile("testdata/svc.yaml")


### PR DESCRIPTION
## Summary

Fixed an operator precedence bug in `getAppInstanceValue` at `util/argo/resource_tracking.go:54`.

## Problem

The missing parentheses caused `&&` to bind tighter than `||`, making the condition evaluate as:

```go
// BEFORE (broken)
if (installationID != "" && un.GetAnnotations() == nil) || un.GetAnnotations()[...] != installationID {
```

When `installationID` was empty (the common case), any resource with a non-empty `argocd.argoproj.io/installation-id` annotation caused the function to return `nil`, breaking resource-to-application matching.

## Fix

Added parentheses to enforce the intended logic:

```go
// AFTER (fixed)
if installationID != "" && (un.GetAnnotations() == nil || un.GetAnnotations()[...] != installationID) {
```

## Test

Added `TestGetAppName_AnnotationWithExistingInstallationID` covering:
- Empty installationID with existing annotation → should return app name
- Wrong installationID → should return empty
- Correct installationID → should return app name

All existing tests pass.