### PR TITLE
fix(ssd): hide secret in last-applied-configuration annotation

### DIFF
--- a/gitops-engine/pkg/diff/diff.go
+++ b/gitops-engine/pkg/diff/diff.go
@@ -1103,7 +1103,7 @@ func HideSecretData(target *unstructured.Unstructured, live *unstructured.Unstru
 	}
 
 	keys := map[string]bool{}
-	for _, obj := range []*unstructured.Unstructured{target, live, liveLastAppliedAnnotation, targetLastAppliedAnnotation} {
+	for _, obj := range []*unstructured.Unstructured{target, live, targetLastAppliedAnnotation, liveLastAppliedAnnotation} {
 		if obj == nil {
 			continue
 		}
@@ -1116,12 +1116,12 @@ func HideSecretData(target *unstructured.Unstructured, live *unstructured.Unstru
 	}
 
 	var err error
-	target, live, liveLastAppliedAnnotation, targetLastAppliedAnnotation, err = hide(target, live, liveLastAppliedAnnotation, targetLastAppliedAnnotation, keys, "data")
+	target, live, targetLastAppliedAnnotation, liveLastAppliedAnnotation, err = hide(target, live, targetLastAppliedAnnotation, liveLastAppliedAnnotation, keys, "data")
 	if err != nil {
 		return nil, nil, err
 	}
 
-	target, live, liveLastAppliedAnnotation, targetLastAppliedAnnotation, err = hide(target, live, liveLastAppliedAnnotation, targetLastAppliedAnnotation, hideAnnotations, "metadata", "annotations")
+	target, live, targetLastAppliedAnnotation, liveLastAppliedAnnotation, err = hide(target, live, targetLastAppliedAnnotation, liveLastAppliedAnnotation, hideAnnotations, "metadata", "annotations")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1163,12 +1163,12 @@ func HideSecretData(target *unstructured.Unstructured, live *unstructured.Unstru
 	return target, live, nil
 }
 
-func hide(target, live, liveLastAppliedAnnotation, targetLastAppliedAnnotation *unstructured.Unstructured, keys map[string]bool, fields ...string) (*unstructured.Unstructured, *unstructured.Unstructured, *unstructured.Unstructured, *unstructured.Unstructured, error) {
+func hide(target, live, targetLastAppliedAnnotation, liveLastAppliedAnnotation *unstructured.Unstructured, keys map[string]bool, fields ...string) (*unstructured.Unstructured, *unstructured.Unstructured, *unstructured.Unstructured, *unstructured.Unstructured, error) {
 	for k := range keys {
 		// we use "+" rather than the more common "*"
 		nextReplacement := replacement
 		valToReplacement := make(map[string]string)
-		for _, obj := range []*unstructured.Unstructured{target, live, liveLastAppliedAnnotation, targetLastAppliedAnnotation} {
+		for _, obj := range []*unstructured.Unstructured{target, live, targetLastAppliedAnnotation, liveLastAppliedAnnotation} {
 			var data map[string]any
 			if obj != nil {
 				// handles an edge case when secret data has nil value
@@ -1206,7 +1206,7 @@ func hide(target, live, liveLastAppliedAnnotation, targetLastAppliedAnnotation *
 			}
 		}
 	}
-	return target, live, liveLastAppliedAnnotation, targetLastAppliedAnnotation, nil
+	return target, live, targetLastAppliedAnnotation, liveLastAppliedAnnotation, nil
 }
 
 func toString(val any) string {

--- a/gitops-engine/pkg/diff/diff.go
+++ b/gitops-engine/pkg/diff/diff.go
@@ -196,15 +196,6 @@ func serverSideDiff(ctx context.Context, config, live *unstructured.Unstructured
 	unstructured.RemoveNestedField(live.Object, "metadata", "resourceVersion")
 	unstructured.RemoveNestedField(live.Object, "metadata", "annotations", AnnotationLastAppliedConfig)
 
-	if isCoreSecret(config) {
-		// Mask Secret data symmetrically before comparison.
-		// Equal values get equal placeholders, different values get different placeholders.
-		predictedLive, live, err = HideSecretData(predictedLive, live, nil)
-		if err != nil {
-			return nil, fmt.Errorf("error hiding secret data for resource %s/%s: %w", config.GetKind(), config.GetName(), err)
-		}
-	}
-
 	predictedLiveBytes, err := json.Marshal(predictedLive)
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling predicted live for resource %s/%s: %w", config.GetKind(), config.GetName(), err)
@@ -403,15 +394,6 @@ func jsonStrToUnstructured(jsonString string) (*unstructured.Unstructured, error
 	return &unstructured.Unstructured{Object: res}, nil
 }
 
-// isCoreSecret reports whether obj is a core/v1 Secret (Group="" and Kind="Secret").
-func isCoreSecret(obj *unstructured.Unstructured) bool {
-	if obj == nil {
-		return false
-	}
-	gvk := obj.GroupVersionKind()
-	return gvk.Group == "" && gvk.Kind == "Secret"
-}
-
 // StructuredMergeDiff will calculate the diff using the structured-merge-diff
 // k8s library (https://github.com/kubernetes-sigs/structured-merge-diff).
 func StructuredMergeDiff(config, live *unstructured.Unstructured, gvkParser *managedfields.GvkParser, manager string) (*DiffResult, error) {
@@ -562,7 +544,7 @@ func normalizeTypedValue(tv *typed.TypedValue) ([]byte, error) {
 
 func buildDiffResult(predictedBytes []byte, liveBytes []byte) *DiffResult {
 	return &DiffResult{
-		Modified:       string(liveBytes) != string(predictedBytes),
+		Modified:       !bytes.Equal(liveBytes, predictedBytes),
 		NormalizedLive: liveBytes,
 		PredictedLive:  predictedBytes,
 	}
@@ -905,7 +887,7 @@ func DiffArray(ctx context.Context, configArray, liveArray []*unstructured.Unstr
 	diffResultList := DiffResultList{
 		Diffs: make([]DiffResult, numItems),
 	}
-	for i := 0; i < numItems; i++ {
+	for i := range numItems {
 		config := configArray[i]
 		live := liveArray[i]
 		diffRes, err := Diff(ctx, config, live, opts...)
@@ -1110,16 +1092,18 @@ func CreateTwoWayMergePatch(orig, new, dataStruct any) ([]byte, bool, error) {
 // in replacement should be different.
 func HideSecretData(target *unstructured.Unstructured, live *unstructured.Unstructured, hideAnnotations map[string]bool) (*unstructured.Unstructured, *unstructured.Unstructured, error) {
 	var liveLastAppliedAnnotation *unstructured.Unstructured
+	var targetLastAppliedAnnotation *unstructured.Unstructured
 	if live != nil {
 		liveLastAppliedAnnotation, _ = GetLastAppliedConfigAnnotation(live)
 		live = live.DeepCopy()
 	}
 	if target != nil {
+		targetLastAppliedAnnotation, _ = GetLastAppliedConfigAnnotation(target)
 		target = target.DeepCopy()
 	}
 
 	keys := map[string]bool{}
-	for _, obj := range []*unstructured.Unstructured{target, live, liveLastAppliedAnnotation} {
+	for _, obj := range []*unstructured.Unstructured{target, live, liveLastAppliedAnnotation, targetLastAppliedAnnotation} {
 		if obj == nil {
 			continue
 		}
@@ -1132,12 +1116,12 @@ func HideSecretData(target *unstructured.Unstructured, live *unstructured.Unstru
 	}
 
 	var err error
-	target, live, liveLastAppliedAnnotation, err = hide(target, live, liveLastAppliedAnnotation, keys, "data")
+	target, live, liveLastAppliedAnnotation, targetLastAppliedAnnotation, err = hide(target, live, liveLastAppliedAnnotation, targetLastAppliedAnnotation, keys, "data")
 	if err != nil {
 		return nil, nil, err
 	}
 
-	target, live, liveLastAppliedAnnotation, err = hide(target, live, liveLastAppliedAnnotation, hideAnnotations, "metadata", "annotations")
+	target, live, liveLastAppliedAnnotation, targetLastAppliedAnnotation, err = hide(target, live, liveLastAppliedAnnotation, targetLastAppliedAnnotation, hideAnnotations, "metadata", "annotations")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1159,15 +1143,32 @@ func HideSecretData(target *unstructured.Unstructured, live *unstructured.Unstru
 		}
 		live.SetAnnotations(annotations)
 	}
+	if target != nil && targetLastAppliedAnnotation != nil {
+		annotations := target.GetAnnotations()
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		// special case: hide "kubectl.kubernetes.io/last-applied-configuration" annotation
+		if _, ok := hideAnnotations[corev1.LastAppliedConfigAnnotation]; ok {
+			annotations[corev1.LastAppliedConfigAnnotation] = replacement
+		} else {
+			lastAppliedData, err := json.Marshal(targetLastAppliedAnnotation)
+			if err != nil {
+				return nil, nil, fmt.Errorf("error marshaling json: %w", err)
+			}
+			annotations[corev1.LastAppliedConfigAnnotation] = string(lastAppliedData)
+		}
+		target.SetAnnotations(annotations)
+	}
 	return target, live, nil
 }
 
-func hide(target, live, liveLastAppliedAnnotation *unstructured.Unstructured, keys map[string]bool, fields ...string) (*unstructured.Unstructured, *unstructured.Unstructured, *unstructured.Unstructured, error) {
+func hide(target, live, liveLastAppliedAnnotation, targetLastAppliedAnnotation *unstructured.Unstructured, keys map[string]bool, fields ...string) (*unstructured.Unstructured, *unstructured.Unstructured, *unstructured.Unstructured, *unstructured.Unstructured, error) {
 	for k := range keys {
 		// we use "+" rather than the more common "*"
 		nextReplacement := replacement
 		valToReplacement := make(map[string]string)
-		for _, obj := range []*unstructured.Unstructured{target, live, liveLastAppliedAnnotation} {
+		for _, obj := range []*unstructured.Unstructured{target, live, liveLastAppliedAnnotation, targetLastAppliedAnnotation} {
 			var data map[string]any
 			if obj != nil {
 				// handles an edge case when secret data has nil value
@@ -1181,7 +1182,7 @@ func hide(target, live, liveLastAppliedAnnotation *unstructured.Unstructured, ke
 				var err error
 				data, _, err = unstructured.NestedMap(obj.Object, fields...)
 				if err != nil {
-					return nil, nil, nil, fmt.Errorf("unstructured.NestedMap error: %w", err)
+					return nil, nil, nil, nil, fmt.Errorf("unstructured.NestedMap error: %w", err)
 				}
 			}
 			if data == nil {
@@ -1201,11 +1202,11 @@ func hide(target, live, liveLastAppliedAnnotation *unstructured.Unstructured, ke
 			data[k] = replacement
 			err := unstructured.SetNestedField(obj.Object, data, fields...)
 			if err != nil {
-				return nil, nil, nil, fmt.Errorf("unstructured.SetNestedField error: %w", err)
+				return nil, nil, nil, nil, fmt.Errorf("unstructured.SetNestedField error: %w", err)
 			}
 		}
 	}
-	return target, live, liveLastAppliedAnnotation, nil
+	return target, live, liveLastAppliedAnnotation, targetLastAppliedAnnotation, nil
 }
 
 func toString(val any) string {

--- a/gitops-engine/pkg/diff/diff.go
+++ b/gitops-engine/pkg/diff/diff.go
@@ -1091,15 +1091,9 @@ func CreateTwoWayMergePatch(orig, new, dataStruct any) ([]byte, bool, error) {
 // applied configuration annotation of both the target and live secrets with plus(+). Also preserves differences between
 // target, live and last applied config values. E.g. if all three are equal the values would be replaced with same number of plus(+). If all are different then number of plus(+)
 // in replacement should be different.
-// If the last-applied-configuration annotation is present but cannot be parsed as JSON, its raw value may still embed
-// sensitive Secret material, so the whole annotation value is replaced with the placeholder (fail closed).
 func HideSecretData(target *unstructured.Unstructured, live *unstructured.Unstructured, hideAnnotations map[string]bool) (*unstructured.Unstructured, *unstructured.Unstructured, error) {
 	var liveLastAppliedAnnotation *unstructured.Unstructured
 	var targetLastAppliedAnnotation *unstructured.Unstructured
-	// liveLastAppliedInvalid/targetLastAppliedInvalid track the case where the
-	// last-applied-configuration annotation is present but cannot be parsed as JSON.
-	// The raw annotation may still embed sensitive Secret material, so it must be
-	// masked rather than left untouched (fail closed).
 	var liveLastAppliedInvalid, targetLastAppliedInvalid bool
 	if live != nil {
 		var err error
@@ -1143,9 +1137,7 @@ func HideSecretData(target *unstructured.Unstructured, live *unstructured.Unstru
 		if annotations == nil {
 			annotations = make(map[string]string)
 		}
-		// special case: hide "kubectl.kubernetes.io/last-applied-configuration" annotation.
-		// When the annotation is explicitly hidden, or its value could not be parsed as JSON
-		// (and may therefore embed raw Secret material), replace the whole value with the placeholder.
+		// special case: hide "kubectl.kubernetes.io/last-applied-configuration" annotation
 		if _, ok := hideAnnotations[corev1.LastAppliedConfigAnnotation]; ok || liveLastAppliedInvalid {
 			annotations[corev1.LastAppliedConfigAnnotation] = replacement
 		} else {
@@ -1162,9 +1154,7 @@ func HideSecretData(target *unstructured.Unstructured, live *unstructured.Unstru
 		if annotations == nil {
 			annotations = make(map[string]string)
 		}
-		// special case: hide "kubectl.kubernetes.io/last-applied-configuration" annotation.
-		// When the annotation is explicitly hidden, or its value could not be parsed as JSON
-		// (and may therefore embed raw Secret material), replace the whole value with the placeholder.
+		// special case: hide "kubectl.kubernetes.io/last-applied-configuration" annotation
 		if _, ok := hideAnnotations[corev1.LastAppliedConfigAnnotation]; ok || targetLastAppliedInvalid {
 			annotations[corev1.LastAppliedConfigAnnotation] = replacement
 		} else {

--- a/gitops-engine/pkg/diff/diff.go
+++ b/gitops-engine/pkg/diff/diff.go
@@ -1087,18 +1087,30 @@ func CreateTwoWayMergePatch(orig, new, dataStruct any) ([]byte, bool, error) {
 	return patch, string(patch) != "{}", nil
 }
 
-// HideSecretData replaces secret data & optional annotations values in specified target, live secrets and in last applied configuration of live secret with plus(+). Also preserves differences between
+// HideSecretData replaces secret data & optional annotations values in specified target, live secrets and in the last
+// applied configuration annotation of both the target and live secrets with plus(+). Also preserves differences between
 // target, live and last applied config values. E.g. if all three are equal the values would be replaced with same number of plus(+). If all are different then number of plus(+)
 // in replacement should be different.
+// If the last-applied-configuration annotation is present but cannot be parsed as JSON, its raw value may still embed
+// sensitive Secret material, so the whole annotation value is replaced with the placeholder (fail closed).
 func HideSecretData(target *unstructured.Unstructured, live *unstructured.Unstructured, hideAnnotations map[string]bool) (*unstructured.Unstructured, *unstructured.Unstructured, error) {
 	var liveLastAppliedAnnotation *unstructured.Unstructured
 	var targetLastAppliedAnnotation *unstructured.Unstructured
+	// liveLastAppliedInvalid/targetLastAppliedInvalid track the case where the
+	// last-applied-configuration annotation is present but cannot be parsed as JSON.
+	// The raw annotation may still embed sensitive Secret material, so it must be
+	// masked rather than left untouched (fail closed).
+	var liveLastAppliedInvalid, targetLastAppliedInvalid bool
 	if live != nil {
-		liveLastAppliedAnnotation, _ = GetLastAppliedConfigAnnotation(live)
+		var err error
+		liveLastAppliedAnnotation, err = GetLastAppliedConfigAnnotation(live)
+		liveLastAppliedInvalid = err != nil
 		live = live.DeepCopy()
 	}
 	if target != nil {
-		targetLastAppliedAnnotation, _ = GetLastAppliedConfigAnnotation(target)
+		var err error
+		targetLastAppliedAnnotation, err = GetLastAppliedConfigAnnotation(target)
+		targetLastAppliedInvalid = err != nil
 		target = target.DeepCopy()
 	}
 
@@ -1126,13 +1138,15 @@ func HideSecretData(target *unstructured.Unstructured, live *unstructured.Unstru
 		return nil, nil, err
 	}
 
-	if live != nil && liveLastAppliedAnnotation != nil {
+	if live != nil && (liveLastAppliedAnnotation != nil || liveLastAppliedInvalid) {
 		annotations := live.GetAnnotations()
 		if annotations == nil {
 			annotations = make(map[string]string)
 		}
-		// special case: hide "kubectl.kubernetes.io/last-applied-configuration" annotation
-		if _, ok := hideAnnotations[corev1.LastAppliedConfigAnnotation]; ok {
+		// special case: hide "kubectl.kubernetes.io/last-applied-configuration" annotation.
+		// When the annotation is explicitly hidden, or its value could not be parsed as JSON
+		// (and may therefore embed raw Secret material), replace the whole value with the placeholder.
+		if _, ok := hideAnnotations[corev1.LastAppliedConfigAnnotation]; ok || liveLastAppliedInvalid {
 			annotations[corev1.LastAppliedConfigAnnotation] = replacement
 		} else {
 			lastAppliedData, err := json.Marshal(liveLastAppliedAnnotation)
@@ -1143,13 +1157,15 @@ func HideSecretData(target *unstructured.Unstructured, live *unstructured.Unstru
 		}
 		live.SetAnnotations(annotations)
 	}
-	if target != nil && targetLastAppliedAnnotation != nil {
+	if target != nil && (targetLastAppliedAnnotation != nil || targetLastAppliedInvalid) {
 		annotations := target.GetAnnotations()
 		if annotations == nil {
 			annotations = make(map[string]string)
 		}
-		// special case: hide "kubectl.kubernetes.io/last-applied-configuration" annotation
-		if _, ok := hideAnnotations[corev1.LastAppliedConfigAnnotation]; ok {
+		// special case: hide "kubectl.kubernetes.io/last-applied-configuration" annotation.
+		// When the annotation is explicitly hidden, or its value could not be parsed as JSON
+		// (and may therefore embed raw Secret material), replace the whole value with the placeholder.
+		if _, ok := hideAnnotations[corev1.LastAppliedConfigAnnotation]; ok || targetLastAppliedInvalid {
 			annotations[corev1.LastAppliedConfigAnnotation] = replacement
 		} else {
 			lastAppliedData, err := json.Marshal(targetLastAppliedAnnotation)

--- a/gitops-engine/pkg/diff/diff_test.go
+++ b/gitops-engine/pkg/diff/diff_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -481,7 +480,7 @@ func TestThreeWayDiffExample2WithDifference(t *testing.T) {
 	showsMissing := 0
 	showsExtra := 0
 	showsChanged := 0
-	for _, line := range strings.Split(ascii, "\n") {
+	for line := range strings.SplitSeq(ascii, "\n") {
 		if strings.HasPrefix(line, `>     foo: bar`) {
 			showsMissing++
 		}
@@ -1255,196 +1254,6 @@ func TestServerSideDiff(t *testing.T) {
 		assert.Contains(t, liveData, "key2")
 		assert.Contains(t, liveData, "key3", "key3 should still be in live state")
 	})
-
-	t.Run("will mask Secret data symmetrically so identical values do not produce a spurious diff", func(t *testing.T) {
-		t.Parallel()
-
-		desired := buildSecret("test-secret", "default", map[string]string{"password": "vault:secret/foo"}, nil)
-		live := buildSecret("test-secret", "default", map[string]string{"password": "injected-by-webhook"}, nil)
-		predictedLiveJSON := mustMarshalJSON(t, buildSecret("test-secret", "default", map[string]string{"password": "injected-by-webhook"}, nil))
-
-		opts := append(buildOpts(predictedLiveJSON), WithIgnoreMutationWebhook(false))
-		result, err := serverSideDiff(t.Context(), desired, live, opts...)
-		require.NoError(t, err)
-		require.NotNil(t, result)
-
-		assert.False(t, result.Modified, "identical secret values on both sides must not be flagged as modified after masking")
-
-		predictedData := mustGetSecretData(t, result.PredictedLive)
-		liveData := mustGetSecretData(t, result.NormalizedLive)
-		assert.Equal(t, "++++++++", predictedData["password"], "predicted data must be masked, not raw")
-		assert.Equal(t, "++++++++", liveData["password"], "live data must be masked, not raw")
-	})
-
-	t.Run("will keep Secret data masked but still detect genuine value differences", func(t *testing.T) {
-		t.Parallel()
-
-		desired := buildSecret("test-secret", "default", map[string]string{"password": "vault:secret/foo"}, nil)
-		live := buildSecret("test-secret", "default", map[string]string{"password": "old-value"}, nil)
-		predictedLiveJSON := mustMarshalJSON(t, buildSecret("test-secret", "default", map[string]string{"password": "new-value"}, nil))
-
-		opts := append(buildOpts(predictedLiveJSON), WithIgnoreMutationWebhook(false))
-		result, err := serverSideDiff(t.Context(), desired, live, opts...)
-		require.NoError(t, err)
-		require.NotNil(t, result)
-
-		assert.True(t, result.Modified, "different secret values must still be flagged as modified")
-
-		predictedData := mustGetSecretData(t, result.PredictedLive)
-		liveData := mustGetSecretData(t, result.NormalizedLive)
-		// HideSecretData yields different placeholder lengths for different values, so the
-		// data field is masked on both sides and the two placeholders differ.
-		assert.NotEqual(t, "new-value", predictedData["password"], "raw new value must not leak into PredictedLive")
-		assert.NotEqual(t, "old-value", liveData["password"], "raw old value must not leak into NormalizedLive")
-		assert.NotEqual(t, predictedData["password"], liveData["password"], "differing values must yield differing placeholders")
-	})
-
-	t.Run("will detect Secret key additions and removals", func(t *testing.T) {
-		t.Parallel()
-
-		desired := buildSecret("test-secret", "default", map[string]string{"password": "x", "token": "y"}, nil)
-		live := buildSecret("test-secret", "default", map[string]string{"password": "x"}, nil)
-		predictedLiveJSON := mustMarshalJSON(t, buildSecret("test-secret", "default", map[string]string{"password": "x", "token": "y"}, nil))
-
-		opts := append(buildOpts(predictedLiveJSON), WithIgnoreMutationWebhook(false))
-		result, err := serverSideDiff(t.Context(), desired, live, opts...)
-		require.NoError(t, err)
-		require.NotNil(t, result)
-
-		assert.True(t, result.Modified, "added Secret keys must still be flagged as modified after masking")
-	})
-
-	t.Run("will not mask non-core Secret resources", func(t *testing.T) {
-		// Resources whose Kind is "Secret" but whose Group is non-empty (e.g. CRDs)
-		// must not be touched by the core/v1 Secret masking path.
-		t.Parallel()
-
-		desired := buildSecret("test-secret", "default", map[string]string{"password": "raw-value"}, nil)
-		desired.SetAPIVersion("custom.io/v1")
-		live := buildSecret("test-secret", "default", map[string]string{"password": "raw-value"}, nil)
-		live.SetAPIVersion("custom.io/v1")
-		predictedLiveJSON := mustMarshalJSON(t, desired)
-
-		opts := append(buildOpts(predictedLiveJSON), WithIgnoreMutationWebhook(false))
-		result, err := serverSideDiff(t.Context(), desired, live, opts...)
-		require.NoError(t, err)
-		require.NotNil(t, result)
-
-		predictedData := mustGetSecretData(t, result.PredictedLive)
-		assert.Equal(t, "raw-value", predictedData["password"], "non-core Secret data must be left untouched")
-	})
-	t.Run("will strip kubectl.kubernetes.io/last-applied-configuration from both sides", func(t *testing.T) {
-		t.Parallel()
-
-		const lastAppliedRaw = `{"apiVersion":"v1","kind":"Secret","metadata":{"name":"secret","namespace":"default","annotations":{"app":"test"}},"data":{"password":"U0VDUkVUVkFM"},"stringData":{"username":"SECRETVAL"}}`
-
-		liveState := StrToUnstructured(`{
-			"apiVersion": "v1",
-			"kind": "Secret",
-			"metadata": {
-				"name": "secret",
-				"namespace": "default",
-				"annotations": {
-					"app": "test",
-					"kubectl.kubernetes.io/last-applied-configuration": ` + strconv.Quote(lastAppliedRaw) + `
-				}
-			},
-			"type": "Opaque",
-			"data": {
-				"password": "U0VDUkVUVkFM"
-			}
-		}`)
-		desiredState := StrToUnstructured(`{
-			"apiVersion": "v1",
-			"kind": "Secret",
-			"metadata": {
-				"name": "secret",
-				"namespace": "default",
-				"annotations": {
-					"app": "test"
-				}
-			},
-			"type": "Opaque",
-			"data": {
-				"password": "U0VDUkVUVkFM"
-			}
-		}`)
-		predictedLiveJSON := `{
-			"apiVersion": "v1",
-			"kind": "Secret",
-			"metadata": {
-				"name": "secret",
-				"namespace": "default",
-				"annotations": {
-					"app": "test",
-					"kubectl.kubernetes.io/last-applied-configuration": ` + strconv.Quote(lastAppliedRaw) + `
-				}
-			},
-			"type": "Opaque",
-			"data": {
-				"password": "U0VDUkVUVkFM"
-			}
-		}`
-		opts := buildOpts(predictedLiveJSON)
-		opts = append(opts, WithIgnoreMutationWebhook(false))
-
-		// when
-		result, err := serverSideDiff(t.Context(), desiredState, liveState, opts...)
-
-		// then
-		require.NoError(t, err)
-		require.NotNil(t, result)
-		assert.NotContains(t, string(result.PredictedLive), "kubectl.kubernetes.io/last-applied-configuration",
-			"PredictedLive must not contain the last-applied-configuration annotation")
-		assert.NotContains(t, string(result.NormalizedLive), "kubectl.kubernetes.io/last-applied-configuration",
-			"NormalizedLive must not contain the last-applied-configuration annotation")
-		assert.NotContains(t, string(result.PredictedLive), "U0VDUkVUVkFM",
-			"PredictedLive must not contain raw secret values from last-applied-configuration")
-		assert.NotContains(t, string(result.PredictedLive), "SECRETVAL",
-			"PredictedLive must not contain raw secret values from last-applied-configuration")
-	})
-}
-
-// buildSecret returns a core/v1 Secret as an *unstructured.Unstructured.
-func buildSecret(name, namespace string, data map[string]string, annotations map[string]string) *unstructured.Unstructured {
-	dataField := make(map[string]any, len(data))
-	for k, v := range data {
-		dataField[k] = v
-	}
-	metadata := map[string]any{
-		"name":      name,
-		"namespace": namespace,
-	}
-	if len(annotations) > 0 {
-		annField := make(map[string]any, len(annotations))
-		for k, v := range annotations {
-			annField[k] = v
-		}
-		metadata["annotations"] = annField
-	}
-	return &unstructured.Unstructured{Object: map[string]any{
-		"apiVersion": "v1",
-		"kind":       "Secret",
-		"metadata":   metadata,
-		"type":       "Opaque",
-		"data":       dataField,
-	}}
-}
-
-func mustMarshalJSON(t *testing.T, obj *unstructured.Unstructured) string {
-	t.Helper()
-	bytes, err := json.Marshal(obj)
-	require.NoError(t, err)
-	return string(bytes)
-}
-
-func mustGetSecretData(t *testing.T, secretBytes []byte) map[string]any {
-	t.Helper()
-	var obj map[string]any
-	require.NoError(t, json.Unmarshal(secretBytes, &obj))
-	data, ok := obj["data"].(map[string]any)
-	require.True(t, ok, "expected data field to be a map")
-	return data
 }
 
 // testIgnoreDifferencesNormalizer implements a simple normalizer that removes specified fields
@@ -1663,85 +1472,210 @@ spec:
 	assert.True(t, result.Modified, "the desired value change must be reflected in the diff")
 }
 
-func TestHideSecretDataSameKeysDifferentValues(t *testing.T) {
-	target, live, err := HideSecretData(
-		createSecret(map[string]string{"key1": "test", "key2": "test"}),
-		createSecret(map[string]string{"key1": "test-1", "key2": "test-1"}),
-		nil,
-	)
-	require.NoError(t, err)
+func TestHideSecretData(t *testing.T) {
+	t.Run("same keys different values", func(t *testing.T) {
+		target, live, err := HideSecretData(
+			createSecret(map[string]string{"key1": "test", "key2": "test"}),
+			createSecret(map[string]string{"key1": "test-1", "key2": "test-1"}),
+			nil,
+		)
+		require.NoError(t, err)
 
-	assert.Equal(t, map[string]any{"key1": replacement1, "key2": replacement1}, secretData(target))
-	assert.Equal(t, map[string]any{"key1": replacement2, "key2": replacement2}, secretData(live))
-}
+		assert.Equal(t, map[string]any{"key1": replacement1, "key2": replacement1}, secretData(target))
+		assert.Equal(t, map[string]any{"key1": replacement2, "key2": replacement2}, secretData(live))
+	})
 
-func TestHideSecretDataSameKeysSameValues(t *testing.T) {
-	target, live, err := HideSecretData(
-		createSecret(map[string]string{"key1": "test", "key2": "test"}),
-		createSecret(map[string]string{"key1": "test", "key2": "test"}),
-		nil,
-	)
-	require.NoError(t, err)
+	t.Run("same keys same values", func(t *testing.T) {
+		target, live, err := HideSecretData(
+			createSecret(map[string]string{"key1": "test", "key2": "test"}),
+			createSecret(map[string]string{"key1": "test", "key2": "test"}),
+			nil,
+		)
+		require.NoError(t, err)
 
-	assert.Equal(t, map[string]any{"key1": replacement1, "key2": replacement1}, secretData(target))
-	assert.Equal(t, map[string]any{"key1": replacement1, "key2": replacement1}, secretData(live))
-}
+		assert.Equal(t, map[string]any{"key1": replacement1, "key2": replacement1}, secretData(target))
+		assert.Equal(t, map[string]any{"key1": replacement1, "key2": replacement1}, secretData(live))
+	})
 
-func TestHideSecretDataDifferentKeysDifferentValues(t *testing.T) {
-	target, live, err := HideSecretData(
-		createSecret(map[string]string{"key1": "test", "key2": "test"}),
-		createSecret(map[string]string{"key2": "test-1", "key3": "test-1"}),
-		nil,
-	)
-	require.NoError(t, err)
+	t.Run("different keys different values", func(t *testing.T) {
+		target, live, err := HideSecretData(
+			createSecret(map[string]string{"key1": "test", "key2": "test"}),
+			createSecret(map[string]string{"key2": "test-1", "key3": "test-1"}),
+			nil,
+		)
+		require.NoError(t, err)
 
-	assert.Equal(t, map[string]any{"key1": replacement1, "key2": replacement1}, secretData(target))
-	assert.Equal(t, map[string]any{"key2": replacement2, "key3": replacement1}, secretData(live))
-}
+		assert.Equal(t, map[string]any{"key1": replacement1, "key2": replacement1}, secretData(target))
+		assert.Equal(t, map[string]any{"key2": replacement2, "key3": replacement1}, secretData(live))
+	})
 
-func TestHideStringDataInInvalidSecret(t *testing.T) {
-	liveUn := &unstructured.Unstructured{
-		Object: map[string]any{
-			"apiVersion": "v1",
-			"kind":       "Secret",
-			"metadata": map[string]any{
-				"name": "test-secret",
+	t.Run("handle empty target secret", func(t *testing.T) {
+		// given
+		targetSecret := bytesToUnstructured(t, getTargetSecretJsonBytes())
+		liveSecret := bytesToUnstructured(t, getLiveSecretJsonBytes())
+
+		// when
+		target, live, err := HideSecretData(targetSecret, liveSecret, nil)
+
+		// then
+		require.NoError(t, err)
+		assert.NotNil(t, target)
+		assert.NotNil(t, live)
+		assert.Nil(t, target.Object["data"])
+		assert.Equal(t, map[string]any{"namespace": replacement1, "token": replacement1}, secretData(live))
+	})
+
+	t.Run("handle empty live secret", func(t *testing.T) {
+		// given
+		targetSecret := bytesToUnstructured(t, getTargetSecretJsonBytes())
+		liveSecret := bytesToUnstructured(t, getLiveSecretJsonBytes())
+		targetSecret.Object["data"] = liveSecret.Object["data"]
+		liveSecret.Object["data"] = nil
+
+		// when
+		target, live, err := HideSecretData(targetSecret, liveSecret, nil)
+
+		// then
+		require.NoError(t, err)
+		assert.NotNil(t, target)
+		assert.NotNil(t, live)
+		assert.Nil(t, live.Object["data"])
+		assert.Equal(t, map[string]any{"namespace": replacement1, "token": replacement1}, secretData(target))
+	})
+
+	t.Run("live last applied config", func(t *testing.T) {
+		lastAppliedSecret := createSecret(map[string]string{"key1": "test1"})
+		targetSecret := createSecret(map[string]string{"key1": "test2"})
+		liveSecret := createSecret(map[string]string{"key1": "test3"})
+		lastAppliedStr, err := json.Marshal(lastAppliedSecret)
+		require.NoError(t, err)
+		liveSecret.SetAnnotations(map[string]string{corev1.LastAppliedConfigAnnotation: string(lastAppliedStr)})
+
+		target, live, err := HideSecretData(targetSecret, liveSecret, nil)
+		require.NoError(t, err)
+		err = json.Unmarshal([]byte(live.GetAnnotations()[corev1.LastAppliedConfigAnnotation]), &lastAppliedSecret)
+		require.NoError(t, err)
+
+		assert.Equal(t, map[string]any{"key1": replacement1}, secretData(target))
+		assert.Equal(t, map[string]any{"key1": replacement2}, secretData(live))
+		assert.Equal(t, map[string]any{"key1": replacement3}, secretData(lastAppliedSecret))
+	})
+
+	t.Run("target last applied config", func(t *testing.T) {
+		// Test case where target also has a last-applied-configuration annotation with secret data
+		// This can happen during server-side diff when the dry-run returns a predictedLive with this annotation
+		targetLastAppliedSecret := createSecret(map[string]string{"key1": "test1"})
+		targetLastAppliedStr, err := json.Marshal(targetLastAppliedSecret)
+		require.NoError(t, err)
+
+		targetSecret := createSecret(map[string]string{"key1": "test1"}) // Same value as in last-applied
+		targetSecret.SetAnnotations(map[string]string{corev1.LastAppliedConfigAnnotation: string(targetLastAppliedStr)})
+
+		liveSecret := createSecret(map[string]string{"key1": "test2"})
+
+		target, live, err := HideSecretData(targetSecret, liveSecret, nil)
+		require.NoError(t, err)
+
+		// Verify target's last-applied-config is masked
+		targetLastAppliedAnnotation := target.GetAnnotations()[corev1.LastAppliedConfigAnnotation]
+		require.NotEmpty(t, targetLastAppliedAnnotation)
+		err = json.Unmarshal([]byte(targetLastAppliedAnnotation), &targetLastAppliedSecret)
+		require.NoError(t, err)
+
+		// target.key1 and targetLastApplied.key1 have the same value "test1", so they should get the same replacement
+		// live.key1 has a different value "test2", so it should get a different replacement
+		assert.Equal(t, map[string]any{"key1": replacement1}, secretData(target))
+		assert.Equal(t, map[string]any{"key1": replacement2}, secretData(live))
+		assert.Equal(t, map[string]any{"key1": replacement1}, secretData(targetLastAppliedSecret))
+	})
+
+	t.Run("both target and live last applied config", func(t *testing.T) {
+		// Test case where both target and live have last-applied-configuration annotations
+		// Use the same value "test1" in targetLastApplied.key1 and target.key1
+		// Use the same value "test2" in both target.key2 and targetLastApplied.key2
+		// Use a different value "test3" in live.key1 and liveLastApplied.key1
+		targetLastAppliedSecret := createSecret(map[string]string{"key1": "test1", "key2": "test2"})
+		targetLastAppliedStr, err := json.Marshal(targetLastAppliedSecret)
+		require.NoError(t, err)
+
+		liveLastAppliedSecret := createSecret(map[string]string{"key1": "test3"})
+		liveLastAppliedStr, err := json.Marshal(liveLastAppliedSecret)
+		require.NoError(t, err)
+
+		targetSecret := createSecret(map[string]string{"key1": "test1", "key2": "test2"})
+		targetSecret.SetAnnotations(map[string]string{corev1.LastAppliedConfigAnnotation: string(targetLastAppliedStr)})
+
+		liveSecret := createSecret(map[string]string{"key1": "test3"})
+		liveSecret.SetAnnotations(map[string]string{corev1.LastAppliedConfigAnnotation: string(liveLastAppliedStr)})
+
+		target, live, err := HideSecretData(targetSecret, liveSecret, nil)
+		require.NoError(t, err)
+
+		// Verify target's last-applied-config is masked
+		targetLastAppliedAnnotation := target.GetAnnotations()[corev1.LastAppliedConfigAnnotation]
+		require.NotEmpty(t, targetLastAppliedAnnotation)
+		err = json.Unmarshal([]byte(targetLastAppliedAnnotation), &targetLastAppliedSecret)
+		require.NoError(t, err)
+
+		// Verify live's last-applied-config is masked
+		liveLastAppliedAnnotation := live.GetAnnotations()[corev1.LastAppliedConfigAnnotation]
+		require.NotEmpty(t, liveLastAppliedAnnotation)
+		err = json.Unmarshal([]byte(liveLastAppliedAnnotation), &liveLastAppliedSecret)
+		require.NoError(t, err)
+
+		// The algorithm processes keys separately and resets valToReplacement for each key
+		// For key1: "test1" (in target and targetLastApplied) gets replacement1, "test3" (in live and liveLastApplied) gets replacement2
+		// For key2: "test2" (in target and targetLastApplied) gets replacement1 (per-key valToReplacement)
+		assert.Equal(t, map[string]any{"key1": replacement1, "key2": replacement1}, secretData(target))
+		assert.Equal(t, map[string]any{"key1": replacement2}, secretData(live))
+		assert.Equal(t, map[string]any{"key1": replacement1, "key2": replacement1}, secretData(targetLastAppliedSecret))
+		assert.Equal(t, map[string]any{"key1": replacement2}, secretData(liveLastAppliedSecret))
+	})
+
+	t.Run("invalid secret", func(t *testing.T) {
+		liveUn := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata": map[string]any{
+					"name": "test-secret",
+				},
+				"type": "Opaque",
+				"data": map[string]any{
+					"key1": "a2V5MQ==",
+					"key2": "a2V5MQ==",
+				},
 			},
-			"type": "Opaque",
-			"data": map[string]any{
-				"key1": "a2V5MQ==",
-				"key2": "a2V5MQ==",
+		}
+		targetUn := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata": map[string]any{
+					"name": "test-secret",
+				},
+				"type": "Opaque",
+				"data": map[string]any{
+					"key1": "a2V5MQ==",
+					"key2": "a2V5Mg==",
+					"key3": false,
+				},
+				"stringData": map[string]any{
+					"key4": "key4",
+					"key5": 5,
+				},
 			},
-		},
-	}
-	targetUn := &unstructured.Unstructured{
-		Object: map[string]any{
-			"apiVersion": "v1",
-			"kind":       "Secret",
-			"metadata": map[string]any{
-				"name": "test-secret",
-			},
-			"type": "Opaque",
-			"data": map[string]any{
-				"key1": "a2V5MQ==",
-				"key2": "a2V5Mg==",
-				"key3": false,
-			},
-			"stringData": map[string]any{
-				"key4": "key4",
-				"key5": 5,
-			},
-		},
-	}
+		}
 
-	liveUn = remarshal(liveUn, applyOptions(diffOptionsForTest()))
-	targetUn = remarshal(targetUn, applyOptions(diffOptionsForTest()))
+		liveUn = remarshal(liveUn, applyOptions(diffOptionsForTest()))
+		targetUn = remarshal(targetUn, applyOptions(diffOptionsForTest()))
 
-	target, live, err := HideSecretData(targetUn, liveUn, nil)
-	require.NoError(t, err)
+		target, live, err := HideSecretData(targetUn, liveUn, nil)
+		require.NoError(t, err)
 
-	assert.Equal(t, map[string]any{"key1": replacement1, "key2": replacement2}, secretData(live))
-	assert.Equal(t, map[string]any{"key1": replacement1, "key2": replacement1, "key3": replacement1, "key4": replacement1, "key5": replacement1}, secretData(target))
+		assert.Equal(t, map[string]any{"key1": replacement1, "key2": replacement2}, secretData(live))
+		assert.Equal(t, map[string]any{"key1": replacement1, "key2": replacement1, "key3": replacement1, "key4": replacement1, "key5": replacement1}, secretData(target))
+	})
 }
 
 // stringData in secrets should be normalized even if it is invalid
@@ -1819,7 +1753,7 @@ func TestNormalizeSecret(t *testing.T) {
 	}
 }
 
-func TestHideSecretAnnotations(t *testing.T) {
+func TestHideSecretData_HideAnnotations(t *testing.T) {
 	tests := []struct {
 		name           string
 		hideAnnots     map[string]bool
@@ -1915,7 +1849,7 @@ func TestHideSecretAnnotations(t *testing.T) {
 	}
 }
 
-func TestHideSecretAnnotationsPreserveDifference(t *testing.T) {
+func TestHideSecretData_HideAnnotations_PreserveDifference(t *testing.T) {
 	hideAnnots := map[string]bool{"token/value": true}
 
 	liveUn := &unstructured.Unstructured{
@@ -2012,40 +1946,6 @@ func bytesToUnstructured(t *testing.T, jsonBytes []byte) *unstructured.Unstructu
 	return &unstructured.Unstructured{
 		Object: jsonMap,
 	}
-}
-
-func TestHideSecretDataHandleEmptySecret(t *testing.T) {
-	// given
-	targetSecret := bytesToUnstructured(t, getTargetSecretJsonBytes())
-	liveSecret := bytesToUnstructured(t, getLiveSecretJsonBytes())
-
-	// when
-	target, live, err := HideSecretData(targetSecret, liveSecret, nil)
-
-	// then
-	require.NoError(t, err)
-	assert.NotNil(t, target)
-	assert.NotNil(t, live)
-	assert.Nil(t, target.Object["data"])
-	assert.Equal(t, map[string]any{"namespace": "++++++++", "token": "++++++++"}, secretData(live))
-}
-
-func TestHideSecretDataLastAppliedConfig(t *testing.T) {
-	lastAppliedSecret := createSecret(map[string]string{"key1": "test1"})
-	targetSecret := createSecret(map[string]string{"key1": "test2"})
-	liveSecret := createSecret(map[string]string{"key1": "test3"})
-	lastAppliedStr, err := json.Marshal(lastAppliedSecret)
-	require.NoError(t, err)
-	liveSecret.SetAnnotations(map[string]string{corev1.LastAppliedConfigAnnotation: string(lastAppliedStr)})
-
-	target, live, err := HideSecretData(targetSecret, liveSecret, nil)
-	require.NoError(t, err)
-	err = json.Unmarshal([]byte(live.GetAnnotations()[corev1.LastAppliedConfigAnnotation]), &lastAppliedSecret)
-	require.NoError(t, err)
-
-	assert.Equal(t, map[string]any{"key1": replacement1}, secretData(target))
-	assert.Equal(t, map[string]any{"key1": replacement2}, secretData(live))
-	assert.Equal(t, map[string]any{"key1": replacement3}, secretData(lastAppliedSecret))
 }
 
 func TestRemarshal(t *testing.T) {

--- a/gitops-engine/pkg/diff/diff_test.go
+++ b/gitops-engine/pkg/diff/diff_test.go
@@ -1254,6 +1254,93 @@ func TestServerSideDiff(t *testing.T) {
 		assert.Contains(t, liveData, "key2")
 		assert.Contains(t, liveData, "key3", "key3 should still be in live state")
 	})
+
+	t.Run("will strip last-applied-configuration annotation from a non-Secret resource on both sides", func(t *testing.T) {
+		// given
+		t.Parallel()
+		const lastApplied = `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"my-cm","namespace":"default"},"data":{"key1":"value1"}}`
+		liveState := StrToUnstructured(`{
+			"apiVersion": "v1",
+			"kind": "ConfigMap",
+			"metadata": {"name": "my-cm", "namespace": "default"}
+		}`)
+		liveState.SetAnnotations(map[string]string{AnnotationLastAppliedConfig: lastApplied})
+		desiredState := StrToUnstructured(`{
+			"apiVersion": "v1",
+			"kind": "ConfigMap",
+			"metadata": {"name": "my-cm", "namespace": "default"},
+			"data": {"key1": "value1"}
+		}`)
+		predictedLiveObj := desiredState.DeepCopy()
+		predictedLiveObj.SetAnnotations(map[string]string{AnnotationLastAppliedConfig: lastApplied})
+		predictedLiveJSON := mustMarshalUnstructured(t, predictedLiveObj)
+		opts := buildOpts(predictedLiveJSON)
+		opts = append(opts, WithIgnoreMutationWebhook(false))
+
+		// when
+		result, err := serverSideDiff(t.Context(), desiredState, liveState, opts...)
+
+		// then
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.NotContains(t, string(result.PredictedLive), AnnotationLastAppliedConfig,
+			"PredictedLive must not contain the last-applied-configuration annotation")
+		assert.NotContains(t, string(result.NormalizedLive), AnnotationLastAppliedConfig,
+			"NormalizedLive must not contain the last-applied-configuration annotation")
+	})
+
+	t.Run("will strip last-applied-configuration annotation from a Secret resource on both sides", func(t *testing.T) {
+		// given
+		t.Parallel()
+		// The annotation embeds a secret value that does not otherwise appear in the object,
+		// so we can assert the annotation (and its contents) is stripped. Masking of the Secret
+		// data field itself is the caller's responsibility and is covered by TestHideSecretData.
+		const annotationOnlySecret = "QU5OT1RBVElPTk9OTFk="
+		lastApplied := `{"apiVersion":"v1","kind":"Secret","metadata":{"name":"my-secret","namespace":"default"},"data":{"password":"` + annotationOnlySecret + `"}}`
+		liveState := StrToUnstructured(`{
+			"apiVersion": "v1",
+			"kind": "Secret",
+			"metadata": {"name": "my-secret", "namespace": "default"},
+			"type": "Opaque",
+			"data": {"password": "U0VDUkVUVkFM"}
+		}`)
+		liveState.SetAnnotations(map[string]string{AnnotationLastAppliedConfig: lastApplied})
+		desiredState := StrToUnstructured(`{
+			"apiVersion": "v1",
+			"kind": "Secret",
+			"metadata": {"name": "my-secret", "namespace": "default"},
+			"type": "Opaque",
+			"data": {"password": "U0VDUkVUVkFM"}
+		}`)
+		predictedLiveObj := desiredState.DeepCopy()
+		predictedLiveObj.SetAnnotations(map[string]string{AnnotationLastAppliedConfig: lastApplied})
+		predictedLiveJSON := mustMarshalUnstructured(t, predictedLiveObj)
+		opts := buildOpts(predictedLiveJSON)
+		opts = append(opts, WithIgnoreMutationWebhook(false))
+
+		// when
+		result, err := serverSideDiff(t.Context(), desiredState, liveState, opts...)
+
+		// then
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.NotContains(t, string(result.PredictedLive), AnnotationLastAppliedConfig,
+			"PredictedLive must not contain the last-applied-configuration annotation")
+		assert.NotContains(t, string(result.NormalizedLive), AnnotationLastAppliedConfig,
+			"NormalizedLive must not contain the last-applied-configuration annotation")
+		assert.NotContains(t, string(result.PredictedLive), annotationOnlySecret,
+			"PredictedLive must not contain secret values embedded only in last-applied-configuration")
+		assert.NotContains(t, string(result.NormalizedLive), annotationOnlySecret,
+			"NormalizedLive must not contain secret values embedded only in last-applied-configuration")
+	})
+}
+
+// mustMarshalUnstructured marshals an unstructured object to a JSON string, failing the test on error.
+func mustMarshalUnstructured(t *testing.T, obj *unstructured.Unstructured) string {
+	t.Helper()
+	data, err := json.Marshal(obj)
+	require.NoError(t, err)
+	return string(data)
 }
 
 // testIgnoreDifferencesNormalizer implements a simple normalizer that removes specified fields
@@ -1630,6 +1717,37 @@ func TestHideSecretData(t *testing.T) {
 		assert.Equal(t, map[string]any{"key1": replacement2}, secretData(live))
 		assert.Equal(t, map[string]any{"key1": replacement1, "key2": replacement1}, secretData(targetLastAppliedSecret))
 		assert.Equal(t, map[string]any{"key1": replacement2}, secretData(liveLastAppliedSecret))
+	})
+
+	t.Run("malformed live last applied config is masked (fail closed)", func(t *testing.T) {
+		// A last-applied-configuration annotation that is not valid JSON may still embed raw
+		// Secret material. It must be replaced with the placeholder rather than left untouched.
+		const malformed = `{"data":{"password":"U0VDUkVUVkFM"` // truncated JSON, unparseable
+		targetSecret := createSecret(map[string]string{"key1": "test1"})
+		liveSecret := createSecret(map[string]string{"key1": "test1"})
+		liveSecret.SetAnnotations(map[string]string{corev1.LastAppliedConfigAnnotation: malformed})
+
+		_, live, err := HideSecretData(targetSecret, liveSecret, nil)
+		require.NoError(t, err)
+
+		annotation := live.GetAnnotations()[corev1.LastAppliedConfigAnnotation]
+		assert.Equal(t, replacement, annotation, "malformed live annotation must be fully masked")
+		assert.NotContains(t, annotation, "U0VDUkVUVkFM", "raw secret material must not survive")
+	})
+
+	t.Run("malformed target last applied config is masked (fail closed)", func(t *testing.T) {
+		// Same as above, but for the target object (e.g. a predictedLive from a server-side dry-run).
+		const malformed = `{"data":{"password":"U0VDUkVUVkFM"` // truncated JSON, unparseable
+		targetSecret := createSecret(map[string]string{"key1": "test1"})
+		targetSecret.SetAnnotations(map[string]string{corev1.LastAppliedConfigAnnotation: malformed})
+		liveSecret := createSecret(map[string]string{"key1": "test1"})
+
+		target, _, err := HideSecretData(targetSecret, liveSecret, nil)
+		require.NoError(t, err)
+
+		annotation := target.GetAnnotations()[corev1.LastAppliedConfigAnnotation]
+		assert.Equal(t, replacement, annotation, "malformed target annotation must be fully masked")
+		assert.NotContains(t, annotation, "U0VDUkVUVkFM", "raw secret material must not survive")
 	})
 
 	t.Run("invalid secret", func(t *testing.T) {

--- a/test/e2e/diff_test.go
+++ b/test/e2e/diff_test.go
@@ -86,16 +86,19 @@ data:
 			// Server-Side diff should show a diff with the sensitive value masked
 			diff, err = fixture.RunCli("app", "diff", ctx.AppQualifiedName(), "--server-side-diff", "--exit-code=false")
 			require.NoError(t, err)
+			assert.False(t, sensitiveData.MatchString(diff))
 			assert.Contains(t, diff, "===== /Secret")
 
 			// Local diff with server-side-generate should show a diff with the sensitive value masked
 			diff, err = fixture.RunCli("app", "diff", ctx.AppQualifiedName(), "--local", localRepoRoot, "--server-side-generate", "--exit-code=false")
 			require.NoError(t, err)
+			assert.False(t, sensitiveData.MatchString(diff))
 			assert.Contains(t, diff, "===== /Secret")
 
 			// Local diff should exclude secret resources completely
 			diff, err = fixture.RunCli("app", "diff", ctx.AppQualifiedName(), "--local", appPath, "--local-repo-root", localRepoRoot, "--exit-code=false")
 			require.NoError(t, err)
+			assert.False(t, sensitiveData.MatchString(diff))
 			assert.Empty(t, diff, "Secret kind should not be displayed in CLI diff output")
 		})
 }
@@ -156,16 +159,19 @@ data:
 			// Server-Side diff should show a diff with the sensitive value masked
 			diff, err = fixture.RunCli("app", "diff", ctx.AppQualifiedName(), "--server-side-diff", "--exit-code=false")
 			require.NoError(t, err)
+			assert.False(t, sensitiveData.MatchString(diff))
 			assert.Contains(t, diff, "===== /Secret")
 
 			// Local diff with server-side-generate should show a diff with the sensitive value masked
 			diff, err = fixture.RunCli("app", "diff", ctx.AppQualifiedName(), "--local", localRepoRoot, "--server-side-generate", "--exit-code=false")
 			require.NoError(t, err)
+			assert.False(t, sensitiveData.MatchString(diff))
 			assert.Contains(t, diff, "===== /Secret")
 
 			// Local diff should exclude secret resources completely
 			diff, err = fixture.RunCli("app", "diff", ctx.AppQualifiedName(), "--local", appPath, "--local-repo-root", localRepoRoot, "--exit-code=false")
 			require.NoError(t, err)
+			assert.False(t, sensitiveData.MatchString(diff))
 			assert.Empty(t, diff, "Secret kind should not be displayed in CLI diff output")
 
 			msg := app.Status.OperationState.Message


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->
based off of https://github.com/argoproj/argo-cd/pull/27790/changes

Fixes #25260

When performing server-side diff on a Secret, if the live resource has the last-applied-configuration annotation, it also appears in the predicted-live target — meaning it must be hidden symmetrically like the rest of the secret data, not just on the live side.

### changes

1. This PR moves secret-hiding fully to the caller (matching client-side diff), so serverSideDiff no longer double-hides secret data that the caller already masks. HideSecretData now also masks the target's last-applied-configuration annotation, and fails closed (masks with the placeholder) if either side's annotation can't be parsed as JSON — since HideSecretData is a public function that may be called with any manifest, not just ones known to carry well-formed kubectl annotations.

2. serverSideDiff still strips the last-applied-configuration annotation from both sides during normalization (unchanged from current behavior), keeping it consistent with StructuredMergeDiff. Unifying that normalization across all three diff strategies (client-side, SSD, StructuredMergeDiff) is a separate refactor tracked in #27933 and is out of scope here.

3. Tests: added coverage asserting the annotation is stripped in SSD for both Secret and non-Secret resources, and that a malformed live/target annotation is masked rather than leaked.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
