### PR TITLE
fix: avoid redundant glob pattern compilation

### DIFF
--- a/util/glob/glob.go
+++ b/util/glob/glob.go
@@ -53,6 +53,15 @@ func cacheKey(pattern string, separators ...rune) globCacheKey {
 	return globCacheKey{Pattern: pattern, Separators: string(separators)}
 }
 
+func tryGetFromCache(key globCacheKey) (glob.Glob, bool) {
+	globCacheLock.Lock()
+	defer globCacheLock.Unlock()
+	if cached, ok := globCache.Get(key); ok {
+		return cached.(glob.Glob), true
+	}
+	return nil, false
+}
+
 // getOrCompile returns a cached compiled glob pattern, compiling and caching it if necessary.
 // Cache hits are a brief lock + map lookup. On cache miss, singleflight ensures each
 // unique pattern is compiled exactly once even under concurrent access, while unrelated
@@ -61,15 +70,15 @@ func cacheKey(pattern string, separators ...rune) globCacheKey {
 func getOrCompile(pattern string, compiler compileFn, separators ...rune) (glob.Glob, error) {
 	key := cacheKey(pattern, separators...)
 
-	globCacheLock.Lock()
-	if cached, ok := globCache.Get(key); ok {
-		globCacheLock.Unlock()
-		return cached.(glob.Glob), nil
+	if cached, ok := tryGetFromCache(key); ok {
+		return cached, nil
 	}
-	globCacheLock.Unlock()
 
 	sfKey := key.Pattern + "\x00" + key.Separators
 	v, err, _ := compileGroup.Do(sfKey, func() (any, error) {
+		if cached, ok := tryGetFromCache(key); ok {
+			return cached, nil
+		}
 		compiled, err := compiler(pattern, separators...)
 		if err != nil {
 			return nil, err

--- a/util/glob/glob.go
+++ b/util/glob/glob.go
@@ -55,10 +55,11 @@ func cacheKey(pattern string, separators ...rune) globCacheKey {
 
 func tryGetFromCache(key globCacheKey) (glob.Glob, bool) {
 	globCacheLock.Lock()
-	defer globCacheLock.Unlock()
 	if cached, ok := globCache.Get(key); ok {
+		globCacheLock.Unlock()
 		return cached.(glob.Glob), true
 	}
+	globCacheLock.Unlock()
 	return nil, false
 }
 


### PR DESCRIPTION
This PR fixes sometimes failing unit test Test_GlobCachingConcurrent.

The failure is caused by race condition in cache lookup and pattern compile + save.
1. A does cache lookup (locks)
1. B waits for lock
1. A unlocks
1. B searches
1. A starts compiling
1. B unlocks
1. A compiles, saves to the cache, leaves the Do block
1. B enters Do block - is accepted since none is here
1. **B compiles again since it does not check the cache anymore**

The problem is if B is fast enough to get after the cache lookup before the value is there, but slow enough that it does not call the Do function yet therefore not getting the result of A immediately from it after it ends.

The fix is to add lookup of the key into the `Do` group to make sure B does not compile again.

```
[...]
=== FAIL: util/glob Test_GlobCachingConcurrent (0.00s)
    glob_test.go:194: 
        	Error Trace:	/Users/jakucera/repository/argo/argo-cd/util/glob/glob_test.go:194
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
        	Test:       	Test_GlobCachingConcurrent
        	Messages:   	glob should compile once for the cached pattern

=== FAIL: util/glob Test_GlobCachingConcurrent (0.00s)
    glob_test.go:194: 
        	Error Trace:	/Users/jakucera/repository/argo/argo-cd/util/glob/glob_test.go:194
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 11
        	Test:       	Test_GlobCachingConcurrent
        	Messages:   	glob should compile once for the cached pattern
[...]
DONE 1000000 tests, 12699 failures in 134.931s
```

- failed 12699 times
- macbook pro M3
- go version go1.26.5 darwin/arm64
- run as: `make TEST_FLAGS="-run Test_GlobCachingConcurrent -count=1000000" test-local`

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
    - bugfix
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
    - no issue found
* [N/A] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
    - no
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
    - no new tests necessary
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
