### PR TITLE
fix(ui): use break-word on sync status message (#5084)

### DIFF
--- a/ui/src/app/applications/components/application-operation-state/application-operation-state.scss
+++ b/ui/src/app/applications/components/application-operation-state/application-operation-state.scss
@@ -16,9 +16,8 @@
         line-height: 16px;
         display: inline-block;
         vertical-align: middle;
-        overflow-y: hidden;
-        overflow-x: auto;
-        width: calc(100%);
+        overflow-wrap: break-word;
+        width: 100%;
     }
 
     &__images-count {

--- a/ui/src/app/applications/components/application-operation-state/application-operation-state.scss
+++ b/ui/src/app/applications/components/application-operation-state/application-operation-state.scss
@@ -16,6 +16,9 @@
         line-height: 16px;
         display: inline-block;
         vertical-align: middle;
+        overflow-y: hidden;
+        overflow-x: auto;
+        width: calc(100%);
     }
 
     &__images-count {


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

As described in #5084 the sync status error message crops and wraps, making it hard to read when it is long. I have added a scroll bar as a solution 
<img width="300" height="163" alt="image" src="https://github.com/user-attachments/assets/7fa5656e-03a0-488d-8234-cb8d346b0237" />

Closes #5084
