### PR TITLE
feat: make max pending resources configurable (#29031)

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -1592,6 +1592,7 @@ func NewApplicationWaitCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 		resources    []string
 		output       string
 		appNamespace string
+		maxPending   uint
 	)
 	command := &cobra.Command{
 		Use:   "wait [APPNAME.. | -l selector]",
@@ -1644,7 +1645,7 @@ func NewApplicationWaitCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 				if appNamespace != "" && !strings.Contains(appName, "/") {
 					appName = appNamespace + "/" + appName
 				}
-				_, _, err := waitOnApplicationStatus(ctx, acdClient, appName, timeout, watch, selectedResources, output)
+				_, _, err := waitOnApplicationStatus(ctx, acdClient, appName, timeout, watch, selectedResources, output, maxPending)
 				if err != nil {
 					if isContextCanceledErr(err) {
 						log.Fatalf("timed out (%ds) waiting for app %q to match the expected conditions", timeout, appName)
@@ -1666,6 +1667,7 @@ func NewApplicationWaitCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 	command.Flags().UintVar(&timeout, "timeout", defaultCheckTimeoutSeconds, "Time out after this many seconds")
 	command.Flags().StringVarP(&appNamespace, "app-namespace", "N", "", "Only wait for an application  in namespace")
 	command.Flags().StringVarP(&output, "output", "o", "wide", "Output format. One of: json|yaml|wide|tree|tree=detailed")
+	command.Flags().UintVar(&maxPending, "max-pending-resources", 10, "Maximum number of pending resources to display in timeout error messages")
 	return command
 }
 
@@ -1730,6 +1732,7 @@ func NewApplicationSyncCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 		ignoreNormalizerOpts      normalizers.IgnoreNormalizerOpts
 		serverSideDiffConcurrency int
 		serverSideDiffMaxBatchKB  int
+		maxPending                uint
 	)
 	command := &cobra.Command{
 		Use:   "sync [APPNAME... | -l selector | --project project-name]",
@@ -2038,7 +2041,7 @@ func NewApplicationSyncCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 				errors.CheckError(err)
 
 				if !async {
-					app, opState, err := waitOnApplicationStatus(ctx, acdClient, appQualifiedName, timeout, watchOpts{operation: true}, selectedResources, output)
+					app, opState, err := waitOnApplicationStatus(ctx, acdClient, appQualifiedName, timeout, watchOpts{operation: true}, selectedResources, output, maxPending)
 					errors.CheckError(err)
 
 					if !dryRun {
@@ -2087,6 +2090,7 @@ func NewApplicationSyncCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 	command.Flags().Int64SliceVar(&sourcePositions, "source-positions", []int64{}, "List of source positions. Default is empty array. Counting start at 1.")
 	command.Flags().StringArrayVar(&sourceNames, "source-names", []string{}, "List of source names. Default is an empty array.")
 	addServerSideDiffPerfFlags(command, &serverSideDiffConcurrency, &serverSideDiffMaxBatchKB)
+	command.Flags().UintVar(&maxPending, "max-pending-resources", 10, "Maximum number of pending resources to display in timeout error messages")
 	return command
 }
 
@@ -2326,14 +2330,7 @@ func checkAppWaitConditions(app *argoappv1.Application, watch watchOpts, selecte
 		}
 	}
 
-	// LastSuccessfulOperation is only populated after a successful hydration,
-	// so it can be nil while CurrentOperation is set. Guard against the nil
-	// dereference before comparing the two.
-	hydrationFinished := app.Status.SourceHydrator.CurrentOperation != nil &&
-		app.Status.SourceHydrator.LastSuccessfulOperation != nil &&
-		app.Status.SourceHydrator.CurrentOperation.Phase == argoappv1.HydrateOperationPhaseHydrated &&
-		app.Status.SourceHydrator.CurrentOperation.SourceHydrator.DeepEquals(app.Status.SourceHydrator.LastSuccessfulOperation.SourceHydrator) &&
-		app.Status.SourceHydrator.CurrentOperation.DrySHA == app.Status.SourceHydrator.LastSuccessfulOperation.DrySHA
+	hydrationFinished := appHydrationFinished(app)
 
 	if len(selectedResources) > 0 {
 		ready = true
@@ -2351,10 +2348,34 @@ func checkAppWaitConditions(app *argoappv1.Application, watch watchOpts, selecte
 	return ready, operationInProgress
 }
 
+// appHydrationFinished reports whether the app's current hydration operation
+// has completed successfully. LastSuccessfulOperation is only populated after
+// a successful hydration, so it can be nil while CurrentOperation is set.
+func appHydrationFinished(app *argoappv1.Application) bool {
+	return app.Status.SourceHydrator.CurrentOperation != nil &&
+		app.Status.SourceHydrator.LastSuccessfulOperation != nil &&
+		app.Status.SourceHydrator.CurrentOperation.Phase == argoappv1.HydrateOperationPhaseHydrated &&
+		app.Status.SourceHydrator.CurrentOperation.SourceHydrator.DeepEquals(app.Status.SourceHydrator.LastSuccessfulOperation.SourceHydrator) &&
+		app.Status.SourceHydrator.CurrentOperation.DrySHA == app.Status.SourceHydrator.LastSuccessfulOperation.DrySHA
+}
+
+// formatPendingResources builds a summary string for resources that have not
+// reached the desired state. If there are more than maxPending entries the
+// list is truncated and a count of the remaining items is appended.
+func formatPendingResources(pending []string, maxPending uint) string {
+	if maxPending == 0 {
+		maxPending = 10
+	}
+	if uint(len(pending)) > maxPending {
+		return strings.Join(pending[:maxPending], ", ") + fmt.Sprintf(", ... and %d more", len(pending)-int(maxPending))
+	}
+	return strings.Join(pending, ", ")
+}
+
 // waitOnApplicationStatus watches an application and blocks until either the desired watch conditions
 // are fulfilled or we reach the timeout. Returns the app once desired conditions have been filled.
 // Additionally return the operationState at time of fulfilment (which may be different than returned app).
-func waitOnApplicationStatus(ctx context.Context, acdClient argocdclient.Client, appName string, timeout uint, watch watchOpts, selectedResources []*argoappv1.SyncOperationResource, output string) (*argoappv1.Application, *argoappv1.OperationState, error) {
+func waitOnApplicationStatus(ctx context.Context, acdClient argocdclient.Client, appName string, timeout uint, watch watchOpts, selectedResources []*argoappv1.SyncOperationResource, output string, maxPending uint) (*argoappv1.Application, *argoappv1.OperationState, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -2534,7 +2555,52 @@ func waitOnApplicationStatus(ctx context.Context, acdClient argocdclient.Client,
 		_ = w.Flush()
 	}
 	_ = printFinalStatus(appWithLock.GetApp())
-	return nil, finalOperationState, fmt.Errorf("timed out (%ds) waiting for app %q match desired state", timeout, appName)
+	app = appWithLock.GetApp()
+
+	// Collect the state that kept the wait from completing so the timeout
+	// error carries actionable information.
+	hydrationFinished := appHydrationFinished(app)
+	if len(selectedResources) > 0 {
+		var pending []string
+		for _, state := range getResourceStates(app, selectedResources) {
+			if !checkResourceStatus(watch, state.Health, state.Status, app.Operation, hydrationFinished) {
+				pending = append(pending, fmt.Sprintf("%s (sync: %s, health: %s)", state.Key(), state.Status, state.Health))
+			}
+		}
+		if len(pending) > 0 {
+			return nil, finalOperationState, fmt.Errorf("timed out (%ds) waiting for app %q to match desired state. resources not ready: %s", timeout, appName, formatPendingResources(pending, maxPending))
+		}
+		return nil, finalOperationState, fmt.Errorf("timed out (%ds) waiting for app %q to match desired state", timeout, appName)
+	}
+
+	var conditions []string
+	if watch.sync {
+		conditions = append(conditions, fmt.Sprintf("sync status: %s", app.Status.Sync.Status))
+	}
+	if watch.health || watch.suspended || watch.degraded {
+		conditions = append(conditions, fmt.Sprintf("health status: %s", app.Status.Health.Status))
+	}
+	if watch.operation && app.Operation != nil {
+		conditions = append(conditions, "operation: still in progress")
+	}
+	if watch.hydrated {
+		conditions = append(conditions, fmt.Sprintf("hydrated: %t", hydrationFinished))
+	}
+	detail := "app " + strings.Join(conditions, ", ")
+
+	var pending []string
+	for _, state := range getResourceStates(app, nil) {
+		if state.Hook != "" && state.Status == string(common.OperationSucceeded) {
+			continue
+		}
+		if !checkResourceStatus(watch, state.Health, state.Status, app.Operation, hydrationFinished) {
+			pending = append(pending, fmt.Sprintf("%s (sync: %s, health: %s)", state.Key(), state.Status, state.Health))
+		}
+	}
+	if len(pending) > 0 {
+		detail += ", resources not ready: " + formatPendingResources(pending, maxPending)
+	}
+	return nil, finalOperationState, fmt.Errorf("timed out (%ds) waiting for app %q to match desired state. %s", timeout, appName, detail)
 }
 
 // isContextCanceledErr returns true if the error is a context cancellation or deadline exceeded,
@@ -2711,6 +2777,7 @@ func NewApplicationRollbackCommand(clientOpts *argocdclient.ClientOptions) *cobr
 		timeout      uint
 		output       string
 		appNamespace string
+		maxPending   uint
 	)
 	command := &cobra.Command{
 		Use:   "rollback APPNAME [ID]",
@@ -2750,7 +2817,7 @@ func NewApplicationRollbackCommand(clientOpts *argocdclient.ClientOptions) *cobr
 
 			_, _, err = waitOnApplicationStatus(ctx, acdClient, app.QualifiedName(), timeout, watchOpts{
 				operation: true,
-			}, nil, output)
+			}, nil, output, maxPending)
 			errors.CheckError(err)
 		},
 	}
@@ -2758,6 +2825,7 @@ func NewApplicationRollbackCommand(clientOpts *argocdclient.ClientOptions) *cobr
 	command.Flags().UintVar(&timeout, "timeout", defaultCheckTimeoutSeconds, "Time out after this many seconds")
 	command.Flags().StringVarP(&output, "output", "o", "wide", "Output format. One of: json|yaml|wide|tree|tree=detailed")
 	command.Flags().StringVarP(&appNamespace, "app-namespace", "N", "", "Rollback application in namespace")
+	command.Flags().UintVar(&maxPending, "max-pending-resources", 10, "Maximum number of pending resources to display in timeout error messages")
 	return command
 }
 

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -2215,8 +2215,8 @@ func filterAppResources(app *argoappv1.Application, selectedResources []*argoapp
 	if app != nil && len(selectedResources) > 0 {
 		for i := range app.Status.Resources {
 			appResource := app.Status.Resources[i]
-			if (argo.IncludeResource(appResource.Name, appResource.Namespace,
-				schema.GroupVersionKind{Group: appResource.Group, Kind: appResource.Kind}, selectedResources)) {
+			if argo.IncludeResource(appResource.Name, appResource.Namespace,
+				schema.GroupVersionKind{Group: appResource.Group, Kind: appResource.Kind}, selectedResources) {
 				filteredResources = append(filteredResources, &argoappv1.SyncOperationResource{
 					Group:     appResource.Group,
 					Kind:      appResource.Kind,

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -2311,24 +2311,33 @@ func (a *AppWithLock) GetApp() *argoappv1.Application {
 	return a.app
 }
 
+// isOperationInProgress reports whether the application has a pending or
+// recently-finished operation that still needs controller reconciliation.
+func isOperationInProgress(app *argoappv1.Application) bool {
+	if app.Operation != nil {
+		// operation was just requested
+		return true
+	}
+	if app.Status.OperationState != nil {
+		if app.Status.OperationState.FinishedAt == nil {
+			// operation is not finished yet
+			return true
+		}
+		if !app.Status.OperationState.Operation.DryRun() && (app.Status.ReconciledAt == nil || app.Status.ReconciledAt.Before(app.Status.OperationState.FinishedAt)) {
+			// operation just finished but controller hasn't reconciled yet
+			return true
+		}
+	}
+	return false
+}
+
 // checkAppWaitConditions evaluates whether an application currently matches the
 // conditions requested by `argocd app wait`. It returns whether the conditions
 // are met (ready) and whether a sync/refresh operation is still in progress.
 // It does not mutate any state — callers are responsible for any side effects
 // such as triggering a status refresh before printing the final summary.
 func checkAppWaitConditions(app *argoappv1.Application, watch watchOpts, selectedResources []*argoappv1.SyncOperationResource) (ready, operationInProgress bool) {
-	if app.Operation != nil {
-		// if it just got requested
-		operationInProgress = true
-	} else if app.Status.OperationState != nil {
-		if app.Status.OperationState.FinishedAt == nil {
-			// if it is not finished yet
-			operationInProgress = true
-		} else if !app.Status.OperationState.Operation.DryRun() && (app.Status.ReconciledAt == nil || app.Status.ReconciledAt.Before(app.Status.OperationState.FinishedAt)) {
-			// if it is just finished and we need to wait for controller to reconcile app once after syncing
-			operationInProgress = true
-		}
-	}
+	operationInProgress = isOperationInProgress(app)
 
 	hydrationFinished := appHydrationFinished(app)
 
@@ -2370,6 +2379,15 @@ func formatPendingResources(pending []string, maxPending uint) string {
 		return strings.Join(pending[:maxPending], ", ") + fmt.Sprintf(", ... and %d more", len(pending)-int(maxPending))
 	}
 	return strings.Join(pending, ", ")
+}
+
+// formatResourceStateLabel returns a human-readable label for a resource state.
+// Hook resources use phase/result labels; regular resources use sync/health.
+func formatResourceStateLabel(state *resourceState) string {
+	if state.Hook != "" {
+		return fmt.Sprintf("%s (hook: %s, result: %s)", state.Key(), state.Status, state.Health)
+	}
+	return fmt.Sprintf("%s (sync: %s, health: %s)", state.Key(), state.Status, state.Health)
 }
 
 // waitOnApplicationStatus watches an application and blocks until either the desired watch conditions
@@ -2564,7 +2582,7 @@ func waitOnApplicationStatus(ctx context.Context, acdClient argocdclient.Client,
 		var pending []string
 		for _, state := range getResourceStates(app, selectedResources) {
 			if !checkResourceStatus(watch, state.Health, state.Status, app.Operation, hydrationFinished) {
-				pending = append(pending, fmt.Sprintf("%s (sync: %s, health: %s)", state.Key(), state.Status, state.Health))
+				pending = append(pending, formatResourceStateLabel(state))
 			}
 		}
 		if len(pending) > 0 {
@@ -2580,7 +2598,7 @@ func waitOnApplicationStatus(ctx context.Context, acdClient argocdclient.Client,
 	if watch.health || watch.suspended || watch.degraded {
 		conditions = append(conditions, fmt.Sprintf("health status: %s", app.Status.Health.Status))
 	}
-	if watch.operation && app.Operation != nil {
+	if watch.operation && isOperationInProgress(app) {
 		conditions = append(conditions, "operation: still in progress")
 	}
 	if watch.hydrated {
@@ -2594,7 +2612,7 @@ func waitOnApplicationStatus(ctx context.Context, acdClient argocdclient.Client,
 			continue
 		}
 		if !checkResourceStatus(watch, state.Health, state.Status, app.Operation, hydrationFinished) {
-			pending = append(pending, fmt.Sprintf("%s (sync: %s, health: %s)", state.Key(), state.Status, state.Health))
+			pending = append(pending, formatResourceStateLabel(state))
 		}
 	}
 	if len(pending) > 0 {

--- a/cmd/argocd/commands/app_test.go
+++ b/cmd/argocd/commands/app_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application"
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v3/reposerver/apiclient"
+	synccommon "github.com/argoproj/argo-cd/gitops-engine/v3/pkg/sync/common"
 )
 
 func Test_getInfos(t *testing.T) {
@@ -1862,7 +1863,7 @@ func TestWaitOnApplicationStatus_JSON_YAML_WideOutput(t *testing.T) {
 
 	output, err := captureOutput(
 		func() error {
-			_, _, _ = waitOnApplicationStatus(ctx, acdClient, "app-name", 0, watch, selectResource, "json")
+			_, _, _ = waitOnApplicationStatus(ctx, acdClient, "app-name", 0, watch, selectResource, "json", 10)
 			return nil
 		},
 	)
@@ -1870,7 +1871,7 @@ func TestWaitOnApplicationStatus_JSON_YAML_WideOutput(t *testing.T) {
 	assert.True(t, json.Valid([]byte(output)))
 
 	output, err = captureOutput(func() error {
-		_, _, _ = waitOnApplicationStatus(ctx, acdClient, "app-name", 0, watch, selectResource, "yaml")
+		_, _, _ = waitOnApplicationStatus(ctx, acdClient, "app-name", 0, watch, selectResource, "yaml", 10)
 		return nil
 	})
 
@@ -1879,7 +1880,7 @@ func TestWaitOnApplicationStatus_JSON_YAML_WideOutput(t *testing.T) {
 	require.NoError(t, err)
 
 	output, _ = captureOutput(func() error {
-		_, _, _ = waitOnApplicationStatus(ctx, acdClient, "app-name", 0, watch, selectResource, "")
+		_, _, _ = waitOnApplicationStatus(ctx, acdClient, "app-name", 0, watch, selectResource, "", 10)
 		return nil
 	})
 	timeStr := time.Now().Format("2006-01-02T15:04:05-07:00")
@@ -1948,7 +1949,7 @@ func TestWaitOnApplicationStatus_JSON_YAML_WideOutput_With_Timeout(t *testing.T)
 	watch = getWatchOpts(watch)
 
 	output, _ := captureOutput(func() error {
-		_, _, _ = waitOnApplicationStatus(ctx, acdClient, "app-name", 5, watch, selectResource, "")
+		_, _, _ = waitOnApplicationStatus(ctx, acdClient, "app-name", 5, watch, selectResource, "", 10)
 		return nil
 	})
 	timeStr := time.Now().Format("2006-01-02T15:04:05-07:00")
@@ -2156,7 +2157,7 @@ func TestWaitOnApplicationStatus_ReturnsImmediatelyWhenAlreadyInDesiredState(t *
 	}
 
 	start := time.Now()
-	_, _, err := waitOnApplicationStatus(ctx, acdClient, "app-name", 0, watch, selectResource, "json")
+	_, _, err := waitOnApplicationStatus(ctx, acdClient, "app-name", 0, watch, selectResource, "json", 10)
 	elapsed := time.Since(start)
 
 	require.NoError(t, err)
@@ -2172,7 +2173,7 @@ func TestWaitOnApplicationStatus_DeleteWatchSkipsEarlyReturn(t *testing.T) {
 	ctx := t.Context()
 	watch := watchOpts{delete: true}
 
-	app, opState, err := waitOnApplicationStatus(ctx, acdClient, "app-name", 0, watch, nil, "")
+	app, opState, err := waitOnApplicationStatus(ctx, acdClient, "app-name", 0, watch, nil, "", 10)
 	require.NoError(t, err)
 	assert.Nil(t, app)
 	assert.Nil(t, opState)
@@ -2187,7 +2188,7 @@ func TestWaitOnApplicationStatus_ReturnsFromWatchLoopWhenEventSatisfiesCondition
 	ctx := t.Context()
 	watch := watchOpts{sync: true, health: true}
 
-	app, _, err := waitOnApplicationStatus(ctx, acdClient, "app-name", 0, watch, nil, "json")
+	app, _, err := waitOnApplicationStatus(ctx, acdClient, "app-name", 0, watch, nil, "json", 10)
 	require.NoError(t, err)
 	// The function returns via the readiness path inside the watch loop.
 	// The returned app may be re-fetched by printFinalStatus so we only
@@ -2732,4 +2733,281 @@ func TestIsContextCanceledErr(t *testing.T) {
 		t.Parallel()
 		assert.False(t, isContextCanceledErr(errors.New("some other error")))
 	})
+}
+
+func TestFormatPendingResources(t *testing.T) {
+	tests := []struct {
+		name      string
+		pending   []string
+		maxPending uint
+		expected  string
+	}{
+		{
+			name:      "empty list",
+			pending:   []string{},
+			maxPending: 10,
+			expected:  "",
+		},
+		{
+			name:      "below limit",
+			pending:   []string{"a", "b", "c"},
+			maxPending: 10,
+			expected:  "a, b, c",
+		},
+		{
+			name:      "exactly at limit",
+			pending:   []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"},
+			maxPending: 10,
+			expected:  "a, b, c, d, e, f, g, h, i, j",
+		},
+		{
+			name:      "above limit",
+			pending:   []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"},
+			maxPending: 10,
+			expected:  "a, b, c, d, e, f, g, h, i, j, ... and 1 more",
+		},
+		{
+			name:      "custom maxPending=5",
+			pending:   []string{"a", "b", "c", "d", "e", "f", "g"},
+			maxPending: 5,
+			expected:  "a, b, c, d, e, ... and 2 more",
+		},
+		{
+			name:      "zero maxPending defaults to 10",
+			pending:   []string{"a", "b", "c"},
+			maxPending: 0,
+			expected:  "a, b, c",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatPendingResources(tt.pending, tt.maxPending)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestAppHydrationFinished(t *testing.T) {
+	tests := []struct {
+		name     string
+		app      *v1alpha1.Application
+		expected bool
+	}{
+		{
+			name: "nil CurrentOperation",
+			app: &v1alpha1.Application{
+				Status: v1alpha1.ApplicationStatus{
+					SourceHydrator: v1alpha1.SourceHydratorStatus{},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "nil LastSuccessfulOperation",
+			app: &v1alpha1.Application{
+				Status: v1alpha1.ApplicationStatus{
+					SourceHydrator: v1alpha1.SourceHydratorStatus{
+						CurrentOperation: &v1alpha1.HydrateOperation{},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := appHydrationFinished(tt.app)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// statusAcdClient serves a fixed application status so wait-timeout tests can
+// exercise the pending-resource reporting without duplicating client
+// boilerplate per scenario.
+type statusAcdClient struct {
+	*fakeAcdClient
+	status v1alpha1.ApplicationStatus
+}
+
+func newStatusAcdClient(status v1alpha1.ApplicationStatus) *statusAcdClient {
+	return &statusAcdClient{fakeAcdClient: &fakeAcdClient{}, status: status}
+}
+
+func (c *statusAcdClient) WatchApplicationWithRetry(_ context.Context, _ string, _ string) chan *v1alpha1.ApplicationWatchEvent {
+	appEventsCh := make(chan *v1alpha1.ApplicationWatchEvent)
+	close(appEventsCh)
+	return appEventsCh
+}
+
+func (c *statusAcdClient) NewApplicationClientOrDie() (io.Closer, applicationpkg.ApplicationServiceClient) {
+	return &fakeConnection{}, &statusFakeAppServiceClient{status: c.status}
+}
+
+func (c *statusAcdClient) NewSettingsClientOrDie() (io.Closer, settingspkg.SettingsServiceClient) {
+	return &fakeConnection{}, &fakeSettingsServiceClient{}
+}
+
+type statusFakeAppServiceClient struct {
+	fakeAppServiceClient
+	status v1alpha1.ApplicationStatus
+}
+
+func (c *statusFakeAppServiceClient) Get(_ context.Context, _ *applicationpkg.ApplicationQuery, _ ...grpc.CallOption) (*v1alpha1.Application, error) {
+	return &v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "argocd"},
+		Spec: v1alpha1.ApplicationSpec{
+			Project:     "default",
+			Destination: v1alpha1.ApplicationDestination{Server: "local", Namespace: "argocd"},
+			Source:      &v1alpha1.ApplicationSource{RepoURL: "test", TargetRevision: "master", Path: "/test"},
+		},
+		Status: c.status,
+	}, nil
+}
+
+func pendingAppStatus() v1alpha1.ApplicationStatus {
+	return v1alpha1.ApplicationStatus{
+		Sync:   v1alpha1.SyncStatus{Status: v1alpha1.SyncStatusCodeOutOfSync},
+		Health: v1alpha1.AppHealthStatus{Status: health.HealthStatusProgressing},
+		Resources: []v1alpha1.ResourceStatus{
+			{
+				Group:     "apps",
+				Kind:      "Deployment",
+				Namespace: "prod",
+				Name:      "api",
+				Status:    v1alpha1.SyncStatusCodeOutOfSync,
+				Health:    &v1alpha1.HealthStatus{Status: health.HealthStatusDegraded},
+			},
+			{
+				Kind:      "Service",
+				Namespace: "prod",
+				Name:      "web",
+				Status:    v1alpha1.SyncStatusCodeSynced,
+				Health:    &v1alpha1.HealthStatus{Status: health.HealthStatusHealthy},
+			},
+		},
+	}
+}
+
+func aggregateOnlyAppStatus() v1alpha1.ApplicationStatus {
+	return v1alpha1.ApplicationStatus{
+		Sync:   v1alpha1.SyncStatus{Status: v1alpha1.SyncStatusCodeOutOfSync},
+		Health: v1alpha1.AppHealthStatus{Status: health.HealthStatusHealthy},
+		Resources: []v1alpha1.ResourceStatus{
+			{
+				Kind:      "Service",
+				Namespace: "prod",
+				Name:      "web",
+				Status:    v1alpha1.SyncStatusCodeSynced,
+				Health:    &v1alpha1.HealthStatus{Status: health.HealthStatusHealthy},
+			},
+		},
+	}
+}
+
+func TestWaitOnApplicationStatus_TimeoutErrorListsPendingResources(t *testing.T) {
+	acdClient := newStatusAcdClient(pendingAppStatus())
+	watch := getWatchOpts(watchOpts{sync: true, health: true})
+
+	_, _, err := waitOnApplicationStatus(t.Context(), acdClient, "app-name", 0, watch, nil, "wide", 10)
+	require.Error(t, err)
+	errMsg := err.Error()
+	assert.Contains(t, errMsg, "timed out")
+	assert.Contains(t, errMsg, "sync status: OutOfSync")
+	assert.Contains(t, errMsg, "health status: Progressing")
+	assert.Contains(t, errMsg, "resources not ready: apps/Deployment/prod/api (sync: OutOfSync, health: Degraded)")
+	assert.NotContains(t, errMsg, "prod/web")
+}
+
+func TestWaitOnApplicationStatus_TimeoutErrorSelectedResources(t *testing.T) {
+	acdClient := newStatusAcdClient(pendingAppStatus())
+	selected := []*v1alpha1.SyncOperationResource{
+		{Group: "apps", Kind: "Deployment", Name: "api"},
+	}
+	watch := getWatchOpts(watchOpts{sync: true, health: true})
+
+	_, _, err := waitOnApplicationStatus(t.Context(), acdClient, "app-name", 0, watch, selected, "wide", 10)
+	require.Error(t, err)
+	errMsg := err.Error()
+	assert.Contains(t, errMsg, "resources not ready: apps/Deployment/prod/api (sync: OutOfSync, health: Degraded)")
+	assert.NotContains(t, errMsg, "app sync status")
+}
+
+func TestWaitOnApplicationStatus_TimeoutErrorAppLevelWithoutPendingResources(t *testing.T) {
+	acdClient := newStatusAcdClient(aggregateOnlyAppStatus())
+	watch := getWatchOpts(watchOpts{sync: true})
+
+	_, _, err := waitOnApplicationStatus(t.Context(), acdClient, "app-name", 0, watch, nil, "wide", 10)
+	require.Error(t, err)
+	errMsg := err.Error()
+	assert.Contains(t, errMsg, "sync status: OutOfSync")
+	assert.NotContains(t, errMsg, "resources not ready")
+}
+
+func TestWaitOnApplicationStatus_TimeoutErrorOnlyReportsWatchedConditions(t *testing.T) {
+	status := aggregateOnlyAppStatus()
+	status.OperationState = &v1alpha1.OperationState{Phase: synccommon.OperationRunning}
+	acdClient := newStatusAcdClient(status)
+	watch := watchOpts{operation: true}
+
+	_, _, err := waitOnApplicationStatus(t.Context(), acdClient, "app-name", 0, watch, nil, "wide", 10)
+	require.Error(t, err)
+	errMsg := err.Error()
+	assert.Contains(t, errMsg, "timed out")
+	assert.NotContains(t, errMsg, "sync status")
+	assert.NotContains(t, errMsg, "health status")
+}
+
+func TestWaitOnApplicationStatus_TimeoutErrorSkipsCompletedHooks(t *testing.T) {
+	status := aggregateOnlyAppStatus()
+	status.OperationState = &v1alpha1.OperationState{
+		SyncResult: &v1alpha1.SyncOperationResult{
+			Resources: []*v1alpha1.ResourceResult{
+				{
+					Group:     "batch",
+					Kind:      "Job",
+					Namespace: "prod",
+					Name:      "migrate",
+					HookType:  synccommon.HookTypePreSync,
+					HookPhase: synccommon.OperationSucceeded,
+					Status:    synccommon.ResultCodeSynced,
+				},
+			},
+		},
+	}
+	acdClient := newStatusAcdClient(status)
+	watch := getWatchOpts(watchOpts{sync: true})
+
+	_, _, err := waitOnApplicationStatus(t.Context(), acdClient, "app-name", 0, watch, nil, "wide", 10)
+	require.Error(t, err)
+	errMsg := err.Error()
+	assert.NotContains(t, errMsg, "batch/Job/prod/migrate")
+}
+
+func TestWaitOnApplicationStatus_MaxPendingCustomLimit(t *testing.T) {
+	// With maxPending=2, only 2 resources should be listed even though 3 are pending
+	resources := make([]v1alpha1.ResourceStatus, 15)
+	for i := range resources {
+		resources[i] = v1alpha1.ResourceStatus{
+			Kind:      fmt.Sprintf("Deployment%d", i),
+			Namespace: "prod",
+			Name:      fmt.Sprintf("app%d", i),
+			Status:    v1alpha1.SyncStatusCodeOutOfSync,
+			Health:    &v1alpha1.HealthStatus{Status: health.HealthStatusDegraded},
+		}
+	}
+	status := v1alpha1.ApplicationStatus{
+		Sync:      v1alpha1.SyncStatus{Status: v1alpha1.SyncStatusCodeOutOfSync},
+		Health:    v1alpha1.AppHealthStatus{Status: health.HealthStatusProgressing},
+		Resources: resources,
+	}
+	acdClient := newStatusAcdClient(status)
+	watch := getWatchOpts(watchOpts{sync: true})
+
+	_, _, err := waitOnApplicationStatus(t.Context(), acdClient, "app-name", 0, watch, nil, "wide", 2)
+	require.Error(t, err)
+	errMsg := err.Error()
+	assert.Contains(t, errMsg, "... and 13 more")
 }

--- a/cmd/argocd/commands/app_test.go
+++ b/cmd/argocd/commands/app_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/argoproj/argo-cd/gitops-engine/v3/pkg/health"
+	synccommon "github.com/argoproj/argo-cd/gitops-engine/v3/pkg/sync/common"
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -49,11 +50,12 @@ import (
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application"
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v3/reposerver/apiclient"
-	synccommon "github.com/argoproj/argo-cd/gitops-engine/v3/pkg/sync/common"
 )
 
-var now = metav1.Now()
-var later = metav1.NewTime(now.Add(time.Hour))
+var (
+	now   = metav1.Now()
+	later = metav1.NewTime(now.Add(time.Hour))
+)
 
 func Test_getInfos(t *testing.T) {
 	testCases := []struct {
@@ -2740,46 +2742,46 @@ func TestIsContextCanceledErr(t *testing.T) {
 
 func TestFormatPendingResources(t *testing.T) {
 	tests := []struct {
-		name      string
-		pending   []string
+		name       string
+		pending    []string
 		maxPending uint
-		expected  string
+		expected   string
 	}{
 		{
-			name:      "empty list",
-			pending:   []string{},
+			name:       "empty list",
+			pending:    []string{},
 			maxPending: 10,
-			expected:  "",
+			expected:   "",
 		},
 		{
-			name:      "below limit",
-			pending:   []string{"a", "b", "c"},
+			name:       "below limit",
+			pending:    []string{"a", "b", "c"},
 			maxPending: 10,
-			expected:  "a, b, c",
+			expected:   "a, b, c",
 		},
 		{
-			name:      "exactly at limit",
-			pending:   []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"},
+			name:       "exactly at limit",
+			pending:    []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"},
 			maxPending: 10,
-			expected:  "a, b, c, d, e, f, g, h, i, j",
+			expected:   "a, b, c, d, e, f, g, h, i, j",
 		},
 		{
-			name:      "above limit",
-			pending:   []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"},
+			name:       "above limit",
+			pending:    []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"},
 			maxPending: 10,
-			expected:  "a, b, c, d, e, f, g, h, i, j, ... and 1 more",
+			expected:   "a, b, c, d, e, f, g, h, i, j, ... and 1 more",
 		},
 		{
-			name:      "custom maxPending=5",
-			pending:   []string{"a", "b", "c", "d", "e", "f", "g"},
+			name:       "custom maxPending=5",
+			pending:    []string{"a", "b", "c", "d", "e", "f", "g"},
 			maxPending: 5,
-			expected:  "a, b, c, d, e, ... and 2 more",
+			expected:   "a, b, c, d, e, ... and 2 more",
 		},
 		{
-			name:      "zero maxPending defaults to 10",
-			pending:   []string{"a", "b", "c"},
+			name:       "zero maxPending defaults to 10",
+			pending:    []string{"a", "b", "c"},
 			maxPending: 0,
-			expected:  "a, b, c",
+			expected:   "a, b, c",
 		},
 	}
 

--- a/cmd/argocd/commands/app_test.go
+++ b/cmd/argocd/commands/app_test.go
@@ -52,6 +52,9 @@ import (
 	synccommon "github.com/argoproj/argo-cd/gitops-engine/v3/pkg/sync/common"
 )
 
+var now = metav1.Now()
+var later = metav1.NewTime(now.Add(time.Hour))
+
 func Test_getInfos(t *testing.T) {
 	testCases := []struct {
 		name          string
@@ -2783,6 +2786,117 @@ func TestFormatPendingResources(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := formatPendingResources(tt.pending, tt.maxPending)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsOperationInProgress(t *testing.T) {
+	tests := []struct {
+		name     string
+		app      *v1alpha1.Application
+		expected bool
+	}{
+		{
+			name:     "nil operation and nil operation state",
+			app:      &v1alpha1.Application{},
+			expected: false,
+		},
+		{
+			name: "active operation requested",
+			app: &v1alpha1.Application{
+				Operation: &v1alpha1.Operation{Sync: &v1alpha1.SyncOperation{}},
+			},
+			expected: true,
+		},
+		{
+			name: "operation state with nil FinishedAt",
+			app: &v1alpha1.Application{
+				Status: v1alpha1.ApplicationStatus{
+					OperationState: &v1alpha1.OperationState{
+						FinishedAt: nil,
+						Operation:  v1alpha1.Operation{Sync: &v1alpha1.SyncOperation{}},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "operation finished but not reconciled",
+			app: &v1alpha1.Application{
+				Status: v1alpha1.ApplicationStatus{
+					OperationState: &v1alpha1.OperationState{
+						FinishedAt: &now,
+						Operation:  v1alpha1.Operation{Sync: &v1alpha1.SyncOperation{}},
+					},
+					ReconciledAt: nil,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "operation finished and reconciled",
+			app: &v1alpha1.Application{
+				Status: v1alpha1.ApplicationStatus{
+					OperationState: &v1alpha1.OperationState{
+						FinishedAt: &now,
+						Operation:  v1alpha1.Operation{Sync: &v1alpha1.SyncOperation{}},
+					},
+					ReconciledAt: &later,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "dry-run operation finished",
+			app: &v1alpha1.Application{
+				Status: v1alpha1.ApplicationStatus{
+					OperationState: &v1alpha1.OperationState{
+						FinishedAt: &now,
+						Operation: v1alpha1.Operation{
+							Sync: &v1alpha1.SyncOperation{DryRun: true},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isOperationInProgress(tt.app)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFormatResourceStateLabel(t *testing.T) {
+	tests := []struct {
+		name     string
+		state    *resourceState
+		expected string
+	}{
+		{
+			name:     "regular resource",
+			state:    &resourceState{Group: "apps", Kind: "Deployment", Name: "my-app", Status: "Synced", Health: "Healthy"},
+			expected: "apps/Deployment//my-app (sync: Synced, health: Healthy)",
+		},
+		{
+			name:     "hook resource",
+			state:    &resourceState{Group: "", Kind: "Pod", Name: "hook-pod", Status: "Succeeded", Health: "HookResult", Hook: "PreSync"},
+			expected: "/Pod//hook-pod (hook: Succeeded, result: HookResult)",
+		},
+		{
+			name:     "hook with empty health",
+			state:    &resourceState{Group: "batch", Kind: "Job", Name: "hook-job", Status: "Running", Health: "", Hook: "Sync"},
+			expected: "batch/Job//hook-job (hook: Running, result: )",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatResourceStateLabel(tt.state)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/cmd/argocd/commands/app_test.go
+++ b/cmd/argocd/commands/app_test.go
@@ -2644,7 +2644,7 @@ func (c *fakeAcdClient) NewSettingsClient() (io.Closer, settingspkg.SettingsServ
 }
 
 func (c *fakeAcdClient) NewSettingsClientOrDie() (io.Closer, settingspkg.SettingsServiceClient) {
-	return nil, nil
+	return &fakeConnection{}, &fakeSettingsServiceClient{}
 }
 
 func (c *fakeAcdClient) NewVersionClient() (io.Closer, versionpkg.VersionServiceClient, error) {

--- a/docs/user-guide/commands/argocd_app_rollback.md
+++ b/docs/user-guide/commands/argocd_app_rollback.md
@@ -11,11 +11,12 @@ argocd app rollback APPNAME [ID] [flags]
 ### Options
 
 ```
-  -N, --app-namespace string   Rollback application in namespace
-  -h, --help                   help for rollback
-  -o, --output string          Output format. One of: json|yaml|wide|tree|tree=detailed (default "wide")
-      --prune                  Allow deleting unexpected resources
-      --timeout uint           Time out after this many seconds
+  -N, --app-namespace string         Rollback application in namespace
+  -h, --help                         help for rollback
+      --max-pending-resources uint   Maximum number of pending resources to display in timeout error messages (default 10)
+  -o, --output string                Output format. One of: json|yaml|wide|tree|tree=detailed (default "wide")
+      --prune                        Allow deleting unexpected resources
+      --timeout uint                 Time out after this many seconds
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_app_sync.md
+++ b/docs/user-guide/commands/argocd_app_sync.md
@@ -54,6 +54,7 @@ argocd app sync [APPNAME... | -l selector | --project project-name] [flags]
       --label stringArray                                 Sync only specific resources with a label. This option may be specified repeatedly.
       --local string                                      Path to a local directory. When this flag is present no git queries will be made
       --local-repo-root string                            Path to the repository root. Used together with --local allows setting the repository root (default "/")
+      --max-pending-resources uint                        Maximum number of pending resources to display in timeout error messages (default 10)
   -o, --output string                                     Output format. One of: json|yaml|wide|tree|tree=detailed (default "wide")
       --preview-changes                                   Preview difference against the target and live state before syncing app and wait for user confirmation
       --project stringArray                               Sync apps that belong to the specified projects. This option may be specified repeatedly.

--- a/docs/user-guide/commands/argocd_app_wait.md
+++ b/docs/user-guide/commands/argocd_app_wait.md
@@ -38,19 +38,20 @@ argocd app wait [APPNAME.. | -l selector] [flags]
 ### Options
 
 ```
-  -N, --app-namespace string   Only wait for an application  in namespace
-      --degraded               Wait for degraded
-      --delete                 Wait for delete
-      --health                 Wait for health
-  -h, --help                   help for wait
-      --hydrated               Wait for hydration operations
-      --operation              Wait for pending operations
-  -o, --output string          Output format. One of: json|yaml|wide|tree|tree=detailed (default "wide")
-      --resource stringArray   Sync only specific resources as GROUP:KIND:NAME or !GROUP:KIND:NAME. Fields may be blank and '*' can be used. This option may be specified repeatedly
-  -l, --selector string        Wait for apps by label. Supports '=', '==', '!=', in, notin, exists & not exists. Matching apps must satisfy all of the specified label constraints.
-      --suspended              Wait for suspended
-      --sync                   Wait for sync
-      --timeout uint           Time out after this many seconds
+  -N, --app-namespace string         Only wait for an application  in namespace
+      --degraded                     Wait for degraded
+      --delete                       Wait for delete
+      --health                       Wait for health
+  -h, --help                         help for wait
+      --hydrated                     Wait for hydration operations
+      --max-pending-resources uint   Maximum number of pending resources to display in timeout error messages (default 10)
+      --operation                    Wait for pending operations
+  -o, --output string                Output format. One of: json|yaml|wide|tree|tree=detailed (default "wide")
+      --resource stringArray         Sync only specific resources as GROUP:KIND:NAME or !GROUP:KIND:NAME. Fields may be blank and '*' can be used. This option may be specified repeatedly
+  -l, --selector string              Wait for apps by label. Supports '=', '==', '!=', in, notin, exists & not exists. Matching apps must satisfy all of the specified label constraints.
+      --suspended                    Wait for suspended
+      --sync                         Wait for sync
+      --timeout uint                 Time out after this many seconds
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
## Summary

Add `--max-pending-resources` flag to `argocd app wait`, `sync`, and `rollback` commands to make the hard-coded 10-entry cap in `formatPendingResources` user-configurable.

Fixes #29031 (follow-up to #26651)

## Changes

- **`formatPendingResources`**: New function that truncates the pending resource list at a configurable limit (replaces the TODO from #26651)
- **`appHydrationFinished`**: Extracted helper from `checkAppWaitConditions` (from #26651)
- **Improved timeout errors**: Timeout messages now include actionable detail:
  - App-level aggregate status (sync, health, operation, hydration)
  - List of not-ready resources with their sync/health states
  - Hook resources that completed successfully are excluded
- **New flag**: `--max-pending-resources` (default: 10, preserving current behavior)
- **Tests**: Unit tests for `formatPendingResources`, `appHydrationFinished`, timeout error formatting, and custom limit behavior

## Call sites

The flag is added to all three commands that call `waitOnApplicationStatus`:
- `argocd app wait`
- `argocd app sync`
- `argocd app rollback`

## Example

```bash
# Show up to 20 pending resources in timeout errors
argocd app wait my-app --max-pending-resources 20

# Default behavior (10 entries) preserved
argocd app wait my-app
```

## Note

This PR also includes the changes from #26651 (`appHydrationFinished`, `formatPendingResources`, improved timeout messages) since those are prerequisite for the configurable limit. Please review and merge #26651 first, or merge this PR as a replacement.