### PR TITLE
docs: fix config management plugin link (#29172)

### DIFF
--- a/docs/user-guide/kustomize.md
+++ b/docs/user-guide/kustomize.md
@@ -274,7 +274,7 @@ It's possible to [render Helm charts with Kustomize](https://github.com/kubernet
 Doing so requires that you pass the `--enable-helm` flag to the `kustomize build` command.
 This flag is not part of the Kustomize options within Argo CD.
 If you would like to render Helm charts through Kustomize in an Argo CD application, you have two options:
-You can either create a [custom plugin](https://argo-cd.readthedocs.io/en/stable/user-guide/config-management-plugins/), or modify the `argocd-cm` ConfigMap to include the `--enable-helm` flag globally for all Kustomize applications:
+You can either create a [custom plugin](../operator-manual/config-management-plugins.md), or modify the `argocd-cm` ConfigMap to include the `--enable-helm` flag globally for all Kustomize applications:
 
 ```yaml
 apiVersion: v1


### PR DESCRIPTION
## What changed

Updates the Kustomizing Helm Charts section to link directly to the canonical operator-manual page for config management plugins. The previous URL led to a moved-page notice and required an extra click.

The new relative link also follows the pattern already used earlier in the same document.

Fixes #29172

## Validation

- confirmed `docs/operator-manual/config-management-plugins.md` exists
- confirmed the obsolete `stable/user-guide/config-management-plugins` URL is gone from the edited page
- ran `git diff --check`

## Checklist

- [x] This documentation-only fix does not need release notes.
- [x] The title states the change and related issue number.
- [x] The description links the issue with `Fixes #29172`.
- [x] The commit includes the required DCO sign-off.
- [x] Documentation is the complete scope of this change; code tests are not applicable.