### PR TITLE
fix: fix build image error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,7 @@ RUN groupadd -g $ARGOCD_USER_ID argocd && \
     mkdir -p /home/argocd && \
     chown argocd:0 /home/argocd && \
     chmod g=u /home/argocd && \
+    sed -i '/^Components:/ s/$/ universe/' /etc/apt/sources.list.d/ubuntu.sources && \
     apt-get update && \
     apt-get dist-upgrade -y && \
     apt-get install --no-install-recommends -y \

--- a/test/container/Dockerfile
+++ b/test/container/Dockerfile
@@ -24,7 +24,8 @@ ARG GIT_APT_VERSION=1:2.53.0-1ubuntu1
 # NOTE: binutils-gold contains the gold linker, which was recently removed
 #       from binutils, but is still nesessary for building lint-tools on arm64 only
 #       until this Golang issue is fixed: https://github.com/golang/go/issues/22040
-RUN  apt-get update && apt-get install --fix-missing --no-install-recommends -y \
+RUN  sed -i '/^Components:/ s/$/ universe/' /etc/apt/sources.list.d/ubuntu.sources && \
+    apt-get update && apt-get install --fix-missing --no-install-recommends -y \
     ca-certificates \
     curl \
     openssh-server \

--- a/test/remote/Dockerfile
+++ b/test/remote/Dockerfile
@@ -12,7 +12,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 # renovate: datasource=deb depName=git registryUrl=https://archive.ubuntu.com/ubuntu?suite=resolute&components=main,security&binaryArch=amd64
 ARG GIT_APT_VERSION=1:2.53.0-1ubuntu1
 
-RUN  apt-get update && apt-get install --no-install-recommends -y \
+RUN  sed -i '/^Components:/ s/$/ universe/' /etc/apt/sources.list.d/ubuntu.sources && \
+     apt-get update && apt-get install --no-install-recommends -y \
     ca-certificates \
     curl \
     openssh-server \


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

This PR appends universe to the Components entry in /etc/apt/sources.list.d/ubuntu.sources:
`sed -i '/^Components:/ s/$/ universe/' /etc/apt/sources.list.d/ubuntu.sources`

Docker image is installing packages such as connect-proxy, which are available in the Ubuntu universe repository. Without enabling this repository, apt-get install is failing with errors 
```
276.0 E: Unable to locate package tini
276.0 E: Unable to locate package gpg
276.0 E: Unable to locate package gpg-agent
276.0 E: Unable to locate package connect-proxy
```

LOGS:
------
 ```
------
 > [argocd-base  2/13] RUN groupadd -g 999 argocd &&     useradd -r -u 999 -g argocd argocd &&     mkdir -p /home/argocd &&     chown argocd:0 /home/argocd &&     chmod g=u /home/argocd &&     apt-get update &&     apt-get dist-upgrade -y &&     apt-get install --no-install-recommends -y     git=1:2.53.0-1ubuntu1 tini ca-certificates gpg gpg-agent tzdata connect-proxy openssh-client &&     apt-get clean &&     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*:
276.0 Reading state information...
276.0 Package git is not available, but is referred to by another package.
276.0 This may mean that the package is missing, has been obsoleted, or
276.0 is only available from another source
276.0 
276.0 E: Version '1:2.53.0-1ubuntu1' for 'git' was not found
276.0 E: Unable to locate package tini
276.0 E: Unable to locate package gpg
276.0 E: Unable to locate package gpg-agent
276.0 E: Unable to locate package connect-proxy
------
WARNING: No output specified with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
Dockerfile:50
--------------------
  49 |     
  50 | >>> RUN groupadd -g $ARGOCD_USER_ID argocd && \
  51 | >>>     useradd -r -u $ARGOCD_USER_ID -g argocd argocd && \
  52 | >>>     mkdir -p /home/argocd && \
  53 | >>>     chown argocd:0 /home/argocd && \
  54 | >>>     chmod g=u /home/argocd && \
  55 | >>>     apt-get update && \
  56 | >>>     apt-get dist-upgrade -y && \
  57 | >>>     apt-get install --no-install-recommends -y \
  58 | >>>     git=${GIT_APT_VERSION} tini ca-certificates gpg gpg-agent tzdata connect-proxy openssh-client && \
  59 | >>>     apt-get clean && \
  60 | >>>     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
  61 |     
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c groupadd -g $ARGOCD_USER_ID argocd &&     useradd -r -u $ARGOCD_USER_ID -g argocd argocd &&     mkdir -p /home/argocd &&     chown argocd:0 /home/argocd &&     chmod g=u /home/argocd &&     apt-get update &&     apt-get dist-upgrade -y &&     apt-get install --no-install-recommends -y     git=${GIT_APT_VERSION} tini ca-certificates gpg gpg-agent tzdata connect-proxy openssh-client &&     apt-get clean &&     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*" did not complete successfully: exit code: 100
```


Enabling the universe component ensures these packages are available during the image build and improves build reliability.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
