### PR TITLE
feat: expose last operation phase per application metric

### DIFF
--- a/controller/metrics/metrics.go
+++ b/controller/metrics/metrics.go
@@ -65,7 +65,7 @@ var (
 	descAppInfo = prometheus.NewDesc(
 		"argocd_app_info",
 		"Information about application.",
-		append(descAppDefaultLabels, "autosync_enabled", "repo", "dest_server", "dest_namespace", "sync_status", "health_status", "operation"),
+		append(descAppDefaultLabels, "autosync_enabled", "repo", "dest_server", "dest_namespace", "sync_status", "health_status", "operation", "last_operation_phase"),
 		nil,
 	)
 
@@ -448,7 +448,12 @@ func (c *appCollector) collectApps(ch chan<- prometheus.Metric, app *argoappv1.A
 
 	autoSyncEnabled := app.Spec.SyncPolicy != nil && app.Spec.SyncPolicy.IsAutomatedSyncEnabled()
 
-	addGauge(descAppInfo, 1, strconv.FormatBool(autoSyncEnabled), git.NormalizeGitURL(app.Spec.GetSource().RepoURL), destServer, app.Spec.Destination.Namespace, string(syncStatus), string(healthStatus), operation)
+	var lastOperationPhase string
+	if app.Status.OperationState != nil {
+		lastOperationPhase = string(app.Status.OperationState.Phase)
+	}
+
+	addGauge(descAppInfo, 1, strconv.FormatBool(autoSyncEnabled), git.NormalizeGitURL(app.Spec.GetSource().RepoURL), destServer, app.Spec.Destination.Namespace, string(syncStatus), string(healthStatus), operation, lastOperationPhase)
 
 	if len(c.appLabels) > 0 {
 		labelValues := []string{}

--- a/controller/metrics/metrics_test.go
+++ b/controller/metrics/metrics_test.go
@@ -236,6 +236,67 @@ status:
     finishedAt: "2025-01-29T08:42:35Z"
 `
 
+const fakeAppOperationFailed = `
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+  namespace: argocd
+  labels:
+    team-name: my-team
+    team-bu: bu-id
+    argoproj.io/cluster: test-cluster
+spec:
+  destination:
+    namespace: dummy-namespace
+    name: cluster1
+  project: important-project
+  source:
+    path: some/path
+    repoURL: https://github.com/argoproj/argocd-example-apps.git
+status:
+  sync:
+    status: OutOfSync
+  health:
+    status: Degraded
+  operationState:
+    phase: Failed
+    startedAt: "2025-01-29T08:42:34Z"
+    finishedAt: "2025-01-29T08:42:35Z"
+`
+
+// fakeAppSyncedAfterFailedOperation represents an app whose last sync attempt failed,
+// but a subsequent Git revert made the live state match Git again without a new
+// operation ever running. status.operationState.phase is stale but never cleared.
+const fakeAppSyncedAfterFailedOperation = `
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+  namespace: argocd
+  labels:
+    team-name: my-team
+    team-bu: bu-id
+    argoproj.io/cluster: test-cluster
+spec:
+  destination:
+    namespace: dummy-namespace
+    name: cluster1
+  project: important-project
+  source:
+    path: some/path
+    repoURL: https://github.com/argoproj/argocd-example-apps.git
+status:
+  sync:
+    status: Synced
+  health:
+    status: Healthy
+  operationState:
+    phase: Failed
+    startedAt: "2025-01-29T08:42:34Z"
+    finishedAt: "2025-01-29T08:42:35Z"
+`
+
 var noOpHealthCheck = func(_ *http.Request) error {
 	return nil
 }
@@ -356,9 +417,9 @@ func TestMetrics(t *testing.T) {
 			responseContains: `
 # HELP argocd_app_info Information about application.
 # TYPE argocd_app_info gauge
-argocd_app_info{autosync_enabled="true",dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Degraded",name="my-app-3",namespace="argocd",operation="delete",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_status="OutOfSync"} 1
-argocd_app_info{autosync_enabled="false",dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Healthy",name="my-app",namespace="argocd",operation="",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_status="Synced"} 1
-argocd_app_info{autosync_enabled="true",dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Healthy",name="my-app-2",namespace="argocd",operation="sync",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_status="Synced"} 1
+argocd_app_info{autosync_enabled="true",dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Degraded",last_operation_phase="",name="my-app-3",namespace="argocd",operation="delete",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_status="OutOfSync"} 1
+argocd_app_info{autosync_enabled="false",dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Healthy",last_operation_phase="",name="my-app",namespace="argocd",operation="",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_status="Synced"} 1
+argocd_app_info{autosync_enabled="true",dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Healthy",last_operation_phase="",name="my-app-2",namespace="argocd",operation="sync",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_status="Synced"} 1
 `,
 		},
 		{
@@ -366,7 +427,50 @@ argocd_app_info{autosync_enabled="true",dest_namespace="dummy-namespace",dest_se
 			responseContains: `
 # HELP argocd_app_info Information about application.
 # TYPE argocd_app_info gauge
-argocd_app_info{autosync_enabled="false",dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Healthy",name="my-app",namespace="argocd",operation="",project="default",repo="https://github.com/argoproj/argocd-example-apps",sync_status="Synced"} 1
+argocd_app_info{autosync_enabled="false",dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Healthy",last_operation_phase="",name="my-app",namespace="argocd",operation="",project="default",repo="https://github.com/argoproj/argocd-example-apps",sync_status="Synced"} 1
+`,
+		},
+	}
+
+	for _, combination := range combinations {
+		testApp(t, combination.applications, combination.responseContains)
+	}
+}
+
+func TestMetricsLastOperationPhase(t *testing.T) {
+	combinations := []testCombination{
+		{
+			// status.operationState is nil: the application has never been synced.
+			applications: []string{fakeApp},
+			responseContains: `
+argocd_app_info{autosync_enabled="false",dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Healthy",last_operation_phase="",name="my-app",namespace="argocd",operation="",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_status="Synced"} 1
+`,
+		},
+		{
+			applications: []string{fakeAppOperationRunning},
+			responseContains: `
+argocd_app_info{autosync_enabled="false",dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Progressing",last_operation_phase="Running",name="my-app",namespace="argocd",operation="",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_status="OutOfSync"} 1
+`,
+		},
+		{
+			applications: []string{fakeAppOperationFinished},
+			responseContains: `
+argocd_app_info{autosync_enabled="false",dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Healthy",last_operation_phase="Succeeded",name="my-app",namespace="argocd",operation="",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_status="Synced"} 1
+`,
+		},
+		{
+			applications: []string{fakeAppOperationFailed},
+			responseContains: `
+argocd_app_info{autosync_enabled="false",dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Degraded",last_operation_phase="Failed",name="my-app",namespace="argocd",operation="",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_status="OutOfSync"} 1
+`,
+		},
+		{
+			// The last sync attempt failed, but the app is Synced again because a subsequent
+			// change reverted the diff without triggering a new operation. sync_status and
+			// health_status alone would hide the failure; last_operation_phase surfaces it.
+			applications: []string{fakeAppSyncedAfterFailedOperation},
+			responseContains: `
+argocd_app_info{autosync_enabled="false",dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Healthy",last_operation_phase="Failed",name="my-app",namespace="argocd",operation="",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_status="Synced"} 1
 `,
 		},
 	}

--- a/docs/operator-manual/metrics.md
+++ b/docs/operator-manual/metrics.md
@@ -54,6 +54,7 @@ Metrics about applications. Scraped at the `argocd-metrics:8082/metrics` endpoin
 | hostname           | argocd-application-controller-0 | Hostname of the Argo CD component that initiated the request to Redis.                                                                                                                          |
 | initiator          | argocd-server                   | Name of the Argo CD component that initiated the request to Redis. Possible values are: argocd-application-controller, argocd-repo-server, argocd-server.                                       |
 | kind               | Deployment                      | Kind name of a Kubernetes resource being monitored.                                                                                                                                             |
+| last_operation_phase | Failed                        | Phase of the most recently completed or in-progress operation on an Application, sourced from `status.operationState.phase` on the `argocd_app_info` metric. Unlike the `operation` label, this value persists after the operation finishes, so it reflects the outcome of the *last sync attempt* rather than whether one is currently running. Possible values are: `""` (no operation has ever run), Error, Failed, Running, Succeeded, Terminating.                                                                                                 |
 | method             | GET                             | HTTP method used for the request. Possible values are: GET, DELETE, PATCH, POST, PUT.                                                                                                           |
 | name               | my-app                          | Name of an Application.                                                                                                                                                                         |
 | namespace          | default                         | Namespace of an Application (namespace where the Application CR is located, not the destination namespace).                                                                                     |
@@ -65,6 +66,34 @@ Metrics about applications. Scraped at the `argocd-metrics:8082/metrics` endpoin
 | result             | hit                             | Result of an attempt to get a transport from the kubectl (client-go) transport cache. Possible values are: hit, miss, unreachable.                                                              |
 | server             | https://example.com             | Server where the operation is performed.                                                                                                                                                        |
 | verb               | List                            | Kubernetes API verb used in the request. Possible values are: Get, Watch, List, Create, Delete, Patch, Update.                                                                                  |
+
+### Alerting on the outcome of the last sync attempt
+
+`sync_status` and `health_status` on `argocd_app_info` describe whether the live state currently matches Git — they say
+nothing about how the *last sync attempt* went. It is possible for a sync to fail (for example, a PreSync hook Job exits
+non-zero) and for the Application to become `Synced`/`Healthy` again afterwards without a new operation ever running, e.g.
+because the offending Git commit was reverted. In that situation `status.operationState.phase` is still `Failed`, but
+nothing in `sync_status` or `health_status` reflects it.
+
+The `last_operation_phase` label exposes `status.operationState.phase` directly on `argocd_app_info` so that this state is
+visible as a gauge (a level), not just as an increment on the `argocd_app_sync_total` counter (an edge). Counter-based
+alerts such as `increase(argocd_app_sync_total{phase="Failed"}[10m]) > 0` fire once and then resolve as the time window
+slides past, even though the Application is still in a failed state, and the counter resets on controller restart.
+`last_operation_phase` lets you alert on "is any Application currently in a failed state" directly:
+
+```yaml
+- alert: ArgoCDLastSyncFailed
+  expr: argocd_app_info{last_operation_phase=~"Failed|Error"} == 1
+  for: 5m
+  labels:
+    severity: warning
+  annotations:
+    summary: "Argo CD application {{ $labels.name }} last sync attempt failed"
+    description: >-
+      The most recent operation on {{ $labels.namespace }}/{{ $labels.name }} ended in
+      {{ $labels.last_operation_phase }}. This may be stale even if sync_status/health_status
+      currently look healthy.
+```
 
 ### Metrics Cache Expiration
 


### PR DESCRIPTION
Closes #28646

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

### What
Adds a `last_operation_phase` label to the `argocd_app_info` gauge, sourced from `status.operationState.phase`. Empty string when the application has never been synced (`OperationState` is nil).

### Why
`argocd_app_info` currently exposes `sync_status` and `health_status`, which describe whether live state matches Git  not how the last sync *attempt* went. The existing `operation` label is only populated while an operation is in flight
and is cleared once it completes, so the outcome of the last attempt is invisible in live-state metrics.

This matters when a sync fails and the Application subsequently becomes `Synced`/`Healthy` without a new operation running , for example, when the offending commit is reverted so the diff resolves to zero. The UI correctly shows
`OPERATION Sync / PHASE Failed`, but metrics report a fully green application.

The only existing signal is `argocd_app_sync_total{phase="Failed"}`, a counter. Counter-based alerts are edge triggers: `increase(...[10m]) > 0` fires once and auto-resolves as the window slides past, even though the application is still in
a failed state, and the counter resets on controller restart or shard rebalance. A level cannot be derived from a counter in PromQL, so this has to be exposed by the collector.

With this label, alerting becomes:

```promql argocd_app_info{last_operation_phase=~"Failed|Error"} == 1
```

### Design note
Implemented as a label on the existing `argocd_app_info` rather than a new gauge. `argocd_app_info` is a per-scrape `ConstMetric` emitting exactly one row per application, so an added label is additive rather than series-fanning, and it
keeps last-operation outcome cross-referenceable against `sync_status` / `health_status` in a single expression without a PromQL join. Happy to switch to a dedicated `argocd_app_last_sync_status` gauge if maintainers prefer.

### Changes
- `controller/metrics/metrics.go` - new label on `descAppInfo`, value from  `app.Status.OperationState.Phase`
- `controller/metrics/metrics_test.go` -updated existing exposition assertions;  new `TestMetricsLastOperationPhase` covering nil, Running, Succeeded, Failed, and the Synced-but-last-op-Failed case from the issue
- `docs/operator-manual/metrics.md` - label documented, plus a section on level-vs-edge alerting with an example rule

No API structs changed, so `make codegen` was not required.


Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
