### PR TITLE
fix(ui): show full History commit messages via tooltip (#15896)

### DIFF
--- a/ui/src/app/applications/components/application-deployment-history/revision-metadata-rows.test.tsx
+++ b/ui/src/app/applications/components/application-deployment-history/revision-metadata-rows.test.tsx
@@ -1,0 +1,90 @@
+import * as React from 'react';
+import {render} from '@testing-library/react';
+import {RevisionMetadataRows, truncateRevisionMessage} from './revision-metadata-rows';
+
+jest.mock('argo-ui', () => ({
+    DataLoader: ({input, load, children}: {input: unknown; load: (input: unknown) => Promise<unknown>; children: (data: unknown) => React.ReactNode}) => {
+        const [data, setData] = React.useState<unknown>(null);
+        React.useEffect(() => {
+            let cancelled = false;
+            load(input).then(result => {
+                if (!cancelled) {
+                    setData(result);
+                }
+            });
+            return () => {
+                cancelled = true;
+            };
+        }, []);
+        return data ? <>{children(data)}</> : null;
+    },
+    Tooltip: ({content, children}: {content: React.ReactNode; children: React.ReactNode}) => (
+        <div>
+            <div data-testid='tooltip'>{content}</div>
+            <div data-testid='preview'>{children}</div>
+        </div>
+    )
+}));
+
+jest.mock('../../../shared/components', () => ({
+    Timestamp: () => null
+}));
+
+jest.mock('../../../shared/services', () => ({
+    services: {
+        applications: {
+            revisionMetadata: jest.fn(() =>
+                Promise.resolve({
+                    author: 'Test Author',
+                    date: '2026-01-01T00:00:00Z',
+                    message: 'update: from release-hotfix-fix-transcript-format-9b5de948 to release-v2.10.8-25124b65',
+                    signatureInfo: ''
+                })
+            ),
+            revisionChartDetails: jest.fn(),
+            ociMetadata: jest.fn()
+        }
+    }
+}));
+
+describe('truncateRevisionMessage', () => {
+    it('returns short first lines unchanged', () => {
+        expect(truncateRevisionMessage('build: bump', 64)).toBe('build: bump');
+    });
+
+    it('uses only the first line', () => {
+        expect(truncateRevisionMessage('line1\nline2', 64)).toBe('line1');
+    });
+
+    it('caps preview length and keeps full first line for tooltip', () => {
+        const message = 'x'.repeat(200);
+        expect(truncateRevisionMessage(message, 64)).toHaveLength(64);
+        expect(truncateRevisionMessage(message)).toBe(message);
+    });
+
+    it('handles empty message', () => {
+        expect(truncateRevisionMessage('', 64)).toBe('');
+        expect(truncateRevisionMessage('')).toBe('');
+    });
+});
+
+describe('RevisionMetadataRows', () => {
+    const gitSource = {repoURL: 'https://example.com/repo.git', targetRevision: 'abc123', path: '.'};
+
+    it('shows 64-char preview and full first-line tooltip for long commit messages', async () => {
+        const message = 'update: from release-hotfix-fix-transcript-format-9b5de948 to release-v2.10.8-25124b65';
+        const {findByTestId} = render(<RevisionMetadataRows applicationName='test-app' applicationNamespace='argocd' source={gitSource as any} index={0} versionId={1} />);
+
+        expect((await findByTestId('preview')).textContent).toBe(message.slice(0, 64));
+        expect((await findByTestId('tooltip')).textContent).toBe(message);
+        expect(message.length).toBeGreaterThan(64);
+    });
+
+    it('calls revisionMetadata for git sources', async () => {
+        const {services} = require('../../../shared/services');
+        services.applications.revisionMetadata.mockClear();
+        const {findByTestId} = render(<RevisionMetadataRows applicationName='test-app' applicationNamespace='argocd' source={gitSource as any} index={1} versionId={2} />);
+        await findByTestId('preview');
+        expect(services.applications.revisionMetadata).toHaveBeenCalledWith('test-app', 'argocd', 'abc123', 1, 2);
+    });
+});

--- a/ui/src/app/applications/components/application-deployment-history/revision-metadata-rows.test.tsx
+++ b/ui/src/app/applications/components/application-deployment-history/revision-metadata-rows.test.tsx
@@ -19,7 +19,7 @@ jest.mock('argo-ui', () => ({
         return data ? <>{children(data)}</> : null;
     },
     Tooltip: ({content, children}: {content: React.ReactNode; children: React.ReactNode}) => (
-        <div>
+        <div data-testid='tooltip-wrapper'>
             <div data-testid='tooltip'>{content}</div>
             <div data-testid='preview'>{children}</div>
         </div>
@@ -56,28 +56,58 @@ describe('truncateRevisionMessage', () => {
         expect(truncateRevisionMessage('line1\nline2', 64)).toBe('line1');
     });
 
-    it('caps preview length and keeps full first line for tooltip', () => {
+    it('caps the preview length', () => {
         const message = 'x'.repeat(200);
         expect(truncateRevisionMessage(message, 64)).toHaveLength(64);
-        expect(truncateRevisionMessage(message)).toBe(message);
     });
 
     it('handles empty message', () => {
         expect(truncateRevisionMessage('', 64)).toBe('');
-        expect(truncateRevisionMessage('')).toBe('');
     });
 });
 
 describe('RevisionMetadataRows', () => {
     const gitSource = {repoURL: 'https://example.com/repo.git', targetRevision: 'abc123', path: '.'};
 
-    it('shows 64-char preview and full first-line tooltip for long commit messages', async () => {
+    it('shows a 64-char first-line preview and the full raw message in the tooltip', async () => {
         const message = 'update: from release-hotfix-fix-transcript-format-9b5de948 to release-v2.10.8-25124b65';
         const {findByTestId} = render(<RevisionMetadataRows applicationName='test-app' applicationNamespace='argocd' source={gitSource as any} index={0} versionId={1} />);
 
         expect((await findByTestId('preview')).textContent).toBe(message.slice(0, 64));
         expect((await findByTestId('tooltip')).textContent).toBe(message);
         expect(message.length).toBeGreaterThan(64);
+    });
+
+    it('preserves multi-line commit message bodies in the tooltip', async () => {
+        const {services} = require('../../../shared/services');
+        const message = 'short subject\n\nLonger body explaining the change in detail.';
+        services.applications.revisionMetadata.mockResolvedValueOnce({
+            author: 'Test Author',
+            date: '2026-01-01T00:00:00Z',
+            message,
+            signatureInfo: ''
+        });
+        const {findByTestId} = render(<RevisionMetadataRows applicationName='test-app' applicationNamespace='argocd' source={gitSource as any} index={2} versionId={3} />);
+
+        expect((await findByTestId('preview')).textContent).toBe('short subject');
+        expect((await findByTestId('tooltip')).textContent).toBe(message);
+    });
+
+    it('skips the Tooltip entirely for short, single-line commit messages', async () => {
+        const {services} = require('../../../shared/services');
+        const message = 'fix: typo';
+        services.applications.revisionMetadata.mockResolvedValueOnce({
+            author: 'Test Author',
+            date: '2026-01-01T00:00:00Z',
+            message,
+            signatureInfo: ''
+        });
+        const {findByText, queryByTestId} = render(
+            <RevisionMetadataRows applicationName='test-app' applicationNamespace='argocd' source={gitSource as any} index={3} versionId={4} />
+        );
+
+        expect(await findByText(message)).toBeTruthy();
+        expect(queryByTestId('tooltip-wrapper')).toBeNull();
     });
 
     it('calls revisionMetadata for git sources', async () => {

--- a/ui/src/app/applications/components/application-deployment-history/revision-metadata-rows.tsx
+++ b/ui/src/app/applications/components/application-deployment-history/revision-metadata-rows.tsx
@@ -1,8 +1,13 @@
-import {DataLoader} from 'argo-ui';
+import {DataLoader, Tooltip} from 'argo-ui';
 import * as React from 'react';
 import {Timestamp} from '../../../shared/components';
 import {ApplicationSource, RevisionMetadata, ChartDetails, OCIMetadata} from '../../../shared/models';
 import {services} from '../../../shared/services';
+
+export const truncateRevisionMessage = (message: string, maxLength?: number): string => {
+    const firstLine = message.split('\n')[0];
+    return maxLength === undefined ? firstLine : firstLine.slice(0, maxLength);
+};
 
 export const RevisionMetadataRows = (props: {applicationName: string; applicationNamespace: string; source: ApplicationSource; index: number; versionId: number | null}) => {
     if (props?.source?.repoURL?.startsWith('oci://')) {
@@ -88,7 +93,21 @@ export const RevisionMetadataRows = (props: {applicationName: string; applicatio
                     {m.message && (
                         <div className='row'>
                             <div className='columns small-3' />
-                            <div className='columns small-9'>{m.message?.split('\n')[0].slice(0, 64)}</div>
+                            <div className='columns small-9'>
+                                <Tooltip
+                                    popperOptions={{
+                                        modifiers: {
+                                            preventOverflow: {enabled: false},
+                                            hide: {enabled: false},
+                                            flip: {enabled: false}
+                                        }
+                                    }}
+                                    content={<span style={{whiteSpace: 'pre-wrap', wordBreak: 'break-word'}}>{truncateRevisionMessage(m.message)}</span>}
+                                    placement='bottom'
+                                    allowHTML={true}>
+                                    <div>{truncateRevisionMessage(m.message, 64)}</div>
+                                </Tooltip>
+                            </div>
                         </div>
                     )}
                     <div className='row'>

--- a/ui/src/app/applications/components/application-deployment-history/revision-metadata-rows.tsx
+++ b/ui/src/app/applications/components/application-deployment-history/revision-metadata-rows.tsx
@@ -4,10 +4,7 @@ import {Timestamp} from '../../../shared/components';
 import {ApplicationSource, RevisionMetadata, ChartDetails, OCIMetadata} from '../../../shared/models';
 import {services} from '../../../shared/services';
 
-export const truncateRevisionMessage = (message: string, maxLength?: number): string => {
-    const firstLine = message.split('\n')[0];
-    return maxLength === undefined ? firstLine : firstLine.slice(0, maxLength);
-};
+export const truncateRevisionMessage = (message: string, maxLength: number): string => message.split('\n')[0].slice(0, maxLength);
 
 export const RevisionMetadataRows = (props: {applicationName: string; applicationNamespace: string; source: ApplicationSource; index: number; versionId: number | null}) => {
     if (props?.source?.repoURL?.startsWith('oci://')) {
@@ -80,42 +77,52 @@ export const RevisionMetadataRows = (props: {applicationName: string; applicatio
         <DataLoader
             input={props}
             load={input => services.applications.revisionMetadata(input.applicationName, input.applicationNamespace, input.source.targetRevision, input.index, input.versionId)}>
-            {(m: RevisionMetadata) => (
-                <div>
-                    <div className='row'>
-                        <div className='columns small-3'>Authored by</div>
-                        <div className='columns small-9'>
-                            {m.author || 'unknown'}
-                            <br />
-                            {m.date && <Timestamp date={m.date} />}
-                        </div>
-                    </div>
-                    {m.message && (
+            {(m: RevisionMetadata) => {
+                const preview = m.message ? truncateRevisionMessage(m.message, 64) : '';
+                // Only pay for the Tooltip/Popper when the preview actually hides
+                // something (a longer first line or additional message lines).
+                const isTruncated = !!m.message && preview !== m.message;
+                return (
+                    <div>
                         <div className='row'>
-                            <div className='columns small-3' />
+                            <div className='columns small-3'>Authored by</div>
                             <div className='columns small-9'>
-                                <Tooltip
-                                    popperOptions={{
-                                        modifiers: {
-                                            preventOverflow: {enabled: false},
-                                            hide: {enabled: false},
-                                            flip: {enabled: false}
-                                        }
-                                    }}
-                                    content={<span style={{whiteSpace: 'pre-wrap', wordBreak: 'break-word'}}>{truncateRevisionMessage(m.message)}</span>}
-                                    placement='bottom'
-                                    allowHTML={true}>
-                                    <div>{truncateRevisionMessage(m.message, 64)}</div>
-                                </Tooltip>
+                                {m.author || 'unknown'}
+                                <br />
+                                {m.date && <Timestamp date={m.date} />}
                             </div>
                         </div>
-                    )}
-                    <div className='row'>
-                        <div className='columns small-3'>GPG signature</div>
-                        <div className='columns small-9'>{m.signatureInfo || '-'}</div>
+                        {m.message && (
+                            <div className='row'>
+                                <div className='columns small-3' />
+                                <div className='columns small-9'>
+                                    {isTruncated ? (
+                                        <Tooltip
+                                            popperOptions={{
+                                                modifiers: {
+                                                    preventOverflow: {enabled: false},
+                                                    hide: {enabled: false},
+                                                    flip: {enabled: false}
+                                                }
+                                            }}
+                                            content={<span style={{whiteSpace: 'pre-wrap', wordBreak: 'break-word'}}>{m.message}</span>}
+                                            placement='bottom'
+                                            allowHTML={true}>
+                                            <div>{preview}</div>
+                                        </Tooltip>
+                                    ) : (
+                                        <div>{preview}</div>
+                                    )}
+                                </div>
+                            </div>
+                        )}
+                        <div className='row'>
+                            <div className='columns small-3'>GPG signature</div>
+                            <div className='columns small-9'>{m.signatureInfo || '-'}</div>
+                        </div>
                     </div>
-                </div>
-            )}
+                );
+            }}
         </DataLoader>
     );
 };


### PR DESCRIPTION
## Summary

- History and Rollback truncated commit messages to the first line and 64 characters, hiding important trailing content (for example Image Updater messages).
- Keep the 64-character first-line preview and show the full first line on hover, using the same `Tooltip` pattern as Sync Status.
- Add unit tests for truncation helpers and History rendering.

Closes #15896
Related to #3308

## Checklist

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).

## Generative AI

Assisted by Cursor (LLM) for locating the truncation site and drafting the patch; change reviewed and validated against #15896 / current master.

## Test plan

- [x] Unit tests for `truncateRevisionMessage` and History tooltip preview
- [x] Open an Application History entry whose commit message is longer than 64 characters
- [x] Confirm the preview stays at 64 characters and the tooltip shows the full first line
- [x] Confirm short messages render unchanged (no unnecessary truncation UI noise)
- [x] Confirm Sync Status panel behavior is unchanged