### PR TITLE
feat(config)!: exclude Crossplane ProviderConfigUsage by default (#29060)

### DIFF
--- a/docs/operator-manual/upgrading/3.5-3.6.md
+++ b/docs/operator-manual/upgrading/3.5-3.6.md
@@ -20,6 +20,34 @@ shipped repo-server Deployment already injects from the `otlp.headers` config ma
 - If you set `ARGOCD_REPO_OTLP_HEADERS` directly (for example via a custom Deployment patch or Helm
   values), rename it to `ARGOCD_REPO_SERVER_OTLP_HEADERS`. The old variable is no longer read.
 
+### Crossplane `ProviderConfigUsage` added to the default `resource.exclusions`
+
+The default `resource.exclusions` in `argocd-cm` now excludes the `ProviderConfigUsage` kind across all
+API groups, [as recommended by the Crossplane documentation](https://docs.crossplane.io/latest/guides/crossplane-with-argo-cd/#set-resource-exclusion).
+
+Crossplane providers create one `ProviderConfigUsage` per managed resource, purely to represent the
+managed resource to `ProviderConfig` relationship so the provider can use it as a finalizer. They are
+never declared in Git and end users are not expected to interact with them, but the application
+controller previously opened a watch for every one of these API types on every managed cluster.
+
+The wildcard `apiGroups` entry is required because each Crossplane provider publishes its own API group:
+
+```yaml
+- apiGroups:
+  - '*'
+  kinds:
+  - ProviderConfigUsage
+```
+
+**Impact:**
+
+- `ProviderConfigUsage` resources no longer appear in the resource tree or UI, and are no longer watched.
+- Most operators are unaffected, and Crossplane users should see reduced watch overhead on clusters with
+  many managed resources.
+- If you relied on seeing these resources, override `resource.exclusions` in `argocd-cm` and omit this
+  entry. Note that overriding the key replaces the whole list, so copy the other default entries across
+  as well. See [Declarative Setup](../declarative-setup.md) for details.
+
 ## Behavioral Improvements / Fixes
 
 ### Health transition events now identify the causing resource(s)

--- a/manifests/base/config/argocd-cm.yaml
+++ b/manifests/base/config/argocd-cm.yaml
@@ -118,3 +118,10 @@ data:
       - BackgroundScanReport
       - ClusterBackgroundScanReport
       - UpdateRequest
+    ### Crossplane internal resources excluded reduce the number of watched events, as recommended by the Crossplane docs.
+    ### Providers create one ProviderConfigUsage per managed resource purely to track the
+    ### managed resource to ProviderConfig relationship, so the wildcard apiGroup covers every provider.
+    - apiGroups:
+      - '*'
+      kinds:
+      - ProviderConfigUsage

--- a/manifests/core-install-with-hydrator.yaml
+++ b/manifests/core-install-with-hydrator.yaml
@@ -31255,6 +31255,13 @@ data:
       - BackgroundScanReport
       - ClusterBackgroundScanReport
       - UpdateRequest
+    ### Crossplane internal resources excluded reduce the number of watched events, as recommended by the Crossplane docs.
+    ### Providers create one ProviderConfigUsage per managed resource purely to track the
+    ### managed resource to ProviderConfig relationship, so the wildcard apiGroup covers every provider.
+    - apiGroups:
+      - '*'
+      kinds:
+      - ProviderConfigUsage
 kind: ConfigMap
 metadata:
   labels:

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -31246,6 +31246,13 @@ data:
       - BackgroundScanReport
       - ClusterBackgroundScanReport
       - UpdateRequest
+    ### Crossplane internal resources excluded reduce the number of watched events, as recommended by the Crossplane docs.
+    ### Providers create one ProviderConfigUsage per managed resource purely to track the
+    ### managed resource to ProviderConfig relationship, so the wildcard apiGroup covers every provider.
+    - apiGroups:
+      - '*'
+      kinds:
+      - ProviderConfigUsage
 kind: ConfigMap
 metadata:
   labels:

--- a/manifests/ha/install-with-hydrator.yaml
+++ b/manifests/ha/install-with-hydrator.yaml
@@ -31654,6 +31654,13 @@ data:
       - BackgroundScanReport
       - ClusterBackgroundScanReport
       - UpdateRequest
+    ### Crossplane internal resources excluded reduce the number of watched events, as recommended by the Crossplane docs.
+    ### Providers create one ProviderConfigUsage per managed resource purely to track the
+    ### managed resource to ProviderConfig relationship, so the wildcard apiGroup covers every provider.
+    - apiGroups:
+      - '*'
+      kinds:
+      - ProviderConfigUsage
 kind: ConfigMap
 metadata:
   labels:

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -31645,6 +31645,13 @@ data:
       - BackgroundScanReport
       - ClusterBackgroundScanReport
       - UpdateRequest
+    ### Crossplane internal resources excluded reduce the number of watched events, as recommended by the Crossplane docs.
+    ### Providers create one ProviderConfigUsage per managed resource purely to track the
+    ### managed resource to ProviderConfig relationship, so the wildcard apiGroup covers every provider.
+    - apiGroups:
+      - '*'
+      kinds:
+      - ProviderConfigUsage
 kind: ConfigMap
 metadata:
   labels:

--- a/manifests/ha/namespace-install-with-hydrator.yaml
+++ b/manifests/ha/namespace-install-with-hydrator.yaml
@@ -568,6 +568,13 @@ data:
       - BackgroundScanReport
       - ClusterBackgroundScanReport
       - UpdateRequest
+    ### Crossplane internal resources excluded reduce the number of watched events, as recommended by the Crossplane docs.
+    ### Providers create one ProviderConfigUsage per managed resource purely to track the
+    ### managed resource to ProviderConfig relationship, so the wildcard apiGroup covers every provider.
+    - apiGroups:
+      - '*'
+      kinds:
+      - ProviderConfigUsage
 kind: ConfigMap
 metadata:
   labels:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -559,6 +559,13 @@ data:
       - BackgroundScanReport
       - ClusterBackgroundScanReport
       - UpdateRequest
+    ### Crossplane internal resources excluded reduce the number of watched events, as recommended by the Crossplane docs.
+    ### Providers create one ProviderConfigUsage per managed resource purely to track the
+    ### managed resource to ProviderConfig relationship, so the wildcard apiGroup covers every provider.
+    - apiGroups:
+      - '*'
+      kinds:
+      - ProviderConfigUsage
 kind: ConfigMap
 metadata:
   labels:

--- a/manifests/install-with-hydrator.yaml
+++ b/manifests/install-with-hydrator.yaml
@@ -31605,6 +31605,13 @@ data:
       - BackgroundScanReport
       - ClusterBackgroundScanReport
       - UpdateRequest
+    ### Crossplane internal resources excluded reduce the number of watched events, as recommended by the Crossplane docs.
+    ### Providers create one ProviderConfigUsage per managed resource purely to track the
+    ### managed resource to ProviderConfig relationship, so the wildcard apiGroup covers every provider.
+    - apiGroups:
+      - '*'
+      kinds:
+      - ProviderConfigUsage
 kind: ConfigMap
 metadata:
   labels:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -31596,6 +31596,13 @@ data:
       - BackgroundScanReport
       - ClusterBackgroundScanReport
       - UpdateRequest
+    ### Crossplane internal resources excluded reduce the number of watched events, as recommended by the Crossplane docs.
+    ### Providers create one ProviderConfigUsage per managed resource purely to track the
+    ### managed resource to ProviderConfig relationship, so the wildcard apiGroup covers every provider.
+    - apiGroups:
+      - '*'
+      kinds:
+      - ProviderConfigUsage
 kind: ConfigMap
 metadata:
   labels:

--- a/manifests/namespace-install-with-hydrator.yaml
+++ b/manifests/namespace-install-with-hydrator.yaml
@@ -519,6 +519,13 @@ data:
       - BackgroundScanReport
       - ClusterBackgroundScanReport
       - UpdateRequest
+    ### Crossplane internal resources excluded reduce the number of watched events, as recommended by the Crossplane docs.
+    ### Providers create one ProviderConfigUsage per managed resource purely to track the
+    ### managed resource to ProviderConfig relationship, so the wildcard apiGroup covers every provider.
+    - apiGroups:
+      - '*'
+      kinds:
+      - ProviderConfigUsage
 kind: ConfigMap
 metadata:
   labels:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -510,6 +510,13 @@ data:
       - BackgroundScanReport
       - ClusterBackgroundScanReport
       - UpdateRequest
+    ### Crossplane internal resources excluded reduce the number of watched events, as recommended by the Crossplane docs.
+    ### Providers create one ProviderConfigUsage per managed resource purely to track the
+    ### managed resource to ProviderConfig relationship, so the wildcard apiGroup covers every provider.
+    - apiGroups:
+      - '*'
+      kinds:
+      - ProviderConfigUsage
 kind: ConfigMap
 metadata:
   labels:

--- a/util/settings/settings_test.go
+++ b/util/settings/settings_test.go
@@ -68,6 +68,66 @@ func TestDocumentedArgoCDConfigMapIsValid(t *testing.T) {
 	updateSettingsFromConfigMap(&settings, argocdCM)
 }
 
+// TestShippedDefaultResourceExclusions guards the resource.exclusions defaults shipped in
+// manifests/base/config/argocd-cm.yaml. Those defaults change what the application controller
+// watches on every managed cluster, so a silent edit there is a user-facing behaviour change.
+func TestShippedDefaultResourceExclusions(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile("../../manifests/base/config/argocd-cm.yaml")
+	require.NoError(t, err)
+
+	var argocdCM *corev1.ConfigMap
+	require.NoError(t, yaml.Unmarshal(data, &argocdCM))
+
+	raw, ok := argocdCM.Data[resourceExclusionsKey]
+	require.True(t, ok, "%s must be present in the shipped argocd-cm", resourceExclusionsKey)
+
+	var exclusions []FilteredResource
+	require.NoError(t, yaml.Unmarshal([]byte(raw), &exclusions))
+
+	rf := &ResourcesFilter{ResourceExclusions: exclusions}
+
+	const cluster = "https://kubernetes.default.svc"
+
+	testCases := []struct {
+		name     string
+		apiGroup string
+		kind     string
+		excluded bool
+	}{
+		// Crossplane providers each publish their own API group, so the wildcard apiGroup has
+		// to catch ProviderConfigUsage regardless of which provider created it.
+		{"crossplane core provider", "kubernetes.crossplane.io", "ProviderConfigUsage", true},
+		{"upbound aws provider", "aws.upbound.io", "ProviderConfigUsage", true},
+		{"upbound gcp provider", "gcp.upbound.io", "ProviderConfigUsage", true},
+		{"unknown future provider", "some-provider.example.com", "ProviderConfigUsage", true},
+
+		// The wildcard apiGroup must not widen the exclusion beyond that single kind.
+		{"managed resource stays watched", "aws.upbound.io", "Bucket", false},
+		{"provider stays watched", "pkg.crossplane.io", "Provider", false},
+		{"provider config stays watched", "aws.upbound.io", "ProviderConfig", false},
+		{"core kinds stay watched", "", "ConfigMap", false},
+
+		// Pre-existing defaults must survive additions to the list.
+		{"endpoints", "", "Endpoints", true},
+		{"endpoint slices", "discovery.k8s.io", "EndpointSlice", true},
+		{"leases", "coordination.k8s.io", "Lease", true},
+		{"subject access reviews", "authorization.k8s.io", "SubjectAccessReview", true},
+		{"certificate signing requests", "certificates.k8s.io", "CertificateSigningRequest", true},
+		{"cert-manager certificate requests", "cert-manager.io", "CertificateRequest", true},
+		{"cilium identities", "cilium.io", "CiliumIdentity", true},
+		{"kyverno policy reports", "kyverno.io", "PolicyReport", true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.excluded, rf.IsExcludedResource(tc.apiGroup, tc.kind, cluster))
+		})
+	}
+}
+
 func TestGetConfigMapByName(t *testing.T) {
 	t.Run("data is never nil", func(t *testing.T) {
 		_, settingsManager := fixtures(t.Context(), nil)


### PR DESCRIPTION
Closes #29060

Adds Crossplane's `ProviderConfigUsage` to the default `resource.exclusions` in `manifests/base/config/argocd-cm.yaml`.

Crossplane providers create one `ProviderConfigUsage` per managed resource, purely to represent the managed-resource-to-`ProviderConfig` relationship so the controller can use it as a finalizer when a `ProviderConfig` is deleted. These objects are never declared in Git and end users never interact with them, but the application controller still opens a watch per API type on every managed cluster. On Crossplane-heavy clusters this is a meaningful share of the watched types, and users are patching this exclusion in by hand today.

This exclusion is [recommended by the Crossplane docs](https://docs.crossplane.io/latest/guides/crossplane-with-argo-cd/#set-resource-exclusion). Argo CD already ships the Lua health checks from that same guide (`resource_customizations/_.crossplane.io/_/health.lua` is a direct copy of it), so this is the remaining piece of that page's guidance that isn't a default.

```yaml
### Crossplane internal resources excluded reduce the number of watched events, as recommended by the Crossplane docs.
- apiGroups:
  - '*'
  kinds:
  - ProviderConfigUsage
```

The `'*'` apiGroup is required because every Crossplane provider defines its own API group, so a wildcard is the only way to cover them all. It stays narrow — `kinds` is matched exactly (`util/settings/filtered_resource.go`), so only the single kind name `ProviderConfigUsage` matches. Verified locally that `Bucket`, `pkg.crossplane.io/Provider` and `ProviderConfig` remain watched, and that the six pre-existing exclusion blocks still match.

Two notes for reviewers:

* Marked `!` following the precedent of ac50d8e1c (`feat(config)!: exclude known interim resources by default`), since it changes default behaviour — Crossplane users currently seeing these in the resource tree will no longer. Happy to drop the `!` if you consider an addition to the existing list non-breaking.
* `resource_customizations/_.crossplane.io/_/health.lua` lists `ProviderConfigUsage` in its `has_no_status` table. That branch becomes unreachable under the default config, but is intentionally left in place — it still applies for anyone who removes the exclusion. No change needed there.

Added in a follow-up commit, addressing the automated review:

* `TestShippedDefaultResourceExclusions` in `util/settings/settings_test.go` parses the shipped `manifests/base/config/argocd-cm.yaml` and asserts the exclusion defaults through `ResourcesFilter`. It covers `ProviderConfigUsage` across several provider API groups, asserts the wildcard does not widen the exclusion beyond that single kind, and pins the pre-existing entries so future additions can't silently drop them. Verified it fails without the manifest change.
* Documented under Breaking Changes in `docs/operator-manual/upgrading/3.5-3.6.md`, including how to override the default. (The automated review pointed at `2.14-3.0.md`, but that guide documents the 3.0 defaults — this change ships in 3.6.)

The generated `install.yaml` / `namespace-install.yaml` / `core-install.yaml` variants were regenerated with `make manifests-local`.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. — n/a, no CLI/UI surface
* [x] Does this PR require documentation updates? — yes; documented in `docs/operator-manual/upgrading/3.5-3.6.md` under Breaking Changes
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.

