### PR TITLE
fix: show Helm values/parameters overrides in App Parameters (#6086)

### DIFF
--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -2591,9 +2591,28 @@ func (s *Service) populateHelmAppDetails(ctx context.Context, res *apiclient.Rep
 	if err != nil {
 		return fmt.Errorf("failed to resolve value files: %w", err)
 	}
+	// Match helmTemplate precedence: valueFiles, then values/valuesObject as an
+	// extra values file, then parameters (--set) overlaying the flattened map.
+	if q.Source.Helm != nil && !q.Source.Helm.ValuesIsEmpty() {
+		rand, err := uuid.NewRandom()
+		if err != nil {
+			return fmt.Errorf("error generating random filename for Helm values file: %w", err)
+		}
+		p := path.Join(os.TempDir(), rand.String())
+		defer func() { _ = os.RemoveAll(p) }()
+		if err := os.WriteFile(p, q.Source.Helm.ValuesYAML(), 0o644); err != nil {
+			return fmt.Errorf("error writing helm values file: %w", err)
+		}
+		resolvedSelectedValueFiles = append(resolvedSelectedValueFiles, pathutil.ResolvedFilePath(p))
+	}
 	params, err := h.GetParameters(resolvedSelectedValueFiles, appPath, repoRoot)
 	if err != nil {
 		return err
+	}
+	if q.Source.Helm != nil {
+		for _, p := range q.Source.Helm.Parameters {
+			params[p.Name] = p.Value
+		}
 	}
 	for k, v := range params {
 		res.Helm.Parameters = append(res.Helm.Parameters, &v1alpha1.HelmParameter{

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -2613,9 +2613,28 @@ func (s *Service) populateHelmAppDetails(ctx context.Context, res *apiclient.Rep
 	if err != nil {
 		return fmt.Errorf("failed to resolve value files: %w", err)
 	}
+	// Match helmTemplate precedence: valueFiles, then values/valuesObject as an
+	// extra values file, then parameters (--set) overlaying the flattened map.
+	if q.Source.Helm != nil && !q.Source.Helm.ValuesIsEmpty() {
+		rand, err := uuid.NewRandom()
+		if err != nil {
+			return fmt.Errorf("error generating random filename for Helm values file: %w", err)
+		}
+		p := path.Join(os.TempDir(), rand.String())
+		defer func() { _ = os.RemoveAll(p) }()
+		if err := os.WriteFile(p, q.Source.Helm.ValuesYAML(), 0o644); err != nil {
+			return fmt.Errorf("error writing helm values file: %w", err)
+		}
+		resolvedSelectedValueFiles = append(resolvedSelectedValueFiles, pathutil.ResolvedFilePath(p))
+	}
 	params, err := h.GetParameters(resolvedSelectedValueFiles, appPath, repoRoot)
 	if err != nil {
 		return err
+	}
+	if q.Source.Helm != nil {
+		for _, p := range q.Source.Helm.Parameters {
+			params[p.Name] = p.Value
+		}
 	}
 	for k, v := range params {
 		res.Helm.Parameters = append(res.Helm.Parameters, &v1alpha1.HelmParameter{

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -3570,6 +3570,80 @@ func Test_populateHelmAppDetails(t *testing.T) {
 	assert.Len(t, res.Helm.ValueFiles, 5)
 }
 
+func Test_populateHelmAppDetails_valuesBlockAndParameters(t *testing.T) {
+	// Regression for https://github.com/argoproj/argo-cd/issues/6086:
+	// App details must project values/valuesObject and parameters the same
+	// way helmTemplate does, so the Parameters UI shows the effective overrides.
+	sha := "632039659e542ed7de0c170a4fcc1c571b288fc0"
+	service := newService(t, ".")
+	emptyTempPaths := utilio.NewRandomizedTempPaths(t.TempDir())
+	appPath, err := filepath.Abs("./testdata/values-files/")
+	require.NoError(t, err)
+
+	paramByName := func(params []*v1alpha1.HelmParameter) map[string]string {
+		out := map[string]string{}
+		for _, p := range params {
+			out[p.Name] = p.Value
+		}
+		return out
+	}
+
+	t.Run("values block overrides valueFiles", func(t *testing.T) {
+		res := apiclient.RepoAppDetailsResponse{}
+		q := apiclient.RepoServerAppDetailsQuery{
+			Repo: &v1alpha1.Repository{},
+			Source: &v1alpha1.ApplicationSource{
+				Helm: &v1alpha1.ApplicationSourceHelm{
+					ValueFiles: []string{"has-the-word-values.yaml"},
+					Values:     "has:\n  the:\n    word:\n      values: hello-from-values-block\n",
+				},
+			},
+		}
+		err := service.populateHelmAppDetails(t.Context(), &res, appPath, appPath, sha, "main", &q, emptyTempPaths)
+		require.NoError(t, err)
+		got := paramByName(res.Helm.Parameters)
+		assert.Equal(t, "hello-from-values-block", got["has.the.word.values"])
+	})
+
+	t.Run("valuesObject overrides values string", func(t *testing.T) {
+		res := apiclient.RepoAppDetailsResponse{}
+		q := apiclient.RepoServerAppDetailsQuery{
+			Repo: &v1alpha1.Repository{},
+			Source: &v1alpha1.ApplicationSource{
+				Helm: &v1alpha1.ApplicationSourceHelm{
+					ValueFiles:   []string{"has-the-word-values.yaml"},
+					Values:       "has:\n  the:\n    word:\n      values: from-values-string\n",
+					ValuesObject: &runtime.RawExtension{Raw: []byte(`{"has":{"the":{"word":{"values":"from-values-object"}}}}`)},
+				},
+			},
+		}
+		err := service.populateHelmAppDetails(t.Context(), &res, appPath, appPath, sha, "main", &q, emptyTempPaths)
+		require.NoError(t, err)
+		got := paramByName(res.Helm.Parameters)
+		assert.Equal(t, "from-values-object", got["has.the.word.values"])
+	})
+
+	t.Run("parameters overlay values", func(t *testing.T) {
+		res := apiclient.RepoAppDetailsResponse{}
+		q := apiclient.RepoServerAppDetailsQuery{
+			Repo: &v1alpha1.Repository{},
+			Source: &v1alpha1.ApplicationSource{
+				Helm: &v1alpha1.ApplicationSourceHelm{
+					ValueFiles: []string{"has-the-word-values.yaml"},
+					Values:     "has:\n  the:\n    word:\n      values: from-values\n",
+					Parameters: []v1alpha1.HelmParameter{
+						{Name: "has.the.word.values", Value: "from-parameter"},
+					},
+				},
+			},
+		}
+		err := service.populateHelmAppDetails(t.Context(), &res, appPath, appPath, sha, "main", &q, emptyTempPaths)
+		require.NoError(t, err)
+		got := paramByName(res.Helm.Parameters)
+		assert.Equal(t, "from-parameter", got["has.the.word.values"])
+	})
+}
+
 func Test_populateHelmAppDetailsWithRef(t *testing.T) {
 	dummyErrMsg := "dummy error"
 	repoURL := "https://github.com/foo/bar"

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -3741,6 +3741,80 @@ func Test_populateHelmAppDetails(t *testing.T) {
 	assert.Len(t, res.Helm.ValueFiles, 5)
 }
 
+func Test_populateHelmAppDetails_valuesBlockAndParameters(t *testing.T) {
+	// Regression for https://github.com/argoproj/argo-cd/issues/6086:
+	// App details must project values/valuesObject and parameters the same
+	// way helmTemplate does, so the Parameters UI shows the effective overrides.
+	sha := "632039659e542ed7de0c170a4fcc1c571b288fc0"
+	service := newService(t, ".")
+	emptyTempPaths := utilio.NewRandomizedTempPaths(t.TempDir())
+	appPath, err := filepath.Abs("./testdata/values-files/")
+	require.NoError(t, err)
+
+	paramByName := func(params []*v1alpha1.HelmParameter) map[string]string {
+		out := map[string]string{}
+		for _, p := range params {
+			out[p.Name] = p.Value
+		}
+		return out
+	}
+
+	t.Run("values block overrides valueFiles", func(t *testing.T) {
+		res := apiclient.RepoAppDetailsResponse{}
+		q := apiclient.RepoServerAppDetailsQuery{
+			Repo: &v1alpha1.Repository{},
+			Source: &v1alpha1.ApplicationSource{
+				Helm: &v1alpha1.ApplicationSourceHelm{
+					ValueFiles: []string{"has-the-word-values.yaml"},
+					Values:     "has:\n  the:\n    word:\n      values: hello-from-values-block\n",
+				},
+			},
+		}
+		err := service.populateHelmAppDetails(t.Context(), &res, appPath, appPath, sha, "main", &q, emptyTempPaths)
+		require.NoError(t, err)
+		got := paramByName(res.Helm.Parameters)
+		assert.Equal(t, "hello-from-values-block", got["has.the.word.values"])
+	})
+
+	t.Run("valuesObject overrides values string", func(t *testing.T) {
+		res := apiclient.RepoAppDetailsResponse{}
+		q := apiclient.RepoServerAppDetailsQuery{
+			Repo: &v1alpha1.Repository{},
+			Source: &v1alpha1.ApplicationSource{
+				Helm: &v1alpha1.ApplicationSourceHelm{
+					ValueFiles:   []string{"has-the-word-values.yaml"},
+					Values:       "has:\n  the:\n    word:\n      values: from-values-string\n",
+					ValuesObject: &runtime.RawExtension{Raw: []byte(`{"has":{"the":{"word":{"values":"from-values-object"}}}}`)},
+				},
+			},
+		}
+		err := service.populateHelmAppDetails(t.Context(), &res, appPath, appPath, sha, "main", &q, emptyTempPaths)
+		require.NoError(t, err)
+		got := paramByName(res.Helm.Parameters)
+		assert.Equal(t, "from-values-object", got["has.the.word.values"])
+	})
+
+	t.Run("parameters overlay values", func(t *testing.T) {
+		res := apiclient.RepoAppDetailsResponse{}
+		q := apiclient.RepoServerAppDetailsQuery{
+			Repo: &v1alpha1.Repository{},
+			Source: &v1alpha1.ApplicationSource{
+				Helm: &v1alpha1.ApplicationSourceHelm{
+					ValueFiles: []string{"has-the-word-values.yaml"},
+					Values:     "has:\n  the:\n    word:\n      values: from-values\n",
+					Parameters: []v1alpha1.HelmParameter{
+						{Name: "has.the.word.values", Value: "from-parameter"},
+					},
+				},
+			},
+		}
+		err := service.populateHelmAppDetails(t.Context(), &res, appPath, appPath, sha, "main", &q, emptyTempPaths)
+		require.NoError(t, err)
+		got := paramByName(res.Helm.Parameters)
+		assert.Equal(t, "from-parameter", got["has.the.word.values"])
+	})
+}
+
 func Test_populateHelmAppDetailsWithRef(t *testing.T) {
 	dummyErrMsg := "dummy error"
 	repoURL := "https://github.com/foo/bar"


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an enhancement proposal and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the Title of the PR guide.
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. (N/A: existing Parameters UI reads this API)
* [x] Does this PR require documentation updates? (No)
* [x] I've updated documentation as required by this PR. (N/A)
* [x] I have signed off all my commits as required by DCO
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green
* [x] My new feature complies with the feature status guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

## Description

`populateHelmAppDetails` only flattened chart values.yaml + valueFiles when building the Parameters projection. Inline `source.helm.values` / `valuesObject` and `parameters` were already applied by `helmTemplate`, but never shown in App Details / Parameters.

This change mirrors `helmTemplate` precedence for the details path:
1. valueFiles
2. values / valuesObject (temp values file)
3. parameters overlay on the flattened map

No UI/CLI change needed; the existing Parameters tab reads this API.

Fixes #6086

## How to test

- [x] `go test -count=1 -run Test_populateHelmAppDetails_valuesBlockAndParameters ./reposerver/repository/`
- [x] Fail-before / pass-after on the new cases (without the fix, projected value stays at the valueFile value)

