### PR TITLE
test: fix Hydration check in TestHydratorHydratesAutomatically_NewCommit_WithChanges

### DIFF
--- a/test/e2e/hydrator_test.go
+++ b/test/e2e/hydrator_test.go
@@ -551,6 +551,7 @@ func TestHydratorHydratesAutomatically_NewCommit_WithChanges(t *testing.T) {
 		Refresh(RefreshTypeNormal).
 		Wait("--hydrated").
 		Then().
+		AndAction(func() { time.Sleep(2 * time.Second) }). // Give the controller time to process the hydration
 		Expect(HydrationPhaseIs(HydrateOperationPhaseHydrated)).
 		And(func(app *Application) {
 			require.NotEqual(t, firstDrySHA, app.Status.SourceHydrator.CurrentOperation.DrySHA,

--- a/test/e2e/hydrator_test.go
+++ b/test/e2e/hydrator_test.go
@@ -551,7 +551,10 @@ func TestHydratorHydratesAutomatically_NewCommit_WithChanges(t *testing.T) {
 		Refresh(RefreshTypeNormal).
 		Wait("--hydrated").
 		Then().
-		AndAction(func() { time.Sleep(2 * time.Second) }). // Give the controller time to process the hydration
+		Expect(App(func(app *Application) bool {
+			op := app.Status.SourceHydrator.CurrentOperation
+			return op != nil && op.DrySHA != firstDrySHA
+		})).
 		Expect(HydrationPhaseIs(HydrateOperationPhaseHydrated)).
 		And(func(app *Application) {
 			require.NotEqual(t, firstDrySHA, app.Status.SourceHydrator.CurrentOperation.DrySHA,


### PR DESCRIPTION
This PR fixes some e2e tests when run with the local toolchain. (Splitted from https://github.com/argoproj/argo-cd/pull/28857)

Fix timing issue caused when wait for hydrated status is called too soon causing it to succeed because the app is still hydrated from the prev SHA as the new state has not been processed yet. Sleep before checking the app status to give argo time to process the hydration.

**`TestHydratorHydratesAutomatically_NewCommit_WithChanges`**

- the app is still hydrated with the old state - the change is queued and the Wait("--hydrated") immediately succeeds, since the status is sill hydrated from the prev state
- fix: wait for and expect the current operation dry sha to change (therefore the hydration was detected and has started) before waiting and checking the rest of the conditions

<details><summary>Log</summary>
<code>
time="2026-07-20T13:49:53+02:00" level=info msg="../../dist/argocd app create -f /var/folders/_d/65t3r9nx0pgc13mtvytrfyvc0000gn/T/902305250 --plaintext --server localhost:8080 --auth-token ****** --insecure" dir= execID=2a0b7
time="2026-07-20T13:49:53+02:00" level=debug msg="application 'test-hydrator-hydrates-automatically--new-commit--with-ch-wkdvp' created\n" duration=507.184125ms execID=2a0b7
time="2026-07-20T13:49:53+02:00" level=info msg="expectation succeeded: no error and output contained ''"
time="2026-07-20T13:49:53+02:00" level=info msg="../../dist/argocd app get test-hydrator-hydrates-automatically--new-commit--with-ch-wkdvp --refresh --plaintext --server localhost:8080 --auth-token ****** --insecure" dir= execID=5d00a
time="2026-07-20T13:49:54+02:00" level=debug msg="Name:               argocd-e2e/test-hydrator-hydrates-automatically--new-commit--with-ch-wkdvp\nProject:            default\nServer:             https://kubernetes.default.svc\nNamespace:          argocd-e2e--test-hydrator-hydrates-automatically--new-com-wkdvp\nURL:                http://localhost:8080/applications/test-hydrator-hydrates-automatically--new-commit--with-ch-wkdvp\nSource:\n- Repo:             file:///Users/jakucera/tmp/test/testdata.git\n  Target:           env/test\n  Path:             guestbook\nSyncWindow:         Sync Allowed\nSync Policy:        Manual\nSync Status:        Unknown (env/tes)\nHealth Status:      Healthy\n\nCONDITION        MESSAGE                                                                                                                                                                        LAST TRANSITION\nComparisonError  Failed to load target state: failed to generate manifest for source 1 of 1: rpc error: code = Unknown desc = unable to resolve 'env/test' to a commit SHA: revision not found  2026-07-20 13:49:53 +0200 CEST\n\n" duration=132.645ms execID=5d00a
time="2026-07-20T13:49:54+02:00" level=info msg="expectation succeeded: no error and output contained ''"
time="2026-07-20T13:49:54+02:00" level=info msg="../../dist/argocd app wait --hydrated test-hydrator-hydrates-automatically--new-commit--with-ch-wkdvp --timeout 20 --plaintext --server localhost:8080 --auth-token ****** --insecure" dir= execID=52941
time="2026-07-20T13:49:55+02:00" level=debug msg="TIMESTAMP  GROUP        KIND   NAMESPACE                  NAME    STATUS   HEALTH        HOOK  MESSAGE\n\nName:               argocd-e2e/test-hydrator-hydrates-automatically--new-commit--with-ch-wkdvp\nProject:            default\nServer:             https://kubernetes.default.svc\nNamespace:          argocd-e2e--test-hydrator-hydrates-automatically--new-com-wkdvp\nURL:                http://localhost:8080/applications/test-hydrator-hydrates-automatically--new-commit--with-ch-wkdvp\nSource:\n- Repo:             file:///Users/jakucera/tmp/test/testdata.git\n  Target:           env/test\n  Path:             guestbook\nSyncWindow:         Sync Allowed\nSync Policy:        Manual\nSync Status:        Unknown (env/tes)\nHealth Status:      Healthy\n\n" duration=1.24729575s execID=52941
time="2026-07-20T13:49:55+02:00" level=info msg="expectation succeeded: no error and output contained ''"
time="2026-07-20T13:49:55+02:00" level=info msg="expectation succeeded: hydration phase to be Hydrated, is Hydrated"
    hydrator_test.go:542: Initial hydration - drySHA: 3b89fa5c6fc5344e8a1eaefe56ae9b8513f8670a, hydratedSHA: 23e052459873dd5144a0c4cff74e7cd9f363938a
time="2026-07-20T13:49:56+02:00" level=info msg=patching jsonPatch="[{\"op\": \"replace\", \"path\": \"/spec/revisionHistoryLimit\", \"value\": 10}]" path=guestbook/guestbook-ui-deployment.yaml
time="2026-07-20T13:49:56+02:00" level=info msg="converting YAML to JSON"
time="2026-07-20T13:49:56+02:00" level=info msg=JSON bytes="{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"labels\":{\"test\":\"true\"},\"name\":\"guestbook-ui\"},\"spec\":{\"replicas\":0,\"revisionHistoryLimit\":3,\"selector\":{\"matchLabels\":{\"app\":\"guestbook-ui\"}},\"template\":{\"metadata\":{\"labels\":{\"app\":\"guestbook-ui\"}},\"spec\":{\"containers\":[{\"image\":\"quay.io/argoprojlabs/argocd-e2e-container:0.2\",\"imagePullPolicy\":\"IfNotPresent\",\"name\":\"guestbook-ui\",\"ports\":[{\"containerPort\":80}]}]}}}}"
time="2026-07-20T13:49:56+02:00" level=info msg="converting JSON back to YAML"
time="2026-07-20T13:49:56+02:00" level=info msg="git diff" dir=/Users/jakucera/tmp/test/testdata.git execID=bb276
time="2026-07-20T13:49:56+02:00" level=debug msg="diff --git a/guestbook/guestbook-ui-deployment.yaml b/guestbook/guestbook-ui-deployment.yaml\nindex bf33756..d214ee4 100644\n--- a/guestbook/guestbook-ui-deployment.yaml\n+++ b/guestbook/guestbook-ui-deployment.yaml\n@@ -1,12 +1,12 @@\n apiVersion: apps/v1\n kind: Deployment\n metadata:\n-  name: guestbook-ui\n   labels:\n     test: \"true\"\n+  name: guestbook-ui\n spec:\n   replicas: 0\n-  revisionHistoryLimit: 3\n+  revisionHistoryLimit: 10\n   selector:\n     matchLabels:\n       app: guestbook-ui\n" duration=48.236792ms execID=bb276
time="2026-07-20T13:49:56+02:00" level=info msg="git commit -am patch" dir=/Users/jakucera/tmp/test/testdata.git execID=6368d
time="2026-07-20T13:49:56+02:00" level=debug msg="[master a84828a] patch\n 1 file changed, 2 insertions(+), 2 deletions(-)\n" duration=64.790916ms execID=6368d
time="2026-07-20T13:49:56+02:00" level=info msg="../../dist/argocd app get test-hydrator-hydrates-automatically--new-commit--with-ch-wkdvp --refresh --plaintext --server localhost:8080 --auth-token ****** --insecure" dir= execID=c869a
time="2026-07-20T13:49:56+02:00" level=debug msg="Name:               argocd-e2e/test-hydrator-hydrates-automatically--new-commit--with-ch-wkdvp\nProject:            default\nServer:             https://kubernetes.default.svc\nNamespace:          argocd-e2e--test-hydrator-hydrates-automatically--new-com-wkdvp\nURL:                http://localhost:8080/applications/test-hydrator-hydrates-automatically--new-commit--with-ch-wkdvp\nSource:\n- Repo:             file:///Users/jakucera/tmp/test/testdata.git\n  Target:           env/test\n  Path:             guestbook\nSyncWindow:         Sync Allowed\nSync Policy:        Manual\nSync Status:        OutOfSync from env/test (23e0524)\nHealth Status:      Missing\n\nGROUP  KIND        NAMESPACE                                                        NAME          STATUS     HEALTH   HOOK  MESSAGE\n       Service     argocd-e2e--test-hydrator-hydrates-automatically--new-com-wkdvp  guestbook-ui  OutOfSync  Missing        \napps   Deployment  argocd-e2e--test-hydrator-hydrates-automatically--new-com-wkdvp  guestbook-ui  OutOfSync  Missing        \n" duration=197.691666ms execID=c869a
time="2026-07-20T13:49:56+02:00" level=info msg="expectation succeeded: no error and output contained ''"
time="2026-07-20T13:49:56+02:00" level=info msg="../../dist/argocd app wait --hydrated test-hydrator-hydrates-automatically--new-commit--with-ch-wkdvp --timeout 20 --plaintext --server localhost:8080 --auth-token ****** --insecure" dir= execID=6d31c
time="2026-07-20T13:49:56+02:00" level=debug msg="\nName:               argocd-e2e/test-hydrator-hydrates-automatically--new-commit--with-ch-wkdvp\nProject:            default\nServer:             https://kubernetes.default.svc\nNamespace:          argocd-e2e--test-hydrator-hydrates-automatically--new-com-wkdvp\nURL:                http://localhost:8080/applications/test-hydrator-hydrates-automatically--new-commit--with-ch-wkdvp\nSource:\n- Repo:             file:///Users/jakucera/tmp/test/testdata.git\n  Target:           env/test\n  Path:             guestbook\nSyncWindow:         Sync Allowed\nSync Policy:        Manual\nSync Status:        OutOfSync from env/test (23e0524)\nHealth Status:      Missing\n\n\nGROUP  KIND        NAMESPACE                                                        NAME          STATUS     HEALTH   HOOK  MESSAGE\n       Service     argocd-e2e--test-hydrator-hydrates-automatically--new-com-wkdvp  guestbook-ui  OutOfSync  Missing        \napps   Deployment  argocd-e2e--test-hydrator-hydrates-automatically--new-com-wkdvp  guestbook-ui  OutOfSync  Missing        \n" duration=82.972833ms execID=6d31c
time="2026-07-20T13:49:56+02:00" level=info msg="expectation succeeded: no error and output contained ''"
time="2026-07-20T13:49:56+02:00" level=info msg="expectation succeeded: hydration phase to be Hydrated, is Hydrated"
    hydrator_test.go:556: 
        	Error Trace:	/Users/jakucera/repository/argo/argo-cd/test/e2e/hydrator_test.go:556
        	            				/Users/jakucera/repository/argo/argo-cd/test/e2e/fixture/app/consequences.go:90
        	            				/Users/jakucera/repository/argo/argo-cd/test/e2e/hydrator_test.go:555
        	Error:      	Should not be: "3b89fa5c6fc5344e8a1eaefe56ae9b8513f8670a"
        	Test:       	TestHydratorHydratesAutomatically_NewCommit_WithChanges
        	Messages:   	Dry SHA should change after a new commit
</code>
</details> 

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
   - did not find any relevant issues to close
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
    - no changes necessary
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
