### PR TITLE
fix(revert): auto-sync skipped when newer commit arrives during sync (cherry-pick #28692 for 3.4)

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -1905,13 +1905,7 @@ func (ctrl *ApplicationController) processAppRefreshQueueItem() (processNext boo
 
 	canSync, _ := project.Spec.SyncWindows.Matches(app).CanSync(false)
 	if canSync {
-		// The manifest-generate-paths optimization can report no changes for a newer commit that
-		// arrives while the app is still syncing, which would skip auto-sync and leave the app
-		// stuck OutOfSync. Only use it to avoid regenerating manifests, never to gate the sync
-		// decision: when the app is OutOfSync, always let autoSync compare the desired revision
-		// against the last synced one (#27875).
-		shouldCompareRevisions := compareResult.revisionsMayHaveChanges || compareResult.syncStatus.Status == appv1.SyncStatusCodeOutOfSync
-		syncErrCond, opDuration := ctrl.autoSync(app, compareResult.syncStatus, compareResult.resources, shouldCompareRevisions)
+		syncErrCond, opDuration := ctrl.autoSync(app, compareResult.syncStatus, compareResult.resources, compareResult.revisionsMayHaveChanges)
 		setOpDuration = opDuration
 		if syncErrCond != nil {
 			app.Status.SetConditions(

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -713,51 +713,6 @@ func TestAutoSyncMultiSourceWithoutSelfHeal(t *testing.T) {
 	})
 }
 
-func TestAutoSyncManifestGeneratePathsNewCommit(t *testing.T) {
-	// Regression for #27875: with the manifest-generate-paths annotation, an app must still
-	// auto-sync to a newer commit while it is OutOfSync, and must not sync when it is already
-	// synced to that revision.
-	revA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-	revB := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-
-	t.Run("NewCommitTriggersAutoSync", func(t *testing.T) {
-		app := newFakeApp()
-		app.Annotations = map[string]string{v1alpha1.AnnotationKeyManifestGeneratePaths: "."}
-		app.Spec.SyncPolicy.Automated.SelfHeal = new(false)
-		app.Status.OperationState.SyncResult.Revision = revA
-		ctrl := newFakeController(t.Context(), &fakeData{apps: []runtime.Object{app}}, nil)
-		syncStatus := v1alpha1.SyncStatus{
-			Status:   v1alpha1.SyncStatusCodeOutOfSync,
-			Revision: revB,
-		}
-		cond, _ := ctrl.autoSync(app, &syncStatus, []v1alpha1.ResourceStatus{{Name: "guestbook", Kind: kube.DeploymentKind, Status: v1alpha1.SyncStatusCodeOutOfSync}}, syncStatus.Status == v1alpha1.SyncStatusCodeOutOfSync)
-		assert.Nil(t, cond)
-		app, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(test.FakeArgoCDNamespace).Get(t.Context(), "my-app", metav1.GetOptions{})
-		require.NoError(t, err)
-		require.NotNil(t, app.Operation)
-		require.NotNil(t, app.Operation.Sync)
-		assert.Equal(t, revB, app.Operation.Sync.Revision)
-		assert.Empty(t, app.Operation.Sync.Resources)
-	})
-
-	t.Run("SameRevisionDriftDoesNotTriggerAutoSync", func(t *testing.T) {
-		app := newFakeApp()
-		app.Annotations = map[string]string{v1alpha1.AnnotationKeyManifestGeneratePaths: "."}
-		app.Spec.SyncPolicy.Automated.SelfHeal = new(false)
-		app.Status.OperationState.SyncResult.Revision = revB
-		ctrl := newFakeController(t.Context(), &fakeData{apps: []runtime.Object{app}}, nil)
-		syncStatus := v1alpha1.SyncStatus{
-			Status:   v1alpha1.SyncStatusCodeOutOfSync,
-			Revision: revB,
-		}
-		cond, _ := ctrl.autoSync(app, &syncStatus, []v1alpha1.ResourceStatus{{Name: "guestbook", Kind: kube.DeploymentKind, Status: v1alpha1.SyncStatusCodeOutOfSync}}, syncStatus.Status == v1alpha1.SyncStatusCodeOutOfSync)
-		assert.Nil(t, cond)
-		app, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(test.FakeArgoCDNamespace).Get(t.Context(), "my-app", metav1.GetOptions{})
-		require.NoError(t, err)
-		assert.Nil(t, app.Operation)
-	})
-}
-
 func TestAutoSyncNotAllowEmpty(t *testing.T) {
 	app := newFakeApp()
 	app.Spec.SyncPolicy.Automated.Prune = new(true)


### PR DESCRIPTION
Cherry-pick of #28692 onto `release-3.4`.

This reverts the `shouldCompareRevisions` gating introduced by #28227 (revert of commit 60d29acbedcc780fd9e6308daf5f801312489e65), so `autoSync` is called with `compareResult.revisionsMayHaveChanges` directly.

Conflicts resolved manually:
- `controller/appcontroller.go`: kept the `release-3.4` `autoSync` signature (no `ctx` parameter) while dropping the `shouldCompareRevisions` logic.
- `controller/appcontroller_test.go`: removed `TestAutoSyncManifestGeneratePathsNewCommit`, matching the upstream revert.

Signed-off-by: Blake Pettersson <blake.pettersson@gmail.com>
Signed-off-by: Alexandre Gaudreault <alexandre_gaudreault@intuit.com>