### PR TITLE
feat: support separate RBAC permission for application rollback

### DIFF
--- a/assets/builtin-policy.csv
+++ b/assets/builtin-policy.csv
@@ -23,6 +23,7 @@ p, role:admin, applications, update/*, */*, allow
 p, role:admin, applications, delete, */*, allow
 p, role:admin, applications, delete/*, */*, allow
 p, role:admin, applications, sync, */*, allow
+p, role:admin, applications, rollback, */*, allow
 p, role:admin, applications, override, */*, allow
 p, role:admin, applications, action/*, */*, allow
 p, role:admin, applicationsets, get, */*, allow

--- a/cmd/argocd/commands/admin/settings_rbac.go
+++ b/cmd/argocd/commands/admin/settings_rbac.go
@@ -88,6 +88,7 @@ var applicationsActions = actionTraitMap{
 	rbac.ActionAction:   rbacTrait{allowPath: true},
 	rbac.ActionOverride: rbacTrait{},
 	rbac.ActionSync:     rbacTrait{},
+	rbac.ActionRollback: rbacTrait{},
 }
 
 var accountsActions = actionTraitMap{

--- a/docs/operator-manual/argocd-cm.yaml
+++ b/docs/operator-manual/argocd-cm.yaml
@@ -373,6 +373,11 @@ data:
   # This is to prevent the UI from becoming unresponsive when rendering a large number of logs. Default is 10.
   server.maxPodLogsToRender: "10"
 
+  # server.rbac.rollback.enforce.enable enables a dedicated 'rollback' RBAC action for applications.
+  # When set to 'true', users must be explicitly granted the 'rollback' action to perform rollbacks.
+  # When omitted or 'false' (the default), rollback uses the 'sync' permission for backwards compatibility.
+  server.rbac.rollback.enforce.enable: "false"
+
   # exec.enabled indicates whether the UI exec feature is enabled. It is disabled by default.
   exec.enabled: "false"
 

--- a/docs/operator-manual/argocd-rbac-cm.yaml
+++ b/docs/operator-manual/argocd-rbac-cm.yaml
@@ -42,8 +42,4 @@ data:
   # will be set to 'glob' as default.
   policy.matchMode: 'glob'
 
-  # policy.enableSeparateRollbackPermission enables a dedicated 'rollback' RBAC action for applications.
-  # When set to 'true', users must be explicitly granted the 'rollback' action to perform rollbacks.
-  # When omitted or 'false' (the default), rollback uses the 'sync' permission for backwards compatibility.
-  # policy.enableSeparateRollbackPermission: 'true'
 

--- a/docs/operator-manual/argocd-rbac-cm.yaml
+++ b/docs/operator-manual/argocd-rbac-cm.yaml
@@ -42,3 +42,8 @@ data:
   # will be set to 'glob' as default.
   policy.matchMode: 'glob'
 
+  # policy.enableSeparateRollbackPermission enables a dedicated 'rollback' RBAC action for applications.
+  # When set to 'true', users must be explicitly granted the 'rollback' action to perform rollbacks.
+  # When omitted or 'false' (the default), rollback uses the 'sync' permission for backwards compatibility.
+  # policy.enableSeparateRollbackPermission: 'true'
+

--- a/docs/operator-manual/rbac.md
+++ b/docs/operator-manual/rbac.md
@@ -221,10 +221,10 @@ The `rollback` action allows rolling back applications to previously synced revi
 
 #### Enabling Separate Rollback Permission
 
-The `rollback` action is **opt-in** and disabled by default for backwards compatibility. To enable it, set the following in `argocd-rbac-cm`:
+The `rollback` action is **opt-in** and disabled by default for backwards compatibility. To enable it, set the following in `argocd-cm`:
 
 ```yaml
-policy.enableSeparateRollbackPermission: 'true'
+server.rbac.rollback.enforce.enable: 'true'
 ```
 
 When disabled (the default), rollback operations continue to use the `sync` permission check, so existing RBAC policies continue to work without changes.

--- a/docs/operator-manual/rbac.md
+++ b/docs/operator-manual/rbac.md
@@ -71,19 +71,19 @@ Syntax: `p, <role/user/group>, <resource>, <action>, <object>, <effect>`
 
 Below is a table that summarizes all possible resources and which actions are valid for each of them.
 
-| Resource\Action     | get | create | update | delete | sync | action | override | invoke |
-| :------------------ | :-: | :----: | :----: | :----: | :--: | :----: | :------: | :----: |
-| **applications**    | ✅  |   ✅   |   ✅   |   ✅   |  ✅  |   ✅   |    ✅    |   ❌   |
-| **applicationsets** | ✅  |   ✅   |   ✅   |   ✅   |  ❌  |   ❌   |    ❌    |   ❌   |
-| **clusters**        | ✅  |   ✅   |   ✅   |   ✅   |  ❌  |   ❌   |    ❌    |   ❌   |
-| **projects**        | ✅  |   ✅   |   ✅   |   ✅   |  ❌  |   ❌   |    ❌    |   ❌   |
-| **repositories**    | ✅  |   ✅   |   ✅   |   ✅   |  ❌  |   ❌   |    ❌    |   ❌   |
-| **accounts**        | ✅  |   ❌   |   ✅   |   ❌   |  ❌  |   ❌   |    ❌    |   ❌   |
-| **certificates**    | ✅  |   ✅   |   ❌   |   ✅   |  ❌  |   ❌   |    ❌    |   ❌   |
-| **gpgkeys**         | ✅  |   ✅   |   ❌   |   ✅   |  ❌  |   ❌   |    ❌    |   ❌   |
-| **logs**            | ✅  |   ❌   |   ❌   |   ❌   |  ❌  |   ❌   |    ❌    |   ❌   |
-| **exec**            | ❌  |   ✅   |   ❌   |   ❌   |  ❌  |   ❌   |    ❌    |   ❌   |
-| **extensions**      | ❌  |   ❌   |   ❌   |   ❌   |  ❌  |   ❌   |    ❌    |   ✅   |
+| Resource\Action     | get | create | update | delete | sync | rollback | action | override | invoke |
+| :------------------ | :-: | :----: | :----: | :----: | :--: | :------: | :----: | :------: | :----: |
+| **applications**    | ✅  |   ✅   |   ✅   |   ✅   |  ✅  |    ✅    |   ✅   |    ✅    |   ❌   |
+| **applicationsets** | ✅  |   ✅   |   ✅   |   ✅   |  ❌  |    ❌    |   ❌   |    ❌    |   ❌   |
+| **clusters**        | ✅  |   ✅   |   ✅   |   ✅   |  ❌  |    ❌    |   ❌   |    ❌    |   ❌   |
+| **projects**        | ✅  |   ✅   |   ✅   |   ✅   |  ❌  |    ❌    |   ❌   |    ❌    |   ❌   |
+| **repositories**    | ✅  |   ✅   |   ✅   |   ✅   |  ❌  |    ❌    |   ❌   |    ❌    |   ❌   |
+| **accounts**        | ✅  |   ❌   |   ✅   |   ❌   |  ❌  |    ❌    |   ❌   |    ❌    |   ❌   |
+| **certificates**    | ✅  |   ✅   |   ❌   |   ✅   |  ❌  |    ❌    |   ❌   |    ❌    |   ❌   |
+| **gpgkeys**         | ✅  |   ✅   |   ❌   |   ✅   |  ❌  |    ❌    |   ❌   |    ❌    |   ❌   |
+| **logs**            | ✅  |   ❌   |   ❌   |   ❌   |  ❌  |    ❌    |   ❌   |    ❌    |   ❌   |
+| **exec**            | ❌  |   ✅   |   ❌   |   ❌   |  ❌  |    ❌    |   ❌   |    ❌    |   ❌   |
+| **extensions**      | ❌  |   ❌   |   ❌   |   ❌   |  ❌  |    ❌    |   ❌   |    ❌    |   ✅   |
 
 ### Application-Specific Policy
 
@@ -208,6 +208,43 @@ To allow the user to perform any actions:
 
 ```csv
 p, example-user, applications, action/*, default/*, allow
+```
+
+#### The `rollback` action
+
+The `rollback` action allows rolling back applications to previously synced revisions. This is a restricted operation compared to the `sync` action with the following constraints:
+
+* Can only rollback to revisions in the application's revision history (up to the configured `revisionHistoryLimit`)
+* Cannot rollback when auto-sync is enabled
+* Uses the application's configured sync options (cannot override with custom options)
+* Cannot use partial sync on specific resources
+
+#### Enabling Separate Rollback Permission
+
+The `rollback` action is **opt-in** and disabled by default for backwards compatibility. To enable it, set the following in `argocd-rbac-cm`:
+
+```yaml
+policy.enableSeparateRollbackPermission: 'true'
+```
+
+When disabled (the default), rollback operations continue to use the `sync` permission check, so existing RBAC policies continue to work without changes.
+
+> [!NOTE]
+> Once enabled, users who previously relied on `sync` permission to perform rollbacks will need to be explicitly granted the `rollback` permission.
+
+**Examples:**
+
+Allow a developer to rollback applications in the dev project:
+
+```csv
+p, developer, applications, rollback, dev-project/*, allow
+```
+
+Allow a team to rollback specific applications:
+
+```csv
+p, release-team, applications, rollback, prod-project/critical-app, allow
+p, release-team, applications, rollback, prod-project/api-service, allow
 ```
 
 #### The `override` action

--- a/docs/operator-manual/rbac.md
+++ b/docs/operator-manual/rbac.md
@@ -216,7 +216,7 @@ The `rollback` action allows rolling back applications to previously synced revi
 
 * Can only rollback to revisions in the application's revision history (up to the configured `revisionHistoryLimit`)
 * Cannot rollback when auto-sync is enabled
-* Uses the application's configured sync options (cannot override with custom options)
+* Supports `dryRun` and `prune` options but cannot override other sync options
 * Cannot use partial sync on specific resources
 
 #### Enabling Separate Rollback Permission

--- a/docs/user-guide/commands/argocd_account_can-i.md
+++ b/docs/user-guide/commands/argocd_account_can-i.md
@@ -21,7 +21,7 @@ argocd account can-i update projects 'default'
 # Can I create a cluster?
 argocd account can-i create clusters '*'
 
-Actions: [get create update delete sync override action invoke]
+Actions: [get create update delete sync rollback override action invoke]
 Resources: [clusters projects applications applicationsets repositories write-repositories certificates accounts gpgkeys logs exec extensions]
 
 ```

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -2704,6 +2704,7 @@ var validActions = map[string]bool{
 	rbac.ActionDelete:   true,
 	rbac.ActionSync:     true,
 	rbac.ActionOverride: true,
+	rbac.ActionRollback: true,
 	"*":                 true,
 }
 

--- a/server/account/account.go
+++ b/server/account/account.go
@@ -129,6 +129,19 @@ func (s *Server) CanI(ctx context.Context, r *account.CanIRequest) (*account.Can
 		return nil, status.Errorf(codes.InvalidArgument, "%v does not contain %s", rbac.Resources, r.Resource)
 	}
 
+	// When server.rbac.rollback.enforce.enable is false (the default), rollback falls back
+	// to the sync permission for backwards compatibility. Mirror that here so can-i
+	// accurately reflects whether the caller can actually perform a rollback.
+	if r.Action == rbac.ActionRollback {
+		rollbackEnforceEnable, err := s.settingsMgr.GetServerRBACRollbackEnforceEnable()
+		if err != nil {
+			return nil, err
+		}
+		if !rollbackEnforceEnable {
+			r.Action = rbac.ActionSync
+		}
+	}
+
 	subresource := r.Subresource
 
 	// For project-scoped resources, normalize the subresource using security.RBACName

--- a/server/account/account_test.go
+++ b/server/account/account_test.go
@@ -352,6 +352,60 @@ func TestCanI_GetLogsDeny(t *testing.T) {
 	assert.Equal(t, "no", resp.Value)
 }
 
+func TestCanI_RollbackFlagDisabled_ChecksSyncPermission(t *testing.T) {
+	t.Parallel()
+	t.Run("denied when no sync permission", func(t *testing.T) {
+		t.Parallel()
+		enforcer := func(_ jwt.Claims, _ ...any) bool { return false }
+		accountServer, _ := newTestAccountServerExt(t, t.Context(), enforcer, func(_ *corev1.ConfigMap, _ *corev1.Secret) {
+			// flag not set → defaults to false
+		})
+		ctx := projTokenContext(t.Context())
+		resp, err := accountServer.CanI(ctx, &account.CanIRequest{Resource: "applications", Action: "rollback", Subresource: "*"})
+		require.NoError(t, err)
+		assert.Equal(t, "no", resp.Value)
+	})
+
+	t.Run("allowed when sync permission granted", func(t *testing.T) {
+		t.Parallel()
+		enforcer := func(_ jwt.Claims, _ ...any) bool { return true }
+		accountServer, _ := newTestAccountServerExt(t, t.Context(), enforcer, func(_ *corev1.ConfigMap, _ *corev1.Secret) {
+			// flag not set → defaults to false
+		})
+		ctx := projTokenContext(t.Context())
+		resp, err := accountServer.CanI(ctx, &account.CanIRequest{Resource: "applications", Action: "rollback", Subresource: "*"})
+		require.NoError(t, err)
+		assert.Equal(t, "yes", resp.Value)
+	})
+}
+
+func TestCanI_RollbackFlagEnabled_EnforcesRBAC(t *testing.T) {
+	t.Parallel()
+	t.Run("allowed", func(t *testing.T) {
+		t.Parallel()
+		enforcer := func(_ jwt.Claims, _ ...any) bool { return true }
+		accountServer, _ := newTestAccountServerExt(t, t.Context(), enforcer, func(cm *corev1.ConfigMap, _ *corev1.Secret) {
+			cm.Data["server.rbac.rollback.enforce.enable"] = "true"
+		})
+		ctx := projTokenContext(t.Context())
+		resp, err := accountServer.CanI(ctx, &account.CanIRequest{Resource: "applications", Action: "rollback", Subresource: "*"})
+		require.NoError(t, err)
+		assert.Equal(t, "yes", resp.Value)
+	})
+
+	t.Run("denied", func(t *testing.T) {
+		t.Parallel()
+		enforcer := func(_ jwt.Claims, _ ...any) bool { return false }
+		accountServer, _ := newTestAccountServerExt(t, t.Context(), enforcer, func(cm *corev1.ConfigMap, _ *corev1.Secret) {
+			cm.Data["server.rbac.rollback.enforce.enable"] = "true"
+		})
+		ctx := projTokenContext(t.Context())
+		resp, err := accountServer.CanI(ctx, &account.CanIRequest{Resource: "applications", Action: "rollback", Subresource: "*"})
+		require.NoError(t, err)
+		assert.Equal(t, "no", resp.Value)
+	})
+}
+
 func TestCanI_RBACPolicyMatchingWithNormalizedSubresource(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -2264,8 +2264,12 @@ func (s *Server) resolveSourceRevisions(ctx context.Context, a *v1alpha1.Applica
 }
 
 func (s *Server) Rollback(ctx context.Context, rollbackReq *application.ApplicationRollbackRequest) (*v1alpha1.Application, error) {
+	rollbackEnforceEnable, err := s.settingsMgr.GetServerRBACRollbackEnforceEnable()
+	if err != nil {
+		return nil, fmt.Errorf("error getting server.rbac.rollback.enforce.enable config: %w", err)
+	}
 	action := rbac.ActionSync
-	if s.enf.IsSeparateRollbackPermissionEnabled() {
+	if rollbackEnforceEnable {
 		action = rbac.ActionRollback
 	}
 	a, _, err := s.getApplicationEnforceRBACClient(ctx, action, rollbackReq.GetProject(), rollbackReq.GetAppNamespace(), rollbackReq.GetName(), "")

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -2264,7 +2264,11 @@ func (s *Server) resolveSourceRevisions(ctx context.Context, a *v1alpha1.Applica
 }
 
 func (s *Server) Rollback(ctx context.Context, rollbackReq *application.ApplicationRollbackRequest) (*v1alpha1.Application, error) {
-	a, _, err := s.getApplicationEnforceRBACClient(ctx, rbac.ActionSync, rollbackReq.GetProject(), rollbackReq.GetAppNamespace(), rollbackReq.GetName(), "")
+	action := rbac.ActionSync
+	if s.enf.IsSeparateRollbackPermissionEnabled() {
+		action = rbac.ActionRollback
+	}
+	a, _, err := s.getApplicationEnforceRBACClient(ctx, action, rollbackReq.GetProject(), rollbackReq.GetAppNamespace(), rollbackReq.GetName(), "")
 	if err != nil {
 		return nil, err
 	}

--- a/server/application/application_test.go
+++ b/server/application/application_test.go
@@ -5238,3 +5238,113 @@ func TestGetUnstructuredLiveResourceOrAppWithImpersonation(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "system:serviceaccount:"+test.FakeDestNamespace+":test-sa", config.Impersonate.UserName)
 }
+
+func TestRollbackRBACPermissions(t *testing.T) {
+	newTestAppWithRollbackHistory := func() *v1alpha1.Application {
+		app := newTestApp()
+		app.Spec.Project = "default"
+		app.Status.History = []v1alpha1.RevisionHistory{{
+			ID:        1,
+			Revision:  "abc",
+			Revisions: []string{"abc"},
+			Source:    *app.Spec.Source.DeepCopy(),
+			Sources:   []v1alpha1.ApplicationSource{*app.Spec.Source.DeepCopy()},
+		}}
+		return app
+	}
+
+	setupServer := func(t *testing.T, testApp *v1alpha1.Application) *Server {
+		t.Helper()
+		f := func(enf *rbac.Enforcer) {
+			_ = enf.SetBuiltinPolicy(assets.BuiltinPolicyCSV)
+			enf.SetDefaultRole("role:readonly")
+		}
+		return newTestAppServerWithEnforcerConfigure(t, f, map[string]string{}, testApp)
+	}
+
+	t.Run("rollback permission allows rollback when feature flag enabled", func(t *testing.T) {
+		testApp := newTestAppWithRollbackHistory()
+		appServer := setupServer(t, testApp)
+		appServer.enf.SetSeparateRollbackPermissionEnabled(true)
+
+		//nolint:staticcheck
+		userCtx := context.WithValue(t.Context(), "claims", &jwt.MapClaims{"sub": "user1"})
+		require.NoError(t, appServer.enf.SetUserPolicy("p, user1, applications, rollback, default/test-app, allow"))
+
+		updatedApp, err := appServer.Rollback(userCtx, &application.ApplicationRollbackRequest{
+			Name: &testApp.Name,
+			Id:   new(int64(1)),
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, updatedApp.Operation)
+	})
+
+	t.Run("rollback permission denied without sync when feature flag disabled", func(t *testing.T) {
+		testApp := newTestAppWithRollbackHistory()
+		appServer := setupServer(t, testApp)
+		// flag=false (default): server checks sync, not rollback
+
+		//nolint:staticcheck
+		userCtx := context.WithValue(t.Context(), "claims", &jwt.MapClaims{"sub": "user1"})
+		require.NoError(t, appServer.enf.SetUserPolicy("p, user1, applications, rollback, default/test-app, allow"))
+
+		_, err := appServer.Rollback(userCtx, &application.ApplicationRollbackRequest{
+			Name: &testApp.Name,
+			Id:   new(int64(1)),
+		})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "permission denied")
+	})
+
+	t.Run("sync permission allows rollback for backwards compatibility", func(t *testing.T) {
+		testApp := newTestAppWithRollbackHistory()
+		appServer := setupServer(t, testApp)
+		// flag=false (default): sync permission is sufficient for rollback
+
+		//nolint:staticcheck
+		userCtx := context.WithValue(t.Context(), "claims", &jwt.MapClaims{"sub": "user1"})
+		require.NoError(t, appServer.enf.SetUserPolicy("p, user1, applications, sync, default/test-app, allow"))
+
+		updatedApp, err := appServer.Rollback(userCtx, &application.ApplicationRollbackRequest{
+			Name: &testApp.Name,
+			Id:   new(int64(1)),
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, updatedApp.Operation)
+	})
+
+	t.Run("rollback denied when feature flag enabled and only sync granted", func(t *testing.T) {
+		testApp := newTestAppWithRollbackHistory()
+		appServer := setupServer(t, testApp)
+		appServer.enf.SetSeparateRollbackPermissionEnabled(true)
+
+		//nolint:staticcheck
+		userCtx := context.WithValue(t.Context(), "claims", &jwt.MapClaims{"sub": "user1"})
+		// user has sync but NOT rollback — with flag enabled, rollback is required
+		require.NoError(t, appServer.enf.SetUserPolicy("p, user1, applications, sync, default/test-app, allow"))
+
+		_, err := appServer.Rollback(userCtx, &application.ApplicationRollbackRequest{
+			Name: &testApp.Name,
+			Id:   new(int64(1)),
+		})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "permission denied")
+	})
+
+	t.Run("no rollback or sync permission is denied", func(t *testing.T) {
+		testApp := newTestAppWithRollbackHistory()
+		appServer := setupServer(t, testApp)
+		appServer.enf.SetSeparateRollbackPermissionEnabled(true)
+
+		//nolint:staticcheck
+		userCtx := context.WithValue(t.Context(), "claims", &jwt.MapClaims{"sub": "user1"})
+		require.NoError(t, appServer.enf.SetUserPolicy("p, user1, applications, get, default/test-app, allow"))
+
+		_, err := appServer.Rollback(userCtx, &application.ApplicationRollbackRequest{
+			Name: &testApp.Name,
+			Id:   new(int64(1)),
+		})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "permission denied")
+	})
+}

--- a/server/application/application_test.go
+++ b/server/application/application_test.go
@@ -5253,19 +5253,22 @@ func TestRollbackRBACPermissions(t *testing.T) {
 		return app
 	}
 
-	setupServer := func(t *testing.T, testApp *v1alpha1.Application) *Server {
+	setupServer := func(t *testing.T, testApp *v1alpha1.Application, rollbackEnforce bool) *Server {
 		t.Helper()
 		f := func(enf *rbac.Enforcer) {
 			_ = enf.SetBuiltinPolicy(assets.BuiltinPolicyCSV)
 			enf.SetDefaultRole("role:readonly")
 		}
-		return newTestAppServerWithEnforcerConfigure(t, f, map[string]string{}, testApp)
+		additionalConfig := map[string]string{}
+		if rollbackEnforce {
+			additionalConfig["server.rbac.rollback.enforce.enable"] = "true"
+		}
+		return newTestAppServerWithEnforcerConfigure(t, f, additionalConfig, testApp)
 	}
 
 	t.Run("rollback permission allows rollback when feature flag enabled", func(t *testing.T) {
 		testApp := newTestAppWithRollbackHistory()
-		appServer := setupServer(t, testApp)
-		appServer.enf.SetSeparateRollbackPermissionEnabled(true)
+		appServer := setupServer(t, testApp, true)
 
 		//nolint:staticcheck
 		userCtx := context.WithValue(t.Context(), "claims", &jwt.MapClaims{"sub": "user1"})
@@ -5281,7 +5284,7 @@ func TestRollbackRBACPermissions(t *testing.T) {
 
 	t.Run("rollback permission denied without sync when feature flag disabled", func(t *testing.T) {
 		testApp := newTestAppWithRollbackHistory()
-		appServer := setupServer(t, testApp)
+		appServer := setupServer(t, testApp, false)
 		// flag=false (default): server checks sync, not rollback
 
 		//nolint:staticcheck
@@ -5298,7 +5301,7 @@ func TestRollbackRBACPermissions(t *testing.T) {
 
 	t.Run("sync permission allows rollback for backwards compatibility", func(t *testing.T) {
 		testApp := newTestAppWithRollbackHistory()
-		appServer := setupServer(t, testApp)
+		appServer := setupServer(t, testApp, false)
 		// flag=false (default): sync permission is sufficient for rollback
 
 		//nolint:staticcheck
@@ -5315,8 +5318,7 @@ func TestRollbackRBACPermissions(t *testing.T) {
 
 	t.Run("rollback denied when feature flag enabled and only sync granted", func(t *testing.T) {
 		testApp := newTestAppWithRollbackHistory()
-		appServer := setupServer(t, testApp)
-		appServer.enf.SetSeparateRollbackPermissionEnabled(true)
+		appServer := setupServer(t, testApp, true)
 
 		//nolint:staticcheck
 		userCtx := context.WithValue(t.Context(), "claims", &jwt.MapClaims{"sub": "user1"})
@@ -5333,8 +5335,7 @@ func TestRollbackRBACPermissions(t *testing.T) {
 
 	t.Run("no rollback or sync permission is denied", func(t *testing.T) {
 		testApp := newTestAppWithRollbackHistory()
-		appServer := setupServer(t, testApp)
-		appServer.enf.SetSeparateRollbackPermissionEnabled(true)
+		appServer := setupServer(t, testApp, true)
 
 		//nolint:staticcheck
 		userCtx := context.WithValue(t.Context(), "claims", &jwt.MapClaims{"sub": "user1"})

--- a/server/application/application_test.go
+++ b/server/application/application_test.go
@@ -5349,3 +5349,136 @@ func TestRollbackRBACPermissions(t *testing.T) {
 		assert.ErrorContains(t, err, "permission denied")
 	})
 }
+
+func TestRollbackRBACPermissions_ProjectScoped(t *testing.T) {
+	const projName = "rollback-proj"
+
+	newTestAppWithRollbackHistory := func() *v1alpha1.Application {
+		app := newTestApp()
+		app.Spec.Project = projName
+		app.Status.History = []v1alpha1.RevisionHistory{{
+			ID:        1,
+			Revision:  "abc",
+			Revisions: []string{"abc"},
+			Source:    *app.Spec.Source.DeepCopy(),
+			Sources:   []v1alpha1.ApplicationSource{*app.Spec.Source.DeepCopy()},
+		}}
+		return app
+	}
+
+	newProjectWithRole := func(roleName string, policies []string) *v1alpha1.AppProject {
+		return &v1alpha1.AppProject{
+			ObjectMeta: metav1.ObjectMeta{Name: projName, Namespace: testNamespace},
+			Spec: v1alpha1.AppProjectSpec{
+				SourceRepos:  []string{"*"},
+				Destinations: []v1alpha1.ApplicationDestination{{Server: "*", Namespace: "*"}},
+				Roles: []v1alpha1.ProjectRole{
+					{Name: roleName, Policies: policies},
+				},
+			},
+		}
+	}
+
+	setupServer := func(t *testing.T, testApp *v1alpha1.Application, proj *v1alpha1.AppProject, rollbackEnforce bool) *Server {
+		t.Helper()
+		f := func(enf *rbac.Enforcer) {
+			_ = enf.SetBuiltinPolicy(assets.BuiltinPolicyCSV)
+			enf.SetDefaultRole("role:readonly")
+		}
+		additionalConfig := map[string]string{}
+		if rollbackEnforce {
+			additionalConfig["server.rbac.rollback.enforce.enable"] = "true"
+		}
+		return newTestAppServerWithEnforcerConfigure(t, f, additionalConfig, testApp, proj)
+	}
+
+	t.Run("project-scoped rollback policy allows rollback when feature flag enabled", func(t *testing.T) {
+		testApp := newTestAppWithRollbackHistory()
+		proj := newProjectWithRole("rollback-role", []string{
+			"p, proj:rollback-proj:rollback-role, applications, rollback, rollback-proj/test-app, allow",
+		})
+		appServer := setupServer(t, testApp, proj, true)
+
+		//nolint:staticcheck
+		userCtx := context.WithValue(t.Context(), "claims", &jwt.MapClaims{"sub": "proj:rollback-proj:rollback-role"})
+
+		updatedApp, err := appServer.Rollback(userCtx, &application.ApplicationRollbackRequest{
+			Name: &testApp.Name,
+			Id:   new(int64(1)),
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, updatedApp.Operation)
+	})
+
+	t.Run("project-scoped rollback policy denied without sync when feature flag disabled", func(t *testing.T) {
+		testApp := newTestAppWithRollbackHistory()
+		proj := newProjectWithRole("rollback-role", []string{
+			"p, proj:rollback-proj:rollback-role, applications, rollback, rollback-proj/test-app, allow",
+		})
+		appServer := setupServer(t, testApp, proj, false)
+
+		//nolint:staticcheck
+		userCtx := context.WithValue(t.Context(), "claims", &jwt.MapClaims{"sub": "proj:rollback-proj:rollback-role"})
+
+		_, err := appServer.Rollback(userCtx, &application.ApplicationRollbackRequest{
+			Name: &testApp.Name,
+			Id:   new(int64(1)),
+		})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "permission denied")
+	})
+
+	t.Run("project-scoped sync policy allows rollback for backwards compatibility", func(t *testing.T) {
+		testApp := newTestAppWithRollbackHistory()
+		proj := newProjectWithRole("sync-role", []string{
+			"p, proj:rollback-proj:sync-role, applications, sync, rollback-proj/test-app, allow",
+		})
+		appServer := setupServer(t, testApp, proj, false)
+
+		//nolint:staticcheck
+		userCtx := context.WithValue(t.Context(), "claims", &jwt.MapClaims{"sub": "proj:rollback-proj:sync-role"})
+
+		updatedApp, err := appServer.Rollback(userCtx, &application.ApplicationRollbackRequest{
+			Name: &testApp.Name,
+			Id:   new(int64(1)),
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, updatedApp.Operation)
+	})
+
+	t.Run("project-scoped rollback denied when feature flag enabled and only sync granted", func(t *testing.T) {
+		testApp := newTestAppWithRollbackHistory()
+		proj := newProjectWithRole("sync-role", []string{
+			"p, proj:rollback-proj:sync-role, applications, sync, rollback-proj/test-app, allow",
+		})
+		appServer := setupServer(t, testApp, proj, true)
+
+		//nolint:staticcheck
+		userCtx := context.WithValue(t.Context(), "claims", &jwt.MapClaims{"sub": "proj:rollback-proj:sync-role"})
+
+		_, err := appServer.Rollback(userCtx, &application.ApplicationRollbackRequest{
+			Name: &testApp.Name,
+			Id:   new(int64(1)),
+		})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "permission denied")
+	})
+
+	t.Run("project-scoped no rollback or sync permission is denied", func(t *testing.T) {
+		testApp := newTestAppWithRollbackHistory()
+		proj := newProjectWithRole("readonly-role", []string{
+			"p, proj:rollback-proj:readonly-role, applications, get, rollback-proj/test-app, allow",
+		})
+		appServer := setupServer(t, testApp, proj, true)
+
+		//nolint:staticcheck
+		userCtx := context.WithValue(t.Context(), "claims", &jwt.MapClaims{"sub": "proj:rollback-proj:readonly-role"})
+
+		_, err := appServer.Rollback(userCtx, &application.ApplicationRollbackRequest{
+			Name: &testApp.Name,
+			Id:   new(int64(1)),
+		})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "permission denied")
+	})
+}

--- a/test/e2e/rollback_rbac_test.go
+++ b/test/e2e/rollback_rbac_test.go
@@ -1,0 +1,241 @@
+package e2e
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/argoproj/argo-cd/gitops-engine/v3/pkg/diff"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	. "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v3/test/e2e/fixture"
+	accountFixture "github.com/argoproj/argo-cd/v3/test/e2e/fixture/account"
+	. "github.com/argoproj/argo-cd/v3/test/e2e/fixture/app"
+	projectFixture "github.com/argoproj/argo-cd/v3/test/e2e/fixture/project"
+)
+
+// waitForRBACPermission polls "argocd account can-i" until the RBAC policy
+// propagates to the server, ensuring SetPermissions has taken effect before
+// the actual API call. Without this, the informer update race causes flaky failures.
+func waitForRBACPermission(t *testing.T, action, resource, scope string, expectAllow bool) {
+	t.Helper()
+	timeout := 15 * time.Second
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		output, _ := fixture.RunCli("account", "can-i", action, resource, scope)
+		if expectAllow && strings.Contains(output, "yes") {
+			return
+		}
+		if !expectAllow && strings.Contains(output, "no") {
+			return
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatalf("RBAC policy for %s/%s/%s (expectAllow=%v) did not propagate within %v", action, resource, scope, expectAllow, timeout)
+}
+
+func TestRollbackWithExplicitRollbackPermission(t *testing.T) {
+	appCtx := Given(t)
+
+	var appName string
+	GivenWithSameState(appCtx).
+		Path("guestbook").
+		When().
+		CreateApp().
+		Sync().
+		Then().
+		Expect(SyncStatusIs(SyncStatusCodeSynced)).
+		And(func(app *Application) {
+			appName = app.Name
+			appWithHistory := app.DeepCopy()
+			appWithHistory.Status.History = []RevisionHistory{
+				{
+					ID:         1,
+					Revision:   app.Status.Sync.Revision,
+					DeployedAt: metav1.Time{Time: metav1.Now().UTC().Add(-1 * time.Minute)},
+					Source:     app.Spec.GetSource(),
+				},
+				{
+					ID:         2,
+					Revision:   "test-revision-2",
+					DeployedAt: metav1.Time{Time: metav1.Now().UTC().Add(-2 * time.Minute)},
+					Source:     app.Spec.GetSource(),
+				},
+			}
+			patch, _, err := diff.CreateTwoWayMergePatch(app, appWithHistory, &Application{})
+			require.NoError(t, err)
+			_, err = fixture.AppClientset.ArgoprojV1alpha1().Applications(fixture.TestNamespace()).Patch(
+				t.Context(), app.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+			require.NoError(t, err)
+		})
+
+	accountFixture.GivenWithSameState(appCtx).
+		Name("rollback-user").
+		When().
+		Create().
+		Login().
+		SetPermissions([]fixture.ACL{
+			{Resource: "applications", Action: "get", Scope: "*"},
+			{Resource: "applications", Action: "rollback", Scope: "*"},
+			{Resource: "projects", Action: "get", Scope: "*"},
+		}, "rollback-user")
+
+	require.NoError(t, fixture.SetParamInSettingConfigMap("server.rbac.rollback.enforce.enable", "true"))
+	waitForRBACPermission(t, "rollback", "applications", "*", true)
+	_, err := fixture.RunCli("app", "rollback", appName, "1")
+	assert.NoError(t, err, "user with rollback permission should be able to rollback")
+}
+
+// TestRollbackWithoutExplicitRollbackPermission verifies that users with neither rollback
+// nor sync permission are denied.
+func TestRollbackWithoutExplicitRollbackPermission(t *testing.T) {
+	appCtx := Given(t)
+
+	var appName string
+	GivenWithSameState(appCtx).
+		Path("guestbook").
+		When().
+		CreateApp().
+		Sync().
+		Then().
+		Expect(SyncStatusIs(SyncStatusCodeSynced)).
+		And(func(app *Application) {
+			appName = app.Name
+			appWithHistory := app.DeepCopy()
+			appWithHistory.Status.History = []RevisionHistory{
+				{
+					ID:         1,
+					Revision:   app.Status.Sync.Revision,
+					DeployedAt: metav1.Time{Time: metav1.Now().UTC().Add(-1 * time.Minute)},
+					Source:     app.Spec.GetSource(),
+				},
+			}
+			patch, _, err := diff.CreateTwoWayMergePatch(app, appWithHistory, &Application{})
+			require.NoError(t, err)
+			_, err = fixture.AppClientset.ArgoprojV1alpha1().Applications(fixture.TestNamespace()).Patch(
+				t.Context(), app.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+			require.NoError(t, err)
+		})
+
+	accountFixture.GivenWithSameState(appCtx).
+		Name("readonly-user").
+		When().
+		Create().
+		Login().
+		SetPermissions([]fixture.ACL{
+			{Resource: "applications", Action: "get", Scope: "*"},
+			{Resource: "projects", Action: "get", Scope: "*"},
+		}, "readonly-user")
+
+	require.NoError(t, fixture.SetParamInSettingConfigMap("server.rbac.rollback.enforce.enable", "true"))
+	waitForRBACPermission(t, "rollback", "applications", "*", false)
+	_, err := fixture.RunCli("app", "rollback", appName, "1")
+	require.Error(t, err, "user without rollback or sync permission should not be able to rollback")
+	assert.ErrorContains(t, err, "permission denied")
+}
+
+// TestRollbackWithSyncPermission tests that users with sync permission can still rollback
+// for backwards compatibility
+func TestRollbackWithSyncPermission(t *testing.T) {
+	appCtx := Given(t)
+
+	var appName string
+	GivenWithSameState(appCtx).
+		Path("guestbook").
+		When().
+		CreateApp().
+		Sync().
+		Then().
+		Expect(SyncStatusIs(SyncStatusCodeSynced)).
+		And(func(app *Application) {
+			appName = app.Name
+			appWithHistory := app.DeepCopy()
+			appWithHistory.Status.History = []RevisionHistory{
+				{
+					ID:         1,
+					Revision:   app.Status.Sync.Revision,
+					DeployedAt: metav1.Time{Time: metav1.Now().UTC().Add(-1 * time.Minute)},
+					Source:     app.Spec.GetSource(),
+				},
+			}
+			patch, _, err := diff.CreateTwoWayMergePatch(app, appWithHistory, &Application{})
+			require.NoError(t, err)
+			_, err = fixture.AppClientset.ArgoprojV1alpha1().Applications(fixture.TestNamespace()).Patch(
+				t.Context(), app.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+			require.NoError(t, err)
+		})
+
+	accountFixture.GivenWithSameState(appCtx).
+		Name("sync-user").
+		When().
+		Create().
+		Login().
+		SetPermissions([]fixture.ACL{
+			{Resource: "applications", Action: "get", Scope: "*"},
+			{Resource: "applications", Action: "sync", Scope: "*"},
+			{Resource: "projects", Action: "get", Scope: "*"},
+		}, "sync-user")
+
+	waitForRBACPermission(t, "sync", "applications", "*", true)
+	_, err := fixture.RunCli("app", "rollback", appName, "1")
+	assert.NoError(t, err, "user with sync permission should be able to rollback for backwards compatibility")
+}
+
+// TestRollbackWithProjectScopedRollbackPermission tests that rollback permission can be scoped to specific projects
+func TestRollbackWithProjectScopedRollbackPermission(t *testing.T) {
+	appCtx := Given(t)
+	projCtx := projectFixture.GivenWithSameState(appCtx)
+	projCtx.Destination("*,*").
+		When().
+		Create().
+		AddSource("*")
+
+	projName := projCtx.GetName()
+
+	var appName string
+	GivenWithSameState(appCtx).
+		Path("guestbook").
+		Project(projName).
+		When().
+		CreateApp().
+		Sync().
+		Then().
+		Expect(SyncStatusIs(SyncStatusCodeSynced)).
+		And(func(app *Application) {
+			appName = app.Name
+			appWithHistory := app.DeepCopy()
+			appWithHistory.Status.History = []RevisionHistory{
+				{
+					ID:         1,
+					Revision:   app.Status.Sync.Revision,
+					DeployedAt: metav1.Time{Time: metav1.Now().UTC().Add(-1 * time.Minute)},
+					Source:     app.Spec.GetSource(),
+				},
+			}
+			patch, _, err := diff.CreateTwoWayMergePatch(app, appWithHistory, &Application{})
+			require.NoError(t, err)
+			_, err = fixture.AppClientset.ArgoprojV1alpha1().Applications(fixture.TestNamespace()).Patch(
+				t.Context(), app.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+			require.NoError(t, err)
+		})
+
+	accountFixture.GivenWithSameState(appCtx).
+		Name("scoped-rollback-user").
+		When().
+		Create().
+		Login().
+		SetPermissions([]fixture.ACL{
+			{Resource: "applications", Action: "get", Scope: projName + "/*"},
+			{Resource: "applications", Action: "rollback", Scope: projName + "/*"},
+			{Resource: "projects", Action: "get", Scope: "*"},
+		}, "scoped-rollback-user")
+
+	require.NoError(t, fixture.SetParamInSettingConfigMap("server.rbac.rollback.enforce.enable", "true"))
+	waitForRBACPermission(t, "rollback", "applications", projName+"/*", true)
+	_, err := fixture.RunCli("app", "rollback", appName, "1")
+	assert.NoError(t, err, "user with rollback permission scoped to default project should be able to rollback")
+}

--- a/util/rbac/rbac.go
+++ b/util/rbac/rbac.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -34,13 +33,12 @@ import (
 )
 
 const (
-	ConfigMapPolicyCSVKey                        = "policy.csv"
-	ConfigMapPolicyDefaultKey                    = "policy.default"
-	ConfigMapScopesKey                           = "scopes"
-	ConfigMapMatchModeKey                        = "policy.matchMode"
-	ConfigMapEnableSeparateRollbackPermissionKey = "policy.enableSeparateRollbackPermission"
-	GlobMatchMode                                = "glob"
-	RegexMatchMode                               = "regex"
+	ConfigMapPolicyCSVKey     = "policy.csv"
+	ConfigMapPolicyDefaultKey = "policy.default"
+	ConfigMapScopesKey        = "scopes"
+	ConfigMapMatchModeKey     = "policy.matchMode"
+	GlobMatchMode             = "glob"
+	RegexMatchMode            = "regex"
 
 	defaultRBACSyncPeriod = 10 * time.Minute
 )
@@ -129,19 +127,18 @@ var ProjectScoped = map[string]bool{
 // * supports a user-defined policy
 // * supports a custom JWT claims enforce function
 type Enforcer struct {
-	lock                             sync.Mutex
-	enforcerCache                    *gocache.Cache
-	adapter                          *argocdAdapter
-	enableLog                        bool
-	enabled                          bool
-	clientset                        kubernetes.Interface
-	namespace                        string
-	configmap                        string
-	claimsEnforcerFunc               ClaimsEnforcerFunc
-	model                            model.Model
-	defaultRole                      string
-	matchMode                        string
-	enableSeparateRollbackPermission bool
+	lock               sync.Mutex
+	enforcerCache      *gocache.Cache
+	adapter            *argocdAdapter
+	enableLog          bool
+	enabled            bool
+	clientset          kubernetes.Interface
+	namespace          string
+	configmap          string
+	claimsEnforcerFunc ClaimsEnforcerFunc
+	model              model.Model
+	defaultRole        string
+	matchMode          string
 }
 
 // cachedEnforcer holds the Casbin enforcer instances and optional custom project policy
@@ -552,31 +549,10 @@ func PolicyCSV(data map[string]string) string {
 	return strBuilder.String()
 }
 
-// SetSeparateRollbackPermissionEnabled enables or disables separate rollback RBAC permission.
-// When enabled, rollback operations require the `rollback` action instead of `sync`.
-func (e *Enforcer) SetSeparateRollbackPermissionEnabled(enable bool) {
-	e.lock.Lock()
-	defer e.lock.Unlock()
-	e.enableSeparateRollbackPermission = enable
-}
-
-// IsSeparateRollbackPermissionEnabled returns whether a separate rollback permission is enabled.
-func (e *Enforcer) IsSeparateRollbackPermissionEnabled() bool {
-	e.lock.Lock()
-	defer e.lock.Unlock()
-	return e.enableSeparateRollbackPermission
-}
-
 // syncUpdate updates the enforcer
 func (e *Enforcer) syncUpdate(cm *corev1.ConfigMap, onUpdated func(cm *corev1.ConfigMap) error) error {
 	e.SetDefaultRole(cm.Data[ConfigMapPolicyDefaultKey])
 	e.SetMatchMode(cm.Data[ConfigMapMatchModeKey])
-	enableSeparateRollbackStr := cm.Data[ConfigMapEnableSeparateRollbackPermissionKey]
-	enableSeparateRollback, err := strconv.ParseBool(enableSeparateRollbackStr)
-	if err != nil && enableSeparateRollbackStr != "" {
-		log.Warnf("Invalid value for %q in RBAC ConfigMap '%s': %v", ConfigMapEnableSeparateRollbackPermissionKey, e.configmap, err)
-	}
-	e.SetSeparateRollbackPermissionEnabled(enableSeparateRollback)
 	policyCSV := PolicyCSV(cm.Data)
 	if err := onUpdated(cm); err != nil {
 		return fmt.Errorf("error running policy update callback: %w", err)

--- a/util/rbac/rbac.go
+++ b/util/rbac/rbac.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -33,12 +34,13 @@ import (
 )
 
 const (
-	ConfigMapPolicyCSVKey     = "policy.csv"
-	ConfigMapPolicyDefaultKey = "policy.default"
-	ConfigMapScopesKey        = "scopes"
-	ConfigMapMatchModeKey     = "policy.matchMode"
-	GlobMatchMode             = "glob"
-	RegexMatchMode            = "regex"
+	ConfigMapPolicyCSVKey                        = "policy.csv"
+	ConfigMapPolicyDefaultKey                    = "policy.default"
+	ConfigMapScopesKey                           = "scopes"
+	ConfigMapMatchModeKey                        = "policy.matchMode"
+	ConfigMapEnableSeparateRollbackPermissionKey = "policy.enableSeparateRollbackPermission"
+	GlobMatchMode                                = "glob"
+	RegexMatchMode                               = "regex"
 
 	defaultRBACSyncPeriod = 10 * time.Minute
 )
@@ -79,6 +81,7 @@ const (
 	ActionOverride = "override"
 	ActionAction   = "action"
 	ActionInvoke   = "invoke"
+	ActionRollback = "rollback"
 )
 
 var (
@@ -103,6 +106,7 @@ var (
 		ActionUpdate,
 		ActionDelete,
 		ActionSync,
+		ActionRollback,
 		ActionOverride,
 		ActionAction,
 		ActionInvoke,
@@ -125,18 +129,19 @@ var ProjectScoped = map[string]bool{
 // * supports a user-defined policy
 // * supports a custom JWT claims enforce function
 type Enforcer struct {
-	lock               sync.Mutex
-	enforcerCache      *gocache.Cache
-	adapter            *argocdAdapter
-	enableLog          bool
-	enabled            bool
-	clientset          kubernetes.Interface
-	namespace          string
-	configmap          string
-	claimsEnforcerFunc ClaimsEnforcerFunc
-	model              model.Model
-	defaultRole        string
-	matchMode          string
+	lock                             sync.Mutex
+	enforcerCache                    *gocache.Cache
+	adapter                          *argocdAdapter
+	enableLog                        bool
+	enabled                          bool
+	clientset                        kubernetes.Interface
+	namespace                        string
+	configmap                        string
+	claimsEnforcerFunc               ClaimsEnforcerFunc
+	model                            model.Model
+	defaultRole                      string
+	matchMode                        string
+	enableSeparateRollbackPermission bool
 }
 
 // cachedEnforcer holds the Casbin enforcer instances and optional custom project policy
@@ -547,10 +552,31 @@ func PolicyCSV(data map[string]string) string {
 	return strBuilder.String()
 }
 
+// SetSeparateRollbackPermissionEnabled enables or disables separate rollback RBAC permission.
+// When enabled, rollback operations require the `rollback` action instead of `sync`.
+func (e *Enforcer) SetSeparateRollbackPermissionEnabled(enable bool) {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	e.enableSeparateRollbackPermission = enable
+}
+
+// IsSeparateRollbackPermissionEnabled returns whether a separate rollback permission is enabled.
+func (e *Enforcer) IsSeparateRollbackPermissionEnabled() bool {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	return e.enableSeparateRollbackPermission
+}
+
 // syncUpdate updates the enforcer
 func (e *Enforcer) syncUpdate(cm *corev1.ConfigMap, onUpdated func(cm *corev1.ConfigMap) error) error {
 	e.SetDefaultRole(cm.Data[ConfigMapPolicyDefaultKey])
 	e.SetMatchMode(cm.Data[ConfigMapMatchModeKey])
+	enableSeparateRollbackStr := cm.Data[ConfigMapEnableSeparateRollbackPermissionKey]
+	enableSeparateRollback, err := strconv.ParseBool(enableSeparateRollbackStr)
+	if err != nil && enableSeparateRollbackStr != "" {
+		log.Warnf("Invalid value for %q in RBAC ConfigMap '%s': %v", ConfigMapEnableSeparateRollbackPermissionKey, e.configmap, err)
+	}
+	e.SetSeparateRollbackPermissionEnabled(enableSeparateRollback)
 	policyCSV := PolicyCSV(cm.Data)
 	if err := onUpdated(cm); err != nil {
 		return fmt.Errorf("error running policy update callback: %w", err)

--- a/util/rbac/rbac_test.go
+++ b/util/rbac/rbac_test.go
@@ -193,51 +193,6 @@ func TestDefaultRole(t *testing.T) {
 	assert.True(t, enf.Enforce("bob", "applications", "get", "foo/bar"))
 }
 
-func TestEnableSeparateRollbackPermission(t *testing.T) {
-	kubeclientset := fake.NewClientset()
-	enf := NewEnforcer(kubeclientset, fakeNamespace, fakeConfigMapName, nil)
-
-	t.Run("defaults to false", func(t *testing.T) {
-		assert.False(t, enf.IsSeparateRollbackPermissionEnabled())
-	})
-
-	t.Run("set and get round-trip", func(t *testing.T) {
-		enf.SetSeparateRollbackPermissionEnabled(true)
-		assert.True(t, enf.IsSeparateRollbackPermissionEnabled())
-
-		enf.SetSeparateRollbackPermissionEnabled(false)
-		assert.False(t, enf.IsSeparateRollbackPermissionEnabled())
-	})
-
-	t.Run("syncUpdate parses 'true'", func(t *testing.T) {
-		cm := fakeConfigMap()
-		cm.Data[ConfigMapEnableSeparateRollbackPermissionKey] = "true"
-		require.NoError(t, enf.syncUpdate(cm, noOpUpdate))
-		assert.True(t, enf.IsSeparateRollbackPermissionEnabled())
-	})
-
-	t.Run("syncUpdate parses 'false'", func(t *testing.T) {
-		cm := fakeConfigMap()
-		cm.Data[ConfigMapEnableSeparateRollbackPermissionKey] = "false"
-		require.NoError(t, enf.syncUpdate(cm, noOpUpdate))
-		assert.False(t, enf.IsSeparateRollbackPermissionEnabled())
-	})
-
-	t.Run("syncUpdate treats absent key as false", func(t *testing.T) {
-		enf.SetSeparateRollbackPermissionEnabled(true)
-		require.NoError(t, enf.syncUpdate(fakeConfigMap(), noOpUpdate))
-		assert.False(t, enf.IsSeparateRollbackPermissionEnabled())
-	})
-
-	t.Run("syncUpdate treats invalid value as false", func(t *testing.T) {
-		enf.SetSeparateRollbackPermissionEnabled(true)
-		cm := fakeConfigMap()
-		cm.Data[ConfigMapEnableSeparateRollbackPermissionKey] = "not-a-bool"
-		require.NoError(t, enf.syncUpdate(cm, noOpUpdate))
-		assert.False(t, enf.IsSeparateRollbackPermissionEnabled())
-	})
-}
-
 // TestConcurrentEnforceAndSyncUpdate exercises the same access pattern that produced
 // a -race failure on the 3.2 branch: gRPC handler goroutines calling Enforce while the
 // RBAC configmap informer goroutine drives SetDefaultRole via syncUpdate, alongside

--- a/util/rbac/rbac_test.go
+++ b/util/rbac/rbac_test.go
@@ -124,6 +124,7 @@ func TestBuiltinPolicyEnforcer(t *testing.T) {
 		{"role:readonly", "applications", "get", "foo/bar"},
 		{"role:admin", "applications", "get", "foo/bar"},
 		{"role:admin", "applications", "delete", "foo/bar"},
+		{"role:admin", "applications", "rollback", "foo/bar"},
 	}
 	for _, a := range allowed {
 		if !assert.True(t, enf.Enforce(a...)) {
@@ -134,6 +135,7 @@ func TestBuiltinPolicyEnforcer(t *testing.T) {
 	disallowed := [][]any{
 		{"role:readonly", "applications", "create", "foo/bar"},
 		{"role:readonly", "applications", "delete", "foo/bar"},
+		{"role:readonly", "applications", "rollback", "foo/bar"},
 	}
 	for _, a := range disallowed {
 		if !assert.False(t, enf.Enforce(a...)) {
@@ -189,6 +191,51 @@ func TestDefaultRole(t *testing.T) {
 	// after setting the default role to be the read-only role, this should now pass
 	enf.SetDefaultRole("role:readonly")
 	assert.True(t, enf.Enforce("bob", "applications", "get", "foo/bar"))
+}
+
+func TestEnableSeparateRollbackPermission(t *testing.T) {
+	kubeclientset := fake.NewClientset()
+	enf := NewEnforcer(kubeclientset, fakeNamespace, fakeConfigMapName, nil)
+
+	t.Run("defaults to false", func(t *testing.T) {
+		assert.False(t, enf.IsSeparateRollbackPermissionEnabled())
+	})
+
+	t.Run("set and get round-trip", func(t *testing.T) {
+		enf.SetSeparateRollbackPermissionEnabled(true)
+		assert.True(t, enf.IsSeparateRollbackPermissionEnabled())
+
+		enf.SetSeparateRollbackPermissionEnabled(false)
+		assert.False(t, enf.IsSeparateRollbackPermissionEnabled())
+	})
+
+	t.Run("syncUpdate parses 'true'", func(t *testing.T) {
+		cm := fakeConfigMap()
+		cm.Data[ConfigMapEnableSeparateRollbackPermissionKey] = "true"
+		require.NoError(t, enf.syncUpdate(cm, noOpUpdate))
+		assert.True(t, enf.IsSeparateRollbackPermissionEnabled())
+	})
+
+	t.Run("syncUpdate parses 'false'", func(t *testing.T) {
+		cm := fakeConfigMap()
+		cm.Data[ConfigMapEnableSeparateRollbackPermissionKey] = "false"
+		require.NoError(t, enf.syncUpdate(cm, noOpUpdate))
+		assert.False(t, enf.IsSeparateRollbackPermissionEnabled())
+	})
+
+	t.Run("syncUpdate treats absent key as false", func(t *testing.T) {
+		enf.SetSeparateRollbackPermissionEnabled(true)
+		require.NoError(t, enf.syncUpdate(fakeConfigMap(), noOpUpdate))
+		assert.False(t, enf.IsSeparateRollbackPermissionEnabled())
+	})
+
+	t.Run("syncUpdate treats invalid value as false", func(t *testing.T) {
+		enf.SetSeparateRollbackPermissionEnabled(true)
+		cm := fakeConfigMap()
+		cm.Data[ConfigMapEnableSeparateRollbackPermissionKey] = "not-a-bool"
+		require.NoError(t, enf.syncUpdate(cm, noOpUpdate))
+		assert.False(t, enf.IsSeparateRollbackPermissionEnabled())
+	})
 }
 
 // TestConcurrentEnforceAndSyncUpdate exercises the same access pattern that produced

--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -545,6 +545,8 @@ const (
 	inClusterEnabledKey = "cluster.inClusterEnabled"
 	// settingsServerRBACEDisableFineGrainedInheritance is the key to configure find-grained RBAC inheritance
 	settingsServerRBACDisableFineGrainedInheritance = "server.rbac.disableApplicationFineGrainedRBACInheritance"
+	// settingsServerRBACRollbackEnforceEnableKey enables the dedicated rollback RBAC action in argocd-cm
+	settingsServerRBACRollbackEnforceEnableKey = "server.rbac.rollback.enforce.enable"
 	// MaxPodLogsToRender the maximum number of pod logs to render
 	settingsMaxPodLogsToRender = "server.maxPodLogsToRender"
 	// helmValuesFileSchemesKey is the key to configure the list of supported helm values file schemas
@@ -948,6 +950,19 @@ func (mgr *SettingsManager) ApplicationFineGrainedRBACInheritanceDisabled() (boo
 	}
 
 	return strconv.ParseBool(argoCDCM.Data[settingsServerRBACDisableFineGrainedInheritance])
+}
+
+func (mgr *SettingsManager) GetServerRBACRollbackEnforceEnable() (bool, error) {
+	argoCDCM, err := mgr.getConfigMap()
+	if err != nil {
+		return false, err
+	}
+
+	if argoCDCM.Data[settingsServerRBACRollbackEnforceEnableKey] == "" {
+		return false, nil
+	}
+
+	return strconv.ParseBool(argoCDCM.Data[settingsServerRBACRollbackEnforceEnableKey])
 }
 
 func (mgr *SettingsManager) GetMaxPodLogsToRender() (int64, error) {

--- a/util/settings/settings_test.go
+++ b/util/settings/settings_test.go
@@ -279,6 +279,33 @@ func TestApplicationFineGrainedRBACInheritanceDisabled(t *testing.T) {
 	assert.False(t, flag)
 }
 
+func TestGetServerRBACRollbackEnforceEnable(t *testing.T) {
+	t.Run("defaults to false when key absent", func(t *testing.T) {
+		_, settingsManager := fixtures(t.Context(), nil)
+		enabled, err := settingsManager.GetServerRBACRollbackEnforceEnable()
+		require.NoError(t, err)
+		assert.False(t, enabled)
+	})
+
+	t.Run("returns true when set to true", func(t *testing.T) {
+		_, settingsManager := fixtures(t.Context(), map[string]string{
+			"server.rbac.rollback.enforce.enable": "true",
+		})
+		enabled, err := settingsManager.GetServerRBACRollbackEnforceEnable()
+		require.NoError(t, err)
+		assert.True(t, enabled)
+	})
+
+	t.Run("returns false when explicitly set to false", func(t *testing.T) {
+		_, settingsManager := fixtures(t.Context(), map[string]string{
+			"server.rbac.rollback.enforce.enable": "false",
+		})
+		enabled, err := settingsManager.GetServerRBACRollbackEnforceEnable()
+		require.NoError(t, err)
+		assert.False(t, enabled)
+	})
+}
+
 func TestGetIsIgnoreResourceUpdatesEnabled(t *testing.T) {
 	_, settingsManager := fixtures(t.Context(), nil)
 	ignoreResourceUpdatesEnabled, err := settingsManager.GetIsIgnoreResourceUpdatesEnabled()


### PR DESCRIPTION
Adds a dedicated rollback RBAC action for applications, allowing operators to grant rollback capability independently from the existing sync permission.

The feature is opt-in via a new `argocd-rbac-cm` setting  / feature-flag :
```
policy.enableSeparateRollbackPermission: 'true'
```

- When disabled or not set at all, rollback continues to require the sync permission — no change to existing behaviour - ensures backwards compatibility.
- When enabled, the rollback action is enforced; users with only sync are denied, and users must be explicitly granted rollback.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Closes #21160

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
