### PR TITLE
fix(cli): handle TestTLS timeout gracefully during login

### DIFF
--- a/cmd/argocd/commands/login.go
+++ b/cmd/argocd/commands/login.go
@@ -78,22 +78,29 @@ argocd login cd.argoproj.io --core`,
 				server = args[0]
 
 				if !skipTestTLS {
-					dialTime := 30 * time.Second
+					dialTime := 5 * time.Second
 					tlsTestResult, err := grpc_util.TestTLS(server, dialTime)
-					errors.CheckError(err)
-					if !tlsTestResult.TLS {
-						if !clientOpts.PlainText {
-							if !cli.AskToProceed("WARNING: server is not configured with TLS. Proceed (y/n)? ") {
-								os.Exit(1)
-							}
-							clientOpts.PlainText = true
+					if err != nil {
+						if strings.Contains(err.Error(), "context deadline exceeded") {
+							log.Warn("TLS test timed out (likely behind a reverse proxy). Proceeding with login... (Use --skip-test-tls to skip this check)")
+						} else {
+							errors.CheckError(err)
 						}
-					} else if tlsTestResult.InsecureErr != nil {
-						if !clientOpts.Insecure {
-							if !cli.AskToProceed(fmt.Sprintf("WARNING: server certificate had error: %s. Proceed insecurely (y/n)? ", tlsTestResult.InsecureErr)) {
-								os.Exit(1)
+					} else {
+						if !tlsTestResult.TLS {
+							if !clientOpts.PlainText {
+								if !cli.AskToProceed("WARNING: server is not configured with TLS. Proceed (y/n)? ") {
+									os.Exit(1)
+								}
+								clientOpts.PlainText = true
 							}
-							clientOpts.Insecure = true
+						} else if tlsTestResult.InsecureErr != nil {
+							if !clientOpts.Insecure {
+								if !cli.AskToProceed(fmt.Sprintf("WARNING: server certificate had error: %s. Proceed insecurely (y/n)? ", tlsTestResult.InsecureErr)) {
+									os.Exit(1)
+								}
+								clientOpts.Insecure = true
+							}
 						}
 					}
 				}


### PR DESCRIPTION
## Summary
When `argocd login` is executed behind a reverse proxy (such as Nginx Ingress) that drops native gRPC probes, `TestTLS` currently hangs for 30 seconds and exits fatally with `context deadline exceeded`.

Rather than forcing users to use `--skip-test-tls` or automatically bypassing user-configured security checks, this PR improves the UX by:
1. Reducing the `TestTLS` probe timeout from 30s to 5s.
2. Handling probe timeouts gracefully: logging a warning message (`TLS test timed out (likely behind a reverse proxy). Proceeding with login...`) and allowing login to continue instead of crashing.
3. Preserving `--skip-test-tls` as an explicit user flag for those who wish to skip probing entirely.

## Checklist
- [x] Signed-off-by added to commit (DCO)