### PR TITLE
fix(cli): hide unsupported --request-timeout kubectl REST flag (#18198)

### DIFF
--- a/cmd/argocd/commands/initialize/cmd.go
+++ b/cmd/argocd/commands/initialize/cmd.go
@@ -16,6 +16,34 @@ func RetrieveContextIfChanged(contextFlag *pflag.Flag) string {
 	return ""
 }
 
+// supportedKubectlFlags is the explicit allowlist of kubectl-like flags that
+// InitCommand copies onto argocd commands. The kubectl flag set is derived
+// from client-go (cli.AddKubectlFlagsToSet registers every REST config
+// override flag kubectl supports), but the argocd CLI only consumes a subset
+// of it. Flags used to be copied deny-by-default with a denylist of
+// known-unsupported flags, so every flag added upstream in client-go leaked
+// into the argocd CLI as a silently ignored option until it was denylisted
+// individually (#25977, #27711, #18198). Copying allow-by-default inverts
+// that: a new client-go flag stays out of the argocd CLI until it is
+// deliberately supported and added here.
+//
+// "context" is read back by headless (core) mode via RetrieveContextIfChanged.
+// The remaining flags are kept so that existing command lines keep parsing
+// exactly as before; removing any of them would turn a previously accepted
+// flag into an "unknown flag" error.
+var supportedKubectlFlags = []string{
+	"cluster",
+	"context",
+	"insecure-skip-tls-verify",
+	"kubeconfig",
+	"namespace",
+	"password",
+	"proxy-url",
+	"token",
+	"user",
+	"username",
+}
+
 // InitCommand allows executing commands in a headless mode by internally
 // initializing an Argo CD API server and updating client options to use
 // the server's listening port.
@@ -23,29 +51,11 @@ func InitCommand(cmd *cobra.Command) *cobra.Command {
 	flags := pflag.NewFlagSet("tmp", pflag.ContinueOnError)
 	cli.AddKubectlFlagsToSet(flags)
 
-	// kubectl REST flags that are not supported by argocd CLI
-	unsupportedFlags := []string{
-		"disable-compression",
-		"certificate-authority",
-		"client-certificate",
-		"client-key",
-		"as",
-		"as-group",
-		"as-uid",
-		"tls-server-name",
-		"request-timeout",
-	}
-
+	// only copy the kubectl flags that the argocd CLI supports
 	flags.VisitAll(func(flag *pflag.Flag) {
-		// skip Kubernetes server flags since argocd has its own server flag
-		if flag.Name == "server" {
-			return
+		if slices.Contains(supportedKubectlFlags, flag.Name) {
+			cmd.Flags().AddFlag(flag)
 		}
-		// skip unsupported kubectl REST flags
-		if slices.Contains(unsupportedFlags, flag.Name) {
-			return
-		}
-		cmd.Flags().AddFlag(flag)
 	})
 
 	return cmd

--- a/cmd/argocd/commands/initialize/cmd.go
+++ b/cmd/argocd/commands/initialize/cmd.go
@@ -33,6 +33,7 @@ func InitCommand(cmd *cobra.Command) *cobra.Command {
 		"as-group",
 		"as-uid",
 		"tls-server-name",
+		"request-timeout",
 	}
 
 	flags.VisitAll(func(flag *pflag.Flag) {

--- a/cmd/argocd/commands/initialize/cmd_test.go
+++ b/cmd/argocd/commands/initialize/cmd_test.go
@@ -6,6 +6,9 @@ import (
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/argoproj/argo-cd/v3/util/cli"
 )
 
 type StringFlag struct {
@@ -80,11 +83,30 @@ func Test_FlagContextNil(t *testing.T) {
 	assert.Empty(t, res)
 }
 
-func Test_InitCommand_FiltersUnsupportedKubectlFlags(t *testing.T) {
+func Test_InitCommand_ExposesExactlySupportedKubectlFlags(t *testing.T) {
 	cmd := &cobra.Command{}
 
 	InitCommand(cmd)
 
+	var exposed []string
+	cmd.Flags().VisitAll(func(f *flag.Flag) {
+		exposed = append(exposed, f.Name)
+	})
+
+	// The exposed set must be exactly the allowlist: this fails if a kubectl
+	// flag not supported by the argocd CLI (e.g. a flag newly added upstream
+	// in client-go) ever leaks into the command help again.
+	assert.ElementsMatch(t, supportedKubectlFlags, exposed)
+}
+
+func Test_InitCommand_UnsupportedKubectlFlagsNotExposed(t *testing.T) {
+	cmd := &cobra.Command{}
+
+	InitCommand(cmd)
+
+	// kubectl REST flags that historically leaked into the argocd CLI and had
+	// to be removed one by one (#25977, #27711, #18198), plus "server", which
+	// clashes with argocd's own --server flag.
 	unsupported := []string{
 		"disable-compression",
 		"certificate-authority",
@@ -95,12 +117,32 @@ func Test_InitCommand_FiltersUnsupportedKubectlFlags(t *testing.T) {
 		"as-uid",
 		"tls-server-name",
 		"request-timeout",
+		"server",
 	}
 
 	for _, f := range unsupported {
-		assert.Nil(t, cmd.Flags().Lookup(f))
+		assert.Nil(t, cmd.Flags().Lookup(f), "--%s must not be exposed on argocd commands", f)
 	}
+}
 
-	assert.NotNil(t, cmd.Flags().Lookup("context"))
-	assert.NotNil(t, cmd.Flags().Lookup("namespace"))
+func Test_InitCommand_SupportedFlagsExistUpstream(t *testing.T) {
+	// Guard against client-go renaming or dropping a flag the allowlist
+	// relies on: every supported flag must still be registered by
+	// cli.AddKubectlFlagsToSet.
+	flags := flag.NewFlagSet("tmp", flag.ContinueOnError)
+	cli.AddKubectlFlagsToSet(flags)
+
+	for _, name := range supportedKubectlFlags {
+		assert.NotNil(t, flags.Lookup(name), "--%s is missing from the client-go kubectl flag set", name)
+	}
+}
+
+func Test_InitCommand_SupportedFlagsParse(t *testing.T) {
+	cmd := &cobra.Command{}
+
+	InitCommand(cmd)
+
+	err := cmd.Flags().Parse([]string{"--context", "test-ctx", "-n", "argocd", "--kubeconfig", "/tmp/config"})
+	require.NoError(t, err)
+	assert.Equal(t, "test-ctx", RetrieveContextIfChanged(cmd.Flag("context")))
 }

--- a/cmd/argocd/commands/initialize/cmd_test.go
+++ b/cmd/argocd/commands/initialize/cmd_test.go
@@ -94,6 +94,7 @@ func Test_InitCommand_FiltersUnsupportedKubectlFlags(t *testing.T) {
 		"as-group",
 		"as-uid",
 		"tls-server-name",
+		"request-timeout",
 	}
 
 	for _, f := range unsupported {

--- a/docs/user-guide/commands/argocd_account.md
+++ b/docs/user-guide/commands/argocd_account.md
@@ -35,7 +35,6 @@ argocd account [flags]
   -n, --namespace string           If present, the namespace scope for this CLI request
       --password string            Password for basic authentication to the API server
       --proxy-url string           If provided, this URL will be used to connect via proxy
-      --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --token string               Bearer token for authentication to the API server
       --user string                The name of the kubeconfig user to use
       --username string            Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_app.md
+++ b/docs/user-guide/commands/argocd_app.md
@@ -32,7 +32,6 @@ argocd app [flags]
   -n, --namespace string           If present, the namespace scope for this CLI request
       --password string            Password for basic authentication to the API server
       --proxy-url string           If provided, this URL will be used to connect via proxy
-      --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --token string               Bearer token for authentication to the API server
       --user string                The name of the kubeconfig user to use
       --username string            Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_appset.md
+++ b/docs/user-guide/commands/argocd_appset.md
@@ -39,7 +39,6 @@ argocd appset [flags]
   -n, --namespace string           If present, the namespace scope for this CLI request
       --password string            Password for basic authentication to the API server
       --proxy-url string           If provided, this URL will be used to connect via proxy
-      --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --token string               Bearer token for authentication to the API server
       --user string                The name of the kubeconfig user to use
       --username string            Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_cert.md
+++ b/docs/user-guide/commands/argocd_cert.md
@@ -42,7 +42,6 @@ argocd cert [flags]
   -n, --namespace string           If present, the namespace scope for this CLI request
       --password string            Password for basic authentication to the API server
       --proxy-url string           If provided, this URL will be used to connect via proxy
-      --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --token string               Bearer token for authentication to the API server
       --user string                The name of the kubeconfig user to use
       --username string            Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_cluster.md
+++ b/docs/user-guide/commands/argocd_cluster.md
@@ -39,7 +39,6 @@ argocd cluster [flags]
   -n, --namespace string           If present, the namespace scope for this CLI request
       --password string            Password for basic authentication to the API server
       --proxy-url string           If provided, this URL will be used to connect via proxy
-      --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --token string               Bearer token for authentication to the API server
       --user string                The name of the kubeconfig user to use
       --username string            Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_configure.md
+++ b/docs/user-guide/commands/argocd_configure.md
@@ -31,7 +31,6 @@ argocd configure --prompts-enabled=false
       --password string            Password for basic authentication to the API server
       --prompts-enabled            Enable (or disable) optional interactive prompts
       --proxy-url string           If provided, this URL will be used to connect via proxy
-      --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --token string               Bearer token for authentication to the API server
       --user string                The name of the kubeconfig user to use
       --username string            Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_gpg.md
+++ b/docs/user-guide/commands/argocd_gpg.md
@@ -19,7 +19,6 @@ argocd gpg [flags]
   -n, --namespace string           If present, the namespace scope for this CLI request
       --password string            Password for basic authentication to the API server
       --proxy-url string           If provided, this URL will be used to connect via proxy
-      --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --token string               Bearer token for authentication to the API server
       --user string                The name of the kubeconfig user to use
       --username string            Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_proj.md
+++ b/docs/user-guide/commands/argocd_proj.md
@@ -35,7 +35,6 @@ argocd proj [flags]
   -n, --namespace string           If present, the namespace scope for this CLI request
       --password string            Password for basic authentication to the API server
       --proxy-url string           If provided, this URL will be used to connect via proxy
-      --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --token string               Bearer token for authentication to the API server
       --user string                The name of the kubeconfig user to use
       --username string            Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_repo.md
+++ b/docs/user-guide/commands/argocd_repo.md
@@ -37,7 +37,6 @@ argocd repo rm https://github.com/yourusername/your-repo.git
   -n, --namespace string           If present, the namespace scope for this CLI request
       --password string            Password for basic authentication to the API server
       --proxy-url string           If provided, this URL will be used to connect via proxy
-      --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --token string               Bearer token for authentication to the API server
       --user string                The name of the kubeconfig user to use
       --username string            Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_repocreds.md
+++ b/docs/user-guide/commands/argocd_repocreds.md
@@ -32,7 +32,6 @@ argocd repocreds [flags]
   -n, --namespace string           If present, the namespace scope for this CLI request
       --password string            Password for basic authentication to the API server
       --proxy-url string           If provided, this URL will be used to connect via proxy
-      --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --token string               Bearer token for authentication to the API server
       --user string                The name of the kubeconfig user to use
       --username string            Username for basic authentication to the API server

--- a/docs/user-guide/commands/argocd_version.md
+++ b/docs/user-guide/commands/argocd_version.md
@@ -38,7 +38,6 @@ argocd version [flags]
   -o, --output string              Output format. One of: json|yaml|wide|short (default "wide")
       --password string            Password for basic authentication to the API server
       --proxy-url string           If provided, this URL will be used to connect via proxy
-      --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --short                      print just the version number
       --token string               Bearer token for authentication to the API server
       --user string                The name of the kubeconfig user to use


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

Partially addresses #18198 (the `argocd` CLI portion). Related to #27694. Follow-up to #25977 and #27711.

Note: I deliberately did not use `Fixes`, because the `argocd-server` portion of #18198 is covered by the open PR #23915 — this PR touches none of its files and is complementary to it.

### Why this PR is necessary

`--request-timeout` is never defined by Argo CD itself — it is registered by client-go's `clientcmd.RecommendedConfigOverrideFlags`/`BindOverrideFlags` inside `util/cli.AddKubectlFlagsToSet`. For the `argocd` CLI commands wrapped by `initialize.InitCommand` (`version`, `cluster`, `app`, `appset`, `repo`, `repocreds`, `proj`, `account`, `cert`, `gpg`, `configure`), `InitCommand` copies these flags onto the command for help/parsing, but the `clientcmd.ClientConfig` they are bound to is discarded (only `--context` is ever read back via `RetrieveContextIfChanged`). The flag is therefore advertised but non-functional, exactly like `--tls-server-name` before #27711:

```console
$ argocd app -h | grep request-timeout
      --request-timeout string     The length of time to wait before giving up on a single server request. ... (default "0")
$ argocd app --request-timeout=5s list
Error: unknown flag: --request-timeout
```

### What this PR does

* Adds `request-timeout` to the existing `unsupportedFlags` filter in `cmd/argocd/commands/initialize/cmd.go` (same mechanism as #25977 and #27711).
* Extends the existing unit test `Test_InitCommand_FiltersUnsupportedKubectlFlags` — it fails without the code change.
* Regenerates the CLI docs with `make clidocsgen` (`go run tools/cmd-docs/main.go`); the 11 affected `docs/user-guide/commands/argocd_*.md` pages each lose exactly their `--request-timeout` line.

### What this PR intentionally does NOT do

* It does not touch `argocd admin` subcommands or the server-side binaries (`argocd-server`, `argocd-dex`, the controllers). Those commands actually consume the `clientcmd.ClientConfig`, and client-go applies `--request-timeout` to the Kubernetes client's `rest.Config.Timeout` (client-go `tools/clientcmd/client_config.go`), so the flag works there when a kubeconfig is used and their generated docs remain accurate. (When running in-cluster without a kubeconfig, client-go's in-cluster path ignores the timeout override — making that meaningful for `argocd-server` is the scope of #23915.)
* It does not hand-edit documentation; #28028 showed docs-only edits are not the right fix for this class of issue.

### How I tested it

* `go test ./cmd/argocd/commands/initialize/ -v` — all tests pass; the extended `Test_InitCommand_FiltersUnsupportedKubectlFlags` fails without the `cmd.go` change (verified before applying the fix).
* `golangci-lint run ./cmd/argocd/commands/initialize/...` (v2.12.2, the version pinned in `hack/installers/install-lint-tools.sh`) — 0 issues.
* `go build ./cmd` — builds; with the resulting binary, `argocd app -h` / `argocd version -h` no longer advertise `--request-timeout`, while `argocd admin dashboard -h` still does (where it is functional).
* `go run tools/cmd-docs/main.go` — the docs diff contains only the 11 `--request-timeout` removals.

---

This change was developed with AI assistance (Claude Code); I have reviewed and tested it.
