### PR TITLE
fix(appset): don't release finalizer while children still terminate

### DIFF
--- a/applicationset/progressivesync/progressive_sync.go
+++ b/applicationset/progressivesync/progressive_sync.go
@@ -2,7 +2,6 @@ package progressivesync
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"reflect"
 	"slices"
@@ -144,12 +143,18 @@ func (m *Manager) PerformReverseDeletion(ctx context.Context, logCtx *log.Entry,
 			}
 			return 0, fmt.Errorf("error retrieving application %s: %w", step.AppName, err)
 		}
-		// Check if the application is already being deleted
+		// The application is already terminating: wait for the object to disappear instead of
+		// re-issuing a Delete. A redundant Delete on a terminating object succeeds as a no-op,
+		// and cacheSyncingClient.Delete evicts the object from the informer store on success
+		// (see applicationset/utils/client.go). The next Get would then return NotFound for an
+		// Application that still exists, and we would release the ApplicationSet finalizer
+		// while the child is still being torn down.
 		if retrievedApp.DeletionTimestamp != nil {
 			logCtx.Infof("application %s has been marked for deletion, but object not removed yet", step.AppName)
 			if time.Since(retrievedApp.DeletionTimestamp.Time) > 2*time.Minute {
-				return 0, errors.New("application has not been deleted in over 2 minutes")
+				logCtx.Warnf("application %s has not been deleted in over 2 minutes; continuing to wait for it to be removed", step.AppName)
 			}
+			return requeueTime, nil
 		}
 		// The application has not been deleted yet, trigger its deletion.
 		// A NotFound here means the object is already gone from the API server while our

--- a/applicationset/progressivesync/progressive_sync.go
+++ b/applicationset/progressivesync/progressive_sync.go
@@ -2,6 +2,7 @@ package progressivesync
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"slices"
@@ -152,7 +153,7 @@ func (m *Manager) PerformReverseDeletion(ctx context.Context, logCtx *log.Entry,
 		if retrievedApp.DeletionTimestamp != nil {
 			logCtx.Infof("application %s has been marked for deletion, but object not removed yet", step.AppName)
 			if time.Since(retrievedApp.DeletionTimestamp.Time) > 2*time.Minute {
-				logCtx.Warnf("application %s has not been deleted in over 2 minutes; continuing to wait for it to be removed", step.AppName)
+				return 0, errors.New("application has not been deleted in over 2 minutes")
 			}
 			return requeueTime, nil
 		}

--- a/applicationset/progressivesync/progressive_sync_test.go
+++ b/applicationset/progressivesync/progressive_sync_test.go
@@ -1672,15 +1672,11 @@ func TestPerformReverseDeletionStaleCache(t *testing.T) {
 	assert.Equal(t, 1, deleteAttempts["appset-stage1"])
 }
 
-// TestPerformReverseDeletionTerminatingApp covers an Application whose deletion is still pending,
-// here past the two minute threshold. Two things must hold:
-//
-//   - No error: the threshold check sits on the only code path that reaches RemoveFinalizer, so
-//     returning an error from it leaves the ApplicationSet in Terminating permanently — the age it
-//     measures only grows, so every retry fails identically.
-//   - No second Delete: a redundant Delete on a terminating object is a no-op success, and
-//     cacheSyncingClient.Delete evicts the object from the informer store on success. The next Get
-//     would then 404 on a still-existing Application and the finalizer would be released early.
+// TestPerformReverseDeletionTerminatingApp covers an Application whose deletion is still pending.
+// Whichever side of the two minute threshold it falls on, no second Delete may be issued: a
+// redundant Delete on a terminating object is a no-op success, and cacheSyncingClient.Delete evicts
+// the object from the informer store on success. The next Get would then 404 on a still-existing
+// Application and the finalizer would be released early.
 func TestPerformReverseDeletionTerminatingApp(t *testing.T) {
 	t.Parallel()
 
@@ -1702,37 +1698,61 @@ func TestPerformReverseDeletionTerminatingApp(t *testing.T) {
 		},
 	}
 
-	// Deletion was requested well beyond the two minute threshold.
-	newApp := func() v1alpha1.Application {
-		deletionTimestamp := metav1.NewTime(time.Now().Add(-5 * time.Minute))
-		return v1alpha1.Application{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:              "appset-stage0",
-				Namespace:         "argocd",
-				Labels:            map[string]string{"stage": "0"},
-				DeletionTimestamp: &deletionTimestamp,
-				Finalizers:        []string{v1alpha1.ResourcesFinalizerName},
-			},
-		}
+	for _, tc := range []struct {
+		name          string
+		deletionAge   time.Duration
+		expectedErr   string
+		expectRequeue time.Duration
+	}{
+		{
+			name:          "within threshold",
+			deletionAge:   30 * time.Second,
+			expectRequeue: 10 * time.Second,
+		},
+		{
+			// Past the threshold the reconcile fails, so the ApplicationSet finalizer stays put and
+			// controller-runtime retries with backoff.
+			name:        "past threshold",
+			deletionAge: 5 * time.Minute,
+			expectedErr: "application has not been deleted in over 2 minutes",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			deletionTimestamp := metav1.NewTime(time.Now().Add(-tc.deletionAge))
+			app := v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "appset-stage0",
+					Namespace:         "argocd",
+					Labels:            map[string]string{"stage": "0"},
+					DeletionTimestamp: &deletionTimestamp,
+					Finalizers:        []string{v1alpha1.ResourcesFinalizerName},
+				},
+			}
+
+			deleteAttempts := 0
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(&app).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+						deleteAttempts++
+						return c.Delete(ctx, obj, opts...)
+					},
+				}).
+				Build()
+
+			m := NewManager(fakeClient, nil)
+			requeue, err := m.PerformReverseDeletion(context.Background(), log.NewEntry(log.New()), appSet, []v1alpha1.Application{app})
+
+			if tc.expectedErr != "" {
+				require.EqualError(t, err, tc.expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tc.expectRequeue, requeue)
+			assert.Zero(t, deleteAttempts, "must not re-Delete an already terminating Application")
+		})
 	}
-
-	app := newApp()
-	deleteAttempts := 0
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(&app).
-		WithInterceptorFuncs(interceptor.Funcs{
-			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
-				deleteAttempts++
-				return c.Delete(ctx, obj, opts...)
-			},
-		}).
-		Build()
-
-	m := NewManager(fakeClient, nil)
-	requeue, err := m.PerformReverseDeletion(context.Background(), log.NewEntry(log.New()), appSet, []v1alpha1.Application{app})
-
-	require.NoError(t, err, "a pending teardown must not surface as a hard error")
-	assert.Equal(t, 10*time.Second, requeue, "should requeue and keep waiting for the child")
-	assert.Zero(t, deleteAttempts, "must not re-Delete an already terminating Application")
 }

--- a/applicationset/progressivesync/progressive_sync_test.go
+++ b/applicationset/progressivesync/progressive_sync_test.go
@@ -3,6 +3,7 @@ package progressivesync
 import (
 	"context"
 	"testing"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -1669,4 +1670,69 @@ func TestPerformReverseDeletionStaleCache(t *testing.T) {
 	// Both steps should have been visited and their (already-gone) deletion attempted.
 	assert.Equal(t, 1, deleteAttempts["appset-stage0"])
 	assert.Equal(t, 1, deleteAttempts["appset-stage1"])
+}
+
+// TestPerformReverseDeletionTerminatingApp covers an Application whose deletion is still pending,
+// here past the two minute threshold. Two things must hold:
+//
+//   - No error: the threshold check sits on the only code path that reaches RemoveFinalizer, so
+//     returning an error from it leaves the ApplicationSet in Terminating permanently — the age it
+//     measures only grows, so every retry fails identically.
+//   - No second Delete: a redundant Delete on a terminating object is a no-op success, and
+//     cacheSyncingClient.Delete evicts the object from the informer store on success. The next Get
+//     would then 404 on a still-existing Application and the finalizer would be released early.
+func TestPerformReverseDeletionTerminatingApp(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+
+	appSet := v1alpha1.ApplicationSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "appset", Namespace: "argocd"},
+		Spec: v1alpha1.ApplicationSetSpec{
+			Strategy: &v1alpha1.ApplicationSetStrategy{
+				Type:          "RollingSync",
+				DeletionOrder: ReverseDeletionOrder,
+				RollingSync: &v1alpha1.ApplicationSetRolloutStrategy{
+					Steps: []v1alpha1.ApplicationSetRolloutStep{
+						{MatchExpressions: []v1alpha1.ApplicationMatchExpression{{Key: "stage", Operator: "In", Values: []string{"0"}}}},
+					},
+				},
+			},
+		},
+	}
+
+	// Deletion was requested well beyond the two minute threshold.
+	newApp := func() v1alpha1.Application {
+		deletionTimestamp := metav1.NewTime(time.Now().Add(-5 * time.Minute))
+		return v1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "appset-stage0",
+				Namespace:         "argocd",
+				Labels:            map[string]string{"stage": "0"},
+				DeletionTimestamp: &deletionTimestamp,
+				Finalizers:        []string{v1alpha1.ResourcesFinalizerName},
+			},
+		}
+	}
+
+	app := newApp()
+	deleteAttempts := 0
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(&app).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				deleteAttempts++
+				return c.Delete(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	m := NewManager(fakeClient, nil)
+	requeue, err := m.PerformReverseDeletion(context.Background(), log.NewEntry(log.New()), appSet, []v1alpha1.Application{app})
+
+	require.NoError(t, err, "a pending teardown must not surface as a hard error")
+	assert.Equal(t, 10*time.Second, requeue, "should requeue and keep waiting for the child")
+	assert.Zero(t, deleteAttempts, "must not re-Delete an already terminating Application")
 }

--- a/applicationset/utils/client.go
+++ b/applicationset/utils/client.go
@@ -89,6 +89,8 @@ func (c *cacheSyncingClient) retrieveStore(ctx context.Context, obj client.Objec
 func (c *cacheSyncingClient) execAndSyncCache(ctx context.Context, op func() error, obj client.Object, deleteObj bool) error {
 	// Execute the operation first; on success sync the informer cache. If it returns NotFound, also attempt to evict any stale entry from the cache.
 	var opErr error
+	// gone records that the API server confirmed the object no longer exists.
+	gone := false
 	if err := op(); err != nil {
 		// A NotFound means the object is already gone from the API server. Fall through to
 		// evict any stale entry from the informer cache below, otherwise a lingering
@@ -102,9 +104,20 @@ func (c *cacheSyncingClient) execAndSyncCache(ctx context.Context, op func() err
 			opErr = err
 		}
 		deleteObj = true
+		gone = true
 	}
 	// sync cache for applications only
 	if _, ok := obj.(*application.Application); !ok {
+		return opErr
+	}
+	// A successful Delete only removes the object outright when nothing holds it back: if it
+	// carries finalizers the API server merely stamps deletionTimestamp and the object lives on.
+	// Evicting the entry here would make cache-backed reads report the object as already gone
+	// while it is still terminating, so a caller waiting for teardown to finish concludes
+	// prematurely that it is done. Leave the entry and let the informer's own MODIFIED/DELETED
+	// events converge it. A NotFound is different: there the object really is absent, so any
+	// stale entry must still be evicted.
+	if deleteObj && !gone && len(obj.GetFinalizers()) > 0 {
 		return opErr
 	}
 

--- a/applicationset/utils/client_test.go
+++ b/applicationset/utils/client_test.go
@@ -234,3 +234,25 @@ func TestExecAndSyncCacheNotFoundHandlesDeleteError(t *testing.T) {
 		_ = c.execAndSyncCache(t.Context(), func() error { return notFound }, app, false)
 	})
 }
+
+// TestDeleteKeepsCacheEntryWhileFinalizersPending covers the premature-release defect. Deleting an
+// Application that carries finalizers does not remove it: the API server only stamps
+// deletionTimestamp and the object lives on. Evicting the store entry anyway makes the next
+// cache-backed read report the Application as gone, so reverse deletion sees an empty list, logs
+// "completed reverse deletion" and drops the ApplicationSet's finalizer while children are still
+// terminating — ordered teardown silently stops being enforced.
+func TestDeleteKeepsCacheEntryWhileFinalizersPending(t *testing.T) {
+	t.Parallel()
+	app := &application.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test",
+			Namespace:  "argocd",
+			Finalizers: []string{application.ResourcesFinalizerName},
+		},
+	}
+	c, store := newClient(t, withObjects(app))
+
+	require.NoError(t, c.Delete(t.Context(), app))
+
+	require.Len(t, store.List(), 1, "an Application held by finalizers is still terminating and must stay in the cache")
+}


### PR DESCRIPTION
Reverse deletion decides teardown is complete from cache-backed reads, and a Delete on an Application held by finalizers does not remove it: the API server stamps deletionTimestamp and the object lives on. Evicting the store entry on that success made the next read report the child as gone, so the controller logged "completed reverse deletion" and dropped the ApplicationSet's resources-finalizer while children were still terminating.

- cacheSyncingClient: keep the cache entry when a successful Delete left finalizers pending, and let the informer's own events converge it. A NotFound still evicts, so stale entries are cleared as before.
- PerformReverseDeletion: requeue once an Application is terminating instead of re-issuing a Delete every reconcile.

Also downgrade the two minute pending-deletion timeout to a warning. It sat on the only path reaching RemoveFinalizer and the age it measured only grows, so every retry failed identically and the ApplicationSet stayed in Terminating.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
