### PR TITLE
fix: include images referenced via Pod volumes in application image list (#28909)

### DIFF
--- a/controller/cache/info.go
+++ b/controller/cache/info.go
@@ -649,6 +649,7 @@ func populatePodInfo(un *unstructured.Unstructured, res *ResourceInfo) {
 	for image := range imagesSet {
 		res.Images = append(res.Images, image)
 	}
+	slices.Sort(res.Images)
 
 	// If the Pod carries {type:PodScheduled, reason:SchedulingGated}, set reason to 'SchedulingGated'.
 	for _, condition := range pod.Status.Conditions {

--- a/controller/cache/info.go
+++ b/controller/cache/info.go
@@ -639,6 +639,11 @@ func populatePodInfo(un *unstructured.Unstructured, res *ResourceInfo) {
 	for _, container := range pod.Spec.Containers {
 		imagesSet[container.Image] = true
 	}
+	for _, volume := range pod.Spec.Volumes {
+		if volume.Image != nil && volume.Image.Reference != "" {
+			imagesSet[volume.Image.Reference] = true
+		}
+	}
 
 	res.Images = nil
 	for image := range imagesSet {

--- a/controller/cache/info_test.go
+++ b/controller/cache/info_test.go
@@ -601,6 +601,44 @@ func TestGetPodInfo(t *testing.T) {
 		assert.Equal(t, &v1alpha1.ResourceNetworkingInfo{Labels: map[string]string{"app": "guestbook"}}, info.NetworkingInfo)
 	})
 
+	t.Run("TestGetPodWithImageVolumeInfo", func(t *testing.T) {
+		t.Parallel()
+
+		pod := strToUnstructured(`
+  apiVersion: v1
+  kind: Pod
+  metadata:
+    name: helm-guestbook-pod
+    namespace: default
+    ownerReferences:
+    - apiVersion: extensions/v1beta1
+      kind: ReplicaSet
+      name: helm-guestbook-rs
+    resourceVersion: "123"
+    labels:
+      app: guestbook
+  spec:
+    nodeName: minikube
+    containers:
+    - image: bar
+      resources:
+        requests:
+          memory: 128Mi
+      volumeMounts:
+      - name: artifact
+        mountPath: /artifact
+    volumes:
+    - name: artifact
+      image:
+        reference: quay.io/example/artifact:1.0.0
+        pullPolicy: IfNotPresent
+`)
+
+		info := &ResourceInfo{}
+		populateNodeInfo(pod, info, []string{})
+		assert.ElementsMatch(t, []string{"bar", "quay.io/example/artifact:1.0.0"}, info.Images)
+	})
+
 	t.Run("TestGetPodWithInitialContainerInfo", func(t *testing.T) {
 		t.Parallel()
 		pod := strToUnstructured(`

--- a/controller/cache/info_test.go
+++ b/controller/cache/info_test.go
@@ -636,7 +636,7 @@ func TestGetPodInfo(t *testing.T) {
 
 		info := &ResourceInfo{}
 		populateNodeInfo(pod, info, []string{})
-		assert.ElementsMatch(t, []string{"bar", "quay.io/example/artifact:1.0.0"}, info.Images)
+		assert.Equal(t, []string{"bar", "quay.io/example/artifact:1.0.0"}, info.Images)
 	})
 
 	t.Run("TestGetPodWithInitialContainerInfo", func(t *testing.T) {

--- a/controller/cache/info_test.go
+++ b/controller/cache/info_test.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"fmt"
 	"sort"
 	"testing"
 
@@ -557,13 +558,12 @@ status:
 
 // These tests are equivalent to tests in ui/src/app/applications/components/utils.test.tsx. If you update tests here,
 // please make sure to update the equivalent tests in the UI.
-func TestGetPodInfo(t *testing.T) {
-	t.Parallel()
-
-	t.Run("TestGetPodInfo", func(t *testing.T) {
-		t.Parallel()
-
-		pod := strToUnstructured(`
+// guestbookPodManifest returns the base guestbook Pod YAML used by several
+// TestGetPodInfo subtests, with extraSpec (already correctly indented)
+// appended under spec: so a subtest can add e.g. volumes without duplicating
+// the whole manifest.
+func guestbookPodManifest(extraSpec string) string {
+	return fmt.Sprintf(`
   apiVersion: v1
   kind: Pod
   metadata:
@@ -583,7 +583,17 @@ func TestGetPodInfo(t *testing.T) {
       resources:
         requests:
           memory: 128Mi
-`)
+%s
+`, extraSpec)
+}
+
+func TestGetPodInfo(t *testing.T) {
+	t.Parallel()
+
+	t.Run("TestGetPodInfo", func(t *testing.T) {
+		t.Parallel()
+
+		pod := strToUnstructured(guestbookPodManifest(""))
 
 		info := &ResourceInfo{}
 		populateNodeInfo(pod, info, []string{})
@@ -604,35 +614,14 @@ func TestGetPodInfo(t *testing.T) {
 	t.Run("TestGetPodWithImageVolumeInfo", func(t *testing.T) {
 		t.Parallel()
 
-		pod := strToUnstructured(`
-  apiVersion: v1
-  kind: Pod
-  metadata:
-    name: helm-guestbook-pod
-    namespace: default
-    ownerReferences:
-    - apiVersion: extensions/v1beta1
-      kind: ReplicaSet
-      name: helm-guestbook-rs
-    resourceVersion: "123"
-    labels:
-      app: guestbook
-  spec:
-    nodeName: minikube
-    containers:
-    - image: bar
-      resources:
-        requests:
-          memory: 128Mi
-      volumeMounts:
+		pod := strToUnstructured(guestbookPodManifest(`      volumeMounts:
       - name: artifact
         mountPath: /artifact
     volumes:
     - name: artifact
       image:
         reference: quay.io/example/artifact:1.0.0
-        pullPolicy: IfNotPresent
-`)
+        pullPolicy: IfNotPresent`))
 
 		info := &ResourceInfo{}
 		populateNodeInfo(pod, info, []string{})


### PR DESCRIPTION
Fixes #28909

## Summary

An Application's image list (`status.summary.images`, shown in the UI Summary tab) is built by walking each Pod resource node's images. That extraction (`populatePodInfo` in `controller/cache/info.go`) only looked at `spec.containers[].image` and `spec.initContainers[].image`. Images referenced via the Kubernetes "image volume source" feature (`spec.volumes[].image.reference`) — where an OCI image/artifact is mounted as a volume rather than run as a container — were silently omitted.

This matters beyond the UI: tools like `argocd-image-updater` rely on this summary to know which images an Application has deployed, so a volume-mounted image was invisible to automated image updates.

## Change

`populatePodInfo` now also walks `pod.Spec.Volumes`, and adds `volume.Image.Reference` to the image set when a volume uses the image volume source.

## Checklist

* [x] This is a bug fix.
* [x] The title of the PR states what changed and the related issue number.
* [x] The title conforms to the semantic PR title convention.
* [x] I've included "Fixes #28909" to auto-close the issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. (N/A — no CLI/UI surface change, only backend image extraction.)
* [ ] Does this PR require documentation updates? No — this is a bug fix restoring expected behavior of an existing field, not a new user-facing feature.
* [x] I have signed off all my commits as required by DCO.
* [x] I have written unit tests for my change (`TestGetPodWithImageVolumeInfo` in `controller/cache/info_test.go`).
* [x] My build is green locally (`go build ./...`, `go vet`, `golangci-lint run`, and `go test ./controller/...` all pass).
* [x] I have added a brief description of why this PR is necessary and what this PR solves.

## Test plan

- Added `TestGetPodWithImageVolumeInfo` covering a Pod with both a regular container image and a volume-mounted image, asserting both appear in `ResourceInfo.Images`.
- Ran `go test ./controller/cache/...` and `go test ./controller/... ./pkg/apis/application/...` — all pass.
- Ran `golangci-lint run ./controller/cache/...` — 0 issues.