### PR TITLE
fix(repository): detect OCI repo URL prefix when type is unset in Upd…

### DIFF
--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -3466,7 +3466,8 @@ func (s *Service) UpdateRevisionForPaths(ctx context.Context, request *apiclient
 	// to the application source type.
 	isGitSource := repo.Type == "git"
 	if repo.Type == "" {
-		isGitSource = request.ApplicationSource == nil || (!request.ApplicationSource.IsHelm() && !request.ApplicationSource.IsOCI())
+		repoIsOCI := strings.HasPrefix(repo.Repo, ociPrefix)
+		isGitSource = !repoIsOCI && (request.ApplicationSource == nil || (!request.ApplicationSource.IsHelm() && !request.ApplicationSource.IsOCI()))
 	}
 
 	if len(refreshPaths) == 0 {


### PR DESCRIPTION

PR #28904 fixed untyped Helm sources in UpdateRevisionForPaths by falling back to ApplicationSource to determine whether a repo is a git source. However, when ApplicationSource is nil, the fallback unconditionally set isGitSource = true, causing OCI repos with an empty Type field to be treated as git — falling through to gitRepoPaths.GetPath and ultimately failing with unsupported scheme oci.

This was causing the following test failure
```
 --- FAIL: TestUpdateRevisionForPaths (0.00s)
  panic:
      assert: mock: I don't know what to return because the method call was unexpected.
          Either do Mock.On("GetPath").Return(...) first, or remove the GetPath() call.
          This method was unexpected:
              GetPath(string)
              0: "oci://example.com/foo"
          at: [/Users/pat/dev/ppapapetrou76/argo-cd/util/io/mocks/TempPaths.go:86 /Users/pat/dev/ppapapetrou76/argo-cd/reposerver/repository/repository.go:2884 /Users/pat/dev/ppapapetrou76/argo-cd/reposerver/repository/repository.go:2897 /Users/pat/dev/ppapapetrou76/argo-cd/reposerver/repository/repository.go:3374 /Users/pat/dev/ppapapetrou76/argo-cd/reposerver/repository/repository.go:3485 /Users/pat/dev/ppapapetrou76/argo-cd/reposerver/repository/repository_test.go:5512 /Users/pat/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.4.darwin-arm64/src/runtime/asm_arm64.s:1447] [recovered, repanicked]

  goroutine 306 [running]:
  testing.tRunner.func1.2({0x106e52920, 0x2807cd437b0})
      /Users/pat/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.4.darwin-arm64/src/testing/testing.go:1974 +0x1a0
  testing.tRunner.func1()
      /Users/pat/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.4.darwin-arm64/src/testing/testing.go:1977 +0x318
  panic({0x106e52920?, 0x2807cd437b0?})
      /Users/pat/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.4.darwin-arm64/src/runtime/panic.go:860 +0x12c
  github.com/stretchr/testify/mock.(*Mock).fail(0x2807ce8cbe0, {0x1049203a7?, 0x8?}, {0x2807cddcf80?, 0x1?, 0x1?})
      /Users/pat/dev/ppapapetrou76/argo-cd/vendor/github.com/stretchr/testify/mock/mock.go:359 +0x138
  github.com/stretchr/testify/mock.(*Mock).MethodCalled(0x2807ce8cbe0, {0x1054aa9da, 0x7}, {0x2807cd43630, 0x1, 0x1})
      /Users/pat/dev/ppapapetrou76/argo-cd/vendor/github.com/stretchr/testify/mock/mock.go:527 +0x614
  github.com/stretchr/testify/mock.(*Mock).Called(0x2807ce8cbe0, {0x2807cd43630, 0x1, 0x1})
      /Users/pat/dev/ppapapetrou76/argo-cd/vendor/github.com/stretchr/testify/mock/mock.go:491 +0xfc
  github.com/argoproj/argo-cd/v3/util/io/mocks.(*TempPaths).GetPath(0x2807ce8cbe0, {0x2807c875de0, 0x15})
      /Users/pat/dev/ppapapetrou76/argo-cd/util/io/mocks/TempPaths.go:86 +0xfc
  github.com/argoproj/argo-cd/v3/reposerver/repository.(*Service).newClient(0x2807cf24180, 0x2807ccf3a00, {0x2807c98b780, 0x1, 0x1})
      /Users/pat/dev/ppapapetrou76/argo-cd/reposerver/repository/repository.go:2884 +0xd4
  github.com/argoproj/argo-cd/v3/reposerver/repository.(*Service).newClientResolveRevision(0x2807cf24180, 0x1022c4f0c?, {0x1047f5d26, 0x5}, {0x2807c98b780?, 0x102a7b74c?, 0x5001889c0?})
      /Users/pat/dev/ppapapetrou76/argo-cd/reposerver/repository/repository.go:2897 +0xac
  github.com/argoproj/argo-cd/v3/reposerver/repository.(*Service).gitSourceHasChanges(0x2807cf24180, {0x107644670, 0x2807ce8c1e0}, 0x2807ccf3a00, {0x1047f5d26, 0x5}, {0x1047f5d49, 0x5}, {0x2807cd43420, 0x1, ...}, ...)
      /Users/pat/dev/ppapapetrou76/argo-cd/reposerver/repository/repository.go:3374 +0x200
  github.com/argoproj/argo-cd/v3/reposerver/repository.(*Service).UpdateRevisionForPaths(0x2807cf24180, {0x107644670, 0x2807ce8c1e0}, 0x2807ca766c0)
      /Users/pat/dev/ppapapetrou76/argo-cd/reposerver/repository/repository.go:3485 +0x7e4
  github.com/argoproj/argo-cd/v3/reposerver/repository.TestUpdateRevisionForPaths.func12(0x2807ca95b08)
      /Users/pat/dev/ppapapetrou76/argo-cd/reposerver/repository/repository_test.go:5512 +0x134
  testing.tRunner(0x2807ca95b08, 0x2807c4a9a40)
      /Users/pat/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.4.darwin-arm64/src/testing/testing.go:2036 +0xc4
  created by testing.(*T).Run in goroutine 41
      /Users/pat/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.4.darwin-arm64/src/testing/testing.go:2101 +0x3a8
```

to fix it I added an exra check ,when `repo.Type` is unset, to veridy that the repo URL has an `oci://` .
An OCI URL with no explicit type is never a git source regardless of ApplicationSource.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
