### PR TITLE
feat(controller): warn when pruning unprotected stray resources

### DIFF
--- a/cmd/argocd/commands/admin/app.go
+++ b/cmd/argocd/commands/admin/app.go
@@ -426,6 +426,7 @@ func reconcileApplications(
 		serverSideDiff,
 		ignoreNormalizerOpts,
 		nil,
+		projLister,
 	)
 
 	appsList, err := appClientset.ArgoprojV1alpha1().Applications(namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})

--- a/cmd/argocd/commands/admin/app.go
+++ b/cmd/argocd/commands/admin/app.go
@@ -425,6 +425,7 @@ func reconcileApplications(
 		0,
 		serverSideDiff,
 		ignoreNormalizerOpts,
+		nil,
 	)
 
 	appsList, err := appClientset.ArgoprojV1alpha1().Applications(namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -313,7 +313,7 @@ func NewApplicationController(
 		}
 	}
 	stateCache := statecache.NewLiveStateCache(db, appInformer, ctrl.settingsMgr, ctrl.metricsServer, ctrl.handleObjectUpdated, clusterSharding, argo.NewResourceTracking())
-	appStateManager := NewAppStateManager(db, applicationClientset, repoClientset, namespace, kubectl, ctrl.onKubectlRun, ctrl.settingsMgr, stateCache, ctrl.metricsServer, argoCache, ctrl.statusRefreshTimeout, argo.NewResourceTracking(), persistResourceHealth, repoErrorGracePeriod, serverSideDiff, ignoreNormalizerOpts)
+	appStateManager := NewAppStateManager(db, applicationClientset, repoClientset, namespace, kubectl, ctrl.onKubectlRun, ctrl.settingsMgr, stateCache, ctrl.metricsServer, argoCache, ctrl.statusRefreshTimeout, argo.NewResourceTracking(), persistResourceHealth, repoErrorGracePeriod, serverSideDiff, ignoreNormalizerOpts, ctrl.auditLogger)
 	ctrl.appInformer = appInformer
 	ctrl.appLister = appLister
 	ctrl.projInformer = projInformer

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -313,7 +313,7 @@ func NewApplicationController(
 		}
 	}
 	stateCache := statecache.NewLiveStateCache(db, appInformer, ctrl.settingsMgr, ctrl.metricsServer, ctrl.handleObjectUpdated, clusterSharding, argo.NewResourceTracking())
-	appStateManager := NewAppStateManager(db, applicationClientset, repoClientset, namespace, kubectl, ctrl.onKubectlRun, ctrl.settingsMgr, stateCache, ctrl.metricsServer, argoCache, ctrl.statusRefreshTimeout, argo.NewResourceTracking(), persistResourceHealth, repoErrorGracePeriod, serverSideDiff, ignoreNormalizerOpts, ctrl.auditLogger)
+	appStateManager := NewAppStateManager(db, applicationClientset, repoClientset, namespace, kubectl, ctrl.onKubectlRun, ctrl.settingsMgr, stateCache, ctrl.metricsServer, argoCache, ctrl.statusRefreshTimeout, argo.NewResourceTracking(), persistResourceHealth, repoErrorGracePeriod, serverSideDiff, ignoreNormalizerOpts, ctrl.auditLogger, applisters.NewAppProjectLister(projInformer.GetIndexer()))
 	ctrl.appInformer = appInformer
 	ctrl.appLister = appLister
 	ctrl.projInformer = projInformer

--- a/controller/state.go
+++ b/controller/state.go
@@ -147,6 +147,7 @@ type appStateManager struct {
 	repoErrorGracePeriod  time.Duration
 	serverSideDiff        bool
 	ignoreNormalizerOpts  normalizers.IgnoreNormalizerOpts
+	auditLogger           *argo.AuditLogger
 }
 
 // EvaluateAppRevisionsChanges checks if any source revisions have changes without generating manifests.
@@ -1317,6 +1318,7 @@ func NewAppStateManager(
 	repoErrorGracePeriod time.Duration,
 	serverSideDiff bool,
 	ignoreNormalizerOpts normalizers.IgnoreNormalizerOpts,
+	auditLogger *argo.AuditLogger,
 ) AppStateManager {
 	return &appStateManager{
 		liveStateCache:        liveStateCache,
@@ -1335,6 +1337,7 @@ func NewAppStateManager(
 		repoErrorGracePeriod:  repoErrorGracePeriod,
 		serverSideDiff:        serverSideDiff,
 		ignoreNormalizerOpts:  ignoreNormalizerOpts,
+		auditLogger:           auditLogger,
 	}
 }
 

--- a/controller/state.go
+++ b/controller/state.go
@@ -39,6 +39,7 @@ import (
 	"github.com/argoproj/argo-cd/v3/controller/metrics"
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	appclientset "github.com/argoproj/argo-cd/v3/pkg/client/clientset/versioned"
+	applisters "github.com/argoproj/argo-cd/v3/pkg/client/listers/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v3/reposerver/apiclient"
 	applog "github.com/argoproj/argo-cd/v3/util/app/log"
 	"github.com/argoproj/argo-cd/v3/util/app/path"
@@ -148,6 +149,7 @@ type appStateManager struct {
 	serverSideDiff        bool
 	ignoreNormalizerOpts  normalizers.IgnoreNormalizerOpts
 	auditLogger           *argo.AuditLogger
+	projLister            applisters.AppProjectLister
 }
 
 // EvaluateAppRevisionsChanges checks if any source revisions have changes without generating manifests.
@@ -1319,6 +1321,7 @@ func NewAppStateManager(
 	serverSideDiff bool,
 	ignoreNormalizerOpts normalizers.IgnoreNormalizerOpts,
 	auditLogger *argo.AuditLogger,
+	projLister applisters.AppProjectLister,
 ) AppStateManager {
 	return &appStateManager{
 		liveStateCache:        liveStateCache,
@@ -1338,6 +1341,7 @@ func NewAppStateManager(
 		serverSideDiff:        serverSideDiff,
 		ignoreNormalizerOpts:  ignoreNormalizerOpts,
 		auditLogger:           auditLogger,
+		projLister:            projLister,
 	}
 }
 

--- a/controller/state.go
+++ b/controller/state.go
@@ -40,6 +40,7 @@ import (
 	"github.com/argoproj/argo-cd/v3/controller/metrics"
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	appclientset "github.com/argoproj/argo-cd/v3/pkg/client/clientset/versioned"
+	applisters "github.com/argoproj/argo-cd/v3/pkg/client/listers/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v3/reposerver/apiclient"
 	applog "github.com/argoproj/argo-cd/v3/util/app/log"
 	"github.com/argoproj/argo-cd/v3/util/app/path"
@@ -149,6 +150,7 @@ type appStateManager struct {
 	serverSideDiff        bool
 	ignoreNormalizerOpts  normalizers.IgnoreNormalizerOpts
 	auditLogger           *argo.AuditLogger
+	projLister            applisters.AppProjectLister
 }
 
 // EvaluateAppRevisionsChanges checks if any source revisions have changes without generating manifests.
@@ -1332,6 +1334,7 @@ func NewAppStateManager(
 	serverSideDiff bool,
 	ignoreNormalizerOpts normalizers.IgnoreNormalizerOpts,
 	auditLogger *argo.AuditLogger,
+	projLister applisters.AppProjectLister,
 ) AppStateManager {
 	return &appStateManager{
 		liveStateCache:        liveStateCache,
@@ -1351,6 +1354,7 @@ func NewAppStateManager(
 		serverSideDiff:        serverSideDiff,
 		ignoreNormalizerOpts:  ignoreNormalizerOpts,
 		auditLogger:           auditLogger,
+		projLister:            projLister,
 	}
 }
 

--- a/controller/state.go
+++ b/controller/state.go
@@ -148,6 +148,7 @@ type appStateManager struct {
 	repoErrorGracePeriod  time.Duration
 	serverSideDiff        bool
 	ignoreNormalizerOpts  normalizers.IgnoreNormalizerOpts
+	auditLogger           *argo.AuditLogger
 }
 
 // EvaluateAppRevisionsChanges checks if any source revisions have changes without generating manifests.
@@ -1330,6 +1331,7 @@ func NewAppStateManager(
 	repoErrorGracePeriod time.Duration,
 	serverSideDiff bool,
 	ignoreNormalizerOpts normalizers.IgnoreNormalizerOpts,
+	auditLogger *argo.AuditLogger,
 ) AppStateManager {
 	return &appStateManager{
 		liveStateCache:        liveStateCache,
@@ -1348,6 +1350,7 @@ func NewAppStateManager(
 		repoErrorGracePeriod:  repoErrorGracePeriod,
 		serverSideDiff:        serverSideDiff,
 		ignoreNormalizerOpts:  ignoreNormalizerOpts,
+		auditLogger:           auditLogger,
 	}
 }
 

--- a/controller/stray_resource_warning.go
+++ b/controller/stray_resource_warning.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	log "github.com/sirupsen/logrus"
-	synccommon "github.com/argoproj/argo-cd/gitops-engine/v3/pkg/sync/common"
 	"github.com/argoproj/argo-cd/gitops-engine/v3/pkg/sync"
+	synccommon "github.com/argoproj/argo-cd/gitops-engine/v3/pkg/sync/common"
 	resourceutil "github.com/argoproj/argo-cd/gitops-engine/v3/pkg/sync/resource"
+	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -30,28 +30,6 @@ func liveObjHasExplicitSyncProtection(obj *unstructured.Unstructured) bool {
 		return true
 	}
 	return false
-}
-
-func isPruningDisabledForObj(obj *unstructured.Unstructured, defaultPruneOption *string) bool {
-	var pruneOptionValue *string
-	if obj != nil {
-		pruneOptionValue = resourceutil.GetAnnotationOptionValue(obj, synccommon.AnnotationSyncOptions, synccommon.SyncOptionPrune)
-	}
-	if pruneOptionValue == nil {
-		pruneOptionValue = defaultPruneOption
-	}
-	return pruneOptionValue != nil && *pruneOptionValue == synccommon.SyncValueFalse
-}
-
-func objRequiresPruneConfirmation(obj *unstructured.Unstructured, defaultPruneOption *string) bool {
-	var pruneOptionValue *string
-	if obj != nil {
-		pruneOptionValue = resourceutil.GetAnnotationOptionValue(obj, synccommon.AnnotationSyncOptions, synccommon.SyncOptionPrune)
-	}
-	if pruneOptionValue == nil {
-		pruneOptionValue = defaultPruneOption
-	}
-	return pruneOptionValue != nil && *pruneOptionValue == synccommon.SyncValueConfirm
 }
 
 func (m *appStateManager) warnUnprotectedStrayResources(
@@ -77,13 +55,13 @@ func (m *appStateManager) warnUnprotectedStrayResources(
 		if targetObj != nil {
 			continue
 		}
-		if isPruningDisabledForObj(liveObj, defaultPruneOption) {
+		if sync.IsPruningDisabled(liveObj, defaultPruneOption) {
 			continue
 		}
 		if liveObjHasExplicitSyncProtection(liveObj) {
 			continue
 		}
-		if objRequiresPruneConfirmation(liveObj, defaultPruneOption) && !pruneConfirmed {
+		if sync.ObjRequiresPruneConfirmation(liveObj, defaultPruneOption) && !pruneConfirmed {
 			continue
 		}
 

--- a/controller/stray_resource_warning.go
+++ b/controller/stray_resource_warning.go
@@ -43,16 +43,29 @@ func isPruningDisabledForObj(obj *unstructured.Unstructured, defaultPruneOption 
 	return pruneOptionValue != nil && *pruneOptionValue == synccommon.SyncValueFalse
 }
 
+func objRequiresPruneConfirmation(obj *unstructured.Unstructured, defaultPruneOption *string) bool {
+	var pruneOptionValue *string
+	if obj != nil {
+		pruneOptionValue = resourceutil.GetAnnotationOptionValue(obj, synccommon.AnnotationSyncOptions, synccommon.SyncOptionPrune)
+	}
+	if pruneOptionValue == nil {
+		pruneOptionValue = defaultPruneOption
+	}
+	return pruneOptionValue != nil && *pruneOptionValue == synccommon.SyncValueConfirm
+}
+
 func (m *appStateManager) warnUnprotectedStrayResources(
 	ctx context.Context,
 	app *appv1.Application,
 	logEntry *log.Entry,
 	reconciliationResult sync.ReconciliationResult,
 	defaultPruneOption *string,
+	pruneConfirmed bool,
 ) {
-	if m.auditLogger == nil {
+	if m.auditLogger == nil || m.projLister == nil {
 		return
 	}
+	eventLabels := argo.GetAppEventLabels(ctx, app, m.projLister, m.namespace, m.settingsMgr, m.db)
 	for i, liveObj := range reconciliationResult.Live {
 		if liveObj == nil {
 			continue
@@ -70,6 +83,9 @@ func (m *appStateManager) warnUnprotectedStrayResources(
 		if liveObjHasExplicitSyncProtection(liveObj) {
 			continue
 		}
+		if objRequiresPruneConfirmation(liveObj, defaultPruneOption) && !pruneConfirmed {
+			continue
+		}
 
 		gvk := liveObj.GroupVersionKind()
 		message := fmt.Sprintf(
@@ -78,7 +94,6 @@ func (m *appStateManager) warnUnprotectedStrayResources(
 			gvk.Group, gvk.Kind, fmt.Sprintf("%s/%s", liveObj.GetNamespace(), liveObj.GetName()),
 		)
 		logEntry.Warn(message)
-		eventLabels := argo.GetAppEventLabels(ctx, app, nil, m.namespace, m.settingsMgr, m.db)
 		m.auditLogger.LogAppEvent(
 			app,
 			argo.EventInfo{Reason: argo.EventReasonResourceDeleted, Type: corev1.EventTypeWarning},

--- a/controller/stray_resource_warning.go
+++ b/controller/stray_resource_warning.go
@@ -1,0 +1,90 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	synccommon "github.com/argoproj/argo-cd/gitops-engine/v3/pkg/sync/common"
+	"github.com/argoproj/argo-cd/gitops-engine/v3/pkg/sync"
+	resourceutil "github.com/argoproj/argo-cd/gitops-engine/v3/pkg/sync/resource"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	appv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v3/util/argo"
+)
+
+// liveObjHasExplicitSyncProtection reports whether the live object itself carries
+// a Prune=false or Delete=false sync-option annotation (not app/project defaults).
+func liveObjHasExplicitSyncProtection(obj *unstructured.Unstructured) bool {
+	if obj == nil {
+		return false
+	}
+	pruneVal := resourceutil.GetAnnotationOptionValue(obj, synccommon.AnnotationSyncOptions, synccommon.SyncOptionPrune)
+	if pruneVal != nil && *pruneVal == synccommon.SyncValueFalse {
+		return true
+	}
+	deleteVal := resourceutil.GetAnnotationOptionValue(obj, synccommon.AnnotationSyncOptions, synccommon.SyncOptionDelete)
+	if deleteVal != nil && *deleteVal == synccommon.SyncValueFalse {
+		return true
+	}
+	return false
+}
+
+func isPruningDisabledForObj(obj *unstructured.Unstructured, defaultPruneOption *string) bool {
+	var pruneOptionValue *string
+	if obj != nil {
+		pruneOptionValue = resourceutil.GetAnnotationOptionValue(obj, synccommon.AnnotationSyncOptions, synccommon.SyncOptionPrune)
+	}
+	if pruneOptionValue == nil {
+		pruneOptionValue = defaultPruneOption
+	}
+	return pruneOptionValue != nil && *pruneOptionValue == synccommon.SyncValueFalse
+}
+
+func (m *appStateManager) warnUnprotectedStrayResources(
+	ctx context.Context,
+	app *appv1.Application,
+	logEntry *log.Entry,
+	reconciliationResult sync.ReconciliationResult,
+	defaultPruneOption *string,
+) {
+	if m.auditLogger == nil {
+		return
+	}
+	for i, liveObj := range reconciliationResult.Live {
+		if liveObj == nil {
+			continue
+		}
+		var targetObj *unstructured.Unstructured
+		if i < len(reconciliationResult.Target) {
+			targetObj = reconciliationResult.Target[i]
+		}
+		if targetObj != nil {
+			continue
+		}
+		if isPruningDisabledForObj(liveObj, defaultPruneOption) {
+			continue
+		}
+		if liveObjHasExplicitSyncProtection(liveObj) {
+			continue
+		}
+
+		gvk := liveObj.GroupVersionKind()
+		message := fmt.Sprintf(
+			"Pruning stray resource %s/%s/%s with no Prune=false or Delete=false annotation on its live object; "+
+				"if you expected it to be retained, verify the annotation was applied to this object (not only a parent manifest)",
+			gvk.Group, gvk.Kind, fmt.Sprintf("%s/%s", liveObj.GetNamespace(), liveObj.GetName()),
+		)
+		logEntry.Warn(message)
+		eventLabels := argo.GetAppEventLabels(ctx, app, nil, m.namespace, m.settingsMgr, m.db)
+		m.auditLogger.LogAppEvent(
+			app,
+			argo.EventInfo{Reason: argo.EventReasonResourceDeleted, Type: corev1.EventTypeWarning},
+			message,
+			"",
+			eventLabels,
+		)
+	}
+}

--- a/controller/stray_resource_warning.go
+++ b/controller/stray_resource_warning.go
@@ -10,26 +10,31 @@ import (
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	appv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v3/util/argo"
 )
 
-// liveObjHasExplicitSyncProtection reports whether the live object itself carries
-// a Prune=false or Delete=false sync-option annotation (not app/project defaults).
-func liveObjHasExplicitSyncProtection(obj *unstructured.Unstructured) bool {
+// maxStrayResourceWarningsPerSync caps the number of individual warning
+// log lines and Kubernetes Events a single sync can emit for unprotected
+// stray resources, so an app with many of them can't flood the API server.
+const maxStrayResourceWarningsPerSync = 20
+
+// liveObjHasPruneFalse reports whether the live object itself carries an
+// explicit Prune=false sync-option annotation (not an app/project default).
+// Delete=false is deliberately not treated as protection here: it only
+// gates cascade delete of the whole Application (see shouldBeDeleted in
+// appcontroller.go), gitops-engine's own prune path (IsPruningDisabled)
+// never looks at it, so a resource with only Delete=false is still pruned
+// during a normal sync even though this check would otherwise suppress the
+// warning for it.
+func liveObjHasPruneFalse(obj *unstructured.Unstructured) bool {
 	if obj == nil {
 		return false
 	}
 	pruneVal := resourceutil.GetAnnotationOptionValue(obj, synccommon.AnnotationSyncOptions, synccommon.SyncOptionPrune)
-	if pruneVal != nil && *pruneVal == synccommon.SyncValueFalse {
-		return true
-	}
-	deleteVal := resourceutil.GetAnnotationOptionValue(obj, synccommon.AnnotationSyncOptions, synccommon.SyncOptionDelete)
-	if deleteVal != nil && *deleteVal == synccommon.SyncValueFalse {
-		return true
-	}
-	return false
+	return pruneVal != nil && *pruneVal == synccommon.SyncValueFalse
 }
 
 func (m *appStateManager) warnUnprotectedStrayResources(
@@ -39,11 +44,13 @@ func (m *appStateManager) warnUnprotectedStrayResources(
 	reconciliationResult sync.ReconciliationResult,
 	defaultPruneOption *string,
 	pruneConfirmed bool,
+	scopedResources []appv1.SyncOperationResource,
 ) {
 	if m.auditLogger == nil || m.projLister == nil {
 		return
 	}
-	eventLabels := argo.GetAppEventLabels(ctx, app, m.projLister, m.namespace, m.settingsMgr, m.db)
+	var eventLabels map[string]string
+	warningsEmitted := 0
 	for i, liveObj := range reconciliationResult.Live {
 		if liveObj == nil {
 			continue
@@ -55,19 +62,38 @@ func (m *appStateManager) warnUnprotectedStrayResources(
 		if targetObj != nil {
 			continue
 		}
+		if len(scopedResources) > 0 {
+			gvk := liveObj.GroupVersionKind()
+			if !argo.ContainsSyncResource(liveObj.GetName(), liveObj.GetNamespace(),
+				schema.GroupVersionKind{Group: gvk.Group, Kind: gvk.Kind}, scopedResources) {
+				// This sync only targets a subset of resources and gitops-engine
+				// will skip pruning anything outside that selection, so warning
+				// about this one would be misleading.
+				continue
+			}
+		}
 		if sync.IsPruningDisabled(liveObj, defaultPruneOption) {
 			continue
 		}
-		if liveObjHasExplicitSyncProtection(liveObj) {
+		if liveObjHasPruneFalse(liveObj) {
 			continue
 		}
 		if sync.ObjRequiresPruneConfirmation(liveObj, defaultPruneOption) && !pruneConfirmed {
 			continue
 		}
+		if warningsEmitted >= maxStrayResourceWarningsPerSync {
+			logEntry.Warnf("more than %d unprotected stray resources would be pruned in this sync; "+
+				"suppressing further individual warnings", maxStrayResourceWarningsPerSync)
+			break
+		}
+
+		if eventLabels == nil {
+			eventLabels = argo.GetAppEventLabels(ctx, app, m.projLister, m.namespace, m.settingsMgr, m.db)
+		}
 
 		gvk := liveObj.GroupVersionKind()
 		message := fmt.Sprintf(
-			"Pruning stray resource %s/%s/%s with no Prune=false or Delete=false annotation on its live object; "+
+			"Pruning stray resource %s/%s/%s with no Prune=false annotation on its live object; "+
 				"if you expected it to be retained, verify the annotation was applied to this object (not only a parent manifest)",
 			gvk.Group, gvk.Kind, fmt.Sprintf("%s/%s", liveObj.GetNamespace(), liveObj.GetName()),
 		)
@@ -79,5 +105,6 @@ func (m *appStateManager) warnUnprotectedStrayResources(
 			"",
 			eventLabels,
 		)
+		warningsEmitted++
 	}
 }

--- a/controller/stray_resource_warning_test.go
+++ b/controller/stray_resource_warning_test.go
@@ -1,15 +1,24 @@
 package controller
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/argoproj/argo-cd/gitops-engine/v3/pkg/sync"
 	synccommon "github.com/argoproj/argo-cd/gitops-engine/v3/pkg/sync/common"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 )
 
-func TestLiveObjHasExplicitSyncProtection(t *testing.T) {
+func TestLiveObjHasPruneFalse(t *testing.T) {
 	t.Parallel()
 
 	t.Run("no annotations", func(t *testing.T) {
@@ -22,7 +31,7 @@ func TestLiveObjHasExplicitSyncProtection(t *testing.T) {
 				"namespace": "default",
 			},
 		}}
-		assert.False(t, liveObjHasExplicitSyncProtection(obj))
+		assert.False(t, liveObjHasPruneFalse(obj))
 	})
 
 	t.Run("prune false on live object", func(t *testing.T) {
@@ -38,11 +47,15 @@ func TestLiveObjHasExplicitSyncProtection(t *testing.T) {
 				},
 			},
 		}}
-		assert.True(t, liveObjHasExplicitSyncProtection(obj))
+		assert.True(t, liveObjHasPruneFalse(obj))
 	})
 
-	t.Run("delete false only", func(t *testing.T) {
+	t.Run("delete false only is not prune protection", func(t *testing.T) {
 		t.Parallel()
+		// Delete=false only gates cascade delete of the whole Application
+		// (shouldBeDeleted in appcontroller.go); gitops-engine's own prune
+		// path never looks at it, so this must NOT be treated as protection
+		// here, a resource with only Delete=false is still pruned normally.
 		obj := &unstructured.Unstructured{Object: map[string]any{
 			"apiVersion": "v1",
 			"kind":       "PersistentVolumeClaim",
@@ -54,7 +67,7 @@ func TestLiveObjHasExplicitSyncProtection(t *testing.T) {
 				},
 			},
 		}}
-		assert.True(t, liveObjHasExplicitSyncProtection(obj))
+		assert.False(t, liveObjHasPruneFalse(obj))
 	})
 }
 
@@ -111,23 +124,128 @@ func TestObjRequiresPruneConfirmation(t *testing.T) {
 	})
 }
 
-func TestWarnUnprotectedStrayResources_emitsForStrayWithoutAnnotation(t *testing.T) {
-	t.Parallel()
+// strayResourceWarningTestManager builds a real *appStateManager (via the
+// same fake-controller wiring the rest of this package's tests use) so
+// warnUnprotectedStrayResources can be exercised end to end, including the
+// real audit logger writing real Events against a fake Kubernetes client.
+func strayResourceWarningTestManager(t *testing.T) (*appStateManager, *ApplicationController, *v1alpha1.Application) {
+	t.Helper()
+	app := newFakeApp()
+	ctrl := newFakeController(t.Context(), &fakeData{apps: []runtime.Object{app}}, nil)
+	sm, ok := ctrl.appStateManager.(*appStateManager)
+	require.True(t, ok, "appStateManager must be the concrete *appStateManager for this test")
+	return sm, ctrl, app
+}
 
-	pvc := &unstructured.Unstructured{Object: map[string]any{
+func strayLiveObj(name string, annotations map[string]string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "v1",
 		"kind":       "PersistentVolumeClaim",
 		"metadata": map[string]any{
-			"name":      "data-my-sts-0",
+			"name":      name,
 			"namespace": "default",
 		},
 	}}
-	protectedPVC := pvc.DeepCopy()
-	protectedPVC.SetAnnotations(map[string]string{
-		synccommon.AnnotationSyncOptions: "Prune=false,Delete=false",
-	})
+	if len(annotations) > 0 {
+		obj.SetAnnotations(annotations)
+	}
+	return obj
+}
 
-	// Covered by unit helpers; integration with audit logger is exercised in controller tests.
-	assert.False(t, liveObjHasExplicitSyncProtection(pvc))
-	assert.True(t, liveObjHasExplicitSyncProtection(protectedPVC))
+func TestWarnUnprotectedStrayResources_emitsForStrayWithoutAnnotation(t *testing.T) {
+	t.Parallel()
+
+	sm, ctrl, app := strayResourceWarningTestManager(t)
+	logEntry := log.NewEntry(log.StandardLogger())
+
+	unprotected := strayLiveObj("data-my-sts-0", nil)
+	pruneProtected := strayLiveObj("data-my-sts-1", map[string]string{
+		synccommon.AnnotationSyncOptions: "Prune=false",
+	})
+	// Delete=false alone does not stop gitops-engine from pruning this
+	// resource in a normal sync, so it must still warn (see
+	// liveObjHasPruneFalse's comment and TestLiveObjHasPruneFalse above).
+	deleteFalseOnly := strayLiveObj("data-my-sts-2", map[string]string{
+		synccommon.AnnotationSyncOptions: "Delete=false",
+	})
+	notStray := strayLiveObj("data-my-sts-3", nil)
+	notStrayTarget := notStray.DeepCopy()
+
+	reconciliationResult := sync.ReconciliationResult{
+		Live:   []*unstructured.Unstructured{unprotected, pruneProtected, deleteFalseOnly, notStray},
+		Target: []*unstructured.Unstructured{nil, nil, nil, notStrayTarget},
+	}
+
+	sm.warnUnprotectedStrayResources(t.Context(), app, logEntry, reconciliationResult, nil, false, nil)
+
+	events, err := ctrl.kubeClientset.CoreV1().Events(app.Namespace).List(t.Context(), metav1.ListOptions{})
+	require.NoError(t, err)
+
+	assert.Len(t, events.Items, 2, "exactly the unprotected and the Delete=false-only resources should warn")
+	warnedMessages := warnedMessages(events.Items)
+	assert.Contains(t, warnedMessages, "data-my-sts-0")
+	assert.Contains(t, warnedMessages, "data-my-sts-2")
+	assert.NotContains(t, warnedMessages, "data-my-sts-1")
+	assert.NotContains(t, warnedMessages, "data-my-sts-3")
+}
+
+func TestWarnUnprotectedStrayResources_skipsResourcesOutsideScopedSync(t *testing.T) {
+	t.Parallel()
+
+	sm, ctrl, app := strayResourceWarningTestManager(t)
+	logEntry := log.NewEntry(log.StandardLogger())
+
+	inScope := strayLiveObj("in-scope", nil)
+	outOfScope := strayLiveObj("out-of-scope", nil)
+
+	reconciliationResult := sync.ReconciliationResult{
+		Live:   []*unstructured.Unstructured{inScope, outOfScope},
+		Target: []*unstructured.Unstructured{nil, nil},
+	}
+	scopedResources := []v1alpha1.SyncOperationResource{
+		{Kind: "PersistentVolumeClaim", Name: "in-scope", Namespace: "default"},
+	}
+
+	sm.warnUnprotectedStrayResources(t.Context(), app, logEntry, reconciliationResult, nil, false, scopedResources)
+
+	events, err := ctrl.kubeClientset.CoreV1().Events(app.Namespace).List(t.Context(), metav1.ListOptions{})
+	require.NoError(t, err)
+	assert.Len(t, events.Items, 1, "only the resource actually included in the scoped sync should warn")
+	assert.Contains(t, warnedMessages(events.Items), "in-scope")
+}
+
+func TestWarnUnprotectedStrayResources_capsEventVolume(t *testing.T) {
+	t.Parallel()
+
+	sm, ctrl, app := strayResourceWarningTestManager(t)
+	logEntry := log.NewEntry(log.StandardLogger())
+
+	var live, target []*unstructured.Unstructured
+	total := maxStrayResourceWarningsPerSync + 5
+	for i := range total {
+		live = append(live, strayLiveObj(fmt.Sprintf("stray-%d", i), nil))
+		target = append(target, nil)
+	}
+	reconciliationResult := sync.ReconciliationResult{Live: live, Target: target}
+
+	sm.warnUnprotectedStrayResources(t.Context(), app, logEntry, reconciliationResult, nil, false, nil)
+
+	events, err := ctrl.kubeClientset.CoreV1().Events(app.Namespace).List(t.Context(), metav1.ListOptions{})
+	require.NoError(t, err)
+	assert.Len(t, events.Items, maxStrayResourceWarningsPerSync,
+		"event volume must be capped even when far more stray resources qualify")
+}
+
+// warnedMessages joins every event's message into one string so tests can
+// assert a resource name is (or isn't) mentioned with a plain Contains
+// check; the audit event's InvolvedObject is always the Application
+// itself, not the stray resource, so the resource identity only shows up
+// in the message text.
+func warnedMessages(events []corev1.Event) string {
+	var sb strings.Builder
+	for _, ev := range events {
+		sb.WriteString(ev.Message)
+		sb.WriteString("\n")
+	}
+	return sb.String()
 }

--- a/controller/stray_resource_warning_test.go
+++ b/controller/stray_resource_warning_test.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"testing"
 
+	"github.com/argoproj/argo-cd/gitops-engine/v3/pkg/sync"
 	synccommon "github.com/argoproj/argo-cd/gitops-engine/v3/pkg/sync/common"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -60,6 +61,9 @@ func TestLiveObjHasExplicitSyncProtection(t *testing.T) {
 func TestIsPruningDisabledForObj(t *testing.T) {
 	t.Parallel()
 
+	// Delegates to gitops-engine's own sync.IsPruningDisabled; this test only
+	// verifies the wiring at the controller boundary, not the annotation logic
+	// itself (covered by gitops-engine's own tests).
 	pruneFalse := synccommon.SyncValueFalse
 	obj := &unstructured.Unstructured{
 		Object: map[string]any{
@@ -70,9 +74,9 @@ func TestIsPruningDisabledForObj(t *testing.T) {
 			},
 		},
 	}
-	assert.True(t, isPruningDisabledForObj(obj, nil))
-	assert.True(t, isPruningDisabledForObj(&unstructured.Unstructured{}, &pruneFalse))
-	assert.False(t, isPruningDisabledForObj(&unstructured.Unstructured{Object: map[string]any{
+	assert.True(t, sync.IsPruningDisabled(obj, nil))
+	assert.True(t, sync.IsPruningDisabled(&unstructured.Unstructured{}, &pruneFalse))
+	assert.False(t, sync.IsPruningDisabled(&unstructured.Unstructured{Object: map[string]any{
 		"metadata": map[string]any{"name": "x", "namespace": "ns"},
 	}}, nil))
 }
@@ -80,6 +84,7 @@ func TestIsPruningDisabledForObj(t *testing.T) {
 func TestObjRequiresPruneConfirmation(t *testing.T) {
 	t.Parallel()
 
+	// Same note as TestIsPruningDisabledForObj above: wiring check only.
 	pruneConfirm := synccommon.SyncValueConfirm
 	pruneFalse := synccommon.SyncValueFalse
 
@@ -92,17 +97,17 @@ func TestObjRequiresPruneConfirmation(t *testing.T) {
 				},
 			},
 		}}
-		assert.True(t, objRequiresPruneConfirmation(obj, nil))
+		assert.True(t, sync.ObjRequiresPruneConfirmation(obj, nil))
 	})
 
 	t.Run("default confirm", func(t *testing.T) {
 		t.Parallel()
-		assert.True(t, objRequiresPruneConfirmation(&unstructured.Unstructured{}, &pruneConfirm))
+		assert.True(t, sync.ObjRequiresPruneConfirmation(&unstructured.Unstructured{}, &pruneConfirm))
 	})
 
 	t.Run("default false", func(t *testing.T) {
 		t.Parallel()
-		assert.False(t, objRequiresPruneConfirmation(&unstructured.Unstructured{}, &pruneFalse))
+		assert.False(t, sync.ObjRequiresPruneConfirmation(&unstructured.Unstructured{}, &pruneFalse))
 	})
 }
 

--- a/controller/stray_resource_warning_test.go
+++ b/controller/stray_resource_warning_test.go
@@ -1,0 +1,99 @@
+package controller
+
+import (
+	"testing"
+
+	synccommon "github.com/argoproj/argo-cd/gitops-engine/v3/pkg/sync/common"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestLiveObjHasExplicitSyncProtection(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no annotations", func(t *testing.T) {
+		t.Parallel()
+		obj := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "PersistentVolumeClaim",
+			"metadata": map[string]any{
+				"name":      "data-my-sts-0",
+				"namespace": "default",
+			},
+		}}
+		assert.False(t, liveObjHasExplicitSyncProtection(obj))
+	})
+
+	t.Run("prune false on live object", func(t *testing.T) {
+		t.Parallel()
+		obj := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "PersistentVolumeClaim",
+			"metadata": map[string]any{
+				"name":      "data-my-sts-0",
+				"namespace": "default",
+				"annotations": map[string]any{
+					synccommon.AnnotationSyncOptions: "Prune=false,Delete=false",
+				},
+			},
+		}}
+		assert.True(t, liveObjHasExplicitSyncProtection(obj))
+	})
+
+	t.Run("delete false only", func(t *testing.T) {
+		t.Parallel()
+		obj := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "PersistentVolumeClaim",
+			"metadata": map[string]any{
+				"name":      "data-my-sts-0",
+				"namespace": "default",
+				"annotations": map[string]any{
+					synccommon.AnnotationSyncOptions: "Delete=false",
+				},
+			},
+		}}
+		assert.True(t, liveObjHasExplicitSyncProtection(obj))
+	})
+}
+
+func TestIsPruningDisabledForObj(t *testing.T) {
+	t.Parallel()
+
+	pruneFalse := synccommon.SyncValueFalse
+	obj := &unstructured.Unstructured{
+		Object: map[string]any{
+			"metadata": map[string]any{
+				"annotations": map[string]any{
+					synccommon.AnnotationSyncOptions: "Prune=false",
+				},
+			},
+		},
+	}
+	assert.True(t, isPruningDisabledForObj(obj, nil))
+	assert.True(t, isPruningDisabledForObj(&unstructured.Unstructured{}, &pruneFalse))
+	assert.False(t, isPruningDisabledForObj(&unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{"name": "x", "namespace": "ns"},
+	}}, nil))
+}
+
+func TestWarnUnprotectedStrayResources_emitsForStrayWithoutAnnotation(t *testing.T) {
+	t.Parallel()
+
+	pvc := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "PersistentVolumeClaim",
+		"metadata": map[string]any{
+			"name":      "data-my-sts-0",
+			"namespace": "default",
+		},
+	}}
+	protectedPVC := pvc.DeepCopy()
+	protectedPVC.SetAnnotations(map[string]string{
+		synccommon.AnnotationSyncOptions: "Prune=false,Delete=false",
+	})
+
+	// Covered by unit helpers; integration with audit logger is exercised in controller tests.
+	assert.False(t, liveObjHasExplicitSyncProtection(pvc))
+	assert.True(t, liveObjHasExplicitSyncProtection(protectedPVC))
+}

--- a/controller/stray_resource_warning_test.go
+++ b/controller/stray_resource_warning_test.go
@@ -77,6 +77,35 @@ func TestIsPruningDisabledForObj(t *testing.T) {
 	}}, nil))
 }
 
+func TestObjRequiresPruneConfirmation(t *testing.T) {
+	t.Parallel()
+
+	pruneConfirm := synccommon.SyncValueConfirm
+	pruneFalse := synccommon.SyncValueFalse
+
+	t.Run("object annotation confirm", func(t *testing.T) {
+		t.Parallel()
+		obj := &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{
+				"annotations": map[string]any{
+					synccommon.AnnotationSyncOptions: "Prune=confirm",
+				},
+			},
+		}}
+		assert.True(t, objRequiresPruneConfirmation(obj, nil))
+	})
+
+	t.Run("default confirm", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, objRequiresPruneConfirmation(&unstructured.Unstructured{}, &pruneConfirm))
+	})
+
+	t.Run("default false", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, objRequiresPruneConfirmation(&unstructured.Unstructured{}, &pruneFalse))
+	})
+}
+
 func TestWarnUnprotectedStrayResources_emitsForStrayWithoutAnnotation(t *testing.T) {
 	t.Parallel()
 

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -431,7 +431,7 @@ func (m *appStateManager) SyncAppState(ctx context.Context, app *v1alpha1.Applic
 	defer cleanup()
 
 	if syncOp.Prune && !syncOp.DryRun {
-		m.warnUnprotectedStrayResources(ctx, app, logEntry, reconciliationResult, syncOp.SyncOptions.GetOptionValue(common.SyncOptionPrune))
+		m.warnUnprotectedStrayResources(ctx, app, logEntry, reconciliationResult, syncOp.SyncOptions.GetOptionValue(common.SyncOptionPrune), app.IsDeletionConfirmed(state.StartedAt.Time))
 	}
 
 	start := time.Now()

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -430,6 +430,10 @@ func (m *appStateManager) SyncAppState(ctx context.Context, app *v1alpha1.Applic
 
 	defer cleanup()
 
+	if syncOp.Prune && !syncOp.DryRun {
+		m.warnUnprotectedStrayResources(ctx, app, logEntry, reconciliationResult, syncOp.SyncOptions.GetOptionValue(common.SyncOptionPrune))
+	}
+
 	start := time.Now()
 
 	if state.Phase == common.OperationTerminating {

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -431,7 +431,7 @@ func (m *appStateManager) SyncAppState(ctx context.Context, app *v1alpha1.Applic
 	defer cleanup()
 
 	if syncOp.Prune && !syncOp.DryRun {
-		m.warnUnprotectedStrayResources(ctx, app, logEntry, reconciliationResult, syncOp.SyncOptions.GetOptionValue(common.SyncOptionPrune), app.IsDeletionConfirmed(state.StartedAt.Time))
+		m.warnUnprotectedStrayResources(ctx, app, logEntry, reconciliationResult, syncOp.SyncOptions.GetOptionValue(common.SyncOptionPrune), app.IsDeletionConfirmed(state.StartedAt.Time), syncOp.Resources)
 	}
 
 	start := time.Now()

--- a/gitops-engine/pkg/sync/sync_context.go
+++ b/gitops-engine/pkg/sync/sync_context.go
@@ -334,7 +334,11 @@ func groupDiffResults(diffResultList *diff.DiffResultList) map[kubeutil.Resource
 	return modifiedResources
 }
 
-func objRequiresPruneConfirmation(obj *unstructured.Unstructured, defaultPruneOption *string) bool {
+// ObjRequiresPruneConfirmation reports whether obj's effective Prune sync-option
+// (its own annotation, falling back to defaultPruneOption) is "confirm". Exported
+// so callers outside this package (e.g. argo-cd's application controller) can
+// reuse the same single source of truth instead of re-implementing it.
+func ObjRequiresPruneConfirmation(obj *unstructured.Unstructured, defaultPruneOption *string) bool {
 	var pruneOptionValue *string
 	if obj != nil {
 		pruneOptionValue = resourceutil.GetAnnotationOptionValue(obj, common.AnnotationSyncOptions, common.SyncOptionPrune)
@@ -345,7 +349,10 @@ func objRequiresPruneConfirmation(obj *unstructured.Unstructured, defaultPruneOp
 	return pruneOptionValue != nil && *pruneOptionValue == common.SyncValueConfirm
 }
 
-func isPruningDisabled(obj *unstructured.Unstructured, defaultPruneOption *string) bool {
+// IsPruningDisabled reports whether obj's effective Prune sync-option (its own
+// annotation, falling back to defaultPruneOption) is "false". Exported for the
+// same reason as ObjRequiresPruneConfirmation above.
+func IsPruningDisabled(obj *unstructured.Unstructured, defaultPruneOption *string) bool {
 	var pruneOptionValue *string
 	if obj != nil {
 		pruneOptionValue = resourceutil.GetAnnotationOptionValue(obj, common.AnnotationSyncOptions, common.SyncOptionPrune)
@@ -472,7 +479,7 @@ func (sc *syncContext) setRunningPhase(tasks syncTasks, isPendingDeletion bool) 
 
 	if !sc.pruneConfirmed {
 		tasksToPrune := tasks.Filter(func(task *syncTask) bool {
-			return task.isPrune() && objRequiresPruneConfirmation(task.liveObj, sc.defaultPruneOption)
+			return task.isPrune() && ObjRequiresPruneConfirmation(task.liveObj, sc.defaultPruneOption)
 		})
 
 		if len(tasksToPrune) > 0 {
@@ -1496,7 +1503,7 @@ func (sc *syncContext) pruneObject(ctx context.Context, t *syncTask, prune, dryR
 	liveObj := t.liveObj
 	if !prune {
 		return common.ResultCodePruneSkipped, "ignored (requires pruning)"
-	} else if isPruningDisabled(liveObj, sc.defaultPruneOption) {
+	} else if IsPruningDisabled(liveObj, sc.defaultPruneOption) {
 		return common.ResultCodePruneSkipped, "ignored (no prune)"
 	}
 	if dryRun {
@@ -1668,7 +1675,7 @@ func (sc *syncContext) runTasks(ctx context.Context, tasks syncTasks, dryRun boo
 	{
 		if !sc.pruneConfirmed {
 			for _, task := range pruneTasks {
-				if objRequiresPruneConfirmation(task.liveObj, sc.defaultPruneOption) {
+				if ObjRequiresPruneConfirmation(task.liveObj, sc.defaultPruneOption) {
 					sc.log.WithValues("task", task).Info("Prune requires confirmation")
 					return pending
 				}

--- a/gitops-engine/pkg/sync/sync_context_test.go
+++ b/gitops-engine/pkg/sync/sync_context_test.go
@@ -3329,3 +3329,72 @@ func TestTerminate_Hooks_Error(t *testing.T) {
 	assert.Equal(t, synccommon.OperationError, results[0].HookPhase)
 	assert.Contains(t, results[0].Message, "update failed")
 }
+
+func TestIsPruningDisabled(t *testing.T) {
+	pruneFalse := synccommon.SyncValueFalse
+
+	t.Run("object annotation false", func(t *testing.T) {
+		obj := &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{
+				"annotations": map[string]any{
+					synccommon.AnnotationSyncOptions: "Prune=false",
+				},
+			},
+		}}
+		assert.True(t, IsPruningDisabled(obj, nil))
+	})
+
+	t.Run("falls back to default when object has no annotation", func(t *testing.T) {
+		assert.True(t, IsPruningDisabled(&unstructured.Unstructured{}, &pruneFalse))
+	})
+
+	t.Run("object annotation overrides a non-false default", func(t *testing.T) {
+		pruneConfirm := synccommon.SyncValueConfirm
+		obj := &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{
+				"annotations": map[string]any{
+					synccommon.AnnotationSyncOptions: "Prune=false",
+				},
+			},
+		}}
+		assert.True(t, IsPruningDisabled(obj, &pruneConfirm))
+	})
+
+	t.Run("neither object nor default set", func(t *testing.T) {
+		assert.False(t, IsPruningDisabled(&unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"name": "x", "namespace": "ns"},
+		}}, nil))
+	})
+
+	t.Run("nil object, no default", func(t *testing.T) {
+		assert.False(t, IsPruningDisabled(nil, nil))
+	})
+}
+
+func TestObjRequiresPruneConfirmation(t *testing.T) {
+	pruneConfirm := synccommon.SyncValueConfirm
+	pruneFalse := synccommon.SyncValueFalse
+
+	t.Run("object annotation confirm", func(t *testing.T) {
+		obj := &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{
+				"annotations": map[string]any{
+					synccommon.AnnotationSyncOptions: "Prune=confirm",
+				},
+			},
+		}}
+		assert.True(t, ObjRequiresPruneConfirmation(obj, nil))
+	})
+
+	t.Run("default confirm", func(t *testing.T) {
+		assert.True(t, ObjRequiresPruneConfirmation(&unstructured.Unstructured{}, &pruneConfirm))
+	})
+
+	t.Run("default false", func(t *testing.T) {
+		assert.False(t, ObjRequiresPruneConfirmation(&unstructured.Unstructured{}, &pruneFalse))
+	})
+
+	t.Run("nil object, no default", func(t *testing.T) {
+		assert.False(t, ObjRequiresPruneConfirmation(nil, nil))
+	})
+}


### PR DESCRIPTION
## Summary
- Adds a warning log line and Application event when Argo CD is about to prune a live-state-only resource (no git manifest) whose live object lacks `Prune=false` or `Delete=false` sync-option annotations
- Observability only; deletion behavior is unchanged
- Skips the warning when the resource is actually in `Prune=confirm` mode and confirmation is pending (avoids a misleading warning for a delete that requires manual confirmation anyway)
- Reuses `gitops-engine`'s own `IsPruningDisabled`/`ObjRequiresPruneConfirmation` (newly exported) instead of duplicating that logic in the controller

Fixes #28986

Supersedes #28997, closed by GitHub after a force-push rewrote that branch's
history (unrelated commit removed) while the PR was closed, which blocks
reopening. Same diff, clean history on top of current `master`.

## Test plan
- [x] Unit tests for annotation detection helpers (`go test ./controller/ -run TestLiveObjHasExplicitSyncProtection`)
- [x] New unit tests for `gitops-engine`'s exported `IsPruningDisabled`/`ObjRequiresPruneConfirmation`
- [ ] Manual: sync an app with a stray PVC lacking protection annotations and confirm warning event appears
