### PR TITLE
fix: don't log the expected helm template retry attempt as an error

### DIFF
--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -1407,7 +1407,13 @@ func helmTemplate(ctx context.Context, appPath string, repoRoot string, env *v1a
 
 	defer h.Dispose()
 
-	out, command, err := h.Template(templateOpts)
+	// The first attempt is expected to fail with a "missing dependency" error whenever the chart's
+	// dependencies have not been built yet; that case is detected and handled below by running
+	// `helm dependency build` and retrying. Skip the default error-level exec log for this attempt so
+	// it doesn't spam the logs with an error that isn't actually a problem.
+	firstAttemptOpts := *templateOpts
+	firstAttemptOpts.SkipErrorLogging = true
+	out, command, err := h.Template(&firstAttemptOpts)
 	if err != nil {
 		if !helm.IsMissingDependencyErr(err) {
 			return nil, "", err

--- a/util/helm/cmd.go
+++ b/util/helm/cmd.go
@@ -30,7 +30,7 @@ type Cmd struct {
 	IsHelmOci       bool
 	proxy           string
 	noProxy         string
-	runWithRedactor func(cmd *exec.Cmd, redactor func(text string) string) (string, error)
+	runWithRedactor func(cmd *exec.Cmd, redactor func(text string) string, skipErrorLogging bool) (string, error)
 }
 
 func NewCmd(workDir string, version string, proxy string, noProxy string) (*Cmd, error) {
@@ -48,10 +48,13 @@ func NewCmd(workDir string, version string, proxy string, noProxy string) (*Cmd,
 }
 
 func NewCmdWithVersion(workDir string, isHelmOci bool, proxy string, noProxy string) (*Cmd, error) {
-	return newCmdWithVersion(workDir, isHelmOci, proxy, noProxy, executil.RunWithRedactor)
+	runWithRedactor := func(cmd *exec.Cmd, redactor func(text string) string, skipErrorLogging bool) (string, error) {
+		return executil.RunWithExecRunOpts(cmd, executil.ExecRunOpts{Redactor: redactor, SkipErrorLogging: skipErrorLogging})
+	}
+	return newCmdWithVersion(workDir, isHelmOci, proxy, noProxy, runWithRedactor)
 }
 
-func newCmdWithVersion(workDir string, isHelmOci bool, proxy string, noProxy string, runWithRedactor func(cmd *exec.Cmd, redactor func(text string) string) (string, error)) (*Cmd, error) {
+func newCmdWithVersion(workDir string, isHelmOci bool, proxy string, noProxy string, runWithRedactor func(cmd *exec.Cmd, redactor func(text string) string, skipErrorLogging bool) (string, error)) (*Cmd, error) {
 	tmpDir, err := os.MkdirTemp("", "helm")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temporary directory for helm: %w", err)
@@ -64,10 +67,10 @@ var redactor = func(text string) string {
 }
 
 func (c Cmd) run(ctx context.Context, args ...string) (string, string, error) {
-	return c.runWithStdin(ctx, nil, args...)
+	return c.runWithStdin(ctx, nil, false, args...)
 }
 
-func (c Cmd) runWithStdin(ctx context.Context, stdin io.Reader, args ...string) (string, string, error) {
+func (c Cmd) runWithStdin(ctx context.Context, stdin io.Reader, skipErrorLogging bool, args ...string) (string, string, error) {
 	cmd := exec.CommandContext(ctx, "helm", args...)
 	cmd.Dir = c.WorkDir
 	cmd.Env = os.Environ()
@@ -83,7 +86,7 @@ func (c Cmd) runWithStdin(ctx context.Context, stdin io.Reader, args ...string) 
 	cmd.Env = proxy.UpsertEnv(cmd, c.proxy, c.noProxy)
 	fullCommand := executil.GetCommandArgsToLog(cmd)
 
-	out, err := c.runWithRedactor(cmd, redactor)
+	out, err := c.runWithRedactor(cmd, redactor, skipErrorLogging)
 	if err != nil {
 		return out, fullCommand, fmt.Errorf("failed running helm: %w", err)
 	}
@@ -142,7 +145,7 @@ func (c *Cmd) RegistryLogin(ctx context.Context, repo string, creds Creds, plain
 	if helmPassword != "" {
 		stdin = strings.NewReader(helmPassword)
 	}
-	out, _, err := c.runWithStdin(ctx, stdin, args...)
+	out, _, err := c.runWithStdin(ctx, stdin, false, args...)
 	if err != nil {
 		return "", fmt.Errorf("failed to login to registry: %w", err)
 	}
@@ -394,6 +397,9 @@ type TemplateOpts struct {
 	SkipCrds             bool
 	SkipSchemaValidation bool
 	SkipTests            bool
+	// SkipErrorLogging skips the default error-level logging of a failed `helm template` command. Used when the
+	// caller expects the command may fail (e.g. due to missing chart dependencies) and will handle/retry it.
+	SkipErrorLogging bool
 }
 
 func cleanSetParameters(val string) string {
@@ -469,7 +475,7 @@ func (c *Cmd) template(chartPath string, opts *TemplateOpts) (string, string, er
 		args = append(args, "--skip-tests")
 	}
 
-	out, command, err := c.run(context.Background(), args...)
+	out, command, err := c.runWithStdin(context.Background(), nil, opts.SkipErrorLogging, args...)
 	if err != nil {
 		msg := err.Error()
 		if strings.Contains(msg, "--api-versions") {

--- a/util/helm/cmd_test.go
+++ b/util/helm/cmd_test.go
@@ -42,6 +42,30 @@ func TestCmd_template_noApiVersionsInError(t *testing.T) {
 	assert.ErrorContains(t, err, "<api versions removed> ")
 }
 
+func TestCmd_template_skipErrorLogging(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name             string
+		skipErrorLogging bool
+	}{
+		{name: "default does not skip error logging", skipErrorLogging: false},
+		{name: "propagates SkipErrorLogging to the executor", skipErrorLogging: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var gotSkipErrorLogging bool
+			c, err := newCmdWithVersion(".", false, "", "", func(_ *exec.Cmd, _ func(string) string, skipErrorLogging bool) (string, error) {
+				gotSkipErrorLogging = skipErrorLogging
+				return "", nil
+			})
+			require.NoError(t, err)
+			_, _, err = c.template("testdata/redis", &TemplateOpts{SkipErrorLogging: tc.skipErrorLogging})
+			require.NoError(t, err)
+			assert.Equal(t, tc.skipErrorLogging, gotSkipErrorLogging)
+		})
+	}
+}
+
 func TestNewCmd_helmInvalidVersion(t *testing.T) {
 	t.Parallel()
 	_, err := NewCmd(".", "abcd", "", "")
@@ -145,7 +169,7 @@ func TestRegistryLogin(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			c, err := newCmdWithVersion(".", false, "", "", func(cmd *exec.Cmd, _ func(_ string) string) (string, error) {
+			c, err := newCmdWithVersion(".", false, "", "", func(cmd *exec.Cmd, _ func(_ string) string, _ bool) (string, error) {
 				var stdin []byte
 				if cmd.Stdin != nil {
 					var readErr error
@@ -207,7 +231,7 @@ func TestPullOCI(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			c, err := newCmdWithVersion(".", false, "", "", func(cmd *exec.Cmd, _ func(_ string) string) (string, error) {
+			c, err := newCmdWithVersion(".", false, "", "", func(cmd *exec.Cmd, _ func(_ string) string, _ bool) (string, error) {
 				return strings.Join(cmd.Args, " "), nil
 			})
 			require.NoError(t, err)
@@ -252,7 +276,7 @@ func TestDependencyBuild(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			c, err := newCmdWithVersion(".", false, "", "", func(cmd *exec.Cmd, _ func(_ string) string) (string, error) {
+			c, err := newCmdWithVersion(".", false, "", "", func(cmd *exec.Cmd, _ func(_ string) string, _ bool) (string, error) {
 				return strings.Join(cmd.Args, " "), nil
 			})
 			require.NoError(t, err)
@@ -287,7 +311,7 @@ func TestRegistryLogout(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			c, err := newCmdWithVersion(".", false, "", "", func(cmd *exec.Cmd, _ func(_ string) string) (string, error) {
+			c, err := newCmdWithVersion(".", false, "", "", func(cmd *exec.Cmd, _ func(_ string) string, _ bool) (string, error) {
 				if tc.execErr != nil {
 					return "", tc.execErr
 				}

--- a/util/helm/helm_test.go
+++ b/util/helm/helm_test.go
@@ -324,7 +324,7 @@ func TestDependencyBuild_PlainHTTPFromDependencyRepo(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			var capturedArgs []string
-			c, err := newCmdWithVersion(".", false, "", "", func(cmd *exec.Cmd, _ func(string) string) (string, error) {
+			c, err := newCmdWithVersion(".", false, "", "", func(cmd *exec.Cmd, _ func(string) string, _ bool) (string, error) {
 				capturedArgs = cmd.Args
 				return "", nil
 			})


### PR DESCRIPTION
Motivation

The Helm manifest generation path in reposerver/repository/repository.go
intentionally runs `helm template` first, and if it fails with a "missing
dependency" error, runs `helm dependency build` and retries. This retry is
expected and already handled by the code, but the first (exploratory)
`helm template` invocation's failure was being logged unconditionally at
ERROR level by the low-level exec layer, in addition to any subsequent
logging. Operators running many Helm apps see this as a constant stream of
misleading ERROR log lines for a condition that is not actually a problem,
making it hard to spot real errors (argoproj/argo-cd#18122). The original
report suspected a concurrency/ordering race; a later comment on the issue
correctly diagnosed that this is not a race, just noisy logging around an
expected, already-handled retry.

Approach

- Added a `SkipErrorLogging` field to `helm.TemplateOpts` and threaded it
  through `util/helm/cmd.go` down to the executor, reusing the existing
  (already-present) `SkipErrorLogging` support in `util/exec/exec.go`.
- In `helmTemplate`, the first `h.Template` call (the one that may hit the
  missing-dependency case) is made with a copy of the options that sets
  `SkipErrorLogging: true`. The retry call after `helm dependency build`
  keeps the original options, so a failure there is still logged at ERROR
  as before. No other helm subcommand (dependency build, repo add,
  registry login, etc.) is affected.

Impact: this only removes the redundant, low-level exec-layer ERROR log
line for the first `helm template` attempt. It does not suppress or lose
any error information: the command is still logged at INFO before it
runs, and if the first attempt fails for a reason other than a missing
dependency, the full error (including the failed command and stderr) is
still returned up the call chain and logged at ERROR by the repo-server's
gRPC logging interceptor when the RPC completes. User-visible behavior
(the generated manifests, and errors surfaced to the caller) is
unchanged; the only difference is one less misleading duplicate log line
per app refresh that needs a dependency build.

Validation

- go build ./... passed.
- go test ./util/helm/... and go test ./reposerver/repository/... passed
  (both require a local `helm`/`kustomize` binary in PATH; installed via
  `brew install helm kustomize` for this run).
- Added TestCmd_template_skipErrorLogging in util/helm/cmd_test.go to
  verify TemplateOpts.SkipErrorLogging is correctly propagated to the
  command executor.
- Manually compared log output of the existing "helm with dependencies"
  subtest of Test_GenerateManifests_Commands before and after this
  change: before, the first (expected-to-fail) `helm template` attempt
  logs `level=error msg="\`helm template ...\` failed exit status 1: ..."`;
  after this change that line is gone, while the following `helm
  dependency build` and successful retry are logged exactly as before.

Fixes #18122

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>