### PR TITLE
fix: guard malformed registry challenges in Azure workload identity creds

### DIFF
--- a/util/helm/creds.go
+++ b/util/helm/creds.go
@@ -275,10 +275,18 @@ func (creds AzureWorkloadIdentityCreds) challengeAzureContainerRegistry(ctx cont
 		return nil, fmt.Errorf("registry does not allow 'Bearer' authentication, got '%s'", tokens[0])
 	}
 
+	if len(tokens) < 2 {
+		return nil, fmt.Errorf("registry '%s' issued a challenge without any parameters", azureContainerRegistry)
+	}
+
 	tokenParams := make(map[string]string)
 
 	for token := range strings.SplitSeq(tokens[1], ",") {
-		kvPair := strings.Split(token, "=")
+		// SplitN keeps a value that itself contains '=' intact
+		kvPair := strings.SplitN(token, "=", 2)
+		if len(kvPair) < 2 {
+			return nil, fmt.Errorf("registry '%s' issued a malformed challenge parameter: %q", azureContainerRegistry, token)
+		}
 		tokenParams[kvPair[0]] = strings.Trim(kvPair[1], "\"")
 	}
 

--- a/util/helm/creds_test.go
+++ b/util/helm/creds_test.go
@@ -153,6 +153,60 @@ func TestChallengeAzureContainerRegistryNonBearer(t *testing.T) {
 	assert.ErrorContains(t, err, "does not allow 'Bearer' authentication")
 }
 
+func TestChallengeAzureContainerRegistryNoParameters(t *testing.T) {
+	t.Parallel()
+	// A challenge with no parameters at all, so there is nothing after "Bearer"
+	mockServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v2/", r.URL.Path)
+		w.Header().Set("Www-Authenticate", "Bearer")
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer mockServer.Close()
+
+	workloadIdentityMock := &mocks.TokenProvider{}
+	creds := NewAzureWorkloadIdentityCreds(mockServer.URL[8:], "", nil, nil, true, workloadIdentityMock)
+
+	_, err := creds.challengeAzureContainerRegistry(t.Context(), creds.repoURL)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "without any parameters")
+}
+
+func TestChallengeAzureContainerRegistryMalformedParameter(t *testing.T) {
+	t.Parallel()
+	// A challenge parameter with no '=' in it
+	mockServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v2/", r.URL.Path)
+		w.Header().Set("Www-Authenticate", "Bearer realm")
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer mockServer.Close()
+
+	workloadIdentityMock := &mocks.TokenProvider{}
+	creds := NewAzureWorkloadIdentityCreds(mockServer.URL[8:], "", nil, nil, true, workloadIdentityMock)
+
+	_, err := creds.challengeAzureContainerRegistry(t.Context(), creds.repoURL)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "malformed challenge parameter")
+}
+
+func TestChallengeAzureContainerRegistryValueWithEquals(t *testing.T) {
+	t.Parallel()
+	// A parameter value containing '=', which must survive intact
+	mockServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v2/", r.URL.Path)
+		w.Header().Set("Www-Authenticate", `Bearer realm="https://login.microsoftonline.com/?a=b",service="registry.example.com"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer mockServer.Close()
+
+	workloadIdentityMock := &mocks.TokenProvider{}
+	creds := NewAzureWorkloadIdentityCreds(mockServer.URL[8:], "", nil, nil, true, workloadIdentityMock)
+
+	tokenParams, err := creds.challengeAzureContainerRegistry(t.Context(), creds.repoURL)
+	require.NoError(t, err)
+	assert.Equal(t, "https://login.microsoftonline.com/?a=b", tokenParams["realm"])
+}
+
 func TestChallengeAzureContainerRegistryNoService(t *testing.T) {
 	t.Parallel()
 	// Set up the mock server with a non-Bearer Www-Authenticate header


### PR DESCRIPTION
`AzureWorkloadIdentityCreds.challengeAzureContainerRegistry` parses the `Www-Authenticate` header the registry returns from `/v2/`:

```go
tokens := strings.Split(authenticate, " ")
if !strings.EqualFold(tokens[0], "bearer") { ... }
for token := range strings.SplitSeq(tokens[1], ",") {
    kvPair := strings.Split(token, "=")
    tokenParams[kvPair[0]] = strings.Trim(kvPair[1], "\"")
}
```

`tokens[0]` is checked, `tokens[1]` is not, so a bare `Www-Authenticate: Bearer` gives `index out of range [1] with length 1`. Likewise a challenge parameter with no `=`, as in `Bearer realm`, panics on `kvPair[1]`.

The header is whatever the registry sends. This runs in the repo-server when Azure Workload Identity credentials are configured for a Helm OCI repository, so a misbehaving or hostile registry endpoint, or simply a non-Azure OCI registry that answers differently, takes down the repo-server rather than failing that one repository.

The existing `TestChallenge*` cases all use well formed `Bearer key="value"` headers, which is why this was not covered.

Two changes:

- return an error when the challenge has no parameters after `Bearer`
- split each parameter with `SplitN(token, "=", 2)` and error when there is no `=`. As a side effect a parameter value that itself contains `=`, for example a realm with a query string, is no longer truncated at the first one.

Tests: three cases added next to the existing ones, for a parameter-less challenge, a parameter with no `=`, and a value containing `=`. The first two panic on master with the error above; all 8 `TestChallenge*` tests pass with this change.

Checklist:

* [x] Either (a) I've created an enhancement proposal and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the Title of the PR
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates? No.
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by DCO
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green.
* [x] My new feature complies with the feature status guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
