### PR TITLE
chore: refresh SECURITY-INSIGHTS.yml last-updated when the release chore bumps project-release (#28725)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -385,6 +385,17 @@ jobs:
           sed -i "s/project-release: v.*$/project-release: v${NEW_VERSION}/" SECURITY-INSIGHTS.yml
           # Update the 'commit-hash: XXXXXXX' line in SECURITY-INSIGHTS.yml
           sed -i "s/commit-hash: .*/commit-hash: ${COMMIT_HASH}/" SECURITY-INSIGHTS.yml
+          # Refresh 'last-updated', because the 'project-release' edit above is a
+          # change this field is required to track. Per the Security Insights v1.0.0
+          # spec, last-updated is "the date of the last update to SECURITY-INSIGHTS.yml,
+          # excluding the properties commit-hash and last-reviewed" -- project-release
+          # is not excluded, so bumping it without bumping last-updated leaves the
+          # manifest reporting an update date older than its own contents.
+          # 'last-reviewed' and 'expiration-date' are deliberately NOT touched here:
+          # they are maintainer attestations ("reviewed by a project maintainer to
+          # confirm holistic accuracy"), and automating them would assert a review
+          # that nobody performed.
+          sed -i "s/last-updated: .*/last-updated: '$(date -u +%Y-%m-%d)'/" SECURITY-INSIGHTS.yml
         if: ${{ env.UPDATE_VERSION == 'true' }}
 
       - name: Create PR to update VERSION on master branch


### PR DESCRIPTION
### What this changes

The `Update VERSION on master branch` step in `.github/workflows/release.yaml` rewrites two fields in `SECURITY-INSIGHTS.yml` — `project-release` and `commit-hash` — and never touches `last-updated`. This adds a third `sed` so `last-updated` tracks the `project-release` edit.

```diff
           sed -i "s/commit-hash: .*/commit-hash: ${COMMIT_HASH}/" SECURITY-INSIGHTS.yml
+          sed -i "s/last-updated: .*/last-updated: '$(date -u +%Y-%m-%d)'/" SECURITY-INSIGHTS.yml
```

(plus a comment block explaining the reasoning, since the omissions below are deliberate and easy to "helpfully" undo later).

### Why `last-updated` specifically

The [Security Insights v1.0.0 spec](https://github.com/ossf/security-insights-spec/blob/v1.0.0/specification.md) defines the field as:

> `last-updated` — "The date of the last update to `SECURITY-INSIGHTS.yml`, **excluding the properties `commit-hash` and `last-reviewed`**."

`commit-hash` *is* excluded, so bumping that alone would not justify a refresh. But `project-release` is **not** in the exclusion list — so each version bump is exactly the kind of change `last-updated` is defined to track. Today the manifest ends up reporting an update date older than its own contents.

### Why this PR deliberately does *not* touch the other two dates

This is the part I'd most like a maintainer to sanity-check, because it's a judgement call rather than a mechanical one.

- `last-reviewed` — spec: *"Date this file was last reviewed by a project maintainer to confirm holistic accuracy."*
- `expiration-date` — spec: *"The date this file should no longer be considered valid, and it can be at most one year from the date it was last reviewed."*

Both are **attestations about human review**. Automating them would make the workflow assert on every release that a maintainer had re-reviewed the security posture, when nobody had. That seemed clearly worse than a stale date, so I left them alone.

That means this PR does **not** complete #28725. That issue proposed two things, and this is only the second of them:

1. A maintainer re-reviews and sets fresh `last-reviewed` / `expiration-date` — *still open, and only the team can do it*
2. Stop the chore from structurally re-staling the manifest — *this PR*

I've deliberately used a plain `Refs` reference rather than any auto-closing keyword, so merging this leaves #28725 open for item 1.

### Testing

I ran the three `sed` commands against the current `SECURITY-INSIGHTS.yml` with representative values and confirmed:

- the file still parses as YAML, with the header key set unchanged
- `last-updated` becomes a correctly quoted date string (`'2026-07-29'`), matching the spec's `Date` type
- `last-reviewed` and `expiration-date` are **byte-identical** afterwards
- indentation and the trailing comment on `expiration-date` are preserved

```
  last-updated:    '2023-10-27'  ->  '2026-07-29'
  last-reviewed:   '2023-10-27'  ->  '2023-10-27'   (unchanged)
  expiration-date: '2024-10-31T00:00:00.000Z'  ->  unchanged
```

I have not added an automated test: this is a `sed` inside a release-only workflow step and there's no existing harness for `release.yaml` that I could find. Happy to add one if you'd point me at the right pattern.

### A note on attribution

@smitkhadatkar123-rgb asked to take #28725 on and I said yes — it's genuinely theirs. They then asked me for a visual of the problem and I let the thread go quiet for two weeks, which was my fault. I've opened this so the tooling half isn't blocked on me any longer, but if @smitkhadatkar123-rgb would rather carry it, I'm glad to close this in favour of their PR — please just say so.

### Generative AI disclosure

Per the [Argo Generative AI policy](https://github.com/argoproj/argoproj/blob/main/community/genai.md): I used an AI coding assistant while investigating and drafting this.

Everything asserted above I verified myself against the current source before opening: the two existing `sed` lines and their location in `release.yaml`, the live header of `SECURITY-INSIGHTS.yml`, the v1.0.0 spec wording for all three date fields (read from the `v1.0.0` tag, not the current v2.2.0 schema, since this manifest declares `schema-version: 1.0.0`), and the `sed` behaviour above by running it. The decision to leave `last-reviewed` and `expiration-date` alone is mine, and I'd rather have it argued with than accepted quietly.

---

Checklist:

* [x] Either (a) I've created an enhancement proposal and discussed it with the community, (b) this is a bug fix, or (c) **this does not need to be in the release notes**
* [x] The title of the PR states what changed and the related issue number
* [x] The title of the PR conforms to the Title of the PR guidance
* [ ] I've included "Closes [ISSUE #]" — **intentionally not**, see above; this addresses only item 2 of #28725
* [x] N/A — no CLI or UI surface
* [ ] Does this PR require documentation updates? — I don't believe so; happy to be corrected
* [x] I have signed off all my commits as required by DCO
* [ ] I have written unit and/or e2e tests — **no**, see Testing above; verified by running the commands instead
* [x] I have added a brief description of why this PR is necessary
