### PR TITLE
fix(repository): restore Normalize in UpdateRevisionForPaths to unbreak master

### DIFF
--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -3459,14 +3459,22 @@ func (s *Service) UpdateRevisionForPaths(ctx context.Context, request *apiclient
 	if repo == nil {
 		return nil, status.Error(codes.InvalidArgument, "must pass a valid repo")
 	}
-	// Determine whether the main source is a git source. An unset repository type must
-	// not be assumed to be git: an untyped Helm or OCI chart source would then have its
-	// revision resolved against the chart repository URL as if it were a git repo and
-	// fail with "repository not found" (issue #28890). When the type is unset, fall back
-	// to the application source type.
+	// Remember whether the type was set by the caller before normalizing: Normalize
+	// infers oci from an oci:// URL and otherwise defaults the type to git, so after the
+	// call an empty type is indistinguishable from an explicit git type.
+	typeWasUnset := repo.Type == ""
+	// Normalize the repository in the request to ensure all fields are correctly set
+	repo = repo.Normalize()
+
+	// Determine whether the main source is a git source. A type that Normalize defaulted
+	// to git must not be trusted on its own: an untyped Helm chart source would then have
+	// its revision resolved against the chart repository URL as if it were a git repo and
+	// fail with "repository not found" (issue #28890). In that case fall back to the
+	// application source type.
 	isGitSource := repo.Type == "git"
-	if repo.Type == "" {
-		isGitSource = request.ApplicationSource == nil || (!request.ApplicationSource.IsHelm() && !request.ApplicationSource.IsOCI())
+	if isGitSource && typeWasUnset && request.ApplicationSource != nil &&
+		(request.ApplicationSource.IsHelm() || request.ApplicationSource.IsOCI()) {
+		isGitSource = false
 	}
 
 	if len(refreshPaths) == 0 {

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -5499,6 +5499,39 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 			ExternalGets:    0,
 			ExternalSets:    0,
 		}},
+		{name: "ExplicitGitTypeWithHelmSourceStillTreatedAsGit", fields: func() fields {
+			// A repository with an explicitly configured git type must keep using the git
+			// path even when the application source carries a chart name. Only a type that
+			// Normalize defaulted to git may be overridden by the application source type,
+			// otherwise a multi source app whose git repo also sets a chart would stop
+			// having its git revision resolved at all.
+			s, _, c := newServiceWithOpt(t, func(gitClient *gitmocks.Client, _ *helmmocks.Client, _ *ocimocks.Client, paths *iomocks.TempPaths) {
+				gitClient.EXPECT().Checkout(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
+				gitClient.EXPECT().LsRemote("HEAD").Once().Return("632039659e542ed7de0c170a4fcc1c571b288fc0", nil)
+				gitClient.EXPECT().LsRemote("SYNCEDHEAD").Once().Return("632039659e542ed7de0c170a4fcc1c571b288fc0", nil)
+				paths.EXPECT().GetPath(mock.Anything).Return(".", nil)
+				paths.EXPECT().GetPathIfExists(mock.Anything).Return(".")
+			}, ".")
+			return fields{
+				service: s,
+				cache:   c,
+			}
+		}(), args: args{
+			ctx: t.Context(),
+			request: &apiclient.UpdateRevisionForPathsRequest{
+				Repo:              &v1alpha1.Repository{Repo: "a-url.com", Type: "git"},
+				Revision:          "HEAD",
+				SyncedRevision:    "SYNCEDHEAD",
+				Paths:             []string{"."},
+				ApplicationSource: &v1alpha1.ApplicationSource{Chart: "my-chart"},
+			},
+		}, want: &apiclient.UpdateRevisionForPathsResponse{
+			Revision: "632039659e542ed7de0c170a4fcc1c571b288fc0",
+		}, wantErr: assert.NoError, cacheCallCount: &repositorymocks.CacheCallCounts{
+			ExternalRenames: 0,
+			ExternalGets:    0,
+			ExternalSets:    0,
+		}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### What

Master is currently red on `Run unit tests` and `Run unit tests with -race`. `TestUpdateRevisionForPaths/OCIRepoWithEmptyTypeShortCircuits` panics. Reported by @blakepettersson in #28904.

This is a merge order race between two PRs that landed 18 minutes apart, not a defect in either one. Both were green on their own branch, and neither was re-run after the other merged:

* 07:22 UTC, #28518 taught `Repository.Normalize()` to infer the `oci` type from an `oci://` URL prefix. Its regression test `OCIRepoWithEmptyTypeShortCircuits` depends on `UpdateRevisionForPaths` calling `Normalize()`.
* 07:40 UTC, #28904 (mine, fixing #28890) removed the `repo = repo.Normalize()` call and derived the source type from `request.ApplicationSource` instead.

On master the OCI test passes `{Repo: "oci://example.com/foo"}` with no `Type` and **no** `ApplicationSource`. With `Normalize()` gone, the fallback resolves to git, so the call enters `gitSourceHasChanges`, reaches `newClient`, and panics on an unmocked `TempPaths.GetPath("oci://example.com/foo")`.

### How

Restore `repo.Normalize()`, so the `oci` inference added by #28518 applies again. Keep the application source check from #28904, but only let it override a type that `Normalize` **defaulted** to git.

The `typeWasUnset` flag is needed because `Normalize` defaults an empty type to git, so after the call an unset type is indistinguishable from an explicitly configured git type. Without that guard, a repository explicitly configured as git whose source also carries a chart name would stop having its git revision resolved at all.

Both original regression tests now pass together:

* `OCIRepoWithEmptyTypeShortCircuits` (#28518) short-circuits on the `oci://` URL.
* `UntypedHelmSourceWithRefSourcesNotTreatedAsGit` (#28904 / #28890) keeps the untyped Helm fix.

### Testing

* Reproduced the exact CI panic locally on unmodified `upstream/master`, same stack trace.
* Added `ExplicitGitTypeWithHelmSourceStillTreatedAsGit`, which fails without the `typeWasUnset` guard and passes with it, so the guard is covered rather than assumed.
* `go test ./reposerver/repository/` and `./controller/` pass. I compared the full-package failure set against unmodified `upstream/master`: with `kustomize` and `helm` installed the only difference is the two `TestUpdateRevisionForPaths` entries that this PR fixes. Nothing newly broken.
* `gofmt`, `go vet`, `go build ./...`, and `golangci-lint run ./reposerver/repository/...` (0 issues) are all clean.

Note that `TestGenerateManifestsHelmWithRefs_CachedNoLsRemote` fails identically on master and on this branch in my environment because of a local Helm version difference, unrelated to this change.

Since master is broken, this is worth merging or reverting promptly. Happy to adjust the approach if you would rather revert #28904 and have me reopen it rebased on top of #28518.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue. There is no separate tracking issue for this: the breakage is visible on master CI and was reported by a maintainer in the #28904 thread, which this PR links.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates? No, this restores previously documented behaviour.
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).
