### PR TITLE
fix(ui): allow GitHub App credential templates (#18741)

### DIFF
--- a/docs/user-guide/private-repositories.md
+++ b/docs/user-guide/private-repositories.md
@@ -136,6 +136,8 @@ Using the UI:
 
 2. Click `Connect Repo using GitHub App` button, choose type: `GitHub` or `GitHub Enterprise`, enter the URL, App Id, Installation Id (optional), and the app's private key.
 
+    If a credentials template matches the repository URL, enter the URL and leave all GitHub App credential fields empty to use the credentials from the template.
+
 > [!NOTE]
 > Enter the GitHub Enterprise Base URL for type `GitHub Enterprise`.
 > ![connect repo](../assets/repo-add-github-app.png)
@@ -547,4 +549,3 @@ Submodules are supported and will be picked up automatically. If the submodule r
 ## Declarative Configuration
 
 See [declarative setup](../operator-manual/declarative-setup.md#repositories)
-

--- a/ui/src/app/settings/components/repos-list/repos-list.tsx
+++ b/ui/src/app/settings/components/repos-list/repos-list.tsx
@@ -41,6 +41,7 @@ import {
     isWrite,
     isTemplate
 } from './repos-filter';
+import {validateGitHubAppCredentials} from './repos-validation';
 
 // Helper functions to convert to UnifiedRepo
 const repoToUnified = (repo: models.Repository, isWriteFlag: boolean): UnifiedRepo => (isWriteFlag ? {writeRepo: repo} : {readRepo: repo});
@@ -357,8 +358,7 @@ export const ReposList = ({match, location}: RouteComponentProps) => {
                 const githubAppValues = params as NewGitHubAppRepoParams;
                 return {
                     url: (!githubAppValues.url && 'Repository URL is required') || (credsTemplate && !isHTTPOrHTTPSUrl(githubAppValues.url) && 'Not a valid HTTP/HTTPS URL'),
-                    githubAppId: !githubAppValues.githubAppId && 'GitHub App ID is required',
-                    githubAppPrivateKey: !githubAppValues.githubAppPrivateKey && 'GitHub App private Key is required',
+                    ...validateGitHubAppCredentials(githubAppValues),
                     depth: githubAppValues.depth != undefined && githubAppValues.depth < 0 && 'Depth must be a non-negative number'
                 };
             }
@@ -1248,6 +1248,7 @@ export const ReposList = ({match, location}: RouteComponentProps) => {
                                                 <div className='argo-form-row'>
                                                     <FormField formApi={formApi} label='Repository URL' field='url' component={Text} />
                                                 </div>
+                                                <p>Leave the GitHub App credential fields empty to use a matching credentials template.</p>
                                                 <div className='argo-form-row'>
                                                     <FormField formApi={formApi} label='GitHub App ID' field='githubAppId' component={NumberField} />
                                                 </div>

--- a/ui/src/app/settings/components/repos-list/repos-validation.test.ts
+++ b/ui/src/app/settings/components/repos-list/repos-validation.test.ts
@@ -1,0 +1,38 @@
+import {validateGitHubAppCredentials} from './repos-validation';
+
+describe('validateGitHubAppCredentials', () => {
+    test('allows all credential fields to be empty so a matching template can be used', () => {
+        expect(validateGitHubAppCredentials({})).toEqual({});
+    });
+
+    test('accepts directly supplied GitHub App credentials', () => {
+        expect(
+            validateGitHubAppCredentials({
+                githubAppId: 123n,
+                githubAppInstallationId: 456n,
+                githubAppPrivateKey: 'private-key'
+            })
+        ).toEqual({githubAppId: false, githubAppPrivateKey: false});
+    });
+
+    test('requires the app ID when other GitHub App credentials are supplied', () => {
+        expect(validateGitHubAppCredentials({githubAppPrivateKey: 'private-key'})).toEqual({
+            githubAppId: 'GitHub App ID is required',
+            githubAppPrivateKey: false
+        });
+    });
+
+    test('requires the private key when other GitHub App credentials are supplied', () => {
+        expect(validateGitHubAppCredentials({githubAppId: 123n})).toEqual({
+            githubAppId: false,
+            githubAppPrivateKey: 'GitHub App private Key is required'
+        });
+    });
+
+    test('does not treat an installation ID by itself as template-based authentication', () => {
+        expect(validateGitHubAppCredentials({githubAppInstallationId: 456n})).toEqual({
+            githubAppId: 'GitHub App ID is required',
+            githubAppPrivateKey: 'GitHub App private Key is required'
+        });
+    });
+});

--- a/ui/src/app/settings/components/repos-list/repos-validation.test.ts
+++ b/ui/src/app/settings/components/repos-list/repos-validation.test.ts
@@ -35,4 +35,25 @@ describe('validateGitHubAppCredentials', () => {
             githubAppPrivateKey: 'GitHub App private Key is required'
         });
     });
+
+    test('does not treat a zero app ID as empty credentials', () => {
+        expect(validateGitHubAppCredentials({githubAppId: 0})).toEqual({
+            githubAppId: 'GitHub App ID is required',
+            githubAppPrivateKey: 'GitHub App private Key is required'
+        });
+    });
+
+    test('does not treat a zero installation ID as empty credentials', () => {
+        expect(validateGitHubAppCredentials({githubAppInstallationId: 0})).toEqual({
+            githubAppId: 'GitHub App ID is required',
+            githubAppPrivateKey: 'GitHub App private Key is required'
+        });
+    });
+
+    test.each([{githubAppId: Number.NaN}, {githubAppInstallationId: Number.NaN}])('does not allow an unnormalized numeric field: %p', values => {
+        expect(validateGitHubAppCredentials(values)).toEqual({
+            githubAppId: 'GitHub App ID is required',
+            githubAppPrivateKey: 'GitHub App private Key is required'
+        });
+    });
 });

--- a/ui/src/app/settings/components/repos-list/repos-validation.ts
+++ b/ui/src/app/settings/components/repos-list/repos-validation.ts
@@ -1,6 +1,6 @@
 export interface GitHubAppCredentialValues {
-    githubAppId?: bigint;
-    githubAppInstallationId?: bigint;
+    githubAppId?: bigint | number;
+    githubAppInstallationId?: bigint | number;
     githubAppPrivateKey?: string;
 }
 
@@ -10,13 +10,14 @@ export interface GitHubAppCredentialErrors {
 }
 
 export const validateGitHubAppCredentials = (values: GitHubAppCredentialValues): GitHubAppCredentialErrors => {
-    const hasDirectCredentials = Boolean(values.githubAppId || values.githubAppInstallationId || values.githubAppPrivateKey);
+    const hasNumericCredential = (value: bigint | number | undefined) => value !== undefined;
+    const hasDirectCredentials = hasNumericCredential(values.githubAppId) || hasNumericCredential(values.githubAppInstallationId) || Boolean(values.githubAppPrivateKey?.trim());
     if (!hasDirectCredentials) {
         return {};
     }
 
     return {
         githubAppId: !values.githubAppId && 'GitHub App ID is required',
-        githubAppPrivateKey: !values.githubAppPrivateKey && 'GitHub App private Key is required'
+        githubAppPrivateKey: !values.githubAppPrivateKey?.trim() && 'GitHub App private Key is required'
     };
 };

--- a/ui/src/app/settings/components/repos-list/repos-validation.ts
+++ b/ui/src/app/settings/components/repos-list/repos-validation.ts
@@ -1,0 +1,22 @@
+export interface GitHubAppCredentialValues {
+    githubAppId?: bigint;
+    githubAppInstallationId?: bigint;
+    githubAppPrivateKey?: string;
+}
+
+export interface GitHubAppCredentialErrors {
+    githubAppId?: string | false;
+    githubAppPrivateKey?: string | false;
+}
+
+export const validateGitHubAppCredentials = (values: GitHubAppCredentialValues): GitHubAppCredentialErrors => {
+    const hasDirectCredentials = Boolean(values.githubAppId || values.githubAppInstallationId || values.githubAppPrivateKey);
+    if (!hasDirectCredentials) {
+        return {};
+    }
+
+    return {
+        githubAppId: !values.githubAppId && 'GitHub App ID is required',
+        githubAppPrivateKey: !values.githubAppPrivateKey && 'GitHub App private Key is required'
+    };
+};

--- a/ui/src/app/shared/components/number-field.test.ts
+++ b/ui/src/app/shared/components/number-field.test.ts
@@ -1,0 +1,15 @@
+import {parseNumberFieldValue} from './number-field';
+
+describe('parseNumberFieldValue', () => {
+    test('returns undefined when the field is cleared', () => {
+        expect(parseNumberFieldValue('')).toBeUndefined();
+    });
+
+    test('preserves zero so validation can reject it', () => {
+        expect(parseNumberFieldValue('0')).toBe(0);
+    });
+
+    test('parses a numeric value', () => {
+        expect(parseNumberFieldValue('123')).toBe(123);
+    });
+});

--- a/ui/src/app/shared/components/number-field.tsx
+++ b/ui/src/app/shared/components/number-field.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import {ReactForm} from 'argo-ui';
 
+export const parseNumberFieldValue = (value: string): number | undefined => (value === '' ? undefined : parseInt(value, 10));
+
 export const NumberField = ReactForm.FormField((props: {fieldApi: ReactForm.FieldApi; className: string; onBlur?: () => void}) => {
     const {
         fieldApi: {getValue, setValue, setTouched},
@@ -8,5 +10,5 @@ export const NumberField = ReactForm.FormField((props: {fieldApi: ReactForm.Fiel
         ...rest
     } = props;
 
-    return <input {...rest} className={props.className} type='number' value={getValue()} onChange={el => setValue(parseInt(el.target.value, 10))} onBlur={onBlur} />;
+    return <input {...rest} className={props.className} type='number' value={getValue()} onChange={el => setValue(parseNumberFieldValue(el.target.value))} onBlur={onBlur} />;
 });


### PR DESCRIPTION
## Summary

When connecting a repository via **GitHub App**, the UI currently requires an App ID and private key even when a matching credentials template already contains them. This prevents the server's existing URL-based credential inheritance from being used.

This change:

- allows all GitHub App credential fields to remain empty so a matching credentials template can be used;
- keeps the existing App ID and private key validation when any credential is entered directly;
- normalizes cleared number fields and rejects invalid zero or `NaN` credential IDs;
- adds inline guidance and user documentation for matching credentials templates.

Fixes #18741

## Screenshots

### Before

GitHub App credentials were treated as required even when a matching credentials template could provide them:

![GitHub App repository form before the fix](https://github.com/user-attachments/assets/c6af0332-9de8-453f-858f-24fce37c0fdd)

### After

The form now explains that credentials may be inherited from a matching template and accepts the repository URL with all GitHub App credential fields left empty:

![GitHub App repository form after the fix](https://raw.githubusercontent.com/SHINMH/argo-cd/pr-assets/screenshots/18741-github-app-credentials-after.png)

## Test plan

- `pnpm exec jest --runInBand` (308 tests passed)
- `pnpm lint` (0 errors; 11 existing React Hooks warnings)
- `make build`
- `make lint`
- `make lint-ui`
- `make cli`
- `make test` (8,214 tests ran; three permission-mode tests fail on the macOS Docker bind mount: `TestPluginNoExecutePermission` and `TestFilePermission` with its parent result)
- `git diff --check`

Focused unit tests cover template-based authentication, complete and incomplete direct credentials, zero and `NaN` IDs, and cleared number-field normalization.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://argo-cd.readthedocs.io/en/stable/proposals/) and discussed it with the community, or (b) this is a minor enhancement that doesn't need its own proposal.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI/UI and documentation to reflect my enhancement.
