### PR TITLE
fix(oidc): skip dollar-sign escape when DEX_EXPAND_ENV is disabled

### DIFF
--- a/util/dex/config.go
+++ b/util/dex/config.go
@@ -143,13 +143,20 @@ func GenerateDexConfigYAML(argocdSettings *settings.ArgoCDSettings, disableTLS b
 	dexCfg = settings.ReplaceMapSecrets(dexCfg, argocdSettings.Secrets)
 
 	if escapedConnectors, ok := dexCfg["connectors"].([]any); ok {
+		// DEX_EXPAND_ENV controls whether Dex expands environment variables in the config.
+		// When disabled, the $ to $$ escape is unnecessary and causes doubled dollar signs.
+		// Only escape when DEX_EXPAND_ENV is not explicitly disabled.
+		dexExpandEnv := os.Getenv("DEX_EXPAND_ENV")
+		shouldEscape := !(dexExpandEnv == "false" || dexExpandEnv == "0" || dexExpandEnv == "no")
 		for i, connectorIf := range escapedConnectors {
 			connector, ok := connectorIf.(map[string]any)
 			if !ok {
 				continue
 			}
 			if connectorCfg, ok := connector["config"].(map[string]any); ok {
-				connector["config"] = settings.EscapeDollarSignsInConnectorConfig(connectorCfg, argocdSettings.Secrets)
+				if shouldEscape {
+					connector["config"] = settings.EscapeDollarSignsInConnectorConfig(connectorCfg, argocdSettings.Secrets)
+				}
 				escapedConnectors[i] = connector
 			}
 		}


### PR DESCRIPTION
### What

`GenerateDexConfigYAML` unconditionally calls `settings.EscapeDollarSignsInConnectorConfig`, escaping every `$` to `$$` in connector config values resolved from secrets. This protection is needed only when Dex expands environment variables in its config (`DEX_EXPAND_ENV` unset/true).

When `DEX_EXPAND_ENV=false` is set on the `argocd-dex-server` deployment, Dex does not expand env vars, so the escape is unnecessary and produces doubled dollar signs (e.g. a `bindPW` of `123$qwe` renders as `123$$qwe`), breaking LDAP bind authentication.

### Fix

Skip the dollar-sign escape when `DEX_EXPAND_ENV` is explicitly disabled (`false`, `0` or `no`), so resolved secret values are written to the Dex config verbatim.

Fixes #29174
