### PR TITLE
chore: use kustomize version from tool-versions.sh

### DIFF
--- a/hack/installers/install-codegen-tools.sh
+++ b/hack/installers/install-codegen-tools.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -eux -o pipefail
 
-KUSTOMIZE_VERSION=5.4.3 "$(dirname "$0")/../install.sh" helm kustomize protoc
+"$(dirname "$0")/../install.sh" helm kustomize protoc


### PR DESCRIPTION
This PR fixes some e2e tests when run with the local toolchain. (Splitted from #28857)

Remove the hardcoded KUSTOMIZE_VERSION=5.4.3 override in install-codegen-tools.sh so make install-tools-local installs the version from hack/tool-versions.sh (5.8.1). The older override broke e2e tests that require Helm 4 compatibility fixes in the newer kustomize.

**`TestKustomizeKubeVersion`, `TestKustomizeApiVersions`, `TestKustomizeNamespaceOverride`**

- when local toolchain is set up like described in developer docs, the installed kustomize version does not match the `hack/tool-versions.sh`
- `hack/tool-versions.sh` has v5.8.1
- `hack/installers/install-codegen-tools.sh` has override v5.4.3
- `BIN=~/go/bin make install-tools-local`
    - first installs v5.8.1, then overrides with v5.4.3
- the tests fail with `unknown shorthand c in helm version -c`
    - this is caused by the old kustomize version, which lacks the necessary compatibility fixes with helm 4
    - https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv5.8.1
    - https://github.com/kubernetes-sigs/kustomize/pull/6016
- relevant older issue with similar problem regarding the version mismatch #21036
- fix: remove the version override and use `hack/tool-versions.sh`

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
   - did not find any relevant issues to close
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
    - no changes necessary
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
