### PR TITLE
test(repository): assert Changes value explicitly in UpdateRevisionForPaths test

### DIFF
--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -5527,6 +5527,7 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 			},
 		}, want: &apiclient.UpdateRevisionForPathsResponse{
 			Revision: "632039659e542ed7de0c170a4fcc1c571b288fc0",
+			Changes:  false,
 		}, wantErr: assert.NoError, cacheCallCount: &repositorymocks.CacheCallCounts{
 			ExternalRenames: 0,
 			ExternalGets:    0,


### PR DESCRIPTION
### What

Review follow up to #28979. @ranakan19 asked whether the new `ExplicitGitTypeWithHelmSourceStillTreatedAsGit` case could assert the `Changes` value as well. The comment arrived just after the merge, so this is a separate PR.

### Detail

`Changes` was already being asserted, but implicitly. The table runner compares the whole response struct:

```go
assert.Equalf(t, tt.want, got, "UpdateRevisionForPaths(%v, %v)", tt.args.ctx, tt.args.request)
```

Because `want` omitted `Changes`, it took the zero value `false`, and the struct comparison enforced it. I confirmed the assertion has teeth by flipping the expectation to `Changes: true` locally, which fails with:

```
expected: ...Changes:true...
actual  : ...Changes:false...
```

So coverage was not missing. That said, the request is a good one on readability grounds: `Changes: false` is the outcome that actually proves the git path ran and found no changes, and leaving it implicit means a reader cannot tell whether `false` was intended or simply forgotten. Sibling cases in the same table, including `UntypedHelmSourceWithRefSourcesNotTreatedAsGit` directly above, already state `Changes` explicitly.

This makes it explicit to match that convention. One line, no behaviour change, test readability only.

### Testing

* All 14 `TestUpdateRevisionForPaths` subtests pass, plus `TestErrorUpdateRevisionForPaths` and `TestUpdateRevisionForPaths_CallerMustPersistResolvedRevision`.
* `gofmt`, `go vet`, and `golangci-lint run ./reposerver/repository/...` (0 issues) are clean.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue. There is no issue: this addresses a review comment on #28979.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates? No, this is a test only change.
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).
