### PR TITLE
fix: respect ApplicationSet update policy in progressive sync (#29142)

### DIFF
--- a/applicationset/controllers/applicationset_controller.go
+++ b/applicationset/controllers/applicationset_controller.go
@@ -141,6 +141,7 @@ func (r *ApplicationSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+	effectivePolicy := utils.DefaultPolicy(applicationSetInfo.Spec.SyncPolicy, r.Policy, r.EnablePolicyOverride)
 
 	defer func() {
 		r.Metrics.ObserveReconcile(&applicationSetInfo, time.Since(startTime))
@@ -150,7 +151,7 @@ func (r *ApplicationSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	if applicationSetInfo.DeletionTimestamp != nil {
 		appsetName := applicationSetInfo.Name
 		logCtx.Debugf("DeletionTimestamp is set on %s", appsetName)
-		deleteAllowed := utils.DefaultPolicy(applicationSetInfo.Spec.SyncPolicy, r.Policy, r.EnablePolicyOverride).AllowDelete()
+		deleteAllowed := effectivePolicy.AllowDelete()
 		if !deleteAllowed {
 			logCtx.Debugf("ApplicationSet policy does not allow to delete")
 			if err := r.removeOwnerReferencesOnDeleteAppSet(ctx, applicationSetInfo); err != nil {
@@ -274,7 +275,7 @@ func (r *ApplicationSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				)
 				return ctrl.Result{RequeueAfter: ReconcileRequeueOnValidationError}, nil
 			}
-			appSyncMap, err = r.ProgressiveSyncManager.PerformProgressiveSyncs(ctx, logCtx, applicationSetInfo, currentApplications, generatedApplications)
+			appSyncMap, err = r.ProgressiveSyncManager.PerformProgressiveSyncs(ctx, logCtx, applicationSetInfo, currentApplications, generatedApplications, effectivePolicy)
 			if err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to perform progressive sync reconciliation for application set: %w", err)
 			}
@@ -339,7 +340,7 @@ func (r *ApplicationSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return validApps[i].Name < validApps[j].Name
 	})
 
-	if utils.DefaultPolicy(applicationSetInfo.Spec.SyncPolicy, r.Policy, r.EnablePolicyOverride).AllowUpdate() {
+	if effectivePolicy.AllowUpdate() {
 		err = r.createOrUpdateInCluster(ctx, logCtx, applicationSetInfo, validApps)
 		if err != nil {
 			_ = r.setApplicationSetStatusCondition(ctx,
@@ -373,7 +374,7 @@ func (r *ApplicationSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 	}
 
-	if utils.DefaultPolicy(applicationSetInfo.Spec.SyncPolicy, r.Policy, r.EnablePolicyOverride).AllowDelete() {
+	if effectivePolicy.AllowDelete() {
 		// Delete the generatedApplications instead of the validApps because we want to be able to delete applications in error/invalid state
 		err = r.deleteInCluster(ctx, logCtx, applicationSetInfo, generatedApplications)
 		if err != nil {

--- a/applicationset/controllers/progressive_sync_dependencies_test.go
+++ b/applicationset/controllers/progressive_sync_dependencies_test.go
@@ -908,7 +908,7 @@ func TestUpdateApplicationSetApplicationStatus(t *testing.T) {
 			if desiredApps == nil {
 				desiredApps = cc.apps
 			}
-			appStatuses, err := r.ProgressiveSyncManager.UpdateApplicationSetApplicationStatus(t.Context(), log.NewEntry(log.StandardLogger()), &cc.appSet, cc.apps, desiredApps, cc.appStepMap)
+			appStatuses, err := r.ProgressiveSyncManager.UpdateApplicationSetApplicationStatus(t.Context(), log.NewEntry(log.StandardLogger()), &cc.appSet, cc.apps, desiredApps, cc.appStepMap, v1alpha1.ApplicationsSyncPolicySync)
 
 			// opt out of testing the LastTransitionTime is accurate
 			for i := range appStatuses {

--- a/applicationset/progressivesync/progressive_sync.go
+++ b/applicationset/progressivesync/progressive_sync.go
@@ -103,7 +103,7 @@ func (m *Manager) applicationGoneFromAPIServer(ctx context.Context, namespace, n
 	}
 }
 
-func (m *Manager) PerformProgressiveSyncs(ctx context.Context, logCtx *log.Entry, appset argov1alpha1.ApplicationSet, applications []argov1alpha1.Application, desiredApplications []argov1alpha1.Application) (map[string]bool, error) {
+func (m *Manager) PerformProgressiveSyncs(ctx context.Context, logCtx *log.Entry, appset argov1alpha1.ApplicationSet, applications []argov1alpha1.Application, desiredApplications []argov1alpha1.Application, effectivePolicy argov1alpha1.ApplicationsSyncPolicy) (map[string]bool, error) {
 	// Initialize validation tracking
 	m.validationIssues = &ValidationIssues{}
 
@@ -114,7 +114,7 @@ func (m *Manager) PerformProgressiveSyncs(ctx context.Context, logCtx *log.Entry
 		m.validationIssues = buildIssues
 	}
 
-	_, err := m.UpdateApplicationSetApplicationStatus(ctx, logCtx, &appset, applications, desiredApplications, appStepMap)
+	_, err := m.UpdateApplicationSetApplicationStatus(ctx, logCtx, &appset, applications, desiredApplications, appStepMap, effectivePolicy)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update applicationset app status: %w", err)
 	}
@@ -393,7 +393,7 @@ func getAppStep(appName string, appStepMap map[string]int) int {
 
 // check the status of each Application's status and promote Applications to the next status if needed
 // update AppSet status in-memory, controller will persist it
-func (m *Manager) UpdateApplicationSetApplicationStatus(ctx context.Context, logCtx *log.Entry, applicationSet *argov1alpha1.ApplicationSet, applications []argov1alpha1.Application, desiredApplications []argov1alpha1.Application, appStepMap map[string]int) ([]argov1alpha1.ApplicationSetApplicationStatus, error) {
+func (m *Manager) UpdateApplicationSetApplicationStatus(ctx context.Context, logCtx *log.Entry, applicationSet *argov1alpha1.ApplicationSet, applications []argov1alpha1.Application, desiredApplications []argov1alpha1.Application, appStepMap map[string]int, effectivePolicy argov1alpha1.ApplicationsSyncPolicy) ([]argov1alpha1.ApplicationSetApplicationStatus, error) {
 	now := metav1.Now()
 	appStatuses := make([]argov1alpha1.ApplicationSetApplicationStatus, 0, len(applications))
 
@@ -446,9 +446,9 @@ func (m *Manager) UpdateApplicationSetApplicationStatus(ctx context.Context, log
 
 		revisionsChanged := !reflect.DeepEqual(currentAppStatus.TargetRevisions, app.Status.GetRevisions())
 
-		// Check if the desired Application spec differs from the current Application spec
+		// Only report spec changes that the effective policy allows the write path to apply.
 		specChanged := false
-		if desiredApp, ok := desiredAppsMap[app.Name]; ok {
+		if desiredApp, ok := desiredAppsMap[app.Name]; ok && effectivePolicy.AllowUpdate() {
 			// Compare the desired spec with the current spec to detect non-Git changes
 			// This will catch changes to generator parameters like image tags, helm values, etc.
 			//

--- a/applicationset/progressivesync/specchanged_regression_test.go
+++ b/applicationset/progressivesync/specchanged_regression_test.go
@@ -116,7 +116,7 @@ func TestSpecChangedHonoursIgnoreApplicationDifferences(t *testing.T) {
 	m := regressionManager(t, &appSet)
 	statuses, err := m.UpdateApplicationSetApplicationStatus(t.Context(), log.NewEntry(log.New()),
 		&appSet, []argov1alpha1.Application{live}, []argov1alpha1.Application{desired},
-		map[string]int{"storm-a": 0})
+		map[string]int{"storm-a": 0}, argov1alpha1.ApplicationsSyncPolicySync)
 	require.NoError(t, err)
 	require.Len(t, statuses, 1)
 
@@ -141,7 +141,7 @@ func TestSpecChangedIgnoresControllerManagedAutomatedEnabled(t *testing.T) {
 	m := regressionManager(t, &appSet)
 	statuses, err := m.UpdateApplicationSetApplicationStatus(t.Context(), log.NewEntry(log.New()),
 		&appSet, []argov1alpha1.Application{live}, []argov1alpha1.Application{desired},
-		map[string]int{"storm-a": 0})
+		map[string]int{"storm-a": 0}, argov1alpha1.ApplicationsSyncPolicySync)
 	require.NoError(t, err)
 	require.Len(t, statuses, 1)
 
@@ -171,13 +171,75 @@ func TestInvalidIgnoreRuleDoesNotReportSpecChange(t *testing.T) {
 	m := regressionManager(t, &appSet)
 	statuses, err := m.UpdateApplicationSetApplicationStatus(t.Context(), log.NewEntry(log.New()),
 		&appSet, []argov1alpha1.Application{live}, []argov1alpha1.Application{desired},
-		map[string]int{"storm-a": 0})
+		map[string]int{"storm-a": 0}, argov1alpha1.ApplicationsSyncPolicySync)
 	require.NoError(t, err)
 	require.Len(t, statuses, 1)
 
 	assert.NotContains(t, statuses[0].Message, "spec differs",
 		"with an unusable ignore rule the comparison cannot be trusted, so the status must not claim "+
 			"a spec change; the write path is erroring, so a change reported here can never be acted on")
+}
+
+// A permanent spec difference is expected when the effective policy forbids Application updates.
+// It must not drive progressive-sync transitions that the write path cannot complete.
+func TestSpecChangedHonoursEffectiveApplicationsSyncPolicy(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name           string
+		policy         argov1alpha1.ApplicationsSyncPolicy
+		wantSpecChange bool
+	}{
+		{name: "create-only", policy: argov1alpha1.ApplicationsSyncPolicyCreateOnly},
+		{name: "create-delete", policy: argov1alpha1.ApplicationsSyncPolicyCreateDelete},
+		{name: "create-update", policy: argov1alpha1.ApplicationsSyncPolicyCreateUpdate, wantSpecChange: true},
+		{name: "sync", policy: argov1alpha1.ApplicationsSyncPolicySync, wantSpecChange: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			appSet := regressionAppSet(nil)
+			live := regressionApp("abc123", new(false))
+			desired := regressionApp("HEAD", new(false))
+
+			statuses, err := regressionManager(t, &appSet).UpdateApplicationSetApplicationStatus(
+				t.Context(), log.NewEntry(log.New()), &appSet,
+				[]argov1alpha1.Application{live}, []argov1alpha1.Application{desired},
+				map[string]int{"storm-a": 0}, tc.policy,
+			)
+			require.NoError(t, err)
+			require.Len(t, statuses, 1)
+
+			if tc.wantSpecChange {
+				assert.Equal(t, argov1alpha1.ProgressiveSyncWaiting, statuses[0].Status)
+				assert.Contains(t, statuses[0].Message, "spec differs")
+			} else {
+				assert.Equal(t, argov1alpha1.ProgressiveSyncHealthy, statuses[0].Status)
+				assert.NotContains(t, statuses[0].Message, "spec differs")
+			}
+		})
+	}
+}
+
+func TestNoUpdatePolicyStillReportsRevisionChanges(t *testing.T) {
+	t.Parallel()
+
+	appSet := regressionAppSet(nil)
+	appSet.Status.ApplicationStatus[0].TargetRevisions = []string{"old-revision"}
+	live := regressionApp("abc123", new(false))
+	desired := regressionApp("HEAD", new(false))
+
+	statuses, err := regressionManager(t, &appSet).UpdateApplicationSetApplicationStatus(
+		t.Context(), log.NewEntry(log.New()), &appSet,
+		[]argov1alpha1.Application{live}, []argov1alpha1.Application{desired},
+		map[string]int{"storm-a": 0}, argov1alpha1.ApplicationsSyncPolicyCreateOnly,
+	)
+	require.NoError(t, err)
+	require.Len(t, statuses, 1)
+
+	assert.Equal(t, argov1alpha1.ProgressiveSyncWaiting, statuses[0].Status)
+	assert.Equal(t, revisionChangedMsg, statuses[0].Message)
+	assert.NotContains(t, statuses[0].Message, "spec differs")
 }
 
 // disableAutomatedSync is the single definition of the rule, used by both the writer and the comparer.


### PR DESCRIPTION
Progressive Sync treated generated spec changes as pending updates even when the effective ApplicationSet policy did not allow updates. This caused the status to loop between `Waiting` and `Pending`.

This passes the effective policy into the progressive sync status calculation and only checks spec changes when updates are allowed.

Fixes #29142

We reproduced the issue with a RollingSync ApplicationSet using `create-only`. With the generated spec at `v2` and the live Application at `v1`, the unpatched controller repeatedly moved the status between `Waiting` and `Pending`. With this fix, the status remained stable and the live Application was not updated.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. Not applicable; this is a controller bug fix.
* [x] Does this PR require documentation updates? No; this restores the existing policy behavior.
* [x] I've updated documentation as required by this PR. No documentation changes are required.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines. Not applicable; this is a bug fix.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md. Not applicable.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity). Suggested: `release-3.5`, `release-3.4`, and `release-3.3`.

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
