### PR TITLE
fix(source): prioritize Helm OCI chart resolution over raw OCI

### DIFF
--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -335,7 +335,7 @@ func (source *ApplicationSource) AllowsConcurrentProcessing() bool {
 }
 
 func (source *ApplicationSource) IsOCI() bool {
-	return strings.HasPrefix(source.RepoURL, "oci://")
+	return strings.HasPrefix(source.RepoURL, "oci://") && !source.IsHelm()
 }
 
 // IsRef returns true when the application source is of type Ref


### PR DESCRIPTION
## Problem

When an Application source has both an `oci://` prefix in `repoURL` and
a `chart` field set, `IsOCI()` returned true, causing the OCI code path
to win over the Helm path in the source resolution switch statement.

The raw OCI path constructs the reference as `${repoURL}:${revision}`:

```
oci://cr.kgateway.dev/kgateway-dev/charts:v2.3.6  ❌ (missing /kgateway)
```

But the correct OCI Helm reference is `${repoURL}/${chart}:${revision}`:

```
oci://cr.kgateway.dev/kgateway-dev/charts/kgateway:v2.3.6  ✅
```

This causes ArgoCD to fail with "cannot get digest for revision" errors
for any chart hosted on an OCI registry when using the `oci://` prefix.

## Root Cause

In `reposerver/repository/repository.go`, the source type switch checks
`IsOCI()` before `IsHelm()`. The Helm path (`newHelmClientResolveRevision`)
takes `source.Chart` as a parameter and correctly constructs the full
OCI reference. But it's never reached because `IsOCI()` returns true.

## Fix

Change `IsOCI()` to return false when `IsHelm()` is also true:

```go
func (source *ApplicationSource) IsOCI() bool {
    return strings.HasPrefix(source.RepoURL, "oci://") && !source.IsHelm()
}
```

This ensures OCI Helm charts take the Helm resolution path, which
properly appends the chart name to the OCI reference. Pure OCI sources
(without a chart field) are unaffected.

## Affected Call Sites

This single change fixes all 5+ locations in the codebase that check
IsOCI() before IsHelm():

- `reposerver/repository/repository.go:372` (source resolution switch)
- `reposerver/repository/repository.go:408` (OCI extraction vs Helm)
- `reposerver/repository/repository.go:3178` (revision resolution)
- `controller/state.go:381`
- `server/application/application.go:586`

## Testing

Our live cluster was encountering this exact issue with
`oci://cr.kgateway.dev/kgateway-dev/charts` + chart `kgateway` @ `v2.3.6`.
The Helm repo path (without `oci://` prefix) works correctly.

## Related

ArgoCD docs explicitly note "the oci:// syntax is not included" for
OCI Helm chart sources: https://argo-cd.readthedocs.io/en/stable/user-guide/helm/

Made with [Cursor](https://cursor.com)