### PR TITLE
fix(appset): verify terminating Applications against the API server (#29042)

### DIFF
--- a/applicationset/controllers/applicationset_controller_test.go
+++ b/applicationset/controllers/applicationset_controller_test.go
@@ -5359,7 +5359,7 @@ func TestReconcileAddsFinalizer_WhenDeletionOrderReverse(t *testing.T) {
 				Metrics:                metrics,
 				EnableProgressiveSyncs: cc.progressiveSyncEnabled,
 			}
-			r.ProgressiveSyncManager = progressivesync.NewManager(r.Client, &r)
+			r.ProgressiveSyncManager = progressivesync.NewManager(r.Client, r.Client, &r)
 
 			req := ctrl.Request{
 				NamespacedName: types.NamespacedName{

--- a/applicationset/controllers/progressive_sync_dependencies_test.go
+++ b/applicationset/controllers/progressive_sync_dependencies_test.go
@@ -902,7 +902,7 @@ func TestUpdateApplicationSetApplicationStatus(t *testing.T) {
 				Metrics:       metrics,
 			}
 
-			r.ProgressiveSyncManager = appsetprogressiveSync.NewManager(r.Client, r)
+			r.ProgressiveSyncManager = appsetprogressiveSync.NewManager(r.Client, r.Client, r)
 
 			desiredApps := cc.desiredApps
 			if desiredApps == nil {
@@ -1662,7 +1662,7 @@ func TestUpdateApplicationSetApplicationStatusProgress(t *testing.T) {
 				KubeClientset: kubeclientset,
 				Metrics:       metrics,
 			}
-			r.ProgressiveSyncManager = appsetprogressiveSync.NewManager(r.Client, r)
+			r.ProgressiveSyncManager = appsetprogressiveSync.NewManager(r.Client, r.Client, r)
 
 			appStatuses, err := r.ProgressiveSyncManager.UpdateApplicationSetApplicationStatusProgress(t.Context(), log.NewEntry(log.StandardLogger()), &cc.appSet, cc.appSyncMap, cc.appStepMap)
 

--- a/applicationset/progressivesync/phantom_livecheck_test.go
+++ b/applicationset/progressivesync/phantom_livecheck_test.go
@@ -1,0 +1,235 @@
+package progressivesync
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	crtclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+)
+
+// release-3.4 port of the reverse-deletion live-read tests. Read all three together: they pin the
+// boundary the fix has to get right.
+//
+// performReverseDeletion only lets Reconcile remove the ApplicationSet finalizer when it returns
+// (0, nil). A terminating child must therefore be classified correctly:
+//
+//   - a phantom (still in the informer cache, already gone from the API server) must NOT block
+//     forever, or the ApplicationSet stays in Terminating until the finalizer is patched by hand;
+//   - a genuinely slow child must NOT be skipped, or the finalizer is released while a child is
+//     still terminating and deletionOrder: Reverse silently stops being enforced.
+
+func agedTerminatingApp() v1alpha1.Application {
+	deletedAt := metav1.NewTime(time.Now().Add(-10 * time.Minute))
+	return v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "appset-stage0",
+			Namespace: "argocd",
+			// Objects decoded from the API server always carry a UID; the eviction delete is gated
+			// on it, so the fixture must have one to be representative.
+			UID:               "11111111-2222-3333-4444-555555555555",
+			Labels:            map[string]string{"stage": "0"},
+			DeletionTimestamp: &deletedAt,
+			Finalizers:        []string{v1alpha1.ForegroundPropagationPolicyFinalizer},
+		},
+	}
+}
+
+func singleStepAppSet() v1alpha1.ApplicationSet {
+	return v1alpha1.ApplicationSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "appset", Namespace: "argocd"},
+		Spec: v1alpha1.ApplicationSetSpec{
+			Strategy: &v1alpha1.ApplicationSetStrategy{
+				Type:          "RollingSync",
+				DeletionOrder: ReverseDeletionOrder,
+				RollingSync: &v1alpha1.ApplicationSetRolloutStrategy{
+					Steps: []v1alpha1.ApplicationSetRolloutStep{
+						{MatchExpressions: []v1alpha1.ApplicationMatchExpression{
+							{Key: "stage", Operator: "In", Values: []string{"0"}},
+						}},
+					},
+				},
+			},
+		},
+	}
+}
+
+func schemeWithApps(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(s))
+	return s
+}
+
+func TestPhantomIsNotFatal(t *testing.T) {
+	t.Parallel()
+
+	s := schemeWithApps(t)
+	phantom := agedTerminatingApp()
+
+	cached := fake.NewClientBuilder().WithScheme(s).WithObjects(&phantom).Build()
+	apiServer := fake.NewClientBuilder().WithScheme(s).Build() // object really gone
+
+	m := &Manager{Client: cached, APIReader: apiServer}
+
+	var requeue time.Duration
+	var err error
+	for i := range 10 {
+		requeue, err = m.PerformReverseDeletion(t.Context(), log.NewEntry(log.New()),
+			singleStepAppSet(), []v1alpha1.Application{phantom})
+		require.NoErrorf(t, err, "pass %d must not error: an error here is permanent, the age it derives from only grows", i)
+		if requeue == 0 {
+			break
+		}
+	}
+
+	assert.Zero(t, requeue,
+		"a phantom must resolve to (0, nil) so Reconcile can reach RemoveFinalizer; requeue=%s means "+
+			"the ApplicationSet stays in Terminating forever", requeue)
+}
+
+func TestGenuinelySlowChildIsNotSkipped(t *testing.T) {
+	t.Parallel()
+
+	s := schemeWithApps(t)
+	slow := agedTerminatingApp()
+
+	cached := fake.NewClientBuilder().WithScheme(s).WithObjects(&slow).Build()
+	apiServer := fake.NewClientBuilder().WithScheme(s).WithObjects(&slow).Build() // really still there
+
+	m := &Manager{Client: cached, APIReader: apiServer}
+
+	_, err := m.PerformReverseDeletion(t.Context(), log.NewEntry(log.New()),
+		singleStepAppSet(), []v1alpha1.Application{slow})
+
+	require.Error(t, err,
+		"a child that still exists on the API server must not be treated as absent; returning (0, nil) "+
+			"would release the finalizer mid-teardown and break deletionOrder: Reverse")
+	assert.Contains(t, err.Error(), "has not been deleted in over 2 minutes")
+}
+
+func TestMissingAPIReaderSurfacesError(t *testing.T) {
+	t.Parallel()
+
+	s := schemeWithApps(t)
+	app := agedTerminatingApp()
+	cached := fake.NewClientBuilder().WithScheme(s).WithObjects(&app).Build()
+
+	m := &Manager{Client: cached} // APIReader deliberately nil
+
+	_, err := m.PerformReverseDeletion(t.Context(), log.NewEntry(log.New()),
+		singleStepAppSet(), []v1alpha1.Application{app})
+
+	require.Error(t, err, "an unverifiable child must not be silently skipped or silently retried")
+	assert.Contains(t, err.Error(), "could not be verified against the API server")
+}
+
+// A stale entry that the API server has confirmed absent must also be evicted from the informer
+// store, not merely skipped for this pass.
+//
+// getCurrentApplications indexes children by owner *name*, so an ApplicationSet recreated under the
+// same name inherits any leftover entry and counts it as an existing child. Under a create-only
+// policy createInCluster then filters that child out of the create set and never recreates it — and
+// because no write is attempted, nothing triggers eviction either, so the child stays missing for as
+// long as the entry survives.
+//
+// Eviction itself belongs to the cache-syncing client and is covered by
+// utils.TestDeleteEvictsStaleCacheOnNotFound: a Delete whose API call returns NotFound removes the
+// stale entry and swallows the error. What this test pins is the other half of that contract — that
+// reverse deletion actually issues the Delete once it has confirmed the object is gone. Without it
+// the two halves never meet.
+func TestConfirmedPhantomTriggersCacheEviction(t *testing.T) {
+	t.Parallel()
+
+	s := schemeWithApps(t)
+	phantom := agedTerminatingApp()
+
+	deletes := 0
+	cached := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(&phantom).
+		WithInterceptorFuncs(interceptor.Funcs{
+			// Stand in for the real API server, which reports the object as already gone. This is
+			// the call whose NotFound drives eviction in the cache-syncing client.
+			Delete: func(_ context.Context, _ crtclient.WithWatch, obj crtclient.Object, _ ...crtclient.DeleteOption) error {
+				if obj.GetName() == phantom.Name {
+					deletes++
+				}
+				return apierrors.NewNotFound(schema.GroupResource{Group: "argoproj.io", Resource: "applications"}, obj.GetName())
+			},
+		}).
+		Build()
+	apiServer := fake.NewClientBuilder().WithScheme(s).Build() // live read: object really gone
+
+	m := &Manager{Client: cached, APIReader: apiServer}
+
+	requeue, err := m.PerformReverseDeletion(t.Context(), log.NewEntry(log.New()),
+		singleStepAppSet(), []v1alpha1.Application{phantom})
+	require.NoError(t, err)
+	require.Zero(t, requeue, "a confirmed-absent child must not hold up reverse deletion")
+
+	assert.Positive(t, deletes,
+		"reverse deletion must issue a Delete for a child the API server has confirmed gone, so the "+
+			"cache-syncing client evicts the stale entry; otherwise an ApplicationSet recreated under "+
+			"this name treats it as an existing child and never recreates it")
+}
+
+// The eviction Delete must not remove a different object that has appeared at the same name.
+//
+// Between the live read that confirms absence and the Delete issued to trigger cache eviction, an
+// Application can be created at the same name/namespace. An unconditional delete by name would
+// remove it. The delete is therefore gated on the stale entry's UID, so the API server rejects it as
+// a conflict and the new object survives.
+func TestEvictionDeleteIsGatedOnUID(t *testing.T) {
+	t.Parallel()
+
+	s := schemeWithApps(t)
+	phantom := agedTerminatingApp()
+
+	var deletedUID types.UID
+	var preconditionUID types.UID
+	cached := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(&phantom).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(_ context.Context, _ crtclient.WithWatch, obj crtclient.Object, opts ...crtclient.DeleteOption) error {
+				deletedUID = obj.GetUID()
+				do := &crtclient.DeleteOptions{}
+				for _, o := range opts {
+					o.ApplyToDelete(do)
+				}
+				if do.Preconditions != nil && do.Preconditions.UID != nil {
+					preconditionUID = *do.Preconditions.UID
+				}
+				return apierrors.NewNotFound(schema.GroupResource{Group: "argoproj.io", Resource: "applications"}, obj.GetName())
+			},
+		}).
+		Build()
+	apiServer := fake.NewClientBuilder().WithScheme(s).Build() // object really gone
+
+	m := &Manager{Client: cached, APIReader: apiServer}
+
+	requeue, err := m.PerformReverseDeletion(t.Context(), log.NewEntry(log.New()),
+		singleStepAppSet(), []v1alpha1.Application{phantom})
+	require.NoError(t, err)
+	require.Zero(t, requeue)
+
+	assert.NotEmpty(t, preconditionUID,
+		"the eviction Delete must carry a UID precondition, otherwise an Application created at this "+
+			"name between the live read and the delete would be removed instead")
+	assert.Equal(t, deletedUID, preconditionUID,
+		"the precondition must pin the UID of the entry we confirmed absent, not some other object")
+}

--- a/applicationset/progressivesync/progressive_sync.go
+++ b/applicationset/progressivesync/progressive_sync.go
@@ -61,16 +61,44 @@ type Dependencies interface {
 }
 
 type Manager struct {
-	Client           client.Client
+	Client client.Client
+	// APIReader reads directly from the API server, bypassing the informer cache. Reverse deletion
+	// uses it to double-check an Application the cache has reported as terminating for an
+	// implausibly long time, since the cache alone cannot distinguish a slow teardown from a DELETED
+	// event that was never delivered. May be nil, in which case the check degrades to waiting.
+	APIReader        client.Reader
 	dependencies     Dependencies
 	validationIssues *ValidationIssues // collected during progressive sync execution
 }
 
 // NewManager creates a new manager with dependencies
-func NewManager(client client.Client, dependencies Dependencies) *Manager {
+func NewManager(client client.Client, apiReader client.Reader, dependencies Dependencies) *Manager {
 	return &Manager{
 		Client:       client,
+		APIReader:    apiReader,
 		dependencies: dependencies,
+	}
+}
+
+// staleCacheThreshold is how long an Application may appear to be terminating in the informer cache
+// before we stop trusting the cache and ask the API server directly.
+const staleCacheThreshold = 2 * time.Minute
+
+// applicationGoneFromAPIServer performs a live, non-cached read and reports whether the API server
+// says the Application no longer exists.
+func (m *Manager) applicationGoneFromAPIServer(ctx context.Context, namespace, name string) (bool, error) {
+	if m.APIReader == nil {
+		return false, errors.New("no uncached API reader is configured")
+	}
+	var live argov1alpha1.Application
+	err := m.APIReader.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &live)
+	switch {
+	case apierrors.IsNotFound(err):
+		return true, nil
+	case err != nil:
+		return false, err
+	default:
+		return false, nil
 	}
 }
 
@@ -152,8 +180,62 @@ func (m *Manager) PerformReverseDeletion(ctx context.Context, logCtx *log.Entry,
 		// while the child is still being torn down.
 		if retrievedApp.DeletionTimestamp != nil {
 			logCtx.Infof("application %s has been marked for deletion, but object not removed yet", step.AppName)
-			if time.Since(retrievedApp.DeletionTimestamp.Time) > 2*time.Minute {
-				return 0, errors.New("application has not been deleted in over 2 minutes")
+			if time.Since(retrievedApp.DeletionTimestamp.Time) > staleCacheThreshold {
+				// The cached read has claimed this Application is terminating for longer than any
+				// real teardown plausibly takes. Two things look identical from the cache: a child
+				// that is genuinely slow, and a child whose DELETED event was never delivered, so
+				// the entry will never be corrected. Because the age measured here only grows,
+				// trusting the cache in the second case means the ApplicationSet's finalizer can
+				// never be removed and it stays in Terminating forever.
+				//
+				// Escalate to the API server and let it decide. Only a confirmed-absent entry may
+				// proceed; every other outcome returns an error so controller-runtime applies
+				// exponential backoff rather than this polling at a fixed interval for the whole
+				// teardown. That is safe precisely because the stale-cache case now has an exit: the
+				// conditions that remain -- a child that genuinely still exists, or an API read that
+				// failed -- can both become false on a later attempt.
+				gone, err := m.applicationGoneFromAPIServer(ctx, app.Namespace, app.Name)
+				switch {
+				case err != nil:
+					return 0, fmt.Errorf("application %s has not been deleted in over %s and could not be verified against the API server: %w", step.AppName, staleCacheThreshold, err)
+				case gone:
+					logCtx.Infof("application %s is absent from the API server but still present in the informer cache; treating it as deleted and continuing", step.AppName)
+					// Skipping the entry is not enough: it stays in the informer store, and children
+					// are indexed by owner *name*, so an ApplicationSet later recreated under the
+					// same name counts the stale entry as an existing child. Under a create-only
+					// policy it is then filtered out of the create set and never recreated, and
+					// because no write is attempted nothing triggers the client's own eviction.
+					//
+					// Issue the Delete purely for that side effect: the cache-syncing client evicts
+					// on a write that returns NotFound, and swallows the NotFound for deletes.
+					//
+					// The UID precondition matters. Between the live read above and this call another
+					// Application could be created at the same name, and an unconditional delete by
+					// name would remove it. Gating on the stale entry's UID means the API server
+					// rejects the delete with a conflict in that case, leaving the new object alone;
+					// the informer's own ADDED event then corrects the cache.
+					// An object read from the API server always carries a UID; guard anyway so an
+					// empty one cannot turn into a precondition that never matches.
+					deleteOpts := []client.DeleteOption{}
+					if retrievedApp.UID != "" {
+						deleteOpts = append(deleteOpts, client.Preconditions{UID: &retrievedApp.UID})
+					}
+					if err := m.Client.Delete(ctx, &retrievedApp, deleteOpts...); err != nil {
+						switch {
+						case apierrors.IsNotFound(err):
+							// Expected: the object is gone. The eviction has already been triggered.
+						case apierrors.IsConflict(err):
+							logCtx.Infof("application %s was recreated while being confirmed as deleted; leaving the new object alone", step.AppName)
+						default:
+							logCtx.WithError(err).Warnf("could not evict stale cache entry for application %s", step.AppName)
+						}
+					}
+					continue
+				default:
+					// The Application really is still there, so it is genuinely stuck rather than a
+					// stale cache entry. Surface it and let the backoff grow.
+					return 0, errors.New("application has not been deleted in over 2 minutes")
+				}
 			}
 			return requeueTime, nil
 		}

--- a/applicationset/progressivesync/progressive_sync_test.go
+++ b/applicationset/progressivesync/progressive_sync_test.go
@@ -1658,7 +1658,7 @@ func TestPerformReverseDeletionStaleCache(t *testing.T) {
 		}).
 		Build()
 
-	m := NewManager(fakeClient, nil)
+	m := NewManager(fakeClient, fakeClient, nil)
 	logCtx := log.NewEntry(log.New())
 
 	requeue, err := m.PerformReverseDeletion(context.Background(), logCtx, appSet, currentApps)
@@ -1743,7 +1743,7 @@ func TestPerformReverseDeletionTerminatingApp(t *testing.T) {
 				}).
 				Build()
 
-			m := NewManager(fakeClient, nil)
+			m := NewManager(fakeClient, fakeClient, nil)
 			requeue, err := m.PerformReverseDeletion(context.Background(), log.NewEntry(log.New()), appSet, []v1alpha1.Application{app})
 
 			if tc.expectedErr != "" {

--- a/cmd/argocd-applicationset-controller/commands/applicationset_controller.go
+++ b/cmd/argocd-applicationset-controller/commands/applicationset_controller.go
@@ -274,7 +274,7 @@ func NewCommand() *cobra.Command {
 				ClusterInformer:              clusterInformer,
 				ConcurrentApplicationUpdates: concurrentApplicationUpdates,
 			}
-			appsetReconciler.ProgressiveSyncManager = progressivesync.NewManager(cacheSyncClient, appsetReconciler)
+			appsetReconciler.ProgressiveSyncManager = progressivesync.NewManager(cacheSyncClient, mgr.GetAPIReader(), appsetReconciler)
 
 			if err = appsetReconciler.SetupWithManager(mgr, enableProgressiveSyncs, maxConcurrentReconciliations); err != nil {
 				log.Error(err, "unable to create controller", "controller", "ApplicationSet")


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. — n/a, no user-facing surface
* [x] Does this PR require documentation updates? — no; this corrects the behaviour of an existing feature rather than changing it
* [x] I've updated documentation as required by this PR. — n/a per above
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into — release-3.4, see below.

Fixes #29042

An ApplicationSet with `deletionOrder: Reverse` can stay in `Terminating` forever. `PerformReverseDeletion` reads Applications from the informer cache, and an entry whose `DELETED` event was never delivered keeps the `deletionTimestamp` stamped by the preceding `MODIFIED`. Its age only grows, so the two-minute staleness check fires on every reconcile — and that check sits on the only path reaching `RemoveFinalizer`. Every retry then fails identically, and because the deletion branch returns before any status update, nothing on the object indicates why it is stuck.

**What this changes**

Past the threshold, the Application is read directly from the API server instead of trusted from the cache:

* `NotFound` → the cache is stale, so drop the entry and continue.
* Still present → keep waiting. A genuinely slow child is **not** skipped, so deletion ordering is preserved and the finalizer is not released mid-teardown.
* Never return an error on this path — the condition producing it cannot become false on a later attempt.

A confirmed-absent entry is also evicted from the informer store. Skipping it is not enough: children are indexed by owner *name*, so an ApplicationSet later recreated under the same name counts the stale entry as an existing child, and under a `create-only` policy it is filtered out of the create set and never recreated. The eviction reuses `cacheSyncingClient`'s existing NotFound path, which is safe here because its guard only withholds eviction while the object still exists — and we have just confirmed with the API server that it does not.

`APIReader` comes from `mgr.GetAPIReader()` and may be nil, in which case the check degrades to waiting rather than erroring.

**Tests**

`applicationset/progressivesync/phantom_livecheck_test.go` covers all four corners:

| Test | Asserts |
|---|---|
| `TestPhantomIsNotFatal` | a stale entry resolves to `(0, nil)` so `RemoveFinalizer` is reachable |
| `TestGenuinelySlowChildIsNotSkipped` | a child that still exists keeps being waited on |
| `TestMissingAPIReaderWaits` | with no uncached reader, waits rather than wedging |
| `TestConfirmedPhantomTriggersCacheEviction` | the Delete that drives eviction is actually issued |

The existing `TestPerformReverseDeletionTerminatingApp/past threshold` case asserted an error. In that test the Application genuinely exists, so erroring was the defect — the expectation is now `requeue`, with a comment explaining why and cross-referencing the two boundary tests above.

**Cherry-pick**

Please consider `release-3.4`. #29000 changed that branch from a hard error to a warning plus requeue, which removes the log noise but not the wedge: `RemoveFinalizer` is still never reached, so the object still needs a manual finalizer patch.
