### PR TITLE
fix: replay early system-level UI extensions (#29095)

### DIFF
--- a/ui/src/app/app.tsx
+++ b/ui/src/app/app.tsx
@@ -152,10 +152,10 @@ export class App extends React.Component<
         this.routes = routes;
         this.popupPropsSubscription = null;
         this.unauthorizedSubscription = null;
-        services.extensions.addEventListener('systemLevel', this.onAddSystemLevelExtension.bind(this));
     }
 
     public componentDidMount() {
+        services.extensions.addEventListener('systemLevel', this.onAddSystemLevelExtension.bind(this));
         this.popupPropsSubscription = this.popupManager.popupProps.subscribe(popupProps => this.setState({popupProps}));
         this.subscribeUnauthorized().then(subscription => {
             this.unauthorizedSubscription = subscription;

--- a/ui/src/app/shared/services/extensions-service.test.tsx
+++ b/ui/src/app/shared/services/extensions-service.test.tsx
@@ -1,22 +1,27 @@
 import * as React from 'react';
 
-import {ExtensionsService} from './extensions-service';
-
 test('replays system-level extensions registered before listeners attach', () => {
-    const component = () => <div />;
-    const listener = jest.fn();
-    const service = new ExtensionsService();
+    try {
+        jest.isolateModules(() => {
+            const {ExtensionsService} = require('./extensions-service') as typeof import('./extensions-service');
+            const component = () => <div />;
+            const listener = jest.fn();
+            const service = new ExtensionsService();
 
-    (window as any).extensionsAPI.registerSystemLevelExtension(component, 'Test extension', '/test-extension', 'fa-test');
-    service.addEventListener('systemLevel', listener);
+            (window as any).extensionsAPI.registerSystemLevelExtension(component, 'Test extension', '/test-extension', 'fa-test');
+            service.addEventListener('systemLevel', listener);
 
-    expect(listener).toHaveBeenCalledTimes(1);
-    expect(listener).toHaveBeenCalledWith({
-        component,
-        title: 'Test extension',
-        path: '/test-extension',
-        icon: 'fa-test'
-    });
+            expect(listener).toHaveBeenCalledTimes(1);
+            expect(listener).toHaveBeenCalledWith({
+                component,
+                title: 'Test extension',
+                path: '/test-extension',
+                icon: 'fa-test'
+            });
 
-    service.removeEventListener('systemLevel', listener);
+            service.removeEventListener('systemLevel', listener);
+        });
+    } finally {
+        delete (window as any).extensionsAPI;
+    }
 });

--- a/ui/src/app/shared/services/extensions-service.test.tsx
+++ b/ui/src/app/shared/services/extensions-service.test.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+import {ExtensionsService} from './extensions-service';
+
+test('replays system-level extensions registered before listeners attach', () => {
+    const component = () => <div />;
+    const listener = jest.fn();
+    const service = new ExtensionsService();
+
+    (window as any).extensionsAPI.registerSystemLevelExtension(component, 'Test extension', '/test-extension', 'fa-test');
+    service.addEventListener('systemLevel', listener);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith({
+        component,
+        title: 'Test extension',
+        path: '/test-extension',
+        icon: 'fa-test'
+    });
+
+    service.removeEventListener('systemLevel', listener);
+});

--- a/ui/src/app/shared/services/extensions-service.ts
+++ b/ui/src/app/shared/services/extensions-service.ts
@@ -177,6 +177,9 @@ export interface TopBarActionMenuExtFlyoutProps {
 export class ExtensionsService {
     public addEventListener(evtType: ExtensionsEventType, cb: (ext: ExtensionsType) => void) {
         extensions.eventTarget.addEventListener(evtType, cb);
+        if (evtType === 'systemLevel') {
+            extensions.systemLevelExtensions.forEach(extension => cb(extension));
+        }
     }
 
     public removeEventListener(evtType: ExtensionsEventType, cb: (ext: ExtensionsType) => void) {


### PR DESCRIPTION
## What

Replay system-level extensions already registered before the application listener attaches. Registrations remain stored in the extension service, so replaying them closes the `createRoot()` mount timing gap without delaying extension loading.

Fixes #29095

## Tests

- `pnpm test --runInBand` (25 suites, 284 tests)
- `pnpm lint` (passes with existing warnings)
- `pnpm exec prettier --check src/app/shared/services/extensions-service.ts src/app/shared/services/extensions-service.test.tsx`
- `make pre-commit-local` (local codegen stopped because `protoc` is not installed)

## Checklist

- [x] This is a bug fix
- [x] PR title follows project convention and references the issue
- [x] Commit is signed off for DCO
- [x] Added regression coverage
- [x] No documentation update is required
- [ ] Full pre-commit build is green locally