### PR TITLE
fix: treat pending PVCs without storage-provisioner annotation as Healthy (WaitForFirstConsumer)

### DIFF
--- a/gitops-engine/pkg/health/health_pvc.go
+++ b/gitops-engine/pkg/health/health_pvc.go
@@ -27,15 +27,30 @@ func getPVCHealth(obj *unstructured.Unstructured) (*HealthStatus, error) {
 
 func getCorev1PVCHealth(pvc *corev1.PersistentVolumeClaim) (*HealthStatus, error) {
 	var status HealthStatusCode
+	var msg string
 	switch pvc.Status.Phase {
 	case corev1.ClaimLost:
 		status = HealthStatusDegraded
 	case corev1.ClaimPending:
-		status = HealthStatusProgressing
+		// PVCs with a storage-provisioner annotation are actively being provisioned.
+		if pvc.Annotations != nil {
+			if _, ok := pvc.Annotations["volume.beta.kubernetes.io/storage-provisioner"]; ok {
+				status = HealthStatusProgressing
+				msg = "Provisioning volume"
+			} else {
+				// PVC is pending but not actively provisioning — it may be
+				// waiting for a consumer (WaitForFirstConsumer) or similar.
+				status = HealthStatusHealthy
+				msg = "Waiting for consumer"
+			}
+		} else {
+			status = HealthStatusHealthy
+			msg = "Waiting for consumer"
+		}
 	case corev1.ClaimBound:
 		status = HealthStatusHealthy
 	default:
 		status = HealthStatusUnknown
 	}
-	return &HealthStatus{Status: status}, nil
+	return &HealthStatus{Status: status, Message: msg}, nil
 }

--- a/gitops-engine/pkg/health/health_test.go
+++ b/gitops-engine/pkg/health/health_test.go
@@ -55,6 +55,7 @@ func TestDaemonSetOnDeleteHealth(t *testing.T) {
 func TestPVCHealth(t *testing.T) {
 	assertAppHealth(t, "./testdata/pvc-bound.yaml", HealthStatusHealthy)
 	assertAppHealth(t, "./testdata/pvc-pending.yaml", HealthStatusProgressing)
+	assertAppHealth(t, "./testdata/pvc-pending-wait-for-first-consumer.yaml", HealthStatusHealthy)
 }
 
 func TestServiceHealth(t *testing.T) {

--- a/gitops-engine/pkg/health/testdata/pvc-pending-wait-for-first-consumer.yaml
+++ b/gitops-engine/pkg/health/testdata/pvc-pending-wait-for-first-consumer.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"labels":{"app.kubernetes.io/instance":"waiting-pvc"},"name":"testpvc-waiting","namespace":"argocd"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"2Gi"}},"storageClassName":"wait-for-first-consumer"}}
+  creationTimestamp: 2026-08-15T10:00:00Z
+  labels:
+    app.kubernetes.io/instance: waiting-pvc
+  name: testpvc-waiting
+  namespace: argocd
+  resourceVersion: "123456"
+  selfLink: /api/v1/namespaces/argocd/persistentvolumeclaims/testpvc-waiting
+  uid: abcdef01-1234-5678-9abc-def012345678
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: wait-for-first-consumer
+status:
+  phase: Pending


### PR DESCRIPTION
### Problem

PVCs with a StorageClass using `volumeBindingMode: WaitForFirstConsumer` are shown as `Progressing` in the Argo CD UI indefinitely, even when their consumer pod may never be scheduled (e.g., a suspended CronJob). This is misleading because the PVC is not actively progressing — it is waiting for a consumer.

### Root Cause

The `getCorev1PVCHealth` function in `pkg/health/health_pvc.go` unconditionally marks all PVCs with `status.phase: Pending` as `HealthStatusProgressing`. This is correct for PVCs that are actively being provisioned (where the storage provisioner has picked up the claim), but incorrect for PVCs that are waiting for a consumer.

### Fix

Check whether the PVC has the `volume.beta.kubernetes.io/storage-provisioner` annotation:

- **With annotation** → `Progressing` (the provisioner is actively creating the volume)
- **Without annotation** → `Healthy` with message "Waiting for consumer" (the PVC is not making progress, e.g., WaitForFirstConsumer)

This annotation is set by the Kubernetes external provisioner when it begins provisioning the volume. If it is absent, the PVC is either waiting for a consumer or no provisioner has picked it up yet — in either case, `Progressing` is misleading.

### Testing

- Existing test `pvc-pending.yaml` (has `storage-provisioner` annotation) → still expects `HealthStatusProgressing`
- New test data `pvc-pending-wait-for-first-consumer.yaml` (no annotation) → expects `HealthStatusHealthy`

### Related Issues

Fixes #29201
Related to #12840
