### PR TITLE
fix(health): report suspended FlinkDeployment as healthy (#26818)

### DIFF
--- a/resource_customizations/flink.apache.org/FlinkDeployment/health.lua
+++ b/resource_customizations/flink.apache.org/FlinkDeployment/health.lua
@@ -19,6 +19,21 @@ if obj.status ~= nil and obj.status.reconciliationStatus ~= nil then
   end 
 end
 
+-- A FlinkDeployment submitted with `job.state: suspended` is never deployed: the
+-- operator returns before its first deployment, so no `lastReconciledSpec` is ever
+-- recorded, `reconciliationStatus` keeps its default `UPGRADING` state and
+-- `jobManagerDeploymentStatus` stays `MISSING`. The deployment already is in its
+-- desired state, so waiting for the operator here would keep it Progressing forever.
+-- A job suspended after it had been deployed is not matched here: it records a
+-- `lastReconciledSpec` and is still converging, so it stays Progressing.
+if obj.spec ~= nil and obj.spec.job ~= nil and obj.spec.job.state == "suspended"
+    and (obj.status == nil or obj.status.reconciliationStatus == nil
+      or obj.status.reconciliationStatus.lastReconciledSpec == nil) then
+  health_status.status = "Healthy"
+  health_status.message = "Job is suspended"
+  return health_status
+end
+
 health_status.status = "Progressing"
 health_status.message = "Waiting for Flink operator"
 return health_status

--- a/resource_customizations/flink.apache.org/FlinkDeployment/health_test.yaml
+++ b/resource_customizations/flink.apache.org/FlinkDeployment/health_test.yaml
@@ -12,6 +12,14 @@ tests:
     status: Healthy
   inputPath: testdata/healthy_suspended_v1.x.yaml
 - healthStatus:
+    status: Healthy
+    message: Job is suspended
+  inputPath: testdata/healthy_suspended_before_first_deployment.yaml
+- healthStatus:
+    status: Progressing
+    message: Waiting for Flink operator
+  inputPath: testdata/progressing_suspending_after_deployment.yaml
+- healthStatus:
     status: Progressing
     message: Waiting for deploying
   inputPath: testdata/progressing_deployedNotReady.yaml

--- a/resource_customizations/flink.apache.org/FlinkDeployment/testdata/healthy_suspended_before_first_deployment.yaml
+++ b/resource_customizations/flink.apache.org/FlinkDeployment/testdata/healthy_suspended_before_first_deployment.yaml
@@ -1,0 +1,13 @@
+# A FlinkDeployment created with `job.state: suspended` is never deployed by the
+# operator, so `reconciliationStatus` keeps its default `UPGRADING` state, no
+# `lastReconciledSpec` is ever recorded and `jobManagerDeploymentStatus` stays
+# `MISSING`.
+apiVersion: flink.apache.org/v1alpha1
+kind: FlinkDeployment
+spec:
+  job:
+    state: suspended
+status:
+  jobManagerDeploymentStatus: MISSING
+  reconciliationStatus:
+    state: UPGRADING

--- a/resource_customizations/flink.apache.org/FlinkDeployment/testdata/progressing_suspending_after_deployment.yaml
+++ b/resource_customizations/flink.apache.org/FlinkDeployment/testdata/progressing_suspending_after_deployment.yaml
@@ -1,0 +1,13 @@
+# A job that is being suspended after it had already been deployed records a
+# `lastReconciledSpec`. It is still converging, so it must stay Progressing rather
+# than be reported as suspended.
+apiVersion: flink.apache.org/v1alpha1
+kind: FlinkDeployment
+spec:
+  job:
+    state: suspended
+status:
+  jobManagerDeploymentStatus: MISSING
+  reconciliationStatus:
+    state: UPGRADING
+    lastReconciledSpec: '{"spec":{"job":{"state":"running"}},"resource_metadata":{}}'


### PR DESCRIPTION
Closes #26818

A `FlinkDeployment` committed with `job.state: suspended` shows up as Progressing in the UI and stays there forever, so the parent Application never settles.

### What's happening

The operator never reconciles a deployment that is created already suspended. `AbstractFlinkResourceReconciler.reconcile`:

```java
if (reconciliationStatus.isBeforeFirstDeployment()) {
    var spec = cr.getSpec();
    // If the job is submitted in suspend state, no need to reconcile
    if (spec.getJob() != null && spec.getJob().getState().equals(JobState.SUSPENDED)) {
        return;
    }
```

It returns before `updateStatusForDeployedSpec` is ever called, so the status keeps its defaults: `reconciliationStatus.state` stays `UPGRADING` (the initial value in `ReconciliationStatus`), `lastReconciledSpec` is never recorded, `jobManagerDeploymentStatus` stays `MISSING`, and `success` is never set.

Run that through `health.lua` and no branch matches. `success` is nil and the state isn't `DEPLOYED`, so the first branch is out; `MISSING` isn't `DEPLOYED_NOT_READY`/`DEPLOYING`/`ERROR`, so the rest are out. It falls through to the terminal `Progressing` / "Waiting for Flink operator", and since nothing will ever update that status again it never recovers.

The two existing suspended fixtures don't cover this: `healthy_suspended_v0.1.x.yaml` has `success: true` and `healthy_suspended_v1.x.yaml` has `state: DEPLOYED`. Both are jobs suspended *after* being deployed, already handled by the first branch.

### The change

One branch, added after the existing `reconciliationStatus` handling so nothing that currently matches changes behaviour:

```lua
if obj.spec ~= nil and obj.spec.job ~= nil and obj.spec.job.state == "suspended"
    and (obj.status == nil or obj.status.reconciliationStatus == nil
      or obj.status.reconciliationStatus.lastReconciledSpec == nil) then
  health_status.status = "Healthy"
  health_status.message = "Job is suspended"
  return health_status
end
```

The `lastReconciledSpec` guard is the part that matters. A job suspended after it had been deployed does record a `lastReconciledSpec` and is still draining, so it stays on the existing Progressing path rather than flipping to healthy halfway through the suspend. There's a fixture covering that.

### Tests

Two fixtures added — the stuck case and the mid-suspend regression guard. The existing seven fixtures and their expectations are untouched.

```
$ go test ./util/lua/ -run 'TestLuaHealthScript/flink' -v
--- PASS: flink.apache.org/FlinkDeployment/testdata/healthy_running_v0.1.x.yaml
--- PASS: flink.apache.org/FlinkDeployment/testdata/healthy_running_v1.x.yaml
--- PASS: flink.apache.org/FlinkDeployment/testdata/healthy_suspended_v0.1.x.yaml
--- PASS: flink.apache.org/FlinkDeployment/testdata/healthy_suspended_v1.x.yaml
--- PASS: flink.apache.org/FlinkDeployment/testdata/healthy_suspended_before_first_deployment.yaml
--- PASS: flink.apache.org/FlinkDeployment/testdata/progressing_suspending_after_deployment.yaml
--- PASS: flink.apache.org/FlinkDeployment/testdata/progressing_deployedNotReady.yaml
--- PASS: flink.apache.org/FlinkDeployment/testdata/progressing_deploying.yaml
--- PASS: flink.apache.org/FlinkDeployment/testdata/degraded_error.yaml

$ go test ./util/lua/
ok  	github.com/argoproj/argo-cd/v3/util/lua	1.923s
```

### One open question

I went with `Healthy` rather than `Suspended`. `Suspended` probably reads better semantically, but both existing suspended fixtures already resolve to `Healthy`, so this keeps a single consistent answer and doesn't change behaviour for anyone suspending an already-deployed job — which is what @crenshaw-dev asked for on #12862 ("if this is something we can change in a backwards-compatible way"). Happy to switch to `Suspended` if you'd rather, it's a one-line change plus a fixture expectation.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
