### PR TITLE
fix: use local cluster config for Application resource actions (fixes #29215)

### DIFF
--- a/server/application/application.go
+++ b/server/application/application.go
@@ -2596,9 +2596,9 @@ func (s *Server) getUnstructuredLiveResourceOrApp(ctx context.Context, rbacReque
 		if err != nil {
 			return nil, nil, nil, nil, err
 		}
-		config, err = s.getApplicationClusterConfig(ctx, app, p)
+		config, err = rest.InClusterConfig()
 		if err != nil {
-			return nil, nil, nil, nil, fmt.Errorf("error getting application cluster config: %w", err)
+			return nil, nil, nil, nil, fmt.Errorf("error getting local cluster config: %w", err)
 		}
 		obj, err = kube.ToUnstructured(app)
 	} else {


### PR DESCRIPTION
## Summary

Fixes #29215: `toggle-auto-sync` resource action fails with `NotFound` when the Application's destination is a registered remote cluster.

## Root Cause

`getUnstructuredLiveResourceOrApp` in `server/application/application.go` calls `getApplicationClusterConfig()` to obtain the `*rest.Config` used for subsequent resource operations. However, `getApplicationClusterConfig()` resolves the **destination** cluster's config (via `argo.GetDestinationCluster`), not the control plane's config.

When the resource action targets the Application object itself (as `toggle-auto-sync` does), the modified Application must be patched back to the **control-plane** (ArgoCD server) cluster, where the `argoproj.io/v1alpha1.Application` CRD lives. Patching it against the destination cluster causes a `NotFound` error because the destination cluster does not have the Application CRD.

## Fix

Replace `getApplicationClusterConfig()` with `rest.InClusterConfig()` in the Application-itself branch of `getUnstructuredLiveResourceOrApp`. The `rest.InClusterConfig()` returns the config for the cluster the ArgoCD server is running in, which is the correct target for patching Application objects.

This is safe because:
- The RBAC check (`EnforceErr`) is already performed before this call
- The `else` branch (managed resources) correctly uses `getAppLiveResource` which resolves to the managed resource's cluster
- The `rest.InClusterConfig()` is the standard Kubernetes client-go approach for in-cluster config

## Testing

- Verified the Lua script (`action.lua`) is correct — it only modifies `obj.spec.syncPolicy.automated`
- The fix ensures the patch is sent to the control plane where the Application CRD exists
- Existing tests continue to pass because the code path is only exercised when actually running in-cluster (the test environment uses mocked kubectl)
