### PR TITLE
fix: reload current spec.source on retry.refresh, not the stale one

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -1588,6 +1588,17 @@ func (ctrl *ApplicationController) processRequestedAppOperation(app *appv1.Appli
 				extraMsg += " with latest revisions"
 				state.Operation.Sync.Revision = ""
 				state.Operation.Sync.Revisions = nil
+				// The source captured when the original sync started can be stale by the time we
+				// retry (e.g. an app-of-apps parent updated this Application's spec.source in the
+				// meantime). Reload it the same way autoSync does, so the retry doesn't reapply
+				// values that no longer match the current spec.
+				if state.Operation.Sync.Source != nil {
+					source := app.Spec.GetSource()
+					state.Operation.Sync.Source = &source
+				}
+				if state.Operation.Sync.Sources != nil {
+					state.Operation.Sync.Sources = app.Spec.Sources
+				}
 			}
 
 			// Get rid of sync results and null out previous operation completion time

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -1626,6 +1626,17 @@ func (ctrl *ApplicationController) processRequestedAppOperation(app *appv1.Appli
 				extraMsg += " with latest revisions"
 				state.Operation.Sync.Revision = ""
 				state.Operation.Sync.Revisions = nil
+				// The source captured when the original sync started can be stale by the time we
+				// retry (e.g. an app-of-apps parent updated this Application's spec.source in the
+				// meantime). Reload it the same way autoSync does, so the retry doesn't reapply
+				// values that no longer match the current spec.
+				if state.Operation.Sync.Source != nil {
+					source := app.Spec.GetSource()
+					state.Operation.Sync.Source = &source
+				}
+				if state.Operation.Sync.Sources != nil {
+					state.Operation.Sync.Sources = app.Spec.Sources
+				}
 			}
 
 			// Get rid of sync results and null out previous operation completion time

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -2878,6 +2878,47 @@ func TestProcessRequestedAppOperation_FailedHasRetries(t *testing.T) {
 	assert.EqualValues(t, 1, patchedApp.Status.OperationState.RetryCount)
 }
 
+func TestProcessRequestedAppOperation_RetryRefreshUpdatesStaleSource(t *testing.T) {
+	failedAttemptFinisedAt := time.Now().Add(-time.Minute * 5)
+	app := newFakeApp()
+	staleSource := app.Spec.Source.DeepCopy()
+	staleSource.Helm = &v1alpha1.ApplicationSourceHelm{ReleaseName: "stale-release"}
+	app.Operation = &v1alpha1.Operation{
+		Sync: &v1alpha1.SyncOperation{
+			Source:   staleSource,
+			Revision: "stale-revision",
+		},
+		Retry: v1alpha1.RetryStrategy{Limit: 1, Refresh: true},
+	}
+	app.Status.OperationState.Operation = *app.Operation
+	app.Status.OperationState.Phase = synccommon.OperationRunning
+	app.Status.OperationState.RetryCount = 0
+	app.Status.OperationState.FinishedAt = &metav1.Time{Time: failedAttemptFinisedAt}
+	app.Status.OperationState.SyncResult.Resources = []*v1alpha1.ResourceResult{{
+		Name:   "guestbook",
+		Kind:   "Deployment",
+		Group:  "apps",
+		Status: synccommon.ResultCodeSyncFailed,
+	}}
+
+	// The parent Application updated this child's spec.source (e.g. a new Helm release name)
+	// after the original sync operation started but before the retry fires.
+	app.Spec.Source.Helm = &v1alpha1.ApplicationSourceHelm{ReleaseName: "current-release"}
+
+	data := &fakeData{apps: []runtime.Object{app, &defaultProj}}
+	ctrl := newFakeController(t.Context(), data, nil)
+
+	ctrl.processRequestedAppOperation(app)
+
+	patchedApp, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(app.Namespace).Get(t.Context(), app.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, patchedApp.Status.OperationState)
+	require.NotNil(t, patchedApp.Status.OperationState.Operation.Sync)
+	assert.Empty(t, patchedApp.Status.OperationState.Operation.Sync.Revision, "revision should be cleared so the latest one is used")
+	require.NotNil(t, patchedApp.Status.OperationState.Operation.Sync.Source, "source should not be dropped")
+	assert.Equal(t, "current-release", patchedApp.Status.OperationState.Operation.Sync.Source.Helm.ReleaseName, "retry with refresh must reload the current spec.source, not reuse the stale one captured at the original sync")
+}
+
 func TestProcessRequestedAppOperation_RunningPreviouslyFailed(t *testing.T) {
 	failedAttemptFinisedAt := time.Now().Add(-time.Minute * 5)
 	app := newFakeApp()

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -3080,6 +3080,47 @@ func TestProcessRequestedAppOperation_FailedRetryMessageTime(t *testing.T) {
 	assert.WithinDuration(t, start.Add(2*time.Minute), retryAt, time.Minute)
 }
 
+func TestProcessRequestedAppOperation_RetryRefreshUpdatesStaleSource(t *testing.T) {
+	failedAttemptFinisedAt := time.Now().Add(-time.Minute * 5)
+	app := newFakeApp()
+	staleSource := app.Spec.Source.DeepCopy()
+	staleSource.Helm = &v1alpha1.ApplicationSourceHelm{ReleaseName: "stale-release"}
+	app.Operation = &v1alpha1.Operation{
+		Sync: &v1alpha1.SyncOperation{
+			Source:   staleSource,
+			Revision: "stale-revision",
+		},
+		Retry: v1alpha1.RetryStrategy{Limit: 1, Refresh: true},
+	}
+	app.Status.OperationState.Operation = *app.Operation
+	app.Status.OperationState.Phase = synccommon.OperationRunning
+	app.Status.OperationState.RetryCount = 0
+	app.Status.OperationState.FinishedAt = &metav1.Time{Time: failedAttemptFinisedAt}
+	app.Status.OperationState.SyncResult.Resources = []*v1alpha1.ResourceResult{{
+		Name:   "guestbook",
+		Kind:   "Deployment",
+		Group:  "apps",
+		Status: synccommon.ResultCodeSyncFailed,
+	}}
+
+	// The parent Application updated this child's spec.source (e.g. a new Helm release name)
+	// after the original sync operation started but before the retry fires.
+	app.Spec.Source.Helm = &v1alpha1.ApplicationSourceHelm{ReleaseName: "current-release"}
+
+	data := &fakeData{apps: []runtime.Object{app, &defaultProj}}
+	ctrl := newFakeController(t.Context(), data, nil)
+
+	ctrl.processRequestedAppOperation(app)
+
+	patchedApp, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(app.Namespace).Get(t.Context(), app.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, patchedApp.Status.OperationState)
+	require.NotNil(t, patchedApp.Status.OperationState.Operation.Sync)
+	assert.Empty(t, patchedApp.Status.OperationState.Operation.Sync.Revision, "revision should be cleared so the latest one is used")
+	require.NotNil(t, patchedApp.Status.OperationState.Operation.Sync.Source, "source should not be dropped")
+	assert.Equal(t, "current-release", patchedApp.Status.OperationState.Operation.Sync.Source.Helm.ReleaseName, "retry with refresh must reload the current spec.source, not reuse the stale one captured at the original sync")
+}
+
 func TestProcessRequestedAppOperation_RunningPreviouslyFailed(t *testing.T) {
 	failedAttemptFinisedAt := time.Now().Add(-time.Minute * 5)
 	app := newFakeApp()

--- a/test/e2e/app_autosync_test.go
+++ b/test/e2e/app_autosync_test.go
@@ -135,8 +135,10 @@ func TestAutoSyncRetryAndRefreshEnabled(t *testing.T) {
 		Expect(SyncStatusIs(SyncStatusCodeSynced))
 }
 
-// TestAutoSyncRetryAndRefreshEnabled verifies that auto-sync+refresh picks up new commits automatically on the original source
-// at the time the sync was triggered
+// TestAutoSyncRetryAndRefreshEnabledChangedSource verifies that auto-sync+refresh
+// reloads the current Application source on retry (not only the revision). That way a
+// parent Application that updates the child's spec.source mid-retry is picked up
+// (see #28794), instead of retrying with the stale source captured at sync start.
 func TestAutoSyncRetryAndRefreshEnabledChangedSource(t *testing.T) {
 	Given(t).
 		Path(guestbookPath).
@@ -167,19 +169,19 @@ func TestAutoSyncRetryAndRefreshEnabledChangedSource(t *testing.T) {
 		Expect(SyncStatusIs(SyncStatusCodeOutOfSync)).
 		Expect(OperationRetriedMinimumTimes(1)).
 		When().
-		PatchApp(`[{"op": "add", "path": "/spec/source/path", "value": "failure-during-sync"}]`).
-		// push a fixed commit on HEAD branch
-		PatchFile("guestbook-ui-deployment.yaml", `[{"op": "replace", "path": "/spec/revisionHistoryLimit", "value": 42}]`).
+		// Parent updates child source to a different valid path while retry is in progress
+		PatchApp(`[{"op": "replace", "path": "/spec/source/path", "value": "two-nice-pods"}]`).
 		Refresh(RefreshTypeNormal).
 		Then().
+		Expect(OperationPhaseIs(OperationSucceeded)).
+		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		Expect(Status(func(status ApplicationStatus) (bool, string) {
-			// Validate that the history contains the sync to the previous sources
-			// The history will only contain  successful sync
-			if len(status.History) != 2 {
-				return false, "expected len to be 2"
+			if len(status.History) < 2 {
+				return false, fmt.Sprintf("expected at least 2 history entries, got %d", len(status.History))
 			}
-			if status.History[1].Source.Path != guestbookPath {
-				return false, fmt.Sprintf("expected source path to be '%s'", guestbookPath)
+			last := status.History[len(status.History)-1]
+			if last.Source.Path != "two-nice-pods" {
+				return false, fmt.Sprintf("expected latest history source path to be 'two-nice-pods', got %q", last.Source.Path)
 			}
 			return true, ""
 		}))

--- a/test/e2e/app_autosync_test.go
+++ b/test/e2e/app_autosync_test.go
@@ -145,7 +145,9 @@ func TestAutoSyncRetryAndRefreshEnabledChangedSource(t *testing.T) {
 		When(). // I create an app with auto-sync and Refresh
 		CreateFromFile(func(app *Application) {
 			app.Spec.SyncPolicy = &SyncPolicy{
-				Automated: &SyncPolicyAutomated{},
+				// Prune so a mid-retry path switch drops the old guestbook live objects;
+				// manual-sync retry tests inherit fixture prune via Sync(), auto-sync does not.
+				Automated: &SyncPolicyAutomated{Prune: new(true)},
 				Retry: &RetryStrategy{
 					Limit:   -1, // Repeat forever
 					Refresh: true,

--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -1856,8 +1856,9 @@ func TestSyncWithInfos(t *testing.T) {
 		})
 }
 
-// TestSyncWithRetryAndRefreshEnabled verifies that sync+refresh picks up new commits automatically on the original source
-// at the time the sync was triggered
+// TestSyncWithRetryAndRefreshEnabled verifies that sync+refresh reloads the current
+// Application source on retry (not only the revision). A source change made while the
+// retry is in progress (e.g. parent updating a child Application) is picked up.
 func TestSyncWithRetryAndRefreshEnabled(t *testing.T) {
 	Given(t).
 		Timeout(2). // Quick timeout since Sync operation is expected to retry forever
@@ -1891,22 +1892,19 @@ func TestSyncWithRetryAndRefreshEnabled(t *testing.T) {
 		Expect(SyncStatusIs(SyncStatusCodeOutOfSync)).
 		Expect(OperationRetriedMinimumTimes(1)).
 		When().
-		PatchApp(`[{"op": "add", "path": "/spec/source/path", "value": "failure-during-sync"}]`).
-		// push a fixed commit on HEAD branch
-		PatchFile("guestbook-ui-deployment.yaml", `[{"op": "replace", "path": "/spec/revisionHistoryLimit", "value": 42}]`).
+		// Parent updates child source to a different valid path while retry is in progress
+		PatchApp(`[{"op": "replace", "path": "/spec/source/path", "value": "two-nice-pods"}]`).
 		Refresh(RefreshTypeNormal).
-		IgnoreErrors().
-		Sync().
-		DoNotIgnoreErrors().
 		Then().
+		Expect(OperationPhaseIs(OperationSucceeded)).
+		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		Expect(Status(func(status ApplicationStatus) (bool, string) {
-			// Validate that the history contains the sync to the previous sources
-			// The history will only contain  successful sync
-			if len(status.History) != 2 {
-				return false, "expected len to be 2"
+			if len(status.History) < 2 {
+				return false, fmt.Sprintf("expected at least 2 history entries, got %d", len(status.History))
 			}
-			if status.History[1].Source.Path != guestbookPath {
-				return false, fmt.Sprintf("expected source path to be '%s'", guestbookPath)
+			last := status.History[len(status.History)-1]
+			if last.Source.Path != "two-nice-pods" {
+				return false, fmt.Sprintf("expected latest history source path to be 'two-nice-pods', got %q", last.Source.Path)
 			}
 			return true, ""
 		}))

--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -1887,8 +1887,9 @@ func TestSyncWithInfos(t *testing.T) {
 		})
 }
 
-// TestSyncWithRetryAndRefreshEnabled verifies that sync+refresh picks up new commits automatically on the original source
-// at the time the sync was triggered
+// TestSyncWithRetryAndRefreshEnabled verifies that sync+refresh reloads the current
+// Application source on retry (not only the revision). A source change made while the
+// retry is in progress (e.g. parent updating a child Application) is picked up.
 func TestSyncWithRetryAndRefreshEnabled(t *testing.T) {
 	Given(t).
 		Timeout(2). // Quick timeout since Sync operation is expected to retry forever
@@ -1922,22 +1923,19 @@ func TestSyncWithRetryAndRefreshEnabled(t *testing.T) {
 		Expect(SyncStatusIs(SyncStatusCodeOutOfSync)).
 		Expect(OperationRetriedMinimumTimes(1)).
 		When().
-		PatchApp(`[{"op": "add", "path": "/spec/source/path", "value": "failure-during-sync"}]`).
-		// push a fixed commit on HEAD branch
-		PatchFile("guestbook-ui-deployment.yaml", `[{"op": "replace", "path": "/spec/revisionHistoryLimit", "value": 42}]`).
+		// Parent updates child source to a different valid path while retry is in progress
+		PatchApp(`[{"op": "replace", "path": "/spec/source/path", "value": "two-nice-pods"}]`).
 		Refresh(RefreshTypeNormal).
-		IgnoreErrors().
-		Sync().
-		DoNotIgnoreErrors().
 		Then().
+		Expect(OperationPhaseIs(OperationSucceeded)).
+		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		Expect(Status(func(status ApplicationStatus) (bool, string) {
-			// Validate that the history contains the sync to the previous sources
-			// The history will only contain  successful sync
-			if len(status.History) != 2 {
-				return false, "expected len to be 2"
+			if len(status.History) < 2 {
+				return false, fmt.Sprintf("expected at least 2 history entries, got %d", len(status.History))
 			}
-			if status.History[1].Source.Path != guestbookPath {
-				return false, fmt.Sprintf("expected source path to be '%s'", guestbookPath)
+			last := status.History[len(status.History)-1]
+			if last.Source.Path != "two-nice-pods" {
+				return false, fmt.Sprintf("expected latest history source path to be 'two-nice-pods', got %q", last.Source.Path)
 			}
 			return true, ""
 		}))


### PR DESCRIPTION
## Proposed Changes

Fixes #28794.

When `syncPolicy.retry.refresh` is set, a retry clears the operation's
captured revision so the latest one gets resolved, but it left
`Operation.Sync.Source/Sources` untouched. In an app-of-apps setup where a
parent Application updates a child's `spec.source` (e.g. new Helm values)
after the child's original sync already started, the retry kept reusing
the source captured at that original sync instead of the app's current
spec, so it retried with stale values even though the revision refreshed
correctly.

Reloads `Source/Sources` from the current `app.Spec` the same way `autoSync`
already populates them for a fresh sync, but only when they were set on the
original operation (kept nil otherwise, matching manual syncs where the app
spec's own source applies directly).

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have added tests that prove my fix is effective
- [x] All tests pass locally with my changes
