### PR TITLE
fix(cli): provide actionable hint when TestTLS times out

### DIFF
--- a/cmd/argocd/commands/login.go
+++ b/cmd/argocd/commands/login.go
@@ -80,7 +80,12 @@ argocd login cd.argoproj.io --core`,
 				if !skipTestTLS {
 					dialTime := 30 * time.Second
 					tlsTestResult, err := grpc_util.TestTLS(server, dialTime)
-					errors.CheckError(err)
+					if err != nil {
+						if strings.Contains(err.Error(), "context deadline exceeded") {
+							err = fmt.Errorf("failed to determine whether server uses TLS: %w\n\nThe server may be behind a reverse proxy or may not accept the TLS probe.\nTry --skip-test-tls. If the proxy requires gRPC-Web, also use --grpc-web.", err)
+						}
+						errors.CheckError(err)
+					}
 					if !tlsTestResult.TLS {
 						if !clientOpts.PlainText {
 							if !cli.AskToProceed("WARNING: server is not configured with TLS. Proceed (y/n)? ") {


### PR DESCRIPTION
## Summary
When `argocd login` is executed behind a reverse proxy (such as Nginx Ingress) that drops native gRPC probe requests, `TestTLS` hangs for 30s and exits with a generic `context deadline exceeded` error.

This PR wraps the error specifically when `TestTLS` times out (`context deadline exceeded`) to provide actionable guidance:

```
failed to determine whether server uses TLS: gRPC connection not ready: context deadline exceeded

The server may be behind a reverse proxy or may not accept the TLS probe.
Try --skip-test-tls. If the proxy requires gRPC-Web, also use --grpc-web.
```

### Benefits
- Does not modify existing login/auth or security verification behavior.
- Low regression risk.
- Provides clear, actionable hints for reverse proxy environments while preserving error context.

## Checklist
- [x] Signed-off-by added to commit (DCO)