### PR TITLE
fix(reposerver): include ref source commit SHAs in app-details cache key

### DIFF
--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -2431,7 +2431,15 @@ func generateManifestsCMP(ctx context.Context, appPath, rootPath string, env []s
 func (s *Service) GetAppDetails(ctx context.Context, q *apiclient.RepoServerAppDetailsQuery) (*apiclient.RepoAppDetailsResponse, error) {
 	res := &apiclient.RepoAppDetailsResponse{}
 
-	cacheFn := s.createGetAppDetailsCacheHandler(res, q)
+	// refSourceCommitSHAs is populated by the cacheFn callback and consumed by
+	// the operation closure so that the cache key reflects the resolved
+	// commit SHAs of all referenced source repositories.
+	var refSourceCommitSHAs cache.ResolvedRevisions
+
+	cacheFn := func(revision string, resolvedRefs cache.ResolvedRevisions, firstInvocation bool) (bool, error) {
+		refSourceCommitSHAs = resolvedRefs
+		return s.createGetAppDetailsCacheHandler(res, q)(revision, resolvedRefs, firstInvocation)
+	}
 	operation := func(repoRoot, commitSHA, revision string, ctxSrc operationContextSrc) error {
 		opContext, err := ctxSrc()
 		if err != nil {
@@ -2461,7 +2469,7 @@ func (s *Service) GetAppDetails(ctx context.Context, q *apiclient.RepoServerAppD
 				return fmt.Errorf("failed to populate plugin app details: %w", err)
 			}
 		}
-		_ = s.cache.SetAppDetails(revision, q.Source, q.RefSources, res, v1alpha1.TrackingMethod(q.TrackingMethod), nil)
+		_ = s.cache.SetAppDetails(revision, q.Source, q.RefSources, res, v1alpha1.TrackingMethod(q.TrackingMethod), refSourceCommitSHAs)
 		return nil
 	}
 
@@ -2489,8 +2497,8 @@ func toUserInputStatusError(err error) error {
 }
 
 func (s *Service) createGetAppDetailsCacheHandler(res *apiclient.RepoAppDetailsResponse, q *apiclient.RepoServerAppDetailsQuery) func(revision string, _ cache.ResolvedRevisions, _ bool) (bool, error) {
-	return func(revision string, _ cache.ResolvedRevisions, _ bool) (bool, error) {
-		err := s.cache.GetAppDetails(revision, q.Source, q.RefSources, res, v1alpha1.TrackingMethod(q.TrackingMethod), nil)
+	return func(revision string, refSourceCommitSHAs cache.ResolvedRevisions, _ bool) (bool, error) {
+		err := s.cache.GetAppDetails(revision, q.Source, q.RefSources, res, v1alpha1.TrackingMethod(q.TrackingMethod), refSourceCommitSHAs)
 		if err == nil {
 			log.Infof("app details cache hit: %s/%s", revision, q.Source.Path)
 			return true, nil

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -1871,6 +1871,46 @@ func TestGetAppDetailsHelm_WithNoValuesFile(t *testing.T) {
 	assert.Empty(t, res.Helm.Values)
 }
 
+func TestGetAppDetailsRefSourceCacheKey(t *testing.T) {
+	service, _, cacheMocks := newServiceWithMocks(t, "../../util/helm/testdata/dependency")
+
+	// Call GetAppDetails — first call misses the cache, triggering the operation
+	// closure which should call SetAppDetails with the ref source commit SHAs
+	// resolved by runRepoOperation (here empty map because no RefSources).
+	res, err := service.GetAppDetails(t.Context(), &apiclient.RepoServerAppDetailsQuery{
+		Repo:   &v1alpha1.Repository{},
+		Source: &v1alpha1.ApplicationSource{Path: "."},
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, res.Helm)
+
+	// Verify that the internal cacheFn wiring does not panic when called with
+	// non-nil ResolvedRevisions (the code before the fix used `_` and nil).
+	handler := service.createGetAppDetailsCacheHandler(&apiclient.RepoAppDetailsResponse{}, &apiclient.RepoServerAppDetailsQuery{
+		Repo:   &v1alpha1.Repository{},
+		Source: &v1alpha1.ApplicationSource{Path: "."},
+		RefSources: v1alpha1.RefTargetRevisionMapping{
+			"$values": &v1alpha1.RefTarget{TargetRevision: "main"},
+		},
+	})
+
+	// Passing a non-nil refSourceCommitSHAs should not panic and should produce
+	// a cache miss (since the key now includes those SHAs and nothing was cached
+	// under that key).
+	hit, err := handler("HEAD", cache.ResolvedRevisions{"https://fake.com/fake_group/fake_repo.git": "abc123"}, false)
+	require.NoError(t, err)
+	assert.False(t, hit, "expected cache miss when ref source SHAs change the cache key")
+
+	// Calling again with the same SHAs after SetAppDetails should hit.
+	_ = cacheMocks.cache.SetAppDetails("HEAD", &v1alpha1.ApplicationSource{Path: "."}, v1alpha1.RefTargetRevisionMapping{
+		"$values": &v1alpha1.RefTarget{TargetRevision: "main"},
+	}, &apiclient.RepoAppDetailsResponse{Type: "Helm"}, v1alpha1.TrackingMethodLabel, cache.ResolvedRevisions{"https://fake.com/fake_group/fake_repo.git": "abc123"})
+
+	hit2, err := handler("HEAD", cache.ResolvedRevisions{"https://fake.com/fake_group/fake_repo.git": "abc123"}, false)
+	require.NoError(t, err)
+	assert.True(t, hit2, "expected cache hit when ref source SHAs match the cached entry")
+}
+
 func TestGetAppDetailsKustomize(t *testing.T) {
 	service := newService(t, "../../util/kustomize/testdata/kustomization_yaml")
 


### PR DESCRIPTION
Fixes #28956

## Problem

When a multi-source Application references a `$values` git ref and the ref branch advances, the repo-server's `app-details` cache is not invalidated. `GetAppDetails`'s cache handler passes `nil` for the ref-source commit SHAs when computing the cache key for both reads and writes. This means the cached entry from a previous (stale) ref-source commit continues to be served even after the branch moves forward.

## Root Cause

`runRepoOperation` resolves ref-source commit SHAs into `repoRefs` and passes them to the `cacheFn` callback as `refSourceCommitSHAs`. The manifest-generation path (`GenerateManifests`) uses this parameter correctly in `cache.NewManifestKey`, but the app-details path (`GetAppDetails`) discards it (`_`) for reads and passes `nil` to `s.cache.SetAppDetails` for writes.

## Fix

Store the resolved `refSourceCommitSHAs` from the `cacheFn` callback in a closure variable, then:

1. **Cache read**: `createGetAppDetailsCacheHandler` now passes the resolved SHAs to `s.cache.GetAppDetails` instead of `nil`, so the cache key includes the ref-source SHAs.
2. **Cache write**: The `operation` closure in `GetAppDetails` now passes the captured SHAs to `s.cache.SetAppDetails` instead of `nil`, so the cached entry is keyed by the full ref-source state.

No changes to the `Cache` interface or to `appSourceKey` — they already accepted and consumed `ResolvedRevisions`.

## Testing

- Added `TestGetAppDetailsRefSourceCacheKey` which verifies:
  - A cache miss when called with ref-source SHAs that weren't previously cached.
  - A cache hit when called with the same SHAs after `SetAppDetails` writes with matching SHAs.
- `TestGetAppDetailsHelm*` all pass; `reposerver/cache` all pass.
- Pre-existing failures in `TestGetAppDetailsKustomize` and `TestGetAppDetailsWithAppParameterFile` are unrelated (missing `kustomize` binary in local PATH).

Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've signed the DCO.
* [x] The PR interacts with an existing GitHub issue.
