### PR TITLE
fix: correct operator precedence in isDestinationMatched deny pattern

### DIFF
--- a/pkg/apis/application/v1alpha1/app_project_types.go
+++ b/pkg/apis/application/v1alpha1/app_project_types.go
@@ -516,7 +516,7 @@ func (proj AppProject) isDestinationMatched(dst ApplicationDestination) bool {
 		switch {
 		case matched:
 			anyDestinationMatched = true
-		case (!dstNameMatched && isDenyPattern(item.Name)) || (!dstServerMatched && isDenyPattern(item.Server)) && dstNamespaceMatched:
+		case ((!dstNameMatched && isDenyPattern(item.Name)) || (!dstServerMatched && isDenyPattern(item.Server))) && dstNamespaceMatched:
 			return false
 		case !dstNamespaceMatched && isDenyPattern(item.Namespace) && dstServerMatched:
 			return false

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -395,6 +395,24 @@ func TestAppProject_IsNegatedDestinationPermitted(t *testing.T) {
 		}},
 		appDest:     ApplicationDestination{Server: "https://other-test-server", Namespace: "other"},
 		isPermitted: true,
+	}, {
+		// Name deny pattern should NOT apply when namespace doesn't match (regression test for operator precedence fix)
+		projDest: []ApplicationDestination{{
+			Name: "*", Namespace: "*",
+		}, {
+			Name: "!bad", Namespace: "other",
+		}},
+		appDest:     ApplicationDestination{Name: "bad", Namespace: "test"},
+		isPermitted: true,
+	}, {
+		// Name deny pattern should apply when namespace matches
+		projDest: []ApplicationDestination{{
+			Name: "*", Namespace: "*",
+		}, {
+			Name: "!bad", Namespace: "test",
+		}},
+		appDest:     ApplicationDestination{Name: "bad", Namespace: "test"},
+		isPermitted: false,
 	}}
 
 	for _, data := range testData {


### PR DESCRIPTION
## Summary

Fixed an operator precedence bug in `isDestinationMatched` at `pkg/apis/application/v1alpha1/app_project_types.go:519`.

## Problem

Due to `&&` binding tighter than `||`, the `&& dstNamespaceMatched` condition only applied to the server deny pattern, not the name deny pattern:

```go
// BEFORE (broken)
case (!dstNameMatched && isDenyPattern(item.Name)) || (!dstServerMatched && isDenyPattern(item.Server)) && dstNamespaceMatched:
// Evaluates as:
// ((name deny) || (server deny && namespace))
```

Name-based deny patterns (like `!prod-*`) rejected destinations regardless of namespace, while server-based deny patterns (like `!https://staging`) correctly required namespace match first. This broke symmetry with the match logic on line 515:

```go
matched := (dstServerMatched || dstNameMatched) && dstNamespaceMatched
```

## Fix

Added parentheses to enforce intended grouping:

```go
// AFTER (fixed)
case ((!dstNameMatched && isDenyPattern(item.Name)) || (!dstServerMatched && isDenyPattern(item.Server))) && dstNamespaceMatched:
```

Both name and server deny patterns now correctly require namespace match, consistent with the match logic.