### PR TITLE
fix(appset): stop progressive sync reconciling in a tight loop (#27577)

### DIFF
--- a/applicationset/progressivesync/progressive_sync.go
+++ b/applicationset/progressivesync/progressive_sync.go
@@ -12,8 +12,6 @@ import (
 	"time"
 
 	"github.com/argoproj/argo-cd/gitops-engine/v3/pkg/health"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	log "github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,6 +20,7 @@ import (
 
 	"github.com/argoproj/argo-cd/v3/applicationset/utils"
 	argov1alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v3/util/argo/normalizers"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -290,6 +289,20 @@ func (m *Manager) UpdateApplicationSetApplicationStatus(ctx context.Context, log
 		desiredAppsMap[desiredApplications[i].Name] = &desiredApplications[i]
 	}
 
+	// Built once per call, as CreateOrUpdate documents. Deciding whether a spec changed must use the
+	// same rules the write path uses when deciding whether to Patch, or the two can disagree.
+	//
+	// Failure is fatal here, matching createOrUpdateInCluster. Continuing with a nil config would
+	// skip the ignore rules entirely, so the comparison below would see exactly the differences the
+	// write path suppresses -- reintroducing the divergence this is meant to remove. Unlike the
+	// staleness check in reverse deletion, this condition is a property of the ApplicationSet spec
+	// and clears as soon as the invalid rule is corrected, so surfacing it as an error is both
+	// recoverable and the fastest way for the user to find out.
+	diffConfig, err := utils.BuildIgnoreDiffConfig(applicationSet.Spec.IgnoreApplicationDifferences, normalizers.IgnoreNormalizerOpts{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to build ignore diff config: %w", err)
+	}
+
 	for _, app := range applications {
 		appHealthStatus := app.Status.Health.Status
 		appSyncStatus := app.Status.Sync.Status
@@ -331,7 +344,31 @@ func (m *Manager) UpdateApplicationSetApplicationStatus(ctx context.Context, log
 		if desiredApp, ok := desiredAppsMap[app.Name]; ok {
 			// Compare the desired spec with the current spec to detect non-Git changes
 			// This will catch changes to generator parameters like image tags, helm values, etc.
-			specChanged = !cmp.Equal(desiredApp.Spec, app.Spec, cmpopts.EquateEmpty(), cmpopts.EquateComparable(argov1alpha1.ApplicationDestination{}))
+			//
+			// This must apply exactly the rules the write path applies when deciding whether to
+			// Patch. A plain comparison sees differences the write path deliberately suppresses, so
+			// the Application is never corrected while the status keeps reporting a pending change --
+			// an unbounded Waiting -> Pending -> sync -> reconcile loop.
+			//
+			// syncDesiredApplications force-disables automated sync on every managed Application
+			// (Automated.Enabled = false), because this controller drives those syncs itself. That
+			// mutation lands on the copy written to the cluster, not on the freshly generated
+			// Application compared here, so the live object always carries automated.enabled=false
+			// while the generated one leaves it unset. Mirror it, or every ApplicationSet whose
+			// template sets syncPolicy.automated reports a spec change forever.
+			desiredForCompare := desiredApp.DeepCopy()
+			if sp := desiredForCompare.Spec.SyncPolicy; sp != nil && sp.Automated != nil {
+				sp.Automated.Enabled = new(false)
+			}
+
+			equivalent, cmpErr := utils.SpecsEquivalent(diffConfig, &app, desiredForCompare)
+			if cmpErr != nil {
+				// Failures here are persistent (for example a malformed jsonPointer), so reporting
+				// "changed" would loop forever. Leave the status alone and surface it.
+				statusLogCtx.WithError(cmpErr).Warn("could not compare desired and live specs; leaving progressive sync status unchanged")
+			} else {
+				specChanged = !equivalent
+			}
 		}
 
 		if revisionsChanged || specChanged {
@@ -416,7 +453,7 @@ func (m *Manager) UpdateApplicationSetApplicationStatus(ctx context.Context, log
 		appStatuses = append(appStatuses, *newAppStatus)
 	}
 
-	err := m.dependencies.SetAppSetApplicationStatus(ctx, logCtx, applicationSet, appStatuses)
+	err = m.dependencies.SetAppSetApplicationStatus(ctx, logCtx, applicationSet, appStatuses)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set AppSet application statuses: %w", err)
 	}

--- a/applicationset/progressivesync/progressive_sync.go
+++ b/applicationset/progressivesync/progressive_sync.go
@@ -289,15 +289,8 @@ func (m *Manager) UpdateApplicationSetApplicationStatus(ctx context.Context, log
 		desiredAppsMap[desiredApplications[i].Name] = &desiredApplications[i]
 	}
 
-	// Built once per call, as CreateOrUpdate documents. Deciding whether a spec changed must use the
-	// same rules the write path uses when deciding whether to Patch, or the two can disagree.
-	//
-	// Failure is fatal here, matching createOrUpdateInCluster. Continuing with a nil config would
-	// skip the ignore rules entirely, so the comparison below would see exactly the differences the
-	// write path suppresses -- reintroducing the divergence this is meant to remove. Unlike the
-	// staleness check in reverse deletion, this condition is a property of the ApplicationSet spec
-	// and clears as soon as the invalid rule is corrected, so surfacing it as an error is both
-	// recoverable and the fastest way for the user to find out.
+	// Built once per call, as CreateOrUpdate documents. Fatal on failure, matching
+	// createOrUpdateInCluster: a nil config would skip the ignore rules entirely.
 	diffConfig, err := utils.BuildIgnoreDiffConfig(applicationSet.Spec.IgnoreApplicationDifferences, normalizers.IgnoreNormalizerOpts{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to build ignore diff config: %w", err)
@@ -345,21 +338,10 @@ func (m *Manager) UpdateApplicationSetApplicationStatus(ctx context.Context, log
 			// Compare the desired spec with the current spec to detect non-Git changes
 			// This will catch changes to generator parameters like image tags, helm values, etc.
 			//
-			// This must apply exactly the rules the write path applies when deciding whether to
-			// Patch. A plain comparison sees differences the write path deliberately suppresses, so
-			// the Application is never corrected while the status keeps reporting a pending change --
-			// an unbounded Waiting -> Pending -> sync -> reconcile loop.
-			//
-			// syncDesiredApplications force-disables automated sync on every managed Application
-			// (Automated.Enabled = false), because this controller drives those syncs itself. That
-			// mutation lands on the copy written to the cluster, not on the freshly generated
-			// Application compared here, so the live object always carries automated.enabled=false
-			// while the generated one leaves it unset. Mirror it, or every ApplicationSet whose
-			// template sets syncPolicy.automated reports a spec change forever.
+			// Via SpecsEquivalent, so this agrees with what the write path will actually do; see its
+			// doc comment for why comparing specs directly loops.
 			desiredForCompare := desiredApp.DeepCopy()
-			if sp := desiredForCompare.Spec.SyncPolicy; sp != nil && sp.Automated != nil {
-				sp.Automated.Enabled = new(false)
-			}
+			disableAutomatedSync(desiredForCompare)
 
 			equivalent, cmpErr := utils.SpecsEquivalent(diffConfig, &app, desiredForCompare)
 			if cmpErr != nil {
@@ -726,6 +708,17 @@ func (m *Manager) updateApplicationSetApplicationStatusConditions(ctx context.Co
 	return applicationSet.Status.Conditions
 }
 
+// disableAutomatedSync clears automated sync on a RollingSync-managed Application, since the
+// ApplicationSet controller triggers those syncs itself. Anything comparing a generated Application
+// against its live counterpart must apply this first: the mutation lands on the written copy, so the
+// live object carries automated.enabled=false while a freshly generated one leaves it unset.
+func disableAutomatedSync(app *argov1alpha1.Application) {
+	if app.Spec.SyncPolicy == nil || app.Spec.SyncPolicy.Automated == nil {
+		return
+	}
+	app.Spec.SyncPolicy.Automated.Enabled = new(false)
+}
+
 func (m *Manager) SyncDesiredApplications(logCtx *log.Entry, applicationSet *argov1alpha1.ApplicationSet, appsToSync map[string]bool, desiredApplications []argov1alpha1.Application) []argov1alpha1.Application {
 	rolloutApps := []argov1alpha1.Application{}
 	for i := range desiredApplications {
@@ -734,8 +727,8 @@ func (m *Manager) SyncDesiredApplications(logCtx *log.Entry, applicationSet *arg
 		// ensure that Applications generated with RollingSync do not have an automated sync policy, since the AppSet controller will handle triggering the sync operation instead
 		if desiredApplications[i].Spec.SyncPolicy != nil && desiredApplications[i].Spec.SyncPolicy.IsAutomatedSyncEnabled() {
 			pruneEnabled = desiredApplications[i].Spec.SyncPolicy.Automated.GetPrune()
-			desiredApplications[i].Spec.SyncPolicy.Automated.Enabled = new(false)
 		}
+		disableAutomatedSync(&desiredApplications[i])
 
 		appSetStatusPending := false
 		idx := utils.FindApplicationStatusIndex(applicationSet.Status.ApplicationStatus, desiredApplications[i].Name)

--- a/applicationset/progressivesync/specchanged_regression_test.go
+++ b/applicationset/progressivesync/specchanged_regression_test.go
@@ -1,0 +1,193 @@
+package progressivesync
+
+import (
+	"context"
+	"testing"
+
+	"github.com/argoproj/argo-cd/gitops-engine/v3/pkg/health"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	argov1alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+)
+
+// Regression tests for the progressive-sync reconcile loop.
+//
+// updateApplicationSetApplicationStatus must only report a spec change when the ApplicationSet
+// controller would actually rewrite the Application's spec. If it reports a change the write path
+// will never act on, the Application is never corrected, so the "pending change" is still there on
+// the next reconcile: status flips to Waiting, then Pending, then triggers a sync, which writes the
+// Application, which triggers another reconcile. Measured at ~137 reconciles/second for a single
+// ApplicationSet with two Applications, with no backoff.
+//
+// Both cases below place the Application in a state where it is NOT (Synced and Healthy). That
+// matters: a Synced+Healthy Application has its Waiting status immediately overwritten with Healthy,
+// which masks the bug entirely and is why it is not universal.
+
+// helper: a progressive-sync ApplicationSet with a single RollingSync step.
+func regressionAppSet(ignore argov1alpha1.ApplicationSetIgnoreDifferences) argov1alpha1.ApplicationSet {
+	return argov1alpha1.ApplicationSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "storm", Namespace: "argocd"},
+		Spec: argov1alpha1.ApplicationSetSpec{
+			IgnoreApplicationDifferences: ignore,
+			Strategy: &argov1alpha1.ApplicationSetStrategy{
+				Type: "RollingSync",
+				RollingSync: &argov1alpha1.ApplicationSetRolloutStrategy{
+					Steps: []argov1alpha1.ApplicationSetRolloutStep{{}},
+				},
+			},
+		},
+		Status: argov1alpha1.ApplicationSetStatus{
+			ApplicationStatus: []argov1alpha1.ApplicationSetApplicationStatus{{
+				Application: "storm-a",
+				Status:      argov1alpha1.ProgressiveSyncHealthy,
+				Message:     "Application resource has synced, updating status to Healthy",
+				Step:        "1",
+				// Pinned to the Application's observed revision so revisionsChanged is false and these
+				// tests isolate specChanged.
+				TargetRevisions: []string{"abc123"},
+			}},
+		},
+	}
+}
+
+// helper: an Application that is deliberately not Synced, so a Waiting status is not overwritten.
+func regressionApp(rev string, automatedEnabled *bool) argov1alpha1.Application {
+	app := argov1alpha1.Application{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "argoproj.io/v1alpha1", Kind: "Application"},
+		ObjectMeta: metav1.ObjectMeta{Name: "storm-a", Namespace: "argocd"},
+		Spec: argov1alpha1.ApplicationSpec{
+			Project: "default",
+			Source: &argov1alpha1.ApplicationSource{
+				RepoURL:        "git://example/repo",
+				Path:           "leaves/x",
+				TargetRevision: rev,
+			},
+			Destination: argov1alpha1.ApplicationDestination{
+				Server: "https://kubernetes.default.svc", Namespace: "storm-a",
+			},
+			SyncPolicy: &argov1alpha1.SyncPolicy{
+				Automated:   &argov1alpha1.SyncPolicyAutomated{Prune: new(true), SelfHeal: new(true), Enabled: automatedEnabled},
+				SyncOptions: []string{"CreateNamespace=true"},
+			},
+		},
+		Status: argov1alpha1.ApplicationStatus{
+			Sync:   argov1alpha1.SyncStatus{Status: argov1alpha1.SyncStatusCodeUnknown, Revision: "abc123"},
+			Health: argov1alpha1.AppHealthStatus{Status: health.HealthStatusHealthy},
+		},
+	}
+	return app
+}
+
+// regressionDeps is a no-op Dependencies: these tests assert on the statuses returned by
+// UpdateApplicationSetApplicationStatus, not on their persistence.
+type regressionDeps struct{}
+
+func (regressionDeps) SetAppSetApplicationStatus(_ context.Context, _ *log.Entry, _ *argov1alpha1.ApplicationSet, _ []argov1alpha1.ApplicationSetApplicationStatus) error {
+	return nil
+}
+
+func (regressionDeps) SetApplicationSetStatusCondition(_ context.Context, _ *argov1alpha1.ApplicationSet, _ []argov1alpha1.ApplicationSetCondition, _ bool) error {
+	return nil
+}
+
+func regressionManager(t *testing.T, appSet *argov1alpha1.ApplicationSet) *Manager {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, argov1alpha1.AddToScheme(scheme))
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(appSet).WithStatusSubresource(appSet).Build()
+	return NewManager(c, regressionDeps{})
+}
+
+// Defect 1: the status path must honour ignoreApplicationDifferences, exactly as
+// createOrUpdateInCluster does when deciding whether to Patch. Here the only difference between live
+// and desired is a field the ApplicationSet explicitly ignores, so the write path will never correct
+// it — reporting a spec change is therefore a permanent, self-sustaining loop.
+//
+// Without the fix this reports "Application has pending changes (spec differs)".
+func TestSpecChangedHonoursIgnoreApplicationDifferences(t *testing.T) {
+	t.Parallel()
+
+	appSet := regressionAppSet(argov1alpha1.ApplicationSetIgnoreDifferences{
+		{JSONPointers: []string{"/spec/source/targetRevision"}},
+	})
+	live := regressionApp("refs/heads/does-not-exist", new(false))
+	desired := regressionApp("HEAD", new(false))
+
+	m := regressionManager(t, &appSet)
+	statuses, err := m.UpdateApplicationSetApplicationStatus(t.Context(), log.NewEntry(log.New()),
+		&appSet, []argov1alpha1.Application{live}, []argov1alpha1.Application{desired},
+		map[string]int{"storm-a": 0})
+	require.NoError(t, err)
+	require.Len(t, statuses, 1)
+
+	assert.NotEqual(t, argov1alpha1.ProgressiveSyncWaiting, statuses[0].Status,
+		"the only difference is an ignored field, which the write path will never correct, so "+
+			"reporting a pending spec change loops forever: %s", statuses[0].Message)
+	assert.NotContains(t, statuses[0].Message, "spec differs")
+}
+
+// Defect 2: applyRolloutStrategy sets Automated.Enabled=false on progressive-sync-managed
+// Applications, because the ApplicationSet controller drives those syncs itself. That mutation lands
+// on the copy written to the cluster, not on the freshly generated Application compared here — so the
+// live object permanently carries automated.enabled=false while the generated one leaves it unset.
+//
+// This needs no ignore rules and no unusual configuration: it applies to every ApplicationSet whose
+// template sets syncPolicy.automated, which is the common case.
+//
+// Without the fix this reports "Application has pending changes (spec differs)".
+func TestSpecChangedIgnoresControllerManagedAutomatedEnabled(t *testing.T) {
+	t.Parallel()
+
+	appSet := regressionAppSet(nil)
+	live := regressionApp("HEAD", new(false)) // written by the controller with Enabled=false
+	desired := regressionApp("HEAD", nil)     // freshly generated: Enabled unset
+
+	m := regressionManager(t, &appSet)
+	statuses, err := m.UpdateApplicationSetApplicationStatus(t.Context(), log.NewEntry(log.New()),
+		&appSet, []argov1alpha1.Application{live}, []argov1alpha1.Application{desired},
+		map[string]int{"storm-a": 0})
+	require.NoError(t, err)
+	require.Len(t, statuses, 1)
+
+	assert.NotEqual(t, argov1alpha1.ProgressiveSyncWaiting, statuses[0].Status,
+		"automated.enabled is set by the controller itself on the written copy only; treating it as a "+
+			"user-visible spec change loops forever for any ApplicationSet using syncPolicy.automated: %s",
+		statuses[0].Message)
+	assert.NotContains(t, statuses[0].Message, "spec differs")
+}
+
+// An invalid ignore rule must not manufacture a spec change.
+//
+// Note where such a rule actually fails. BuildIgnoreDiffConfig only validates structural invariants,
+// so an unparseable JQ expression passes it; the failure surfaces later, from applyIgnoreDifferences
+// inside SpecsEquivalent. The write path turns that into a reconcile error. The status path cannot
+// usefully do the same for a single Application, so it must at least not report a change it cannot
+// substantiate -- reporting one would trigger a sync the write path is failing to perform, which is
+// the loop this file exists to prevent.
+func TestInvalidIgnoreRuleDoesNotReportSpecChange(t *testing.T) {
+	t.Parallel()
+
+	appSet := regressionAppSet(argov1alpha1.ApplicationSetIgnoreDifferences{
+		// Unparseable JQ: accepted by BuildIgnoreDiffConfig, rejected by gojq during normalization.
+		{JQPathExpressions: []string{"this is not( valid jq"}},
+	})
+	live := regressionApp("refs/heads/does-not-exist", new(false))
+	desired := regressionApp("HEAD", nil)
+
+	m := regressionManager(t, &appSet)
+	statuses, err := m.UpdateApplicationSetApplicationStatus(t.Context(), log.NewEntry(log.New()),
+		&appSet, []argov1alpha1.Application{live}, []argov1alpha1.Application{desired},
+		map[string]int{"storm-a": 0})
+	require.NoError(t, err)
+	require.Len(t, statuses, 1)
+
+	assert.NotContains(t, statuses[0].Message, "spec differs",
+		"with an unusable ignore rule the comparison cannot be trusted, so the status must not claim "+
+			"a spec change; the write path is erroring, so a change reported here can never be acted on")
+}

--- a/applicationset/progressivesync/specchanged_regression_test.go
+++ b/applicationset/progressivesync/specchanged_regression_test.go
@@ -15,14 +15,9 @@ import (
 	argov1alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 )
 
-// Regression tests for the progressive-sync reconcile loop.
-//
-// updateApplicationSetApplicationStatus must only report a spec change when the ApplicationSet
-// controller would actually rewrite the Application's spec. If it reports a change the write path
-// will never act on, the Application is never corrected, so the "pending change" is still there on
-// the next reconcile: status flips to Waiting, then Pending, then triggers a sync, which writes the
-// Application, which triggers another reconcile. Measured at ~137 reconciles/second for a single
-// ApplicationSet with two Applications, with no backoff.
+// Regression tests for the progressive-sync reconcile loop: updateApplicationSetApplicationStatus
+// must only report a spec change when the write path would actually rewrite the spec. See
+// utils.SpecsEquivalent for why reporting one it will not act on cannot converge.
 //
 // Both cases below place the Application in a state where it is NOT (Synced and Healthy). That
 // matters: a Synced+Healthy Application has its Waiting status immediately overwritten with Healthy,
@@ -105,9 +100,8 @@ func regressionManager(t *testing.T, appSet *argov1alpha1.ApplicationSet) *Manag
 }
 
 // Defect 1: the status path must honour ignoreApplicationDifferences, exactly as
-// createOrUpdateInCluster does when deciding whether to Patch. Here the only difference between live
-// and desired is a field the ApplicationSet explicitly ignores, so the write path will never correct
-// it — reporting a spec change is therefore a permanent, self-sustaining loop.
+// createOrUpdateInCluster does when deciding whether to Patch. Here the only difference is a field the
+// ApplicationSet explicitly ignores, so the write path will never correct it.
 //
 // Without the fix this reports "Application has pending changes (spec differs)".
 func TestSpecChangedHonoursIgnoreApplicationDifferences(t *testing.T) {
@@ -132,13 +126,9 @@ func TestSpecChangedHonoursIgnoreApplicationDifferences(t *testing.T) {
 	assert.NotContains(t, statuses[0].Message, "spec differs")
 }
 
-// Defect 2: applyRolloutStrategy sets Automated.Enabled=false on progressive-sync-managed
-// Applications, because the ApplicationSet controller drives those syncs itself. That mutation lands
-// on the copy written to the cluster, not on the freshly generated Application compared here — so the
-// live object permanently carries automated.enabled=false while the generated one leaves it unset.
-//
-// This needs no ignore rules and no unusual configuration: it applies to every ApplicationSet whose
-// template sets syncPolicy.automated, which is the common case.
+// Defect 2: the Automated.Enabled mutation lands on the written copy, not on the generated
+// Application compared here (see disableAutomatedSync). This needs no ignore rules and no unusual
+// configuration -- it applies to every ApplicationSet whose template sets syncPolicy.automated.
 //
 // Without the fix this reports "Application has pending changes (spec differs)".
 func TestSpecChangedIgnoresControllerManagedAutomatedEnabled(t *testing.T) {
@@ -164,12 +154,10 @@ func TestSpecChangedIgnoresControllerManagedAutomatedEnabled(t *testing.T) {
 
 // An invalid ignore rule must not manufacture a spec change.
 //
-// Note where such a rule actually fails. BuildIgnoreDiffConfig only validates structural invariants,
-// so an unparseable JQ expression passes it; the failure surfaces later, from applyIgnoreDifferences
-// inside SpecsEquivalent. The write path turns that into a reconcile error. The status path cannot
-// usefully do the same for a single Application, so it must at least not report a change it cannot
-// substantiate -- reporting one would trigger a sync the write path is failing to perform, which is
-// the loop this file exists to prevent.
+// Note where such a rule fails: BuildIgnoreDiffConfig validates only structural invariants, so an
+// unparseable JQ expression passes it and the failure surfaces later from applyIgnoreDifferences. The
+// write path turns that into a reconcile error; the status path cannot usefully do the same for a
+// single Application, so it must at least not report a change it cannot substantiate.
 func TestInvalidIgnoreRuleDoesNotReportSpecChange(t *testing.T) {
 	t.Parallel()
 
@@ -190,4 +178,41 @@ func TestInvalidIgnoreRuleDoesNotReportSpecChange(t *testing.T) {
 	assert.NotContains(t, statuses[0].Message, "spec differs",
 		"with an unusable ignore rule the comparison cannot be trusted, so the status must not claim "+
 			"a spec change; the write path is erroring, so a change reported here can never be acted on")
+}
+
+// disableAutomatedSync is the single definition of the rule, used by both the writer and the comparer.
+// The end state must be the same for every Enabled value, including the one the original guard skipped
+// because it was already false.
+func TestDisableAutomatedSyncIsIdempotentAcrossEnabledStates(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name       string
+		syncPolicy *argov1alpha1.SyncPolicy
+		wantNil    bool
+	}{
+		{"no sync policy", nil, true},
+		{"no automated block", &argov1alpha1.SyncPolicy{}, true},
+		{"automated, enabled unset", &argov1alpha1.SyncPolicy{Automated: &argov1alpha1.SyncPolicyAutomated{}}, false},
+		{"automated, explicitly enabled", &argov1alpha1.SyncPolicy{Automated: &argov1alpha1.SyncPolicyAutomated{Enabled: new(true)}}, false},
+		{"automated, already disabled", &argov1alpha1.SyncPolicy{Automated: &argov1alpha1.SyncPolicyAutomated{Enabled: new(false)}}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			app := &argov1alpha1.Application{Spec: argov1alpha1.ApplicationSpec{SyncPolicy: tc.syncPolicy}}
+			disableAutomatedSync(app)
+
+			if tc.wantNil {
+				if app.Spec.SyncPolicy != nil {
+					assert.Nil(t, app.Spec.SyncPolicy.Automated, "nothing to disable, so nothing should be created")
+				}
+				return
+			}
+			require.NotNil(t, app.Spec.SyncPolicy.Automated.Enabled)
+			assert.False(t, *app.Spec.SyncPolicy.Automated.Enabled,
+				"automated sync must end up disabled whatever it started as, so the writer and the "+
+					"comparer always see the same value")
+		})
+	}
 }

--- a/applicationset/utils/comparison_agreement_test.go
+++ b/applicationset/utils/comparison_agreement_test.go
@@ -15,18 +15,13 @@ import (
 	"github.com/argoproj/argo-cd/v3/util/argo/normalizers"
 )
 
-// SpecsEquivalent and CreateOrUpdate must always agree on whether a spec has changed.
+// SpecsEquivalent and CreateOrUpdate must agree on whether the *spec* has changed: the first decides
+// whether progressive sync reports a pending change, the second whether anything is actually written.
 //
-// That agreement is the whole contract: progressive sync uses SpecsEquivalent to decide whether to
-// report a pending change, and CreateOrUpdate decides whether to actually write. If the first says
-// "changed" where the second declines to patch, the Application is never corrected, the change is
-// still pending on the next reconcile, and the ApplicationSet reconciles in a tight loop that never
-// converges. If the reverse, rollout ordering is decided from stale status.
-//
-// The case exercised here is the awkward one: a JQ ignore rule that selects on a value which only
-// exists after normalization (spec.project defaulting to "default"), against a generated Application
-// that omits it. The relative order of normalization and ignore rules is load bearing and easy to
-// change in one place only, which is why this is pinned.
+// The case exercised here is the awkward one: a JQ ignore rule selecting on a value that only exists
+// after normalization (spec.project defaulting to "default"), against a generated Application that
+// omits it. The relative order of normalization and ignore rules is load bearing and easy to change in
+// one place only, which is why this is pinned.
 func TestSpecComparisonAgreesWithWritePath(t *testing.T) {
 	t.Parallel()
 
@@ -86,7 +81,9 @@ func TestSpecComparisonAgreesWithWritePath(t *testing.T) {
 		statusPathSeesChange, writePathWouldPatch, op)
 
 	require.Equal(t, writePathWouldPatch, statusPathSeesChange,
-		"the two paths must agree. If the status path reports a change the write path will not make, "+
-			"the Application is never corrected and progressive sync loops forever; if the write path "+
-			"patches while the status path sees nothing, ordering decisions are made on stale status.")
+		"the two paths must reach the same verdict on a spec difference. If the status path reports a "+
+			"change the write path will not make, the Application is never corrected and progressive "+
+			"sync loops forever. (Metadata-only changes are out of scope here: CreateOrUpdate compares "+
+			"whole objects and will patch those without SpecsEquivalent reporting a change, which cannot "+
+			"loop.)")
 }

--- a/applicationset/utils/comparison_agreement_test.go
+++ b/applicationset/utils/comparison_agreement_test.go
@@ -1,0 +1,92 @@
+package utils
+
+import (
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	argov1alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v3/util/argo"
+	"github.com/argoproj/argo-cd/v3/util/argo/normalizers"
+)
+
+// SpecsEquivalent and CreateOrUpdate must always agree on whether a spec has changed.
+//
+// That agreement is the whole contract: progressive sync uses SpecsEquivalent to decide whether to
+// report a pending change, and CreateOrUpdate decides whether to actually write. If the first says
+// "changed" where the second declines to patch, the Application is never corrected, the change is
+// still pending on the next reconcile, and the ApplicationSet reconciles in a tight loop that never
+// converges. If the reverse, rollout ordering is decided from stale status.
+//
+// The case exercised here is the awkward one: a JQ ignore rule that selects on a value which only
+// exists after normalization (spec.project defaulting to "default"), against a generated Application
+// that omits it. The relative order of normalization and ignore rules is load bearing and easy to
+// change in one place only, which is why this is pinned.
+func TestSpecComparisonAgreesWithWritePath(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, argov1alpha1.AddToScheme(scheme))
+
+	newApp := func(project, rev string) *argov1alpha1.Application {
+		return &argov1alpha1.Application{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "argoproj.io/v1alpha1", Kind: "Application"},
+			ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "argocd"},
+			Spec: argov1alpha1.ApplicationSpec{
+				Project: project,
+				Source: &argov1alpha1.ApplicationSource{
+					RepoURL:        "git://example/repo",
+					Path:           "x",
+					TargetRevision: rev,
+				},
+				Destination: argov1alpha1.ApplicationDestination{
+					Server: "https://kubernetes.default.svc", Namespace: "argocd",
+				},
+			},
+		}
+	}
+
+	ignore := argov1alpha1.ApplicationSetIgnoreDifferences{
+		{JQPathExpressions: []string{`.spec | select(.project == "default") | .source.targetRevision`}},
+	}
+	diffConfig, err := BuildIgnoreDiffConfig(ignore, normalizers.IgnoreNormalizerOpts{})
+	require.NoError(t, err)
+
+	live := newApp("default", "abc123") // stored: project already defaulted
+	desired := newApp("", "HEAD")       // generated: project omitted
+
+	// 1. What the status path concludes.
+	equivalent, err := SpecsEquivalent(diffConfig, live, desired)
+	require.NoError(t, err)
+
+	// 2. What the write path concludes, driven through the real CreateOrUpdate.
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(live.DeepCopy()).Build()
+	obj := live.DeepCopy()
+	generated := desired.DeepCopy()
+	// createOrUpdateInCluster normalizes the generated spec before calling CreateOrUpdate, which
+	// documents that its caller must do so. Reproducing that here is essential: an ignore rule
+	// selecting on a normalized value only matches once normalization has happened, so omitting this
+	// step hides any ordering divergence between the two paths.
+	generated.Spec = *argo.NormalizeApplicationSpec(&generated.Spec)
+	op, err := CreateOrUpdate(t.Context(), log.NewEntry(log.New()), c, diffConfig, obj, func() error {
+		obj.Spec = generated.Spec
+		return nil
+	})
+	require.NoError(t, err)
+
+	writePathWouldPatch := op == controllerutil.OperationResultUpdated
+	statusPathSeesChange := !equivalent
+
+	t.Logf("statusPathSeesChange=%v  writePathWouldPatch=%v (op=%s)",
+		statusPathSeesChange, writePathWouldPatch, op)
+
+	require.Equal(t, writePathWouldPatch, statusPathSeesChange,
+		"the two paths must agree. If the status path reports a change the write path will not make, "+
+			"the Application is never corrected and progressive sync loops forever; if the write path "+
+			"patches while the status path sees nothing, ordering decisions are made on stale status.")
+}

--- a/applicationset/utils/createOrUpdate.go
+++ b/applicationset/utils/createOrUpdate.go
@@ -62,17 +62,17 @@ func BuildIgnoreDiffConfig(ignoreDifferences argov1alpha1.ApplicationSetIgnoreDi
 }
 
 // SpecsEquivalent reports whether the desired Application spec matches the live one, applying the
-// same normalization and ignoreApplicationDifferences rules that CreateOrUpdate applies before it
-// decides whether to issue a Patch.
+// same normalization and ignoreApplicationDifferences rules CreateOrUpdate applies before deciding
+// whether to Patch. Callers asking "has the spec changed?" must use this rather than comparing specs
+// directly: a difference the write path would not act on leaves the Application uncorrected and still
+// reported as pending on every reconcile.
 //
-// Callers asking "has the spec changed?" must use this rather than comparing specs directly. If the
-// two answers can differ, the write path may decline to patch while the caller keeps reporting a
-// pending change: the Application is never corrected, the change is still pending on the next
-// reconcile, and progressive sync loops without converging.
+// Scoped to the spec. CreateOrUpdate compares whole objects, so a metadata-only change is patched
+// without being reported here; that direction cannot loop.
 //
-// Unlike CreateOrUpdate -- whose caller has already normalized the generated spec -- both specs are
-// normalized here, since callers pass the Application straight from the template. The order matters:
-// an ignore rule selecting on a normalized value only matches once the defaults are in place.
+// Both specs are normalized here, unlike in CreateOrUpdate whose caller normalizes the generated spec
+// first. Order matters: an ignore rule selecting on a normalized value only matches once the defaults
+// are in place.
 func SpecsEquivalent(diffConfig argodiff.DiffConfig, live, desired *argov1alpha1.Application) (bool, error) {
 	normalizedLive := live.DeepCopy()
 	normalizedDesired := desired.DeepCopy()
@@ -191,16 +191,11 @@ func applyIgnoreDifferences(diffConfig argodiff.DiffConfig, found *argov1alpha1.
 	generatedAppCopy := generatedApp.DeepCopy()
 	foundTypeMeta := found.TypeMeta
 
-	// The rules carried by diffConfig are scoped to Group=argoproj.io, Kind=Application, but
-	// appToUnstructured goes through runtime.DefaultUnstructuredConverter, which does not populate
-	// apiVersion/kind. The two objects also reach us with inconsistent TypeMeta: the live Application
-	// is decoded from the API server, while the generated one is built in Go by the template renderer
-	// and has none.
-	//
-	// Without stamping the GVK explicitly the rules match only whichever side happens to carry it, so
-	// an ignored field is neutralised on one side and left intact on the other. The two can then never
-	// compare equal, which silently defeats ignoreApplicationDifferences and -- for progressive syncs
-	// -- reports a spec change on every reconcile.
+	// diffConfig's rules are scoped to Group=argoproj.io, Kind=Application, but appToUnstructured goes
+	// through runtime.DefaultUnstructuredConverter, which does not populate apiVersion/kind -- and the
+	// live object arrives decoded from the API server while the generated one is built in Go with no
+	// TypeMeta. Without stamping the GVK the rules match one side only, so an ignored field is
+	// neutralised there and left intact on the other, and the two can never compare equal.
 	foundForDiff := found.DeepCopy()
 	foundForDiff.SetGroupVersionKind(argov1alpha1.ApplicationSchemaGroupVersionKind)
 	generatedForDiff := generatedApp.DeepCopy()
@@ -212,7 +207,7 @@ func applyIgnoreDifferences(diffConfig argodiff.DiffConfig, found *argov1alpha1.
 	}
 	unstructuredGenerated, err := appToUnstructured(generatedForDiff)
 	if err != nil {
-		return fmt.Errorf("failed to convert found application to unstructured: %w", err)
+		return fmt.Errorf("failed to convert generated application to unstructured: %w", err)
 	}
 	result, err := argodiff.Normalize([]*unstructured.Unstructured{unstructuredFound}, []*unstructured.Unstructured{unstructuredGenerated}, diffConfig)
 	if err != nil {

--- a/applicationset/utils/createOrUpdate.go
+++ b/applicationset/utils/createOrUpdate.go
@@ -61,6 +61,32 @@ func BuildIgnoreDiffConfig(ignoreDifferences argov1alpha1.ApplicationSetIgnoreDi
 		Build()
 }
 
+// SpecsEquivalent reports whether the desired Application spec matches the live one, applying the
+// same normalization and ignoreApplicationDifferences rules that CreateOrUpdate applies before it
+// decides whether to issue a Patch.
+//
+// Callers asking "has the spec changed?" must use this rather than comparing specs directly. If the
+// two answers can differ, the write path may decline to patch while the caller keeps reporting a
+// pending change: the Application is never corrected, the change is still pending on the next
+// reconcile, and progressive sync loops without converging.
+//
+// Unlike CreateOrUpdate -- whose caller has already normalized the generated spec -- both specs are
+// normalized here, since callers pass the Application straight from the template. The order matters:
+// an ignore rule selecting on a normalized value only matches once the defaults are in place.
+func SpecsEquivalent(diffConfig argodiff.DiffConfig, live, desired *argov1alpha1.Application) (bool, error) {
+	normalizedLive := live.DeepCopy()
+	normalizedDesired := desired.DeepCopy()
+
+	normalizedLive.Spec = *argo.NormalizeApplicationSpec(&normalizedLive.Spec)
+	normalizedDesired.Spec = *argo.NormalizeApplicationSpec(&normalizedDesired.Spec)
+
+	if err := applyIgnoreDifferences(diffConfig, normalizedLive, normalizedDesired); err != nil {
+		return false, fmt.Errorf("failed to apply ignore differences: %w", err)
+	}
+
+	return appEquality.DeepEqual(normalizedLive.Spec, normalizedDesired.Spec), nil
+}
+
 // CreateOrUpdate overrides "sigs.k8s.io/controller-runtime" function
 // in sigs.k8s.io/controller-runtime/pkg/controller/controllerutil/controllerutil.go
 // to add equality for argov1alpha1.ApplicationDestination
@@ -163,11 +189,28 @@ func applyIgnoreDifferences(diffConfig argodiff.DiffConfig, found *argov1alpha1.
 	}
 
 	generatedAppCopy := generatedApp.DeepCopy()
-	unstructuredFound, err := appToUnstructured(found)
+	foundTypeMeta := found.TypeMeta
+
+	// The rules carried by diffConfig are scoped to Group=argoproj.io, Kind=Application, but
+	// appToUnstructured goes through runtime.DefaultUnstructuredConverter, which does not populate
+	// apiVersion/kind. The two objects also reach us with inconsistent TypeMeta: the live Application
+	// is decoded from the API server, while the generated one is built in Go by the template renderer
+	// and has none.
+	//
+	// Without stamping the GVK explicitly the rules match only whichever side happens to carry it, so
+	// an ignored field is neutralised on one side and left intact on the other. The two can then never
+	// compare equal, which silently defeats ignoreApplicationDifferences and -- for progressive syncs
+	// -- reports a spec change on every reconcile.
+	foundForDiff := found.DeepCopy()
+	foundForDiff.SetGroupVersionKind(argov1alpha1.ApplicationSchemaGroupVersionKind)
+	generatedForDiff := generatedApp.DeepCopy()
+	generatedForDiff.SetGroupVersionKind(argov1alpha1.ApplicationSchemaGroupVersionKind)
+
+	unstructuredFound, err := appToUnstructured(foundForDiff)
 	if err != nil {
 		return fmt.Errorf("failed to convert found application to unstructured: %w", err)
 	}
-	unstructuredGenerated, err := appToUnstructured(generatedApp)
+	unstructuredGenerated, err := appToUnstructured(generatedForDiff)
 	if err != nil {
 		return fmt.Errorf("failed to convert found application to unstructured: %w", err)
 	}
@@ -191,6 +234,7 @@ func applyIgnoreDifferences(diffConfig argodiff.DiffConfig, found *argov1alpha1.
 		return fmt.Errorf("expected 1 normalized application, got %d", len(result.Targets))
 	}
 	foundNormalized.DeepCopyInto(found)
+	found.TypeMeta = foundTypeMeta
 	generatedJSONNormalized, err := json.Marshal(result.Targets[0].Object)
 	if err != nil {
 		return fmt.Errorf("failed to marshal normalized app to json: %w", err)

--- a/applicationset/utils/typemeta_ignore_test.go
+++ b/applicationset/utils/typemeta_ignore_test.go
@@ -10,17 +10,10 @@ import (
 )
 
 // applyIgnoreDifferences must neutralise an ignored field on BOTH the live and the generated
-// Application, regardless of the TypeMeta each happens to arrive with.
-//
-// The rules produced by ToApplicationResourceIgnoreDifferences are scoped to
-// Group=argoproj.io, Kind=Application, while appToUnstructured goes through
-// runtime.DefaultUnstructuredConverter, which does not populate apiVersion/kind. The two sides also
-// arrive inconsistently: the live Application is decoded from the API server, the generated one is
-// built in Go by the template renderer with TypeMeta zero. Unless the GVK is stamped explicitly the
-// rule matches only whichever side carries TypeMeta, leaving the field stripped on one side and
-// intact on the other, so the specs can never compare equal -- silently defeating
-// ignoreApplicationDifferences, and for progressive syncs reporting a spec change on every reconcile
-// forever.
+// Application, regardless of the TypeMeta each happens to arrive with. Its rules are GVK-scoped, but
+// the live object is decoded from the API server while the generated one is built in Go with TypeMeta
+// zero, so a rule matching one side only leaves the field stripped there and intact on the other --
+// and the specs then never compare equal. See applyIgnoreDifferences for the mechanism.
 func TestApplyIgnoreDifferencesIsTypeMetaIndependent(t *testing.T) {
 	t.Parallel()
 

--- a/applicationset/utils/typemeta_ignore_test.go
+++ b/applicationset/utils/typemeta_ignore_test.go
@@ -1,0 +1,85 @@
+package utils
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	argov1alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v3/util/argo/normalizers"
+)
+
+// applyIgnoreDifferences must neutralise an ignored field on BOTH the live and the generated
+// Application, regardless of the TypeMeta each happens to arrive with.
+//
+// The rules produced by ToApplicationResourceIgnoreDifferences are scoped to
+// Group=argoproj.io, Kind=Application, while appToUnstructured goes through
+// runtime.DefaultUnstructuredConverter, which does not populate apiVersion/kind. The two sides also
+// arrive inconsistently: the live Application is decoded from the API server, the generated one is
+// built in Go by the template renderer with TypeMeta zero. Unless the GVK is stamped explicitly the
+// rule matches only whichever side carries TypeMeta, leaving the field stripped on one side and
+// intact on the other, so the specs can never compare equal -- silently defeating
+// ignoreApplicationDifferences, and for progressive syncs reporting a spec change on every reconcile
+// forever.
+func TestApplyIgnoreDifferencesIsTypeMetaIndependent(t *testing.T) {
+	t.Parallel()
+
+	withTypeMeta := metav1.TypeMeta{APIVersion: "argoproj.io/v1alpha1", Kind: "Application"}
+
+	newApp := func(tm metav1.TypeMeta, rev string) *argov1alpha1.Application {
+		return &argov1alpha1.Application{
+			TypeMeta:   tm,
+			ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "argocd"},
+			Spec: argov1alpha1.ApplicationSpec{
+				Project: "default",
+				Source: &argov1alpha1.ApplicationSource{
+					RepoURL:        "git://example/repo",
+					Path:           "x",
+					TargetRevision: rev,
+				},
+				Destination: argov1alpha1.ApplicationDestination{
+					Server: "https://kubernetes.default.svc", Namespace: "argocd",
+				},
+			},
+		}
+	}
+
+	ignore := argov1alpha1.ApplicationSetIgnoreDifferences{
+		{JSONPointers: []string{"/spec/source/targetRevision"}},
+	}
+	diffConfig, err := BuildIgnoreDiffConfig(ignore, normalizers.IgnoreNormalizerOpts{})
+	if err != nil {
+		t.Fatalf("BuildIgnoreDiffConfig: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name      string
+		liveTM    metav1.TypeMeta
+		desiredTM metav1.TypeMeta
+	}{
+		{"both have TypeMeta", withTypeMeta, withTypeMeta},
+		{"live has TypeMeta, desired does not (what the controller actually sees)", withTypeMeta, metav1.TypeMeta{}},
+		{"neither has TypeMeta", metav1.TypeMeta{}, metav1.TypeMeta{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			live := newApp(tc.liveTM, "refs/heads/does-not-exist")
+			desired := newApp(tc.desiredTM, "HEAD")
+
+			if err := applyIgnoreDifferences(diffConfig, live, desired); err != nil {
+				t.Fatalf("applyIgnoreDifferences: %v", err)
+			}
+
+			t.Logf("live.targetRevision=%q  desired.targetRevision=%q",
+				live.Spec.Source.TargetRevision, desired.Spec.Source.TargetRevision)
+
+			if live.Spec.Source.TargetRevision != desired.Spec.Source.TargetRevision {
+				t.Errorf("ignored field must be neutralised on BOTH sides irrespective of TypeMeta; "+
+					"got live=%q desired=%q -- the two specs can never compare equal, so progressive sync "+
+					"reports a spec change on every reconcile",
+					live.Spec.Source.TargetRevision, desired.Spec.Source.TargetRevision)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. — n/a, no user-facing surface
* [x] Does this PR require documentation updates? — no; this corrects the behaviour of an existing feature rather than changing it
* [x] I've updated documentation as required by this PR. — n/a per above
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into — release-3.4, see below.

Fixes #27577

`UpdateApplicationSetApplicationStatus` could report a spec change that the write path would never act on. The Application was then never corrected, so the change was still pending on the next reconcile: `Waiting` → `Pending` → trigger sync → write the Application → reconcile again. Measured at **~137 reconciles per second for a single ApplicationSet with two Applications**, with no backoff.

**Three causes, all of which had to be addressed — fixing any subset changes nothing**

1. **The status path and the write path compared differently.** `CreateOrUpdate` applies the `ignoreApplicationDifferences` rules and `NormalizeApplicationSpec` before deciding whether to Patch; the status path used a plain `cmp.Equal` doing neither. So the write path declined to patch while the status path reported a pending change on every reconcile. Both now go through `SpecsEquivalent`, reusing the same rules and the same `appEquality` definition, with the `diffConfig` built once per call as `CreateOrUpdate` documents.

2. **`applyIgnoreDifferences` was TypeMeta-dependent.** Its rules are scoped to `Group=argoproj.io, Kind=Application`, but `appToUnstructured` goes through `runtime.DefaultUnstructuredConverter`, which does not populate `apiVersion`/`kind`. Live Applications arrive decoded from the API server while generated ones are built in Go with no TypeMeta, so the rules matched **one side only** — the ignored field was stripped from the live object and left intact on the desired one, and the two could never compare equal. This silently defeated `ignoreApplicationDifferences` in general, not only for progressive syncs. The GVK is now stamped before conversion.

3. **`Automated.Enabled` was mirrored on the written copy only.** `syncDesiredApplications` force-disables automated sync on managed Applications, since this controller drives those syncs itself, but that mutation lands on the copy written to the cluster rather than the one compared. The live object therefore permanently carried `automated.enabled: false` while the generated one left it unset — affecting **every** ApplicationSet whose template sets `syncPolicy.automated`.

A further condition is required for the loop to be observable: the Application must be persistently **not** (`Synced` and `Healthy`), because a `Synced` and `Healthy` Application has its `Waiting` status overwritten immediately. That is why this is not universal, and why it can be hard to spot.

**Tests**

* `TestSpecChangedHonoursIgnoreApplicationDifferences` and `TestSpecChangedIgnoresControllerManagedAutomatedEnabled` — both fail on unpatched `master` with `Application has pending changes (spec differs), setting status to Waiting`.
* `TestApplyIgnoreDifferencesIsTypeMetaIndependent` — the ignored field must be neutralised on both sides irrespective of the TypeMeta each object arrives with.
* `TestSpecComparisonAgreesWithWritePath` — pins the invariant the first change relies on: whatever `SpecsEquivalent` concludes, `CreateOrUpdate` must reach the matching decision about whether to write. It reproduces the generated-spec normalization that `createOrUpdateInCluster` performs, without which an ordering divergence between the two paths is invisible to the test.

**Longer-term**

A stronger guarantee would be for `createOrUpdateInCluster` to report whether it actually patched and drive `specChanged` off that, so "the spec changed" means "we changed the spec" and the two answers cannot drift apart again. Happy to follow up separately if that shape is preferred.

**Cherry-pick**

Please consider `release-3.4`. The same three causes are present there, though the code lives in `applicationset/controllers/` rather than `applicationset/progressivesync/`.
