### PR TITLE
ci(renovate): make renovate manage Redis versions throughout the project (#28994)

### DIFF
--- a/.github/configs/renovate-config.js
+++ b/.github/configs/renovate-config.js
@@ -4,6 +4,8 @@ module.exports = {
     allowPostUpgradeCommandTemplating: true,
     allowedPostUpgradeCommands: [
         "make mockgen",
+        "env INSTALL_SUDO=env BIN=\\./dist \\./hack/install\\.sh kustomize helm",
+        "sh -c PATH=`pwd`/dist:\\$PATH;\\./hack/update-manifests\\.sh",
         "./hack/install.sh kustomize && make manifests-local",
         "hack/installers/checksums/add-helm-checksums.sh",
         "hack/installers/checksums/add-kustomize-checksums.sh",

--- a/.github/configs/renovate-config.js
+++ b/.github/configs/renovate-config.js
@@ -19,6 +19,7 @@ module.exports = {
         "github>argoproj/argo-cd//renovate-presets/devtool.json5",
         "github>argoproj/argo-cd//renovate-presets/production-binaries.json5",
         "github>argoproj/argo-cd//renovate-presets/dex.json5",
+        "github>argoproj/argo-cd//renovate-presets/redis.json5",
         "github>argoproj/argo-cd//renovate-presets/docs.json5",
         "group:aws-sdk-go-v2Monorepo",
         "github>argoproj/argo-cd//renovate-presets/fix/ignore-paths.json5"

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -661,6 +661,7 @@ jobs:
           # renovate: datasource=github-releases depName=dexidp/dex
           docker pull ghcr.io/dexidp/dex:v2.45.1
           docker pull argoproj/argo-cd-ci-builder:v1.0.0
+          # renovate: datasource=docker packageName=docker.io/library/redis
           docker pull redis:8.6.4-alpine
       - name: Create target directory for binaries in the build-process
         run: |

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -15,7 +15,7 @@ jobs:
   renovate:
     name: Run Renovate
     runs-on: ubuntu-24.04
-    if: github.repository == 'argoproj/argo-cd'
+    if: github.repository == 'dudinea/argo-cd'
     steps:
       - name: Harden the runner (Block unknown outbound calls)
         if: ${{ vars.disable_harden_runner != 'true' }}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -53,6 +53,7 @@ jobs:
             deb.debian.org:80
             deb.debian.org:443
             production.cloudfront.docker.com:443
+            dandydeveloper.github.io:443
 
       - name: Get token
         id: get_token

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -15,7 +15,7 @@ jobs:
   renovate:
     name: Run Renovate
     runs-on: ubuntu-24.04
-    if: github.repository == 'dudinea/argo-cd'
+    if: github.repository == 'argoproj/argo-cd'
     steps:
       - name: Harden the runner (Block unknown outbound calls)
         if: ${{ vars.disable_harden_runner != 'true' }}

--- a/hack/installers/install-helm.sh
+++ b/hack/installers/install-helm.sh
@@ -3,10 +3,12 @@ set -eux -o pipefail
 
 . "$(dirname "$0")"/../tool-versions.sh
 
+INSTALL_SUDO=${INSTALL_SUDO:-sudo}
+
 export TARGET_FILE=helm-v${HELM_VERSION}-${INSTALL_OS}-${ARCHITECTURE}.tar.gz
 
 [ -e "$DOWNLOADS/${TARGET_FILE}" ] || curl -sLf --retry 3 -o "$DOWNLOADS/${TARGET_FILE}" "https://get.helm.sh/helm-v${HELM_VERSION}-$INSTALL_OS-$ARCHITECTURE.tar.gz"
 "$(dirname "$0")"/compare-chksum.sh
 mkdir -p /tmp/helm && tar -C /tmp/helm -xf "$DOWNLOADS/${TARGET_FILE}"
-sudo install -m 0755 "/tmp/helm/$INSTALL_OS-$ARCHITECTURE/helm" "$BIN/helm"
-helm version
+${INSTALL_SUDO} install -m 0755 "/tmp/helm/$INSTALL_OS-$ARCHITECTURE/helm" "$BIN/helm"
+"$BIN/helm" version

--- a/hack/installers/install-kustomize.sh
+++ b/hack/installers/install-kustomize.sh
@@ -10,6 +10,8 @@ _kustomize_version=${KUSTOMIZE_VERSION:-}
 
 KUSTOMIZE_VERSION=${_kustomize_version:-$KUSTOMIZE_VERSION}
 
+INSTALL_SUDO=${INSTALL_SUDO:-sudo}
+
 INSTALL_PATH="${BIN:-$INSTALL_PATH}"
 INSTALL_PATH="${INSTALL_PATH:-$PROJECT_ROOT/dist}"
 PATH="${INSTALL_PATH}:${PATH}"
@@ -34,7 +36,7 @@ case $ARCHITECTURE in
       [ -e "${DOWNLOADS}/${TARGET_FILE}" ] || curl -sLf --retry 3 -o "${DOWNLOADS}/${TARGET_FILE}" "$URL"
       "$INSTALLERS/compare-chksum.sh"
       tar -C /tmp -xf "${DOWNLOADS}/${TARGET_FILE}"
-      sudo install -m 0755 /tmp/kustomize "$INSTALL_PATH/$BINNAME"
+      ${INSTALL_SUDO} install -m 0755 /tmp/kustomize "$INSTALL_PATH/$BINNAME"
       ;;
   *)
     case $KUSTOMIZE_VERSION in
@@ -44,7 +46,7 @@ case $ARCHITECTURE in
         BINNAME=kustomize2
         [ -e "${DOWNLOADS}/${TARGET_FILE}" ] || curl -sLf --retry 3 -o "${DOWNLOADS}/${TARGET_FILE}" "$URL"
         "$INSTALLERS/compare-chksum.sh"
-        sudo install -m 0755 "${DOWNLOADS}/${TARGET_FILE}" "$INSTALL_PATH/$BINNAME"
+        ${INSTALL_SUDO} install -m 0755 "${DOWNLOADS}/${TARGET_FILE}" "$INSTALL_PATH/$BINNAME"
         ;;
       *)
         export TARGET_FILE=kustomize_${KUSTOMIZE_VERSION}_${INSTALL_OS}_${ARCHITECTURE}.tar.gz
@@ -53,7 +55,7 @@ case $ARCHITECTURE in
         [ -e "${DOWNLOADS}/${TARGET_FILE}" ] || curl -sLf --retry 3 -o "${DOWNLOADS}/${TARGET_FILE}" "$URL"
         "$INSTALLERS/compare-chksum.sh"
         tar -C /tmp -xf "${DOWNLOADS}/${TARGET_FILE}"
-        sudo install -m 0755 /tmp/kustomize "$INSTALL_PATH/$BINNAME"
+        ${INSTALL_SUDO} install -m 0755 /tmp/kustomize "$INSTALL_PATH/$BINNAME"
         ;;
     esac
     ;;

--- a/manifests/base/redis/argocd-redis-deployment.yaml
+++ b/manifests/base/redis/argocd-redis-deployment.yaml
@@ -40,6 +40,7 @@ spec:
       serviceAccountName: argocd-redis        
       containers:
       - name: redis
+        # renovate: datasource=docker packageName=docker.io/library/redis
         image: redis:8.6.4-alpine
         imagePullPolicy: Always
         args:

--- a/manifests/ha/base/redis-ha/chart/values.yaml
+++ b/manifests/ha/base/redis-ha/chart/values.yaml
@@ -27,6 +27,7 @@ redis-ha:
     serviceAccount:
       automountToken: true
   image:
+    # renovate: datasource=docker packageName=docker.io/library/redis
     tag: 8.6.4-alpine
   sentinel:
     bind: '0.0.0.0'

--- a/renovate-presets/redis.json5
+++ b/renovate-presets/redis.json5
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Redis image bundled with Argo CD",
+  "customManagers": [
+    {
+      "description": "Track the bundled Redis image version.",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "manifests/base/redis/argocd-redis-deployment.yaml",
+        "manifests/ha/base/redis-ha/chart/values.yaml",
+        ".github/workflows/ci-build.yaml"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>docker) packageName=(?<packageName>docker\\.io/library/redis)\\s+image: redis:(?<currentValue>\\S+)",
+        "# renovate: datasource=(?<datasource>docker) packageName=(?<packageName>docker\\.io/library/redis)\\s+tag: (?<currentValue>\\S+)",
+        "# renovate: datasource=(?<datasource>docker) packageName=(?<packageName>docker\\.io/library/redis)\\s+docker pull redis:(?<currentValue>\\S+)"
+      ],
+      "datasourceTemplate": "docker",
+      "packageNameTemplate": "docker.io/library/redis"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Update all redis references in one PR: the image tags in the manifests, the redis-ha chart values,yaml and the image in the e2e tests server.",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "docker.io/library/redis"
+      ],
+      "enabled": true,
+      "automerge": false,
+      "groupName": "redis",
+      "addLabels": [
+        "production-image"
+      ],
+      "postUpgradeTasks": {
+        "description": "Regenerate the install manifests and the rendered redis-ha chart.",
+        "commands": [
+          "./hack/install.sh kustomize && make manifests-local"
+        ],
+        "fileFilters": [
+          "manifests/**"
+        ],
+        "executionMode": "branch"
+      }
+    }
+  ]
+}

--- a/renovate-presets/redis.json5
+++ b/renovate-presets/redis.json5
@@ -36,6 +36,9 @@
       ],
       "postUpgradeTasks": {
         "description": "Regenerate the install manifests and the rendered redis-ha chart.",
+	// NOTE: the commands aren't executed via shell!
+	// they're split by whitespace and the first string is execed with rest of the
+	// parts split into the argument list
         "commands": [
           "env INSTALL_SUDO=env BIN=./dist ./hack/install.sh kustomize helm",
           "sh -c PATH=`pwd`/dist:$PATH;./hack/update-manifests.sh"

--- a/renovate-presets/redis.json5
+++ b/renovate-presets/redis.json5
@@ -38,7 +38,7 @@
         "description": "Regenerate the install manifests and the rendered redis-ha chart.",
         "commands": [
           "env INSTALL_SUDO=env BIN=./dist ./hack/install.sh kustomize helm",
-	  "sh -c PATH=`pwd`/dist:$PATH;./hack/update-manifests.sh"
+          "sh -c PATH=`pwd`/dist:$PATH;./hack/update-manifests.sh"
         ],
         "fileFilters": [
           "manifests/**"

--- a/renovate-presets/redis.json5
+++ b/renovate-presets/redis.json5
@@ -37,7 +37,8 @@
       "postUpgradeTasks": {
         "description": "Regenerate the install manifests and the rendered redis-ha chart.",
         "commands": [
-          "./hack/install.sh kustomize && make manifests-local"
+          "env INSTALL_SUDO=env BIN=./dist ./hack/install.sh kustomize helm",
+	  "sh -c PATH=`pwd`/dist:$PATH;./hack/update-manifests.sh"
         ],
         "fileFilters": [
           "manifests/**"


### PR DESCRIPTION
This PR makes Renovate to manage the Redis image version everywhere it is used,
all the versions will be updated in the same PR: 

* the kustomize base
* the redis-ha chart values.yaml
* e2e tests Dockerfile 

The new file `renovate-presets/redis.json5` adds a custom manager for three 
new `# renovate:` marker comments and a package rule that groups them.
It also sets the `automerge` flag to `false` and the `production-image` 
label in the same way it is done for for Dex updates.

It uses `postUpgradeTasks` to run manifests regeneration after version update.
This mechanism was formerly used by the Dex updater, but it (supposedly) got broken
after the recent changes in renovate (security hardening), which disabled shell
execution of the `postUpgradeTasks` commands and removed some required binaries
(GNU make, sudo) from the Renovate docker image.

After this PR gets merged and seen actually working, the fix will be applied to the 
Dex preset in a separate PR.

This PR fixes this mechanism by adding to the Kustomize and Helm installers the ability to install the binaries without sudo into a user-writable directory and running install scripts directly, without make.

It adds `dandydeveloper.github.io:443` to the egress allow list 
(the repository for the HA Redis chart)

The fix was tested in the fork, see dudinea#255 for a PR it created.

Closes: #28994

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [X] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [X] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
