### PR TITLE
chore: apply linter to gitops-engine

### DIFF
--- a/gitops-engine/pkg/sync/hook/hook.go
+++ b/gitops-engine/pkg/sync/hook/hook.go
@@ -1,6 +1,8 @@
 package hook
 
 import (
+	"slices"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/argoproj/argo-cd/gitops-engine/v3/pkg/sync/common"
@@ -15,12 +17,7 @@ const (
 
 func HasHookFinalizer(obj *unstructured.Unstructured) bool {
 	finalizers := obj.GetFinalizers()
-	for _, finalizer := range finalizers {
-		if finalizer == HookFinalizer {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(finalizers, HookFinalizer)
 }
 
 func IsHook(obj *unstructured.Unstructured) bool {
@@ -32,10 +29,8 @@ func IsHook(obj *unstructured.Unstructured) bool {
 }
 
 func Skip(obj *unstructured.Unstructured) bool {
-	for _, hookType := range Types(obj) {
-		if hookType == common.HookTypeSkip {
-			return len(Types(obj)) == 1
-		}
+	if slices.Contains(Types(obj), common.HookTypeSkip) {
+		return len(Types(obj)) == 1
 	}
 	return false
 }

--- a/gitops-engine/pkg/sync/resource/annotations.go
+++ b/gitops-engine/pkg/sync/resource/annotations.go
@@ -1,6 +1,7 @@
 package resource
 
 import (
+	"slices"
 	"strings"
 )
 
@@ -17,7 +18,7 @@ func GetAnnotationCSVs(obj AnnotationGetter, key string) []string {
 	// map for de-duping
 	seen := make(map[string]bool)
 	var values []string
-	for _, item := range strings.Split(obj.GetAnnotations()[key], ",") {
+	for item := range strings.SplitSeq(obj.GetAnnotations()[key], ",") {
 		val := strings.TrimSpace(item)
 		if val == "" {
 			continue
@@ -34,12 +35,7 @@ func GetAnnotationCSVs(obj AnnotationGetter, key string) []string {
 // HasAnnotationOption will return if the given obj has an annotation defined
 // as the given key and has in its values, the occurrence of val.
 func HasAnnotationOption(obj AnnotationGetter, key, val string) bool {
-	for _, item := range GetAnnotationCSVs(obj, key) {
-		if item == val {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(GetAnnotationCSVs(obj, key), val)
 }
 
 // GetAnnotationOptionValue will return the value of an option inside the

--- a/gitops-engine/pkg/sync/sync_context.go
+++ b/gitops-engine/pkg/sync/sync_context.go
@@ -1845,11 +1845,9 @@ func newStateSync(currentState runState) *stateSync {
 }
 
 func (s *stateSync) Go(f func(runState) runState) {
-	s.wg.Add(1)
-	go func() {
-		defer s.wg.Done()
+	s.wg.Go(func() {
 		s.results <- f(s.currentState)
-	}()
+	})
 }
 
 func (s *stateSync) Wait() runState {

--- a/gitops-engine/pkg/sync/sync_context_test.go
+++ b/gitops-engine/pkg/sync/sync_context_test.go
@@ -898,7 +898,6 @@ func TestServerResourcesRetry(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			// Given
 			t.Parallel()
@@ -936,7 +935,7 @@ func TestSync_getSyncTasks_FailureMessage(t *testing.T) {
 			Resources: []*metav1.APIResourceList{},
 		},
 	}
-	fakeDisco.Fake.PrependReactor("get", "resource", func(action testcore.Action) (handled bool, ret runtime.Object, err error) {
+	fakeDisco.PrependReactor("get", "resource", func(action testcore.Action) (handled bool, ret runtime.Object, err error) {
 		reactorCalls++
 		return true, nil, errors.New("discovery failed")
 	})
@@ -950,7 +949,7 @@ func TestSync_getSyncTasks_FailureMessage(t *testing.T) {
 	syncCtx.Sync(context.Background())
 	phase, msg, _ := syncCtx.GetState()
 
-	require.Greater(t, reactorCalls, 0, "FakeDiscovery reactor must have been invoked for this test to be meaningful")
+	require.Positive(t, reactorCalls, "FakeDiscovery reactor must have been invoked for this test to be meaningful")
 
 	assert.Equal(t, synccommon.OperationFailed, phase)
 	assert.Contains(t, msg, "one or more synchronization tasks are not valid")
@@ -974,7 +973,7 @@ func Test_getSyncTasks_ErrorCaching(t *testing.T) {
 			Resources: []*metav1.APIResourceList{},
 		},
 	}
-	fakeDisco.Fake.PrependReactor("get", "resource", func(action testcore.Action) (handled bool, ret runtime.Object, err error) {
+	fakeDisco.PrependReactor("get", "resource", func(action testcore.Action) (handled bool, ret runtime.Object, err error) {
 		discoveryCalls++
 		return true, nil, errors.New("persistent discovery error")
 	})
@@ -989,7 +988,7 @@ func Test_getSyncTasks_ErrorCaching(t *testing.T) {
 	assert.False(t, ok)
 	assert.NotNil(t, tasks)
 
-	require.Greater(t, discoveryCalls, 0, "FakeDiscovery reactor must have been invoked for the caching test to be meaningful")
+	require.Positive(t, discoveryCalls, "FakeDiscovery reactor must have been invoked for the caching test to be meaningful")
 	assert.Equal(t, 1, discoveryCalls, "Discovery should have been called only once due to error caching")
 }
 
@@ -1238,7 +1237,6 @@ func TestSync_ServerSideApply(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			syncCtx := newTestSyncCtx(nil)

--- a/gitops-engine/pkg/sync/sync_task.go
+++ b/gitops-engine/pkg/sync/sync_task.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"fmt"
+	"slices"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -123,12 +124,7 @@ func (t *syncTask) hasHookDeletePolicy(policy common.HookDeletePolicy) bool {
 	if !t.isHook() {
 		return false
 	}
-	for _, p := range hook.DeletePolicies(t.obj()) {
-		if p == policy {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(hook.DeletePolicies(t.obj()), policy)
 }
 
 func (t *syncTask) deleteBeforeCreation() bool {

--- a/gitops-engine/pkg/sync/sync_tasks.go
+++ b/gitops-engine/pkg/sync/sync_tasks.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -218,12 +219,7 @@ func (s syncTasks) All(predicate func(task *syncTask) bool) bool {
 }
 
 func (s syncTasks) Any(predicate func(task *syncTask) bool) bool {
-	for _, task := range s {
-		if predicate(task) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(s, predicate)
 }
 
 func (s syncTasks) Find(predicate func(task *syncTask) bool) *syncTask {


### PR DESCRIPTION
With the gitops-engine being a submodule/package with a replace directive, the IDE cannot detect and apply lint correctly, unless `-mod=mod` is used.

When configured, it correctly suggests the code style changes.

This PR applies the lint changes.

VSCode settings
```yaml
  // -mod=mod makes the IDE detect the gitops-engine modifications directly.
  "go.buildFlags": ["-mod=mod"],
  "go.testFlags": ["-mod=mod"],
  "gopls": {
    // This enables gopls to suggest tidy
    "ui.codelenses": {
      "tidy": true
    },
    // Do not update the the go.sum with transitive dependencies (they can be cleaned up by go mod tidy)
    "build.buildFlags": ["-mod=readonly"]
  },
  "go.lintTool": "golangci-lint",
  "go.lintFlags": ["--fix"],
```
