### PR TITLE
fix: prevent infinite recursion and fix nanosecond vs second bug in session manager

### DIFF
--- a/util/session/sessionmanager.go
+++ b/util/session/sessionmanager.go
@@ -124,7 +124,7 @@ func getMaxLoginFailures() int {
 
 // Returns the number of maximum seconds the login is allowed to delay for
 func getLoginFailureWindow() time.Duration {
-	return time.Duration(env.ParseNumFromEnv(envLoginFailureWindowSeconds, defaultFailureWindow, 0, math.MaxInt32))
+	return time.Duration(env.ParseNumFromEnv(envLoginFailureWindowSeconds, defaultFailureWindow, 0, math.MaxInt32)) * time.Second
 }
 
 // NewSessionManager creates a new session manager from Argo CD settings
@@ -327,7 +327,7 @@ func (mgr *SessionManager) GetLoginFailures() map[string]LoginAttempts {
 func expireOldFailedAttempts(maxAge time.Duration, failures map[string]LoginAttempts) int {
 	expiredCount := 0
 	for key, attempt := range failures {
-		if time.Since(attempt.LastFailed) > maxAge*time.Second {
+		if time.Since(attempt.LastFailed) > maxAge {
 			expiredCount++
 			delete(failures, key)
 		}
@@ -337,18 +337,17 @@ func expireOldFailedAttempts(maxAge time.Duration, failures map[string]LoginAtte
 
 // Protect admin user from login attempt reset caused by attempts to overflow cache in a brute force attack. Instead remove random non-admin to make room in cache.
 func pickRandomNonAdminLoginFailure(failures map[string]LoginAttempts, username string) *string {
-	idx := rand.Intn(len(failures) - 1)
-	i := 0
+	eligible := make([]string, 0, len(failures))
 	for key := range failures {
-		if i == idx {
-			if key == common.ArgoCDAdminUsername || key == username {
-				return pickRandomNonAdminLoginFailure(failures, username)
-			}
-			return &key
+		if key != common.ArgoCDAdminUsername && key != username {
+			eligible = append(eligible, key)
 		}
-		i++
 	}
-	return nil
+	if len(eligible) == 0 {
+		return nil
+	}
+	k := eligible[rand.Intn(len(eligible))]
+	return &k
 }
 
 // Updates the failure count for a given username. If failed is true, increases the counter. Otherwise, sets counter back to 0.
@@ -421,7 +420,7 @@ func (mgr *SessionManager) exceededFailedLoginAttempts(attempt LoginAttempts) bo
 
 	// Whether we are in the failure window for given attempt
 	inWindow := func() bool {
-		if failureWindow == 0 || time.Since(attempt.LastFailed).Seconds() <= float64(failureWindow) {
+		if failureWindow == 0 || time.Since(attempt.LastFailed) <= failureWindow {
 			return true
 		}
 		return false

--- a/util/session/sessionmanager_test.go
+++ b/util/session/sessionmanager_test.go
@@ -1566,6 +1566,70 @@ func Test_PickFailureAttemptWhenOverflowed(t *testing.T) {
 	})
 }
 
+func Test_PickFailureAttemptEdgeCases(t *testing.T) {
+	t.Run("Empty map returns nil", func(t *testing.T) {
+		failures := map[string]LoginAttempts{}
+		user := pickRandomNonAdminLoginFailure(failures, "test")
+		assert.Nil(t, user)
+	})
+
+	t.Run("Single eligible entry is returned", func(t *testing.T) {
+		failures := map[string]LoginAttempts{
+			"test2": {FailCount: 1},
+		}
+		user := pickRandomNonAdminLoginFailure(failures, "test")
+		assert.NotNil(t, user)
+		assert.Equal(t, "test2", *user)
+	})
+
+	t.Run("Only admin and current user returns nil", func(t *testing.T) {
+		failures := map[string]LoginAttempts{
+			common.ArgoCDAdminUsername: {FailCount: 1},
+			"test":                     {FailCount: 1},
+		}
+		user := pickRandomNonAdminLoginFailure(failures, "test")
+		assert.Nil(t, user)
+	})
+
+	t.Run("Multiple eligible entries, always returns an eligible key", func(t *testing.T) {
+		failures := map[string]LoginAttempts{
+			"user1": {FailCount: 1},
+			"user2": {FailCount: 1},
+			"user3": {FailCount: 1},
+		}
+		for range 1000 {
+			user := pickRandomNonAdminLoginFailure(failures, "test")
+			assert.NotNil(t, user)
+			assert.NotEqual(t, common.ArgoCDAdminUsername, *user)
+			assert.NotEqual(t, "test", *user)
+		}
+	})
+}
+
+func Test_GetLoginFailureWindow(t *testing.T) {
+	t.Run("Default window is in seconds not nanoseconds", func(t *testing.T) {
+		window := getLoginFailureWindow()
+		// defaultFailureWindow is 300, should be 300 seconds = 5 minutes
+		assert.Equal(t, 300*time.Second, window)
+	})
+}
+
+func Test_ExpireOldFailedAttempts(t *testing.T) {
+	t.Run("Expiring entries based on duration", func(t *testing.T) {
+		now := time.Now()
+		failures := map[string]LoginAttempts{
+			"old-user": {FailCount: 3, LastFailed: now.Add(-10 * time.Minute)},
+			"new-user": {FailCount: 1, LastFailed: now.Add(-1 * time.Minute)},
+		}
+		expired := expireOldFailedAttempts(5*time.Minute, failures)
+		assert.Equal(t, 1, expired)
+		_, exists := failures["old-user"]
+		assert.False(t, exists)
+		_, exists = failures["new-user"]
+		assert.True(t, exists)
+	})
+}
+
 func TestTokenUniqueID(t *testing.T) {
 	testCases := []struct {
 		name   string


### PR DESCRIPTION
## Summary

Fixed multiple bugs in `util/session/sessionmanager.go` related to login failure tracking.

Fixes #28870

## Changes

- **Prevent infinite recursion**: Replaced recursive `pickRandomNonAdminLoginFailure` with iterative approach to prevent stack overflow when all entries are admin/username
- **Prevent panic**: Added bounds check for `len(failures) <= 1` to prevent panic from `rand.Intn(0)`
- **Fix duration units**: Fixed `getLoginFailureWindow` returning nanoseconds instead of seconds by multiplying by `time.Second`
- **Fix comparison logic**: Fixed `expireOldFailedAttempts` to use duration comparison directly instead of multiplying by `time.Second` again
- **Fix comparison logic**: Fixed `exceededFailedLoginAttempts` to compare durations directly instead of converting to `float64` seconds