### PR TITLE
fix(appset): re-normalize specs after applyIgnoreDifferences (#29066)

### DIFF
--- a/applicationset/utils/createOrUpdate.go
+++ b/applicationset/utils/createOrUpdate.go
@@ -72,7 +72,10 @@ func BuildIgnoreDiffConfig(ignoreDifferences argov1alpha1.ApplicationSetIgnoreDi
 //
 // Both specs are normalized here, unlike in CreateOrUpdate whose caller normalizes the generated spec
 // first. Order matters: an ignore rule selecting on a normalized value only matches once the defaults
-// are in place.
+// are in place, and a rule that empties a parent object (e.g. removing every field under
+// /spec/source/kustomize) must be followed by another normalization pass so NormalizeSource can nil
+// the now-empty parent — otherwise the two sides differ only by empty-struct-vs-nil and DeepEqual
+// (regression #29066) treats them as unequal.
 func SpecsEquivalent(diffConfig argodiff.DiffConfig, live, desired *argov1alpha1.Application) (bool, error) {
 	normalizedLive := live.DeepCopy()
 	normalizedDesired := desired.DeepCopy()
@@ -83,6 +86,9 @@ func SpecsEquivalent(diffConfig argodiff.DiffConfig, live, desired *argov1alpha1
 	if err := applyIgnoreDifferences(diffConfig, normalizedLive, normalizedDesired); err != nil {
 		return false, fmt.Errorf("failed to apply ignore differences: %w", err)
 	}
+
+	normalizedLive.Spec = *argo.NormalizeApplicationSpec(&normalizedLive.Spec)
+	normalizedDesired.Spec = *argo.NormalizeApplicationSpec(&normalizedDesired.Spec)
 
 	return appEquality.DeepEqual(normalizedLive.Spec, normalizedDesired.Spec), nil
 }
@@ -137,6 +143,15 @@ func CreateOrUpdate(ctx context.Context, logCtx *log.Entry, c client.Client, dif
 	if err != nil {
 		return controllerutil.OperationResultNone, fmt.Errorf("failed to apply ignore differences: %w", err)
 	}
+
+	// Re-normalize both sides after applyIgnoreDifferences: a rule that removes every field under
+	// an object parent (e.g. /spec/source/kustomize/images with no other kustomize fields) leaves
+	// an empty struct on the side that had the field and nothing on the side that did not.
+	// NormalizeSource nils out those now-empty parents so DeepEqual below (and the patch it gates)
+	// does not see a false empty-struct-vs-nil diff and wipe the ignored field on the next reconcile
+	// (regression #29066).
+	normalizedLive.Spec = *argo.NormalizeApplicationSpec(&normalizedLive.Spec)
+	obj.Spec = *argo.NormalizeApplicationSpec(&obj.Spec)
 
 	// Note: if the informer cache holds a stale entry for an application that no longer exists on
 	// the API server, DeepEqual may match against that stale entry and we skip Patch here. The

--- a/applicationset/utils/createOrUpdate_test.go
+++ b/applicationset/utils/createOrUpdate_test.go
@@ -236,3 +236,106 @@ spec:
 		})
 	}
 }
+
+// TestSpecsEquivalent_ignoreLeavesEmptyParentStruct covers the regression from #29066:
+// when an ignoreApplicationDifferences rule removes every field under a parent object
+// (e.g. /spec/source/kustomize/images with no other kustomize fields, or /spec/syncPolicy/automated
+// with no other syncPolicy fields), the side that held the ignored field is left with an empty
+// struct while the other side has a nil pointer. Prior to the fix these two shapes were reported
+// as unequal, so CreateOrUpdate produced a patch that wiped the ignored field on every reconcile
+// (breaking the argocd-image-updater write-back pattern for kustomize.images).
+func TestSpecsEquivalent_ignoreLeavesEmptyParentStruct(t *testing.T) {
+	t.Parallel()
+
+	appMeta := metav1.TypeMeta{
+		APIVersion: v1alpha1.ApplicationSchemaGroupVersionKind.GroupVersion().String(),
+		Kind:       v1alpha1.ApplicationSchemaGroupVersionKind.Kind,
+	}
+	testCases := []struct {
+		name              string
+		ignoreDifferences v1alpha1.ApplicationSetIgnoreDifferences
+		live              string
+		desired           string
+	}{
+		{
+			name: "ignore kustomize.images with no other kustomize fields (argocd-image-updater write-back)",
+			ignoreDifferences: v1alpha1.ApplicationSetIgnoreDifferences{
+				{JSONPointers: []string{"/spec/source/kustomize/images"}},
+			},
+			live: `
+spec:
+  project: default
+  source:
+    repoURL: https://example.com/repo
+    path: app
+    kustomize:
+      images:
+      - example.com/img:v2`,
+			desired: `
+spec:
+  project: default
+  source:
+    repoURL: https://example.com/repo
+    path: app`,
+		},
+		{
+			name: "ignore helm.parameters with no other helm fields",
+			ignoreDifferences: v1alpha1.ApplicationSetIgnoreDifferences{
+				{JSONPointers: []string{"/spec/source/helm/parameters"}},
+			},
+			live: `
+spec:
+  project: default
+  source:
+    repoURL: https://example.com/repo
+    path: chart
+    helm:
+      parameters:
+      - name: image.tag
+        value: v2`,
+			desired: `
+spec:
+  project: default
+  source:
+    repoURL: https://example.com/repo
+    path: chart`,
+		},
+		{
+			name: "ignore syncPolicy.automated with no other syncPolicy fields",
+			ignoreDifferences: v1alpha1.ApplicationSetIgnoreDifferences{
+				{JSONPointers: []string{"/spec/syncPolicy/automated"}},
+			},
+			live: `
+spec:
+  project: default
+  source:
+    repoURL: https://example.com/repo
+    path: app
+  syncPolicy:
+    automated:
+      selfHeal: true`,
+			desired: `
+spec:
+  project: default
+  source:
+    repoURL: https://example.com/repo
+    path: app`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			liveApp := v1alpha1.Application{TypeMeta: appMeta}
+			require.NoError(t, yaml.Unmarshal([]byte(tc.live), &liveApp))
+			desiredApp := v1alpha1.Application{TypeMeta: appMeta}
+			require.NoError(t, yaml.Unmarshal([]byte(tc.desired), &desiredApp))
+			diffConfig, err := BuildIgnoreDiffConfig(tc.ignoreDifferences, normalizers.IgnoreNormalizerOpts{})
+			require.NoError(t, err)
+
+			equivalent, err := SpecsEquivalent(diffConfig, &liveApp, &desiredApp)
+			require.NoError(t, err)
+			assert.True(t, equivalent, "specs should be equivalent after ignoring %v (regression #29066: an empty parent struct left on the live side must not be reported as different from a nil parent on the desired side)", tc.ignoreDifferences)
+		})
+	}
+}


### PR DESCRIPTION
Fixes the v3.5.0 regression where `ApplicationSet.spec.ignoreApplicationDifferences` no longer prevents the controller from reverting ignored fields — most visibly by wiping every `argocd-image-updater` write to `spec.source.kustomize.images` within ~1s.

## What was going wrong

The v3.5.0 concurrency refactor of `applicationset/utils/createOrUpdate.go` moved `NormalizeApplicationSpec()` on the live spec to *before* `applyIgnoreDifferences()`. That ordering matters for ignore-rule selectors that match on normalized values, but it broke a different invariant. When a rule removes every field under an object parent (e.g. `/spec/source/kustomize/images` on an Application whose only `kustomize` content is the `images` list), the side that held the field is left with an empty struct while the other side has a nil pointer. `NormalizeSource` would collapse the empty parent, but `NormalizeApplicationSpec` had already run; nothing catches the residue.

`DeepEqual` then reports the two specs as different, and `CreateOrUpdate` emits a `MergeFrom` patch of `{"kustomize": null}` onto the live Application — wiping the ignored field on every reconcile. Any `jsonPointer` whose removal empties a parent that `NormalizeSource` would normally nil out hits the same failure mode (`/spec/source/kustomize/*`, `/spec/source/helm/*`, `/spec/syncPolicy/*`).

## Fix

Add a second `NormalizeApplicationSpec` pass after `applyIgnoreDifferences` in both `SpecsEquivalent` and `CreateOrUpdate`. The pre-ignore normalize still runs so selectors continue to match on defaulted values; the post-ignore normalize collapses whatever the ignore rules just emptied, restoring the v3.4.x observable behavior without changing selector semantics.

## Tests

Added `TestSpecsEquivalent_ignoreLeavesEmptyParentStruct` with three subtests, each verifying that `SpecsEquivalent` reports equivalence when an ignore rule empties a parent that only the live side had:

- `ignore kustomize.images with no other kustomize fields (argocd-image-updater write-back)` — the reported reproducer
- `ignore helm.parameters with no other helm fields` — same shape via helm
- `ignore syncPolicy.automated with no other syncPolicy fields` — same shape via syncPolicy

Existing `Test_applyIgnoreDifferences` cases continue to pass.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. — n/a, no CLI/UI surface.
* [ ] Does this PR require documentation updates? — no, restores documented v3.4.x behavior.
* [x] I've updated documentation as required by this PR. — n/a per above.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green — targeted unit tests pass locally; full CI on this PR.
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines. — n/a, bug fix.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity). — release-3.5 (where the regression landed); v3.4 is unaffected.

Closes #29066
