### PR TITLE
fix(ui): show operation state on applications list page (#29063)

### DIFF
--- a/pkg/apiclient/application/forwarder_overwrite.go
+++ b/pkg/apiclient/application/forwarder_overwrite.go
@@ -79,8 +79,8 @@ var appFields = map[string]func(app *v1alpha1.Application) any{
 		return nil
 	},
 	"status.operationState.operation.sync": func(app *v1alpha1.Application) any {
-		if app.Status.OperationState != nil {
-			return app.Status.OperationState.SyncResult
+		if app.Status.OperationState != nil && app.Status.OperationState.Operation.Sync != nil {
+			return app.Status.OperationState.Operation.Sync
 		}
 		return nil
 	},

--- a/pkg/apiclient/application/forwarder_overwrite.go
+++ b/pkg/apiclient/application/forwarder_overwrite.go
@@ -80,7 +80,10 @@ var appFields = map[string]func(app *v1alpha1.Application) any{
 	},
 	"status.operationState.operation.sync": func(app *v1alpha1.Application) any {
 		if app.Status.OperationState != nil && app.Status.OperationState.Operation.Sync != nil {
-			return app.Status.OperationState.Operation.Sync
+			// The UI only needs the field's presence (and the revision) to classify the
+			// operation type; drop potentially large fields such as resources, manifests
+			// and sources to keep the list/watch payload small.
+			return &v1alpha1.SyncOperation{Revision: app.Status.OperationState.Operation.Sync.Revision}
 		}
 		return nil
 	},

--- a/pkg/apiclient/application/forwarder_overwrite.go
+++ b/pkg/apiclient/application/forwarder_overwrite.go
@@ -80,10 +80,11 @@ var appFields = map[string]func(app *v1alpha1.Application) any{
 	},
 	"status.operationState.operation.sync": func(app *v1alpha1.Application) any {
 		if app.Status.OperationState != nil && app.Status.OperationState.Operation.Sync != nil {
-			// The UI only needs the field's presence (and the revision) to classify the
-			// operation type; drop potentially large fields such as resources, manifests
-			// and sources to keep the list/watch payload small.
-			return &v1alpha1.SyncOperation{Revision: app.Status.OperationState.Operation.Sync.Revision}
+			// The UI only needs the field's presence to classify the operation type,
+			// so project an empty object as a pure presence marker and drop the
+			// potentially large fields such as resources, manifests and sources to
+			// keep the list/watch payload small.
+			return &v1alpha1.SyncOperation{}
 		}
 		return nil
 	},

--- a/pkg/apiclient/application/forwarder_overwrite_test.go
+++ b/pkg/apiclient/application/forwarder_overwrite_test.go
@@ -96,9 +96,42 @@ func TestProcessApplicationListField_OperationStateOperationSync(t *testing.T) {
 	syncMap, ok, err := unstructured.NestedMap(item, "status", "operationState", "operation", "sync")
 	require.NoError(t, err)
 	require.True(t, ok)
-	// Only the revision is projected; large fields (resources, manifests, sources)
-	// must not be included in the list payload.
-	require.Equal(t, map[string]any{"revision": "abc"}, syncMap)
+	// The field is a pure presence marker: it must be an empty object, with none
+	// of the operation's payload (revision, resources, manifests, sources).
+	require.Empty(t, syncMap)
+}
+
+func TestProcessApplicationListField_OperationStateOperationSyncMultiSource(t *testing.T) {
+	t.Parallel()
+	list := v1alpha1.ApplicationList{
+		Items: []v1alpha1.Application{{Status: v1alpha1.ApplicationStatus{
+			OperationState: &v1alpha1.OperationState{
+				Operation: v1alpha1.Operation{Sync: &v1alpha1.SyncOperation{
+					Revisions: []string{"abc", "def"},
+					Sources: v1alpha1.ApplicationSources{
+						{RepoURL: "https://example.com/repo1.git"},
+						{RepoURL: "https://example.com/repo2.git"},
+					},
+				}},
+			},
+		}}},
+	}
+
+	res, err := processApplicationListField(&list, map[string]any{"items.status.operationState.operation.sync": true}, false)
+	require.NoError(t, err)
+	resMap, ok := res.(map[string]any)
+	require.True(t, ok)
+
+	items, ok := resMap["items"].([]map[string]any)
+	require.True(t, ok)
+	item := test.ToMap(items[0])
+
+	syncMap, ok, err := unstructured.NestedMap(item, "status", "operationState", "operation", "sync")
+	require.NoError(t, err)
+	require.True(t, ok)
+	// Multi-source operations get the same empty presence marker; their sources
+	// and revisions must not leak into the list payload.
+	require.Empty(t, syncMap)
 }
 
 func TestProcessApplicationListField_OperationStateOperationSyncMissing(t *testing.T) {

--- a/pkg/apiclient/application/forwarder_overwrite_test.go
+++ b/pkg/apiclient/application/forwarder_overwrite_test.go
@@ -69,6 +69,54 @@ func TestProcessApplicationListField_SyncOperationMissing(t *testing.T) {
 	require.False(t, ok)
 }
 
+func TestProcessApplicationListField_OperationStateOperationSync(t *testing.T) {
+	t.Parallel()
+	list := v1alpha1.ApplicationList{
+		Items: []v1alpha1.Application{{Status: v1alpha1.ApplicationStatus{
+			OperationState: &v1alpha1.OperationState{
+				Operation:  v1alpha1.Operation{Sync: &v1alpha1.SyncOperation{Revision: "abc"}},
+				SyncResult: &v1alpha1.SyncOperationResult{Revision: "def"},
+			},
+		}}},
+	}
+
+	res, err := processApplicationListField(&list, map[string]any{"items.status.operationState.operation.sync": true}, false)
+	require.NoError(t, err)
+	resMap, ok := res.(map[string]any)
+	require.True(t, ok)
+
+	items, ok := resMap["items"].([]map[string]any)
+	require.True(t, ok)
+	item := test.ToMap(items[0])
+
+	val, ok, err := unstructured.NestedString(item, "status", "operationState", "operation", "sync", "revision")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "abc", val)
+}
+
+func TestProcessApplicationListField_OperationStateOperationSyncMissing(t *testing.T) {
+	t.Parallel()
+	list := v1alpha1.ApplicationList{
+		Items: []v1alpha1.Application{{Status: v1alpha1.ApplicationStatus{
+			OperationState: &v1alpha1.OperationState{Operation: v1alpha1.Operation{Sync: nil}},
+		}}},
+	}
+
+	res, err := processApplicationListField(&list, map[string]any{"items.status.operationState.operation.sync": true}, false)
+	require.NoError(t, err)
+	resMap, ok := res.(map[string]any)
+	require.True(t, ok)
+
+	items, ok := resMap["items"].([]map[string]any)
+	require.True(t, ok)
+	item := test.ToMap(items[0])
+
+	_, ok, err = unstructured.NestedMap(item, "status")
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
 func TestStreamApplicationListJSON_WithFieldFilter(t *testing.T) {
 	list := &v1alpha1.ApplicationList{
 		ListMeta: metav1.ListMeta{ResourceVersion: "100"},

--- a/pkg/apiclient/application/forwarder_overwrite_test.go
+++ b/pkg/apiclient/application/forwarder_overwrite_test.go
@@ -74,7 +74,11 @@ func TestProcessApplicationListField_OperationStateOperationSync(t *testing.T) {
 	list := v1alpha1.ApplicationList{
 		Items: []v1alpha1.Application{{Status: v1alpha1.ApplicationStatus{
 			OperationState: &v1alpha1.OperationState{
-				Operation:  v1alpha1.Operation{Sync: &v1alpha1.SyncOperation{Revision: "abc"}},
+				Operation: v1alpha1.Operation{Sync: &v1alpha1.SyncOperation{
+					Revision:  "abc",
+					Resources: []v1alpha1.SyncOperationResource{{Group: "apps", Kind: "Deployment", Name: "web"}},
+					Manifests: []string{"apiVersion: v1\nkind: ConfigMap"},
+				}},
 				SyncResult: &v1alpha1.SyncOperationResult{Revision: "def"},
 			},
 		}}},
@@ -89,10 +93,12 @@ func TestProcessApplicationListField_OperationStateOperationSync(t *testing.T) {
 	require.True(t, ok)
 	item := test.ToMap(items[0])
 
-	val, ok, err := unstructured.NestedString(item, "status", "operationState", "operation", "sync", "revision")
+	syncMap, ok, err := unstructured.NestedMap(item, "status", "operationState", "operation", "sync")
 	require.NoError(t, err)
 	require.True(t, ok)
-	require.Equal(t, "abc", val)
+	// Only the revision is projected; large fields (resources, manifests, sources)
+	// must not be included in the list payload.
+	require.Equal(t, map[string]any{"revision": "abc"}, syncMap)
 }
 
 func TestProcessApplicationListField_OperationStateOperationSyncMissing(t *testing.T) {

--- a/ui/src/app/applications/components/applications-list/applications-list.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-list.tsx
@@ -53,6 +53,7 @@ const APP_FIELDS = [
     'status.sync.revision',
     'status.health',
     'status.operationState.phase',
+    'status.operationState.operation.sync',
     'status.operationState.startedAt',
     'status.operationState.finishedAt'
 ];


### PR DESCRIPTION
# fix(ui): restore operation state on applications list page (#29063)

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

Fixes #29063

## What / Why

Since 3.5.0, the applications **list** page reports the operation status as **Unknown** for
every application - in the "OPERATION" filter facet and in the operation label on tiles/table
rows - even though `argocd app get` and the `Application` CRs show a fully populated
`status.operationState`. UI-only regression: only the projected list/watch payload is affected.

Regression introduced by #25451 (commit 566c62259), which removed
`status.operationState.operation.sync` from `APP_FIELDS` in `applications-list.tsx`.
`getOperationType()` (`ui/src/app/applications/components/utils.tsx`) needs an operation object
with a `.sync` field to classify the app's operation as a Sync; with the field stripped from the
payload it returns `Unknown` for every app that isn't mid-operation or being deleted, and
`getOperationStateTitle()` follows.

Before 3.5 this worked only by accident: the server-side projection getter for
`status.operationState.operation.sync` in `pkg/apiclient/application/forwarder_overwrite.go`
returned `app.Status.OperationState.SyncResult` - the wrong field, but truthy after any sync,
and truthiness is all `getOperationType()` checks.

## How

* Re-add `status.operationState.operation.sync` to `APP_FIELDS` in
  `ui/src/app/applications/components/applications-list/applications-list.tsx` so the list/watch
  requests carry the operation type again. Payload cost is negligible (a small fixed-size object
  per app), preserving the intent of #25451.
* Fix the projection getter in `pkg/apiclient/application/forwarder_overwrite.go` to project from
  `app.Status.OperationState.Operation.Sync` instead of `app.Status.OperationState.SyncResult`,
  so the field actually contains what its key claims. To keep the list/watch payload small, it
  returns a reduced `SyncOperation` carrying only the revision — `SyncOperation` can embed large
  nested fields (per-resource selective-sync lists, local `manifests`, rollback sources), and the
  UI only needs the field's presence to classify the operation type.

## How to verify

1. Sync any application successfully.
2. Open the applications list page and expand the "OPERATION" filter: the app is now counted
   under "Sync OK" instead of "Unknown".
3. The `/api/v1/applications?fields=...` response issued by the list page now contains
   `status.operationState.operation.sync`.

Before | After screenshots:

<img width="240" height="715" alt="Before" src="https://github.com/user-attachments/assets/6db7b842-5713-4088-bede-702280493052" />


<img width="229" height="709" alt="image" src="https://github.com/user-attachments/assets/8beff5d9-1684-487f-a6eb-3cc28acbede0" />
