### PR TITLE
fix(appset): progressive sync fixes (3.4 backports of #29042 and #27577)

### DIFF
--- a/applicationset/controllers/applicationset_controller.go
+++ b/applicationset/controllers/applicationset_controller.go
@@ -16,6 +16,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"runtime/debug"
@@ -97,6 +98,11 @@ type deleteInOrder struct {
 // ApplicationSetReconciler reconciles a ApplicationSet object
 type ApplicationSetReconciler struct {
 	client.Client
+	// APIReader reads directly from the API server, bypassing the informer cache. Reverse deletion
+	// uses it to verify an Application the cache has reported as terminating for implausibly long.
+	// Required: without it the cache cannot be checked, so past the threshold reverse deletion errors
+	// rather than trusting it. Production supplies mgr.GetAPIReader().
+	APIReader            client.Reader
 	Scheme               *runtime.Scheme
 	Recorder             record.EventRecorder
 	Generators           map[string]generators.Generator
@@ -422,6 +428,28 @@ func (r *ApplicationSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}, nil
 }
 
+// staleCacheThreshold is how long an Application may appear to be terminating in the informer cache
+// before we stop trusting the cache and ask the API server directly.
+const staleCacheThreshold = 2 * time.Minute
+
+// applicationGoneFromAPIServer performs a live, non-cached read and reports whether the API server
+// says the Application no longer exists.
+func (r *ApplicationSetReconciler) applicationGoneFromAPIServer(ctx context.Context, namespace, name string) (bool, error) {
+	if r.APIReader == nil {
+		return false, errors.New("no uncached API reader is configured")
+	}
+	var live argov1alpha1.Application
+	err := r.APIReader.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &live)
+	switch {
+	case apierrors.IsNotFound(err):
+		return true, nil
+	case err != nil:
+		return false, err
+	default:
+		return false, nil
+	}
+}
+
 func (r *ApplicationSetReconciler) performReverseDeletion(ctx context.Context, logCtx *log.Entry, appset argov1alpha1.ApplicationSet, currentApps []argov1alpha1.Application) (time.Duration, error) {
 	requeueTime := 10 * time.Second
 	stepLength := len(appset.Spec.Strategy.RollingSync.Steps)
@@ -463,8 +491,74 @@ func (r *ApplicationSetReconciler) performReverseDeletion(ctx context.Context, l
 		// while the child is still being torn down.
 		if retrievedApp.DeletionTimestamp != nil {
 			logCtx.Infof("application %s has been marked for deletion, but object not removed yet", step.AppName)
-			if time.Since(retrievedApp.DeletionTimestamp.Time) > 2*time.Minute {
-				logCtx.Warnf("application %s has not been deleted in over 2 minutes; continuing to wait for it to be removed", step.AppName)
+			if time.Since(retrievedApp.DeletionTimestamp.Time) > staleCacheThreshold {
+				// A child that is genuinely slow and one whose DELETED event was never delivered look
+				// identical from the cache, and the age measured here only grows -- so trusting the
+				// cache in the second case leaves the finalizer in place forever.
+				//
+				// Escalate to the API server. Only a confirmed-absent entry may proceed, and only
+				// once its stale cache entry is evicted: children are indexed by owner name, so an
+				// entry left in the store makes an ApplicationSet recreated under the same name treat
+				// it as an existing child, which a create-only policy then never recreates. Every
+				// other outcome returns an error, which is safe because each of those conditions can
+				// become false on a later attempt.
+				gone, err := r.applicationGoneFromAPIServer(ctx, app.Namespace, app.Name)
+				switch {
+				case err != nil:
+					return 0, fmt.Errorf("application %s has not been deleted in over %s and could not be verified against the API server: %w", step.AppName, staleCacheThreshold, err)
+				case gone:
+					logCtx.Infof("application %s is absent from the API server but still present in the informer cache; evicting the stale entry", step.AppName)
+					// The Delete is issued purely for its side effect: cacheSyncingClient evicts on a
+					// write that returns NotFound, and swallows that NotFound for deletes.
+					//
+					// The UID precondition matters. Another Application could have been created at
+					// this name since the live read, and a delete by name would remove it; gating on
+					// the confirmed-absent entry's UID makes the API server reject that as a conflict
+					// instead. Guard on the empty case so it cannot become a precondition that never
+					// matches.
+					deleteOpts := []client.DeleteOption{}
+					if retrievedApp.UID != "" {
+						deleteOpts = append(deleteOpts, client.Preconditions{UID: &retrievedApp.UID})
+					}
+					if err := r.Delete(ctx, &retrievedApp, deleteOpts...); err != nil {
+						switch {
+						case apierrors.IsNotFound(err):
+							// Expected: the object is gone. The eviction has already been triggered.
+						case apierrors.IsConflict(err):
+							// An Application exists at this name that is not the one confirmed absent,
+							// so the verdict this step rests on no longer holds and it may be a child
+							// still owed an ordered deletion. The next pass reclassifies it: the
+							// informer's ADDED event refreshes the entry and getCurrentApplications
+							// rebuilds the step list.
+							return 0, fmt.Errorf("application %s was recreated while being confirmed as deleted", step.AppName)
+						default:
+							// cacheSyncingClient returns before evicting on any non-NotFound error, so
+							// the stale entry is still in the store and this step cannot complete.
+							return 0, fmt.Errorf("application %s is absent from the API server but its stale cache entry could not be evicted: %w", step.AppName, err)
+						}
+					}
+					// A nil error above does not prove the entry was evicted: cacheSyncingClient logs
+					// store lookup and store deletion failures and returns the original error, which
+					// for a NotFound delete is nil. Confirm the postcondition against the cache
+					// itself, because releasing the finalizer with the phantom still in the store is
+					// the recreation failure this eviction exists to prevent.
+					var evicted argov1alpha1.Application
+					switch err := r.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: app.Namespace}, &evicted); {
+					case apierrors.IsNotFound(err):
+						// Gone from the cache, which is what this step needed.
+					case err != nil:
+						return 0, fmt.Errorf("could not confirm the stale cache entry for application %s was evicted: %w", step.AppName, err)
+					default:
+						return 0, fmt.Errorf("stale cache entry for application %s is still present after eviction", step.AppName)
+					}
+
+					logCtx.Infof("application %s confirmed absent and its stale cache entry evicted; treating it as deleted and continuing", step.AppName)
+					continue
+				default:
+					// The Application really is still there, so it is genuinely stuck rather than a
+					// stale cache entry. Surface it and let the backoff grow.
+					return 0, errors.New("application has not been deleted in over 2 minutes")
+				}
 			}
 			return requeueTime, nil
 		}

--- a/applicationset/controllers/applicationset_controller.go
+++ b/applicationset/controllers/applicationset_controller.go
@@ -450,6 +450,17 @@ func (r *ApplicationSetReconciler) applicationGoneFromAPIServer(ctx context.Cont
 	}
 }
 
+// disableAutomatedSync clears automated sync on a RollingSync-managed Application, since the
+// ApplicationSet controller triggers those syncs itself. Anything comparing a generated Application
+// against its live counterpart must apply this first: the mutation lands on the written copy, so the
+// live object carries automated.enabled=false while a freshly generated one leaves it unset.
+func disableAutomatedSync(app *argov1alpha1.Application) {
+	if app.Spec.SyncPolicy == nil || app.Spec.SyncPolicy.Automated == nil {
+		return
+	}
+	app.Spec.SyncPolicy.Automated.Enabled = new(false)
+}
+
 func (r *ApplicationSetReconciler) performReverseDeletion(ctx context.Context, logCtx *log.Entry, appset argov1alpha1.ApplicationSet, currentApps []argov1alpha1.Application) (time.Duration, error) {
 	requeueTime := 10 * time.Second
 	stepLength := len(appset.Spec.Strategy.RollingSync.Steps)
@@ -1306,7 +1317,20 @@ func (r *ApplicationSetReconciler) updateApplicationSetApplicationStatus(ctx con
 		if desiredApp, ok := desiredAppsMap[app.Name]; ok {
 			// Compare the desired spec with the current spec to detect non-Git changes
 			// This will catch changes to generator parameters like image tags, helm values, etc.
-			specChanged = !cmp.Equal(desiredApp.Spec, app.Spec, cmpopts.EquateEmpty(), cmpopts.EquateComparable(argov1alpha1.ApplicationDestination{}))
+			//
+			// Via SpecsEquivalent, so this agrees with what the write path will actually do; see its
+			// doc comment for why comparing specs directly loops.
+			desiredForCompare := desiredApp.DeepCopy()
+			disableAutomatedSync(desiredForCompare)
+
+			equivalent, cmpErr := utils.SpecsEquivalent(applicationSet.Spec.IgnoreApplicationDifferences, normalizers.IgnoreNormalizerOpts{}, &app, desiredForCompare)
+			if cmpErr != nil {
+				// Failures here are persistent (for example a malformed jsonPointer), so reporting
+				// "changed" would loop forever. Leave the status alone and surface it.
+				logCtx.WithError(cmpErr).Warn("could not compare desired and live specs; leaving progressive sync status unchanged")
+			} else {
+				specChanged = !equivalent
+			}
 		}
 
 		if revisionsChanged || specChanged {
@@ -1721,8 +1745,8 @@ func (r *ApplicationSetReconciler) syncDesiredApplications(logCtx *log.Entry, ap
 		// ensure that Applications generated with RollingSync do not have an automated sync policy, since the AppSet controller will handle triggering the sync operation instead
 		if desiredApplications[i].Spec.SyncPolicy != nil && desiredApplications[i].Spec.SyncPolicy.IsAutomatedSyncEnabled() {
 			pruneEnabled = desiredApplications[i].Spec.SyncPolicy.Automated.GetPrune()
-			desiredApplications[i].Spec.SyncPolicy.Automated.Enabled = new(false)
 		}
+		disableAutomatedSync(&desiredApplications[i])
 
 		appSetStatusPending := false
 		idx := findApplicationStatusIndex(applicationSet.Status.ApplicationStatus, desiredApplications[i].Name)

--- a/applicationset/controllers/applicationset_controller.go
+++ b/applicationset/controllers/applicationset_controller.go
@@ -1327,7 +1327,7 @@ func (r *ApplicationSetReconciler) updateApplicationSetApplicationStatus(ctx con
 			if cmpErr != nil {
 				// Failures here are persistent (for example a malformed jsonPointer), so reporting
 				// "changed" would loop forever. Leave the status alone and surface it.
-				logCtx.WithError(cmpErr).Warn("could not compare desired and live specs; leaving progressive sync status unchanged")
+				statusLogCtx.WithError(cmpErr).Warn("could not compare desired and live specs; leaving progressive sync status unchanged")
 			} else {
 				specChanged = !equivalent
 			}

--- a/applicationset/controllers/applicationset_controller_test.go
+++ b/applicationset/controllers/applicationset_controller_test.go
@@ -8003,15 +8003,11 @@ func TestPerformReverseDeletionStaleCache(t *testing.T) {
 	assert.Equal(t, 1, deleteAttempts["appset-stage1"])
 }
 
-// TestPerformReverseDeletionTerminatingApp covers an Application whose deletion is still pending,
-// here past the two minute threshold. Two things must hold:
-//
-//   - No error: the threshold check sits on the only code path that reaches RemoveFinalizer, so
-//     returning an error from it leaves the ApplicationSet in Terminating permanently — the age it
-//     measures only grows, so every retry fails identically.
-//   - No second Delete: a redundant Delete on a terminating object is a no-op success, and
-//     cacheSyncingClient.Delete evicts the object from the informer store on success. The next Get
-//     would then 404 on a still-existing Application and the finalizer would be released early.
+// TestPerformReverseDeletionTerminatingApp covers an Application whose deletion is still pending.
+// Whichever side of the two minute threshold it falls on, no second Delete may be issued: a
+// redundant Delete on a terminating object is a no-op success, and cacheSyncingClient.Delete evicts
+// the object from the informer store on success. The next Get would then 404 on a still-existing
+// Application and the finalizer would be released early.
 func TestPerformReverseDeletionTerminatingApp(t *testing.T) {
 	t.Parallel()
 
@@ -8033,36 +8029,70 @@ func TestPerformReverseDeletionTerminatingApp(t *testing.T) {
 		},
 	}
 
-	// Deletion was requested well beyond the two minute threshold.
-	deletionTimestamp := metav1.NewTime(time.Now().Add(-5 * time.Minute))
-	app := v1alpha1.Application{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:              "appset-stage0",
-			Namespace:         "argocd",
-			Labels:            map[string]string{"stage": "0"},
-			DeletionTimestamp: &deletionTimestamp,
-			Finalizers:        []string{v1alpha1.ResourcesFinalizerName},
+	for _, tc := range []struct {
+		name          string
+		deletionAge   time.Duration
+		expectedErr   string
+		expectRequeue time.Duration
+	}{
+		{
+			name:          "within threshold",
+			deletionAge:   30 * time.Second,
+			expectRequeue: 10 * time.Second,
 		},
+		{
+			// Past the threshold the Application is verified against the API server, where it still
+			// exists, so it is genuinely stuck rather than a stale cache entry. The reconcile fails,
+			// which keeps the ApplicationSet finalizer in place and lets controller-runtime retry
+			// with backoff. See phantom_livecheck_test.go for the boundary cases.
+			name:        "past threshold",
+			deletionAge: 5 * time.Minute,
+			expectedErr: "application has not been deleted in over 2 minutes",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			deletionTimestamp := metav1.NewTime(time.Now().Add(-tc.deletionAge))
+			app := v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "appset-stage0",
+					Namespace:         "argocd",
+					Labels:            map[string]string{"stage": "0"},
+					DeletionTimestamp: &deletionTimestamp,
+					Finalizers:        []string{v1alpha1.ResourcesFinalizerName},
+				},
+			}
+
+			deleteAttempts := 0
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(&app).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Delete: func(ctx context.Context, c crtclient.WithWatch, obj crtclient.Object, opts ...crtclient.DeleteOption) error {
+						deleteAttempts++
+						return c.Delete(ctx, obj, opts...)
+					},
+				}).
+				Build()
+
+			r := ApplicationSetReconciler{
+				Client:    fakeClient,
+				APIReader: fakeClient,
+				Scheme:    scheme,
+				Metrics:   appsetmetrics.NewFakeAppsetMetrics(),
+			}
+			requeue, err := r.performReverseDeletion(t.Context(), log.NewEntry(log.New()), appSet, []v1alpha1.Application{app})
+
+			if tc.expectedErr != "" {
+				require.EqualError(t, err, tc.expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tc.expectRequeue, requeue)
+			assert.Zero(t, deleteAttempts, "must not re-Delete an already terminating Application")
+		})
 	}
-
-	deleteAttempts := 0
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(&app).
-		WithInterceptorFuncs(interceptor.Funcs{
-			Delete: func(ctx context.Context, c crtclient.WithWatch, obj crtclient.Object, opts ...crtclient.DeleteOption) error {
-				deleteAttempts++
-				return c.Delete(ctx, obj, opts...)
-			},
-		}).
-		Build()
-
-	r := ApplicationSetReconciler{Client: fakeClient, Scheme: scheme, Metrics: appsetmetrics.NewFakeAppsetMetrics()}
-	requeue, err := r.performReverseDeletion(t.Context(), log.NewEntry(log.New()), appSet, []v1alpha1.Application{app})
-
-	require.NoError(t, err, "a pending teardown must not surface as a hard error")
-	assert.Equal(t, 10*time.Second, requeue, "should requeue and keep waiting for the child")
-	assert.Zero(t, deleteAttempts, "must not re-Delete an already terminating Application")
 }
 
 func TestReconcileProgressiveSyncDisabled(t *testing.T) {

--- a/applicationset/controllers/phantom_livecheck_test.go
+++ b/applicationset/controllers/phantom_livecheck_test.go
@@ -376,3 +376,70 @@ func TestSilentEvictionFailureDoesNotReleaseTheFinalizer(t *testing.T) {
 	assert.Contains(t, err.Error(), "still present after eviction",
 		"the error should say the eviction could not be confirmed, not something unrelated")
 }
+
+// A conflict on the eviction Delete stops the step, and the comment there claims that is bounded
+// because a later pass reclassifies the replacement. This pins that claim, because an unbounded
+// version of it would be the very defect this file exists to prevent: a condition that can never
+// become false, blocking RemoveFinalizer forever.
+//
+// Pass 1 sees the stale entry, confirms it absent, and the eviction Delete conflicts -- a different
+// Application now holds the name. Pass 2 sees what the informer's ADDED event left behind: the
+// replacement, which is not terminating. Reverse deletion must make progress there rather than
+// returning the same error again.
+func TestConflictOnEvictionConvergesOnALaterPass(t *testing.T) {
+	t.Parallel()
+
+	s := schemeWithApps(t)
+	phantom := agedTerminatingApp()
+
+	// The object that appeared at the same name between the live read and the eviction Delete.
+	replacement := phantom.DeepCopy()
+	replacement.UID = "99999999-8888-7777-6666-555555555555"
+	replacement.DeletionTimestamp = nil
+	replacement.Finalizers = nil
+
+	pass := 0
+	deletes := 0
+	cached := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(&phantom).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c crtclient.WithWatch, key crtclient.ObjectKey, obj crtclient.Object, opts ...crtclient.GetOption) error {
+				if key.Name == phantom.Name && pass > 1 {
+					// What the informer holds once the ADDED event for the replacement lands.
+					replacement.DeepCopyInto(obj.(*argov1alpha1.Application))
+					return nil
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+			Delete: func(_ context.Context, _ crtclient.WithWatch, obj crtclient.Object, _ ...crtclient.DeleteOption) error {
+				deletes++
+				if pass == 1 {
+					return apierrors.NewConflict(schema.GroupResource{Group: "argoproj.io", Resource: "applications"}, obj.GetName(), errors.New("uid mismatch"))
+				}
+				return nil
+			},
+		}).
+		Build()
+	apiServer := fake.NewClientBuilder().WithScheme(s).Build() // the entry we confirmed absent really is gone
+
+	r := &ApplicationSetReconciler{Client: cached, APIReader: apiServer}
+
+	pass = 1
+	_, err := r.performReverseDeletion(t.Context(), log.NewEntry(log.New()),
+		singleStepAppSet(), []argov1alpha1.Application{phantom})
+	require.Error(t, err, "pass 1: a conflict invalidates the absence verdict, so the step must not complete")
+	require.Contains(t, err.Error(), "was recreated while being confirmed as deleted",
+		"pass 1 must stop *because of the conflict*. Any error would satisfy a bare Error() assertion "+
+			"-- a conflict left non-fatal still trips the eviction check below it -- so pin the reason.")
+
+	pass = 2
+	_, err = r.performReverseDeletion(t.Context(), log.NewEntry(log.New()),
+		singleStepAppSet(), []argov1alpha1.Application{*replacement})
+
+	require.NoError(t, err,
+		"pass 2 must make progress: the replacement is a live child, so it is deleted in its proper "+
+			"order. Returning the same error here would mean the conflict branch can never clear, "+
+			"which is the unbounded wedge this whole change removes")
+	assert.GreaterOrEqual(t, deletes, 2, "the replacement must actually be deleted on pass 2, not skipped")
+}

--- a/applicationset/controllers/phantom_livecheck_test.go
+++ b/applicationset/controllers/phantom_livecheck_test.go
@@ -1,0 +1,378 @@
+package controllers
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	crtclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	argov1alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+)
+
+// release-3.4 port of the reverse-deletion live-read tests. Read all three together: they pin the
+// boundary the fix has to get right.
+//
+// performReverseDeletion only lets Reconcile remove the ApplicationSet finalizer when it returns
+// (0, nil). A terminating child must therefore be classified correctly:
+//
+//   - a phantom (still in the informer cache, already gone from the API server) must NOT block
+//     forever, or the ApplicationSet stays in Terminating until the finalizer is patched by hand;
+//   - a genuinely slow child must NOT be skipped, or the finalizer is released while a child is
+//     still terminating and deletionOrder: Reverse silently stops being enforced.
+
+func agedTerminatingApp() argov1alpha1.Application {
+	deletedAt := metav1.NewTime(time.Now().Add(-10 * time.Minute))
+	return argov1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "appset-stage0",
+			Namespace: "argocd",
+			// Objects decoded from the API server always carry a UID; the eviction delete is gated
+			// on it, so the fixture must have one to be representative.
+			UID:               "11111111-2222-3333-4444-555555555555",
+			Labels:            map[string]string{"stage": "0"},
+			DeletionTimestamp: &deletedAt,
+			Finalizers:        []string{argov1alpha1.ForegroundPropagationPolicyFinalizer},
+		},
+	}
+}
+
+func singleStepAppSet() argov1alpha1.ApplicationSet {
+	return argov1alpha1.ApplicationSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "appset", Namespace: "argocd"},
+		Spec: argov1alpha1.ApplicationSetSpec{
+			Strategy: &argov1alpha1.ApplicationSetStrategy{
+				Type:          "RollingSync",
+				DeletionOrder: ReverseDeletionOrder,
+				RollingSync: &argov1alpha1.ApplicationSetRolloutStrategy{
+					Steps: []argov1alpha1.ApplicationSetRolloutStep{
+						{MatchExpressions: []argov1alpha1.ApplicationMatchExpression{
+							{Key: "stage", Operator: "In", Values: []string{"0"}},
+						}},
+					},
+				},
+			},
+		},
+	}
+}
+
+func schemeWithApps(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, argov1alpha1.AddToScheme(s))
+	return s
+}
+
+// evictingCacheClient models the production cache-syncing client for a phantom entry: the object is
+// already gone from the API server, so the eviction Delete comes back NotFound, and the entry is then
+// removed from the informer store so cache-backed reads stop seeing it. Tests that only simulate the
+// Delete without that second half are not representative -- reverse deletion verifies the eviction
+// actually happened before it lets a step complete.
+//
+// onDelete, when set, overrides what the Delete returns; the store is only evicted when it reports
+// NotFound, mirroring execAndSyncCache.
+func evictingCacheClient(s *runtime.Scheme, app *argov1alpha1.Application, onDelete func() error) crtclient.WithWatch {
+	evicted := false
+	return fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(app).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(_ context.Context, _ crtclient.WithWatch, obj crtclient.Object, _ ...crtclient.DeleteOption) error {
+				err := error(nil)
+				if onDelete != nil {
+					err = onDelete()
+				} else {
+					err = apierrors.NewNotFound(schema.GroupResource{Group: "argoproj.io", Resource: "applications"}, obj.GetName())
+				}
+				if apierrors.IsNotFound(err) {
+					evicted = true
+				}
+				return err
+			},
+			Get: func(ctx context.Context, c crtclient.WithWatch, key crtclient.ObjectKey, obj crtclient.Object, opts ...crtclient.GetOption) error {
+				if evicted && key.Name == app.Name && key.Namespace == app.Namespace {
+					return apierrors.NewNotFound(schema.GroupResource{Group: "argoproj.io", Resource: "applications"}, key.Name)
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+}
+
+func TestPhantomIsNotFatal(t *testing.T) {
+	t.Parallel()
+
+	s := schemeWithApps(t)
+	phantom := agedTerminatingApp()
+
+	cached := evictingCacheClient(s, &phantom, nil)
+	apiServer := fake.NewClientBuilder().WithScheme(s).Build() // object really gone
+
+	r := &ApplicationSetReconciler{Client: cached, APIReader: apiServer}
+
+	var requeue time.Duration
+	var err error
+	for i := range 10 {
+		requeue, err = r.performReverseDeletion(t.Context(), log.NewEntry(log.New()),
+			singleStepAppSet(), []argov1alpha1.Application{phantom})
+		require.NoErrorf(t, err, "pass %d must not error: an error here is permanent, the age it derives from only grows", i)
+		if requeue == 0 {
+			break
+		}
+	}
+
+	assert.Zero(t, requeue,
+		"a phantom must resolve to (0, nil) so Reconcile can reach RemoveFinalizer; requeue=%s means "+
+			"the ApplicationSet stays in Terminating forever", requeue)
+}
+
+func TestGenuinelySlowChildIsNotSkipped(t *testing.T) {
+	t.Parallel()
+
+	s := schemeWithApps(t)
+	slow := agedTerminatingApp()
+
+	cached := fake.NewClientBuilder().WithScheme(s).WithObjects(&slow).Build()
+	apiServer := fake.NewClientBuilder().WithScheme(s).WithObjects(&slow).Build() // really still there
+
+	r := &ApplicationSetReconciler{Client: cached, APIReader: apiServer}
+
+	_, err := r.performReverseDeletion(t.Context(), log.NewEntry(log.New()),
+		singleStepAppSet(), []argov1alpha1.Application{slow})
+
+	require.Error(t, err,
+		"a child that still exists on the API server must not be treated as absent; returning (0, nil) "+
+			"would release the finalizer mid-teardown and break deletionOrder: Reverse")
+	assert.Contains(t, err.Error(), "has not been deleted in over 2 minutes")
+}
+
+func TestMissingAPIReaderSurfacesError(t *testing.T) {
+	t.Parallel()
+
+	s := schemeWithApps(t)
+	app := agedTerminatingApp()
+	cached := fake.NewClientBuilder().WithScheme(s).WithObjects(&app).Build()
+
+	r := &ApplicationSetReconciler{Client: cached} // APIReader deliberately nil
+
+	_, err := r.performReverseDeletion(t.Context(), log.NewEntry(log.New()),
+		singleStepAppSet(), []argov1alpha1.Application{app})
+
+	require.Error(t, err, "an unverifiable child must not be silently skipped or silently retried")
+	assert.Contains(t, err.Error(), "could not be verified against the API server")
+}
+
+// A stale entry that the API server has confirmed absent must also be evicted from the informer
+// store, not merely skipped for this pass.
+//
+// getCurrentApplications indexes children by owner *name*, so an ApplicationSet recreated under the
+// same name inherits any leftover entry and counts it as an existing child. Under a create-only
+// policy createInCluster then filters that child out of the create set and never recreates it — and
+// because no write is attempted, nothing triggers eviction either, so the child stays missing for as
+// long as the entry survives.
+//
+// Eviction itself belongs to the cache-syncing client and is covered by
+// utils.TestDeleteEvictsStaleCacheOnNotFound: a Delete whose API call returns NotFound removes the
+// stale entry and swallows the error. What this test pins is the other half of that contract — that
+// reverse deletion actually issues the Delete once it has confirmed the object is gone. Without it
+// the two halves never meet.
+func TestConfirmedPhantomTriggersCacheEviction(t *testing.T) {
+	t.Parallel()
+
+	s := schemeWithApps(t)
+	phantom := agedTerminatingApp()
+
+	deletes := 0
+	// Stand in for the real API server, which reports the object as already gone. That NotFound is
+	// what drives eviction in the cache-syncing client, which the helper then models.
+	cached := evictingCacheClient(s, &phantom, func() error {
+		deletes++
+		return apierrors.NewNotFound(schema.GroupResource{Group: "argoproj.io", Resource: "applications"}, phantom.Name)
+	})
+	apiServer := fake.NewClientBuilder().WithScheme(s).Build() // live read: object really gone
+
+	r := &ApplicationSetReconciler{Client: cached, APIReader: apiServer}
+
+	requeue, err := r.performReverseDeletion(t.Context(), log.NewEntry(log.New()),
+		singleStepAppSet(), []argov1alpha1.Application{phantom})
+	require.NoError(t, err)
+	require.Zero(t, requeue, "a confirmed-absent child must not hold up reverse deletion")
+
+	assert.Positive(t, deletes,
+		"reverse deletion must issue a Delete for a child the API server has confirmed gone, so the "+
+			"cache-syncing client evicts the stale entry; otherwise an ApplicationSet recreated under "+
+			"this name treats it as an existing child and never recreates it")
+}
+
+// The eviction Delete must not remove a different object that has appeared at the same name.
+//
+// Between the live read that confirms absence and the Delete issued to trigger cache eviction, an
+// Application can be created at the same name/namespace. An unconditional delete by name would
+// remove it. The delete is therefore gated on the stale entry's UID, so the API server rejects it as
+// a conflict and the new object survives.
+func TestEvictionDeleteIsGatedOnUID(t *testing.T) {
+	t.Parallel()
+
+	s := schemeWithApps(t)
+	phantom := agedTerminatingApp()
+
+	var deletedUID types.UID
+	var preconditionUID types.UID
+	evicted := false
+	cached := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(&phantom).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(_ context.Context, _ crtclient.WithWatch, obj crtclient.Object, opts ...crtclient.DeleteOption) error {
+				deletedUID = obj.GetUID()
+				do := &crtclient.DeleteOptions{}
+				for _, o := range opts {
+					o.ApplyToDelete(do)
+				}
+				if do.Preconditions != nil && do.Preconditions.UID != nil {
+					preconditionUID = *do.Preconditions.UID
+				}
+				evicted = true
+				return apierrors.NewNotFound(schema.GroupResource{Group: "argoproj.io", Resource: "applications"}, obj.GetName())
+			},
+			// The cache-syncing client evicts the entry on that NotFound, so cached reads stop
+			// seeing it. Reverse deletion checks for exactly that before completing the step.
+			Get: func(ctx context.Context, c crtclient.WithWatch, key crtclient.ObjectKey, obj crtclient.Object, opts ...crtclient.GetOption) error {
+				if evicted && key.Name == phantom.Name {
+					return apierrors.NewNotFound(schema.GroupResource{Group: "argoproj.io", Resource: "applications"}, key.Name)
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+	apiServer := fake.NewClientBuilder().WithScheme(s).Build() // object really gone
+
+	r := &ApplicationSetReconciler{Client: cached, APIReader: apiServer}
+
+	requeue, err := r.performReverseDeletion(t.Context(), log.NewEntry(log.New()),
+		singleStepAppSet(), []argov1alpha1.Application{phantom})
+	require.NoError(t, err)
+	require.Zero(t, requeue)
+
+	assert.NotEmpty(t, preconditionUID,
+		"the eviction Delete must carry a UID precondition, otherwise an Application created at this "+
+			"name between the live read and the delete would be removed instead")
+	assert.Equal(t, deletedUID, preconditionUID,
+		"the precondition must pin the UID of the entry we confirmed absent, not some other object")
+}
+
+// Past the staleness threshold, a step may only be treated as complete once the Application is both
+// confirmed absent and its stale cache entry evicted. Neither failure mode may let reverse deletion
+// proceed, because each would release the ApplicationSet's finalizer on an unproven premise:
+//
+//   - an unexpected Delete error means the cache-syncing client returned before evicting, leaving the
+//     phantom in the store -- the recreation failure the eviction exists to prevent;
+//   - a conflict means the UID precondition failed, so an Application exists at this name that is not
+//     the one confirmed absent. It may be a child of this ApplicationSet still owed an ordered
+//     deletion, and nothing at this point can tell.
+//
+// Both are transient, so erroring lets a later pass classify the situation instead of guessing.
+func TestEvictionFailureDoesNotReleaseTheFinalizer(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name      string
+		deleteErr error
+		wantErr   bool
+		reason    string
+	}{
+		{
+			name:      "unexpected failure blocks progress",
+			deleteErr: apierrors.NewInternalError(errors.New("etcd unavailable")),
+			wantErr:   true,
+			reason: "the client returns before evicting on any non-NotFound error, so the phantom is " +
+				"still in the store; continuing would release the finalizer and leave it there",
+		},
+		{
+			name:      "conflict blocks progress too",
+			deleteErr: apierrors.NewConflict(schema.GroupResource{Group: "argoproj.io", Resource: "applications"}, "repro-app", errors.New("uid mismatch")),
+			wantErr:   true,
+			reason: "the precondition failed because an Application exists at this name that is not " +
+				"the one confirmed absent, which invalidates the verdict this step rests on; the " +
+				"replacement may be a child still owed an ordered deletion, so the finalizer must " +
+				"not be released until a later pass has classified it",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := schemeWithApps(t)
+			phantom := agedTerminatingApp()
+			cached := fake.NewClientBuilder().
+				WithScheme(s).
+				WithObjects(&phantom).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Delete: func(_ context.Context, _ crtclient.WithWatch, _ crtclient.Object, _ ...crtclient.DeleteOption) error {
+						return tc.deleteErr
+					},
+				}).
+				Build()
+			apiServer := fake.NewClientBuilder().WithScheme(s).Build() // object really gone
+
+			r := &ApplicationSetReconciler{Client: cached, APIReader: apiServer}
+
+			_, err := r.performReverseDeletion(t.Context(), log.NewEntry(log.New()),
+				singleStepAppSet(), []argov1alpha1.Application{phantom})
+
+			if tc.wantErr {
+				require.Error(t, err, tc.reason)
+			} else {
+				require.NoError(t, err, tc.reason)
+			}
+		})
+	}
+}
+
+// A nil error from the eviction Delete is not proof the entry left the informer store.
+// cacheSyncingClient.execAndSyncCache logs a failure to reach the store, or to delete from it, and
+// then returns the original error -- which for a NotFound delete is nil. Reverse deletion must not
+// take that as success: releasing the ApplicationSet's finalizer with the phantom still cached is the
+// create-only recreation failure the eviction exists to prevent, and unlike the entry's age, a store
+// failure can clear on a later attempt.
+func TestSilentEvictionFailureDoesNotReleaseTheFinalizer(t *testing.T) {
+	t.Parallel()
+
+	s := schemeWithApps(t)
+	phantom := agedTerminatingApp()
+
+	// Delete reports the object gone, as the API server would, but the entry is never evicted --
+	// the store failure the production client only logs.
+	cached := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(&phantom).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(_ context.Context, _ crtclient.WithWatch, obj crtclient.Object, _ ...crtclient.DeleteOption) error {
+				return apierrors.NewNotFound(schema.GroupResource{Group: "argoproj.io", Resource: "applications"}, obj.GetName())
+			},
+		}).
+		Build()
+	apiServer := fake.NewClientBuilder().WithScheme(s).Build() // object really gone
+
+	r := &ApplicationSetReconciler{Client: cached, APIReader: apiServer}
+
+	_, err := r.performReverseDeletion(t.Context(), log.NewEntry(log.New()),
+		singleStepAppSet(), []argov1alpha1.Application{phantom})
+
+	require.Error(t, err,
+		"the stale entry is still readable from the cache, so this step is not complete; completing it "+
+			"would release the finalizer and leave the phantom behind")
+	assert.Contains(t, err.Error(), "still present after eviction",
+		"the error should say the eviction could not be confirmed, not something unrelated")
+}

--- a/applicationset/controllers/specchanged_regression_test.go
+++ b/applicationset/controllers/specchanged_regression_test.go
@@ -1,0 +1,206 @@
+package controllers
+
+import (
+	"testing"
+
+	"github.com/argoproj/argo-cd/gitops-engine/pkg/health"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	appsetmetrics "github.com/argoproj/argo-cd/v3/applicationset/metrics"
+	argov1alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+)
+
+// Regression tests for the progressive-sync reconcile loop: updateApplicationSetApplicationStatus
+// must only report a spec change when the write path would actually rewrite the spec. See
+// utils.SpecsEquivalent for why reporting one it will not act on cannot converge.
+//
+// Both cases below place the Application in a state where it is NOT (Synced and Healthy). That
+// matters: a Synced+Healthy Application has its Waiting status immediately overwritten with Healthy,
+// which masks the bug entirely and is why it is not universal.
+
+// helper: a progressive-sync ApplicationSet with a single RollingSync step.
+func regressionAppSet(ignore argov1alpha1.ApplicationSetIgnoreDifferences) argov1alpha1.ApplicationSet {
+	return argov1alpha1.ApplicationSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "storm", Namespace: "argocd"},
+		Spec: argov1alpha1.ApplicationSetSpec{
+			IgnoreApplicationDifferences: ignore,
+			Strategy: &argov1alpha1.ApplicationSetStrategy{
+				Type: "RollingSync",
+				RollingSync: &argov1alpha1.ApplicationSetRolloutStrategy{
+					Steps: []argov1alpha1.ApplicationSetRolloutStep{{}},
+				},
+			},
+		},
+		Status: argov1alpha1.ApplicationSetStatus{
+			ApplicationStatus: []argov1alpha1.ApplicationSetApplicationStatus{{
+				Application: "storm-a",
+				Status:      argov1alpha1.ProgressiveSyncHealthy,
+				Message:     "Application resource has synced, updating status to Healthy",
+				Step:        "1",
+				// Pinned to the Application's observed revision so revisionsChanged is false and these
+				// tests isolate specChanged.
+				TargetRevisions: []string{"abc123"},
+			}},
+		},
+	}
+}
+
+// helper: an Application that is deliberately not Synced, so a Waiting status is not overwritten.
+func regressionApp(rev string, automatedEnabled *bool) argov1alpha1.Application {
+	app := argov1alpha1.Application{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "argoproj.io/v1alpha1", Kind: "Application"},
+		ObjectMeta: metav1.ObjectMeta{Name: "storm-a", Namespace: "argocd"},
+		Spec: argov1alpha1.ApplicationSpec{
+			Project: "default",
+			Source: &argov1alpha1.ApplicationSource{
+				RepoURL:        "git://example/repo",
+				Path:           "leaves/x",
+				TargetRevision: rev,
+			},
+			Destination: argov1alpha1.ApplicationDestination{
+				Server: "https://kubernetes.default.svc", Namespace: "storm-a",
+			},
+			SyncPolicy: &argov1alpha1.SyncPolicy{
+				Automated:   &argov1alpha1.SyncPolicyAutomated{Prune: new(true), SelfHeal: new(true), Enabled: automatedEnabled},
+				SyncOptions: []string{"CreateNamespace=true"},
+			},
+		},
+		Status: argov1alpha1.ApplicationStatus{
+			Sync:   argov1alpha1.SyncStatus{Status: argov1alpha1.SyncStatusCodeUnknown, Revision: "abc123"},
+			Health: argov1alpha1.AppHealthStatus{Status: health.HealthStatusHealthy},
+		},
+	}
+	return app
+}
+
+func regressionReconciler(t *testing.T, appSet *argov1alpha1.ApplicationSet) ApplicationSetReconciler {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, argov1alpha1.AddToScheme(scheme))
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(appSet).WithStatusSubresource(appSet).Build()
+	return ApplicationSetReconciler{Client: c, Scheme: scheme, Metrics: appsetmetrics.NewFakeAppsetMetrics()}
+}
+
+// Defect 1: the status path must honour ignoreApplicationDifferences, exactly as
+// createOrUpdateInCluster does when deciding whether to Patch. Here the only difference is a field the
+// ApplicationSet explicitly ignores, so the write path will never correct it.
+//
+// Without the fix this reports "Application has pending changes (spec differs)".
+func TestSpecChangedHonoursIgnoreApplicationDifferences(t *testing.T) {
+	t.Parallel()
+
+	appSet := regressionAppSet(argov1alpha1.ApplicationSetIgnoreDifferences{
+		{JSONPointers: []string{"/spec/source/targetRevision"}},
+	})
+	live := regressionApp("refs/heads/does-not-exist", new(false))
+	desired := regressionApp("HEAD", new(false))
+
+	r := regressionReconciler(t, &appSet)
+	statuses, err := r.updateApplicationSetApplicationStatus(t.Context(), log.NewEntry(log.New()),
+		&appSet, []argov1alpha1.Application{live}, []argov1alpha1.Application{desired},
+		map[string]int{"storm-a": 0})
+	require.NoError(t, err)
+	require.Len(t, statuses, 1)
+
+	assert.NotEqual(t, argov1alpha1.ProgressiveSyncWaiting, statuses[0].Status,
+		"the only difference is an ignored field, which the write path will never correct, so "+
+			"reporting a pending spec change loops forever: %s", statuses[0].Message)
+	assert.NotContains(t, statuses[0].Message, "spec differs")
+}
+
+// Defect 2: the Automated.Enabled mutation lands on the written copy, not on the generated
+// Application compared here (see disableAutomatedSync). This needs no ignore rules and no unusual
+// configuration -- it applies to every ApplicationSet whose template sets syncPolicy.automated.
+//
+// Without the fix this reports "Application has pending changes (spec differs)".
+func TestSpecChangedIgnoresControllerManagedAutomatedEnabled(t *testing.T) {
+	t.Parallel()
+
+	appSet := regressionAppSet(nil)
+	live := regressionApp("HEAD", new(false)) // written by the controller with Enabled=false
+	desired := regressionApp("HEAD", nil)     // freshly generated: Enabled unset
+
+	r := regressionReconciler(t, &appSet)
+	statuses, err := r.updateApplicationSetApplicationStatus(t.Context(), log.NewEntry(log.New()),
+		&appSet, []argov1alpha1.Application{live}, []argov1alpha1.Application{desired},
+		map[string]int{"storm-a": 0})
+	require.NoError(t, err)
+	require.Len(t, statuses, 1)
+
+	assert.NotEqual(t, argov1alpha1.ProgressiveSyncWaiting, statuses[0].Status,
+		"automated.enabled is set by the controller itself on the written copy only; treating it as a "+
+			"user-visible spec change loops forever for any ApplicationSet using syncPolicy.automated: %s",
+		statuses[0].Message)
+	assert.NotContains(t, statuses[0].Message, "spec differs")
+}
+
+// An invalid ignore rule must not manufacture a spec change.
+//
+// Note where such a rule fails: BuildIgnoreDiffConfig validates only structural invariants, so an
+// unparseable JQ expression passes it and the failure surfaces later from applyIgnoreDifferences. The
+// write path turns that into a reconcile error; the status path cannot usefully do the same for a
+// single Application, so it must at least not report a change it cannot substantiate.
+func TestInvalidIgnoreRuleDoesNotReportSpecChange(t *testing.T) {
+	t.Parallel()
+
+	appSet := regressionAppSet(argov1alpha1.ApplicationSetIgnoreDifferences{
+		// Unparseable JQ: accepted by BuildIgnoreDiffConfig, rejected by gojq during normalization.
+		{JQPathExpressions: []string{"this is not( valid jq"}},
+	})
+	live := regressionApp("refs/heads/does-not-exist", new(false))
+	desired := regressionApp("HEAD", nil)
+
+	r := regressionReconciler(t, &appSet)
+	statuses, err := r.updateApplicationSetApplicationStatus(t.Context(), log.NewEntry(log.New()),
+		&appSet, []argov1alpha1.Application{live}, []argov1alpha1.Application{desired},
+		map[string]int{"storm-a": 0})
+	require.NoError(t, err)
+	require.Len(t, statuses, 1)
+
+	assert.NotContains(t, statuses[0].Message, "spec differs",
+		"with an unusable ignore rule the comparison cannot be trusted, so the status must not claim "+
+			"a spec change; the write path is erroring, so a change reported here can never be acted on")
+}
+
+// disableAutomatedSync is the single definition of the rule, used by both the writer and the comparer.
+// The end state must be the same for every Enabled value, including the one the original guard skipped
+// because it was already false.
+func TestDisableAutomatedSyncIsIdempotentAcrossEnabledStates(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name       string
+		syncPolicy *argov1alpha1.SyncPolicy
+		wantNil    bool
+	}{
+		{"no sync policy", nil, true},
+		{"no automated block", &argov1alpha1.SyncPolicy{}, true},
+		{"automated, enabled unset", &argov1alpha1.SyncPolicy{Automated: &argov1alpha1.SyncPolicyAutomated{}}, false},
+		{"automated, explicitly enabled", &argov1alpha1.SyncPolicy{Automated: &argov1alpha1.SyncPolicyAutomated{Enabled: new(true)}}, false},
+		{"automated, already disabled", &argov1alpha1.SyncPolicy{Automated: &argov1alpha1.SyncPolicyAutomated{Enabled: new(false)}}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			app := &argov1alpha1.Application{Spec: argov1alpha1.ApplicationSpec{SyncPolicy: tc.syncPolicy}}
+			disableAutomatedSync(app)
+
+			if tc.wantNil {
+				if app.Spec.SyncPolicy != nil {
+					assert.Nil(t, app.Spec.SyncPolicy.Automated, "nothing to disable, so nothing should be created")
+				}
+				return
+			}
+			require.NotNil(t, app.Spec.SyncPolicy.Automated.Enabled)
+			assert.False(t, *app.Spec.SyncPolicy.Automated.Enabled,
+				"automated sync must end up disabled whatever it started as, so the writer and the "+
+					"comparer always see the same value")
+		})
+	}
+}

--- a/applicationset/utils/comparison_agreement_test.go
+++ b/applicationset/utils/comparison_agreement_test.go
@@ -1,0 +1,95 @@
+package utils
+
+import (
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	argov1alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v3/util/argo"
+	"github.com/argoproj/argo-cd/v3/util/argo/normalizers"
+)
+
+// SpecsEquivalent and CreateOrUpdate must agree on whether the *spec* has changed: the first decides
+// whether progressive sync reports a pending change, the second whether anything is actually written.
+// If the first says "changed" where the second declines to patch, the Application is never corrected
+// and progressive sync loops without converging.
+//
+// The case exercised here is the awkward one: a JQ ignore rule selecting on a value that only exists
+// after normalization (spec.project defaulting to "default"), against a generated Application that
+// omits it. On this branch CreateOrUpdate applies the ignore rules *before* normalizing while its
+// caller has already normalized the generated spec, so the rule sees a normalized desired side and an
+// un-normalized live one. That asymmetry is easy to get wrong in one place only, which is why it is
+// pinned here rather than reasoned about.
+func TestSpecComparisonAgreesWithWritePath(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, argov1alpha1.AddToScheme(scheme))
+
+	newApp := func(project, rev string) *argov1alpha1.Application {
+		return &argov1alpha1.Application{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "argoproj.io/v1alpha1", Kind: "Application"},
+			ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "argocd"},
+			Spec: argov1alpha1.ApplicationSpec{
+				Project: project,
+				Source: &argov1alpha1.ApplicationSource{
+					RepoURL:        "git://example/repo",
+					Path:           "x",
+					TargetRevision: rev,
+				},
+				Destination: argov1alpha1.ApplicationDestination{
+					Server: "https://kubernetes.default.svc", Namespace: "argocd",
+				},
+			},
+		}
+	}
+
+	ignore := argov1alpha1.ApplicationSetIgnoreDifferences{
+		{JQPathExpressions: []string{`.spec | select(.project == "default") | .source.targetRevision`}},
+	}
+
+	// Both sides omit spec.project, so it only becomes "default" once NormalizeApplicationSpec runs.
+	// That is what makes the ordering observable: the caller normalizes the generated spec before the
+	// ignore rules see it, while the live side reaches them un-normalized, so the selector matches one
+	// side only. Normalizing both up front instead (master's order) would make it match both and the
+	// divergence would be invisible here.
+	live := newApp("", "abc123")  // stored without an explicit project
+	desired := newApp("", "HEAD") // generated without one either
+
+	// 1. What the status path concludes.
+	equivalent, err := SpecsEquivalent(ignore, normalizers.IgnoreNormalizerOpts{}, live, desired)
+	require.NoError(t, err)
+
+	// 2. What the write path concludes, driven through the real CreateOrUpdate.
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(live.DeepCopy()).Build()
+	obj := live.DeepCopy()
+	generated := desired.DeepCopy()
+	// createOrUpdateInCluster normalizes the generated spec before calling CreateOrUpdate.
+	// Reproducing that here is essential: the ignore rules run before normalization on this branch,
+	// so omitting this step hides an ordering divergence between the two paths.
+	generated.Spec = *argo.NormalizeApplicationSpec(&generated.Spec)
+	op, err := CreateOrUpdate(t.Context(), log.NewEntry(log.New()), c, ignore, normalizers.IgnoreNormalizerOpts{}, obj, func() error {
+		obj.Spec = generated.Spec
+		return nil
+	})
+	require.NoError(t, err)
+
+	writePathWouldPatch := op == controllerutil.OperationResultUpdated
+	statusPathSeesChange := !equivalent
+
+	t.Logf("statusPathSeesChange=%v  writePathWouldPatch=%v (op=%s)",
+		statusPathSeesChange, writePathWouldPatch, op)
+
+	require.Equal(t, writePathWouldPatch, statusPathSeesChange,
+		"the two paths must reach the same verdict on a spec difference. If the status path reports a "+
+			"change the write path will not make, the Application is never corrected and progressive "+
+			"sync loops forever. (Metadata-only changes are out of scope here: CreateOrUpdate compares "+
+			"whole objects and will patch those without SpecsEquivalent reporting a change, which cannot "+
+			"loop.)")
+}

--- a/applicationset/utils/createOrUpdate.go
+++ b/applicationset/utils/createOrUpdate.go
@@ -37,6 +37,33 @@ import (
 // The MutateFn is called regardless of creating or updating an object.
 //
 // It returns the executed operation and an error.
+// appEquality is the equality definition the write path uses when deciding whether to Patch.
+// Anything asking "did the spec change?" must use the same one, or the two can disagree.
+var appEquality = conversion.EqualitiesOrDie(
+	func(a, b resource.Quantity) bool {
+		// Ignore formatting, only care that numeric value stayed the same.
+		// TODO: if we decide it's important, it should be safe to start comparing the format.
+		//
+		// Uninitialized quantities are equivalent to 0 quantities.
+		return a.Cmp(b) == 0
+	},
+	func(a, b metav1.MicroTime) bool {
+		return a.UTC().Equal(b.UTC())
+	},
+	func(a, b metav1.Time) bool {
+		return a.UTC().Equal(b.UTC())
+	},
+	func(a, b labels.Selector) bool {
+		return a.String() == b.String()
+	},
+	func(a, b fields.Selector) bool {
+		return a.String() == b.String()
+	},
+	func(a, b argov1alpha1.ApplicationDestination) bool {
+		return a.Namespace == b.Namespace && a.Name == b.Name && a.Server == b.Server
+	},
+)
+
 func CreateOrUpdate(ctx context.Context, logCtx *log.Entry, c client.Client, ignoreAppDifferences argov1alpha1.ApplicationSetIgnoreDifferences, ignoreNormalizerOpts normalizers.IgnoreNormalizerOpts, obj *argov1alpha1.Application, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
 	key := client.ObjectKeyFromObject(obj)
 	if err := c.Get(ctx, key, obj); err != nil {
@@ -70,36 +97,11 @@ func CreateOrUpdate(ctx context.Context, logCtx *log.Entry, c client.Client, ign
 	normalizedLive.Spec = *argo.NormalizeApplicationSpec(&normalizedLive.Spec)
 	obj.Spec = *argo.NormalizeApplicationSpec(&obj.Spec)
 
-	equality := conversion.EqualitiesOrDie(
-		func(a, b resource.Quantity) bool {
-			// Ignore formatting, only care that numeric value stayed the same.
-			// TODO: if we decide it's important, it should be safe to start comparing the format.
-			//
-			// Uninitialized quantities are equivalent to 0 quantities.
-			return a.Cmp(b) == 0
-		},
-		func(a, b metav1.MicroTime) bool {
-			return a.UTC().Equal(b.UTC())
-		},
-		func(a, b metav1.Time) bool {
-			return a.UTC().Equal(b.UTC())
-		},
-		func(a, b labels.Selector) bool {
-			return a.String() == b.String()
-		},
-		func(a, b fields.Selector) bool {
-			return a.String() == b.String()
-		},
-		func(a, b argov1alpha1.ApplicationDestination) bool {
-			return a.Namespace == b.Namespace && a.Name == b.Name && a.Server == b.Server
-		},
-	)
-
 	// Note: if the informer cache holds a stale entry for an application that no longer exists on
 	// the API server, DeepEqual may match against that stale entry and we skip Patch here. The
 	// eviction in cacheSyncingClient only runs on NotFound from a write operation, so this edge
 	// case is not covered and relies on Kubernetes propagating the delete event to the informer.
-	if equality.DeepEqual(normalizedLive, obj) {
+	if appEquality.DeepEqual(normalizedLive, obj) {
 		return controllerutil.OperationResultNone, nil
 	}
 
@@ -139,12 +141,43 @@ func mutate(f controllerutil.MutateFn, key client.ObjectKey, obj client.Object) 
 }
 
 // applyIgnoreDifferences applies the ignore differences rules to the found application. It modifies the applications in place.
+// SpecsEquivalent reports whether the desired Application spec matches the live one, applying the
+// same ignoreApplicationDifferences rules and normalization CreateOrUpdate applies before deciding
+// whether to Patch. Callers asking "has the spec changed?" must use this rather than comparing specs
+// directly: a difference the write path would not act on leaves the Application uncorrected and still
+// reported as pending every reconcile. Scoped to the spec -- CreateOrUpdate compares whole objects, so
+// a metadata-only change is patched without being reported here, which cannot loop.
+//
+// The ordering below is load bearing and deliberately differs from master. Here CreateOrUpdate applies
+// the ignore rules before normalizing, and its caller has already normalized the generated spec, so
+// when the rules run the desired side is normalized and the live side is not. A rule selecting on a
+// value that only appears after normalization therefore matches one side only. Reproducing that
+// asymmetry is what keeps this answer and the write path's in step; normalizing both up front does not,
+// and TestSpecComparisonAgreesWithWritePath fails if this is changed to match master.
+func SpecsEquivalent(ignoreDifferences argov1alpha1.ApplicationSetIgnoreDifferences, ignoreNormalizerOpts normalizers.IgnoreNormalizerOpts, live, desired *argov1alpha1.Application) (bool, error) {
+	normalizedLive := live.DeepCopy()
+	normalizedDesired := desired.DeepCopy()
+
+	// As createOrUpdateInCluster does before calling CreateOrUpdate.
+	normalizedDesired.Spec = *argo.NormalizeApplicationSpec(&normalizedDesired.Spec)
+
+	if err := applyIgnoreDifferences(ignoreDifferences, normalizedLive, normalizedDesired, ignoreNormalizerOpts); err != nil {
+		return false, fmt.Errorf("failed to apply ignore differences: %w", err)
+	}
+
+	normalizedLive.Spec = *argo.NormalizeApplicationSpec(&normalizedLive.Spec)
+	normalizedDesired.Spec = *argo.NormalizeApplicationSpec(&normalizedDesired.Spec)
+
+	return appEquality.DeepEqual(normalizedLive.Spec, normalizedDesired.Spec), nil
+}
+
 func applyIgnoreDifferences(applicationSetIgnoreDifferences argov1alpha1.ApplicationSetIgnoreDifferences, found *argov1alpha1.Application, generatedApp *argov1alpha1.Application, ignoreNormalizerOpts normalizers.IgnoreNormalizerOpts) error {
 	if len(applicationSetIgnoreDifferences) == 0 {
 		return nil
 	}
 
 	generatedAppCopy := generatedApp.DeepCopy()
+	foundTypeMeta := found.TypeMeta
 	diffConfig, err := argodiff.NewDiffConfigBuilder().
 		WithDiffSettings(applicationSetIgnoreDifferences.ToApplicationIgnoreDifferences(), nil, false, ignoreNormalizerOpts).
 		WithNoCache().
@@ -152,13 +185,23 @@ func applyIgnoreDifferences(applicationSetIgnoreDifferences argov1alpha1.Applica
 	if err != nil {
 		return fmt.Errorf("failed to build diff config: %w", err)
 	}
-	unstructuredFound, err := appToUnstructured(found)
+	// diffConfig's rules are scoped to Group=argoproj.io, Kind=Application, but appToUnstructured goes
+	// through runtime.DefaultUnstructuredConverter, which does not populate apiVersion/kind -- and the
+	// live object arrives decoded from the API server while the generated one is built in Go with no
+	// TypeMeta. Without stamping the GVK the rules match one side only, so an ignored field is
+	// neutralised there and left intact on the other, and the two can never compare equal.
+	foundForDiff := found.DeepCopy()
+	foundForDiff.SetGroupVersionKind(argov1alpha1.ApplicationSchemaGroupVersionKind)
+	generatedForDiff := generatedApp.DeepCopy()
+	generatedForDiff.SetGroupVersionKind(argov1alpha1.ApplicationSchemaGroupVersionKind)
+
+	unstructuredFound, err := appToUnstructured(foundForDiff)
 	if err != nil {
 		return fmt.Errorf("failed to convert found application to unstructured: %w", err)
 	}
-	unstructuredGenerated, err := appToUnstructured(generatedApp)
+	unstructuredGenerated, err := appToUnstructured(generatedForDiff)
 	if err != nil {
-		return fmt.Errorf("failed to convert found application to unstructured: %w", err)
+		return fmt.Errorf("failed to convert generated application to unstructured: %w", err)
 	}
 	result, err := argodiff.Normalize([]*unstructured.Unstructured{unstructuredFound}, []*unstructured.Unstructured{unstructuredGenerated}, diffConfig)
 	if err != nil {
@@ -180,6 +223,7 @@ func applyIgnoreDifferences(applicationSetIgnoreDifferences argov1alpha1.Applica
 		return fmt.Errorf("expected 1 normalized application, got %d", len(result.Targets))
 	}
 	foundNormalized.DeepCopyInto(found)
+	found.TypeMeta = foundTypeMeta
 	generatedJSONNormalized, err := json.Marshal(result.Targets[0].Object)
 	if err != nil {
 		return fmt.Errorf("failed to marshal normalized app to json: %w", err)

--- a/applicationset/utils/typemeta_ignore_test.go
+++ b/applicationset/utils/typemeta_ignore_test.go
@@ -1,0 +1,73 @@
+package utils
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	argov1alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v3/util/argo/normalizers"
+)
+
+// applyIgnoreDifferences must neutralise an ignored field on BOTH the live and the generated
+// Application, regardless of the TypeMeta each happens to arrive with. Its rules are GVK-scoped, but
+// the live object is decoded from the API server while the generated one is built in Go with TypeMeta
+// zero, so a rule matching one side only leaves the field stripped there and intact on the other --
+// and the specs then never compare equal. See applyIgnoreDifferences for the mechanism.
+func TestApplyIgnoreDifferencesIsTypeMetaIndependent(t *testing.T) {
+	t.Parallel()
+
+	withTypeMeta := metav1.TypeMeta{APIVersion: "argoproj.io/v1alpha1", Kind: "Application"}
+
+	newApp := func(tm metav1.TypeMeta, rev string) *argov1alpha1.Application {
+		return &argov1alpha1.Application{
+			TypeMeta:   tm,
+			ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "argocd"},
+			Spec: argov1alpha1.ApplicationSpec{
+				Project: "default",
+				Source: &argov1alpha1.ApplicationSource{
+					RepoURL:        "git://example/repo",
+					Path:           "x",
+					TargetRevision: rev,
+				},
+				Destination: argov1alpha1.ApplicationDestination{
+					Server: "https://kubernetes.default.svc", Namespace: "argocd",
+				},
+			},
+		}
+	}
+
+	ignore := argov1alpha1.ApplicationSetIgnoreDifferences{
+		{JSONPointers: []string{"/spec/source/targetRevision"}},
+	}
+	for _, tc := range []struct {
+		name      string
+		liveTM    metav1.TypeMeta
+		desiredTM metav1.TypeMeta
+	}{
+		{"both have TypeMeta", withTypeMeta, withTypeMeta},
+		{"live has TypeMeta, desired does not (what the controller actually sees)", withTypeMeta, metav1.TypeMeta{}},
+		{"neither has TypeMeta", metav1.TypeMeta{}, metav1.TypeMeta{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			live := newApp(tc.liveTM, "refs/heads/does-not-exist")
+			desired := newApp(tc.desiredTM, "HEAD")
+
+			if err := applyIgnoreDifferences(ignore, live, desired, normalizers.IgnoreNormalizerOpts{}); err != nil {
+				t.Fatalf("applyIgnoreDifferences: %v", err)
+			}
+
+			t.Logf("live.targetRevision=%q  desired.targetRevision=%q",
+				live.Spec.Source.TargetRevision, desired.Spec.Source.TargetRevision)
+
+			if live.Spec.Source.TargetRevision != desired.Spec.Source.TargetRevision {
+				t.Errorf("ignored field must be neutralised on BOTH sides irrespective of TypeMeta; "+
+					"got live=%q desired=%q -- the two specs can never compare equal, so progressive sync "+
+					"reports a spec change on every reconcile",
+					live.Spec.Source.TargetRevision, desired.Spec.Source.TargetRevision)
+			}
+		})
+	}
+}

--- a/cmd/argocd-applicationset-controller/commands/applicationset_controller.go
+++ b/cmd/argocd-applicationset-controller/commands/applicationset_controller.go
@@ -239,8 +239,11 @@ func NewCommand() *cobra.Command {
 				})
 
 			if err = (&controllers.ApplicationSetReconciler{
-				Generators:                 topLevelGenerators,
-				Client:                     utils.NewCacheSyncingClient(mgr.GetClient(), mgr.GetCache()),
+				Generators: topLevelGenerators,
+				Client:     utils.NewCacheSyncingClient(mgr.GetClient(), mgr.GetCache()),
+				// Uncached reads, used by reverse deletion to verify an Application the informer
+				// cache has reported as terminating for implausibly long.
+				APIReader:                  mgr.GetAPIReader(),
 				Scheme:                     mgr.GetScheme(),
 				Recorder:                   mgr.GetEventRecorderFor("applicationset-controller"),
 				Renderer:                   &utils.Render{},


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. — n/a, no user-facing surface
* [x] Does this PR require documentation updates? — no; backport of existing fixes
* [x] I've updated documentation as required by this PR. — n/a per above
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into — this *is* the oldest backport; 3.3 was agreed out of scope.

Backports to `release-3.4` of #29043 (issue #29042) and #29044 (issue #27577), plus their follow-ups in #29140. Two commits, one per fix, following the shape of #29000.

> [!IMPORTANT]
> **This is a re-implementation, not a cherry-pick — please review it as new code.** The automated cherry-pick failed for a structural reason: progressive sync lives in `applicationset/controllers/` on this branch, not the `applicationset/progressivesync/` package it was extracted into for 3.5+, and there is no `BuildIgnoreDiffConfig` — `CreateOrUpdate` and `applyIgnoreDifferences` take the raw ignore rules plus normalizer options. Diffing this against what merged on master will show large differences that are expected. The same divergence Blake noted on #29000.

**Commit 1 — the ApplicationSet stuck in Terminating (#29042)**

`performReverseDeletion` reads Applications from the informer cache, and an entry whose `DELETED` event was never delivered keeps the `deletionTimestamp` stamped by the preceding `MODIFIED`. Its age only grows, so the two-minute staleness check fires on every reconcile — and that check sits on the only path reaching `RemoveFinalizer`.

Past the threshold the Application is now read directly from the API server. A step completes only when it is both confirmed absent **and** its stale cache entry confirmed evicted; every other outcome returns an error, which is safe because each of those conditions can become false on a later attempt, unlike the entry's age. A genuinely slow child is never skipped, so deletion ordering holds.

#29000 changed this branch from a hard error to a warning plus requeue. That removed the log noise but not the wedge — `RemoveFinalizer` was still never reached, so the object still needed a manual finalizer patch. This is what actually releases it.

**Commit 2 — the reconcile loop (#27577)**

`updateApplicationSetApplicationStatus` could report a spec change the write path would never act on, so the Application was never corrected and the change was still pending next reconcile. Three causes, all required:

1. The status path used a plain `cmp.Equal` while `CreateOrUpdate` applies the `ignoreApplicationDifferences` rules and `NormalizeApplicationSpec`. Both now go through `SpecsEquivalent`, sharing one `appEquality` definition lifted out of `CreateOrUpdate`.
2. `applyIgnoreDifferences` was TypeMeta-dependent: its rules are GVK-scoped but `appToUnstructured` goes through `runtime.DefaultUnstructuredConverter`, which does not populate `apiVersion`/`kind`. Live objects arrive decoded from the API server and generated ones are built in Go with none, so the rules matched one side only and the two could never compare equal. The GVK is now stamped before conversion.
3. `Automated.Enabled` was mirrored on the written copy only. `disableAutomatedSync` gives the writer and the comparer one definition.

> [!WARNING]
> **The ordering inside `SpecsEquivalent` deliberately differs from master and must not be "corrected" to match it.** On this branch `CreateOrUpdate` applies the ignore rules *before* normalizing — the reverse of master — and its caller has already normalized the generated spec, so when the rules run the desired side is normalized and the live side is not. A rule selecting on a value that only appears after normalization therefore matches one side only. `TestSpecComparisonAgreesWithWritePath` fails if this is changed to master's order; I verified that by making the change and watching it fail, rather than assuming.

**Verification on this branch**

* Builds `./applicationset/...` and `./cmd/...`; 11/11 and 7/7 packages pass
* Every fix was checked by disabling it and confirming the tests fail — 6 wedge tests, 3 storm tests, and the agreement test
* Linted with golangci-lint 2.11.3, the version pinned in `hack/installers/install-lint-tools.sh` on this branch — clean
* `go.mod`/`go.sum` unchanged

Fixes #29042 and #27577 on `release-3.4`.
