### PR TITLE
fix(repository): keep OCI sources out of Git revision checks

### DIFF
--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -3480,12 +3480,13 @@ func (s *Service) UpdateRevisionForPaths(ctx context.Context, request *apiclient
 	// Determine whether the main source is a git source. A type that Normalize defaulted
 	// to git must not be trusted on its own: an untyped Helm chart source would then have
 	// its revision resolved against the chart repository URL as if it were a git repo and
-	// fail with "repository not found" (issue #28890). In that case fall back to the
-	// application source type.
+	// fail with "repository not found" (issue #28890). OCI sources are identified by their
+	// URL and must never enter the Git revision path, even when a repository secret has
+	// persisted the default git type (issue #29058).
 	isGitSource := repo.Type == "git"
-	if isGitSource && typeWasUnset && request.ApplicationSource != nil &&
-		(request.ApplicationSource.IsHelm() || request.ApplicationSource.IsOCI()) {
-		isGitSource = false
+	if isGitSource && request.ApplicationSource != nil {
+		isGitSource = !(request.ApplicationSource.IsOCI() ||
+			typeWasUnset && request.ApplicationSource.IsHelm())
 	}
 
 	if len(refreshPaths) == 0 {

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -3485,8 +3485,8 @@ func (s *Service) UpdateRevisionForPaths(ctx context.Context, request *apiclient
 	// persisted the default git type (issue #29058).
 	isGitSource := repo.Type == "git"
 	if isGitSource && request.ApplicationSource != nil {
-		isGitSource = !(request.ApplicationSource.IsOCI() ||
-			typeWasUnset && request.ApplicationSource.IsHelm())
+		isGitSource = !request.ApplicationSource.IsOCI() &&
+			(!typeWasUnset || !request.ApplicationSource.IsHelm())
 	}
 
 	if len(refreshPaths) == 0 {

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -5079,6 +5079,20 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 				Paths:          []string{"."},
 			},
 		}, want: &apiclient.UpdateRevisionForPathsResponse{}, wantErr: assert.NoError},
+		{name: "OCIRepoWithExplicitGitTypeShortCircuits", fields: func() fields {
+			s, _, c := newServiceWithOpt(t, func(_ *gitmocks.Client, _ *helmmocks.Client, _ *ocimocks.Client, _ *iomocks.TempPaths) {
+			}, ".")
+			return fields{service: s, cache: c}
+		}(), args: args{
+			ctx: t.Context(),
+			request: &apiclient.UpdateRevisionForPathsRequest{
+				Repo:              &v1alpha1.Repository{Repo: "oci://example.com/foo", Type: "git"},
+				Revision:          "1.0.0",
+				SyncedRevision:    "0.9.0",
+				Paths:             []string{"."},
+				ApplicationSource: &v1alpha1.ApplicationSource{RepoURL: "oci://example.com/foo", Path: "."},
+			},
+		}, want: &apiclient.UpdateRevisionForPathsResponse{}, wantErr: assert.NoError},
 		{name: "SameResolvedRevisionAbort", fields: func() fields {
 			s, _, c := newServiceWithOpt(t, func(gitClient *gitmocks.Client, _ *helmmocks.Client, _ *ocimocks.Client, paths *iomocks.TempPaths) {
 				gitClient.EXPECT().Checkout(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)


### PR DESCRIPTION
Fixes #29058

## Summary

OCI application sources can enter the Git revision/path comparison path when a repository secret carries the default `git` type. That causes reconciliation to call Git ref resolution against an `oci://` URL and intermittently mark the application `Unknown`.

Treat an OCI source URL as authoritative when deciding whether `UpdateRevisionForPaths` should perform Git checks, while preserving the existing compatibility behavior for untyped Helm sources and explicitly configured Git repositories.

## Testing

- `go test ./reposerver/repository -run TestUpdateRevisionForPaths -count=1`
- `go vet ./reposerver/repository`

Signed-off-by: iroiro147 <iroiro147@users.noreply.github.com>