### PR TITLE
feat(ui): add parent app breadcrumb navigation for app-of-apps

### DIFF
--- a/ui/src/app/applications/components/application-details/application-details.tsx
+++ b/ui/src/app/applications/components/application-details/application-details.tsx
@@ -28,7 +28,7 @@ import {AppSetResourceDetails} from '../resource-details/appset-resource-details
 import * as AppUtils from '../utils';
 import {ApplicationResourceList, ApplicationResourceParentRef} from './application-resource-list';
 import {Filters, FiltersProps} from './application-resource-filter';
-import {getAppDefaultSource, getAppCurrentVersion, urlPattern, getAppParentName} from '../utils';
+import {getAppDefaultSource, getAppCurrentVersion, urlPattern, getAppParentName, loadAppAncestors} from '../utils';
 import {ChartDetails, OCIMetadata} from '../../../shared/models';
 import {ApplicationsDetailsAppDropdown} from './application-details-app-dropdown';
 import {useSidebarTarget} from '../../../sidebar/sidebar';
@@ -83,31 +83,14 @@ export const SelectNode = (fullName: string, containerIndex = 0, tab: string = n
 };
 
 const AppBreadcrumb = ({app, appName, objectListKind}: {app: appModels.Application; appName: string; objectListKind: string}) => {
+    const ctx = useContext(Context);
     const directParentName = getAppParentName(app);
     const appDropdown = <ApplicationsDetailsAppDropdown appName={appName} objectListKind={objectListKind} />;
     if (!directParentName) return appDropdown;
     return (
         <DataLoader
             input={`${app.metadata.name}/${app.metadata.namespace}`}
-            load={async () => {
-                const ancestors: Array<{name: string; namespace: string}> = [];
-                let currentName = directParentName;
-                let currentNamespace = app.metadata.namespace;
-                const visited = new Set<string>([app.metadata.name]);
-                for (let i = 0; i < 10; i++) {
-                    if (!currentName || visited.has(currentName)) break;
-                    ancestors.unshift({name: currentName, namespace: currentNamespace});
-                    visited.add(currentName);
-                    try {
-                        const parentApp = (await services.applications.get(currentName, currentNamespace, 'application')) as appModels.Application;
-                        currentName = getAppParentName(parentApp);
-                        currentNamespace = parentApp.metadata.namespace;
-                    } catch {
-                        break;
-                    }
-                }
-                return ancestors;
-            }}>
+            load={() => loadAppAncestors(app, directParentName)}>
             {(ancestors: Array<{name: string; namespace: string}>) => {
                 const chain = ancestors.filter(a => a.name !== app.metadata.name);
                 if (chain.length === 0) return appDropdown;
@@ -120,8 +103,8 @@ const AppBreadcrumb = ({app, appName, objectListKind}: {app: appModels.Applicati
                                 <DropDownMenu
                                     anchor={() => <a style={{cursor: 'pointer'}}>+{higher.length}</a>}
                                     items={higher.map(a => ({
-                                        title: <Link to={`/applications/${a.namespace}/${a.name}`}>{a.name}</Link>,
-                                        action: () => {}
+                                        title: a.name,
+                                        action: () => ctx.navigation.goto(`/applications/${a.namespace}/${a.name}`)
                                     }))}
                                 />
                                 <span style={{opacity: 0.5}}>›</span>

--- a/ui/src/app/applications/components/application-details/application-details.tsx
+++ b/ui/src/app/applications/components/application-details/application-details.tsx
@@ -1,4 +1,5 @@
-import {NotificationType, SlidingPanel, Tooltip, SplitButtonAction} from 'argo-ui';
+import {NotificationType, SlidingPanel, Tooltip, SplitButtonAction, DropDownMenu} from 'argo-ui';
+import {Link} from 'react-router-dom';
 import classNames from 'classnames';
 import React, {useState, useEffect, useCallback, useRef, useContext, FC} from 'react';
 import * as ReactDOM from 'react-dom';
@@ -27,7 +28,7 @@ import {AppSetResourceDetails} from '../resource-details/appset-resource-details
 import * as AppUtils from '../utils';
 import {ApplicationResourceList, ApplicationResourceParentRef} from './application-resource-list';
 import {Filters, FiltersProps} from './application-resource-filter';
-import {getAppDefaultSource, getAppCurrentVersion, urlPattern} from '../utils';
+import {getAppDefaultSource, getAppCurrentVersion, urlPattern, getAppParentName} from '../utils';
 import {ChartDetails, OCIMetadata} from '../../../shared/models';
 import {ApplicationsDetailsAppDropdown} from './application-details-app-dropdown';
 import {useSidebarTarget} from '../../../sidebar/sidebar';
@@ -79,6 +80,61 @@ export const NodeInfo = (node?: string): {key: string; container: number} => {
 export const SelectNode = (fullName: string, containerIndex = 0, tab: string = null, appContext: ContextApis) => {
     const node = fullName ? `${fullName}/${containerIndex}` : null;
     appContext.navigation.goto('.', {node, tab}, {replace: true});
+};
+
+const AppBreadcrumb = ({app, appName, objectListKind}: {app: appModels.Application; appName: string; objectListKind: string}) => {
+    const directParentName = getAppParentName(app);
+    const appDropdown = <ApplicationsDetailsAppDropdown appName={appName} objectListKind={objectListKind} />;
+    if (!directParentName) return appDropdown;
+    return (
+        <DataLoader
+            input={`${app.metadata.name}/${app.metadata.namespace}`}
+            load={async () => {
+                const ancestors: Array<{name: string; namespace: string}> = [];
+                let currentName = directParentName;
+                let currentNamespace = app.metadata.namespace;
+                const visited = new Set<string>([app.metadata.name]);
+                for (let i = 0; i < 10; i++) {
+                    if (!currentName || visited.has(currentName)) break;
+                    ancestors.unshift({name: currentName, namespace: currentNamespace});
+                    visited.add(currentName);
+                    try {
+                        const parentApp = (await services.applications.get(currentName, currentNamespace, 'application')) as appModels.Application;
+                        currentName = getAppParentName(parentApp);
+                        currentNamespace = parentApp.metadata.namespace;
+                    } catch {
+                        break;
+                    }
+                }
+                return ancestors;
+            }}>
+            {(ancestors: Array<{name: string; namespace: string}>) => {
+                const chain = ancestors.filter(a => a.name !== app.metadata.name);
+                if (chain.length === 0) return appDropdown;
+                const directParent = chain[chain.length - 1];
+                const higher = chain.slice(0, chain.length - 1);
+                return (
+                    <span style={{display: 'inline-flex', alignItems: 'center', gap: '4px'}}>
+                        {higher.length > 0 && (
+                            <React.Fragment>
+                                <DropDownMenu
+                                    anchor={() => <a style={{cursor: 'pointer'}}>+{higher.length}</a>}
+                                    items={higher.map(a => ({
+                                        title: <Link to={`/applications/${a.namespace}/${a.name}`}>{a.name}</Link>,
+                                        action: () => {}
+                                    }))}
+                                />
+                                <span style={{opacity: 0.5}}>›</span>
+                            </React.Fragment>
+                        )}
+                        <Link to={`/applications/${directParent.namespace}/${directParent.name}`}>{directParent.name}</Link>
+                        <span className='top-bar__sep' />
+                        {appDropdown}
+                    </span>
+                );
+            }}
+        </DataLoader>
+    );
 };
 
 export const ApplicationDetails: FC<RouteComponentProps<{appnamespace: string; name: string}> & {objectListKind: string}> = props => {
@@ -908,7 +964,11 @@ Are you sure you want to disable auto-sync and rollback application '${props.mat
                                                     title: isApplication ? 'Applications' : 'ApplicationSets',
                                                     path: isApplication ? '/applications' : '/applicationsets'
                                                 },
-                                                {title: <ApplicationsDetailsAppDropdown appName={props.match.params.name} objectListKind={objectListKind} />}
+                                                {
+                                                    title: isApplication
+                                                        ? <AppBreadcrumb app={application as appModels.Application} appName={props.match.params.name} objectListKind={objectListKind} />
+                                                        : <ApplicationsDetailsAppDropdown appName={props.match.params.name} objectListKind={objectListKind} />
+                                                }
                                             ],
                                             actionMenu: {
                                                 items: isApplication

--- a/ui/src/app/applications/components/application-details/application-details.tsx
+++ b/ui/src/app/applications/components/application-details/application-details.tsx
@@ -94,9 +94,7 @@ const AppBreadcrumb = ({app, appName, objectListKind}: {app: appModels.Applicati
     const appDropdown = <ApplicationsDetailsAppDropdown appName={appName} objectListKind={objectListKind} />;
     if (!directParentName) return appDropdown;
     return (
-        <DataLoader
-            input={`${app.metadata.name}/${app.metadata.namespace}`}
-            load={() => loadAppAncestors(app, directParentName)}>
+        <DataLoader input={`${app.metadata.name}/${app.metadata.namespace}`} load={() => loadAppAncestors(app, directParentName)}>
             {(ancestors: Array<{name: string; namespace: string}>) => {
                 const chain = ancestors.filter(a => a.name !== app.metadata.name);
                 if (chain.length === 0) return appDropdown;
@@ -964,9 +962,15 @@ Are you sure you want to disable auto-sync and rollback application '${props.mat
                                                     path: isApplication ? '/applications' : '/applicationsets'
                                                 },
                                                 {
-                                                    title: isApplication
-                                                        ? <AppBreadcrumb app={application as appModels.Application} appName={props.match.params.name} objectListKind={objectListKind} />
-                                                        : <ApplicationsDetailsAppDropdown appName={props.match.params.name} objectListKind={objectListKind} />
+                                                    title: isApplication ? (
+                                                        <AppBreadcrumb
+                                                            app={application as appModels.Application}
+                                                            appName={props.match.params.name}
+                                                            objectListKind={objectListKind}
+                                                        />
+                                                    ) : (
+                                                        <ApplicationsDetailsAppDropdown appName={props.match.params.name} objectListKind={objectListKind} />
+                                                    )
                                                 }
                                             ],
                                             actionMenu: {

--- a/ui/src/app/applications/components/application-details/application-details.tsx
+++ b/ui/src/app/applications/components/application-details/application-details.tsx
@@ -1,4 +1,5 @@
-import {NotificationType, SlidingPanel, Tooltip, SplitButtonAction} from 'argo-ui';
+import {NotificationType, SlidingPanel, Tooltip, SplitButtonAction, DropDownMenu} from 'argo-ui';
+import {Link} from 'react-router-dom';
 import classNames from 'classnames';
 import React, {useState, useEffect, useCallback, useRef, useContext, FC} from 'react';
 import * as ReactDOM from 'react-dom';
@@ -29,7 +30,7 @@ import {ApplicationResourceList, ApplicationResourceParentRef} from './applicati
 import {APPLICATION_DETAILS_SORT_KEY, ApplicationResourceSortKey, compareApplicationResource, GROUPED_NODES_DETAILS_SORT_KEY} from './application-resource-sort';
 import {useListSort} from '../../../shared/hooks/use-list-sort';
 import {Filters, FiltersProps, getEffectiveResourceFilter} from './application-resource-filter';
-import {getAppDefaultSource, getAppCurrentVersion, urlPattern, getApplicationDetailsContainerClass} from '../utils';
+import {getAppDefaultSource, getAppCurrentVersion, urlPattern, getAppParentName, getApplicationDetailsContainerClass} from '../utils';
 import {ChartDetails, OCIMetadata} from '../../../shared/models';
 import {ApplicationsDetailsAppDropdown} from './application-details-app-dropdown';
 import {useSidebarTarget} from '../../../sidebar/sidebar';
@@ -85,6 +86,61 @@ export const SelectNode = (fullName: string, containerIndex = 0, tab: string = n
     const highlightKey = NodeInfo(new URLSearchParams(window.location.search).get('highlight')).key;
     const clearHighlight = Boolean(fullName) && highlightKey === fullName;
     appContext.navigation.goto('.', clearHighlight ? {node, tab, highlight: null} : {node, tab}, {replace: true});
+};
+
+const AppBreadcrumb = ({app, appName, objectListKind}: {app: appModels.Application; appName: string; objectListKind: string}) => {
+    const directParentName = getAppParentName(app);
+    const appDropdown = <ApplicationsDetailsAppDropdown appName={appName} objectListKind={objectListKind} />;
+    if (!directParentName) return appDropdown;
+    return (
+        <DataLoader
+            input={`${app.metadata.name}/${app.metadata.namespace}`}
+            load={async () => {
+                const ancestors: Array<{name: string; namespace: string}> = [];
+                let currentName = directParentName;
+                let currentNamespace = app.metadata.namespace;
+                const visited = new Set<string>([app.metadata.name]);
+                for (let i = 0; i < 10; i++) {
+                    if (!currentName || visited.has(currentName)) break;
+                    ancestors.unshift({name: currentName, namespace: currentNamespace});
+                    visited.add(currentName);
+                    try {
+                        const parentApp = (await services.applications.get(currentName, currentNamespace, 'application')) as appModels.Application;
+                        currentName = getAppParentName(parentApp);
+                        currentNamespace = parentApp.metadata.namespace;
+                    } catch {
+                        break;
+                    }
+                }
+                return ancestors;
+            }}>
+            {(ancestors: Array<{name: string; namespace: string}>) => {
+                const chain = ancestors.filter(a => a.name !== app.metadata.name);
+                if (chain.length === 0) return appDropdown;
+                const directParent = chain[chain.length - 1];
+                const higher = chain.slice(0, chain.length - 1);
+                return (
+                    <span style={{display: 'inline-flex', alignItems: 'center', gap: '4px'}}>
+                        {higher.length > 0 && (
+                            <React.Fragment>
+                                <DropDownMenu
+                                    anchor={() => <a style={{cursor: 'pointer'}}>+{higher.length}</a>}
+                                    items={higher.map(a => ({
+                                        title: <Link to={`/applications/${a.namespace}/${a.name}`}>{a.name}</Link>,
+                                        action: () => {}
+                                    }))}
+                                />
+                                <span style={{opacity: 0.5}}>›</span>
+                            </React.Fragment>
+                        )}
+                        <Link to={`/applications/${directParent.namespace}/${directParent.name}`}>{directParent.name}</Link>
+                        <span className='top-bar__sep' />
+                        {appDropdown}
+                    </span>
+                );
+            }}
+        </DataLoader>
+    );
 };
 
 export const ApplicationDetails: FC<RouteComponentProps<{appnamespace: string; name: string}> & {objectListKind: string}> = props => {
@@ -924,7 +980,11 @@ Are you sure you want to disable auto-sync and rollback application '${props.mat
                                                     title: isApplication ? 'Applications' : 'ApplicationSets',
                                                     path: isApplication ? '/applications' : '/applicationsets'
                                                 },
-                                                {title: <ApplicationsDetailsAppDropdown appName={props.match.params.name} objectListKind={objectListKind} />}
+                                                {
+                                                    title: isApplication
+                                                        ? <AppBreadcrumb app={application as appModels.Application} appName={props.match.params.name} objectListKind={objectListKind} />
+                                                        : <ApplicationsDetailsAppDropdown appName={props.match.params.name} objectListKind={objectListKind} />
+                                                }
                                             ],
                                             actionMenu: {
                                                 items: isApplication

--- a/ui/src/app/applications/components/application-details/application-details.tsx
+++ b/ui/src/app/applications/components/application-details/application-details.tsx
@@ -30,7 +30,7 @@ import {ApplicationResourceList, ApplicationResourceParentRef} from './applicati
 import {APPLICATION_DETAILS_SORT_KEY, ApplicationResourceSortKey, compareApplicationResource, GROUPED_NODES_DETAILS_SORT_KEY} from './application-resource-sort';
 import {useListSort} from '../../../shared/hooks/use-list-sort';
 import {Filters, FiltersProps, getEffectiveResourceFilter} from './application-resource-filter';
-import {getAppDefaultSource, getAppCurrentVersion, urlPattern, getAppParentName, getApplicationDetailsContainerClass} from '../utils';
+import {getAppDefaultSource, getAppCurrentVersion, urlPattern, getAppParentName, loadAppAncestors, getApplicationDetailsContainerClass} from '../utils';
 import {ChartDetails, OCIMetadata} from '../../../shared/models';
 import {ApplicationsDetailsAppDropdown} from './application-details-app-dropdown';
 import {useSidebarTarget} from '../../../sidebar/sidebar';
@@ -89,31 +89,14 @@ export const SelectNode = (fullName: string, containerIndex = 0, tab: string = n
 };
 
 const AppBreadcrumb = ({app, appName, objectListKind}: {app: appModels.Application; appName: string; objectListKind: string}) => {
+    const ctx = useContext(Context);
     const directParentName = getAppParentName(app);
     const appDropdown = <ApplicationsDetailsAppDropdown appName={appName} objectListKind={objectListKind} />;
     if (!directParentName) return appDropdown;
     return (
         <DataLoader
             input={`${app.metadata.name}/${app.metadata.namespace}`}
-            load={async () => {
-                const ancestors: Array<{name: string; namespace: string}> = [];
-                let currentName = directParentName;
-                let currentNamespace = app.metadata.namespace;
-                const visited = new Set<string>([app.metadata.name]);
-                for (let i = 0; i < 10; i++) {
-                    if (!currentName || visited.has(currentName)) break;
-                    ancestors.unshift({name: currentName, namespace: currentNamespace});
-                    visited.add(currentName);
-                    try {
-                        const parentApp = (await services.applications.get(currentName, currentNamespace, 'application')) as appModels.Application;
-                        currentName = getAppParentName(parentApp);
-                        currentNamespace = parentApp.metadata.namespace;
-                    } catch {
-                        break;
-                    }
-                }
-                return ancestors;
-            }}>
+            load={() => loadAppAncestors(app, directParentName)}>
             {(ancestors: Array<{name: string; namespace: string}>) => {
                 const chain = ancestors.filter(a => a.name !== app.metadata.name);
                 if (chain.length === 0) return appDropdown;
@@ -126,8 +109,8 @@ const AppBreadcrumb = ({app, appName, objectListKind}: {app: appModels.Applicati
                                 <DropDownMenu
                                     anchor={() => <a style={{cursor: 'pointer'}}>+{higher.length}</a>}
                                     items={higher.map(a => ({
-                                        title: <Link to={`/applications/${a.namespace}/${a.name}`}>{a.name}</Link>,
-                                        action: () => {}
+                                        title: a.name,
+                                        action: () => ctx.navigation.goto(`/applications/${a.namespace}/${a.name}`)
                                     }))}
                                 />
                                 <span style={{opacity: 0.5}}>›</span>

--- a/ui/src/app/applications/components/application-summary/application-summary.tsx
+++ b/ui/src/app/applications/components/application-summary/application-summary.tsx
@@ -17,7 +17,7 @@ import {
     RevisionHelpIcon
 } from '../../../shared/components';
 import {BadgePanel} from '../../../shared/components';
-import {AuthSettingsCtx, Consumer, ContextApis} from '../../../shared/context';
+import {AuthSettingsCtx, Consumer, Context, ContextApis} from '../../../shared/context';
 import * as models from '../../../shared/models';
 import {services} from '../../../shared/services';
 import {isValidURL} from '../../../shared/utils';
@@ -34,7 +34,8 @@ import {
     getAppSpecDefaultSource,
     getHydratorSyncSourceRepoURL,
     appRBACName,
-    getAppParentName
+    getAppParentName,
+    loadAppAncestors
 } from '../utils';
 import {ApplicationRetryOptions} from '../application-retry-options/application-retry-options';
 import {ApplicationRetryView} from '../application-retry-view/application-retry-view';
@@ -77,6 +78,7 @@ export const ApplicationSummary = (props: ApplicationSummaryProps) => {
     const [isHydratorEnabled, setIsHydratorEnabled] = React.useState(!!app.spec.sourceHydrator);
     const [savedSyncSource, setSavedSyncSource] = React.useState(app.spec.sourceHydrator?.syncSource || {targetBranch: '', path: ''});
 
+    const ctx = React.useContext(Context);
     const notificationSubscriptions = useEditNotificationSubscriptions(app.metadata.annotations || {});
     const updateApp = notificationSubscriptions.withNotificationSubscriptions(props.updateApp);
 
@@ -111,25 +113,7 @@ export const ApplicationSummary = (props: ApplicationSummaryProps) => {
                       view: (
                           <DataLoader
                               input={`${app.metadata.name}/${app.metadata.namespace}`}
-                              load={async () => {
-                                  const ancestors: Array<{name: string; namespace: string}> = [];
-                                  let currentName = directParentName;
-                                  let currentNamespace = app.metadata.namespace;
-                                  const visited = new Set<string>([app.metadata.name]);
-                                  for (let i = 0; i < 10; i++) {
-                                      if (!currentName || visited.has(currentName)) break;
-                                      ancestors.unshift({name: currentName, namespace: currentNamespace});
-                                      visited.add(currentName);
-                                      try {
-                                          const parentApp = (await services.applications.get(currentName, currentNamespace, 'application')) as models.Application;
-                                          currentName = getAppParentName(parentApp);
-                                          currentNamespace = parentApp.metadata.namespace;
-                                      } catch {
-                                          break;
-                                      }
-                                  }
-                                  return ancestors;
-                              }}>
+                              load={() => loadAppAncestors(app, directParentName)}>
                               {(ancestors: Array<{name: string; namespace: string}>) => {
                                   const chain = ancestors.filter(a => a.name !== app.metadata.name);
                                   if (chain.length === 0) return null;
@@ -146,8 +130,8 @@ export const ApplicationSummary = (props: ApplicationSummaryProps) => {
                                                           </a>
                                                       )}
                                                       items={higher.map(a => ({
-                                                          title: <Link to={`/applications/${a.namespace}/${a.name}`}>{a.name}</Link>,
-                                                          action: () => {}
+                                                          title: a.name,
+                                                          action: () => ctx.navigation.goto(`/applications/${a.namespace}/${a.name}`)
                                                       }))}
                                                   />
                                                   <span style={{opacity: 0.5}}>›</span>

--- a/ui/src/app/applications/components/application-summary/application-summary.tsx
+++ b/ui/src/app/applications/components/application-summary/application-summary.tsx
@@ -33,7 +33,8 @@ import {
     getAppDefaultSource,
     getAppSpecDefaultSource,
     getHydratorSyncSourceRepoURL,
-    appRBACName
+    appRBACName,
+    getAppParentName
 } from '../utils';
 import {ApplicationRetryOptions} from '../application-retry-options/application-retry-options';
 import {ApplicationRetryView} from '../application-retry-view/application-retry-view';
@@ -91,6 +92,8 @@ export const ApplicationSummary = (props: ApplicationSummaryProps) => {
     const isHydrator = isHydratorEnabled;
     const repoType = source.repoURL.startsWith('oci://') ? 'oci' : (source.hasOwnProperty('chart') && 'helm') || 'git';
 
+    const directParentName = getAppParentName(app);
+
     const attributes = [
         {
             title: 'PROJECT',
@@ -101,6 +104,64 @@ export const ApplicationSummary = (props: ApplicationSummaryProps) => {
                 </DataLoader>
             )
         },
+        ...(directParentName
+            ? [
+                  {
+                      title: 'PARENT APP',
+                      view: (
+                          <DataLoader
+                              input={`${app.metadata.name}/${app.metadata.namespace}`}
+                              load={async () => {
+                                  const ancestors: Array<{name: string; namespace: string}> = [];
+                                  let currentName = directParentName;
+                                  let currentNamespace = app.metadata.namespace;
+                                  const visited = new Set<string>([app.metadata.name]);
+                                  for (let i = 0; i < 10; i++) {
+                                      if (!currentName || visited.has(currentName)) break;
+                                      ancestors.unshift({name: currentName, namespace: currentNamespace});
+                                      visited.add(currentName);
+                                      try {
+                                          const parentApp = (await services.applications.get(currentName, currentNamespace, 'application')) as models.Application;
+                                          currentName = getAppParentName(parentApp);
+                                          currentNamespace = parentApp.metadata.namespace;
+                                      } catch {
+                                          break;
+                                      }
+                                  }
+                                  return ancestors;
+                              }}>
+                              {(ancestors: Array<{name: string; namespace: string}>) => {
+                                  const chain = ancestors.filter(a => a.name !== app.metadata.name);
+                                  if (chain.length === 0) return null;
+                                  const directParent = chain[chain.length - 1];
+                                  const higher = chain.slice(0, chain.length - 1);
+                                  return (
+                                      <span style={{display: 'flex', alignItems: 'center', gap: '4px'}}>
+                                          {higher.length > 0 && (
+                                              <React.Fragment>
+                                                  <DropDownMenu
+                                                      anchor={() => (
+                                                          <a style={{cursor: 'pointer'}}>
+                                                              +{higher.length}
+                                                          </a>
+                                                      )}
+                                                      items={higher.map(a => ({
+                                                          title: <Link to={`/applications/${a.namespace}/${a.name}`}>{a.name}</Link>,
+                                                          action: () => {}
+                                                      }))}
+                                                  />
+                                                  <span style={{opacity: 0.5}}>›</span>
+                                              </React.Fragment>
+                                          )}
+                                          <Link to={`/applications/${directParent.namespace}/${directParent.name}`}>{directParent.name}</Link>
+                                      </span>
+                                  );
+                              }}
+                          </DataLoader>
+                      )
+                  }
+              ]
+            : []),
         {
             title: 'LABELS',
             view: Object.keys(app.metadata.labels || {})

--- a/ui/src/app/applications/components/application-summary/application-summary.tsx
+++ b/ui/src/app/applications/components/application-summary/application-summary.tsx
@@ -111,9 +111,7 @@ export const ApplicationSummary = (props: ApplicationSummaryProps) => {
                   {
                       title: 'PARENT APP',
                       view: (
-                          <DataLoader
-                              input={`${app.metadata.name}/${app.metadata.namespace}`}
-                              load={() => loadAppAncestors(app, directParentName)}>
+                          <DataLoader input={`${app.metadata.name}/${app.metadata.namespace}`} load={() => loadAppAncestors(app, directParentName)}>
                               {(ancestors: Array<{name: string; namespace: string}>) => {
                                   const chain = ancestors.filter(a => a.name !== app.metadata.name);
                                   if (chain.length === 0) return null;
@@ -124,11 +122,7 @@ export const ApplicationSummary = (props: ApplicationSummaryProps) => {
                                           {higher.length > 0 && (
                                               <React.Fragment>
                                                   <DropDownMenu
-                                                      anchor={() => (
-                                                          <a style={{cursor: 'pointer'}}>
-                                                              +{higher.length}
-                                                          </a>
-                                                      )}
+                                                      anchor={() => <a style={{cursor: 'pointer'}}>+{higher.length}</a>}
                                                       items={higher.map(a => ({
                                                           title: a.name,
                                                           action: () => ctx.navigation.goto(`/applications/${a.namespace}/${a.name}`)

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -2175,3 +2175,25 @@ export function getAppParentName(app: appModels.Application): string | null {
     }
     return null;
 }
+
+export async function loadAppAncestors(app: appModels.Application, directParentName: string): Promise<Array<{name: string; namespace: string}>> {
+    const ancestors: Array<{name: string; namespace: string}> = [];
+    let currentName = directParentName;
+    let currentNamespace = app.metadata.namespace;
+    const visited = new Set<string>([`${app.metadata.namespace}/${app.metadata.name}`]);
+    for (let i = 0; i < 10; i++) {
+        if (!currentName) break;
+        const key = `${currentNamespace}/${currentName}`;
+        if (visited.has(key)) break;
+        ancestors.unshift({name: currentName, namespace: currentNamespace});
+        visited.add(key);
+        try {
+            const parentApp = (await services.applications.get(currentName, currentNamespace, 'application')) as appModels.Application;
+            currentName = getAppParentName(parentApp);
+            currentNamespace = parentApp.metadata.namespace;
+        } catch {
+            break;
+        }
+    }
+    return ancestors;
+}

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -2160,3 +2160,18 @@ export function formatResourceInfo(name: string, value: string): {displayValue: 
         tooltipValue: `${name}: ${value}`
     };
 }
+
+export function getAppParentName(app: appModels.Application): string | null {
+    const instanceLabel = app.metadata.labels?.['app.kubernetes.io/instance'];
+    if (instanceLabel && instanceLabel.trim() !== '' && instanceLabel.trim() !== app.metadata.name) {
+        return instanceLabel.trim();
+    }
+    const trackingId = app.metadata.annotations?.['argocd.argoproj.io/tracking-id'];
+    if (trackingId) {
+        const name = trackingId.split(':')[0].trim();
+        if (name && name !== app.metadata.name) {
+            return name;
+        }
+    }
+    return null;
+}

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -2200,3 +2200,25 @@ export function getAppParentName(app: appModels.Application): string | null {
     }
     return null;
 }
+
+export async function loadAppAncestors(app: appModels.Application, directParentName: string): Promise<Array<{name: string; namespace: string}>> {
+    const ancestors: Array<{name: string; namespace: string}> = [];
+    let currentName = directParentName;
+    let currentNamespace = app.metadata.namespace;
+    const visited = new Set<string>([`${app.metadata.namespace}/${app.metadata.name}`]);
+    for (let i = 0; i < 10; i++) {
+        if (!currentName) break;
+        const key = `${currentNamespace}/${currentName}`;
+        if (visited.has(key)) break;
+        ancestors.unshift({name: currentName, namespace: currentNamespace});
+        visited.add(key);
+        try {
+            const parentApp = (await services.applications.get(currentName, currentNamespace, 'application')) as appModels.Application;
+            currentName = getAppParentName(parentApp);
+            currentNamespace = parentApp.metadata.namespace;
+        } catch {
+            break;
+        }
+    }
+    return ancestors;
+}

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -2185,3 +2185,18 @@ export function formatResourceInfo(name: string, value: string): {displayValue: 
         tooltipValue: `${name}: ${value}`
     };
 }
+
+export function getAppParentName(app: appModels.Application): string | null {
+    const instanceLabel = app.metadata.labels?.['app.kubernetes.io/instance'];
+    if (instanceLabel && instanceLabel.trim() !== '' && instanceLabel.trim() !== app.metadata.name) {
+        return instanceLabel.trim();
+    }
+    const trackingId = app.metadata.annotations?.['argocd.argoproj.io/tracking-id'];
+    if (trackingId) {
+        const name = trackingId.split(':')[0].trim();
+        if (name && name !== app.metadata.name) {
+            return name;
+        }
+    }
+    return null;
+}


### PR DESCRIPTION
## Summary

- Adds a parent app breadcrumb to the application detail page header and SUMMARY tab
- The direct parent app is always shown as a clickable link
- Additional ancestors (grandparent and above) are collapsed into a `+N` dropdown to keep the breadcrumb compact
- Works with both label-mode and annotation-mode resource tracking — no backend changes required

## Motivation

App-of-apps is a widely used pattern. When drilling into a child app's details there is no way to navigate back to the parent without leaving and searching the app list manually. In large deployments this gets tedious quickly.

## Implementation

Parent detection reads ArgoCD's existing tracking metadata:
- `app.kubernetes.io/instance` label (label-mode tracking, same namespace guaranteed)
- `argocd.argoproj.io/tracking-id` annotation (annotation-mode tracking, parent name before the first `:`)

The ancestor chain is walked asynchronously (up to 10 levels, cycle-safe via a visited set). A shared `getAppParentName()` utility is used by both the page breadcrumb and the SUMMARY panel row.

Closes #26537

## Test plan

- [x] Child app with a single parent: breadcrumb shows `Applications / parent-app / child-app`
- [x] Child app with 3+ ancestors: breadcrumb shows `Applications / +N › parent-app / child-app`; clicking `+N` lists the hidden ancestors as links
- [x] Standalone app (no parent): breadcrumb unchanged — `Applications / app-name`
- [x] ApplicationSet-managed apps: unaffected (`AppBreadcrumb` only active for `isApplication`)
- [x] Clicking any ancestor link navigates correctly to that app
- [x] SUMMARY tab PARENT APP row mirrors the same breadcrumb behaviour

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<img width="1678" height="374" alt="image" src="https://github.com/user-attachments/assets/26ed78fb-9507-448f-af0e-03a2eb3c9d81" />
<img width="1678" height="374" alt="image" src="https://github.com/user-attachments/assets/9dbf754a-a32b-4e51-9b8d-c01d33701dfd" />
