### PR TITLE
test: fix race condition wait for healthy in TestPermissions

### DIFF
--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -1226,6 +1226,7 @@ func TestPermissions(t *testing.T) {
 		CreateApp().
 		Sync().
 		Then().
+		Expect(HealthIs(health.HealthStatusHealthy)).
 		// make sure application resource actions are successful
 		And(func(app *Application) {
 			assertResourceActions(t, app.Name, true, appCtx.DeploymentNamespace())


### PR DESCRIPTION
This PR fixes some e2e tests when run with the local toolchain. (Splitted from #28857)

Fixes race condition in TestPermissions where the deployment status is checked while its health is still progressing after sync causing it not to be found.

**`TestPermissions`**

- race issue, the test sometimes fails when checking deployment status, sometimes the change is fast enough
- according to logs the health status is still progressing therefore the check fails to get the new state
<details><summary>Cleaned up log</summary>
<code>
TIMESTAMP                  GROUP        KIND   NAMESPACE                                          NAME    STATUS    HEALTH        HOOK  MESSAGE
2026-07-16T09:22:02+02:00            Service  argocd-e2e--test-permissions-yvbam          guestbook-ui  OutOfSync  Missing              
2026-07-16T09:22:02+02:00   apps  Deployment  argocd-e2e--test-permissions-yvbam          guestbook-ui  OutOfSync  Missing              
2026-07-16T09:22:02+02:00            Service  argocd-e2e--test-permissions-yvbam          guestbook-ui    Synced  Healthy              

Name:               argocd-e2e/test-permissions-yvbam
Project:            test-permissions-yvbam
Server:             https://kubernetes.default.svc
Namespace:          argocd-e2e--test-permissions-yvbam
URL:                http://localhost:8080/applications/test-permissions-yvbam
Source:
- Repo:             file:///Users/jakucera/tmp/test/testdata.git
  Target:           
  Path:             guestbook-logs
SyncWindow:         Sync Allowed
Sync Policy:        Manual
Sync Status:        Synced to  (2ed5c35)
Health Status:      Progressing

Operation:          Sync
Sync Revision:      2ed5c359d472ff09a8f8ab22e17a1510a31b9054
Phase:              Succeeded
</code>
</details> 

- failed 29/50 times (MacBook Pro M3)
- fix: expect (and wait for) the health status to be healthy before continuing with the rest of the checks

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
   - did not find any relevant issues to close
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
    - no changes necessary
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
