### PR TITLE
test: fix OutOfSync status in TestSyncWithRetryAndRefreshEnabled

### DIFF
--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -1839,6 +1839,7 @@ func TestSyncWithRetryAndRefreshEnabled(t *testing.T) {
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		When().
 		PatchFile("guestbook-ui-deployment.yaml", `[{"op": "replace", "path": "/spec/revisionHistoryLimit", "value": "badValue"}]`).
+		Refresh(RefreshTypeNormal).
 		IgnoreErrors().
 		Sync().
 		DoNotIgnoreErrors().
@@ -1850,6 +1851,7 @@ func TestSyncWithRetryAndRefreshEnabled(t *testing.T) {
 		PatchApp(`[{"op": "add", "path": "/spec/source/path", "value": "failure-during-sync"}]`).
 		// push a fixed commit on HEAD branch
 		PatchFile("guestbook-ui-deployment.yaml", `[{"op": "replace", "path": "/spec/revisionHistoryLimit", "value": 42}]`).
+		Refresh(RefreshTypeNormal).
 		IgnoreErrors().
 		Sync().
 		DoNotIgnoreErrors().


### PR DESCRIPTION
This PR fixes some e2e tests when run with the local toolchain. (Splitted from #28857)

Add Refresh after patching the file to trigger sync status update, which was stuck on Synced with the old revision SHA. Force update similar to TestAutoSyncRetryAndRefreshEnabled.

**`TestSyncWithRetryAndRefreshEnabled`**

- timing issue, sometimes fails, usually the automatic rerun fixes it in the next 2-4 runs
- also a problem in CI: https://github.com/kuci-JK/argo-cd/actions/runs/29903527760/job/88869957817
- when run isolated 20 times it failed 14 times (MacBook Pro M3)
- is waiting for sync status to be OutOfSync, but it is still Synced
- the sync revision shows the new commit, but the sync status is still synced to the old SHA
- the other similar test `TestAutoSyncRetryAndRefreshEnabled` uses `Refresh`
- fix: call Refresh as in `TestAutoSyncRetryAndRefreshEnabled`

<details><summary>Log</summary>
<code>
time="2026-07-20T10:10:59+02:00" level=info msg="../../dist/argocd app sync test-sync-with-retry-and-refresh-enabled-koihw --timeout 2 --prune --plaintext --server localhost:8080 --auth-token ****** --insecure" dir= execID=e0e1f
time="2026-07-20T10:11:01+02:00" level=debug msg="TIMESTAMP                  GROUP        KIND   NAMESPACE                                                                  NAME    STATUS   HEALTH        HOOK  MESSAGE\n2026-07-20T10:10:59+02:00            Service  argocd-e2e--test-sync-with-retry-and-refresh-enabled-koihw          guestbook-ui    Synced  Healthy              \n2026-07-20T10:10:59+02:00   apps  Deployment  argocd-e2e--test-sync-with-retry-and-refresh-enabled-koihw          guestbook-ui    Synced  Healthy              \n2026-07-20T10:11:00+02:00   apps  Deployment  argocd-e2e--test-sync-with-retry-and-refresh-enabled-koihw          guestbook-ui    Synced  Healthy              error when patching \"/var/folders/_d/65t3r9nx0pgc13mtvytrfyvc0000gn/T/1490102064\":  \"\" is invalid: patch: Invalid value: \"\": unrecognized type: int32\n2026-07-20T10:11:00+02:00            Service  argocd-e2e--test-sync-with-retry-and-refresh-enabled-koihw          guestbook-ui    Synced  Healthy              service/guestbook-ui unchanged\n2026-07-20T10:11:01+02:00   apps  Deployment  argocd-e2e--test-sync-with-retry-and-refresh-enabled-koihw          guestbook-ui    Synced  Healthy              error when patching \"/var/folders/_d/65t3r9nx0pgc13mtvytrfyvc0000gn/T/3202758496\":  \"\" is invalid: patch: Invalid value: \"\": unrecognized type: int32\n\nThis is the state of the app after wait timed out:\n\nThe command timed out waiting for the conditions to be met.\n\nName:               argocd-e2e/test-sync-with-retry-and-refresh-enabled-koihw\nProject:            default\nServer:             https://kubernetes.default.svc\nNamespace:          argocd-e2e--test-sync-with-retry-and-refresh-enabled-koihw\nURL:                http://localhost:8080/applications/test-sync-with-retry-and-refresh-enabled-koihw\nSource:\n- Repo:             file:///tmp/argo-e2e/testdata.git\n  Target:           \n  Path:             guestbook\nSyncWindow:         Sync Allowed\nSync Policy:        Manual\nSync Status:        Synced to  (fecaf29)\nHealth Status:      Healthy\n\nOperation:          Sync\nSync Revision:      c80eb3fc411adf7236af10e6e7f2963101be9069\nPhase:              Running\nStart:              2026-07-20 10:10:59 +0200 CEST\nFinished:           2026-07-20 10:11:01 +0200 CEST\nDuration:           2s\nMessage:            one or more synchronization tasks completed unsuccessfully, reason: error when patching \"/var/folders/_d/65t3r9nx0pgc13mtvytrfyvc0000gn/T/3202758496\":  \"\" is invalid: patch: Invalid value: \"\": unrecognized type: int32. Retrying attempt #2 at 10:11AM.\n\nGROUP  KIND        NAMESPACE                                                   NAME          STATUS  HEALTH   HOOK  MESSAGE\n       Service     argocd-e2e--test-sync-with-retry-and-refresh-enabled-koihw  guestbook-ui  Synced  Healthy        service/guestbook-ui unchanged\napps   Deployment  argocd-e2e--test-sync-with-retry-and-refresh-enabled-koihw  guestbook-ui  Synced  Healthy        error when patching \"/var/folders/_d/65t3r9nx0pgc13mtvytrfyvc0000gn/T/3202758496\":  \"\" is invalid: patch: Invalid value: \"\": unrecognized type: int32\n" duration=2.155652084s execID=e0e1f
time="2026-07-20T10:11:01+02:00" level=error msg="`../../dist/argocd app sync test-sync-with-retry-and-refresh-enabled-koihw --timeout 2 --prune --plaintext --server localhost:8080 --auth-token ****** --insecure` failed exit status 20: {\"level\":\"fatal\",\"msg\":\"timed out (2s) waiting for app \\\"test-sync-with-retry-and-refresh-enabled-koihw\\\" match desired state\",\"time\":\"2026-07-20T10:11:01+02:00\"}" execID=e0e1f
time="2026-07-20T10:11:01+02:00" level=info msg="expectation succeeded: operation phase should be Running, is Running, message: 'one or more synchronization tasks completed unsuccessfully, reason: error when patching \"/var/folders/_d/65t3r9nx0pgc13mtvytrfyvc0000gn/T/3202758496\":  \"\" is invalid: patch: Invalid value: \"\": unrecognized type: int32. Retrying attempt #2 at 10:11AM.'"
time="2026-07-20T10:11:01+02:00" level=info msg="pending: sync status to be OutOfSync, is Synced"
[...truncated...]
time="2026-07-20T10:11:26+02:00" level=info msg="pending: sync status to be OutOfSync, is Synced"
    app_management_test.go:1848: timeout waiting for: sync status to be OutOfSync, is Synced
--- FAIL: TestSyncWithRetryAndRefreshEnabled (32.60s)
FAIL test/e2e.TestSyncWithRetryAndRefreshEnabled (32.60s)
</code>
</details> 

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
   - did not find any relevant issues to close
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
    - no changes necessary
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
