### PR TITLE
feat(health): add health check for AWS ACK resources

### DIFF
--- a/resource_customizations/_.services.k8s.aws/_/health.lua
+++ b/resource_customizations/_.services.k8s.aws/_/health.lua
@@ -1,0 +1,29 @@
+-- AWS ACK: https://aws-controllers-k8s.github.io/docs/
+local hs = {}
+
+if obj.status ~= nil and obj.status.conditions ~= nil then
+  for i, condition in ipairs(obj.status.conditions) do
+
+    if condition.type == "ACK.Terminal" and condition.status == "True" then
+      hs.status = "Degraded"
+      hs.message = condition.message
+      return hs
+    end
+    
+    if condition.type == "Ready" then
+      if condition.status == "False" then
+        hs.status = "Progressing"
+        hs.message = condition.message
+        return hs
+      elseif condition.status == "True" then
+        hs.status = "Healthy"
+        hs.message = ""
+        return hs
+      end
+    end
+  end
+end
+
+hs.status = "Progressing"
+hs.message = "Waiting for resource to be ready"
+return hs

--- a/resource_customizations/_.services.k8s.aws/_/health_test.yaml
+++ b/resource_customizations/_.services.k8s.aws/_/health_test.yaml
@@ -1,0 +1,17 @@
+tests:
+  - healthStatus:
+      status: Healthy
+      message: ""
+    inputPath: testdata/healthy.yaml
+  - healthStatus:
+      status: Progressing
+      message: bucket in CREATING state
+    inputPath: testdata/progressing.yaml
+  - healthStatus:
+      status: Progressing
+      message: Waiting for resource to be ready
+    inputPath: testdata/progressing_no_conditions.yaml
+  - healthStatus:
+      status: Degraded
+      message: Resource already exists
+    inputPath: testdata/degraded.yaml

--- a/resource_customizations/_.services.k8s.aws/_/testdata/degraded.yaml
+++ b/resource_customizations/_.services.k8s.aws/_/testdata/degraded.yaml
@@ -1,0 +1,28 @@
+apiVersion: s3.services.k8s.aws/v1alpha1
+kind: Bucket
+metadata:
+  name: test-s3-bucket
+  namespace: default
+spec:
+  name: test-s3-bucket
+status:
+  ackResourceMetadata:
+    arn: arn:aws:s3:::test-s3-bucket
+    ownerAccountID: "111111111111"
+    region: us-west-2
+  conditions:
+  - lastTransitionTime: "2026-04-15T18:20:17Z"
+    message: Resource already exists
+    reason: This resource already exists but is not managed by ACK.
+    status: "True"
+    type: ACK.Terminal
+  - lastTransitionTime: "2026-04-15T18:20:17Z"
+    message: Resource not synced
+    reason: resource is in terminal condition
+    status: "False"
+    type: ACK.ResourceSynced
+  - lastTransitionTime: "2026-04-15T18:20:17Z"
+    message: Resource already exists
+    reason: ACK.Terminal
+    status: "False"
+    type: Ready

--- a/resource_customizations/_.services.k8s.aws/_/testdata/healthy.yaml
+++ b/resource_customizations/_.services.k8s.aws/_/testdata/healthy.yaml
@@ -1,0 +1,24 @@
+apiVersion: s3.services.k8s.aws/v1alpha1
+kind: Bucket
+metadata:
+  name: test-s3-bucket
+  namespace: default
+spec:
+  name: test-s3-bucket
+status:
+  ackResourceMetadata:
+    arn: arn:aws:s3:::test-s3-bucket
+    ownerAccountID: "111111111111"
+    region: us-west-2
+  conditions:
+  - lastTransitionTime: "2026-04-15T18:20:17Z"
+    message: Resource synced successfully
+    reason: ""
+    status: "True"
+    type: ACK.ResourceSynced
+  - lastTransitionTime: "2026-04-15T18:20:17Z"
+    message: Resource synced successfully
+    reason: ""
+    status: "True"
+    type: Ready
+  location: http://test-s3-bucket.s3.amazonaws.com/

--- a/resource_customizations/_.services.k8s.aws/_/testdata/progressing.yaml
+++ b/resource_customizations/_.services.k8s.aws/_/testdata/progressing.yaml
@@ -1,0 +1,23 @@
+apiVersion: s3.services.k8s.aws/v1alpha1
+kind: Bucket
+metadata:
+  name: test-s3-bucket
+  namespace: default
+spec:
+  name: test-s3-bucket
+status:
+  ackResourceMetadata:
+    arn: arn:aws:s3:::test-s3-bucket
+    ownerAccountID: "111111111111"
+    region: us-west-2
+  conditions:
+  - lastTransitionTime: "2026-04-15T18:20:17Z"
+    message: bucket in CREATING state
+    reason: bucket in CREATING state
+    status: "False"
+    type: ACK.ResourceSynced
+  - lastTransitionTime: "2026-04-15T18:20:17Z"
+    message: bucket in CREATING state
+    reason: bucket in CREATING state
+    status: "False"
+    type: Ready

--- a/resource_customizations/_.services.k8s.aws/_/testdata/progressing_no_conditions.yaml
+++ b/resource_customizations/_.services.k8s.aws/_/testdata/progressing_no_conditions.yaml
@@ -1,0 +1,12 @@
+apiVersion: s3.services.k8s.aws/v1alpha1
+kind: Bucket
+metadata:
+  name: test-s3-bucket
+  namespace: default
+spec:
+  name: test-s3-bucket
+status:
+  ackResourceMetadata:
+    arn: arn:aws:s3:::test-s3-bucket
+    ownerAccountID: "111111111111"
+    region: us-west-2

--- a/util/lua/lua_test.go
+++ b/util/lua/lua_test.go
@@ -1125,6 +1125,7 @@ func Test_getHealthScriptPaths(t *testing.T) {
 	assert.Equal(t, []string{
 		"_.cnrm.cloud.google.com/_",
 		"_.crossplane.io/_",
+		"_.services.k8s.aws/_",
 		"_.upbound.io/_",
 		"grafana-org-operator.kubitus-project.gitlab.io/_",
 		"microgateway.airlock.com/_",


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [X] I've updated documentation as required by this PR.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [X] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [X] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [X] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->

---

 ## Summary

  Adds built-in Lua health checks for AWS ACK resource

  **AWS Controllers for Kubernetes ([ACK](https://aws.amazon.com/blogs/containers/aws-controllers-for-kubernetes-ack/))** — CRDs from the `<aws-service>.services.k8s.aws` API groups, handled with a single wildcard check (`_.services.k8s.aws`). Some example groups are:
  - `s3.services.k8s.aws`
  - `dynamodb.services.k8s.aws`

  ## Health Mapping

All ACK resources share a common set of conditions, which can be used to determine the state of the resource ([ref](https://docs.aws.amazon.com/eks/latest/userguide/ack-concepts.html#_status_conditions)).

  ACK conditions do not carry an `observedGeneration`, so the check evaluates the conditions as-is rather than gating on the current generation.

  | Condition type and status | Argo CD Health |
  |---|---|
  | `ACK.Terminal` + `True` | Degraded |
  | `Ready` + `False` | Progressing |
  | `Ready` + `True` | Healthy |
  | Any other phase or missing status | Progressing |

  ## Validation

  New health check tests were added and pass for every scenario in each check:
  - **ACK:** healthy, progressing, degraded, and missing/empty status.