### PR TITLE
fix: restore ManageServerSideDiffDryRuns API compatibility with published gitops-engine module

### DIFF
--- a/gitops-engine/pkg/utils/kube/ctl.go
+++ b/gitops-engine/pkg/utils/kube/ctl.go
@@ -339,6 +339,22 @@ func (k *KubectlCmd) ManageServerSideDiffDryRuns(config *rest.Config) (diff.Kube
 	}, cleanup, nil
 }
 
+// ManageServerSideDiffDryRuns creates a KubeApplier for server-side diff dry runs.
+//
+// This package-level function is kept for backward compatibility with external
+// consumers that resolve against the published (archived) standalone module at
+// github.com/argoproj/gitops-engine, which predates the method form below. Its
+// signature matches the published API; the implementation delegates to the method
+// form so behavior stays identical within this module.
+func ManageServerSideDiffDryRuns(config *rest.Config, openAPISchema openapi.Resources, tracer tracing.Tracer, log logr.Logger, onKubectlRun OnKubectlRunFunc) (diff.KubeApplier, func(), error) {
+	k := &KubectlCmd{
+		Tracer:       tracer,
+		Log:          log,
+		OnKubectlRun: onKubectlRun,
+	}
+	return k.ManageServerSideDiffDryRuns(config)
+}
+
 // ConvertToVersion converts an unstructured object into the specified group/version
 func (k *KubectlCmd) ConvertToVersion(obj *unstructured.Unstructured, group string, version string) (*unstructured.Unstructured, error) {
 	span := k.Tracer.StartSpan("ConvertToVersion")

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -42,6 +42,7 @@ import (
 
 	argocommon "github.com/argoproj/argo-cd/v3/common"
 	"github.com/argoproj/argo-cd/v3/pkg/apiclient/application"
+	kubeutil "github.com/argoproj/argo-cd/v3/util/kube"
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 
 	appclientset "github.com/argoproj/argo-cd/v3/pkg/client/clientset/versioned"
@@ -2958,7 +2959,7 @@ func (s *Server) ServerSideDiff(ctx context.Context, q *application.ApplicationS
 		return nil, fmt.Errorf("failed to get OpenAPI schema: %w", err)
 	}
 
-	applier, cleanup, err := s.kubectl.ManageServerSideDiffDryRuns(clusterConfig)
+	applier, cleanup, err := kubeutil.ManageServerSideDiffDryRuns(clusterConfig, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating server-side dry run applier: %w", err)
 	}

--- a/util/kube/kubectl.go
+++ b/util/kube/kubectl.go
@@ -29,10 +29,5 @@ func NewKubectl() kube.Kubectl {
 }
 
 func ManageServerSideDiffDryRuns(config *rest.Config, onKubectlRun kube.OnKubectlRunFunc) (diff.KubeApplier, func(), error) {
-	k := &kube.KubectlCmd{
-		Log:          logger,
-		Tracer:       tracer,
-		OnKubectlRun: onKubectlRun,
-	}
-	return k.ManageServerSideDiffDryRuns(config)
+	return kube.ManageServerSideDiffDryRuns(config, nil, tracer, logger, onKubectlRun)
 }


### PR DESCRIPTION
External consumers importing `github.com/argoproj/argo-cd/v3` fail to compile against v3.3.13+ because `ManageServerSideDiffDryRuns` was changed from a package-level function (in the published standalone module) to a method on `*KubectlCmd` (in the in-repo copy). The `replace` directive in `go.mod` only applies to the main module, so consumers resolve the published (archived) standalone module which lacks the method form.

## Root Cause

Commit `fac2752` (cherry-pick of #28027/#27601) changed `ManageServerSideDiffDryRuns` from a package-level function to a method on `*KubectlCmd`, added to the `Kubectl` interface. The standalone `argoproj/gitops-engine` repo was archived in May 2026 and still carries the old package-level function. No version of the published module can satisfy the new method form.

## Changes

1. **`gitops-engine/pkg/utils/kube/ctl.go`** — Added a package-level `ManageServerSideDiffDryRuns` function matching the published module's signature, delegating to the method form.
2. **`util/kube/kubectl.go`** — Changed the wrapper to call the package-level function instead of creating a `*KubectlCmd` and calling the method.
3. **`server/application/application.go`** — Changed to use the `kubeutil` wrapper instead of the interface method form.

## Verification

- `go vet ./util/kube/` passes
- All method-form calls removed from main module
- Fix backported to `release-3.3` branch
- No breaking changes to existing API

Closes #29220
Fixes the regression introduced in v3.3.13 where any external Go module importing ArgoCD fails to compile.