### PR TITLE
feat: add --file filter to 'argocd app list' to find apps affected by changed files (#21052)

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -1413,6 +1413,7 @@ func NewApplicationListCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 		appNamespace string
 		cluster      string
 		path         string
+		files        []string
 	)
 	command := &cobra.Command{
 		Use:   "list",
@@ -1425,7 +1426,10 @@ func NewApplicationListCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
   argocd app list -l app.kubernetes.io/instance!=my-app
   argocd app list -l app.kubernetes.io/instance
   argocd app list -l '!app.kubernetes.io/instance'
-  argocd app list -l 'app.kubernetes.io/instance notin (my-app,other-app)'`,
+  argocd app list -l 'app.kubernetes.io/instance notin (my-app,other-app)'
+
+  # List apps affected by a set of changed files, e.g. to find which apps a pull request impacts in a monorepo
+  argocd app list --file path/to/changed/file.yaml --file another/changed/file.yaml`,
 		Run: func(c *cobra.Command, _ []string) {
 			ctx := c.Context()
 
@@ -1451,6 +1455,9 @@ func NewApplicationListCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 			if path != "" {
 				appList = argo.FilterByPath(appList, path)
 			}
+			if len(files) != 0 {
+				appList = argo.FilterByFiles(appList, files)
+			}
 
 			switch output {
 			case "yaml", "json":
@@ -1472,6 +1479,7 @@ func NewApplicationListCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 	command.Flags().StringVarP(&appNamespace, "app-namespace", "N", "", "Only list applications in namespace")
 	command.Flags().StringVarP(&cluster, "cluster", "c", "", "List apps by cluster name or url")
 	command.Flags().StringVarP(&path, "path", "P", "", "List apps by path")
+	command.Flags().StringArrayVar(&files, "file", []string{}, "List apps affected by the given changed files, using the same matching as the 'argocd.argoproj.io/manifest-generate-paths' annotation. Can be specified multiple times.")
 	return command
 }
 

--- a/docs/user-guide/commands/argocd_app_list.md
+++ b/docs/user-guide/commands/argocd_app_list.md
@@ -20,6 +20,9 @@ argocd app list [flags]
   argocd app list -l app.kubernetes.io/instance
   argocd app list -l '!app.kubernetes.io/instance'
   argocd app list -l 'app.kubernetes.io/instance notin (my-app,other-app)'
+
+  # List apps affected by a set of changed files, e.g. to find which apps a pull request impacts in a monorepo
+  argocd app list --file path/to/changed/file.yaml --file another/changed/file.yaml
 ```
 
 ### Options
@@ -27,6 +30,7 @@ argocd app list [flags]
 ```
   -N, --app-namespace string   Only list applications in namespace
   -c, --cluster string         List apps by cluster name or url
+      --file stringArray       List apps affected by the given changed files, using the same matching as the 'argocd.argoproj.io/manifest-generate-paths' annotation. Can be specified multiple times.
   -h, --help                   help for list
   -o, --output string          Output format. One of: wide|name|json|yaml (default "wide")
   -P, --path string            List apps by path

--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -583,6 +583,21 @@ func TestAppLabels(t *testing.T) {
 		Sync("-l", label)
 }
 
+func TestAppListFilterByChangedFiles(t *testing.T) {
+	ctx := Given(t)
+	ctx.
+		Path(guestbookPath).
+		When().
+		CreateApp().
+		Then().
+		And(func(_ *Application) {
+			// A changed file under the app's source path matches the app.
+			assert.Contains(t, errors.NewHandler(t).FailOnErr(fixture.RunCli("app", "list", "--file", guestbookPath+"/guestbook-ui-deployment.yaml")), ctx.GetName())
+			// A changed file outside the app's source path does not.
+			assert.NotContains(t, errors.NewHandler(t).FailOnErr(fixture.RunCli("app", "list", "--file", "some-other-path/deployment.yaml")), ctx.GetName())
+		})
+}
+
 func TestTrackAppStateAndSyncApp(t *testing.T) {
 	ctx := Given(t)
 	ctx.Path(guestbookPath).

--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -27,6 +27,7 @@ import (
 	"github.com/argoproj/argo-cd/v3/pkg/client/clientset/versioned/typed/application/v1alpha1"
 	applicationsv1 "github.com/argoproj/argo-cd/v3/pkg/client/listers/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v3/reposerver/apiclient"
+	"github.com/argoproj/argo-cd/v3/util/app/path"
 	"github.com/argoproj/argo-cd/v3/util/db"
 	"github.com/argoproj/argo-cd/v3/util/git"
 	"github.com/argoproj/argo-cd/v3/util/glob"
@@ -187,6 +188,42 @@ func FilterByPath(apps []argoappv1.Application, path string) []argoappv1.Applica
 	for i := range apps {
 		if apps[i].Spec.GetSource().Path == path {
 			items = append(items, apps[i])
+		}
+	}
+	return items
+}
+
+// FilterByFiles returns the applications affected by the given list of changed files.
+// It reuses the same manifest-generate-paths matching that the webhook uses to decide
+// which applications to refresh when files change in a repository, which makes it useful
+// for finding the applications impacted by a set of changed files in a monorepo.
+//
+// When an application defines the manifest-generate-paths annotation, its refresh paths
+// are derived from that annotation. Otherwise the application's source path is used as the
+// refresh path, so that the filter matches only files under the application's own path
+// instead of matching every application unconditionally.
+func FilterByFiles(apps []argoappv1.Application, files []string) []argoappv1.Application {
+	if len(files) == 0 {
+		return apps
+	}
+	items := []argoappv1.Application{}
+	for i := range apps {
+		app := apps[i]
+		sources := app.Spec.GetSources()
+		if app.Spec.SourceHydrator != nil {
+			sources = append(sources, app.Spec.SourceHydrator.GetDrySource())
+		}
+		for _, source := range sources {
+			refreshPaths := path.GetSourceRefreshPaths(&app, source)
+			if len(refreshPaths) == 0 && source.Path != "" {
+				// Without a manifest-generate-paths annotation, fall back to the source
+				// path so an unannotated app matches only files under its own path.
+				refreshPaths = []string{source.Path}
+			}
+			if path.AppFilesHaveChanged(refreshPaths, files) {
+				items = append(items, app)
+				break
+			}
 		}
 	}
 	return items

--- a/util/argo/argo_test.go
+++ b/util/argo/argo_test.go
@@ -873,6 +873,76 @@ func TestFilterByPath(t *testing.T) {
 	})
 }
 
+func TestFilterByFiles(t *testing.T) {
+	t.Parallel()
+	// annotated app: refresh paths derived from the manifest-generate-paths annotation.
+	// "." resolves to the source path and "../shared" to a sibling directory.
+	annotated := argoappv1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "annotated",
+			Annotations: map[string]string{
+				argoappv1.AnnotationKeyManifestGeneratePaths: ".; ../shared",
+			},
+		},
+		Spec: argoappv1.ApplicationSpec{
+			Source: &argoappv1.ApplicationSource{Path: "apps/foo"},
+		},
+	}
+	// unannotated app: without the annotation the source path is used as the refresh path,
+	// so the filter matches only files under the app's own path.
+	unannotated := argoappv1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "unannotated"},
+		Spec: argoappv1.ApplicationSpec{
+			Source: &argoappv1.ApplicationSource{Path: "apps/bar"},
+		},
+	}
+	apps := []argoappv1.Application{annotated, unannotated}
+
+	names := func(res []argoappv1.Application) []string {
+		out := make([]string, 0, len(res))
+		for _, a := range res {
+			out = append(out, a.Name)
+		}
+		return out
+	}
+
+	t.Run("Empty filter returns all apps", func(t *testing.T) {
+		t.Parallel()
+		res := FilterByFiles(apps, nil)
+		assert.Len(t, res, 2)
+	})
+
+	t.Run("File under annotated source path matches", func(t *testing.T) {
+		t.Parallel()
+		res := FilterByFiles(apps, []string{"apps/foo/deployment.yaml"})
+		assert.Equal(t, []string{"annotated"}, names(res))
+	})
+
+	t.Run("File under annotation relative path matches", func(t *testing.T) {
+		t.Parallel()
+		res := FilterByFiles(apps, []string{"apps/shared/config.yaml"})
+		assert.Equal(t, []string{"annotated"}, names(res))
+	})
+
+	t.Run("Unannotated app matches files under its source path", func(t *testing.T) {
+		t.Parallel()
+		res := FilterByFiles(apps, []string{"apps/bar/values.yaml"})
+		assert.Equal(t, []string{"unannotated"}, names(res))
+	})
+
+	t.Run("Multiple files match multiple apps", func(t *testing.T) {
+		t.Parallel()
+		res := FilterByFiles(apps, []string{"apps/foo/x.yaml", "apps/bar/y.yaml"})
+		assert.Equal(t, []string{"annotated", "unannotated"}, names(res))
+	})
+
+	t.Run("No match returns empty", func(t *testing.T) {
+		t.Parallel()
+		res := FilterByFiles(apps, []string{"apps/other/x.yaml"})
+		assert.Empty(t, res)
+	})
+}
+
 func TestValidatePermissions(t *testing.T) {
 	t.Parallel()
 	t.Run("Empty Repo URL result in condition", func(t *testing.T) {


### PR DESCRIPTION
Closes #21052

## What does this PR do / why do we need it?

`argocd app list` can already filter applications by repo, project, cluster and path, but not by a **list of changed files**. As described in #21052, this is very useful in monorepos: given the files changed by a pull request, you often want to know exactly which applications are affected.

The single-source `--path` filter requested in #21052 already exists. This PR adds the remaining piece: a repeatable `--file` flag.

```bash
# Which apps does this PR's changed files affect?
argocd app list --file apps/foo/deployment.yaml --file libs/shared/values.yaml
```

## How it works

`--file` reuses the exact same matching that Argo CD already uses to decide which applications to refresh when files change via a webhook:

- `path.GetSourceRefreshPaths(app, source)` — derives an app's refresh paths, honoring the `argocd.argoproj.io/manifest-generate-paths` annotation (including relative entries like `.` and `../shared`).
- `path.AppFilesHaveChanged(refreshPaths, files)` — reports whether any changed file falls under those paths.

Multi-source apps and the source hydrator's dry source are handled the same way the webhook handles them (`util/webhook/webhook.go`), so `--file` and webhook-triggered refreshes stay consistent.

## One design decision worth a look

`AppFilesHaveChanged` returns `true` when an app has **no** `manifest-generate-paths` annotation (the webhook's "no annotation ⇒ always refresh" default). For a CLI *filter*, that would make every annotation-less app match unconditionally, which defeats the purpose.

So when an app has no annotation, this PR falls back to using the app's **source path** as its refresh path — an app then matches only files under its own path. This keeps `--file` useful for the common case where apps don't set the annotation. Happy to change this if maintainers prefer the strict webhook semantics instead — flagging it explicitly since it's the one behavioral judgement call here.

## Checklist

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes. — implements the accepted good-first-issue #21052.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. — this is a CLI-only command (`argocd app list`); there is no UI equivalent for it.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR. — regenerated `docs/user-guide/commands/argocd_app_list.md` and added a usage example to the command.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged. — added `TestFilterByFiles` covering annotated paths, relative annotation paths, the unannotated fallback, multi-file, and no-match cases.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). — locally: `go build`, `go test ./util/argo/`, `go vet`, `gofmt`, and `golangci-lint run` (v2.12.2) all pass; opening as draft to confirm full CI.
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).
