### PR TITLE
fix(controller): do not complete a hook phase on AlreadyExists (#29100)

### DIFF
--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -95,10 +95,16 @@ type MockKubectl struct {
 
 	DeletedResources []kube.ResourceKey
 	CreatedResources []*unstructured.Unstructured
+	// CreateErrors maps a resource name to the error CreateResource returns instead
+	// of delegating, so a test can simulate the API server rejecting a create.
+	CreateErrors map[string]error
 }
 
 func (m *MockKubectl) CreateResource(ctx context.Context, config *rest.Config, gvk schema.GroupVersionKind, name string, namespace string, obj *unstructured.Unstructured, createOptions metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error) {
 	m.CreatedResources = append(m.CreatedResources, obj)
+	if err, ok := m.CreateErrors[name]; ok {
+		return nil, err
+	}
 	return m.Kubectl.CreateResource(ctx, config, gvk, name, namespace, obj, createOptions, subresources...)
 }
 
@@ -1252,6 +1258,44 @@ func TestFinalizeAppDeletion(t *testing.T) {
 		// pre-delete hook is created
 		require.Len(t, ctrl.kubectl.(*MockKubectl).CreatedResources, 1)
 		require.Equal(t, "pre-delete-hook", ctrl.kubectl.(*MockKubectl).CreatedResources[0].GetName())
+	})
+
+	t.Run("PreDelete_HookAlreadyExistsIsNotCompletion", func(t *testing.T) {
+		// Regression test for https://github.com/argoproj/argo-cd/issues/29100.
+		// An earlier pass created the hook, but this pass still sees an empty
+		// cluster cache, so the create is rejected with AlreadyExists. That proves
+		// the live state is stale, and the phase must not be reported complete:
+		// doing so drops the finalizer and cascade deletion takes the hook with it.
+		app := newFakeApp()
+		app.SetPreDeleteFinalizer()
+		app.Spec.Destination.Namespace = test.FakeArgoCDNamespace
+		ctrl := newFakeController(t.Context(), &fakeData{
+			manifestResponses: []*apiclient.ManifestResponse{{
+				Manifests: []string{fakePreDeleteHook},
+			}},
+			apps:            []runtime.Object{app, &defaultProj},
+			managedLiveObjs: map[kube.ResourceKey]*unstructured.Unstructured{},
+		}, nil)
+		ctrl.kubectl.(*MockKubectl).CreateErrors = map[string]error{
+			"pre-delete-hook": apierrors.NewAlreadyExists(schema.GroupResource{Resource: "pods"}, "pre-delete-hook"),
+		}
+
+		patched := false
+		fakeAppCs := ctrl.applicationClientset.(*appclientset.Clientset)
+		defaultReactor := fakeAppCs.ReactionChain[0]
+		fakeAppCs.ReactionChain = nil
+		fakeAppCs.AddReactor("get", "*", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+			return defaultReactor.React(action)
+		})
+		fakeAppCs.AddReactor("patch", "*", func(_ kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+			patched = true
+			return true, &v1alpha1.Application{}, nil
+		})
+		err := ctrl.finalizeApplicationDeletion(t.Context(), app, func(_ string) ([]*v1alpha1.Cluster, error) {
+			return []*v1alpha1.Cluster{}, nil
+		})
+		require.NoError(t, err)
+		assert.False(t, patched, "finalizer must stay until the hook is observed in the live state")
 	})
 
 	t.Run("PreDelete_HookIsCreatedForLongAppName", func(t *testing.T) {

--- a/controller/hook.go
+++ b/controller/hook.go
@@ -150,6 +150,9 @@ func (ctrl *ApplicationController) executeHooks(ctx context.Context, hookType Ho
 
 	// Create hooks that don't exist yet
 	createdCnt := 0
+	// existingCnt counts hooks whose create was rejected because they already
+	// exist. That proves liveObjs is stale, so this pass must not report completion.
+	existingCnt := 0
 	for key, obj := range expectedHook {
 		// Apply app instance tracking metadata so the hook can be tracked and cleaned up.
 		// Use the same code path as regular sync resources so the configured
@@ -165,7 +168,8 @@ func (ctrl *ApplicationController) executeHooks(ctx context.Context, hookType Ho
 		_, err = ctrl.kubectl.CreateResource(ctx, config, obj.GroupVersionKind(), obj.GetName(), obj.GetNamespace(), obj, metav1.CreateOptions{})
 		if err != nil {
 			if apierrors.IsAlreadyExists(err) {
-				logCtx.Warnf("Hook resource %s already exists, skipping", key)
+				existingCnt++
+				logCtx.Warnf("Hook resource %s already exists but is missing from the live state; waiting for the cluster cache to catch up", key)
 				continue
 			}
 			return false, err
@@ -234,6 +238,14 @@ func (ctrl *ApplicationController) executeHooks(ctx context.Context, hookType Ho
 
 	if progressingHooksCount > 0 {
 		logCtx.Infof("Waiting for %d %s hooks to complete", progressingHooksCount, hookType)
+		return false, nil
+	}
+
+	// The hooks judged above are the ones liveObjs knew about, and existingCnt says
+	// it did not know about all of them. Failures and progress are still worth
+	// reporting from a partial view, but completion is not.
+	if existingCnt > 0 {
+		logCtx.Infof("Waiting for the cluster cache to observe %d existing %s hook(s)", existingCnt, hookType)
 		return false, nil
 	}
 


### PR DESCRIPTION
Fixes #29100

`executeHooks` builds `runningHooks` from `liveObjs`, which is a cluster cache snapshot. Deleting an Application produces a burst of updates, so several finalization passes can run before that cache catches up. When an earlier pass has already created the hook and the current pass still sees an empty cache, the hook is back in `expectedHook`, the create returns `AlreadyExists`, and today that error is dropped with a warning and a `continue`.

Everything downstream then reads as success. `createdCnt` is still 0, so the "created hooks, wait" return is skipped, and the health loop runs over an empty `runningHooks`: nothing progressing, nothing failed, phase complete. For `PreDelete` that removes the finalizer and cascade deletion takes the hook with it, seconds after it was created and before it ever ran. `PostDelete` shares the function and behaves the same way.

`AlreadyExists` is the API server telling us the snapshot we just made a decision from is incomplete, so the fix counts it and waits, which is exactly what the phase already does after creating a hook. The wait is not new behaviour, this case was simply skipping it.

I kept the `continue` rather than returning as soon as the first `AlreadyExists` shows up. `expectedHook` is a map, so an early return would leave the remaining hooks uncreated on this pass and make progress depend on map iteration order.

#### One consequence worth flagging

If the name belongs to something that is not a hook of this type, it never lands in `runningHooks`, so the phase now waits indefinitely instead of declaring itself complete. That trade is deliberate for a `PreDelete` hook, where stalling deletion is much safer than skipping the hook and deleting anyway, but it is a behaviour change and I would rather say so than have it found later.

Closing that hole properly means a live `GET` on `AlreadyExists` and a decision based on tracking metadata: owned by this Application means keep waiting, owned by another Application means report a collision, and no tracking metadata means we must not assume it is ours. That needs the tracking-method handling to be threaded through and is worth its own PR rather than growing this one. Glad to follow up with it if you agree with the shape.

#### Testing

`TestFinalizeAppDeletion/PreDelete_HookAlreadyExistsIsNotCompletion` drives the real path: an empty live state, a manifest carrying the `PreDelete` hook, and a create that returns `AlreadyExists`. It asserts the finalizer is still there afterwards. Reverting only `controller/hook.go` makes it fail with `patched == true`, which is the bug: the finalizer had been removed.

`MockKubectl` grew a `CreateErrors` map so a test can make a create fail. It is nil in every existing test, so they all keep the current delegate path.

#### Cherry-pick

This is a data-loss-shaped bug for anyone relying on `PreDelete` hooks, and the change is small and self-contained, so it looks like a reasonable candidate for the active release branches. Happy to open the backports once you tell me how far back you want it.

---

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR. (none required, the change is not user-configurable)
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines. (not a new feature)
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).
