### PR TITLE
feat(controller): add FailedError condition for failed PostSync hooks

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -2026,6 +2026,30 @@ func (ctrl *ApplicationController) processAppRefreshQueueItem() (processNext boo
 	app.Status.Health.Status = compareResult.healthStatus
 	app.Status.Health.Message = compareResult.healthMessage
 	app.Status.Resources = compareResult.resources
+
+	if failed, msg := hasFailedPostSyncHook(app); failed {
+		failedMsg := "PostSync hook failed"
+		if strings.TrimSpace(msg) != "" {
+			failedMsg = "PostSync hook failed: " + msg
+		}
+		app.Status.SetConditions(
+			[]appv1.ApplicationCondition{{
+				Type:    appv1.ApplicationConditionFailedError,
+				Message: failedMsg,
+			}},
+			map[appv1.ApplicationConditionType]bool{
+				appv1.ApplicationConditionFailedError: true,
+			},
+		)
+	} else {
+		app.Status.SetConditions(
+			[]appv1.ApplicationCondition{},
+			map[appv1.ApplicationConditionType]bool{
+				appv1.ApplicationConditionFailedError: true,
+			},
+		)
+	}
+
 	sort.Slice(app.Status.Resources, func(i, j int) bool {
 		return resourceStatusKey(app.Status.Resources[i]) < resourceStatusKey(app.Status.Resources[j])
 	})
@@ -2138,6 +2162,57 @@ func (ctrl *ApplicationController) processHydrationQueueItem() (processNext bool
 
 func resourceStatusKey(res appv1.ResourceStatus) string {
 	return strings.Join([]string{res.Group, res.Kind, res.Namespace, res.Name}, "/")
+}
+
+func hasFailedPostSyncHook(app *appv1.Application) (bool, string) {
+	op := app.Status.OperationState
+	if op == nil || op.SyncResult == nil {
+		return false, ""
+	}
+
+	if !app.Spec.HasMultipleSources() {
+		if op.SyncResult.Revision == "" || app.Status.Sync.Revision == "" || op.SyncResult.Revision != app.Status.Sync.Revision {
+			return false, ""
+		}
+	} else {
+		if len(op.SyncResult.Revisions) == 0 || len(app.Status.Sync.Revisions) == 0 {
+			return false, ""
+		}
+		if !reflect.DeepEqual(op.SyncResult.Revisions, app.Status.Sync.Revisions) {
+			return false, ""
+		}
+	}
+
+	if op.Phase.Successful() {
+		return false, ""
+	}
+
+	var msgs []string
+	for _, rr := range op.SyncResult.Resources {
+		if rr == nil {
+			continue
+		}
+		isPostSync := rr.HookType == synccommon.HookTypePostSync || rr.SyncPhase == synccommon.SyncPhasePostSync
+		if !isPostSync {
+			continue
+		}
+		if !rr.HookPhase.Completed() || rr.HookPhase.Successful() {
+			continue
+		}
+		why := strings.TrimSpace(rr.Message)
+		if why == "" {
+			why = "unknown reason"
+		}
+		if rr.Namespace != "" {
+			msgs = append(msgs, fmt.Sprintf("%s/%s: %s", rr.Namespace, rr.Name, why))
+		} else {
+			msgs = append(msgs, fmt.Sprintf("%s: %s", rr.Name, why))
+		}
+	}
+	if len(msgs) == 0 {
+		return false, ""
+	}
+	return true, strings.Join(msgs, "; ")
 }
 
 func currentSourceEqualsSyncedSource(app *appv1.Application) bool {

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -2511,6 +2511,172 @@ apps/Deployment:
 	}
 }
 
+func TestHasFailedPostSyncHook(t *testing.T) {
+	cases := []struct {
+		name       string
+		setup      func(app *v1alpha1.Application)
+		wantFailed bool
+		wantMsg    string
+	}{
+		{
+			name: "single/aggregates-postsync-failures",
+			setup: func(app *v1alpha1.Application) {
+				app.Status.Sync.Revision = "r1"
+				app.Status.OperationState = &v1alpha1.OperationState{
+					Phase: synccommon.OperationFailed,
+					SyncResult: &v1alpha1.SyncOperationResult{
+						Revision: "r1",
+						Resources: []*v1alpha1.ResourceResult{
+							{
+								Kind:      "Job",
+								Namespace: "default",
+								Name:      "post-1",
+								HookType:  synccommon.HookTypePostSync,
+								HookPhase: synccommon.OperationFailed,
+								Message:   "exit code 1",
+							},
+							{
+								Kind:      "Job",
+								Name:      "post-2",
+								SyncPhase: synccommon.SyncPhasePostSync,
+								HookPhase: synccommon.OperationFailed,
+								Message:   "",
+							},
+						},
+					},
+				}
+			},
+			wantFailed: true,
+			wantMsg:    "default/post-1: exit code 1; post-2: unknown reason",
+		},
+		{
+			name: "single/revision-mismatch",
+			setup: func(app *v1alpha1.Application) {
+				app.Status.Sync.Revision = "status-rev"
+				app.Status.OperationState = &v1alpha1.OperationState{
+					Phase: synccommon.OperationFailed,
+					SyncResult: &v1alpha1.SyncOperationResult{
+						Revision: "op-rev",
+						Resources: []*v1alpha1.ResourceResult{
+							{
+								Kind:      "Job",
+								Name:      "post",
+								HookType:  synccommon.HookTypePostSync,
+								HookPhase: synccommon.OperationFailed,
+								Message:   "boom",
+							},
+						},
+					},
+				}
+			},
+			wantFailed: false,
+			wantMsg:    "",
+		},
+		{
+			name: "multi/matches-all-revisions",
+			setup: func(app *v1alpha1.Application) {
+				revs := []string{"r1", "r2"}
+				app.Spec.Sources = []v1alpha1.ApplicationSource{{}, {}}
+				app.Status.Sync.Revisions = append([]string{}, revs...)
+				app.Status.OperationState = &v1alpha1.OperationState{
+					Phase: synccommon.OperationFailed,
+					SyncResult: &v1alpha1.SyncOperationResult{
+						Revisions: append([]string{}, revs...),
+						Resources: []*v1alpha1.ResourceResult{
+							{
+								Kind:      "Job",
+								Namespace: "ns-a",
+								Name:      "post-hook",
+								HookType:  synccommon.HookTypePostSync,
+								HookPhase: synccommon.OperationFailed,
+								Message:   "boom",
+							},
+						},
+					},
+				}
+			},
+			wantFailed: true,
+			wantMsg:    "ns-a/post-hook: boom",
+		},
+		{
+			name: "ignores-successful-operation",
+			setup: func(app *v1alpha1.Application) {
+				app.Status.Sync.Revision = "r1"
+				app.Status.OperationState = &v1alpha1.OperationState{
+					Phase: synccommon.OperationSucceeded,
+					SyncResult: &v1alpha1.SyncOperationResult{
+						Revision: "r1",
+						Resources: []*v1alpha1.ResourceResult{
+							{
+								Kind:      "Job",
+								Name:      "post",
+								HookType:  synccommon.HookTypePostSync,
+								HookPhase: synccommon.OperationFailed,
+								Message:   "should be ignored",
+							},
+						},
+					},
+				}
+			},
+			wantFailed: false,
+			wantMsg:    "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			app := newFakeApp()
+			tc.setup(app)
+
+			failed, msg := hasFailedPostSyncHook(app)
+
+			require.Equal(t, tc.wantFailed, failed)
+			assert.Equal(t, tc.wantMsg, msg)
+		})
+	}
+}
+
+// PostSync hook failures on the latest revision set FailedError condition (health is unchanged).
+func TestProcessQueue_FailedError_SetsCondition(t *testing.T) {
+	app := newFakeApp()
+	app.Spec.Project = "default"
+	app.Status.OperationState = &v1alpha1.OperationState{
+		Phase: synccommon.OperationFailed,
+		SyncResult: &v1alpha1.SyncOperationResult{
+			Revision: "r1",
+			Resources: []*v1alpha1.ResourceResult{
+				{Kind: "Job", Namespace: "default", Name: "post-1", HookType: synccommon.HookTypePostSync, HookPhase: synccommon.OperationFailed, Message: "exit code 1"},
+				{Kind: "Job", Name: "post-2", SyncPhase: synccommon.SyncPhasePostSync, HookPhase: synccommon.OperationFailed, Message: ""},
+			},
+		},
+	}
+
+	ctrl := newFakeController(t.Context(), &fakeData{
+		apps: []runtime.Object{app, &defaultProj},
+		manifestResponse: &apiclient.ManifestResponse{
+			Manifests: []string{}, Namespace: test.FakeDestNamespace, Server: test.FakeClusterURL, Revision: "r1",
+		},
+		managedLiveObjs: map[kube.ResourceKey]*unstructured.Unstructured{},
+	}, nil)
+
+	ctrl.processAppRefreshQueueItem()
+
+	apps, err := ctrl.appLister.List(labels.Everything())
+	require.NoError(t, err)
+	require.NotEmpty(t, apps)
+	got := apps[0]
+
+	var cond *v1alpha1.ApplicationCondition
+	for i := range got.Status.Conditions {
+		if got.Status.Conditions[i].Type == v1alpha1.ApplicationConditionFailedError {
+			cond = &got.Status.Conditions[i]
+			break
+		}
+	}
+	require.NotNil(t, cond, "FailedError condition must exist")
+	assert.Equal(t, "PostSync hook failed: default/post-1: exit code 1; post-2: unknown reason", cond.Message)
+}
+
 func TestUpdateHealthStatusProgression(t *testing.T) {
 	app := newFakeAppWithHealthAndTime(health.HealthStatusDegraded, testTimestamp)
 	deployment := kube.MustToUnstructured(&appsv1.Deployment{

--- a/controller/metrics/metrics_test.go
+++ b/controller/metrics/metrics_test.go
@@ -159,6 +159,85 @@ status:
     type: ExcludedResourceWarning
 `
 
+const fakeApp5 = `
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: my-app-5
+  namespace: argocd
+  labels:
+    team-name: my-team
+    team-bu: bu-id
+    argoproj.io/cluster: test-cluster
+spec:
+  destination:
+    namespace: dummy-namespace
+    name: cluster1
+  project: important-project
+  source:
+    path: some/path
+    repoURL: https://github.com/argoproj/argocd-example-apps.git
+status:
+  sync:
+    status: Unknown
+  health:
+    status: Unknown
+  conditions:
+  - lastTransitionTime: "2024-08-07T12:25:40Z"
+    message: Failed to compare desired state to live state
+    type: ComparisonError
+  - lastTransitionTime: "2024-08-07T12:25:40Z"
+    message: Failed to sync application
+    type: SyncError
+  - lastTransitionTime: "2024-08-07T12:25:40Z"
+    message: Application referencing project which does not exist
+    type: InvalidSpecError
+  - lastTransitionTime: "2024-08-07T12:25:40Z"
+    message: Failed to delete application resources
+    type: DeletionError
+  - lastTransitionTime: "2024-08-07T12:25:40Z"
+    message: Unknown controller error
+    type: UnknownError
+  - lastTransitionTime: "2024-08-07T12:25:40Z"
+    message: Failed to sync application (retry)
+    type: SyncError
+  - lastTransitionTime: "2024-08-07T12:25:40Z"
+    message: "PostSync hook failed: default/fail-postsync: Job has reached the specified backoff limit"
+    type: FailedError
+`
+
+const fakeApp6 = `
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: my-app-6
+  namespace: argocd
+  labels:
+    team-name: my-team
+    team-bu: bu-id
+    argoproj.io/cluster: test-cluster
+spec:
+  destination:
+    namespace: dummy-namespace
+    name: cluster1
+  project: important-project
+  source:
+    path: some/path
+    repoURL: https://github.com/argoproj/argocd-example-apps.git
+status:
+  sync:
+    status: OutOfSync
+  health:
+    status: Degraded
+  conditions:
+  - lastTransitionTime: "2024-08-07T12:25:40Z"
+    message: Failed to sync application
+    type: SyncError
+  - lastTransitionTime: "2024-08-07T12:25:40Z"
+    message: Application has 1 orphaned resources
+    type: OrphanedResourceWarning
+`
+
 const fakeDefaultApp = `
 apiVersion: argoproj.io/v1alpha1
 kind: Application
@@ -462,6 +541,94 @@ argocd_app_condition{condition="ExcludedResourceWarning",name="my-app-4",namespa
 `,
 			},
 		},
+		{
+			description:      "metric will output SyncError failed condition",
+			metricConditions: []string{argoappv1.ApplicationConditionSyncError},
+			testCombination: testCombination{
+				applications: []string{fakeApp5},
+				responseContains: `
+# HELP argocd_app_condition Report application conditions.
+# TYPE argocd_app_condition gauge
+argocd_app_condition{condition="SyncError",name="my-app-5",namespace="argocd",project="important-project"} 2
+`,
+			},
+		},
+		{
+			description:      "metric will output ComparisonError failed condition",
+			metricConditions: []string{argoappv1.ApplicationConditionComparisonError},
+			testCombination: testCombination{
+				applications: []string{fakeApp5},
+				responseContains: `
+# HELP argocd_app_condition Report application conditions.
+# TYPE argocd_app_condition gauge
+argocd_app_condition{condition="ComparisonError",name="my-app-5",namespace="argocd",project="important-project"} 1
+`,
+			},
+		},
+		{
+			description:      "metric will output InvalidSpecError failed condition",
+			metricConditions: []string{argoappv1.ApplicationConditionInvalidSpecError},
+			testCombination: testCombination{
+				applications: []string{fakeApp5},
+				responseContains: `
+# HELP argocd_app_condition Report application conditions.
+# TYPE argocd_app_condition gauge
+argocd_app_condition{condition="InvalidSpecError",name="my-app-5",namespace="argocd",project="important-project"} 1
+`,
+			},
+		},
+		{
+			description:      "metric will output FailedError condition",
+			metricConditions: []string{argoappv1.ApplicationConditionFailedError},
+			testCombination: testCombination{
+				applications: []string{fakeApp5},
+				responseContains: `
+# HELP argocd_app_condition Report application conditions.
+# TYPE argocd_app_condition gauge
+argocd_app_condition{condition="FailedError",name="my-app-5",namespace="argocd",project="important-project"} 1
+`,
+			},
+		},
+		{
+			description: "metric will output all Error-type failed conditions",
+			metricConditions: []string{
+				argoappv1.ApplicationConditionComparisonError,
+				argoappv1.ApplicationConditionSyncError,
+				argoappv1.ApplicationConditionInvalidSpecError,
+				argoappv1.ApplicationConditionDeletionError,
+				argoappv1.ApplicationConditionUnknownError,
+				argoappv1.ApplicationConditionFailedError,
+			},
+			testCombination: testCombination{
+				applications: []string{fakeApp5},
+				responseContains: `
+# HELP argocd_app_condition Report application conditions.
+# TYPE argocd_app_condition gauge
+argocd_app_condition{condition="ComparisonError",name="my-app-5",namespace="argocd",project="important-project"} 1
+argocd_app_condition{condition="SyncError",name="my-app-5",namespace="argocd",project="important-project"} 2
+argocd_app_condition{condition="InvalidSpecError",name="my-app-5",namespace="argocd",project="important-project"} 1
+argocd_app_condition{condition="DeletionError",name="my-app-5",namespace="argocd",project="important-project"} 1
+argocd_app_condition{condition="UnknownError",name="my-app-5",namespace="argocd",project="important-project"} 1
+argocd_app_condition{condition="FailedError",name="my-app-5",namespace="argocd",project="important-project"} 1
+`,
+			},
+		},
+		{
+			description: "metric will output mixed Error and Warning conditions without omitting failed conditions",
+			metricConditions: []string{
+				argoappv1.ApplicationConditionSyncError,
+				argoappv1.ApplicationConditionOrphanedResourceWarning,
+			},
+			testCombination: testCombination{
+				applications: []string{fakeApp6},
+				responseContains: `
+# HELP argocd_app_condition Report application conditions.
+# TYPE argocd_app_condition gauge
+argocd_app_condition{condition="SyncError",name="my-app-6",namespace="argocd",project="important-project"} 1
+argocd_app_condition{condition="OrphanedResourceWarning",name="my-app-6",namespace="argocd",project="important-project"} 1
+`,
+			},
+		},
 	}
 
 	for _, c := range cases {
@@ -469,6 +636,31 @@ argocd_app_condition{condition="ExcludedResourceWarning",name="my-app-4",namespa
 			testMetricServer(t, c.applications, c.responseContains, []string{}, c.metricConditions)
 		})
 	}
+
+	t.Run("metric will not emit failed conditions when only warnings are configured", func(t *testing.T) {
+		cancel, appLister := newFakeLister(t.Context(), fakeApp5)
+		defer cancel()
+		mockDB := mocks.NewArgoDB(t)
+		mockDB.EXPECT().GetClusterServersByName(mock.Anything, "cluster1").Return([]string{"https://localhost:6443"}, nil).Maybe()
+		mockDB.EXPECT().GetCluster(mock.Anything, "https://localhost:6443").Return(&argoappv1.Cluster{Name: "cluster1", Server: "https://localhost:6443"}, nil).Maybe()
+		metricsServ, err := NewMetricsServer("localhost:8082", appLister, appFilter, noOpHealthCheck, []string{}, []string{argoappv1.ApplicationConditionOrphanedResourceWarning}, mockDB)
+		require.NoError(t, err)
+
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/metrics", http.NoBody)
+		require.NoError(t, err)
+		rr := httptest.NewRecorder()
+		metricsServ.Handler.ServeHTTP(rr, req)
+		require.Equal(t, http.StatusOK, rr.Code)
+		body := rr.Body.String()
+
+		assert.Contains(t, body, `argocd_app_info{autosync_enabled="false",dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Unknown",name="my-app-5",namespace="argocd",operation="",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_status="Unknown"} 1`)
+		assert.NotContains(t, body, `condition="SyncError"`)
+		assert.NotContains(t, body, `condition="ComparisonError"`)
+		assert.NotContains(t, body, `condition="InvalidSpecError"`)
+		assert.NotContains(t, body, `condition="DeletionError"`)
+		assert.NotContains(t, body, `condition="UnknownError"`)
+		assert.NotContains(t, body, `condition="FailedError"`)
+	})
 }
 
 func TestMetricsSyncCounter(t *testing.T) {

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -1906,6 +1906,8 @@ const (
 	ApplicationConditionSyncError = "SyncError"
 	// ApplicationConditionUnknownError indicates an unknown controller error
 	ApplicationConditionUnknownError = "UnknownError"
+	// ApplicationConditionFailedError indicates a PostSync hook (e.g. Job) failed during the latest sync
+	ApplicationConditionFailedError = "FailedError"
 	// ApplicationConditionSharedResourceWarning indicates that controller detected resources which belongs to more than one application
 	ApplicationConditionSharedResourceWarning = "SharedResourceWarning"
 	// ApplicationConditionRepeatedResourceWarning indicates that application source has resource with same Group, Kind, Name, Namespace multiple times


### PR DESCRIPTION
Closes  #23719 
based on PR : https://github.com/argoproj/argo-cd/pull/24089

### Summary
Add FailedError Application condition.
On each sync, if any PostSync hook fails:
- Add/refresh FailedError with aggregated messages `(namespace/name: reason)`
When no PostSync failures remain, clear the condition.

This also surfaces in metrics via argocd_app_condition{condition="PostSyncHookError", ...} = 1.

### Motivation
Teams often run E2E/smoke tests in PostSync Jobs. When those tests fail (e.g., BackoffLimitExceeded), the failure is visible in the manifest, but not exposed as a dedicated condition/metric. This PR makes those failures observable and alertable.

### Changes
- controller/appcontroller.go: detect failed PostSync hooks in the latest sync and manage the PostSyncHookError condition.
- pkg/apis/application/v1alpha1/types.go: add ApplicationConditionPostSyncHookError (condition type) so it’s exported via metrics.

### Screenshots / Verification
Metrics—argocd_app_condition
    - `argocd_app_condition{condition="PostSyncHookError",name="test-post-job-failed-test",namespace="argo",project="default"} 1`
    - Screenshot: <img width="2004" height="184" alt="image" src="https://github.com/user-attachments/assets/d355e5b9-4e21-44df-8872-de88b8e0e178" />

Application conditions detail modal
    - Aggregated message like: 
        `PostSync hook failed: default/fail-postsync: Job has reached the specified backoff limit`
    - Screenshot: <img width="2412" height="412" alt="image" src="https://github.com/user-attachments/assets/08e50c2f-52a0-40ee-a694-c79d33697d9a" />


### Related
- Issue: https://github.com/argoproj/argo-cd/issues/23719
- Slack discussion: https://cloud-native.slack.com/archives/C01TSERG0KZ/p1752056389728489


<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
