### PR TITLE
fix(appset): fail reverse deletion when a stale cache entry cannot be evicted (#29042)

### DIFF
--- a/applicationset/progressivesync/phantom_livecheck_test.go
+++ b/applicationset/progressivesync/phantom_livecheck_test.go
@@ -376,3 +376,70 @@ func TestSilentEvictionFailureDoesNotReleaseTheFinalizer(t *testing.T) {
 	assert.Contains(t, err.Error(), "still present after eviction",
 		"the error should say the eviction could not be confirmed, not something unrelated")
 }
+
+// A conflict on the eviction Delete stops the step, and the comment there claims that is bounded
+// because a later pass reclassifies the replacement. This pins that claim, because an unbounded
+// version of it would be the very defect this file exists to prevent: a condition that can never
+// become false, blocking RemoveFinalizer forever.
+//
+// Pass 1 sees the stale entry, confirms it absent, and the eviction Delete conflicts -- a different
+// Application now holds the name. Pass 2 sees what the informer's ADDED event left behind: the
+// replacement, which is not terminating. Reverse deletion must make progress there rather than
+// returning the same error again.
+func TestConflictOnEvictionConvergesOnALaterPass(t *testing.T) {
+	t.Parallel()
+
+	s := schemeWithApps(t)
+	phantom := agedTerminatingApp()
+
+	// The object that appeared at the same name between the live read and the eviction Delete.
+	replacement := phantom.DeepCopy()
+	replacement.UID = "99999999-8888-7777-6666-555555555555"
+	replacement.DeletionTimestamp = nil
+	replacement.Finalizers = nil
+
+	pass := 0
+	deletes := 0
+	cached := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(&phantom).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c crtclient.WithWatch, key crtclient.ObjectKey, obj crtclient.Object, opts ...crtclient.GetOption) error {
+				if key.Name == phantom.Name && pass > 1 {
+					// What the informer holds once the ADDED event for the replacement lands.
+					replacement.DeepCopyInto(obj.(*v1alpha1.Application))
+					return nil
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+			Delete: func(_ context.Context, _ crtclient.WithWatch, obj crtclient.Object, _ ...crtclient.DeleteOption) error {
+				deletes++
+				if pass == 1 {
+					return apierrors.NewConflict(schema.GroupResource{Group: "argoproj.io", Resource: "applications"}, obj.GetName(), errors.New("uid mismatch"))
+				}
+				return nil
+			},
+		}).
+		Build()
+	apiServer := fake.NewClientBuilder().WithScheme(s).Build() // the entry we confirmed absent really is gone
+
+	m := &Manager{Client: cached, APIReader: apiServer}
+
+	pass = 1
+	_, err := m.PerformReverseDeletion(t.Context(), log.NewEntry(log.New()),
+		singleStepAppSet(), []v1alpha1.Application{phantom})
+	require.Error(t, err, "pass 1: a conflict invalidates the absence verdict, so the step must not complete")
+	require.Contains(t, err.Error(), "was recreated while being confirmed as deleted",
+		"pass 1 must stop *because of the conflict*. Any error would satisfy a bare Error() assertion "+
+			"-- a conflict left non-fatal still trips the eviction check below it -- so pin the reason.")
+
+	pass = 2
+	_, err = m.PerformReverseDeletion(t.Context(), log.NewEntry(log.New()),
+		singleStepAppSet(), []v1alpha1.Application{*replacement})
+
+	require.NoError(t, err,
+		"pass 2 must make progress: the replacement is a live child, so it is deleted in its proper "+
+			"order. Returning the same error here would mean the conflict branch can never clear, "+
+			"which is the unbounded wedge this whole change removes")
+	assert.GreaterOrEqual(t, deletes, 2, "the replacement must actually be deleted on pass 2, not skipped")
+}

--- a/applicationset/progressivesync/phantom_livecheck_test.go
+++ b/applicationset/progressivesync/phantom_livecheck_test.go
@@ -75,13 +75,49 @@ func schemeWithApps(t *testing.T) *runtime.Scheme {
 	return s
 }
 
+// evictingCacheClient models the production cache-syncing client for a phantom entry: the object is
+// already gone from the API server, so the eviction Delete comes back NotFound, and the entry is then
+// removed from the informer store so cache-backed reads stop seeing it. Tests that only simulate the
+// Delete without that second half are not representative -- reverse deletion verifies the eviction
+// actually happened before it lets a step complete.
+//
+// onDelete, when set, overrides what the Delete returns; the store is only evicted when it reports
+// NotFound, mirroring execAndSyncCache.
+func evictingCacheClient(s *runtime.Scheme, app *v1alpha1.Application, onDelete func() error) crtclient.WithWatch {
+	evicted := false
+	return fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(app).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(_ context.Context, _ crtclient.WithWatch, obj crtclient.Object, _ ...crtclient.DeleteOption) error {
+				err := error(nil)
+				if onDelete != nil {
+					err = onDelete()
+				} else {
+					err = apierrors.NewNotFound(schema.GroupResource{Group: "argoproj.io", Resource: "applications"}, obj.GetName())
+				}
+				if apierrors.IsNotFound(err) {
+					evicted = true
+				}
+				return err
+			},
+			Get: func(ctx context.Context, c crtclient.WithWatch, key crtclient.ObjectKey, obj crtclient.Object, opts ...crtclient.GetOption) error {
+				if evicted && key.Name == app.Name && key.Namespace == app.Namespace {
+					return apierrors.NewNotFound(schema.GroupResource{Group: "argoproj.io", Resource: "applications"}, key.Name)
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+}
+
 func TestPhantomIsNotFatal(t *testing.T) {
 	t.Parallel()
 
 	s := schemeWithApps(t)
 	phantom := agedTerminatingApp()
 
-	cached := fake.NewClientBuilder().WithScheme(s).WithObjects(&phantom).Build()
+	cached := evictingCacheClient(s, &phantom, nil)
 	apiServer := fake.NewClientBuilder().WithScheme(s).Build() // object really gone
 
 	m := &Manager{Client: cached, APIReader: apiServer}
@@ -159,20 +195,12 @@ func TestConfirmedPhantomTriggersCacheEviction(t *testing.T) {
 	phantom := agedTerminatingApp()
 
 	deletes := 0
-	cached := fake.NewClientBuilder().
-		WithScheme(s).
-		WithObjects(&phantom).
-		WithInterceptorFuncs(interceptor.Funcs{
-			// Stand in for the real API server, which reports the object as already gone. This is
-			// the call whose NotFound drives eviction in the cache-syncing client.
-			Delete: func(_ context.Context, _ crtclient.WithWatch, obj crtclient.Object, _ ...crtclient.DeleteOption) error {
-				if obj.GetName() == phantom.Name {
-					deletes++
-				}
-				return apierrors.NewNotFound(schema.GroupResource{Group: "argoproj.io", Resource: "applications"}, obj.GetName())
-			},
-		}).
-		Build()
+	// Stand in for the real API server, which reports the object as already gone. That NotFound is
+	// what drives eviction in the cache-syncing client, which the helper then models.
+	cached := evictingCacheClient(s, &phantom, func() error {
+		deletes++
+		return apierrors.NewNotFound(schema.GroupResource{Group: "argoproj.io", Resource: "applications"}, phantom.Name)
+	})
 	apiServer := fake.NewClientBuilder().WithScheme(s).Build() // live read: object really gone
 
 	m := &Manager{Client: cached, APIReader: apiServer}
@@ -202,6 +230,7 @@ func TestEvictionDeleteIsGatedOnUID(t *testing.T) {
 
 	var deletedUID types.UID
 	var preconditionUID types.UID
+	evicted := false
 	cached := fake.NewClientBuilder().
 		WithScheme(s).
 		WithObjects(&phantom).
@@ -215,7 +244,16 @@ func TestEvictionDeleteIsGatedOnUID(t *testing.T) {
 				if do.Preconditions != nil && do.Preconditions.UID != nil {
 					preconditionUID = *do.Preconditions.UID
 				}
+				evicted = true
 				return apierrors.NewNotFound(schema.GroupResource{Group: "argoproj.io", Resource: "applications"}, obj.GetName())
+			},
+			// The cache-syncing client evicts the entry on that NotFound, so cached reads stop
+			// seeing it. Reverse deletion checks for exactly that before completing the step.
+			Get: func(ctx context.Context, c crtclient.WithWatch, key crtclient.ObjectKey, obj crtclient.Object, opts ...crtclient.GetOption) error {
+				if evicted && key.Name == phantom.Name {
+					return apierrors.NewNotFound(schema.GroupResource{Group: "argoproj.io", Resource: "applications"}, key.Name)
+				}
+				return c.Get(ctx, key, obj, opts...)
 			},
 		}).
 		Build()
@@ -300,4 +338,41 @@ func TestEvictionFailureDoesNotReleaseTheFinalizer(t *testing.T) {
 			}
 		})
 	}
+}
+
+// A nil error from the eviction Delete is not proof the entry left the informer store.
+// cacheSyncingClient.execAndSyncCache logs a failure to reach the store, or to delete from it, and
+// then returns the original error -- which for a NotFound delete is nil. Reverse deletion must not
+// take that as success: releasing the ApplicationSet's finalizer with the phantom still cached is the
+// create-only recreation failure the eviction exists to prevent, and unlike the entry's age, a store
+// failure can clear on a later attempt.
+func TestSilentEvictionFailureDoesNotReleaseTheFinalizer(t *testing.T) {
+	t.Parallel()
+
+	s := schemeWithApps(t)
+	phantom := agedTerminatingApp()
+
+	// Delete reports the object gone, as the API server would, but the entry is never evicted --
+	// the store failure the production client only logs.
+	cached := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(&phantom).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(_ context.Context, _ crtclient.WithWatch, obj crtclient.Object, _ ...crtclient.DeleteOption) error {
+				return apierrors.NewNotFound(schema.GroupResource{Group: "argoproj.io", Resource: "applications"}, obj.GetName())
+			},
+		}).
+		Build()
+	apiServer := fake.NewClientBuilder().WithScheme(s).Build() // object really gone
+
+	m := &Manager{Client: cached, APIReader: apiServer}
+
+	_, err := m.PerformReverseDeletion(t.Context(), log.NewEntry(log.New()),
+		singleStepAppSet(), []v1alpha1.Application{phantom})
+
+	require.Error(t, err,
+		"the stale entry is still readable from the cache, so this step is not complete; completing it "+
+			"would release the finalizer and leave the phantom behind")
+	assert.Contains(t, err.Error(), "still present after eviction",
+		"the error should say the eviction could not be confirmed, not something unrelated")
 }

--- a/applicationset/progressivesync/phantom_livecheck_test.go
+++ b/applicationset/progressivesync/phantom_livecheck_test.go
@@ -235,11 +235,17 @@ func TestEvictionDeleteIsGatedOnUID(t *testing.T) {
 		"the precondition must pin the UID of the entry we confirmed absent, not some other object")
 }
 
-// The eviction Delete is what removes the stale entry from the informer store, and the cache-syncing
-// client only evicts when that write succeeds or comes back NotFound -- any other error returns
-// before eviction. So a failed eviction must not let reverse deletion proceed: releasing the
-// ApplicationSet's finalizer with the phantom still in the store reintroduces the recreation failure
-// the eviction exists to prevent. A conflict is different, and must stay non-fatal.
+// Past the staleness threshold, a step may only be treated as complete once the Application is both
+// confirmed absent and its stale cache entry evicted. Neither failure mode may let reverse deletion
+// proceed, because each would release the ApplicationSet's finalizer on an unproven premise:
+//
+//   - an unexpected Delete error means the cache-syncing client returned before evicting, leaving the
+//     phantom in the store -- the recreation failure the eviction exists to prevent;
+//   - a conflict means the UID precondition failed, so an Application exists at this name that is not
+//     the one confirmed absent. It may be a child of this ApplicationSet still owed an ordered
+//     deletion, and nothing at this point can tell.
+//
+// Both are transient, so erroring lets a later pass classify the situation instead of guessing.
 func TestEvictionFailureDoesNotReleaseTheFinalizer(t *testing.T) {
 	t.Parallel()
 
@@ -257,11 +263,13 @@ func TestEvictionFailureDoesNotReleaseTheFinalizer(t *testing.T) {
 				"still in the store; continuing would release the finalizer and leave it there",
 		},
 		{
-			name:      "conflict is not a failure",
+			name:      "conflict blocks progress too",
 			deleteErr: apierrors.NewConflict(schema.GroupResource{Group: "argoproj.io", Resource: "applications"}, "repro-app", errors.New("uid mismatch")),
-			wantErr:   false,
-			reason: "the UID precondition failed because a real Application now holds this name, so " +
-				"there is no stale entry to evict and deletion may proceed",
+			wantErr:   true,
+			reason: "the precondition failed because an Application exists at this name that is not " +
+				"the one confirmed absent, which invalidates the verdict this step rests on; the " +
+				"replacement may be a child still owed an ordered deletion, so the finalizer must " +
+				"not be released until a later pass has classified it",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/applicationset/progressivesync/phantom_livecheck_test.go
+++ b/applicationset/progressivesync/phantom_livecheck_test.go
@@ -2,6 +2,7 @@ package progressivesync
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -232,4 +233,63 @@ func TestEvictionDeleteIsGatedOnUID(t *testing.T) {
 			"name between the live read and the delete would be removed instead")
 	assert.Equal(t, deletedUID, preconditionUID,
 		"the precondition must pin the UID of the entry we confirmed absent, not some other object")
+}
+
+// The eviction Delete is what removes the stale entry from the informer store, and the cache-syncing
+// client only evicts when that write succeeds or comes back NotFound -- any other error returns
+// before eviction. So a failed eviction must not let reverse deletion proceed: releasing the
+// ApplicationSet's finalizer with the phantom still in the store reintroduces the recreation failure
+// the eviction exists to prevent. A conflict is different, and must stay non-fatal.
+func TestEvictionFailureDoesNotReleaseTheFinalizer(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name      string
+		deleteErr error
+		wantErr   bool
+		reason    string
+	}{
+		{
+			name:      "unexpected failure blocks progress",
+			deleteErr: apierrors.NewInternalError(errors.New("etcd unavailable")),
+			wantErr:   true,
+			reason: "the client returns before evicting on any non-NotFound error, so the phantom is " +
+				"still in the store; continuing would release the finalizer and leave it there",
+		},
+		{
+			name:      "conflict is not a failure",
+			deleteErr: apierrors.NewConflict(schema.GroupResource{Group: "argoproj.io", Resource: "applications"}, "repro-app", errors.New("uid mismatch")),
+			wantErr:   false,
+			reason: "the UID precondition failed because a real Application now holds this name, so " +
+				"there is no stale entry to evict and deletion may proceed",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := schemeWithApps(t)
+			phantom := agedTerminatingApp()
+			cached := fake.NewClientBuilder().
+				WithScheme(s).
+				WithObjects(&phantom).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Delete: func(_ context.Context, _ crtclient.WithWatch, _ crtclient.Object, _ ...crtclient.DeleteOption) error {
+						return tc.deleteErr
+					},
+				}).
+				Build()
+			apiServer := fake.NewClientBuilder().WithScheme(s).Build() // object really gone
+
+			m := &Manager{Client: cached, APIReader: apiServer}
+
+			_, err := m.PerformReverseDeletion(t.Context(), log.NewEntry(log.New()),
+				singleStepAppSet(), []v1alpha1.Application{phantom})
+
+			if tc.wantErr {
+				require.Error(t, err, tc.reason)
+			} else {
+				require.NoError(t, err, tc.reason)
+			}
+		})
+	}
 }

--- a/applicationset/progressivesync/progressive_sync.go
+++ b/applicationset/progressivesync/progressive_sync.go
@@ -245,6 +245,21 @@ func (m *Manager) PerformReverseDeletion(ctx context.Context, logCtx *log.Entry,
 							return 0, fmt.Errorf("application %s is absent from the API server but its stale cache entry could not be evicted: %w", step.AppName, err)
 						}
 					}
+					// A nil error above does not prove the entry was evicted: cacheSyncingClient logs
+					// store lookup and store deletion failures and returns the original error, which
+					// for a NotFound delete is nil. Confirm the postcondition against the cache
+					// itself, because releasing the finalizer with the phantom still in the store is
+					// the recreation failure this eviction exists to prevent.
+					var evicted argov1alpha1.Application
+					switch err := m.Client.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: app.Namespace}, &evicted); {
+					case apierrors.IsNotFound(err):
+						// Gone from the cache, which is what this step needed.
+					case err != nil:
+						return 0, fmt.Errorf("could not confirm the stale cache entry for application %s was evicted: %w", step.AppName, err)
+					default:
+						return 0, fmt.Errorf("stale cache entry for application %s is still present after eviction", step.AppName)
+					}
+
 					logCtx.Infof("application %s confirmed absent and its stale cache entry evicted; treating it as deleted and continuing", step.AppName)
 					continue
 				default:

--- a/applicationset/progressivesync/progressive_sync.go
+++ b/applicationset/progressivesync/progressive_sync.go
@@ -200,7 +200,7 @@ func (m *Manager) PerformReverseDeletion(ctx context.Context, logCtx *log.Entry,
 				case err != nil:
 					return 0, fmt.Errorf("application %s has not been deleted in over %s and could not be verified against the API server: %w", step.AppName, staleCacheThreshold, err)
 				case gone:
-					logCtx.Infof("application %s is absent from the API server but still present in the informer cache; treating it as deleted and continuing", step.AppName)
+					logCtx.Infof("application %s is absent from the API server but still present in the informer cache; evicting the stale entry", step.AppName)
 					// Skipping the entry is not enough: it stays in the informer store, and children
 					// are indexed by owner *name*, so an ApplicationSet later recreated under the
 					// same name counts the stale entry as an existing child. Under a create-only
@@ -212,9 +212,8 @@ func (m *Manager) PerformReverseDeletion(ctx context.Context, logCtx *log.Entry,
 					//
 					// The UID precondition matters. Between the live read above and this call another
 					// Application could be created at the same name, and an unconditional delete by
-					// name would remove it. Gating on the stale entry's UID means the API server
-					// rejects the delete with a conflict in that case, leaving the new object alone;
-					// the informer's own ADDED event then corrects the cache.
+					// name would remove it. Gating on the stale entry's UID makes the API server
+					// reject the delete with a conflict instead, leaving that object untouched.
 					// An object read from the API server always carries a UID; guard anyway so an
 					// empty one cannot turn into a precondition that never matches.
 					deleteOpts := []client.DeleteOption{}
@@ -226,10 +225,16 @@ func (m *Manager) PerformReverseDeletion(ctx context.Context, logCtx *log.Entry,
 						case apierrors.IsNotFound(err):
 							// Expected: the object is gone. The eviction has already been triggered.
 						case apierrors.IsConflict(err):
-							// The UID precondition failed, so a different Application now holds this
-							// name. The informer entry describes a real object, so there is nothing
-							// stale left to evict and deletion of this step can proceed.
-							logCtx.Infof("application %s was recreated while being confirmed as deleted; leaving the new object alone", step.AppName)
+							// The precondition failed, so an Application exists at this name that is
+							// not the one just confirmed absent. That invalidates the verdict this
+							// step rests on, and nothing here can tell whether the replacement is a
+							// child of this ApplicationSet still owed an ordered deletion. Treating
+							// the step as complete could release the finalizer with a live child, so
+							// stop and let the next pass classify it: the informer's ADDED event
+							// refreshes the entry and getCurrentApplications rebuilds the step list,
+							// after which the replacement is either deleted in its proper order or is
+							// not part of this ApplicationSet at all.
+							return 0, fmt.Errorf("application %s was recreated while being confirmed as deleted", step.AppName)
 						default:
 							// Any other failure means the cache-syncing client returned before
 							// evicting, so the stale entry is still in the store. Continuing would
@@ -240,6 +245,7 @@ func (m *Manager) PerformReverseDeletion(ctx context.Context, logCtx *log.Entry,
 							return 0, fmt.Errorf("application %s is absent from the API server but its stale cache entry could not be evicted: %w", step.AppName, err)
 						}
 					}
+					logCtx.Infof("application %s confirmed absent and its stale cache entry evicted; treating it as deleted and continuing", step.AppName)
 					continue
 				default:
 					// The Application really is still there, so it is genuinely stuck rather than a

--- a/applicationset/progressivesync/progressive_sync.go
+++ b/applicationset/progressivesync/progressive_sync.go
@@ -64,7 +64,9 @@ type Manager struct {
 	// APIReader reads directly from the API server, bypassing the informer cache. Reverse deletion
 	// uses it to double-check an Application the cache has reported as terminating for an
 	// implausibly long time, since the cache alone cannot distinguish a slow teardown from a DELETED
-	// event that was never delivered. May be nil, in which case the check degrades to waiting.
+	// event that was never delivered. Required: with no uncached reader the cache cannot be verified,
+	// so past the threshold reverse deletion errors rather than trusting it. Production supplies
+	// mgr.GetAPIReader().
 	APIReader        client.Reader
 	dependencies     Dependencies
 	validationIssues *ValidationIssues // collected during progressive sync execution
@@ -224,9 +226,18 @@ func (m *Manager) PerformReverseDeletion(ctx context.Context, logCtx *log.Entry,
 						case apierrors.IsNotFound(err):
 							// Expected: the object is gone. The eviction has already been triggered.
 						case apierrors.IsConflict(err):
+							// The UID precondition failed, so a different Application now holds this
+							// name. The informer entry describes a real object, so there is nothing
+							// stale left to evict and deletion of this step can proceed.
 							logCtx.Infof("application %s was recreated while being confirmed as deleted; leaving the new object alone", step.AppName)
 						default:
-							logCtx.WithError(err).Warnf("could not evict stale cache entry for application %s", step.AppName)
+							// Any other failure means the cache-syncing client returned before
+							// evicting, so the stale entry is still in the store. Continuing would
+							// release the ApplicationSet's finalizer while the phantom remains, which
+							// is exactly the recreation failure this eviction exists to prevent.
+							// Surface it: unlike the stale-cache condition, a write that failed once
+							// can succeed on a later attempt, so the backoff has somewhere to go.
+							return 0, fmt.Errorf("application %s is absent from the API server but its stale cache entry could not be evicted: %w", step.AppName, err)
 						}
 					}
 					continue


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. — n/a, no user-facing surface
* [x] Does this PR require documentation updates? — no
* [x] I've updated documentation as required by this PR. — n/a per above
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into — none needed; folded into the `release-3.5` backport #29138 directly, and will be included in the `release-3.4` port.

Follow-up to #29043 (issue #29042), from review raised on its `release-3.5` backport.

**The defect**

In the confirmed-phantom path, #29043 issues a `Delete` purely to trigger cache eviction, then treated an unexpected failure as non-fatal — warn and continue.

But `cacheSyncingClient.execAndSyncCache` returns on any non-NotFound error *before* reaching the eviction:

```go
if !apierrors.IsNotFound(err) {
    return err
}
```

So on such an error the stale entry is still in the informer store, and continuing releases the ApplicationSet's finalizer with the phantom left behind — which is precisely the create-only recreation failure the eviction was added to prevent. It was also inconsistent with the contract stated a few lines above, that only a confirmed-absent entry may proceed and every other outcome errors.

The fix surfaces the error. That is safe for the same reason the rest of that block is: unlike the stale-cache condition — whose age can only grow — a write that failed once can succeed on a later attempt, so the backoff has somewhere to go. `NotFound` and `Conflict` remain non-fatal: the first means eviction already happened, the second means a real Application now holds the name, so there is nothing stale to evict.

**Also**

The `APIReader` doc comment still claimed a nil reader "degrades to waiting". It has returned an error since that contract changed during review of #29043 — documentation drift, not a runtime issue, since production always supplies `mgr.GetAPIReader()`.

**Tests**

`TestEvictionFailureDoesNotReleaseTheFinalizer` pins both directions — an unexpected `Delete` error must block progress, a conflict must not. The first subtest fails against the previous warn-and-continue behaviour; the second passes either way, which is the point.

Verified: builds, 12/12 `applicationset` packages, golangci-lint 2.12.2 clean.

**Note**

#29138 (the `release-3.5` backport) already carries this same commit, so the two branches stay consistent whichever merges first.
