### PR TITLE
test: fix docker bind mount recreation

### DIFF
--- a/test/e2e/fixture/fixture.go
+++ b/test/e2e/fixture/fixture.go
@@ -895,9 +895,15 @@ func EnsureCleanState(t *testing.T, opts ...TestOption) *TestState {
 		},
 		func() error {
 			tmpDir := TmpDir()
-			err := os.RemoveAll(tmpDir)
+			entries, err := os.ReadDir(tmpDir)
 			if err != nil {
 				return err
+			}
+			for _, entry := range entries {
+				err := os.RemoveAll(filepath.Join(tmpDir, entry.Name()))
+				if err != nil {
+					return err
+				}
 			}
 			_, err = Run("", "mkdir", "-p", tmpDir)
 			if err != nil {


### PR DESCRIPTION
This PR fixes some e2e tests when run with the local toolchain. (Splitted from https://github.com/argoproj/argo-cd/pull/28857)

Fixes e2e-git container loosing access to the bind mount folder upon its delete and recreation causing "unable to ls-remote HEAD..." failure.

**`TestOCISourceIgnoredWithSourceIntegrity`**

- `EnsureCleanState` breaks docker bind mounts for e2e-git container on macOS or when using the `ARGOCD_E2E_DIR` causing the repository folder to become stuck and empty causing `unable to ls-remote HEAD on repository: failed to list refs: repository not found`
- e2e-git has bind mounts:
    - host `/tmp` to `/tmp`
    - host `ARGOCD_E2E_DIR` (default is `/tmp/argo-e2e`) to `/tmp/argo-e2e`
- EnsureCleanState recreates the `ARGOCD_E2E_DIR` folder (calls `os.RemoveAll(ARGOCD_E2E_DIR)` and then `mkdir -p ARGOCD_E2E_DIR`)
    - docker binds the `ARGOCD_E2E_DIR`, the directory (i-node) is then deleted, new one is created, but the container sees empty folder (the old removed directory)
    - details:
        - when `ARGOCD_E2E_DIR` is not in the host `/tmp` subtree, the mount always breaks (tested on fedora + docker engine; macOS + docker desktop)
        - when not using the `ARGOCD_E2E_DIR` variable (the `ARGOCD_E2E_DIR` is `/tmp/argo-e2e`)
           - on macOS + docker desktop - the directory cannot be deleted (permission denied)
               - the permission denied is not `/tmp` specific
           - on fedora + docker engine - can be deleted (disappears) and recreated, and the change is visible inside the container through the `/tmp` mount (that is why the CI does not fail)
    - steps to verify:

        - **1. nested (does not work on MacOS)**

            ```sh
            mkdir -p /tmp/argo-e2e
            touch /tmp/argo-e2e/file
            docker run --rm -it -v /tmp:/tmp -v /tmp/argo-e2e:/tmp:argo-e2e alpine
            ls /tmp/argo-e2e # inside container should see file

            # outside container (don't stop the container)
            rm -r /tmp/argo-e2e # permission denied on macOS, on linux works
            mkdir -p /tmp/argo-e2e
            touch /tmp/argo-e2e/newfile

            # inside the container
            ls /tmp/argo-e2e # newfile is not there, the directory is empty (works on linux - can see the newfile)
            ```

            - MacOS: the same behavior can be observed if trying with some other nested path not in /tmp so it's not /tmp specific issue
            - I have tried with $HOME/tmp/ and $HOME/tmp/argo-e2e
            - Linux: also behaves consistently when not using /tmp (was trying if tmpfs of /tmp in my VM was the issue)

        - **2. not nested (like using the env variable)**

            ```sh
            mkdir -p $HOME/tmp/argo-e2e
            touch $HOME/tmp/argo-e2e/file
            docker run --rm -it -v /tmp:/tmp -v $HOME/tmp/argo-e2e:/tmp:argo-e2e alpine
            ls $HOME/tmp/argo-e2e # inside container should see file

            # outside container (don't stop the container)
            rm -r $HOME/tmp/argo-e2e # works
            mkdir -p $HOME/tmp/argo-e2e
            touch $HOME/tmp/argo-e2e/newfile

            # inside the container
            ls /tmp/argo-e2e # newfile is not there, the directory is empty (both macos and linux)
            ```

            - The mount breaks consistently on macOS and linux - after the directory is recreated the content in the container stays empty

    - fix: instead of removeAll, remove only the content inside the ARGOCD_E2E_DIR


<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
   - did not find any relevant issues to close
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
    - no changes necessary
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->