### PR TITLE
fix(notifications): read AppProject from cache in getAppProjectForTemplate

### DIFF
--- a/notification_controller/controller/controller.go
+++ b/notification_controller/controller/controller.go
@@ -92,7 +92,8 @@ func NewController(
 	}
 	secretInformer := k8s.NewSecretInformer(k8sClient, notificationConfigNamespace, secretName)
 	configMapInformer := k8s.NewConfigMapInformer(k8sClient, notificationConfigNamespace, configMapName)
-	apiFactory := api.NewFactory(settings.GetFactorySettings(argocdService, secretName, configMapName, selfServiceNotificationEnabled), namespace, secretInformer, configMapInformer)
+	appProjectGetter := newAppProjectGetter(appProjInformer)
+	apiFactory := api.NewFactory(settings.GetFactorySettings(argocdService, appProjectGetter, secretName, configMapName, selfServiceNotificationEnabled), namespace, secretInformer, configMapInformer)
 
 	res := &notificationController{
 		secretInformer:    secretInformer,
@@ -196,6 +197,27 @@ func (c *notificationController) Init(ctx context.Context) error {
 
 func (c *notificationController) Run(ctx context.Context, processors int) {
 	c.ctrl.Run(processors, ctx.Done())
+}
+
+// newAppProjectGetter returns a settings.AppProjectGetter backed by the
+// AppProject informer cache so that notification template evaluation reads the
+// AppProject from the local cache instead of making a live API call on every
+// trigger evaluation.
+func newAppProjectGetter(appProjInformer cache.SharedIndexInformer) settings.AppProjectGetter {
+	return func(namespace, name string) (*unstructured.Unstructured, error) {
+		projObj, exists, err := appProjInformer.GetIndexer().GetByKey(fmt.Sprintf("%s/%s", namespace, name))
+		if err != nil {
+			return nil, err
+		}
+		if !exists {
+			return nil, nil
+		}
+		proj, ok := projObj.(*unstructured.Unstructured)
+		if !ok {
+			return nil, nil
+		}
+		return proj, nil
+	}
 }
 
 func getAppProj(app *unstructured.Unstructured, appProjInformer cache.SharedIndexInformer) *unstructured.Unstructured {

--- a/server/notification/notification_test.go
+++ b/server/notification/notification_test.go
@@ -72,7 +72,7 @@ func TestNotificationServer(t *testing.T) {
 	argocdService, err := service.NewArgoCDService(kubeclientset, dynamicClient, testNamespace, mockRepoClient)
 	require.NoError(t, err)
 	t.Cleanup(argocdService.Close)
-	apiFactory := api.NewFactory(settings.GetFactorySettings(argocdService, "argocd-notifications-secret", "argocd-notifications-cm", false), testNamespace, secretInformer, configMapInformer)
+	apiFactory := api.NewFactory(settings.GetFactorySettings(argocdService, nil, "argocd-notifications-secret", "argocd-notifications-cm", false), testNamespace, secretInformer, configMapInformer)
 
 	t.Run("TestListServices", func(t *testing.T) {
 		t.Parallel()

--- a/server/server.go
+++ b/server/server.go
@@ -378,7 +378,7 @@ func NewServer(ctx context.Context, opts ArgoCDServerOpts, appsetOpts Applicatio
 	secretInformer := k8s.NewSecretInformer(opts.KubeClientset, opts.Namespace, "argocd-notifications-secret")
 	configMapInformer := k8s.NewConfigMapInformer(opts.KubeClientset, opts.Namespace, "argocd-notifications-cm")
 
-	apiFactory := api.NewFactory(settings_notif.GetFactorySettings(argocdService, "argocd-notifications-secret", "argocd-notifications-cm", false), opts.Namespace, secretInformer, configMapInformer)
+	apiFactory := api.NewFactory(settings_notif.GetFactorySettings(argocdService, nil, "argocd-notifications-secret", "argocd-notifications-cm", false), opts.Namespace, secretInformer, configMapInformer)
 
 	dbInstance := db.NewDB(opts.Namespace, settingsMgr, opts.KubeClientset)
 	logger := log.NewEntry(log.StandardLogger())

--- a/util/notification/settings/settings.go
+++ b/util/notification/settings/settings.go
@@ -17,15 +17,21 @@ import (
 	service "github.com/argoproj/argo-cd/v3/util/notification/argocd"
 )
 
-func GetFactorySettings(argocdService service.Service, secretName, configMapName string, selfServiceNotificationEnabled bool) api.Settings {
+// AppProjectGetter retrieves an AppProject as an unstructured object from a
+// local cache, avoiding a live API call on every trigger evaluation. namespace
+// is the Application namespace and name is the AppProject name. It returns a nil
+// object without an error when the AppProject is not present in the cache.
+type AppProjectGetter func(namespace, name string) (*unstructured.Unstructured, error)
+
+func GetFactorySettings(argocdService service.Service, appProjectGetter AppProjectGetter, secretName, configMapName string, selfServiceNotificationEnabled bool) api.Settings {
 	return api.Settings{
 		SecretName:    secretName,
 		ConfigMapName: configMapName,
 		InitGetVars: func(cfg *api.Config, configMap *corev1.ConfigMap, secret *corev1.Secret) (api.GetVars, error) {
 			if selfServiceNotificationEnabled {
-				return initGetVarsWithoutSecret(argocdService, cfg, configMap, secret)
+				return initGetVarsWithoutSecret(argocdService, appProjectGetter, cfg, configMap, secret)
 			}
-			return initGetVars(argocdService, cfg, configMap, secret)
+			return initGetVars(argocdService, appProjectGetter, cfg, configMap, secret)
 		},
 	}
 }
@@ -41,10 +47,11 @@ func GetFactorySettingsForCLI(serviceGetter func() service.Service, secretName, 
 				return nil, errors.New("argocdService is not initialized")
 			}
 
+			// The CLI has no local AppProject cache, so fall back to a live lookup.
 			if selfServiceNotificationEnabled {
-				return initGetVarsWithoutSecret(argocdService, cfg, configMap, secret)
+				return initGetVarsWithoutSecret(argocdService, nil, cfg, configMap, secret)
 			}
-			return initGetVars(argocdService, cfg, configMap, secret)
+			return initGetVars(argocdService, nil, cfg, configMap, secret)
 		},
 	}
 }
@@ -62,7 +69,7 @@ func getContext(cfg *api.Config, configMap *corev1.ConfigMap, secret *corev1.Sec
 	return context, nil
 }
 
-func initGetVarsWithoutSecret(argocdService service.Service, cfg *api.Config, configMap *corev1.ConfigMap, secret *corev1.Secret) (api.GetVars, error) {
+func initGetVarsWithoutSecret(argocdService service.Service, appProjectGetter AppProjectGetter, cfg *api.Config, configMap *corev1.ConfigMap, secret *corev1.Secret) (api.GetVars, error) {
 	context, err := getContext(cfg, configMap, secret)
 	if err != nil {
 		return nil, err
@@ -75,7 +82,7 @@ func initGetVarsWithoutSecret(argocdService service.Service, cfg *api.Config, co
 		}
 
 		// Add AppProject to template variables
-		if appProject := getAppProjectForTemplate(argocdService, obj); appProject != nil {
+		if appProject := getAppProjectForTemplate(argocdService, appProjectGetter, obj); appProject != nil {
 			vars["appProject"] = appProject
 		} else {
 			vars["appProject"] = map[string]any{}
@@ -85,7 +92,7 @@ func initGetVarsWithoutSecret(argocdService service.Service, cfg *api.Config, co
 	}, nil
 }
 
-func initGetVars(argocdService service.Service, cfg *api.Config, configMap *corev1.ConfigMap, secret *corev1.Secret) (api.GetVars, error) {
+func initGetVars(argocdService service.Service, appProjectGetter AppProjectGetter, cfg *api.Config, configMap *corev1.ConfigMap, secret *corev1.Secret) (api.GetVars, error) {
 	context, err := getContext(cfg, configMap, secret)
 	if err != nil {
 		return nil, err
@@ -99,7 +106,7 @@ func initGetVars(argocdService service.Service, cfg *api.Config, configMap *core
 		}
 
 		// Add AppProject to template variables
-		if appProject := getAppProjectForTemplate(argocdService, obj); appProject != nil {
+		if appProject := getAppProjectForTemplate(argocdService, appProjectGetter, obj); appProject != nil {
 			vars["appProject"] = appProject
 		} else {
 			vars["appProject"] = map[string]any{}
@@ -109,12 +116,11 @@ func initGetVars(argocdService service.Service, cfg *api.Config, configMap *core
 	}, nil
 }
 
-// getAppProjectForTemplate retrieves the AppProject as an unstructured object for an Application object
-// Returns nil if the project cannot be found or an error occurs
-func getAppProjectForTemplate(argocdService service.Service, obj map[string]any) map[string]any {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
+// getAppProjectForTemplate retrieves the AppProject as an unstructured object for an Application object.
+// When an appProjectGetter is provided it reads from the local cache instead of
+// making a live API call, which otherwise runs on every trigger evaluation.
+// Returns nil if the project cannot be found or an error occurs.
+func getAppProjectForTemplate(argocdService service.Service, appProjectGetter AppProjectGetter, obj map[string]any) map[string]any {
 	// Extract project name from app.spec.project
 	spec, ok := obj["spec"].(map[string]any)
 	if !ok {
@@ -140,14 +146,33 @@ func getAppProjectForTemplate(argocdService service.Service, obj map[string]any)
 	// Extract app name for logging context
 	appName, _ := metadata["name"].(string)
 
+	logFields := log.Fields{
+		"app":       appName,
+		"project":   projectName,
+		"namespace": namespace,
+	}
+
+	// Prefer the local cache when it is available to avoid a live API call on
+	// every trigger evaluation.
+	if appProjectGetter != nil {
+		appProjectObj, err := appProjectGetter(namespace, projectName)
+		if err != nil {
+			log.WithFields(logFields).Warnf("Failed to get AppProject for notification template: %v", err)
+			return nil
+		}
+		if appProjectObj == nil {
+			return nil
+		}
+		return appProjectObj.Object
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
 	// Fetch the AppProject
 	appProjectObj, err := argocdService.GetAppProject(ctx, projectName, namespace)
 	if err != nil {
-		log.WithFields(log.Fields{
-			"app":       appName,
-			"project":   projectName,
-			"namespace": namespace,
-		}).Warnf("Failed to get AppProject for notification template: %v", err)
+		log.WithFields(logFields).Warnf("Failed to get AppProject for notification template: %v", err)
 		return nil
 	}
 

--- a/util/notification/settings/settings_test.go
+++ b/util/notification/settings/settings_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
@@ -17,6 +18,7 @@ import (
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v3/reposerver/apiclient/mocks"
 	service "github.com/argoproj/argo-cd/v3/util/notification/argocd"
+	servicemocks "github.com/argoproj/argo-cd/v3/util/notification/argocd/mocks"
 )
 
 const (
@@ -73,7 +75,7 @@ func TestInitGetVars(t *testing.T) {
 	}
 	emptyAppData := map[string]any{}
 
-	varsProvider, _ := initGetVars(argocdService, &config, &notificationsCm, &notificationsSecret)
+	varsProvider, _ := initGetVars(argocdService, nil, &config, &notificationsCm, &notificationsSecret)
 
 	t.Run("Vars provider serves Application data on app key", func(t *testing.T) {
 		t.Parallel()
@@ -154,7 +156,7 @@ func TestInitGetVarsAppProject(t *testing.T) {
 
 	config := api.Config{}
 	testDestination := services.Destination{Service: "webhook"}
-	varsProvider, _ := initGetVars(argocdService, &config, &notificationsCm, &notificationsSecret)
+	varsProvider, _ := initGetVars(argocdService, nil, &config, &notificationsCm, &notificationsSecret)
 
 	appData := map[string]any{
 		"spec": map[string]any{
@@ -185,4 +187,78 @@ func TestInitGetVarsAppProject(t *testing.T) {
 		_, exists := result["appProject"]
 		assert.True(t, exists)
 	})
+}
+
+// TestGetAppProjectForTemplateUsesCache proves that when an AppProjectGetter is
+// provided, the AppProject is read from the cache and no live API call is made.
+// The mock Service has no GetAppProject expectation configured, so it would
+// panic if getAppProjectForTemplate fell back to the live lookup.
+func TestGetAppProjectForTemplateUsesCache(t *testing.T) {
+	t.Parallel()
+
+	appData := map[string]any{
+		"spec": map[string]any{
+			"project": "my-project",
+		},
+		"metadata": map[string]any{
+			"namespace": testNamespace,
+			"name":      "my-app",
+		},
+	}
+
+	cachedProject := &unstructured.Unstructured{
+		Object: map[string]any{
+			"metadata": map[string]any{
+				"name":      "my-project",
+				"namespace": testNamespace,
+			},
+		},
+	}
+
+	var gotNamespace, gotName string
+	getter := func(namespace, name string) (*unstructured.Unstructured, error) {
+		gotNamespace, gotName = namespace, name
+		return cachedProject, nil
+	}
+
+	// A mock with no expectations: any live GetAppProject call fails the test.
+	mockService := servicemocks.NewService(t)
+
+	result := getAppProjectForTemplate(mockService, getter, appData)
+
+	require.NotNil(t, result)
+	assert.Equal(t, testNamespace, gotNamespace)
+	assert.Equal(t, "my-project", gotName)
+	projMeta, ok := result["metadata"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "my-project", projMeta["name"])
+	assert.Equal(t, testNamespace, projMeta["namespace"])
+	mockService.AssertNotCalled(t, "GetAppProject")
+}
+
+// TestGetAppProjectForTemplateCacheMiss proves that a cache miss returns nil
+// without falling back to a live API call.
+func TestGetAppProjectForTemplateCacheMiss(t *testing.T) {
+	t.Parallel()
+
+	appData := map[string]any{
+		"spec": map[string]any{
+			"project": "missing-project",
+		},
+		"metadata": map[string]any{
+			"namespace": testNamespace,
+			"name":      "my-app",
+		},
+	}
+
+	getter := func(_, _ string) (*unstructured.Unstructured, error) {
+		return nil, nil
+	}
+
+	mockService := servicemocks.NewService(t)
+
+	result := getAppProjectForTemplate(mockService, getter, appData)
+
+	assert.Nil(t, result)
+	mockService.AssertNotCalled(t, "GetAppProject")
 }


### PR DESCRIPTION
Fixes #28530

## What
The notification controller resolved the AppProject for template variables through a live API call on every trigger evaluation (getAppProjectForTemplate to Service.GetAppProject to a live client Get). With many applications and triggers this produced a large number of API requests per reconcile and a significant performance regression in v3.4.x.

## How
The controller already runs a synced AppProject informer cache (used by getAppProj), but that cache was not reachable from the settings package that builds template variables. This change threads the existing cache into the notification settings factory through an optional AppProjectGetter:

- getAppProjectForTemplate reads from the getter (local synced cache) when present.
- The notification controller supplies a getter backed by its existing AppProject informer.
- Callers without a cache (API server, CLI) pass nil and keep the previous live lookup.

No change to the returned template variable shape.

Note for reviewers: GetFactorySettings is exported and its signature gains an AppProjectGetter parameter. All in-tree callers are updated. If any out-of-tree code calls it this is a breaking change, which seems reasonable for a bug fix but is worth flagging.

## Testing
Added unit tests proving the cache path is used and the live GetAppProject is never called, plus a cache-miss test. Verified via revert-check that disabling the cache branch makes the new tests fail. go build, go vet, gofmt and go test ./util/notification/... all clean.