### PR TITLE
fix: register pprof endpoints in repo-server using the params config map (cherry-pick #26237 for 3.3)

### DIFF
--- a/cmd/argocd-repo-server/commands/argocd_repo_server.go
+++ b/cmd/argocd-repo-server/commands/argocd_repo_server.go
@@ -34,6 +34,7 @@ import (
 	"github.com/argoproj/argo-cd/v3/util/gpg"
 	"github.com/argoproj/argo-cd/v3/util/healthz"
 	utilio "github.com/argoproj/argo-cd/v3/util/io"
+	"github.com/argoproj/argo-cd/v3/util/profile"
 	"github.com/argoproj/argo-cd/v3/util/tls"
 	traceutil "github.com/argoproj/argo-cd/v3/util/trace"
 )
@@ -175,7 +176,8 @@ func NewCommand() *cobra.Command {
 			listener, err := lc.Listen(ctx, "tcp", fmt.Sprintf("%s:%d", listenHost, listenPort))
 			errors.CheckError(err)
 
-			healthz.ServeHealthCheck(http.DefaultServeMux, func(r *http.Request) error {
+			mux := http.NewServeMux()
+			healthz.ServeHealthCheck(mux, func(r *http.Request) error {
 				if val, ok := r.URL.Query()["full"]; ok && len(val) > 0 && val[0] == "true" {
 					// connect to itself to make sure repo server is able to serve connection
 					// used by liveness probe to auto restart repo server
@@ -197,8 +199,9 @@ func NewCommand() *cobra.Command {
 				}
 				return nil
 			})
-			http.Handle("/metrics", metricsServer.GetHandler())
-			go func() { errors.CheckError(http.ListenAndServe(fmt.Sprintf("%s:%d", metricsHost, metricsPort), nil)) }()
+			mux.Handle("/metrics", metricsServer.GetHandler())
+			profile.RegisterProfiler(mux)
+			go func() { errors.CheckError(http.ListenAndServe(fmt.Sprintf("%s:%d", metricsHost, metricsPort), mux)) }()
 			go func() { errors.CheckError(askPassServer.Run()) }()
 
 			if gpg.IsGPGEnabled() {

--- a/docs/operator-manual/argocd-cmd-params-cm.yaml
+++ b/docs/operator-manual/argocd-cmd-params-cm.yaml
@@ -225,6 +225,8 @@ data:
   reposerver.enable.builtin.git.config: "true"
   # Include hidden directories from Git
   reposerver.include.hidden.directories: "false"
+  # Enables profile endpoint on the internal metrics port
+  reposerver.profile.enabled: "false"
 
   ## Commit-server properties
   # Listen on given address for incoming connections (default "0.0.0.0")

--- a/docs/operator-manual/high_availability.md
+++ b/docs/operator-manual/high_availability.md
@@ -522,12 +522,12 @@ Not all HTTP responses are eligible for retries. The following conditions will n
 
 Argo CD optionally exposes a profiling endpoint that can be used to profile the CPU and memory usage of the Argo CD
 component.
-The profiling endpoint is available on metrics port of each component. See [metrics](./metrics.md) for more information
+The profiling endpoint is available on the metrics port of each component. See [metrics](./metrics.md) for more information
 about the port.
 For security reasons, the profiling endpoint is disabled by default. The endpoint can be enabled by setting the
-`server.profile.enabled`, `applicationsetcontroller.profile.enabled`, or `controller.profile.enabled` key
-of [argocd-cmd-params-cm](argocd-cmd-params-cm.yaml) ConfigMap to `true`.
-Once the endpoint is enabled, you can use go profile tool to collect the CPU and memory profiles. Example:
+`server.profile.enabled`, `applicationsetcontroller.profile.enabled`, `reposerver.profile.enabled` or 
+`controller.profile.enabled` key of [argocd-cmd-params-cm](argocd-cmd-params-cm.yaml) ConfigMap to `true`.
+Once the endpoint is enabled, you can use the go profile tool to collect the CPU and memory profiles. Example:
 
 ```bash
 $ kubectl port-forward svc/argocd-metrics 8082:8082

--- a/manifests/base/repo-server/argocd-repo-server-deployment.yaml
+++ b/manifests/base/repo-server/argocd-repo-server-deployment.yaml
@@ -359,6 +359,13 @@ spec:
           name: var-files
         - emptyDir: {}
           name: plugins
+        - name: argocd-cmd-params-cm
+          configMap:
+            optional: true
+            name: argocd-cmd-params-cm
+            items:
+              - key: reposerver.profile.enabled
+                path: profiler.enabled
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/manifests/core-install-with-hydrator.yaml
+++ b/manifests/core-install-with-hydrator.yaml
@@ -31936,6 +31936,13 @@ spec:
         name: var-files
       - emptyDir: {}
         name: plugins
+      - configMap:
+          items:
+          - key: reposerver.profile.enabled
+            path: profiler.enabled
+          name: argocd-cmd-params-cm
+          optional: true
+        name: argocd-cmd-params-cm
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -31770,6 +31770,13 @@ spec:
         name: var-files
       - emptyDir: {}
         name: plugins
+      - configMap:
+          items:
+          - key: reposerver.profile.enabled
+            path: profiler.enabled
+          name: argocd-cmd-params-cm
+          optional: true
+        name: argocd-cmd-params-cm
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/manifests/ha/install-with-hydrator.yaml
+++ b/manifests/ha/install-with-hydrator.yaml
@@ -33571,6 +33571,13 @@ spec:
         name: var-files
       - emptyDir: {}
         name: plugins
+      - configMap:
+          items:
+          - key: reposerver.profile.enabled
+            path: profiler.enabled
+          name: argocd-cmd-params-cm
+          optional: true
+        name: argocd-cmd-params-cm
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -33407,6 +33407,13 @@ spec:
         name: var-files
       - emptyDir: {}
         name: plugins
+      - configMap:
+          items:
+          - key: reposerver.profile.enabled
+            path: profiler.enabled
+          name: argocd-cmd-params-cm
+          optional: true
+        name: argocd-cmd-params-cm
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/ha/namespace-install-with-hydrator.yaml
+++ b/manifests/ha/namespace-install-with-hydrator.yaml
@@ -2829,6 +2829,13 @@ spec:
         name: var-files
       - emptyDir: {}
         name: plugins
+      - configMap:
+          items:
+          - key: reposerver.profile.enabled
+            path: profiler.enabled
+          name: argocd-cmd-params-cm
+          optional: true
+        name: argocd-cmd-params-cm
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -2665,6 +2665,13 @@ spec:
         name: var-files
       - emptyDir: {}
         name: plugins
+      - configMap:
+          items:
+          - key: reposerver.profile.enabled
+            path: profiler.enabled
+          name: argocd-cmd-params-cm
+          optional: true
+        name: argocd-cmd-params-cm
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/install-with-hydrator.yaml
+++ b/manifests/install-with-hydrator.yaml
@@ -32601,6 +32601,13 @@ spec:
         name: var-files
       - emptyDir: {}
         name: plugins
+      - configMap:
+          items:
+          - key: reposerver.profile.enabled
+            path: profiler.enabled
+          name: argocd-cmd-params-cm
+          optional: true
+        name: argocd-cmd-params-cm
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -32435,6 +32435,13 @@ spec:
         name: var-files
       - emptyDir: {}
         name: plugins
+      - configMap:
+          items:
+          - key: reposerver.profile.enabled
+            path: profiler.enabled
+          name: argocd-cmd-params-cm
+          optional: true
+        name: argocd-cmd-params-cm
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/namespace-install-with-hydrator.yaml
+++ b/manifests/namespace-install-with-hydrator.yaml
@@ -1859,6 +1859,13 @@ spec:
         name: var-files
       - emptyDir: {}
         name: plugins
+      - configMap:
+          items:
+          - key: reposerver.profile.enabled
+            path: profiler.enabled
+          name: argocd-cmd-params-cm
+          optional: true
+        name: argocd-cmd-params-cm
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -1693,6 +1693,13 @@ spec:
         name: var-files
       - emptyDir: {}
         name: plugins
+      - configMap:
+          items:
+          - key: reposerver.profile.enabled
+            path: profiler.enabled
+          name: argocd-cmd-params-cm
+          optional: true
+        name: argocd-cmd-params-cm
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Cherry-pick of #26237 for release-3.3.

#28865 (cherry-pick of #28863) added the `argocd-cmd-params-cm` volumeMount to the repo-server deployment, but release-3.3 never got #26237 which defines the volume itself. Since v3.3.13 the install manifests produce an invalid Deployment:

```
Deployment.apps "argocd-repo-server" is invalid:
  spec.template.spec.containers[0].volumeMounts[4].name: Not found: "argocd-cmd-params-cm"
```

Backporting #26237 adds the missing volume (and the pprof registration the mount was meant to enable).

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).
