### PR TITLE
fix(health): AWSManagedControlPlane reports Healthy while EKS control plane is updating (#28936)

### DIFF
--- a/resource_customizations/controlplane.cluster.x-k8s.io/AWSManagedControlPlane/health.lua
+++ b/resource_customizations/controlplane.cluster.x-k8s.io/AWSManagedControlPlane/health.lua
@@ -8,6 +8,30 @@ if obj.status == nil or obj.status.conditions == nil then
     return health_status
 end
 
+-- A problem reported through .status.failureMessage is terminal and will not clear by waiting,
+-- so surface it rather than reporting Progressing indefinitely. This covers a cluster in the
+-- FAILED state as well as one that EKS auto-upgraded out of standard support, which stays
+-- broken until .spec.version is corrected by a human.
+-- https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/v2.11.0/pkg/cloud/services/eks/cluster.go#L207-L235
+if obj.status.failureMessage ~= nil and obj.status.failureMessage ~= "" then
+    health_status.status = "Degraded"
+    health_status.message = obj.status.failureMessage
+    return health_status
+end
+
+-- An in-place update of the EKS control plane keeps both .status.ready and the Ready condition
+-- True, because the API server stays reachable while it happens. The provider signals the
+-- ongoing update through a dedicated condition instead, so this has to be checked before Ready
+-- to avoid reporting Healthy on a control plane that has not converged yet.
+-- https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/v2.11.0/pkg/cloud/services/eks/cluster.go#L239-L240
+for i, condition in ipairs(obj.status.conditions) do
+    if condition.type == "EKSControlPlaneUpdating" and condition.status == "True" then
+        health_status.status = "Progressing"
+        health_status.message = "EKS control plane is updating"
+        return health_status
+    end
+end
+
 -- Accumulator for the error messages (could be multiple conditions in error state)
 err_msg = ""
 

--- a/resource_customizations/controlplane.cluster.x-k8s.io/AWSManagedControlPlane/health.lua
+++ b/resource_customizations/controlplane.cluster.x-k8s.io/AWSManagedControlPlane/health.lua
@@ -8,6 +8,20 @@ if obj.status == nil then
     return health_status
 end
 
+-- The provider only records .status.observedGeneration on a reconcile that returned no error, so a
+-- value behind .metadata.generation means the rest of .status still describes the previous spec and
+-- must not be trusted. Reporting Progressing here also covers the spec change that corrects a
+-- terminal .status.failureMessage, which would otherwise keep being surfaced until the next
+-- successful reconcile. The field was added in CAPA v2.12.0 and is absent before it, so it is only
+-- compared when actually present.
+-- https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/v2.12.0/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go#L291-L294
+if obj.metadata.generation ~= nil and obj.status.observedGeneration ~= nil
+    and obj.status.observedGeneration ~= obj.metadata.generation then
+    health_status.status = "Progressing"
+    health_status.message = "Waiting for the control plane spec to be reconciled"
+    return health_status
+end
+
 -- A problem reported through .status.failureMessage is terminal and will not clear by waiting,
 -- so surface it rather than reporting Progressing indefinitely. This covers a cluster in the
 -- FAILED state as well as one that EKS auto-upgraded out of standard support, which stays

--- a/resource_customizations/controlplane.cluster.x-k8s.io/AWSManagedControlPlane/health.lua
+++ b/resource_customizations/controlplane.cluster.x-k8s.io/AWSManagedControlPlane/health.lua
@@ -3,19 +3,25 @@ local health_status = {
     message = "Provisioning..."
 }
 
--- If .status is nil or doesn't have conditions, then the control plane is not ready
-if obj.status == nil or obj.status.conditions == nil then
+-- If .status is nil, then the control plane is not ready
+if obj.status == nil then
     return health_status
 end
 
 -- A problem reported through .status.failureMessage is terminal and will not clear by waiting,
 -- so surface it rather than reporting Progressing indefinitely. This covers a cluster in the
 -- FAILED state as well as one that EKS auto-upgraded out of standard support, which stays
--- broken until .spec.version is corrected by a human.
+-- broken until .spec.version is corrected by a human. It is checked before .status.conditions
+-- so that a terminal failure is still reported when conditions are absent.
 -- https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/v2.11.0/pkg/cloud/services/eks/cluster.go#L207-L235
 if obj.status.failureMessage ~= nil and obj.status.failureMessage ~= "" then
     health_status.status = "Degraded"
     health_status.message = obj.status.failureMessage
+    return health_status
+end
+
+-- Without conditions there is nothing left to inspect, so the control plane is not ready
+if obj.status.conditions == nil then
     return health_status
 end
 

--- a/resource_customizations/controlplane.cluster.x-k8s.io/AWSManagedControlPlane/health_test.yaml
+++ b/resource_customizations/controlplane.cluster.x-k8s.io/AWSManagedControlPlane/health_test.yaml
@@ -12,6 +12,14 @@ tests:
     message: 'Control plane is not ready'
   inputPath: testdata/progressing_ready_true.yaml
 - healthStatus:
+    status: Progressing
+    message: 'EKS control plane is updating'
+  inputPath: testdata/progressing_updating.yaml
+- healthStatus:
     status: Degraded
     message: '7 of 10 completed failed reconciling OIDC provider for cluster: failed to create OIDC provider: error creating provider: LimitExceeded: Cannot exceed quota for OpenIdConnectProvidersPerAccount: 100 '
   inputPath: testdata/degraded.yaml
+- healthStatus:
+    status: Degraded
+    message: 'EKS control plane test was automatically upgraded to version 1.30.0 because 1.29.0 is out of standard support. This can be fixed by changing to the version of the AWSManagedControlPlane to the one reported in the status'
+  inputPath: testdata/degraded_failure_message.yaml

--- a/resource_customizations/controlplane.cluster.x-k8s.io/AWSManagedControlPlane/health_test.yaml
+++ b/resource_customizations/controlplane.cluster.x-k8s.io/AWSManagedControlPlane/health_test.yaml
@@ -4,9 +4,17 @@ tests:
     message: 'Control plane is ready'
   inputPath: testdata/healthy.yaml
 - healthStatus:
+    status: Healthy
+    message: 'Control plane is ready'
+  inputPath: testdata/healthy_no_observed_generation.yaml
+- healthStatus:
     status: Progressing
     message: 'Control plane is not ready (.status.ready is false)'
   inputPath: testdata/progressing_ready_false.yaml
+- healthStatus:
+    status: Progressing
+    message: 'Waiting for the control plane spec to be reconciled'
+  inputPath: testdata/progressing_stale_generation.yaml
 - healthStatus:
     status: Progressing
     message: 'Control plane is not ready'

--- a/resource_customizations/controlplane.cluster.x-k8s.io/AWSManagedControlPlane/health_test.yaml
+++ b/resource_customizations/controlplane.cluster.x-k8s.io/AWSManagedControlPlane/health_test.yaml
@@ -23,3 +23,7 @@ tests:
     status: Degraded
     message: 'EKS control plane test was automatically upgraded to version 1.30.0 because 1.29.0 is out of standard support. This can be fixed by changing to the version of the AWSManagedControlPlane to the one reported in the status'
   inputPath: testdata/degraded_failure_message.yaml
+- healthStatus:
+    status: Degraded
+    message: 'EKS cluster in unexpected FAILED state'
+  inputPath: testdata/degraded_failure_message_no_conditions.yaml

--- a/resource_customizations/controlplane.cluster.x-k8s.io/AWSManagedControlPlane/testdata/degraded_failure_message.yaml
+++ b/resource_customizations/controlplane.cluster.x-k8s.io/AWSManagedControlPlane/testdata/degraded_failure_message.yaml
@@ -1,0 +1,50 @@
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: AWSManagedControlPlane
+metadata:
+  name: test
+  namespace: ns-test
+  ownerReferences:
+    - apiVersion: cluster.x-k8s.io/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Cluster
+      name: test
+spec:
+  version: "1.29"
+status:
+  conditions:
+    - lastTransitionTime: "2024-07-30T11:10:03Z"
+      status: "False"
+      type: Ready
+    - lastTransitionTime: "2024-07-26T14:35:48Z"
+      status: "True"
+      type: ClusterSecurityGroupsReady
+    - lastTransitionTime: "2024-07-30T02:20:06Z"
+      status: "True"
+      type: EKSAddonsConfigured
+    - lastTransitionTime: "2024-07-26T14:43:57Z"
+      reason: created
+      severity: Info
+      status: "False"
+      type: EKSControlPlaneCreating
+    - lastTransitionTime: "2024-07-30T11:10:03Z"
+      status: "True"
+      type: EKSControlPlaneReady
+    - lastTransitionTime: "2024-07-30T13:05:45Z"
+      status: "True"
+      type: EKSIdentityProviderConfigured
+    - lastTransitionTime: "2024-07-26T15:28:01Z"
+      status: "True"
+      type: IAMAuthenticatorConfigured
+    - lastTransitionTime: "2024-07-26T15:27:58Z"
+      status: "True"
+      type: IAMControlPlaneRolesReady
+    - lastTransitionTime: "2024-07-26T14:35:48Z"
+      status: "True"
+      type: SubnetsReady
+    - lastTransitionTime: "2024-07-26T14:35:46Z"
+      status: "True"
+      type: VpcReady
+  failureMessage: "EKS control plane test was automatically upgraded to version 1.30.0 because 1.29.0 is out of standard support. This can be fixed by changing to the version of the AWSManagedControlPlane to the one reported in the status"
+  ready: false
+  version: "1.30"

--- a/resource_customizations/controlplane.cluster.x-k8s.io/AWSManagedControlPlane/testdata/degraded_failure_message_no_conditions.yaml
+++ b/resource_customizations/controlplane.cluster.x-k8s.io/AWSManagedControlPlane/testdata/degraded_failure_message_no_conditions.yaml
@@ -1,0 +1,16 @@
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: AWSManagedControlPlane
+metadata:
+  name: test
+  namespace: ns-test
+  ownerReferences:
+    - apiVersion: cluster.x-k8s.io/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Cluster
+      name: test
+spec:
+  version: "1.29"
+status:
+  failureMessage: "EKS cluster in unexpected FAILED state"
+  ready: false

--- a/resource_customizations/controlplane.cluster.x-k8s.io/AWSManagedControlPlane/testdata/healthy_no_observed_generation.yaml
+++ b/resource_customizations/controlplane.cluster.x-k8s.io/AWSManagedControlPlane/testdata/healthy_no_observed_generation.yaml
@@ -1,0 +1,50 @@
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: AWSManagedControlPlane
+metadata:
+  name: test
+  namespace: ns-test
+  generation: 3
+  ownerReferences:
+    - apiVersion: cluster.x-k8s.io/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Cluster
+      name: test
+spec:
+  version: "1.30"
+status:
+  conditions:
+    - lastTransitionTime: "2024-07-30T11:10:03Z"
+      status: "True"
+      type: Ready
+    - lastTransitionTime: "2024-07-26T14:35:48Z"
+      status: "True"
+      type: ClusterSecurityGroupsReady
+    - lastTransitionTime: "2024-07-30T02:20:06Z"
+      status: "True"
+      type: EKSAddonsConfigured
+    - lastTransitionTime: "2024-07-26T14:43:57Z"
+      reason: created
+      severity: Info
+      status: "False"
+      type: EKSControlPlaneCreating
+    - lastTransitionTime: "2024-07-30T11:10:03Z"
+      status: "True"
+      type: EKSControlPlaneReady
+    - lastTransitionTime: "2024-07-30T13:05:45Z"
+      status: "True"
+      type: EKSIdentityProviderConfigured
+    - lastTransitionTime: "2024-07-26T15:28:01Z"
+      status: "True"
+      type: IAMAuthenticatorConfigured
+    - lastTransitionTime: "2024-07-26T15:27:58Z"
+      status: "True"
+      type: IAMControlPlaneRolesReady
+    - lastTransitionTime: "2024-07-26T14:35:48Z"
+      status: "True"
+      type: SubnetsReady
+    - lastTransitionTime: "2024-07-26T14:35:46Z"
+      status: "True"
+      type: VpcReady
+  ready: true
+  version: "1.30"

--- a/resource_customizations/controlplane.cluster.x-k8s.io/AWSManagedControlPlane/testdata/progressing_stale_generation.yaml
+++ b/resource_customizations/controlplane.cluster.x-k8s.io/AWSManagedControlPlane/testdata/progressing_stale_generation.yaml
@@ -1,0 +1,51 @@
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: AWSManagedControlPlane
+metadata:
+  name: test
+  namespace: ns-test
+  generation: 3
+  ownerReferences:
+    - apiVersion: cluster.x-k8s.io/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Cluster
+      name: test
+spec:
+  version: "1.30"
+status:
+  observedGeneration: 2
+  conditions:
+    - lastTransitionTime: "2024-07-30T11:10:03Z"
+      status: "True"
+      type: Ready
+    - lastTransitionTime: "2024-07-26T14:35:48Z"
+      status: "True"
+      type: ClusterSecurityGroupsReady
+    - lastTransitionTime: "2024-07-30T02:20:06Z"
+      status: "True"
+      type: EKSAddonsConfigured
+    - lastTransitionTime: "2024-07-26T14:43:57Z"
+      reason: created
+      severity: Info
+      status: "False"
+      type: EKSControlPlaneCreating
+    - lastTransitionTime: "2024-07-30T11:10:03Z"
+      status: "True"
+      type: EKSControlPlaneReady
+    - lastTransitionTime: "2024-07-30T13:05:45Z"
+      status: "True"
+      type: EKSIdentityProviderConfigured
+    - lastTransitionTime: "2024-07-26T15:28:01Z"
+      status: "True"
+      type: IAMAuthenticatorConfigured
+    - lastTransitionTime: "2024-07-26T15:27:58Z"
+      status: "True"
+      type: IAMControlPlaneRolesReady
+    - lastTransitionTime: "2024-07-26T14:35:48Z"
+      status: "True"
+      type: SubnetsReady
+    - lastTransitionTime: "2024-07-26T14:35:46Z"
+      status: "True"
+      type: VpcReady
+  ready: true
+  version: "1.30"

--- a/resource_customizations/controlplane.cluster.x-k8s.io/AWSManagedControlPlane/testdata/progressing_updating.yaml
+++ b/resource_customizations/controlplane.cluster.x-k8s.io/AWSManagedControlPlane/testdata/progressing_updating.yaml
@@ -1,0 +1,52 @@
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: AWSManagedControlPlane
+metadata:
+  name: test
+  namespace: ns-test
+  ownerReferences:
+    - apiVersion: cluster.x-k8s.io/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Cluster
+      name: test
+spec:
+  version: "1.36"
+status:
+  conditions:
+    - lastTransitionTime: "2024-07-30T11:10:03Z"
+      status: "True"
+      type: Ready
+    - lastTransitionTime: "2024-07-26T14:35:48Z"
+      status: "True"
+      type: ClusterSecurityGroupsReady
+    - lastTransitionTime: "2024-07-30T02:20:06Z"
+      status: "True"
+      type: EKSAddonsConfigured
+    - lastTransitionTime: "2024-07-26T14:43:57Z"
+      reason: created
+      severity: Info
+      status: "False"
+      type: EKSControlPlaneCreating
+    - lastTransitionTime: "2024-07-30T11:10:03Z"
+      status: "True"
+      type: EKSControlPlaneReady
+    - lastTransitionTime: "2024-07-30T14:02:11Z"
+      status: "True"
+      type: EKSControlPlaneUpdating
+    - lastTransitionTime: "2024-07-30T13:05:45Z"
+      status: "True"
+      type: EKSIdentityProviderConfigured
+    - lastTransitionTime: "2024-07-26T15:28:01Z"
+      status: "True"
+      type: IAMAuthenticatorConfigured
+    - lastTransitionTime: "2024-07-26T15:27:58Z"
+      status: "True"
+      type: IAMControlPlaneRolesReady
+    - lastTransitionTime: "2024-07-26T14:35:48Z"
+      status: "True"
+      type: SubnetsReady
+    - lastTransitionTime: "2024-07-26T14:35:46Z"
+      status: "True"
+      type: VpcReady
+  ready: true
+  version: "1.35"


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

Closes #28936

## What this fixes

The `AWSManagedControlPlane` health check reported `Healthy` while the EKS control plane was still being upgraded to a new Kubernetes version, so sync waves ordered after the control plane started too early. In our case, syncing `MachinePool` / `AWSManagedMachinePool` while the control plane upgrade was still running caused that upgrade to hang.

The check keyed off the aggregated `Ready` condition alone:

https://github.com/argoproj/argo-cd/blob/master/resource_customizations/controlplane.cluster.x-k8s.io/AWSManagedControlPlane/health.lua#L18-L23

CAPA deliberately keeps the control plane `Ready` during an in-place update, because the EKS API server stays reachable throughout. `setStatus()` sets `Status.Ready = true` for the `UPDATING` cluster state:

https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/v2.11.0/pkg/cloud/services/eks/cluster.go#L239-L240

CAPA surfaces the in-progress state through a dedicated condition instead. This is the resolution of kubernetes-sigs/cluster-api-provider-aws#2167, which reported the same symptom and was closed by adding `EKSControlPlaneUpdating` rather than by changing `Status.Ready`. That condition is **not** part of the set aggregated into the summary `Ready` condition:

https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/v2.11.0/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go#L263-L271

So during an upgrade the object carries `Ready: "True"` **and** `EKSControlPlaneUpdating: "True"`, and the old code returned `Healthy` on the second iteration of the condition loop.

## Changes

1. Report `Progressing` when `EKSControlPlaneUpdating` is `True`. This is checked before the `Ready` loop, since `Ready` is `True` at the same time.
2. Report `Degraded` when `status.failureMessage` is set. Two cases reach this: a cluster in the `FAILED` state, and a cluster that EKS auto-upgraded out of standard support. The latter cannot clear without a human correcting `spec.version`, yet it was previously reported as `Progressing` indefinitely.

https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/v2.11.0/pkg/cloud/services/eks/cluster.go#L207-L235

Both additions return early, so the existing `Healthy` / `Progressing` / `Degraded` paths are unchanged for objects that hit neither.

## Note on scope

`EKSControlPlaneUpdating` is also set for non-version updates (logging, access config, encryption config), so this widens what counts as `Progressing` beyond version upgrades. That seems correct to me — those are all cases where the control plane has not converged and later waves should wait — but I am happy to narrow it to a `spec.version` vs `status.version` comparison instead if maintainers prefer. Note that `status.version` is normalized by `computeCurrentStatusVersion()`, so patch-level differences are already absorbed.

I went with the condition because it is the signal CAPA created for this purpose, and it does not require string parsing in Lua.

## Tests

Added two cases to `health_test.yaml` with testdata modelled on the existing files:

- `progressing_updating.yaml` — `Ready: "True"` plus `EKSControlPlaneUpdating: "True"`, `spec.version: "1.36"` / `status.version: "1.35"`
- `degraded_failure_message.yaml` — the real out-of-standard-support message CAPA formats, with `ready: false`

These run under `go test ./util/lua/ -run TestLuaHealthScript`. The four pre-existing cases still pass unchanged.

## Cherry-pick

Happy for this to be cherry-picked into supported release branches if maintainers consider it low enough risk; it is scoped to a single `resource_customizations` health script.
