### PR TITLE
fix(appset): prefer GitHub App enterprise API URL

### DIFF
--- a/applicationset/services/internal/github_app/client.go
+++ b/applicationset/services/internal/github_app/client.go
@@ -33,9 +33,7 @@ func getInstallationClient(g github_app_auth.Authentication, url string, httpCli
 		return nil, fmt.Errorf("failed to create GitHub installation transport: %w", err)
 	}
 
-	if url == "" {
-		url = g.EnterpriseBaseURL
-	}
+	url = resolveAPIURL(g, url)
 
 	var client *github.Client
 	if url == "" {
@@ -53,9 +51,7 @@ func getInstallationClient(g github_app_auth.Authentication, url string, httpCli
 
 // Client builds a github client for the given app authentication.
 func Client(ctx context.Context, g github_app_auth.Authentication, url, org string, optionalHTTPClient ...*http.Client) (*github.Client, error) {
-	if url == "" {
-		url = g.EnterpriseBaseURL
-	}
+	url = resolveAPIURL(g, url)
 
 	// If an installation ID is already provided, use it directly.
 	if g.InstallationId != 0 {
@@ -71,4 +67,11 @@ func Client(ctx context.Context, g github_app_auth.Authentication, url, org stri
 
 	g.InstallationId = installationId
 	return getInstallationClient(g, url, optionalHTTPClient...)
+}
+
+func resolveAPIURL(g github_app_auth.Authentication, configuredURL string) string {
+	if g.EnterpriseBaseURL != "" {
+		return g.EnterpriseBaseURL
+	}
+	return configuredURL
 }

--- a/applicationset/services/internal/github_app/client_test.go
+++ b/applicationset/services/internal/github_app/client_test.go
@@ -1,0 +1,18 @@
+package github_app
+
+import (
+	"testing"
+
+	"github.com/argoproj/argo-cd/v3/applicationset/services/github_app_auth"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveAPIURLPrefersCredentialEnterpriseURL(t *testing.T) {
+	enterpriseURL := "https://api.example.ghe.com"
+	configuredURL := "https://api.other.example.com"
+
+	assert.Equal(t, enterpriseURL, resolveAPIURL(github_app_auth.Authentication{
+		EnterpriseBaseURL: enterpriseURL,
+	}, configuredURL))
+	assert.Equal(t, configuredURL, resolveAPIURL(github_app_auth.Authentication{}, configuredURL))
+}

--- a/applicationset/services/internal/github_app/client_test.go
+++ b/applicationset/services/internal/github_app/client_test.go
@@ -1,9 +1,14 @@
 package github_app
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/argoproj/argo-cd/v3/applicationset/services/github_app_auth"
 )
@@ -16,4 +21,26 @@ func TestResolveAPIURLPrefersCredentialEnterpriseURL(t *testing.T) {
 		EnterpriseBaseURL: enterpriseURL,
 	}, configuredURL))
 	assert.Equal(t, configuredURL, resolveAPIURL(github_app_auth.Authentication{}, configuredURL))
+}
+
+// Covers the call site in getInstallationClient, not just the helper: #28981 was
+// that a credential's EnterpriseBaseURL never reached the client when a URL was
+// also configured, so asserting the resolved string alone would not have caught
+// it. ghinstallation only parses the key, so this stays offline.
+func TestGetInstallationClientUsesCredentialEnterpriseURL(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	pem := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+
+	client, err := getInstallationClient(github_app_auth.Authentication{
+		Id:                1,
+		InstallationId:    2,
+		PrivateKey:        string(pem),
+		EnterpriseBaseURL: "https://api.example.ghe.com",
+	}, "https://api.other.example.com")
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.example.ghe.com/", client.BaseURL.String())
 }

--- a/applicationset/services/internal/github_app/client_test.go
+++ b/applicationset/services/internal/github_app/client_test.go
@@ -3,8 +3,9 @@ package github_app
 import (
 	"testing"
 
-	"github.com/argoproj/argo-cd/v3/applicationset/services/github_app_auth"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/argoproj/argo-cd/v3/applicationset/services/github_app_auth"
 )
 
 func TestResolveAPIURLPrefersCredentialEnterpriseURL(t *testing.T) {


### PR DESCRIPTION
Fixes #28981

## Summary

When an ApplicationSet GitHub generator uses a GitHub App repo-credentials secret, the generator API setting could override the credential’s `githubAppEnterpriseBaseUrl`. For GitHub Enterprise Data Residency, that sends installation-token requests to the wrong host and leaves generated applications unable to load repository refs.

Use the Enterprise API URL carried by the GitHub App credentials whenever it is configured, falling back to the generator API URL for credentials that do not specify one.

## Testing

- `go test ./applicationset/services/internal/github_app`
- `go vet ./applicationset/services/internal/github_app`

Signed-off-by: iroiro147 <iroiro147@users.noreply.github.com>