### PR TITLE
docs: fix typo and brand name inconsistency in operator-manual docs

### DIFF
--- a/docs/operator-manual/cluster-management.md
+++ b/docs/operator-manual/cluster-management.md
@@ -10,7 +10,7 @@ Run `argocd cluster add context-name`.
 
 If you're unsure about the context names, run `kubectl config get-contexts` to get them all listed.
 
-This will connect to the cluster and install the necessary resources for ArgoCD to connect to it.
+This will connect to the cluster and install the necessary resources for Argo CD to connect to it.
 Note that you will need privileged access to the cluster.
 
 ## Skipping cluster reconciliation

--- a/docs/operator-manual/troubleshooting.md
+++ b/docs/operator-manual/troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting Tools
 
-The document describes how to use `argocd admin` subcommands to simplify Argo CD settings customizations and troubleshot
+The document describes how to use `argocd admin` subcommands to simplify Argo CD settings customizations and troubleshoot
 connectivity issues.
 
 ## Settings


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an enhancement proposal and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes. *(c — docs-only typo and brand name fix)*
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue. *(no related issue — proactive fix)*
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. *(N/A — docs only)*
* [x] Does this PR require documentation updates? *(this PR IS the documentation update)*
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged. *(N/A — docs-only change)*
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines. *(N/A)*
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.

---

Two small docs fixes in `docs/operator-manual/`:

**1. `troubleshooting.md`** — typo in the opening sentence:
> "simplify Argo CD settings customizations and **troubleshot** connectivity issues"

`troubleshot` → `troubleshoot`

**2. `cluster-management.md`** — brand name inconsistency:
> "install the necessary resources for **ArgoCD** to connect to it"

`ArgoCD` → `Argo CD` to match the official brand style used consistently throughout the rest of the docs.