### PR TITLE
fix: --http-retry-max is ignored on TLS connections

### DIFF
--- a/docs/operator-manual/upgrading/3.5-3.6.md
+++ b/docs/operator-manual/upgrading/3.5-3.6.md
@@ -86,3 +86,25 @@ One specific change to be aware of: `otelgrpc` now sets the `server.address`/`se
 attributes from the gRPC dial target rather than the resolved peer IP. If a dashboard or alert
 keys on `server.address` expecting a literal pod/service IP for internal Argo CD gRPC calls
 (`argocd-server` ↔ `repo-server` ↔ `cmp-server`), it may need updating.
+
+## `--http-retry-max` now applies to TLS (and `--grpc-web`) connections
+
+Prior to v3.6, the CLI's global `--http-retry-max` flag had no effect on TLS
+connections (the default) — the retryable HTTP transport was silently discarded
+during TLS setup, so retries only ever applied to `--plaintext` connections.
+This is now fixed, so `--http-retry-max` retries transient failures (connection
+errors, HTTP `429`, and `5xx`) on all connections, including `--grpc-web`.
+
+The flag still defaults to `0` (no retries), so behavior is unchanged unless you
+have opted in. If you do set `--http-retry-max`, be aware:
+
+- Retries apply to **all** gRPC-web requests, including non-idempotent ones.
+  gRPC-web tunnels every RPC as an HTTP `POST`, so the retry layer cannot
+  distinguish reads from writes. A transient `5xx` returned *after* the server
+  has already processed a mutating request (e.g. `argocd account generate-token`,
+  `argocd app actions run`) will cause the request to be re-sent. Prefer enabling
+  the flag for idempotent/declarative operations (e.g. `app set`/`app sync`), and
+  consider this before enabling it globally for mutating commands.
+- Retries add latency ahead of any command-level timeout. Backoff is capped at
+  10s per attempt, but `--http-retry-max` attempts still accumulate; size it with
+  your `--timeout` values (e.g. `app sync`/`app wait`) in mind.

--- a/pkg/apiclient/apiclient.go
+++ b/pkg/apiclient/apiclient.go
@@ -263,21 +263,33 @@ func NewClient(opts *ClientOptions) (Client, error) {
 		c.GRPCWebRootPath = opts.GRPCWebRootPath
 	}
 
-	if opts.HttpRetryMax > 0 {
-		retryClient := retryablehttp.NewClient()
-		retryClient.RetryMax = opts.HttpRetryMax
-		c.httpClient = retryClient.StandardClient()
-	} else {
-		c.httpClient = &http.Client{}
-	}
-
+	var transport http.RoundTripper
 	if !c.PlainText {
 		tlsConfig, err := c.tlsConfig()
 		if err != nil {
 			return nil, err
 		}
-		c.httpClient.Transport = &http.Transport{
+		transport = &http.Transport{
 			TLSClientConfig: tlsConfig,
+		}
+	}
+
+	if opts.HttpRetryMax > 0 {
+		retryClient := retryablehttp.NewClient()
+		retryClient.RetryMax = opts.HttpRetryMax
+		// Apply the TLS transport to the retryable client's inner HTTP client
+		// before wrapping it. StandardClient() returns an *http.Client whose
+		// Transport is the retry RoundTripper, so overwriting Transport after
+		// the fact (as the non-plaintext branch used to do) would silently
+		// discard the retry behavior on TLS connections.
+		if transport != nil {
+			retryClient.HTTPClient.Transport = transport
+		}
+		c.httpClient = retryClient.StandardClient()
+	} else {
+		c.httpClient = &http.Client{}
+		if transport != nil {
+			c.httpClient.Transport = transport
 		}
 	}
 	if !c.GRPCWeb {

--- a/pkg/apiclient/apiclient.go
+++ b/pkg/apiclient/apiclient.go
@@ -149,6 +149,11 @@ type client struct {
 	proxyServer     *grpc.Server
 	proxyUsersCount int
 	httpClient      *http.Client
+	// tlsTransport is the underlying *http.Transport used for non-plaintext
+	// connections. When HttpRetryMax > 0, httpClient wraps a retryablehttp
+	// RoundTripper (which does not implement CloseIdleConnections), so we keep
+	// a direct reference to close idle connections in the grpc-web proxy.
+	tlsTransport *http.Transport
 }
 
 // NewClient creates a new API client from a set of config options.
@@ -263,13 +268,16 @@ func NewClient(opts *ClientOptions) (Client, error) {
 		c.GRPCWebRootPath = opts.GRPCWebRootPath
 	}
 
-	var transport http.RoundTripper
+	// Keep a typed reference to the TLS transport (not http.RoundTripper) so the
+	// grpc-web proxy can close idle connections on it directly: when retries are
+	// enabled, httpClient wraps a retryablehttp RoundTripper that does not
+	// implement CloseIdleConnections.
 	if !c.PlainText {
 		tlsConfig, err := c.tlsConfig()
 		if err != nil {
 			return nil, err
 		}
-		transport = &http.Transport{
+		c.tlsTransport = &http.Transport{
 			TLSClientConfig: tlsConfig,
 		}
 	}
@@ -282,19 +290,27 @@ func NewClient(opts *ClientOptions) (Client, error) {
 		// plain http.Client path below is silent, so disable the logger to keep
 		// behavior consistent and avoid per-request noise on the CLI.
 		retryClient.Logger = nil
+		// Use ErrorPropagatedRetryPolicy so that when retries are exhausted the
+		// returned error still carries the underlying cause (e.g. "unexpected
+		// HTTP status 502"). The default policy discards it, turning a persistent
+		// 502 into a bare "giving up after N attempt(s)" with the status stripped.
+		retryClient.CheckRetry = retryablehttp.ErrorPropagatedRetryPolicy
+		// Cap the backoff so retries can't stack unbounded latency ahead of
+		// command-level timeouts (e.g. app sync/wait).
+		retryClient.RetryWaitMax = 10 * time.Second
 		// Apply the TLS transport to the retryable client's inner HTTP client
 		// before wrapping it. StandardClient() returns an *http.Client whose
 		// Transport is the retry RoundTripper, so overwriting Transport after
 		// the fact (as the non-plaintext branch used to do) would silently
 		// discard the retry behavior on TLS connections.
-		if transport != nil {
-			retryClient.HTTPClient.Transport = transport
+		if c.tlsTransport != nil {
+			retryClient.HTTPClient.Transport = c.tlsTransport
 		}
 		c.httpClient = retryClient.StandardClient()
 	} else {
 		c.httpClient = &http.Client{}
-		if transport != nil {
-			c.httpClient.Transport = transport
+		if c.tlsTransport != nil {
+			c.httpClient.Transport = c.tlsTransport
 		}
 	}
 	if !c.GRPCWeb {

--- a/pkg/apiclient/apiclient.go
+++ b/pkg/apiclient/apiclient.go
@@ -277,6 +277,11 @@ func NewClient(opts *ClientOptions) (Client, error) {
 	if opts.HttpRetryMax > 0 {
 		retryClient := retryablehttp.NewClient()
 		retryClient.RetryMax = opts.HttpRetryMax
+		// retryablehttp.NewClient() installs a default logger that writes a line
+		// to stderr for every request, even successful non-retried ones. The
+		// plain http.Client path below is silent, so disable the logger to keep
+		// behavior consistent and avoid per-request noise on the CLI.
+		retryClient.Logger = nil
 		// Apply the TLS transport to the retryable client's inner HTTP client
 		// before wrapping it. StandardClient() returns an *http.Client whose
 		// Transport is the retry RoundTripper, so overwriting Transport after

--- a/pkg/apiclient/apiclient_test.go
+++ b/pkg/apiclient/apiclient_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -280,4 +281,117 @@ func (c *closeTracker) Close() error {
 		c.onClose()
 	}
 	return c.ReadCloser.Close()
+}
+
+// TestNewClient_HttpRetryMax_TLSTransport is a regression test for the bug
+// where --http-retry-max was silently ignored on TLS (non-plaintext)
+// connections. The retryable client's Transport must survive TLS setup.
+func TestNewClient_HttpRetryMax_TLSTransport(t *testing.T) {
+	t.Run("retry transport survives on TLS connection", func(t *testing.T) {
+		ci, err := NewClient(&ClientOptions{
+			ServerAddr:   "argocd.example.com:443",
+			HttpRetryMax: 4,
+			Insecure:     true, // avoid needing a real CA; still a TLS (non-plaintext) client
+			GRPCWeb:      true, // skip the plain-gRPC server probe; matches real --grpc-web usage
+		})
+		require.NoError(t, err)
+		c := ci.(*client)
+
+		rt, ok := c.httpClient.Transport.(*retryablehttp.RoundTripper)
+		require.True(t, ok, "expected retryablehttp.RoundTripper, got %T", c.httpClient.Transport)
+		assert.Equal(t, 4, rt.Client.RetryMax)
+
+		// TLS config must still be honored via the retry client's inner transport.
+		inner, ok := rt.Client.HTTPClient.Transport.(*http.Transport)
+		require.True(t, ok, "expected inner *http.Transport, got %T", rt.Client.HTTPClient.Transport)
+		require.NotNil(t, inner.TLSClientConfig)
+		assert.True(t, inner.TLSClientConfig.InsecureSkipVerify)
+	})
+
+	t.Run("no retry transport when HttpRetryMax is zero", func(t *testing.T) {
+		ci, err := NewClient(&ClientOptions{
+			ServerAddr: "argocd.example.com:443",
+			Insecure:   true,
+			GRPCWeb:    true,
+		})
+		require.NoError(t, err)
+		c := ci.(*client)
+
+		tr, ok := c.httpClient.Transport.(*http.Transport)
+		require.True(t, ok, "expected plain *http.Transport, got %T", c.httpClient.Transport)
+		require.NotNil(t, tr.TLSClientConfig)
+	})
+}
+
+// TestExecuteRequest_RetriesOn502 proves that with HttpRetryMax set, a
+// transient 502 is retried rather than returned fatally on the first attempt.
+func TestExecuteRequest_RetriesOn502(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if attempts.Add(1) < 3 {
+			w.WriteHeader(http.StatusBadGateway) // 502 on first two attempts
+			return
+		}
+		w.Header().Set("Grpc-Status", "0") // OK on the third
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	retryClient := retryablehttp.NewClient()
+	retryClient.RetryMax = 4
+	retryClient.RetryWaitMin = time.Millisecond
+	retryClient.RetryWaitMax = 5 * time.Millisecond
+	retryClient.Logger = nil
+
+	c := &client{
+		ServerAddr: server.URL[7:], // Remove "http://"
+		PlainText:  true,
+		httpClient: retryClient.StandardClient(),
+	}
+
+	ctx := t.Context()
+	md := metadata.New(map[string]string{})
+	_, err := c.executeRequest(ctx, "/test.Service/Method", []byte("test"), md)
+	require.NoError(t, err)
+	assert.Equal(t, int32(3), attempts.Load(), "expected two 502 retries before success")
+}
+
+// TestNewClient_RetriesOn502_OverTLS is the end-to-end regression test for the
+// bug: it wires the client through NewClient (not a hand-built httpClient),
+// talks to a real TLS server, and verifies that --http-retry-max actually
+// retries a transient 502 over that TLS connection. Against the pre-fix code
+// the retry transport is clobbered by TLS setup and this fails on the first 502.
+func TestNewClient_RetriesOn502_OverTLS(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if attempts.Add(1) < 3 {
+			w.WriteHeader(http.StatusBadGateway) // 502 on first two attempts
+			return
+		}
+		w.Header().Set("Grpc-Status", "0") // OK on the third
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ci, err := NewClient(&ClientOptions{
+		ServerAddr:   server.Listener.Addr().String(), // real TLS endpoint
+		HttpRetryMax: 4,
+		Insecure:     true, // trust the httptest self-signed cert
+		GRPCWeb:      true, // skip the plain-gRPC probe; matches real --grpc-web usage
+	})
+	require.NoError(t, err)
+	c := ci.(*client)
+
+	// Speed up backoff so the test doesn't wait seconds between retries.
+	rt, ok := c.httpClient.Transport.(*retryablehttp.RoundTripper)
+	require.True(t, ok, "expected retryablehttp.RoundTripper, got %T", c.httpClient.Transport)
+	rt.Client.RetryWaitMin = time.Millisecond
+	rt.Client.RetryWaitMax = 5 * time.Millisecond
+	rt.Client.Logger = nil
+
+	ctx := t.Context()
+	md := metadata.New(map[string]string{})
+	_, err = c.executeRequest(ctx, "/test.Service/Method", []byte("test"), md)
+	require.NoError(t, err)
+	assert.Equal(t, int32(3), attempts.Load(), "expected two 502 retries before success over TLS")
 }

--- a/pkg/apiclient/apiclient_test.go
+++ b/pkg/apiclient/apiclient_test.go
@@ -351,8 +351,10 @@ func TestExecuteRequest_RetriesOn502(t *testing.T) {
 
 	ctx := t.Context()
 	md := metadata.New(map[string]string{})
-	_, err := c.executeRequest(ctx, "/test.Service/Method", []byte("test"), md)
+	resp, err := c.executeRequest(ctx, "/test.Service/Method", []byte("test"), md)
 	require.NoError(t, err)
+	require.NotNil(t, resp)
+	defer resp.Body.Close()
 	assert.Equal(t, int32(3), attempts.Load(), "expected two 502 retries before success")
 }
 
@@ -391,7 +393,9 @@ func TestNewClient_RetriesOn502_OverTLS(t *testing.T) {
 
 	ctx := t.Context()
 	md := metadata.New(map[string]string{})
-	_, err = c.executeRequest(ctx, "/test.Service/Method", []byte("test"), md)
+	resp, err := c.executeRequest(ctx, "/test.Service/Method", []byte("test"), md)
 	require.NoError(t, err)
+	require.NotNil(t, resp)
+	defer resp.Body.Close()
 	assert.Equal(t, int32(3), attempts.Load(), "expected two 502 retries before success over TLS")
 }

--- a/pkg/apiclient/apiclient_test.go
+++ b/pkg/apiclient/apiclient_test.go
@@ -324,8 +324,9 @@ func TestNewClient_HttpRetryMax_TLSTransport(t *testing.T) {
 	})
 }
 
-// TestExecuteRequest_RetriesOn502 proves that with HttpRetryMax set, a
-// transient 502 is retried rather than returned fatally on the first attempt.
+// TestExecuteRequest_RetriesOn502 covers executeRequest's handling of a response
+// delivered through a retrying transport. The regression test for the TLS bug is
+// TestNewClient_RetriesOn502_OverTLS.
 func TestExecuteRequest_RetriesOn502(t *testing.T) {
 	var attempts atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -357,6 +358,60 @@ func TestExecuteRequest_RetriesOn502(t *testing.T) {
 	require.NotNil(t, resp)
 	defer resp.Body.Close()
 	assert.Equal(t, int32(3), attempts.Load(), "expected two 502 retries before success")
+}
+
+// TestNewClient_RetryPath_ExposesTLSTransport verifies that when retries are
+// enabled, NewClient keeps a direct reference to the underlying *http.Transport.
+// The grpc-web proxy relies on this to close idle connections, since the
+// retryablehttp RoundTripper wrapping httpClient does not implement
+// CloseIdleConnections (so calling it on httpClient would be a silent no-op).
+func TestNewClient_RetryPath_ExposesTLSTransport(t *testing.T) {
+	ci, err := NewClient(&ClientOptions{
+		ServerAddr:   "argocd.example.com:443",
+		HttpRetryMax: 4,
+		Insecure:     true,
+		GRPCWeb:      true,
+	})
+	require.NoError(t, err)
+	c := ci.(*client)
+
+	require.NotNil(t, c.tlsTransport, "retry path should retain the *http.Transport for idle-conn cleanup")
+	// The retry RoundTripper's inner transport must be the same one we can close.
+	rt, ok := c.httpClient.Transport.(*retryablehttp.RoundTripper)
+	require.True(t, ok, "expected retryablehttp.RoundTripper, got %T", c.httpClient.Transport)
+	assert.Same(t, c.tlsTransport, rt.Client.HTTPClient.Transport,
+		"tlsTransport should be the retry client's underlying transport")
+}
+
+// TestNewClient_PersistentError_PreservesStatus ensures that when retries are
+// exhausted against a persistent 502, the returned error still carries the
+// status code. This relies on ErrorPropagatedRetryPolicy; the default policy
+// would strip it, leaving only "giving up after N attempt(s)".
+func TestNewClient_PersistentError_PreservesStatus(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway) // always 502
+	}))
+	defer server.Close()
+
+	ci, err := NewClient(&ClientOptions{
+		ServerAddr:   server.Listener.Addr().String(),
+		HttpRetryMax: 2,
+		Insecure:     true,
+		GRPCWeb:      true,
+	})
+	require.NoError(t, err)
+	c := ci.(*client)
+
+	rt, ok := c.httpClient.Transport.(*retryablehttp.RoundTripper)
+	require.True(t, ok, "expected retryablehttp.RoundTripper, got %T", c.httpClient.Transport)
+	rt.Client.RetryWaitMin = time.Millisecond
+	rt.Client.RetryWaitMax = 5 * time.Millisecond
+
+	ctx := t.Context()
+	md := metadata.New(map[string]string{})
+	_, err = c.executeRequest(ctx, "/test.Service/Method", []byte("test"), md)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "502", "exhausted-retry error should preserve the HTTP status")
 }
 
 // TestNewClient_RetriesOn502_OverTLS is the end-to-end regression test for the

--- a/pkg/apiclient/apiclient_test.go
+++ b/pkg/apiclient/apiclient_test.go
@@ -300,6 +300,7 @@ func TestNewClient_HttpRetryMax_TLSTransport(t *testing.T) {
 		rt, ok := c.httpClient.Transport.(*retryablehttp.RoundTripper)
 		require.True(t, ok, "expected retryablehttp.RoundTripper, got %T", c.httpClient.Transport)
 		assert.Equal(t, 4, rt.Client.RetryMax)
+		assert.Nil(t, rt.Client.Logger, "NewClient should disable the retryablehttp default logger")
 
 		// TLS config must still be honored via the retry client's inner transport.
 		inner, ok := rt.Client.HTTPClient.Transport.(*http.Transport)
@@ -387,9 +388,11 @@ func TestNewClient_RetriesOn502_OverTLS(t *testing.T) {
 	// Speed up backoff so the test doesn't wait seconds between retries.
 	rt, ok := c.httpClient.Transport.(*retryablehttp.RoundTripper)
 	require.True(t, ok, "expected retryablehttp.RoundTripper, got %T", c.httpClient.Transport)
+	// NewClient disables the retryablehttp logger to avoid per-request stderr
+	// noise; assert that here rather than working around it.
+	assert.Nil(t, rt.Client.Logger, "NewClient should disable the retryablehttp default logger")
 	rt.Client.RetryWaitMin = time.Millisecond
 	rt.Client.RetryWaitMax = 5 * time.Millisecond
-	rt.Client.Logger = nil
 
 	ctx := t.Context()
 	md := metadata.New(map[string]string{})

--- a/pkg/apiclient/grpcproxy.go
+++ b/pkg/apiclient/grpcproxy.go
@@ -156,7 +156,15 @@ func (c *client) startGRPCProxy(ctx context.Context) (*grpc.Server, net.Listener
 				utilio.Close(resp.Body)
 			}()
 			defer utilio.Close(resp.Body)
-			c.httpClient.CloseIdleConnections()
+			// When retries are enabled, httpClient wraps a retryablehttp
+			// RoundTripper that does not implement CloseIdleConnections, so
+			// closing on httpClient would be a no-op. Close idle connections on
+			// the underlying TLS transport directly when we have one.
+			if c.tlsTransport != nil {
+				c.tlsTransport.CloseIdleConnections()
+			} else {
+				c.httpClient.CloseIdleConnections()
+			}
 
 			for {
 				header := make([]byte, frameHeaderLength)


### PR DESCRIPTION

## What does this PR do / why do we need it?

The global CLI flag `--http-retry-max` (and `ClientOptions.HttpRetryMax` in
`pkg/apiclient`) has no effect on any TLS (non-`--plaintext`) connection, which
is the normal case. `NewClient` builds a retryable HTTP client and then
immediately overwrites its `Transport` in the TLS-setup block, discarding the
retry behavior. A single transient failure (e.g. a `502` from a load balancer
in front of `argocd-server`) is therefore returned to the caller as `fatal` on
the first attempt, with no retry.

This is especially impactful for `--grpc-web` invocations, because in grpc-web
mode every RPC is sent through `c.httpClient` (`pkg/apiclient/grpcproxy.go`,
`executeRequest` -> `c.httpClient.Do(req)`) -- exactly the client whose retry
behavior is being thrown away.

### Root cause

In `pkg/apiclient/apiclient.go`, `NewClient` had:

```go
if opts.HttpRetryMax > 0 {
    retryClient := retryablehttp.NewClient()
    retryClient.RetryMax = opts.HttpRetryMax
    c.httpClient = retryClient.StandardClient()   // Transport = *retryablehttp.RoundTripper
} else {
    c.httpClient = &http.Client{}
}

if !c.PlainText {
    tlsConfig, err := c.tlsConfig()
    if err != nil {
        return nil, err
    }
    c.httpClient.Transport = &http.Transport{      // overwrites the retry RoundTripper
        TLSClientConfig: tlsConfig,
    }
}
```

`retryablehttp.Client.StandardClient()` returns an `*http.Client` whose retry
logic lives entirely in its `Transport` (`&retryablehttp.RoundTripper{Client: c}`).
The `if !c.PlainText` block then assigns a bare `&http.Transport{...}` over that
field, so on any TLS connection the retry wrapper is silently discarded. Retry
only survived for `--plaintext` connections, where the TLS block is skipped.

This looks like an unintended interaction between two earlier changes rather
than a deliberate design choice: #6444 hoisted the shared HTTP client + TLS
block into `NewClient`, and #6632 later wrapped only the client construction in
`if opts.HttpRetryMax > 0 { ... StandardClient() }`, leaving the TLS block below
it untouched.

### Fix

Build the TLS transport first, then apply it to the retryable client's *inner*
`HTTPClient.Transport` before wrapping with `StandardClient()`, so both TLS and
retry are preserved. The non-retry path is behaviorally unchanged.

## Tests

Added to `pkg/apiclient/apiclient_test.go`:

- `TestNewClient_HttpRetryMax_TLSTransport` -- asserts the retry `RoundTripper`
  survives on a TLS connection and still carries a `TLSClientConfig`, and that
  the plain transport is used when `HttpRetryMax` is zero.
- `TestExecuteRequest_RetriesOn502` -- proves a transient 502 is retried through
  `executeRequest` (plain HTTP, focused on the retry mechanics).
- `TestNewClient_RetriesOn502_OverTLS` -- end-to-end: wires the client through
  `NewClient`, talks to a real `httptest.NewTLSServer`, and verifies a transient
  502 is retried over TLS and ultimately succeeds. This test fails against the
  pre-fix code (`expected retryablehttp.RoundTripper, got *http.Transport`).

## Checklist

* [x] Either (a) I've created an enhancement proposal and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the Title of the PR guidelines.
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. (N/A -- no user-facing surface change; existing flag now works.)
* [ ] Does this PR require documentation updates? (No -- documented flag now behaves as documented.)
* [x] I've updated documentation as required by this PR. (N/A)
* [x] I have signed off all my commits as required by DCO.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green.
* [x] My new feature complies with the feature status guidelines. (Bug fix.)
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into.

Fixes #29188

<!--
Cherry-pick candidates: this bug affects the release branches that ship the
current NewClient code path (verified present from v3.1.x through master).
Suggest labeling cherry-pick/3.1 (and any other actively-maintained release
lines the maintainers want the fix in).
-->
