### PR TITLE
fix(appset): verify terminating Applications against the API server (#29042)

### DIFF
--- a/applicationset/controllers/applicationset_controller_test.go
+++ b/applicationset/controllers/applicationset_controller_test.go
@@ -5295,7 +5295,7 @@ func TestReconcileAddsFinalizer_WhenDeletionOrderReverse(t *testing.T) {
 				Metrics:                metrics,
 				EnableProgressiveSyncs: cc.progressiveSyncEnabled,
 			}
-			r.ProgressiveSyncManager = progressivesync.NewManager(r.Client, &r)
+			r.ProgressiveSyncManager = progressivesync.NewManager(r.Client, r.Client, &r)
 
 			req := ctrl.Request{
 				NamespacedName: types.NamespacedName{

--- a/applicationset/controllers/progressive_sync_dependencies_test.go
+++ b/applicationset/controllers/progressive_sync_dependencies_test.go
@@ -902,7 +902,7 @@ func TestUpdateApplicationSetApplicationStatus(t *testing.T) {
 				Metrics:       metrics,
 			}
 
-			r.ProgressiveSyncManager = appsetprogressiveSync.NewManager(r.Client, r)
+			r.ProgressiveSyncManager = appsetprogressiveSync.NewManager(r.Client, r.Client, r)
 
 			desiredApps := cc.desiredApps
 			if desiredApps == nil {
@@ -1662,7 +1662,7 @@ func TestUpdateApplicationSetApplicationStatusProgress(t *testing.T) {
 				KubeClientset: kubeclientset,
 				Metrics:       metrics,
 			}
-			r.ProgressiveSyncManager = appsetprogressiveSync.NewManager(r.Client, r)
+			r.ProgressiveSyncManager = appsetprogressiveSync.NewManager(r.Client, r.Client, r)
 
 			appStatuses, err := r.ProgressiveSyncManager.UpdateApplicationSetApplicationStatusProgress(t.Context(), log.NewEntry(log.StandardLogger()), &cc.appSet, cc.appSyncMap, cc.appStepMap)
 

--- a/applicationset/progressivesync/phantom_livecheck_test.go
+++ b/applicationset/progressivesync/phantom_livecheck_test.go
@@ -376,3 +376,70 @@ func TestSilentEvictionFailureDoesNotReleaseTheFinalizer(t *testing.T) {
 	assert.Contains(t, err.Error(), "still present after eviction",
 		"the error should say the eviction could not be confirmed, not something unrelated")
 }
+
+// A conflict on the eviction Delete stops the step, and the comment there claims that is bounded
+// because a later pass reclassifies the replacement. This pins that claim, because an unbounded
+// version of it would be the very defect this file exists to prevent: a condition that can never
+// become false, blocking RemoveFinalizer forever.
+//
+// Pass 1 sees the stale entry, confirms it absent, and the eviction Delete conflicts -- a different
+// Application now holds the name. Pass 2 sees what the informer's ADDED event left behind: the
+// replacement, which is not terminating. Reverse deletion must make progress there rather than
+// returning the same error again.
+func TestConflictOnEvictionConvergesOnALaterPass(t *testing.T) {
+	t.Parallel()
+
+	s := schemeWithApps(t)
+	phantom := agedTerminatingApp()
+
+	// The object that appeared at the same name between the live read and the eviction Delete.
+	replacement := phantom.DeepCopy()
+	replacement.UID = "99999999-8888-7777-6666-555555555555"
+	replacement.DeletionTimestamp = nil
+	replacement.Finalizers = nil
+
+	pass := 0
+	deletes := 0
+	cached := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(&phantom).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c crtclient.WithWatch, key crtclient.ObjectKey, obj crtclient.Object, opts ...crtclient.GetOption) error {
+				if key.Name == phantom.Name && pass > 1 {
+					// What the informer holds once the ADDED event for the replacement lands.
+					replacement.DeepCopyInto(obj.(*v1alpha1.Application))
+					return nil
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+			Delete: func(_ context.Context, _ crtclient.WithWatch, obj crtclient.Object, _ ...crtclient.DeleteOption) error {
+				deletes++
+				if pass == 1 {
+					return apierrors.NewConflict(schema.GroupResource{Group: "argoproj.io", Resource: "applications"}, obj.GetName(), errors.New("uid mismatch"))
+				}
+				return nil
+			},
+		}).
+		Build()
+	apiServer := fake.NewClientBuilder().WithScheme(s).Build() // the entry we confirmed absent really is gone
+
+	m := &Manager{Client: cached, APIReader: apiServer}
+
+	pass = 1
+	_, err := m.PerformReverseDeletion(t.Context(), log.NewEntry(log.New()),
+		singleStepAppSet(), []v1alpha1.Application{phantom})
+	require.Error(t, err, "pass 1: a conflict invalidates the absence verdict, so the step must not complete")
+	require.Contains(t, err.Error(), "was recreated while being confirmed as deleted",
+		"pass 1 must stop *because of the conflict*. Any error would satisfy a bare Error() assertion "+
+			"-- a conflict left non-fatal still trips the eviction check below it -- so pin the reason.")
+
+	pass = 2
+	_, err = m.PerformReverseDeletion(t.Context(), log.NewEntry(log.New()),
+		singleStepAppSet(), []v1alpha1.Application{*replacement})
+
+	require.NoError(t, err,
+		"pass 2 must make progress: the replacement is a live child, so it is deleted in its proper "+
+			"order. Returning the same error here would mean the conflict branch can never clear, "+
+			"which is the unbounded wedge this whole change removes")
+	assert.GreaterOrEqual(t, deletes, 2, "the replacement must actually be deleted on pass 2, not skipped")
+}

--- a/applicationset/progressivesync/phantom_livecheck_test.go
+++ b/applicationset/progressivesync/phantom_livecheck_test.go
@@ -75,13 +75,49 @@ func schemeWithApps(t *testing.T) *runtime.Scheme {
 	return s
 }
 
+// evictingCacheClient models the production cache-syncing client for a phantom entry: the object is
+// already gone from the API server, so the eviction Delete comes back NotFound, and the entry is then
+// removed from the informer store so cache-backed reads stop seeing it. Tests that only simulate the
+// Delete without that second half are not representative -- reverse deletion verifies the eviction
+// actually happened before it lets a step complete.
+//
+// onDelete, when set, overrides what the Delete returns; the store is only evicted when it reports
+// NotFound, mirroring execAndSyncCache.
+func evictingCacheClient(s *runtime.Scheme, app *v1alpha1.Application, onDelete func() error) crtclient.WithWatch {
+	evicted := false
+	return fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(app).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(_ context.Context, _ crtclient.WithWatch, obj crtclient.Object, _ ...crtclient.DeleteOption) error {
+				err := error(nil)
+				if onDelete != nil {
+					err = onDelete()
+				} else {
+					err = apierrors.NewNotFound(schema.GroupResource{Group: "argoproj.io", Resource: "applications"}, obj.GetName())
+				}
+				if apierrors.IsNotFound(err) {
+					evicted = true
+				}
+				return err
+			},
+			Get: func(ctx context.Context, c crtclient.WithWatch, key crtclient.ObjectKey, obj crtclient.Object, opts ...crtclient.GetOption) error {
+				if evicted && key.Name == app.Name && key.Namespace == app.Namespace {
+					return apierrors.NewNotFound(schema.GroupResource{Group: "argoproj.io", Resource: "applications"}, key.Name)
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+}
+
 func TestPhantomIsNotFatal(t *testing.T) {
 	t.Parallel()
 
 	s := schemeWithApps(t)
 	phantom := agedTerminatingApp()
 
-	cached := fake.NewClientBuilder().WithScheme(s).WithObjects(&phantom).Build()
+	cached := evictingCacheClient(s, &phantom, nil)
 	apiServer := fake.NewClientBuilder().WithScheme(s).Build() // object really gone
 
 	m := &Manager{Client: cached, APIReader: apiServer}
@@ -159,20 +195,12 @@ func TestConfirmedPhantomTriggersCacheEviction(t *testing.T) {
 	phantom := agedTerminatingApp()
 
 	deletes := 0
-	cached := fake.NewClientBuilder().
-		WithScheme(s).
-		WithObjects(&phantom).
-		WithInterceptorFuncs(interceptor.Funcs{
-			// Stand in for the real API server, which reports the object as already gone. This is
-			// the call whose NotFound drives eviction in the cache-syncing client.
-			Delete: func(_ context.Context, _ crtclient.WithWatch, obj crtclient.Object, _ ...crtclient.DeleteOption) error {
-				if obj.GetName() == phantom.Name {
-					deletes++
-				}
-				return apierrors.NewNotFound(schema.GroupResource{Group: "argoproj.io", Resource: "applications"}, obj.GetName())
-			},
-		}).
-		Build()
+	// Stand in for the real API server, which reports the object as already gone. That NotFound is
+	// what drives eviction in the cache-syncing client, which the helper then models.
+	cached := evictingCacheClient(s, &phantom, func() error {
+		deletes++
+		return apierrors.NewNotFound(schema.GroupResource{Group: "argoproj.io", Resource: "applications"}, phantom.Name)
+	})
 	apiServer := fake.NewClientBuilder().WithScheme(s).Build() // live read: object really gone
 
 	m := &Manager{Client: cached, APIReader: apiServer}
@@ -202,6 +230,7 @@ func TestEvictionDeleteIsGatedOnUID(t *testing.T) {
 
 	var deletedUID types.UID
 	var preconditionUID types.UID
+	evicted := false
 	cached := fake.NewClientBuilder().
 		WithScheme(s).
 		WithObjects(&phantom).
@@ -215,7 +244,16 @@ func TestEvictionDeleteIsGatedOnUID(t *testing.T) {
 				if do.Preconditions != nil && do.Preconditions.UID != nil {
 					preconditionUID = *do.Preconditions.UID
 				}
+				evicted = true
 				return apierrors.NewNotFound(schema.GroupResource{Group: "argoproj.io", Resource: "applications"}, obj.GetName())
+			},
+			// The cache-syncing client evicts the entry on that NotFound, so cached reads stop
+			// seeing it. Reverse deletion checks for exactly that before completing the step.
+			Get: func(ctx context.Context, c crtclient.WithWatch, key crtclient.ObjectKey, obj crtclient.Object, opts ...crtclient.GetOption) error {
+				if evicted && key.Name == phantom.Name {
+					return apierrors.NewNotFound(schema.GroupResource{Group: "argoproj.io", Resource: "applications"}, key.Name)
+				}
+				return c.Get(ctx, key, obj, opts...)
 			},
 		}).
 		Build()
@@ -300,4 +338,41 @@ func TestEvictionFailureDoesNotReleaseTheFinalizer(t *testing.T) {
 			}
 		})
 	}
+}
+
+// A nil error from the eviction Delete is not proof the entry left the informer store.
+// cacheSyncingClient.execAndSyncCache logs a failure to reach the store, or to delete from it, and
+// then returns the original error -- which for a NotFound delete is nil. Reverse deletion must not
+// take that as success: releasing the ApplicationSet's finalizer with the phantom still cached is the
+// create-only recreation failure the eviction exists to prevent, and unlike the entry's age, a store
+// failure can clear on a later attempt.
+func TestSilentEvictionFailureDoesNotReleaseTheFinalizer(t *testing.T) {
+	t.Parallel()
+
+	s := schemeWithApps(t)
+	phantom := agedTerminatingApp()
+
+	// Delete reports the object gone, as the API server would, but the entry is never evicted --
+	// the store failure the production client only logs.
+	cached := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(&phantom).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(_ context.Context, _ crtclient.WithWatch, obj crtclient.Object, _ ...crtclient.DeleteOption) error {
+				return apierrors.NewNotFound(schema.GroupResource{Group: "argoproj.io", Resource: "applications"}, obj.GetName())
+			},
+		}).
+		Build()
+	apiServer := fake.NewClientBuilder().WithScheme(s).Build() // object really gone
+
+	m := &Manager{Client: cached, APIReader: apiServer}
+
+	_, err := m.PerformReverseDeletion(t.Context(), log.NewEntry(log.New()),
+		singleStepAppSet(), []v1alpha1.Application{phantom})
+
+	require.Error(t, err,
+		"the stale entry is still readable from the cache, so this step is not complete; completing it "+
+			"would release the finalizer and leave the phantom behind")
+	assert.Contains(t, err.Error(), "still present after eviction",
+		"the error should say the eviction could not be confirmed, not something unrelated")
 }

--- a/applicationset/progressivesync/phantom_livecheck_test.go
+++ b/applicationset/progressivesync/phantom_livecheck_test.go
@@ -1,0 +1,235 @@
+package progressivesync
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	crtclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+)
+
+// release-3.4 port of the reverse-deletion live-read tests. Read all three together: they pin the
+// boundary the fix has to get right.
+//
+// performReverseDeletion only lets Reconcile remove the ApplicationSet finalizer when it returns
+// (0, nil). A terminating child must therefore be classified correctly:
+//
+//   - a phantom (still in the informer cache, already gone from the API server) must NOT block
+//     forever, or the ApplicationSet stays in Terminating until the finalizer is patched by hand;
+//   - a genuinely slow child must NOT be skipped, or the finalizer is released while a child is
+//     still terminating and deletionOrder: Reverse silently stops being enforced.
+
+func agedTerminatingApp() v1alpha1.Application {
+	deletedAt := metav1.NewTime(time.Now().Add(-10 * time.Minute))
+	return v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "appset-stage0",
+			Namespace: "argocd",
+			// Objects decoded from the API server always carry a UID; the eviction delete is gated
+			// on it, so the fixture must have one to be representative.
+			UID:               "11111111-2222-3333-4444-555555555555",
+			Labels:            map[string]string{"stage": "0"},
+			DeletionTimestamp: &deletedAt,
+			Finalizers:        []string{v1alpha1.ForegroundPropagationPolicyFinalizer},
+		},
+	}
+}
+
+func singleStepAppSet() v1alpha1.ApplicationSet {
+	return v1alpha1.ApplicationSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "appset", Namespace: "argocd"},
+		Spec: v1alpha1.ApplicationSetSpec{
+			Strategy: &v1alpha1.ApplicationSetStrategy{
+				Type:          "RollingSync",
+				DeletionOrder: ReverseDeletionOrder,
+				RollingSync: &v1alpha1.ApplicationSetRolloutStrategy{
+					Steps: []v1alpha1.ApplicationSetRolloutStep{
+						{MatchExpressions: []v1alpha1.ApplicationMatchExpression{
+							{Key: "stage", Operator: "In", Values: []string{"0"}},
+						}},
+					},
+				},
+			},
+		},
+	}
+}
+
+func schemeWithApps(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(s))
+	return s
+}
+
+func TestPhantomIsNotFatal(t *testing.T) {
+	t.Parallel()
+
+	s := schemeWithApps(t)
+	phantom := agedTerminatingApp()
+
+	cached := fake.NewClientBuilder().WithScheme(s).WithObjects(&phantom).Build()
+	apiServer := fake.NewClientBuilder().WithScheme(s).Build() // object really gone
+
+	m := &Manager{Client: cached, APIReader: apiServer}
+
+	var requeue time.Duration
+	var err error
+	for i := range 10 {
+		requeue, err = m.PerformReverseDeletion(t.Context(), log.NewEntry(log.New()),
+			singleStepAppSet(), []v1alpha1.Application{phantom})
+		require.NoErrorf(t, err, "pass %d must not error: an error here is permanent, the age it derives from only grows", i)
+		if requeue == 0 {
+			break
+		}
+	}
+
+	assert.Zero(t, requeue,
+		"a phantom must resolve to (0, nil) so Reconcile can reach RemoveFinalizer; requeue=%s means "+
+			"the ApplicationSet stays in Terminating forever", requeue)
+}
+
+func TestGenuinelySlowChildIsNotSkipped(t *testing.T) {
+	t.Parallel()
+
+	s := schemeWithApps(t)
+	slow := agedTerminatingApp()
+
+	cached := fake.NewClientBuilder().WithScheme(s).WithObjects(&slow).Build()
+	apiServer := fake.NewClientBuilder().WithScheme(s).WithObjects(&slow).Build() // really still there
+
+	m := &Manager{Client: cached, APIReader: apiServer}
+
+	_, err := m.PerformReverseDeletion(t.Context(), log.NewEntry(log.New()),
+		singleStepAppSet(), []v1alpha1.Application{slow})
+
+	require.Error(t, err,
+		"a child that still exists on the API server must not be treated as absent; returning (0, nil) "+
+			"would release the finalizer mid-teardown and break deletionOrder: Reverse")
+	assert.Contains(t, err.Error(), "has not been deleted in over 2 minutes")
+}
+
+func TestMissingAPIReaderSurfacesError(t *testing.T) {
+	t.Parallel()
+
+	s := schemeWithApps(t)
+	app := agedTerminatingApp()
+	cached := fake.NewClientBuilder().WithScheme(s).WithObjects(&app).Build()
+
+	m := &Manager{Client: cached} // APIReader deliberately nil
+
+	_, err := m.PerformReverseDeletion(t.Context(), log.NewEntry(log.New()),
+		singleStepAppSet(), []v1alpha1.Application{app})
+
+	require.Error(t, err, "an unverifiable child must not be silently skipped or silently retried")
+	assert.Contains(t, err.Error(), "could not be verified against the API server")
+}
+
+// A stale entry that the API server has confirmed absent must also be evicted from the informer
+// store, not merely skipped for this pass.
+//
+// getCurrentApplications indexes children by owner *name*, so an ApplicationSet recreated under the
+// same name inherits any leftover entry and counts it as an existing child. Under a create-only
+// policy createInCluster then filters that child out of the create set and never recreates it — and
+// because no write is attempted, nothing triggers eviction either, so the child stays missing for as
+// long as the entry survives.
+//
+// Eviction itself belongs to the cache-syncing client and is covered by
+// utils.TestDeleteEvictsStaleCacheOnNotFound: a Delete whose API call returns NotFound removes the
+// stale entry and swallows the error. What this test pins is the other half of that contract — that
+// reverse deletion actually issues the Delete once it has confirmed the object is gone. Without it
+// the two halves never meet.
+func TestConfirmedPhantomTriggersCacheEviction(t *testing.T) {
+	t.Parallel()
+
+	s := schemeWithApps(t)
+	phantom := agedTerminatingApp()
+
+	deletes := 0
+	cached := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(&phantom).
+		WithInterceptorFuncs(interceptor.Funcs{
+			// Stand in for the real API server, which reports the object as already gone. This is
+			// the call whose NotFound drives eviction in the cache-syncing client.
+			Delete: func(_ context.Context, _ crtclient.WithWatch, obj crtclient.Object, _ ...crtclient.DeleteOption) error {
+				if obj.GetName() == phantom.Name {
+					deletes++
+				}
+				return apierrors.NewNotFound(schema.GroupResource{Group: "argoproj.io", Resource: "applications"}, obj.GetName())
+			},
+		}).
+		Build()
+	apiServer := fake.NewClientBuilder().WithScheme(s).Build() // live read: object really gone
+
+	m := &Manager{Client: cached, APIReader: apiServer}
+
+	requeue, err := m.PerformReverseDeletion(t.Context(), log.NewEntry(log.New()),
+		singleStepAppSet(), []v1alpha1.Application{phantom})
+	require.NoError(t, err)
+	require.Zero(t, requeue, "a confirmed-absent child must not hold up reverse deletion")
+
+	assert.Positive(t, deletes,
+		"reverse deletion must issue a Delete for a child the API server has confirmed gone, so the "+
+			"cache-syncing client evicts the stale entry; otherwise an ApplicationSet recreated under "+
+			"this name treats it as an existing child and never recreates it")
+}
+
+// The eviction Delete must not remove a different object that has appeared at the same name.
+//
+// Between the live read that confirms absence and the Delete issued to trigger cache eviction, an
+// Application can be created at the same name/namespace. An unconditional delete by name would
+// remove it. The delete is therefore gated on the stale entry's UID, so the API server rejects it as
+// a conflict and the new object survives.
+func TestEvictionDeleteIsGatedOnUID(t *testing.T) {
+	t.Parallel()
+
+	s := schemeWithApps(t)
+	phantom := agedTerminatingApp()
+
+	var deletedUID types.UID
+	var preconditionUID types.UID
+	cached := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(&phantom).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(_ context.Context, _ crtclient.WithWatch, obj crtclient.Object, opts ...crtclient.DeleteOption) error {
+				deletedUID = obj.GetUID()
+				do := &crtclient.DeleteOptions{}
+				for _, o := range opts {
+					o.ApplyToDelete(do)
+				}
+				if do.Preconditions != nil && do.Preconditions.UID != nil {
+					preconditionUID = *do.Preconditions.UID
+				}
+				return apierrors.NewNotFound(schema.GroupResource{Group: "argoproj.io", Resource: "applications"}, obj.GetName())
+			},
+		}).
+		Build()
+	apiServer := fake.NewClientBuilder().WithScheme(s).Build() // object really gone
+
+	m := &Manager{Client: cached, APIReader: apiServer}
+
+	requeue, err := m.PerformReverseDeletion(t.Context(), log.NewEntry(log.New()),
+		singleStepAppSet(), []v1alpha1.Application{phantom})
+	require.NoError(t, err)
+	require.Zero(t, requeue)
+
+	assert.NotEmpty(t, preconditionUID,
+		"the eviction Delete must carry a UID precondition, otherwise an Application created at this "+
+			"name between the live read and the delete would be removed instead")
+	assert.Equal(t, deletedUID, preconditionUID,
+		"the precondition must pin the UID of the entry we confirmed absent, not some other object")
+}

--- a/applicationset/progressivesync/phantom_livecheck_test.go
+++ b/applicationset/progressivesync/phantom_livecheck_test.go
@@ -235,11 +235,17 @@ func TestEvictionDeleteIsGatedOnUID(t *testing.T) {
 		"the precondition must pin the UID of the entry we confirmed absent, not some other object")
 }
 
-// The eviction Delete is what removes the stale entry from the informer store, and the cache-syncing
-// client only evicts when that write succeeds or comes back NotFound -- any other error returns
-// before eviction. So a failed eviction must not let reverse deletion proceed: releasing the
-// ApplicationSet's finalizer with the phantom still in the store reintroduces the recreation failure
-// the eviction exists to prevent. A conflict is different, and must stay non-fatal.
+// Past the staleness threshold, a step may only be treated as complete once the Application is both
+// confirmed absent and its stale cache entry evicted. Neither failure mode may let reverse deletion
+// proceed, because each would release the ApplicationSet's finalizer on an unproven premise:
+//
+//   - an unexpected Delete error means the cache-syncing client returned before evicting, leaving the
+//     phantom in the store -- the recreation failure the eviction exists to prevent;
+//   - a conflict means the UID precondition failed, so an Application exists at this name that is not
+//     the one confirmed absent. It may be a child of this ApplicationSet still owed an ordered
+//     deletion, and nothing at this point can tell.
+//
+// Both are transient, so erroring lets a later pass classify the situation instead of guessing.
 func TestEvictionFailureDoesNotReleaseTheFinalizer(t *testing.T) {
 	t.Parallel()
 
@@ -257,11 +263,13 @@ func TestEvictionFailureDoesNotReleaseTheFinalizer(t *testing.T) {
 				"still in the store; continuing would release the finalizer and leave it there",
 		},
 		{
-			name:      "conflict is not a failure",
+			name:      "conflict blocks progress too",
 			deleteErr: apierrors.NewConflict(schema.GroupResource{Group: "argoproj.io", Resource: "applications"}, "repro-app", errors.New("uid mismatch")),
-			wantErr:   false,
-			reason: "the UID precondition failed because a real Application now holds this name, so " +
-				"there is no stale entry to evict and deletion may proceed",
+			wantErr:   true,
+			reason: "the precondition failed because an Application exists at this name that is not " +
+				"the one confirmed absent, which invalidates the verdict this step rests on; the " +
+				"replacement may be a child still owed an ordered deletion, so the finalizer must " +
+				"not be released until a later pass has classified it",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/applicationset/progressivesync/phantom_livecheck_test.go
+++ b/applicationset/progressivesync/phantom_livecheck_test.go
@@ -2,6 +2,7 @@ package progressivesync
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -232,4 +233,63 @@ func TestEvictionDeleteIsGatedOnUID(t *testing.T) {
 			"name between the live read and the delete would be removed instead")
 	assert.Equal(t, deletedUID, preconditionUID,
 		"the precondition must pin the UID of the entry we confirmed absent, not some other object")
+}
+
+// The eviction Delete is what removes the stale entry from the informer store, and the cache-syncing
+// client only evicts when that write succeeds or comes back NotFound -- any other error returns
+// before eviction. So a failed eviction must not let reverse deletion proceed: releasing the
+// ApplicationSet's finalizer with the phantom still in the store reintroduces the recreation failure
+// the eviction exists to prevent. A conflict is different, and must stay non-fatal.
+func TestEvictionFailureDoesNotReleaseTheFinalizer(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name      string
+		deleteErr error
+		wantErr   bool
+		reason    string
+	}{
+		{
+			name:      "unexpected failure blocks progress",
+			deleteErr: apierrors.NewInternalError(errors.New("etcd unavailable")),
+			wantErr:   true,
+			reason: "the client returns before evicting on any non-NotFound error, so the phantom is " +
+				"still in the store; continuing would release the finalizer and leave it there",
+		},
+		{
+			name:      "conflict is not a failure",
+			deleteErr: apierrors.NewConflict(schema.GroupResource{Group: "argoproj.io", Resource: "applications"}, "repro-app", errors.New("uid mismatch")),
+			wantErr:   false,
+			reason: "the UID precondition failed because a real Application now holds this name, so " +
+				"there is no stale entry to evict and deletion may proceed",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := schemeWithApps(t)
+			phantom := agedTerminatingApp()
+			cached := fake.NewClientBuilder().
+				WithScheme(s).
+				WithObjects(&phantom).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Delete: func(_ context.Context, _ crtclient.WithWatch, _ crtclient.Object, _ ...crtclient.DeleteOption) error {
+						return tc.deleteErr
+					},
+				}).
+				Build()
+			apiServer := fake.NewClientBuilder().WithScheme(s).Build() // object really gone
+
+			m := &Manager{Client: cached, APIReader: apiServer}
+
+			_, err := m.PerformReverseDeletion(t.Context(), log.NewEntry(log.New()),
+				singleStepAppSet(), []v1alpha1.Application{phantom})
+
+			if tc.wantErr {
+				require.Error(t, err, tc.reason)
+			} else {
+				require.NoError(t, err, tc.reason)
+			}
+		})
+	}
 }

--- a/applicationset/progressivesync/progressive_sync.go
+++ b/applicationset/progressivesync/progressive_sync.go
@@ -65,7 +65,9 @@ type Manager struct {
 	// APIReader reads directly from the API server, bypassing the informer cache. Reverse deletion
 	// uses it to double-check an Application the cache has reported as terminating for an
 	// implausibly long time, since the cache alone cannot distinguish a slow teardown from a DELETED
-	// event that was never delivered. May be nil, in which case the check degrades to waiting.
+	// event that was never delivered. Required: with no uncached reader the cache cannot be verified,
+	// so past the threshold reverse deletion errors rather than trusting it. Production supplies
+	// mgr.GetAPIReader().
 	APIReader    client.Reader
 	dependencies Dependencies
 }
@@ -213,9 +215,18 @@ func (m *Manager) PerformReverseDeletion(ctx context.Context, logCtx *log.Entry,
 						case apierrors.IsNotFound(err):
 							// Expected: the object is gone. The eviction has already been triggered.
 						case apierrors.IsConflict(err):
+							// The UID precondition failed, so a different Application now holds this
+							// name. The informer entry describes a real object, so there is nothing
+							// stale left to evict and deletion of this step can proceed.
 							logCtx.Infof("application %s was recreated while being confirmed as deleted; leaving the new object alone", step.AppName)
 						default:
-							logCtx.WithError(err).Warnf("could not evict stale cache entry for application %s", step.AppName)
+							// Any other failure means the cache-syncing client returned before
+							// evicting, so the stale entry is still in the store. Continuing would
+							// release the ApplicationSet's finalizer while the phantom remains, which
+							// is exactly the recreation failure this eviction exists to prevent.
+							// Surface it: unlike the stale-cache condition, a write that failed once
+							// can succeed on a later attempt, so the backoff has somewhere to go.
+							return 0, fmt.Errorf("application %s is absent from the API server but its stale cache entry could not be evicted: %w", step.AppName, err)
 						}
 					}
 					continue

--- a/applicationset/progressivesync/progressive_sync.go
+++ b/applicationset/progressivesync/progressive_sync.go
@@ -189,7 +189,7 @@ func (m *Manager) PerformReverseDeletion(ctx context.Context, logCtx *log.Entry,
 				case err != nil:
 					return 0, fmt.Errorf("application %s has not been deleted in over %s and could not be verified against the API server: %w", step.AppName, staleCacheThreshold, err)
 				case gone:
-					logCtx.Infof("application %s is absent from the API server but still present in the informer cache; treating it as deleted and continuing", step.AppName)
+					logCtx.Infof("application %s is absent from the API server but still present in the informer cache; evicting the stale entry", step.AppName)
 					// Skipping the entry is not enough: it stays in the informer store, and children
 					// are indexed by owner *name*, so an ApplicationSet later recreated under the
 					// same name counts the stale entry as an existing child. Under a create-only
@@ -201,9 +201,8 @@ func (m *Manager) PerformReverseDeletion(ctx context.Context, logCtx *log.Entry,
 					//
 					// The UID precondition matters. Between the live read above and this call another
 					// Application could be created at the same name, and an unconditional delete by
-					// name would remove it. Gating on the stale entry's UID means the API server
-					// rejects the delete with a conflict in that case, leaving the new object alone;
-					// the informer's own ADDED event then corrects the cache.
+					// name would remove it. Gating on the stale entry's UID makes the API server
+					// reject the delete with a conflict instead, leaving that object untouched.
 					// An object read from the API server always carries a UID; guard anyway so an
 					// empty one cannot turn into a precondition that never matches.
 					deleteOpts := []client.DeleteOption{}
@@ -215,10 +214,16 @@ func (m *Manager) PerformReverseDeletion(ctx context.Context, logCtx *log.Entry,
 						case apierrors.IsNotFound(err):
 							// Expected: the object is gone. The eviction has already been triggered.
 						case apierrors.IsConflict(err):
-							// The UID precondition failed, so a different Application now holds this
-							// name. The informer entry describes a real object, so there is nothing
-							// stale left to evict and deletion of this step can proceed.
-							logCtx.Infof("application %s was recreated while being confirmed as deleted; leaving the new object alone", step.AppName)
+							// The precondition failed, so an Application exists at this name that is
+							// not the one just confirmed absent. That invalidates the verdict this
+							// step rests on, and nothing here can tell whether the replacement is a
+							// child of this ApplicationSet still owed an ordered deletion. Treating
+							// the step as complete could release the finalizer with a live child, so
+							// stop and let the next pass classify it: the informer's ADDED event
+							// refreshes the entry and getCurrentApplications rebuilds the step list,
+							// after which the replacement is either deleted in its proper order or is
+							// not part of this ApplicationSet at all.
+							return 0, fmt.Errorf("application %s was recreated while being confirmed as deleted", step.AppName)
 						default:
 							// Any other failure means the cache-syncing client returned before
 							// evicting, so the stale entry is still in the store. Continuing would
@@ -229,6 +234,7 @@ func (m *Manager) PerformReverseDeletion(ctx context.Context, logCtx *log.Entry,
 							return 0, fmt.Errorf("application %s is absent from the API server but its stale cache entry could not be evicted: %w", step.AppName, err)
 						}
 					}
+					logCtx.Infof("application %s confirmed absent and its stale cache entry evicted; treating it as deleted and continuing", step.AppName)
 					continue
 				default:
 					// The Application really is still there, so it is genuinely stuck rather than a

--- a/applicationset/progressivesync/progressive_sync.go
+++ b/applicationset/progressivesync/progressive_sync.go
@@ -61,15 +61,43 @@ type Dependencies interface {
 }
 
 type Manager struct {
-	Client       client.Client
+	Client client.Client
+	// APIReader reads directly from the API server, bypassing the informer cache. Reverse deletion
+	// uses it to double-check an Application the cache has reported as terminating for an
+	// implausibly long time, since the cache alone cannot distinguish a slow teardown from a DELETED
+	// event that was never delivered. May be nil, in which case the check degrades to waiting.
+	APIReader    client.Reader
 	dependencies Dependencies
 }
 
 // NewManager creates a new manager with dependencies
-func NewManager(client client.Client, dependencies Dependencies) *Manager {
+func NewManager(client client.Client, apiReader client.Reader, dependencies Dependencies) *Manager {
 	return &Manager{
 		Client:       client,
+		APIReader:    apiReader,
 		dependencies: dependencies,
+	}
+}
+
+// staleCacheThreshold is how long an Application may appear to be terminating in the informer cache
+// before we stop trusting the cache and ask the API server directly.
+const staleCacheThreshold = 2 * time.Minute
+
+// applicationGoneFromAPIServer performs a live, non-cached read and reports whether the API server
+// says the Application no longer exists.
+func (m *Manager) applicationGoneFromAPIServer(ctx context.Context, namespace, name string) (bool, error) {
+	if m.APIReader == nil {
+		return false, errors.New("no uncached API reader is configured")
+	}
+	var live argov1alpha1.Application
+	err := m.APIReader.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &live)
+	switch {
+	case apierrors.IsNotFound(err):
+		return true, nil
+	case err != nil:
+		return false, err
+	default:
+		return false, nil
 	}
 }
 
@@ -140,8 +168,62 @@ func (m *Manager) PerformReverseDeletion(ctx context.Context, logCtx *log.Entry,
 		// while the child is still being torn down.
 		if retrievedApp.DeletionTimestamp != nil {
 			logCtx.Infof("application %s has been marked for deletion, but object not removed yet", step.AppName)
-			if time.Since(retrievedApp.DeletionTimestamp.Time) > 2*time.Minute {
-				return 0, errors.New("application has not been deleted in over 2 minutes")
+			if time.Since(retrievedApp.DeletionTimestamp.Time) > staleCacheThreshold {
+				// The cached read has claimed this Application is terminating for longer than any
+				// real teardown plausibly takes. Two things look identical from the cache: a child
+				// that is genuinely slow, and a child whose DELETED event was never delivered, so
+				// the entry will never be corrected. Because the age measured here only grows,
+				// trusting the cache in the second case means the ApplicationSet's finalizer can
+				// never be removed and it stays in Terminating forever.
+				//
+				// Escalate to the API server and let it decide. Only a confirmed-absent entry may
+				// proceed; every other outcome returns an error so controller-runtime applies
+				// exponential backoff rather than this polling at a fixed interval for the whole
+				// teardown. That is safe precisely because the stale-cache case now has an exit: the
+				// conditions that remain -- a child that genuinely still exists, or an API read that
+				// failed -- can both become false on a later attempt.
+				gone, err := m.applicationGoneFromAPIServer(ctx, app.Namespace, app.Name)
+				switch {
+				case err != nil:
+					return 0, fmt.Errorf("application %s has not been deleted in over %s and could not be verified against the API server: %w", step.AppName, staleCacheThreshold, err)
+				case gone:
+					logCtx.Infof("application %s is absent from the API server but still present in the informer cache; treating it as deleted and continuing", step.AppName)
+					// Skipping the entry is not enough: it stays in the informer store, and children
+					// are indexed by owner *name*, so an ApplicationSet later recreated under the
+					// same name counts the stale entry as an existing child. Under a create-only
+					// policy it is then filtered out of the create set and never recreated, and
+					// because no write is attempted nothing triggers the client's own eviction.
+					//
+					// Issue the Delete purely for that side effect: the cache-syncing client evicts
+					// on a write that returns NotFound, and swallows the NotFound for deletes.
+					//
+					// The UID precondition matters. Between the live read above and this call another
+					// Application could be created at the same name, and an unconditional delete by
+					// name would remove it. Gating on the stale entry's UID means the API server
+					// rejects the delete with a conflict in that case, leaving the new object alone;
+					// the informer's own ADDED event then corrects the cache.
+					// An object read from the API server always carries a UID; guard anyway so an
+					// empty one cannot turn into a precondition that never matches.
+					deleteOpts := []client.DeleteOption{}
+					if retrievedApp.UID != "" {
+						deleteOpts = append(deleteOpts, client.Preconditions{UID: &retrievedApp.UID})
+					}
+					if err := m.Client.Delete(ctx, &retrievedApp, deleteOpts...); err != nil {
+						switch {
+						case apierrors.IsNotFound(err):
+							// Expected: the object is gone. The eviction has already been triggered.
+						case apierrors.IsConflict(err):
+							logCtx.Infof("application %s was recreated while being confirmed as deleted; leaving the new object alone", step.AppName)
+						default:
+							logCtx.WithError(err).Warnf("could not evict stale cache entry for application %s", step.AppName)
+						}
+					}
+					continue
+				default:
+					// The Application really is still there, so it is genuinely stuck rather than a
+					// stale cache entry. Surface it and let the backoff grow.
+					return 0, errors.New("application has not been deleted in over 2 minutes")
+				}
 			}
 			return requeueTime, nil
 		}

--- a/applicationset/progressivesync/progressive_sync.go
+++ b/applicationset/progressivesync/progressive_sync.go
@@ -234,6 +234,21 @@ func (m *Manager) PerformReverseDeletion(ctx context.Context, logCtx *log.Entry,
 							return 0, fmt.Errorf("application %s is absent from the API server but its stale cache entry could not be evicted: %w", step.AppName, err)
 						}
 					}
+					// A nil error above does not prove the entry was evicted: cacheSyncingClient logs
+					// store lookup and store deletion failures and returns the original error, which
+					// for a NotFound delete is nil. Confirm the postcondition against the cache
+					// itself, because releasing the finalizer with the phantom still in the store is
+					// the recreation failure this eviction exists to prevent.
+					var evicted argov1alpha1.Application
+					switch err := m.Client.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: app.Namespace}, &evicted); {
+					case apierrors.IsNotFound(err):
+						// Gone from the cache, which is what this step needed.
+					case err != nil:
+						return 0, fmt.Errorf("could not confirm the stale cache entry for application %s was evicted: %w", step.AppName, err)
+					default:
+						return 0, fmt.Errorf("stale cache entry for application %s is still present after eviction", step.AppName)
+					}
+
 					logCtx.Infof("application %s confirmed absent and its stale cache entry evicted; treating it as deleted and continuing", step.AppName)
 					continue
 				default:

--- a/applicationset/progressivesync/progressive_sync_test.go
+++ b/applicationset/progressivesync/progressive_sync_test.go
@@ -1498,7 +1498,7 @@ func TestPerformReverseDeletionStaleCache(t *testing.T) {
 		}).
 		Build()
 
-	m := NewManager(fakeClient, nil)
+	m := NewManager(fakeClient, fakeClient, nil)
 	logCtx := log.NewEntry(log.New())
 
 	requeue, err := m.PerformReverseDeletion(context.Background(), logCtx, appSet, currentApps)
@@ -1583,7 +1583,7 @@ func TestPerformReverseDeletionTerminatingApp(t *testing.T) {
 				}).
 				Build()
 
-			m := NewManager(fakeClient, nil)
+			m := NewManager(fakeClient, fakeClient, nil)
 			requeue, err := m.PerformReverseDeletion(context.Background(), log.NewEntry(log.New()), appSet, []v1alpha1.Application{app})
 
 			if tc.expectedErr != "" {

--- a/cmd/argocd-applicationset-controller/commands/applicationset_controller.go
+++ b/cmd/argocd-applicationset-controller/commands/applicationset_controller.go
@@ -274,7 +274,7 @@ func NewCommand() *cobra.Command {
 				ClusterInformer:              clusterInformer,
 				ConcurrentApplicationUpdates: concurrentApplicationUpdates,
 			}
-			appsetReconciler.ProgressiveSyncManager = progressivesync.NewManager(cacheSyncClient, appsetReconciler)
+			appsetReconciler.ProgressiveSyncManager = progressivesync.NewManager(cacheSyncClient, mgr.GetAPIReader(), appsetReconciler)
 
 			if err = appsetReconciler.SetupWithManager(mgr, enableProgressiveSyncs, maxConcurrentReconciliations); err != nil {
 				log.Error(err, "unable to create controller", "controller", "ApplicationSet")


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. — n/a, no user-facing surface
* [x] Does this PR require documentation updates? — no; backport of an existing fix
* [x] I've updated documentation as required by this PR. — n/a per above
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into — this *is* the backport; `release-3.4` to follow separately.

Fixes #29042 on `release-3.5`.

Backport of #29043, raised manually because the automated cherry-pick failed.

**What differed from master**

One conflict, in the `Manager` struct: `release-3.5` has no `validationIssues` field, so only `APIReader` was added. The patch is otherwise identical to what merged on master — diffing the two patch bodies shows no difference beyond gofmt column alignment.

**Verification on this branch**

* Builds: `./applicationset/...` and `./cmd/...`
* Full `applicationset` and `cmd` test suites pass
* The five new tests in `phantom_livecheck_test.go` fail without the fix — 4 of the 5, since `TestGenuinelySlowChildIsNotSkipped` passes either way by design (pre-fix code also returned an error for a child that genuinely still exists)
* Linted with golangci-lint 2.11.4, the version pinned in `hack/installers/install-lint-tools.sh` on this branch — 0 issues

**Note for reviewers**

`release-3.4` needs the same two fixes, but the progressive-sync code there still lives in `applicationset/controllers/` rather than `applicationset/progressivesync/`, so it is a re-implementation rather than a cherry-pick and will be raised separately for its own review — the same divergence noted in #29000.
