### PR TITLE
fix(redis): incorrect fail metrics on RENAME cache miss

### DIFF
--- a/controller/metrics/metrics.go
+++ b/controller/metrics/metrics.go
@@ -123,7 +123,7 @@ var (
 			Name: "argocd_redis_request_total",
 			Help: "Number of redis requests executed during application reconciliation.",
 		},
-		[]string{"hostname", "initiator", "failed"},
+		[]string{"hostname", "initiator", "command", "failed"},
 	)
 
 	redisRequestHistogram = prometheus.NewHistogramVec(
@@ -299,8 +299,8 @@ func (m *MetricsServer) IncKubernetesRequest(app *argoappv1.Application, server,
 	).Inc()
 }
 
-func (m *MetricsServer) IncRedisRequest(failed bool) {
-	m.redisRequestCounter.WithLabelValues(m.hostname, common.CommandApplicationController, strconv.FormatBool(failed)).Inc()
+func (m *MetricsServer) IncRedisRequest(command string, failed bool) {
+	m.redisRequestCounter.WithLabelValues(m.hostname, common.CommandApplicationController, command, strconv.FormatBool(failed)).Inc()
 }
 
 // ObserveRedisRequestDuration observes redis request duration

--- a/docs/operator-manual/metrics.md
+++ b/docs/operator-manual/metrics.md
@@ -6,39 +6,39 @@ Argo CD exposes different sets of Prometheus metrics per server.
 
 Metrics about applications. Scraped at the `argocd-metrics:8082/metrics` endpoint.
 
-| Metric                                            |   Type    | Description                                                                                                                                 |
-| ------------------------------------------------- | :-------: | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `argocd_app_info`                                 |   gauge   | Information about Applications. It contains labels such as `sync_status` and `health_status` that reflect the application state in Argo CD. |
-| `argocd_app_condition`                            |   gauge   | Report Applications conditions. It contains the conditions currently present in the application status.                                     |
-| `argocd_app_k8s_request_total`                    |  counter  | Number of Kubernetes requests executed during application reconciliation                                                                    |
-| `argocd_app_labels`                               |   gauge   | Argo Application labels converted to Prometheus labels. Disabled by default. See section below about how to enable it.                      |
-| `argocd_app_orphaned_resources_count`             |   gauge   | Number of orphaned resources per application.                                                                                               |
-| `argocd_app_reconcile`                            | histogram | Application reconciliation performance in seconds.                                                                                          |
-| `argocd_app_sync_total`                           |  counter  | Counter for application sync history                                                                                                        |
-| `argocd_app_sync_duration_seconds_total`          |  counter  | Application sync performance in seconds total.                                                                                                        |
-| `argocd_cluster_api_resource_objects`             |   gauge   | Number of k8s resource objects in the cache.                                                                                                |
-| `argocd_cluster_api_resources`                    |   gauge   | Number of monitored Kubernetes API resources.                                                                                               |
-| `argocd_cluster_cache_age_seconds`                |   gauge   | Cluster cache age in seconds.                                                                                                               |
-| `argocd_cluster_connection_status`                |   gauge   | The k8s cluster current connection status.                                                                                                  |
-| `argocd_cluster_events_total`                     |  counter  | Number of processes k8s resource events.                                                                                                    |
-| `argocd_cluster_info`                             |   gauge   | Information about cluster.                                                                                                                  |
-| `argocd_redis_request_duration`                   | histogram | Redis requests duration.                                                                                                                    |
-| `argocd_redis_request_total`                      |  counter  | Number of redis requests executed during application reconciliation                                                                         |
-| `argocd_resource_events_processing`               | histogram | Time to process resource events in batch in seconds                                                                                         |
-| `argocd_resource_events_processed_in_batch`       |   gauge   | Number of resource events processed in batch                                                                                                |
-| `argocd_kubectl_exec_pending`                     |   gauge   | Number of pending kubectl executions                                                                                                        |
-| `argocd_kubectl_exec_total`                       |  counter  | Number of kubectl executions                                                                                                                |
-| `argocd_kubectl_client_cert_rotation_age_seconds` |   gauge   | Age of kubectl client certificate rotation.                                                                                                 |
-| `argocd_kubectl_request_duration_seconds`         | histogram | Latency of kubectl requests.                                                                                                                |
-| `argocd_kubectl_dns_resolution_duration_seconds`  | histogram | Latency of kubectl resolver.                                                                                                                |
-| `argocd_kubectl_request_size_bytes`               | histogram | Size of kubectl requests.                                                                                                                   |
-| `argocd_kubectl_response_size_bytes`              | histogram | Size of kubectl responses.                                                                                                                  |
-| `argocd_kubectl_rate_limiter_duration_seconds`    | histogram | Latency of kubectl rate limiter.                                                                                                            |
-| `argocd_kubectl_requests_total`                   |  counter  | Result of kubectl requests.                                                                                                                 |
-| `argocd_kubectl_exec_plugin_call_total`           |  counter  | Number of kubectl exec plugin calls.                                                                                                        |
-| `argocd_kubectl_request_retries_total`            |  counter  | Number of kubectl request retries.                                                                                                          |
-| `argocd_kubectl_transport_cache_entries`          |   gauge   | Number of kubectl transport cache entries.                                                                                                  |
-| `argocd_kubectl_transport_create_calls_total`     |  counter  | Number of kubectl transport create calls.                                                                                                   |
+| Metric                                            |   Type    | Description                                                                                                                                                                                             |
+| ------------------------------------------------- | :-------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `argocd_app_info`                                 |   gauge   | Information about Applications. It contains labels such as `sync_status` and `health_status` that reflect the application state in Argo CD.                                                             |
+| `argocd_app_condition`                            |   gauge   | Report Applications conditions. It contains the conditions currently present in the application status.                                                                                                 |
+| `argocd_app_k8s_request_total`                    |  counter  | Number of Kubernetes requests executed during application reconciliation                                                                                                                                |
+| `argocd_app_labels`                               |   gauge   | Argo Application labels converted to Prometheus labels. Disabled by default. See section below about how to enable it.                                                                                  |
+| `argocd_app_orphaned_resources_count`             |   gauge   | Number of orphaned resources per application.                                                                                                                                                           |
+| `argocd_app_reconcile`                            | histogram | Application reconciliation performance in seconds.                                                                                                                                                      |
+| `argocd_app_sync_total`                           |  counter  | Counter for application sync history                                                                                                                                                                    |
+| `argocd_app_sync_duration_seconds_total`          |  counter  | Application sync performance in seconds total.                                                                                                                                                          |
+| `argocd_cluster_api_resource_objects`             |   gauge   | Number of k8s resource objects in the cache.                                                                                                                                                            |
+| `argocd_cluster_api_resources`                    |   gauge   | Number of monitored Kubernetes API resources.                                                                                                                                                           |
+| `argocd_cluster_cache_age_seconds`                |   gauge   | Cluster cache age in seconds.                                                                                                                                                                           |
+| `argocd_cluster_connection_status`                |   gauge   | The k8s cluster current connection status.                                                                                                                                                              |
+| `argocd_cluster_events_total`                     |  counter  | Number of processes k8s resource events.                                                                                                                                                                |
+| `argocd_cluster_info`                             |   gauge   | Information about cluster.                                                                                                                                                                              |
+| `argocd_redis_request_duration`                   | histogram | Redis requests duration.                                                                                                                                                                                |
+| `argocd_redis_request_total`                      |  counter  | Number of redis requests executed during application reconciliation, labeled by `command` and `failed`. Manifest-rename cache misses are reported as `failed="false"` (treated as a normal cache miss). |
+| `argocd_resource_events_processing`               | histogram | Time to process resource events in batch in seconds                                                                                                                                                     |
+| `argocd_resource_events_processed_in_batch`       |   gauge   | Number of resource events processed in batch                                                                                                                                                            |
+| `argocd_kubectl_exec_pending`                     |   gauge   | Number of pending kubectl executions                                                                                                                                                                    |
+| `argocd_kubectl_exec_total`                       |  counter  | Number of kubectl executions                                                                                                                                                                            |
+| `argocd_kubectl_client_cert_rotation_age_seconds` |   gauge   | Age of kubectl client certificate rotation.                                                                                                                                                             |
+| `argocd_kubectl_request_duration_seconds`         | histogram | Latency of kubectl requests.                                                                                                                                                                            |
+| `argocd_kubectl_dns_resolution_duration_seconds`  | histogram | Latency of kubectl resolver.                                                                                                                                                                            |
+| `argocd_kubectl_request_size_bytes`               | histogram | Size of kubectl requests.                                                                                                                                                                               |
+| `argocd_kubectl_response_size_bytes`              | histogram | Size of kubectl responses.                                                                                                                                                                              |
+| `argocd_kubectl_rate_limiter_duration_seconds`    | histogram | Latency of kubectl rate limiter.                                                                                                                                                                        |
+| `argocd_kubectl_requests_total`                   |  counter  | Result of kubectl requests.                                                                                                                                                                             |
+| `argocd_kubectl_exec_plugin_call_total`           |  counter  | Number of kubectl exec plugin calls.                                                                                                                                                                    |
+| `argocd_kubectl_request_retries_total`            |  counter  | Number of kubectl request retries.                                                                                                                                                                      |
+| `argocd_kubectl_transport_cache_entries`          |   gauge   | Number of kubectl transport cache entries.                                                                                                                                                              |
+| `argocd_kubectl_transport_create_calls_total`     |  counter  | Number of kubectl transport create calls.                                                                                                                                                               |
 
 ### Labels
 
@@ -91,7 +91,7 @@ The example below will expose the Argo CD Application labels `team-name` and `bu
     controller.metrics.application.labels: "team-name,business-unit"
 
 !!! warning
-    Each distinct label value becomes a separate `argocd_app_labels` time series. Exposing labels with many distinct values increases the metric's cardinality, which can degrade Prometheus performance and increase storage requirements. Prefer low-cardinality labels and add them sparingly.
+Each distinct label value becomes a separate `argocd_app_labels` time series. Exposing labels with many distinct values increases the metric's cardinality, which can degrade Prometheus performance and increase storage requirements. Prefer low-cardinality labels and add them sparingly.
 
 Alternatively, the labels can be passed as `--metrics-application-labels` flags directly to the application controller:
 
@@ -224,28 +224,28 @@ All the following `argocd_github_api_*` metrics can be enabled upon setting `app
 
 Metrics about API Server API request and response activity (request totals, response codes, etc...).
 Scraped at the `argocd-server-metrics:8083/metrics` endpoint.
-For GRPC metrics to show up environment variable ARGOCD_ENABLE_GRPC_TIME_HISTOGRAM must be set to true. 
+For GRPC metrics to show up environment variable ARGOCD_ENABLE_GRPC_TIME_HISTOGRAM must be set to true.
 
-| Metric                                            |   Type    | Description                                                                        
-|---------------------------------------------------|:---------:|---------------------------------------------------------------------------------------------|
-| `argocd_login_request_total`                      | counter   | Number of login requests.                                                                   |
-| `argocd_redis_request_duration`                   | histogram | Redis requests duration.                                                                    |
-| `argocd_redis_request_total`                      |  counter  | Number of Kubernetes requests executed during application reconciliation.                   |
-| `grpc_server_handled_total`                       |  counter  | Total number of RPCs completed on the server, regardless of success or failure.             |
-| `grpc_server_msg_sent_total`                      |  counter  | Total number of gRPC stream messages sent by the server.                                    |
-| `argocd_proxy_extension_request_total`            |  counter  | Number of requests sent to the configured proxy extensions.                                 |
-| `argocd_proxy_extension_request_duration_seconds` | histogram | Request duration in seconds between the Argo CD API server and the proxy extension backend. |
-| `argocd_kubectl_client_cert_rotation_age_seconds` |   gauge   | Age of kubectl client certificate rotation.                                                 |
-| `argocd_kubectl_request_duration_seconds`         | histogram | Latency of kubectl requests.                                                                |
-| `argocd_kubectl_dns_resolution_duration_seconds`  | histogram | Latency of kubectl resolver.                                                                |
-| `argocd_kubectl_request_size_bytes`               | histogram | Size of kubectl requests.                                                                   |
-| `argocd_kubectl_response_size_bytes`              | histogram | Size of kubectl responses.                                                                  |
-| `argocd_kubectl_rate_limiter_duration_seconds`    | histogram | Latency of kubectl rate limiter.                                                            |
-| `argocd_kubectl_requests_total`                   |  counter  | Result of kubectl requests.                                                                 |
-| `argocd_kubectl_exec_plugin_call_total`           |  counter  | Number of kubectl exec plugin calls.                                                        |
-| `argocd_kubectl_request_retries_total`            |  counter  | Number of kubectl request retries.                                                          |
-| `argocd_kubectl_transport_cache_entries`          |   gauge   | Number of kubectl transport cache entries.                                                  |
-| `argocd_kubectl_transport_create_calls_total`     |  counter  | Number of kubectl transport create calls.                                                   |
+| Metric                                            |   Type    | Description                                                                                                                                                                                             |
+| ------------------------------------------------- | :-------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `argocd_login_request_total`                      |  counter  | Number of login requests.                                                                                                                                                                               |
+| `argocd_redis_request_duration`                   | histogram | Redis requests duration.                                                                                                                                                                                |
+| `argocd_redis_request_total`                      |  counter  | Number of redis requests executed during application reconciliation, labeled by `command` and `failed`. Manifest-rename cache misses are reported as `failed="false"` (treated as a normal cache miss). |
+| `grpc_server_handled_total`                       |  counter  | Total number of RPCs completed on the server, regardless of success or failure.                                                                                                                         |
+| `grpc_server_msg_sent_total`                      |  counter  | Total number of gRPC stream messages sent by the server.                                                                                                                                                |
+| `argocd_proxy_extension_request_total`            |  counter  | Number of requests sent to the configured proxy extensions.                                                                                                                                             |
+| `argocd_proxy_extension_request_duration_seconds` | histogram | Request duration in seconds between the Argo CD API server and the proxy extension backend.                                                                                                             |
+| `argocd_kubectl_client_cert_rotation_age_seconds` |   gauge   | Age of kubectl client certificate rotation.                                                                                                                                                             |
+| `argocd_kubectl_request_duration_seconds`         | histogram | Latency of kubectl requests.                                                                                                                                                                            |
+| `argocd_kubectl_dns_resolution_duration_seconds`  | histogram | Latency of kubectl resolver.                                                                                                                                                                            |
+| `argocd_kubectl_request_size_bytes`               | histogram | Size of kubectl requests.                                                                                                                                                                               |
+| `argocd_kubectl_response_size_bytes`              | histogram | Size of kubectl responses.                                                                                                                                                                              |
+| `argocd_kubectl_rate_limiter_duration_seconds`    | histogram | Latency of kubectl rate limiter.                                                                                                                                                                        |
+| `argocd_kubectl_requests_total`                   |  counter  | Result of kubectl requests.                                                                                                                                                                             |
+| `argocd_kubectl_exec_plugin_call_total`           |  counter  | Number of kubectl exec plugin calls.                                                                                                                                                                    |
+| `argocd_kubectl_request_retries_total`            |  counter  | Number of kubectl request retries.                                                                                                                                                                      |
+| `argocd_kubectl_transport_cache_entries`          |   gauge   | Number of kubectl transport cache entries.                                                                                                                                                              |
+| `argocd_kubectl_transport_create_calls_total`     |  counter  | Number of kubectl transport create calls.                                                                                                                                                               |
 
 ### Labels
 
@@ -265,27 +265,26 @@ For GRPC metrics to show up environment variable ARGOCD_ENABLE_GRPC_TIME_HISTOGR
 
 ## Repo Server Metrics
 
-Metrics about the Repo Server. The gRPC metrics are not exposed by default.  Metrics can be enabled using
-`ARGOCD_ENABLE_GRPC_TIME_HISTOGRAM=true` environment variable.  
+Metrics about the Repo Server. The gRPC metrics are not exposed by default. Metrics can be enabled using
+`ARGOCD_ENABLE_GRPC_TIME_HISTOGRAM=true` environment variable.
 Scraped at the `argocd-repo-server:8084/metrics` endpoint.
 
-
-| Metric                                   |    Type    | Description                                                               |
-|------------------------------------------|:----------:|---------------------------------------------------------------------------|
-| `argocd_git_request_duration_seconds`    | histogram  | Git requests duration seconds.                                            |
-| `argocd_git_request_total`               |  counter   | Number of git requests performed by repo server                           |
-| `argocd_git_fetch_fail_total`            |  counter   | Number of git fetch requests failures by repo server                      |
-| `argocd_redis_request_duration_seconds`  | histogram  | Redis requests duration seconds.                                          |
-| `argocd_redis_request_total`             |  counter   | Number of Kubernetes requests executed during application reconciliation. |
-| `argocd_repo_pending_request_total`      |   gauge    | Number of pending requests requiring repository lock                      |
-| `argocd_repo_parallelism_wait_duration_seconds` | histogram  | Time spent waiting for the repo-server manifest generation parallelism semaphore (`--parallelismlimit`). Observed on every acquire attempt, including those that fail (e.g. context canceled). |
-| `argocd_oci_request_total`               |  counter   | Number of OCI requests performed by repo server                           |
-| `argocd_oci_request_duration_seconds`    | histogram  | Duration of OCI requests performed by the repo server.                      |
-| `argocd_oci_test_repo_fail_total`        |  counter   | Number of OCI test repo requests failures by repo server                  |
-| `argocd_oci_get_tags_fail_total`         |  counter   | Number of OCI get tags requests failures by repo server                   |
-| `argocd_oci_digest_metadata_fail_total`  |  counter   | Number of OCI digest metadata failures by repo server                     |
-| `argocd_oci_resolve_revision_fail_total` |  counter   | Number of OCI resolve revision failures by repo server                   |
-| `argocd_oci_extract_fail_total`          |  counter   | Number of OCI extract requests failures by repo server                    |
+| Metric                                          |   Type    | Description                                                                                                                                                                                    |
+| ----------------------------------------------- | :-------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `argocd_git_request_duration_seconds`           | histogram | Git requests duration seconds.                                                                                                                                                                 |
+| `argocd_git_request_total`                      |  counter  | Number of git requests performed by repo server                                                                                                                                                |
+| `argocd_git_fetch_fail_total`                   |  counter  | Number of git fetch requests failures by repo server                                                                                                                                           |
+| `argocd_redis_request_duration_seconds`         | histogram | Redis requests duration seconds.                                                                                                                                                               |
+| `argocd_redis_request_total`                    |  counter  | Number of redis requests executed during application reconciliation, labeled by `command` and `failed`.                                                                                        |
+| `argocd_repo_pending_request_total`             |   gauge   | Number of pending requests requiring repository lock                                                                                                                                           |
+| `argocd_repo_parallelism_wait_duration_seconds` | histogram | Time spent waiting for the repo-server manifest generation parallelism semaphore (`--parallelismlimit`). Observed on every acquire attempt, including those that fail (e.g. context canceled). |
+| `argocd_oci_request_total`                      |  counter  | Number of OCI requests performed by repo server                                                                                                                                                |
+| `argocd_oci_request_duration_seconds`           | histogram | Duration of OCI requests performed by the repo server.                                                                                                                                         |
+| `argocd_oci_test_repo_fail_total`               |  counter  | Number of OCI test repo requests failures by repo server                                                                                                                                       |
+| `argocd_oci_get_tags_fail_total`                |  counter  | Number of OCI get tags requests failures by repo server                                                                                                                                        |
+| `argocd_oci_digest_metadata_fail_total`         |  counter  | Number of OCI digest metadata failures by repo server                                                                                                                                          |
+| `argocd_oci_resolve_revision_fail_total`        |  counter  | Number of OCI resolve revision failures by repo server                                                                                                                                         |
+| `argocd_oci_extract_fail_total`                 |  counter  | Number of OCI extract requests failures by repo server                                                                                                                                         |
 
 ## Commit Server Metrics
 

--- a/reposerver/cache/cache.go
+++ b/reposerver/cache/cache.go
@@ -390,27 +390,12 @@ func trackingKey(appLabelKey string, trackingMethod string) string {
 	return trackingKey
 }
 
-// LogDebugManifestCacheKeyFields logs all the information included in a manifest cache key. It's intended to be run
-// before every manifest cache operation to help debug cache misses.
-func LogDebugManifestCacheKeyFields(message string, reason string, manifestKey manifestKey) {
-	if log.IsLevelEnabled(log.DebugLevel) {
-		log.WithFields(log.Fields{
-			"revision":    manifestKey.Revision,
-			"appSrc":      appSourceKeyJSON(manifestKey.AppSource, manifestKey.RefSources, manifestKey.RefSourceCommitSHAs),
-			"namespace":   manifestKey.Namespace,
-			"trackingKey": trackingKey(manifestKey.AppLabelKey, manifestKey.TrackingMethod),
-			"appName":     manifestKey.AppName,
-			"clusterInfo": clusterRuntimeInfoKeyUnhashed(manifestKey.ClusterInfo),
-			"reason":      reason,
-		}).Debug(message)
-	}
-}
-
 func (c *Cache) SetNewRevisionManifests(oldKey, newKey manifestKey) error {
 	return c.cache.RenameItem(oldKey.String(), newKey.String(), c.repoCacheExpiration)
 }
 
 func (c *Cache) GetManifests(manifestKey manifestKey, res *CachedManifestResponse) error {
+	logCtx := log.WithField("cacheKey", manifestKey.String())
 	err := c.cache.GetItem(manifestKey.String(), res)
 	if err != nil {
 		return err
@@ -423,9 +408,8 @@ func (c *Cache) GetManifests(manifestKey manifestKey, res *CachedManifestRespons
 
 	// If cached result does not have manifests or the expected hash of the cache entry does not match the actual hash value...
 	if hash != res.CacheEntryHash || res.ManifestResponse == nil && res.MostRecentError == "" {
-		log.Warnf("Manifest hash did not match expected value or cached manifests response is empty, treating as a cache miss: %s", manifestKey.AppName)
-
-		LogDebugManifestCacheKeyFields("deleting manifests cache", "manifest hash did not match or cached response is empty", manifestKey)
+		logCtx.Warnf("Manifest hash did not match expected value or cached manifests response is empty, treating as a cache miss: %s", manifestKey.AppName)
+		logCtx.Debug("deleting manifests cache: manifest hash did not match or cached response is empty")
 
 		err = c.DeleteManifests(manifestKey)
 		if err != nil {

--- a/reposerver/metrics/metrics.go
+++ b/reposerver/metrics/metrics.go
@@ -103,7 +103,7 @@ func NewMetricsServer() *MetricsServer {
 			Name: "argocd_redis_request_total",
 			Help: "Number of kubernetes requests executed during application reconciliation.",
 		},
-		[]string{"initiator", "failed"},
+		[]string{"initiator", "command", "failed"},
 	)
 	registry.MustRegister(redisRequestCounter)
 
@@ -239,8 +239,8 @@ func (m *MetricsServer) ObserveParallelismWaitDuration(duration time.Duration) {
 	m.parallelismWaitHistogram.Observe(duration.Seconds())
 }
 
-func (m *MetricsServer) IncRedisRequest(failed bool) {
-	m.redisRequestCounter.WithLabelValues("argocd-repo-server", strconv.FormatBool(failed)).Inc()
+func (m *MetricsServer) IncRedisRequest(command string, failed bool) {
+	m.redisRequestCounter.WithLabelValues("argocd-repo-server", command, strconv.FormatBool(failed)).Inc()
 }
 
 func (m *MetricsServer) ObserveRedisRequestDuration(duration time.Duration) {

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -969,16 +969,16 @@ func (s *Service) runManifestGenAsync(ctx context.Context, repoRoot, commitSHA, 
 	manifestKey := cache.NewManifestKey(revision, appSourceCopy, q.GetRefSources(), q.GetNamespace(), q.GetTrackingMethod(),
 		q.GetAppLabelKey(), q.GetAppName(), q.GetInstallationID(), q.GetSourceIntegrity(), q, refSourceCommitSHAs,
 	)
+	logCtx := log.WithFields(log.Fields{
+		"application":  q.AppName,
+		"appNamespace": q.Namespace,
+		"cacheKey":     manifestKey.String(),
+	})
 
 	if err != nil {
-		logCtx := log.WithFields(log.Fields{
-			"application":  q.AppName,
-			"appNamespace": q.Namespace,
-		})
-
 		// If manifest generation error caching is enabled
 		if s.initConstants.PauseGenerationAfterFailedGenerationAttempts > 0 {
-			cache.LogDebugManifestCacheKeyFields("getting manifests cache", "GenerateManifests error", manifestKey)
+			logCtx.Debug("getting manifests cache: GenerateManifests error")
 
 			// Retrieve a new copy (if available) of the cached response: this ensures we are updating the latest copy of the cache,
 			// rather than a copy of the cache that occurred before (a potentially lengthy) manifest generation.
@@ -996,7 +996,7 @@ func (s *Service) runManifestGenAsync(ctx context.Context, repoRoot, commitSHA, 
 				innerRes.FirstFailureTimestamp = s.now().Unix()
 			}
 
-			cache.LogDebugManifestCacheKeyFields("setting manifests cache", "GenerateManifests error", manifestKey)
+			logCtx.Info("setting manifests cache (error)")
 
 			// Update the cache to include failure information
 			innerRes.NumberOfConsecutiveFailures++
@@ -1013,7 +1013,7 @@ func (s *Service) runManifestGenAsync(ctx context.Context, repoRoot, commitSHA, 
 		return
 	}
 
-	cache.LogDebugManifestCacheKeyFields("setting manifests cache", "fresh GenerateManifests response", manifestKey)
+	logCtx.Info("setting manifests cache")
 
 	// Otherwise, no error occurred, so ensure the manifest generation error data in the cache entry is reset before we cache the value
 	manifestGenCacheEntry := cache.CachedManifestResponse{
@@ -1044,7 +1044,12 @@ func (s *Service) getManifestCacheEntry(revision string, q *apiclient.ManifestRe
 	cacheKey := cache.NewManifestKey(revision, q.ApplicationSource, q.GetRefSources(), q.GetNamespace(), q.GetTrackingMethod(),
 		q.GetAppLabelKey(), q.GetAppName(), q.GetInstallationID(), q.GetSourceIntegrity(), q, refSourceCommitSHAs,
 	)
-	cache.LogDebugManifestCacheKeyFields("getting manifests cache", "GenerateManifest API call", cacheKey)
+	logCtx := log.WithFields(log.Fields{
+		"application":  q.AppName,
+		"appNamespace": q.Namespace,
+		"cacheKey":     cacheKey.String(),
+	})
+	logCtx.Debug("getting manifests cache: GenerateManifest API call")
 
 	res := cache.CachedManifestResponse{}
 	err := s.cache.GetManifests(cacheKey, &res)
@@ -1061,14 +1066,14 @@ func (s *Service) getManifestCacheEntry(revision string, q *apiclient.ManifestRe
 
 					// After X minutes, reset the cache and retry the operation (e.g. perhaps the error is ephemeral and has passed)
 					if elapsedTimeInMinutes >= s.initConstants.PauseGenerationOnFailureForMinutes {
-						cache.LogDebugManifestCacheKeyFields("deleting manifests cache", "manifest hash did not match or cached response is empty", cacheKey)
+						logCtx.Debug("deleting manifests cache: manifest hash did not match or cached response is empty")
 
 						// We can now try again, so reset the cache state and run the operation below
 						err = s.cache.DeleteManifests(cacheKey)
 						if err != nil {
-							log.Warnf("manifest cache delete error %s/%s: %v", q.ApplicationSource.String(), revision, err)
+							logCtx.Warnf("manifest cache delete error %s/%s: %v", q.ApplicationSource.String(), revision, err)
 						}
-						log.Infof("manifest error cache hit and reset: %s/%s", q.ApplicationSource.String(), revision)
+						logCtx.Infof("manifest error cache hit and reset: %s/%s", q.ApplicationSource.String(), revision)
 						return false, nil, nil
 					}
 				}
@@ -1076,33 +1081,33 @@ func (s *Service) getManifestCacheEntry(revision string, q *apiclient.ManifestRe
 				// Check if enough cached responses have been returned to try generation again (e.g. to exit the 'manifest generation caching' state)
 				if s.initConstants.PauseGenerationOnFailureForRequests > 0 && res.NumberOfCachedResponsesReturned > 0 {
 					if res.NumberOfCachedResponsesReturned >= s.initConstants.PauseGenerationOnFailureForRequests {
-						cache.LogDebugManifestCacheKeyFields("deleting manifests cache", "reset after paused generation count", cacheKey)
+						logCtx.Debug("deleting manifests cache: reset after paused generation count")
 
 						// We can now try again, so reset the error cache state and run the operation below
 						err = s.cache.DeleteManifests(cacheKey)
 						if err != nil {
-							log.Warnf("manifest cache delete error %s/%s: %v", q.ApplicationSource.String(), revision, err)
+							logCtx.Warnf("manifest cache delete error %s/%s: %v", q.ApplicationSource.String(), revision, err)
 						}
-						log.Infof("manifest error cache hit and reset: %s/%s", q.ApplicationSource.String(), revision)
+						logCtx.Infof("manifest error cache hit and reset: %s/%s", q.ApplicationSource.String(), revision)
 						return false, nil, nil
 					}
 				}
 
 				// Otherwise, manifest generation is still paused
-				log.Infof("manifest error cache hit: %s/%s", q.ApplicationSource.String(), revision)
+				logCtx.Infof("manifest error cache hit: %s/%s", q.ApplicationSource.String(), revision)
 
 				// nolint:staticcheck // Error message constant is very old, best not to lowercase the first letter.
 				cachedErrorResponse := fmt.Errorf(cachedManifestGenerationPrefix+": %s", res.MostRecentError)
 
 				if firstInvocation {
-					cache.LogDebugManifestCacheKeyFields("setting manifests cache", "update error count", cacheKey)
+					logCtx.Debug("setting manifests cache: update error count")
 
 					// Increment the number of returned cached responses and push that new value to the cache
 					// (if we have not already done so previously in this function)
 					res.NumberOfCachedResponsesReturned++
 					err = s.cache.SetManifests(cacheKey, &res)
 					if err != nil {
-						log.Warnf("manifest cache set error %s/%s: %v", q.ApplicationSource.String(), revision, err)
+						logCtx.Warnf("manifest cache set error %s/%s: %v", q.ApplicationSource.String(), revision, err)
 					}
 				}
 
@@ -1111,18 +1116,18 @@ func (s *Service) getManifestCacheEntry(revision string, q *apiclient.ManifestRe
 
 			// Otherwise we are not yet in the manifest generation error state, and not enough consecutive errors have
 			// yet occurred to put us in that state.
-			log.Infof("manifest error cache miss: %s/%s", q.ApplicationSource.String(), revision)
+			logCtx.Infof("manifest error cache miss: %s/%s", q.ApplicationSource.String(), revision)
 			return false, res.ManifestResponse, nil
 		}
 
-		log.Infof("manifest cache hit: %s/%s", q.ApplicationSource.String(), revision)
+		logCtx.Info("manifest cache hit")
 		return true, res.ManifestResponse, nil
 	}
 
 	if !errors.Is(err, cache.ErrCacheMiss) {
-		log.Warnf("manifest cache error %s: %v", q.ApplicationSource.String(), err)
+		logCtx.Warnf("manifest cache error %s: %v", q.ApplicationSource.String(), err)
 	} else {
-		log.Infof("manifest cache miss: %s/%s", q.ApplicationSource.String(), revision)
+		logCtx.Info("manifest cache miss")
 	}
 
 	return false, nil, nil
@@ -3579,8 +3584,10 @@ func (s *Service) UpdateRevisionForPaths(ctx context.Context, request *apiclient
 	// No changes detected, update the cache using resolved revisions
 	err := s.updateCachedRevision(logCtx, sRevision, rRevision, request, oldRepoRefs, newRepoRefs)
 	if err != nil {
-		// Only warn with the error, no need to block anything if there is a caching error.
-		logCtx.Warnf("error updating cached revision for source %s with revision %s: %v", request.ApplicationSource.RepoURL, rRevision, err)
+		if !errors.Is(err, cache.ErrCacheMiss) {
+			// Only warn with the error, no need to block anything if there is a caching error.
+			logCtx.Warnf("error updating cached revision for source %s with revision %s: %v", request.ApplicationSource.RepoURL, rRevision, err)
+		}
 		return &apiclient.UpdateRevisionForPathsResponse{
 			Revision: rRevision,
 			Changes:  true,
@@ -3594,23 +3601,28 @@ func (s *Service) UpdateRevisionForPaths(ctx context.Context, request *apiclient
 }
 
 func (s *Service) updateCachedRevision(logCtx *log.Entry, oldRev string, newRev string, request *apiclient.UpdateRevisionForPathsRequest, oldRepoRefs map[string]string, newRepoRefs map[string]string) error {
-	err := s.cache.SetNewRevisionManifests(
-		cache.NewManifestKey(oldRev, request.ApplicationSource, request.GetRefSources(), request.GetNamespace(),
-			request.GetTrackingMethod(), request.GetAppLabelKey(), request.GetAppName(), request.GetInstallationID(),
-			request.GetSourceIntegrity(), request, oldRepoRefs),
-		cache.NewManifestKey(newRev, request.ApplicationSource, request.GetRefSources(), request.GetNamespace(),
-			request.GetTrackingMethod(), request.GetAppLabelKey(), request.GetAppName(), request.GetInstallationID(),
-			request.GetSourceIntegrity(), request, newRepoRefs),
-	)
+	oldKey := cache.NewManifestKey(oldRev, request.ApplicationSource, request.GetRefSources(), request.GetNamespace(),
+		request.GetTrackingMethod(), request.GetAppLabelKey(), request.GetAppName(), request.GetInstallationID(),
+		request.GetSourceIntegrity(), request, oldRepoRefs)
+	newKey := cache.NewManifestKey(newRev, request.ApplicationSource, request.GetRefSources(), request.GetNamespace(),
+		request.GetTrackingMethod(), request.GetAppLabelKey(), request.GetAppName(), request.GetInstallationID(),
+		request.GetSourceIntegrity(), request, newRepoRefs)
+
+	logCtx = logCtx.WithFields(log.Fields{
+		"old_cacheKey": oldKey.String(),
+		"new_cacheKey": newKey.String(),
+	})
+
+	err := s.cache.SetNewRevisionManifests(oldKey, newKey)
 	if err != nil {
 		if errors.Is(err, cache.ErrCacheMiss) {
-			logCtx.Debugf("manifest cache miss during comparison for application %s in repo %s from revision %s", request.AppName, request.GetRepo().Repo, oldRev)
-			return fmt.Errorf("manifest cache miss during comparison for application %s in repo %s from revision %s", request.AppName, request.GetRepo().Repo, oldRev)
+			logCtx.Info("manifest cache miss while moving manifests cache to the new revision")
+			return fmt.Errorf("manifest cache miss during comparison for application %s in repo %s from revision %s: %w", request.AppName, request.GetRepo().Repo, oldRev, cache.ErrCacheMiss)
 		}
 		return fmt.Errorf("manifest cache move error for %s: %w", request.AppName, err)
 	}
 
-	logCtx.Debugf("manifest cache updated for application %s in repo %s from revision %s to revision %s", request.AppName, request.GetRepo().Repo, oldRev, newRev)
+	logCtx.Infof("manifest cache moved")
 	return nil
 }
 

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -30,7 +30,7 @@ var (
 			Name: "argocd_redis_request_total",
 			Help: "Number of kubernetes requests executed during application reconciliation.",
 		},
-		[]string{"initiator", "failed"},
+		[]string{"initiator", "command", "failed"},
 	)
 	redisRequestHistogram = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -107,8 +107,8 @@ func NewMetricsServer(host string, port int) *MetricsServer {
 	}
 }
 
-func (m *MetricsServer) IncRedisRequest(failed bool) {
-	m.redisRequestCounter.WithLabelValues("argocd-server", strconv.FormatBool(failed)).Inc()
+func (m *MetricsServer) IncRedisRequest(command string, failed bool) {
+	m.redisRequestCounter.WithLabelValues("argocd-server", command, strconv.FormatBool(failed)).Inc()
 }
 
 // ObserveRedisRequestDuration observes redis request duration

--- a/util/cache/redis.go
+++ b/util/cache/redis.go
@@ -30,6 +30,9 @@ var (
 const (
 	// envRedisKeyPrefix is an env variable name which stores the prefix for redis keys
 	envRedisKeyPrefix = "ARGOCD_REDIS_KEY_PREFIX"
+	// redisNoSuchKeyErr is the error string Redis returns from RENAME when the source key does not
+	// exist. It is treated as a cache miss rather than a failed request.
+	redisNoSuchKeyErr = "ERR no such key"
 )
 
 func CompressionTypeFromString(s string) (RedisCompressionType, error) {
@@ -116,7 +119,7 @@ func (r *redisCache) unmarshal(data []byte, obj any) error {
 
 func (r *redisCache) Rename(oldKey string, newKey string, _ time.Duration) error {
 	err := r.client.Rename(context.TODO(), r.getKey(oldKey), r.getKey(newKey)).Err()
-	if err != nil && err.Error() == "ERR no such key" {
+	if err != nil && err.Error() == redisNoSuchKeyErr {
 		err = ErrCacheMiss
 	}
 
@@ -180,7 +183,7 @@ func (r *redisCache) NotifyUpdated(key string) error {
 }
 
 type MetricsRegistry interface {
-	IncRedisRequest(failed bool)
+	IncRedisRequest(command string, failed bool)
 	ObserveRedisRequestDuration(duration time.Duration)
 }
 
@@ -199,10 +202,21 @@ var ignoredRedisCommandNames = map[string]struct{}{
 	// "ping":   {},
 }
 
+// redisCmdName returns the normalized (lower-cased, trimmed) name of a Redis command
+func redisCmdName(cmd redis.Cmder) string {
+	return strings.ToLower(strings.TrimSpace(cmd.Name()))
+}
+
 func shouldIgnoreRedisCmd(cmd redis.Cmder) bool {
-	name := strings.ToLower(strings.TrimSpace(cmd.Name()))
-	_, ok := ignoredRedisCommandNames[name]
+	_, ok := ignoredRedisCommandNames[redisCmdName(cmd)]
 	return ok
+}
+
+// isBenignRedisMiss reports whether err represents a benign cache miss rather than a real Redis
+// failure. redis.Nil is the normal "key not found" reply, and "ERR no such key" is returned by
+// RENAME when the source key is absent; neither should be counted as a failed request.
+func isBenignRedisMiss(err error) bool {
+	return errors.Is(err, redis.Nil) || (err != nil && err.Error() == redisNoSuchKeyErr)
 }
 
 func (rh *redisHook) DialHook(next redis.DialHook) redis.DialHook {
@@ -222,7 +236,7 @@ func (rh *redisHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
 			return err
 		}
 
-		rh.registry.IncRedisRequest(err != nil && !errors.Is(err, redis.Nil))
+		rh.registry.IncRedisRequest(redisCmdName(cmd), err != nil && !isBenignRedisMiss(err))
 		rh.registry.ObserveRedisRequestDuration(time.Since(startTime))
 
 		return err

--- a/util/cache/redis_test.go
+++ b/util/cache/redis_test.go
@@ -21,7 +21,7 @@ var (
 		prometheus.CounterOpts{
 			Name: "argocd_redis_request_total",
 		},
-		[]string{"initiator", "failed"},
+		[]string{"initiator", "command", "failed"},
 	)
 	redisRequestHistogram = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -47,8 +47,8 @@ func NewMockMetricsServer() *MockMetricsServer {
 	}
 }
 
-func (m *MockMetricsServer) IncRedisRequest(failed bool) {
-	m.redisRequestCounter.WithLabelValues("mock", strconv.FormatBool(failed)).Inc()
+func (m *MockMetricsServer) IncRedisRequest(command string, failed bool) {
+	m.redisRequestCounter.WithLabelValues("mock", command, strconv.FormatBool(failed)).Inc()
 }
 
 func (m *MockMetricsServer) ObserveRedisRequestDuration(duration time.Duration) {
@@ -182,31 +182,40 @@ func TestRedisMetrics(t *testing.T) {
 	faultyClient := NewRedisCache(faultyRedisClient, 60*time.Second, RedisCompressionNone)
 	var res string
 
+	assertCounter := func(command, failed string, expected float64) {
+		t.Helper()
+		m := &promcm.Metric{}
+		c, err := ms.redisRequestCounter.GetMetricWithLabelValues("mock", command, failed)
+		require.NoError(t, err)
+		require.NoError(t, c.Write(m))
+		assert.InEpsilon(t, expected, m.Counter.GetValue(), 0.0001)
+	}
+
 	// client successful request
 	err = client.Set(&Item{Key: "foo", Object: "bar"})
 	require.NoError(t, err)
 	err = client.Get("foo", &res)
 	require.NoError(t, err)
 
-	c, err := ms.redisRequestCounter.GetMetricWithLabelValues("mock", "false")
-	require.NoError(t, err)
-	err = c.Write(metric)
-	require.NoError(t, err)
-	assert.InEpsilon(t, float64(2), metric.Counter.GetValue(), 0.0001)
+	// successful commands are recorded per command with failed="false"
+	assertCounter("set", "false", 1)
+	assertCounter("get", "false", 1)
+
+	// Rename against a missing source key is a benign cache miss: it returns ErrCacheMiss and must
+	// NOT be counted as a failed request.
+	err = client.Rename("missing-old", "new", 0)
+	require.ErrorIs(t, err, ErrCacheMiss)
+	assertCounter("rename", "false", 1)
 
 	// faulty client failed request
 	err = faultyClient.Get("foo", &res)
 	require.Error(t, err)
-	c, err = ms.redisRequestCounter.GetMetricWithLabelValues("mock", "true")
-	require.NoError(t, err)
-	err = c.Write(metric)
-	require.NoError(t, err)
-	assert.InEpsilon(t, float64(1), metric.Counter.GetValue(), 0.0001)
+	assertCounter("get", "true", 1)
 
-	// both clients histogram count
+	// every client request observes a duration sample (set, get, rename, faulty get)
 	o, err := ms.redisRequestHistogram.GetMetricWithLabelValues("mock")
 	require.NoError(t, err)
 	err = o.(prometheus.Metric).Write(metric)
 	require.NoError(t, err)
-	assert.Equal(t, 3, int(metric.Histogram.GetSampleCount()))
+	assert.Equal(t, 4, int(metric.Histogram.GetSampleCount()))
 }

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -37,6 +37,7 @@ import (
 	appclientset "github.com/argoproj/argo-cd/v3/pkg/client/clientset/versioned"
 	"github.com/argoproj/argo-cd/v3/reposerver/cache"
 	servercache "github.com/argoproj/argo-cd/v3/server/cache"
+	applog "github.com/argoproj/argo-cd/v3/util/app/log"
 	"github.com/argoproj/argo-cd/v3/util/app/path"
 	"github.com/argoproj/argo-cd/v3/util/argo"
 	"github.com/argoproj/argo-cd/v3/util/db"
@@ -477,7 +478,7 @@ func (a *ArgoCDWebhookHandler) HandleEvent(payload any) {
 		if !cacheWarmDisabled {
 			repo, err := a.lookupRepository(context.Background(), webURL)
 			if err != nil {
-				log.Debugf("Failed to look up repository for %s: %v", webURL, err)
+				log.Errorf("Failed to look up repository for %s: %v", webURL, err)
 			} else if repo != nil && repo.WebhookManifestCacheWarmDisabled {
 				cacheWarmDisabled = true
 			}
@@ -486,6 +487,7 @@ func (a *ArgoCDWebhookHandler) HandleEvent(payload any) {
 		appCount := 0
 		// iterate over apps and check if any files specified in their sources have changed
 		for _, app := range filteredApps {
+			logCtx := log.WithFields(applog.GetAppLogFields(&app))
 			// get all sources, including sync source and dry source if source hydrator is configured
 			sources := app.Spec.GetSources()
 			if app.Spec.SourceHydrator != nil {
@@ -508,9 +510,9 @@ func (a *ArgoCDWebhookHandler) HandleEvent(payload any) {
 						}
 
 						// refresh paths have changed, so we need to refresh the app
-						log.Infof("refreshing app '%s' from webhook", app.Name)
+						logCtx.Info("refreshing app from webhook")
 						if hydrateType != nil {
-							log.Infof("webhook trigger refresh app to hydrate '%s'", app.Name)
+							logCtx.Infof("webhook trigger refresh app to hydrate")
 						}
 						appCount++
 						req := &appRefreshRequest{
@@ -528,11 +530,10 @@ func (a *ArgoCDWebhookHandler) HandleEvent(payload any) {
 						break // we don't need to check other sources
 					} else if change.shaBefore != "" && change.shaAfter != "" && !cacheWarmDisabled {
 						// update the cached manifests with the new revision cache key
-						if err := a.storePreviouslyCachedManifests(&app, change, trackingMethod, appInstanceLabelKey, installationID, source); err != nil {
-							log.Debugf("Failed to store cached manifests of previous revision for app '%s': %v", app.Name, err)
-							webhookStoreCacheAttemptsTotal.WithLabelValues(git.NormalizeGitURL(webURL), "false").Inc()
-						} else {
-							webhookStoreCacheAttemptsTotal.WithLabelValues(git.NormalizeGitURL(webURL), "true").Inc()
+						if err := a.storePreviouslyCachedManifests(logCtx, &app, change, trackingMethod, appInstanceLabelKey, installationID, source); err != nil {
+							// Errors while updating the cache are non-fatal since the manifest will simply be regenerated on
+							// the next reconciliation.
+							logCtx.Warnf("Failed to store cached manifests of previous revision: %v", err)
 						}
 					}
 				}
@@ -585,7 +586,7 @@ func getURLRegex(originalURL string, regexpFormat string) (*regexp.Regexp, error
 	return repoRegexp, nil
 }
 
-func (a *ArgoCDWebhookHandler) storePreviouslyCachedManifests(app *v1alpha1.Application, change changeInfo, trackingMethod string, appInstanceLabelKey string, installationID string, source v1alpha1.ApplicationSource) error {
+func (a *ArgoCDWebhookHandler) storePreviouslyCachedManifests(logCtx *log.Entry, app *v1alpha1.Application, change changeInfo, trackingMethod string, appInstanceLabelKey string, installationID string, source v1alpha1.ApplicationSource) error {
 	destCluster, err := argo.GetDestinationCluster(context.Background(), app.Spec.Destination, a.db)
 	if err != nil {
 		return fmt.Errorf("error validating destination: %w", err)
@@ -637,15 +638,25 @@ func (a *ArgoCDWebhookHandler) storePreviouslyCachedManifests(app *v1alpha1.Appl
 		&clusterInfo,
 		nil,
 	)
-	cache.LogDebugManifestCacheKeyFields("moving manifests cache", "webhook app revision changed", oldManifestKey)
-
 	newManifestKey := oldManifestKey
 	newManifestKey.Revision = change.shaAfter
 
+	logEntry := logCtx.WithFields(log.Fields{
+		"old_cacheKey": oldManifestKey.String(),
+		"new_cacheKey": newManifestKey.String(),
+	})
+
 	if err := a.repoCache.SetNewRevisionManifests(oldManifestKey, newManifestKey); err != nil {
+		webhookStoreCacheAttemptsTotal.WithLabelValues(git.NormalizeGitURL(source.RepoURL), "false").Inc()
+		if errors.Is(err, cache.ErrCacheMiss) {
+			logEntry.Info("manifest cache miss while moving manifests cache to the new revision")
+			return nil
+		}
 		return fmt.Errorf("error setting new revision manifests: %w", err)
 	}
 
+	webhookStoreCacheAttemptsTotal.WithLabelValues(git.NormalizeGitURL(source.RepoURL), "true").Inc()
+	logEntry.Info("manifests cache moved")
 	return nil
 }
 

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -1227,6 +1227,7 @@ func Test_storePreviouslyCachedManifests(t *testing.T) {
 		name         string
 		app          *v1alpha1.Application
 		project      *v1alpha1.AppProject
+		seedCache    bool // seed the cache with manifests for the previous revision
 		cacheUpdated bool // cache should be updated with the new revision
 		errExpected  bool
 	}{
@@ -1273,7 +1274,45 @@ func Test_storePreviouslyCachedManifests(t *testing.T) {
 					},
 				},
 			},
+			seedCache:    true,
 			cacheUpdated: true,
+			errExpected:  false,
+		},
+		{
+			name: "single source rename cache miss is not an error",
+			app: &v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "argocd",
+					Annotations: map[string]string{
+						"argocd.argoproj.io/manifest-generate-paths": "deploy",
+					},
+				},
+				Spec: v1alpha1.ApplicationSpec{
+					Project: "default",
+					Source: &v1alpha1.ApplicationSource{
+						RepoURL:        "https://github.com/test/repo",
+						TargetRevision: "main",
+					},
+				},
+			},
+			project: &v1alpha1.AppProject{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "default",
+					Namespace: "argocd",
+				},
+				Spec: v1alpha1.AppProjectSpec{
+					SourceRepos: []string{"*"},
+					Destinations: []v1alpha1.ApplicationDestination{
+						{
+							Server:    "*",
+							Namespace: "*",
+						},
+					},
+				},
+			},
+			seedCache:    false,
+			cacheUpdated: false,
 			errExpected:  false,
 		},
 		{
@@ -1372,8 +1411,12 @@ func Test_storePreviouslyCachedManifests(t *testing.T) {
 				&fakeProjectNamespaceLister{clientset: appClientset, namespace: "argocd"},
 			)
 
-			setupTestCache(t, repoCache, tt.app.Name, source, tt.project.EffectiveSourceIntegrity(), []string{"test-manifest"})
-			err = h.storePreviouslyCachedManifests(tt.app, changeInfo{shaBefore: testBeforeSHA, shaAfter: testAfterSHA}, "", testAppLabelKey, "", *source)
+			if tt.seedCache {
+				setupTestCache(t, repoCache, tt.app.Name, source, tt.project.EffectiveSourceIntegrity(), []string{"test-manifest"})
+			}
+			logger, _ := test.NewNullLogger()
+			logCtx := logger.WithField("application", tt.app.Name)
+			err = h.storePreviouslyCachedManifests(logCtx, tt.app, changeInfo{shaBefore: testBeforeSHA, shaAfter: testAfterSHA}, "", testAppLabelKey, "", *source)
 
 			if tt.errExpected {
 				require.Error(t, err)


### PR DESCRIPTION
## Summary

Manifest-generate-paths uses a Redis `RENAME` to move a cached manifest from the previously-synced revision key to the new-revision key. When the source key is absent, Redis replies `ERR no such key`, which was being counted as `argocd_redis_request_total{failed="true"}` and producing false-positive Redis failure alerts. This is a benign cache miss, not an infrastructure failure.

Query example: `sum(increase(argocd_redis_request_total{failed="true"}[1m])) by (namespace)`

This PR fixes the metric, makes Redis failures easier to investigate, and makes manifest-cache logs actually usable for diagnosing key mismatches.

## Changes

- **RENAME miss no longer counts as a Redis failure.** `ERR no such key` is now treated like a normal cache miss (`redis.Nil`) and reported as `argocd_redis_request_total{failed="false"}`. 
- `argocd_webhook_store_cache_attempts_total` is only increase on actual calls to `SetNewRevisionManifests`, other errors like failures to get destination/cluster info will not increase the metric.
- **Added a `command` label to `argocd_redis_request_total`** (e.g. `command="get"`, `command="rename"`), so failing/slow commands are attributable when investigating errors and performance.
- **Always log the fully-rendered `cacheKey`.** Both the reposerver manifest-cache path and the webhook cache-move path now attach the rendered key to the logger: `cacheKey` for single-key operations, and `old_cacheKey` / `new_cacheKey` for renames. This lets a hit-vs-rename-miss key mismatch be diagnosed directly from logs without enabling debug.

## Impact

- **Metrics:** `argocd_redis_request_total` gains a `command` label. Existing dashboards/alerts that sum without grouping keep working; alerts keying on `failed="true"` will stop firing on benign rename misses (the intended fix).
- **Logging:** A handful of existing hit/miss/rename logs now carry `cacheKey`, plus a couple of new info lines on the benign-miss path.
- No behavioral change to manifest generation: on a rename miss the manifest is regenerated exactly as before.

Related to https://github.com/argoproj/argo-cd/pull/27215 