### PR TITLE
fix(ui): avoid revision-metadata error toast for unresolved sync revisions

### DIFF
--- a/ui/src/app/applications/components/application-details/application-details.tsx
+++ b/ui/src/app/applications/components/application-details/application-details.tsx
@@ -7,7 +7,7 @@ import {RouteComponentProps} from 'react-router';
 import {BehaviorSubject, combineLatest, from, merge, Observable} from 'rxjs';
 import {delay, filter, map, mergeMap, repeat, retryWhen} from 'rxjs/operators';
 
-import {DataLoader, EmptyState, ErrorNotification, ObservableQuery, Page, Paginate, Revision, Timestamp} from '../../../shared/components';
+import {DataLoader, EmptyState, ErrorNotification, ObservableQuery, Page, Paginate, Revision, Timestamp, isSHA} from '../../../shared/components';
 import {AppContext, Context, ContextApis} from '../../../shared/context';
 import * as appModels from '../../../shared/models';
 import {AppDetailsPreferences, AppsDetailsViewKey, AppsDetailsViewType, services} from '../../../shared/services';
@@ -532,6 +532,17 @@ Are you sure you want to disable auto-sync and rollback application '${props.mat
                     </>
                 );
             };
+            if (!isSHA(aRevision)) {
+                // The repo server rejects revision metadata lookups for revisions that haven't been resolved to a
+                // commit SHA yet (e.g. a sync/comparison error left the app pointed at an unresolved branch or tag).
+                // Skip the request so the DataLoader below doesn't surface a raw RPC error to the user.
+                return (
+                    <div key={indx} className='white-box' style={{marginTop: '1.5em'}}>
+                        {sourceHeader && sourceHeader}
+                        {showNonMetadataInfo(aSource, aRevision)}
+                    </div>
+                );
+            }
             return (
                 <DataLoader
                     key={indx}

--- a/ui/src/app/applications/components/application-details/application-details.tsx
+++ b/ui/src/app/applications/components/application-details/application-details.tsx
@@ -517,7 +517,7 @@ Are you sure you want to disable auto-sync and rollback application '${props.mat
                     <>
                         <div className='white-box__details'>
                             <div className='row white-box__details-row'>
-                                <div className='columns small-3'>SHA:</div>
+                                <div className='columns small-3'>{isSHA(aRevision) ? 'SHA:' : 'Revision:'}</div>
                                 <div className='columns small-9'>
                                     <Revision repoUrl={aSource.repoURL} revision={aRevision} />
                                 </div>


### PR DESCRIPTION
Motivation:
When an application's manifest generation fails during a sync/comparison
(for example a repo-server timeout), the controller leaves
status.sync.revision (and status.operationState.syncResult.revision)
pointing at the raw, unresolved target revision (e.g. a branch or tag
name) instead of a resolved commit SHA, because that field is only
overwritten with the resolved SHA once manifest generation succeeds.

When a user then opens the "Sync Revision" or "Operation State Revision"
panel in the UI, application-details.tsx calls the revisionMetadata API
with that unresolved revision string. The repo server's
GetRevisionMetadata rejects any revision that isn't a resolved commit
SHA with "revision %s must be resolved". Because argo-ui's DataLoader
shows an "Unable to load data: ..." toast notification unconditionally
whenever its load() promise rejects (regardless of any errorRenderer),
the user is shown a confusing, unactionable popup instead of useful
revision info.

This does not change the underlying failure that left the revision
unresolved (e.g. a manifest-generation timeout) - that is still
surfaced normally via the application's ComparisonError condition. The
change only avoids a redundant, confusing secondary error toast when
displaying revision details for such a revision.

Approach:
In getContentForNonChart (application-details.tsx), skip the
revisionMetadata DataLoader/API call when the revision is not a
resolved commit SHA (checked with the existing, already-tested isSHA
helper from shared/components/revision.tsx, used the same way
elsewhere in the codebase to distinguish SHAs from branch/tag names).
In that case, render the same SHA/Source fallback rows already used
elsewhere in this component when metadata is unavailable, instead of
making a request that is guaranteed to fail. The chart/OCI content
paths were left untouched since their backend RPCs (GetRevisionChartDetails,
GetOCIMetadata) resolve the revision themselves rather than rejecting
unresolved refs, so they are not affected by this failure mode.

Validation:
- pnpm exec tsc --noEmit --project ./src/app (from ui/) passes with no
  errors.
- pnpm exec eslint src/app/applications/components/application-details/application-details.tsx
  passes (one prettier formatting issue was auto-fixed).
- pnpm exec jest src/app/shared/components/revision.test.tsx passes,
  covering the isSHA helper this fix relies on for both a resolved SHA
  and a branch name.
- No live cluster was used to reproduce the failure end-to-end; the
  diagnosis was instead confirmed by matching the reported error
  string to reposerver/repository/repository.go's
  GetRevisionMetadata check, and by reading the vendored argo-ui
  DataLoader source to confirm it shows the "Unable to load data"
  toast unconditionally on any load() rejection, independent of
  errorRenderer.
- There is no unit test yet exercising the new `!isSHA(aRevision)`
  branch in application-details.tsx itself, since getContentForNonChart
  is a non-exported closure inside a large, currently-untested
  component; adding one would require extracting that logic first,
  which felt like a separate follow-up rather than a minimal fix.

Scope note: this PR only suppresses the confusing secondary error
toast when viewing revision details for an app whose revision hasn't
resolved to a SHA. It does not fix why the revision failed to resolve
in the first place, so it is not a complete fix for #27348 - it is
related to it and addresses the popup/UX symptom described there.

Related to https://github.com/argoproj/argo-cd/issues/27348
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

---
AI assistance: this change was drafted with Claude Code.

Related to #27348
