### PR TITLE
fix: preserve --http-retry-max on TLS connections

### DIFF
--- a/pkg/apiclient/apiclient.go
+++ b/pkg/apiclient/apiclient.go
@@ -263,22 +263,26 @@ func NewClient(opts *ClientOptions) (Client, error) {
 		c.GRPCWebRootPath = opts.GRPCWebRootPath
 	}
 
-	if opts.HttpRetryMax > 0 {
-		retryClient := retryablehttp.NewClient()
-		retryClient.RetryMax = opts.HttpRetryMax
-		c.httpClient = retryClient.StandardClient()
-	} else {
-		c.httpClient = &http.Client{}
-	}
-
+	// Build the base transport, optionally with TLS config
+	var transport http.RoundTripper = &http.Transport{}
 	if !c.PlainText {
 		tlsConfig, err := c.tlsConfig()
 		if err != nil {
 			return nil, err
 		}
-		c.httpClient.Transport = &http.Transport{
+		transport = &http.Transport{
 			TLSClientConfig: tlsConfig,
 		}
+	}
+
+	// Wrap with retryable client if configured
+	if opts.HttpRetryMax > 0 {
+		retryClient := retryablehttp.NewClient()
+		retryClient.RetryMax = opts.HttpRetryMax
+		retryClient.HTTPClient = &http.Client{Transport: transport}
+		c.httpClient = retryClient.StandardClient()
+	} else {
+		c.httpClient = &http.Client{Transport: transport}
 	}
 	if !c.GRPCWeb {
 		if parts := strings.Split(c.ServerAddr, ":"); len(parts) == 1 {


### PR DESCRIPTION
Fixes #29188

**Bug**: The global CLI flag `--http-retry-max` (and `ClientOptions.HttpRetryMax`)
has no effect when the client connects via TLS (non-plaintext). The retryable
transport was constructed at line 267-269 and then immediately overwritten by the
TLS setup block at line 279-281, so requests went through a plain, non-retrying
transport.

**Fix**: Build the base transport (with TLS config if applicable) first, then
wrap it with the retryable client. This ensures retry settings are preserved
regardless of TLS mode.

```go
// Before: retryable transport set up, then overwritten by TLS block
if opts.HttpRetryMax > 0 {
    retryClient := retryablehttp.NewClient()
    retryClient.RetryMax = opts.HttpRetryMax
    c.httpClient = retryClient.StandardClient()
} else {
    c.httpClient = &http.Client{}
}
if !c.PlainText {
    c.httpClient.Transport = &http.Transport{TLSClientConfig: tlsConfig}
}

// After: TLS transport built first, then wrapped by retryable client
var transport http.RoundTripper = &http.Transport{}
if !c.PlainText {
    transport = &http.Transport{TLSClientConfig: tlsConfig}
}
if opts.HttpRetryMax > 0 {
    retryClient := retryablehttp.NewClient()
    retryClient.RetryMax = opts.HttpRetryMax
    retryClient.HTTPClient = &http.Client{Transport: transport}
    c.httpClient = retryClient.StandardClient()
} else {
    c.httpClient = &http.Client{Transport: transport}
}
```