### PR TITLE
fix(cli): allow repeated --header flags in ARGOCD_OPTS

### DIFF
--- a/util/config/env.go
+++ b/util/config/env.go
@@ -36,6 +36,12 @@ func LoadFlags() error {
 				flags[key] = append(flags[key], "true")
 			}
 			key = strings.TrimPrefix(opt, "--")
+			// pkg shellquota doesn't recognize `=` so that the opts in format `foo=bar` could not work.
+			// issue ref: https://github.com/argoproj/argo-cd/issues/6822
+			if idx := strings.Index(key, "="); idx >= 0 {
+				flags[key[:idx]] = append(flags[key[:idx]], key[idx+1:])
+				key = ""
+			}
 		case key != "":
 			flags[key] = append(flags[key], opt)
 			key = ""
@@ -45,17 +51,6 @@ func LoadFlags() error {
 	}
 	if key != "" {
 		flags[key] = append(flags[key], "true")
-	}
-	// pkg shellquota doesn't recognize `=` so that the opts in format `foo=bar` could not work.
-	// issue ref: https://github.com/argoproj/argo-cd/issues/6822
-	for k, v := range flags {
-		if strings.Contains(k, "=") && len(v) == 1 && v[0] == "true" {
-			kv := strings.SplitN(k, "=", 2)
-			actualKey, actualValue := kv[0], kv[1]
-			if _, ok := flags[actualKey]; !ok {
-				flags[actualKey] = []string{actualValue}
-			}
-		}
 	}
 	return nil
 }

--- a/util/config/env.go
+++ b/util/config/env.go
@@ -11,6 +11,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// slice per key: some flags (e.g. --header) are meant to be repeatable
+// issue ref: https://github.com/argoproj/argo-cd/issues/24065
 var flags map[string][]string
 
 func init() {

--- a/util/config/env.go
+++ b/util/config/env.go
@@ -11,7 +11,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var flags map[string]string
+var flags map[string][]string
 
 func init() {
 	err := LoadFlags()
@@ -21,7 +21,7 @@ func init() {
 }
 
 func LoadFlags() error {
-	flags = make(map[string]string)
+	flags = make(map[string][]string)
 
 	opts, err := shellquote.Split(os.Getenv("ARGOCD_OPTS"))
 	if err != nil {
@@ -33,27 +33,27 @@ func LoadFlags() error {
 		switch {
 		case strings.HasPrefix(opt, "--"):
 			if key != "" {
-				flags[key] = "true"
+				flags[key] = append(flags[key], "true")
 			}
 			key = strings.TrimPrefix(opt, "--")
 		case key != "":
-			flags[key] = opt
+			flags[key] = append(flags[key], opt)
 			key = ""
 		default:
 			return errors.New("ARGOCD_OPTS invalid at '" + opt + "'")
 		}
 	}
 	if key != "" {
-		flags[key] = "true"
+		flags[key] = append(flags[key], "true")
 	}
 	// pkg shellquota doesn't recognize `=` so that the opts in format `foo=bar` could not work.
 	// issue ref: https://github.com/argoproj/argo-cd/issues/6822
 	for k, v := range flags {
-		if strings.Contains(k, "=") && v == "true" {
+		if strings.Contains(k, "=") && len(v) == 1 && v[0] == "true" {
 			kv := strings.SplitN(k, "=", 2)
 			actualKey, actualValue := kv[0], kv[1]
 			if _, ok := flags[actualKey]; !ok {
-				flags[actualKey] = actualValue
+				flags[actualKey] = []string{actualValue}
 			}
 		}
 	}
@@ -62,8 +62,8 @@ func LoadFlags() error {
 
 func GetFlag(key, fallback string) string {
 	val, ok := flags[key]
-	if ok {
-		return val
+	if ok && len(val) > 0 {
+		return val[len(val)-1]
 	}
 	return fallback
 }
@@ -74,11 +74,11 @@ func GetBoolFlag(key string) bool {
 
 func GetIntFlag(key string, fallback int) int {
 	val, ok := flags[key]
-	if !ok {
+	if !ok || len(val) == 0 {
 		return fallback
 	}
 
-	v, err := strconv.Atoi(val)
+	v, err := strconv.Atoi(val[len(val)-1])
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -91,14 +91,18 @@ func GetStringSliceFlag(key string, fallback []string) []string {
 		return fallback
 	}
 
-	if val == "" {
-		return []string{}
+	result := []string{}
+	for _, v := range val {
+		if v == "" {
+			continue
+		}
+		stringReader := strings.NewReader(v)
+		csvReader := csv.NewReader(stringReader)
+		parsed, err := csvReader.Read()
+		if err != nil {
+			log.Fatal(err)
+		}
+		result = append(result, parsed...)
 	}
-	stringReader := strings.NewReader(val)
-	csvReader := csv.NewReader(stringReader)
-	v, err := csvReader.Read()
-	if err != nil {
-		log.Fatal(err)
-	}
-	return v
+	return result
 }

--- a/util/config/env_test.go
+++ b/util/config/env_test.go
@@ -186,3 +186,10 @@ func TestStringSliceFlagFallback(t *testing.T) {
 
 	assert.Equal(t, []string{"default"}, strings)
 }
+
+func TestIntFlagEmptySlice(t *testing.T) {
+	loadOpts(t, "")
+	flags["foo"] = []string{}
+
+	assert.Equal(t, 5, GetIntFlag("foo", 5))
+}

--- a/util/config/env_test.go
+++ b/util/config/env_test.go
@@ -163,3 +163,12 @@ func TestFlagWithEqualSign(t *testing.T) {
 
 	assert.Equal(t, "bar", GetFlag("foo", ""))
 }
+
+func TestStringSliceFlagRepeatedWithEqualSign(t *testing.T) {
+	loadOpts(t, "--header='CF-Access-Client-Id: foo' --header='CF-Access-Client-Secret: bar'")
+	strings := GetStringSliceFlag("header", []string{})
+
+	assert.Len(t, strings, 2)
+	assert.Equal(t, "CF-Access-Client-Id: foo", strings[0])
+	assert.Equal(t, "CF-Access-Client-Secret: bar", strings[1])
+}

--- a/util/config/env_test.go
+++ b/util/config/env_test.go
@@ -172,3 +172,17 @@ func TestStringSliceFlagRepeatedWithEqualSign(t *testing.T) {
 	assert.Equal(t, "CF-Access-Client-Id: foo", strings[0])
 	assert.Equal(t, "CF-Access-Client-Secret: bar", strings[1])
 }
+
+func TestStringSliceFlagEmptyValue(t *testing.T) {
+	loadOpts(t, "--header ''")
+	strings := GetStringSliceFlag("header", []string{})
+
+	assert.Empty(t, strings)
+}
+
+func TestStringSliceFlagFallback(t *testing.T) {
+	loadOpts(t, "")
+	strings := GetStringSliceFlag("header", []string{"default"})
+
+	assert.Equal(t, []string{"default"}, strings)
+}

--- a/util/config/env_test.go
+++ b/util/config/env_test.go
@@ -113,6 +113,21 @@ func TestStringSliceFlagAtEnd(t *testing.T) {
 	assert.Equal(t, "Strict-Transport-Security: max-age=31536000", strings[0])
 }
 
+func TestStringSliceFlagRepeated(t *testing.T) {
+	loadOpts(t, `--header "CF-Access-Client-Id: foo" --header "CF-Access-Client-Secret: bar"`)
+	strings := GetStringSliceFlag("header", []string{})
+
+	assert.Len(t, strings, 2)
+	assert.Equal(t, "CF-Access-Client-Id: foo", strings[0])
+	assert.Equal(t, "CF-Access-Client-Secret: bar", strings[1])
+}
+
+func TestFlagRepeatedLastWins(t *testing.T) {
+	loadOpts(t, "--foo bar --foo baz")
+
+	assert.Equal(t, "baz", GetFlag("foo", ""))
+}
+
 func TestFlagAtStart(t *testing.T) {
 	loadOpts(t, "--foo bar")
 


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Fixes #24065

- Switched string map to storing values as a slice per key so repeated --header flags accumulate instead of the last one winning
- Fixed Qodo review flagging --key=value opts having a similar overwrite bug

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
