### PR TITLE
fix: Support rabbitmq scale to zero in health check

### DIFF
--- a/resource_customizations/rabbitmq.com/RabbitmqCluster/health.lua
+++ b/resource_customizations/rabbitmq.com/RabbitmqCluster/health.lua
@@ -18,6 +18,7 @@ if obj.status ~= nil then
       if condition.type == "AllReplicasReady" then
         allReplicasReady.status = condition.status
         allReplicasReady.message = condition.message
+        allReplicasReady.reason = condition.reason
       end
     end
 
@@ -27,6 +28,12 @@ if obj.status ~= nil then
     if clusterAvailable.status == "Unknown" or allReplicasReady.status == "Unknown" then
       hs.status = "Progressing"
       hs.message = "Waiting for RabbitMQ cluster readiness (conditions unknown)"
+      return hs
+    end
+
+    if (allReplicasReady.reason == "ScaledToZero" and allReplicasReady.status == "False" and obj.spec.replicas == 0) then
+      hs.status = "Suspended"
+      hs.message = "RabbitmqCluster is scaled to 0 replicas"
       return hs
     end
 

--- a/resource_customizations/rabbitmq.com/RabbitmqCluster/health_test.yaml
+++ b/resource_customizations/rabbitmq.com/RabbitmqCluster/health_test.yaml
@@ -4,6 +4,10 @@ tests:
     message: Unknown 'foo' parameter
   inputPath: testdata/degraded_badconfig.yaml
 - healthStatus:
+    status: Suspended
+    message: RabbitmqCluster is scaled to 0 replicas
+  inputPath: testdata/scaled_to_zero.yaml
+- healthStatus:
     status: Progressing
     message: Waiting for RabbitMQ cluster readiness (conditions unknown)
   inputPath: testdata/degraded_cluster_unknown.yaml

--- a/resource_customizations/rabbitmq.com/RabbitmqCluster/testdata/scaled_to_zero.yaml
+++ b/resource_customizations/rabbitmq.com/RabbitmqCluster/testdata/scaled_to_zero.yaml
@@ -1,0 +1,43 @@
+apiVersion: rabbitmq.com/v1beta1
+kind: RabbitmqCluster
+metadata:
+  labels:
+    app: example-rabbitmq
+  name: example-rabbitmq
+  namespace: example
+spec:
+  image: docker.io/bitnami/rabbitmq:3.10.7-debian-11-r8
+  persistence:
+    storage: 32Gi
+    storageClassName: default
+  rabbitmq:
+  replicas: 0
+  resources:
+    limits:
+      cpu: 250m
+      memory: 1792Mi
+    requests:
+      cpu: 250m
+      memory: 1792Mi
+  service:
+    type: ClusterIP
+status:
+  conditions:
+  - lastTransitionTime: '2026-08-07T06:28:20Z'
+    reason: ScaledToZero
+    status: 'False'
+    type: AllReplicasReady
+  - lastTransitionTime: '2026-08-07T06:29:03Z'
+    message: The service has no endpoints available
+    reason: NoEndpointsAvailable
+    status: 'False'
+    type: ClusterAvailable
+  - lastTransitionTime: '2026-08-05T07:30:25Z'
+    reason: NoWarnings
+    status: 'True'
+    type: NoWarnings
+  - lastTransitionTime: '2026-08-05T07:31:28Z'
+    message: Finish reconciling
+    reason: Success
+    status: 'True'
+    type: ReconcileSuccess


### PR DESCRIPTION
RabbitMQCluster resource supports replicas: 0 since v2.16.0. This sets the status fields a bit different as currently expected. Right now the rabbit-cluster has message: "Waiting for RabbitMQ cluster formation", while still in status Progressing.

With this change the status changes to Suspended, with a custom message, similar to how its done for other resources that support scale to zero.

As reference, scale to zero support for the rabbitmq operator was added in: https://github.com/rabbitmq/cluster-operator/pull/1899

Could this please be backported to 3.5?

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
