### PR TITLE
fix: HTTPRoute health check stuck in Progressing when controller reports no status (#28352)

### DIFF
--- a/resource_customizations/gateway.networking.k8s.io/HTTPRoute/health.lua
+++ b/resource_customizations/gateway.networking.k8s.io/HTTPRoute/health.lua
@@ -93,6 +93,17 @@ if obj.status ~= nil then
   end
 end
 
+-- Some Gateway API implementations never populate .status.parents even though the
+-- route is functional. A health check cannot time out, so reporting "Progressing"
+-- here would leave the Application progressing forever (see issue #28352). When no
+-- controller has reported any parent status, assume the route is healthy, matching
+-- how Argo CD treats resources without a health check.
+if obj.status == nil or obj.status.parents == nil or #obj.status.parents == 0 then
+  hs.status = "Healthy"
+  hs.message = "No status reported by the Gateway controller; assuming HTTPRoute is healthy"
+  return hs
+end
+
 hs.status = "Progressing"
 hs.message = "Waiting for HTTPRoute status"
 return hs

--- a/resource_customizations/gateway.networking.k8s.io/HTTPRoute/health_test.yaml
+++ b/resource_customizations/gateway.networking.k8s.io/HTTPRoute/health_test.yaml
@@ -19,3 +19,15 @@ tests:
     status: Healthy
     message: HTTPRoute is healthy
   inputPath: testdata/healthy_multiple_generations.yaml
+- healthStatus:
+    status: Healthy
+    message: No status reported by the Gateway controller; assuming HTTPRoute is healthy
+  inputPath: testdata/healthy_no_status.yaml
+- healthStatus:
+    status: Healthy
+    message: No status reported by the Gateway controller; assuming HTTPRoute is healthy
+  inputPath: testdata/healthy_empty_parents.yaml
+- healthStatus:
+    status: Progressing
+    message: Waiting for HTTPRoute status
+  inputPath: testdata/progressing_no_conditions.yaml

--- a/resource_customizations/gateway.networking.k8s.io/HTTPRoute/testdata/healthy_empty_parents.yaml
+++ b/resource_customizations/gateway.networking.k8s.io/HTTPRoute/testdata/healthy_empty_parents.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-httproute
+  namespace: default
+  generation: 1
+spec:
+  parentRefs:
+  - name: example-gateway
+    sectionName: http
+  rules:
+  - backendRefs:
+    - name: example-service
+      port: 8080
+status:
+  parents: []

--- a/resource_customizations/gateway.networking.k8s.io/HTTPRoute/testdata/healthy_no_status.yaml
+++ b/resource_customizations/gateway.networking.k8s.io/HTTPRoute/testdata/healthy_no_status.yaml
@@ -1,0 +1,14 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-httproute
+  namespace: default
+  generation: 1
+spec:
+  parentRefs:
+  - name: example-gateway
+    sectionName: http
+  rules:
+  - backendRefs:
+    - name: example-service
+      port: 8080

--- a/resource_customizations/gateway.networking.k8s.io/HTTPRoute/testdata/progressing_no_conditions.yaml
+++ b/resource_customizations/gateway.networking.k8s.io/HTTPRoute/testdata/progressing_no_conditions.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-httproute
+  namespace: default
+  generation: 1
+spec:
+  parentRefs:
+  - name: example-gateway
+    sectionName: http
+  rules:
+  - backendRefs:
+    - name: example-service
+      port: 8080
+status:
+  parents:
+  - controllerName: example.io/gateway-controller
+    parentRef:
+      name: example-gateway
+      namespace: default
+      sectionName: http


### PR DESCRIPTION
Fixes #28352

## What this PR does

The built-in HTTPRoute health check returns `Progressing: "Waiting for HTTPRoute status"` forever when the Gateway controller never populates `.status` (`kubectl get httproute -o jsonpath='{.status}'` → `null`). Several Gateway API implementations do not report route status even though the route is programmed and serving traffic, and since Lua health checks are pure functions of the object (they cannot time out), affected Applications stay Progressing permanently — blocking sync waves, PostSync hooks, and App-of-Apps health gates. Before the Gateway API health checks were introduced, these resources had no health check and were therefore treated as Healthy, so this is an upgrade regression for those users.

With this change, when **no parent status has been reported at all** (`.status` missing, `.status.parents` missing, or an empty `parents` list), the check reports `Healthy` with an explicit message:

> No status reported by the Gateway controller; assuming HTTPRoute is healthy

This matches how Argo CD treats resources that have no health check, while the distinct message keeps the state debuggable (e.g. a route that is not attached to any Gateway shows this message instead of the generic "HTTPRoute is healthy").

Behavior is **unchanged** whenever a controller has reported parent status:

* `Accepted`/`ResolvedRefs` condition `False` → still `Degraded`
* `Programmed` not `True` → still `Progressing`
* Parent entries without conditions, or whose conditions have a stale `observedGeneration` → still `Progressing: "Waiting for HTTPRoute status"` (covered by a new regression fixture)

### Why `Healthy` rather than `Unknown` or keeping `Progressing`

A commenter on the issue asked whether the intended behavior for absent status is `Healthy` or `Unknown`:

* `Unknown` is the *worst* status in gitops-engine's `healthOrder`, so it would make the aggregated Application health worse, not better.
* `Progressing` cannot resolve itself for implementations that never write status — health checks have no notion of time — leaving users no recourse besides overriding the whole check in `argocd-cm`.
* `Healthy` restores the pre-health-check behavior for these implementations and is consistent with Argo CD's convention that resources without a health check are considered healthy.

The trade-off is that a route rejected silently by all controllers (no status written) now reports Healthy with the "No status reported" message rather than Progressing — the same visibility as any CRD without a health check. If maintainers prefer different semantics for this case, happy to adjust. A concrete example of this trade-off is [#28352 (comment)](https://github.com/argoproj/argo-cd/issues/28352#issuecomment-5026089662), where the missing status turned out to be a Gateway attachment misconfiguration — under this change such routes report Healthy with the distinct "No status reported" message instead of Progressing. If reviewers consider that case the more important one, an alternative is keeping the current Progressing fallback but with a clearer message naming the likely causes; the fix here is a 2-line adjustment either way.

Note: `GRPCRoute/health.lua` has the same fallback behavior; this PR is intentionally scoped to HTTPRoute (the reported issue), and there is an open PR (#28087) already touching the GRPCRoute check. I can follow up with the same handling for GRPCRoute if desired.

## How it was tested

New table-driven fixtures in `resource_customizations/gateway.networking.k8s.io/HTTPRoute/`:

* `testdata/healthy_no_status.yaml` — no `.status` at all (the issue's exact repro) → `Healthy`
* `testdata/healthy_empty_parents.yaml` — `status.parents: []` → `Healthy`
* `testdata/progressing_no_conditions.yaml` — parent entry without conditions → still `Progressing` (regression guard)

```
$ go test ./util/lua/ -run 'TestLuaHealthScript/gateway.networking.k8s.io/HTTPRoute' -v
--- PASS: TestLuaHealthScript (0.06s)
    --- PASS: .../HTTPRoute/testdata/healthy.yaml
    --- PASS: .../HTTPRoute/testdata/degraded_resolved_refs.yaml
    --- PASS: .../HTTPRoute/testdata/degraded_accepted.yaml
    --- PASS: .../HTTPRoute/testdata/progressing.yaml
    --- PASS: .../HTTPRoute/testdata/healthy_multiple_generations.yaml
    --- PASS: .../HTTPRoute/testdata/healthy_no_status.yaml
    --- PASS: .../HTTPRoute/testdata/healthy_empty_parents.yaml
    --- PASS: .../HTTPRoute/testdata/progressing_no_conditions.yaml

$ go test ./util/lua/
ok  	github.com/argoproj/argo-cd/v3/util/lua	2.750s
```

Without the `health.lua` change, the two new `healthy_*` fixtures fail with `Progressing: "Waiting for HTTPRoute status"`, reproducing the issue.

## Cherry-pick

Suggested for `release-3.5`, `release-3.4`, and `release-3.3` (low-risk, self-contained Lua health check change; 3.3 is the version reported in the issue).

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. (N/A — health check behavior, no CLI/UI surface)
* [x] Does this PR require documentation updates? (No — individual built-in Lua health checks are not documented in `docs/operator-manual/health.md`)
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

---

This change was developed with AI assistance (Claude Code); I have reviewed and tested it.

