### PR TITLE
fix: handle percentage partition in kruise daemonset health

### DIFF
--- a/resource_customizations/apps.kruise.io/DaemonSet/health.lua
+++ b/resource_customizations/apps.kruise.io/DaemonSet/health.lua
@@ -1,15 +1,42 @@
 hs={ status = "Progressing", message = "Waiting for initialization" }
 
+local function getTargetUpdated(desired, partition)
+    if desired == nil then
+        return nil
+    end
+
+    if partition == nil then
+        return desired
+    end
+
+    if type(partition) == "string" then
+        local percentage = string.match(partition, "^(%d+)%%$")
+        if percentage ~= nil then
+            return desired * (100 - tonumber(percentage)) / 100
+        end
+
+        partition = tonumber(partition)
+    end
+
+    if partition == nil then
+        return desired
+    end
+
+    return desired - partition
+end
+
 if obj.status ~= nil then
 
     if obj.metadata.generation == obj.status.observedGeneration then
+
+        local targetUpdated = getTargetUpdated(obj.status.desiredNumberScheduled, obj.spec.updateStrategy.rollingUpdate.partition)
 
         if obj.spec.updateStrategy.rollingUpdate.paused == true or not obj.status.updatedNumberScheduled then
             hs.status = "Suspended"
             hs.message = "Daemonset is paused"
             return hs
-        elseif (obj.spec.updateStrategy.rollingUpdate.partition ~= nil) and (obj.spec.updateStrategy.rollingUpdate.partition ~= 0 and obj.metadata.generation > 1) then
-            if obj.status.updatedNumberScheduled > (obj.status.desiredNumberScheduled - obj.spec.updateStrategy.rollingUpdate.partition) then
+        elseif targetUpdated ~= nil and targetUpdated ~= obj.status.desiredNumberScheduled and obj.metadata.generation > 1 then
+            if obj.status.updatedNumberScheduled > targetUpdated then
                 hs.status = "Suspended"
                 hs.message = "Daemonset needs manual intervention"
                 return hs

--- a/resource_customizations/apps.kruise.io/DaemonSet/health.lua
+++ b/resource_customizations/apps.kruise.io/DaemonSet/health.lua
@@ -12,7 +12,8 @@ local function getTargetUpdated(desired, partition)
     if type(partition) == "string" then
         local percentage = string.match(partition, "^(%d+)%%$")
         if percentage ~= nil then
-            return desired * (100 - tonumber(percentage)) / 100
+            local held = math.floor(desired * tonumber(percentage) / 100)
+            return desired - math.min(held, desired)
         end
 
         partition = tonumber(partition)

--- a/resource_customizations/apps.kruise.io/DaemonSet/health_test.yaml
+++ b/resource_customizations/apps.kruise.io/DaemonSet/health_test.yaml
@@ -4,6 +4,14 @@ tests:
       message: "All Daemonset workloads are ready and updated"
     inputPath: testdata/healthy.yaml
   - healthStatus:
+      status: Healthy
+      message: "All Daemonset workloads are ready and updated"
+    inputPath: testdata/partition_string_zero_healthy.yaml
+  - healthStatus:
+      status: Healthy
+      message: "All Daemonset workloads are ready and updated"
+    inputPath: testdata/partition_percentage_zero_healthy.yaml
+  - healthStatus:
       status: Degraded
       message: "Some pods are not ready or available"
     inputPath: testdata/degraded.yaml
@@ -23,3 +31,11 @@ tests:
       status: Suspended
       message: "Daemonset needs manual intervention"
     inputPath: testdata/partition_suspended.yaml
+  - healthStatus:
+      status: Suspended
+      message: "Daemonset needs manual intervention"
+    inputPath: testdata/partition_percentage_suspended.yaml
+  - healthStatus:
+      status: Progressing
+      message: "Waiting for initialization"
+    inputPath: testdata/partition_percentage_hold.yaml

--- a/resource_customizations/apps.kruise.io/DaemonSet/health_test.yaml
+++ b/resource_customizations/apps.kruise.io/DaemonSet/health_test.yaml
@@ -38,4 +38,12 @@ tests:
   - healthStatus:
       status: Progressing
       message: "Waiting for initialization"
+    inputPath: testdata/partition_percentage_rounding.yaml
+  - healthStatus:
+      status: Suspended
+      message: "Daemonset needs manual intervention"
+    inputPath: testdata/partition_numeric_string_suspended.yaml
+  - healthStatus:
+      status: Progressing
+      message: "Waiting for initialization"
     inputPath: testdata/partition_percentage_hold.yaml

--- a/resource_customizations/apps.kruise.io/DaemonSet/testdata/partition_numeric_string_suspended.yaml
+++ b/resource_customizations/apps.kruise.io/DaemonSet/testdata/partition_numeric_string_suspended.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps.kruise.io/v1alpha1
+kind: DaemonSet
+metadata:
+  name: daemonset-test
+  namespace: kruise
+  generation: 6
+  labels:
+    app: sample
+spec:
+  selector:
+    matchLabels:
+      app: sample
+  template:
+    metadata:
+      labels:
+        app: sample
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:alpine
+  updateStrategy:
+    rollingUpdate:
+      partition: "3"
+
+status:
+  currentNumberScheduled: 10
+  daemonSetHash: 5f8cdcdc65
+  desiredNumberScheduled: 10
+  numberAvailable: 10
+  numberMisscheduled: 0
+  numberReady: 10
+  observedGeneration: 6
+  updatedNumberScheduled: 8

--- a/resource_customizations/apps.kruise.io/DaemonSet/testdata/partition_percentage_hold.yaml
+++ b/resource_customizations/apps.kruise.io/DaemonSet/testdata/partition_percentage_hold.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps.kruise.io/v1beta1
+kind: DaemonSet
+metadata:
+  name: daemonset-test
+  namespace: kruise
+  generation: 6
+  labels:
+    app: sample
+spec:
+  selector:
+    matchLabels:
+      app: sample
+  template:
+    metadata:
+      labels:
+        app: sample
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:alpine
+  updateStrategy:
+    rollingUpdate:
+      partition: "100%"
+
+status:
+  currentNumberScheduled: 10
+  daemonSetHash: 5f8cdcdc65
+  desiredNumberScheduled: 10
+  numberAvailable: 10
+  numberMisscheduled: 0
+  numberReady: 10
+  observedGeneration: 6
+  updatedNumberScheduled: 0

--- a/resource_customizations/apps.kruise.io/DaemonSet/testdata/partition_percentage_rounding.yaml
+++ b/resource_customizations/apps.kruise.io/DaemonSet/testdata/partition_percentage_rounding.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps.kruise.io/v1alpha1
+kind: DaemonSet
+metadata:
+  name: daemonset-test
+  namespace: kruise
+  generation: 6
+  labels:
+    app: sample
+spec:
+  selector:
+    matchLabels:
+      app: sample
+  template:
+    metadata:
+      labels:
+        app: sample
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:alpine
+  updateStrategy:
+    rollingUpdate:
+      partition: "50%"
+
+status:
+  currentNumberScheduled: 3
+  daemonSetHash: 5f8cdcdc65
+  desiredNumberScheduled: 3
+  numberAvailable: 3
+  numberMisscheduled: 0
+  numberReady: 3
+  observedGeneration: 6
+  updatedNumberScheduled: 2

--- a/resource_customizations/apps.kruise.io/DaemonSet/testdata/partition_percentage_suspended.yaml
+++ b/resource_customizations/apps.kruise.io/DaemonSet/testdata/partition_percentage_suspended.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps.kruise.io/v1beta1
+kind: DaemonSet
+metadata:
+  name: daemonset-test
+  namespace: kruise
+  generation: 6
+  labels:
+    app: sample
+spec:
+  selector:
+    matchLabels:
+      app: sample
+  template:
+    metadata:
+      labels:
+        app: sample
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:alpine
+  updateStrategy:
+    rollingUpdate:
+      partition: "50%"
+
+status:
+  currentNumberScheduled: 10
+  daemonSetHash: 5f8cdcdc65
+  desiredNumberScheduled: 10
+  numberAvailable: 10
+  numberMisscheduled: 0
+  numberReady: 10
+  observedGeneration: 6
+  updatedNumberScheduled: 7

--- a/resource_customizations/apps.kruise.io/DaemonSet/testdata/partition_percentage_zero_healthy.yaml
+++ b/resource_customizations/apps.kruise.io/DaemonSet/testdata/partition_percentage_zero_healthy.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps.kruise.io/v1alpha1
+kind: DaemonSet
+metadata:
+  name: daemonset-test
+  namespace: kruise
+  generation: 2
+  labels:
+    app: sample
+spec:
+  selector:
+    matchLabels:
+      app: sample
+  template:
+    metadata:
+      labels:
+        app: sample
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:alpine
+  updateStrategy:
+    rollingUpdate:
+      partition: "0%"
+      paused: false
+
+status:
+  currentNumberScheduled: 1
+  daemonSetHash: 5dffcdfcd7
+  desiredNumberScheduled: 1
+  numberAvailable: 1
+  numberMisscheduled: 0
+  numberReady: 1
+  observedGeneration: 2
+  updatedNumberScheduled: 1

--- a/resource_customizations/apps.kruise.io/DaemonSet/testdata/partition_string_zero_healthy.yaml
+++ b/resource_customizations/apps.kruise.io/DaemonSet/testdata/partition_string_zero_healthy.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps.kruise.io/v1alpha1
+kind: DaemonSet
+metadata:
+  name: daemonset-test
+  namespace: kruise
+  generation: 2
+  labels:
+    app: sample
+spec:
+  selector:
+    matchLabels:
+      app: sample
+  template:
+    metadata:
+      labels:
+        app: sample
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:alpine
+  updateStrategy:
+    rollingUpdate:
+      partition: "0"
+      paused: false
+
+status:
+  currentNumberScheduled: 1
+  daemonSetHash: 5dffcdfcd7
+  desiredNumberScheduled: 1
+  numberAvailable: 1
+  numberMisscheduled: 0
+  numberReady: 1
+  observedGeneration: 2
+  updatedNumberScheduled: 1


### PR DESCRIPTION
## Summary

Fixes the OpenKruise Advanced DaemonSet health customization when
`spec.updateStrategy.rollingUpdate.partition` is an `IntOrString` percentage
such as `"100%"`.

OpenKruise v1beta1 allows `partition` to be either a number or a percentage. The
current health script subtracts the value directly from
`status.desiredNumberScheduled`, which fails when the value is a string
percentage.

This change parses percentage partitions before calculating the expected number
of updated pods.

## Tests

```sh
go test ./util/lua -run TestLuaHealthScript -count=1
```

## Checklist

* [x] Either (a) I've created an enhancement proposal and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the Title of the PR.
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates? No.
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by DCO.
* [x] I have written unit and/or e2e tests for my change.
* [x] My build is green.
* [x] My new feature complies with the feature status guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into.
