### PR TITLE
fix(ui): stop New App panel render loop in multi-source mode (#29097)

### DIFF
--- a/ui/src/app/shared/components/editable-panel/__tests__/editable-panel.test.tsx
+++ b/ui/src/app/shared/components/editable-panel/__tests__/editable-panel.test.tsx
@@ -193,6 +193,37 @@ describe('EditablePanel – noReadonlyMode', () => {
         // save() should have been called at least once via formDidUpdate
         expect(save).toHaveBeenCalled();
     });
+
+    // Regression for #29097: syncing an externally updated `values` prop into the
+    // form must NOT re-trigger the auto-save. When the parent updates `values` in
+    // response to a save (e.g. the New App panel mirrors state back via
+    // setAllValues), the effect calls setAllValues(values) which re-fires
+    // formDidUpdate with the already-saved values. If that echo saves again it
+    // feeds back into `values` and loops forever ("Maximum update depth exceeded").
+    test('does not auto-save when syncing an externally updated values prop (no render loop)', async () => {
+        const save = jest.fn().mockResolvedValue(undefined);
+        const editItems: EditablePanelItem[] = [
+            {
+                title: 'Name',
+                view: <span>alice</span>,
+                edit: (api: FormApi) => <input value={api.values.name || ''} onChange={e => api.setValue('name', e.target.value)} />,
+            },
+        ];
+
+        const {rerender} = renderPanel(<EditablePanel values={{name: 'v1'}} items={editItems} save={save} noReadonlyMode />);
+
+        // Parent pushes a new value (as if a prior save mirrored state back).
+        await act(async () => {
+            rerender(
+                <Wrapper>
+                    <EditablePanel values={{name: 'v2'}} items={editItems} save={save} noReadonlyMode />
+                </Wrapper>
+            );
+        });
+
+        // The programmatic sync of the external value must not trigger a save.
+        expect(save).not.toHaveBeenCalled();
+    });
 });
 
 // ===========================================================================

--- a/ui/src/app/shared/components/editable-panel/editable-panel.tsx
+++ b/ui/src/app/shared/components/editable-panel/editable-panel.tsx
@@ -233,7 +233,15 @@ function EditablePanel<T extends {} = {}>({
                                 getApi={api => (formApiRef.current = api)}
                                 formDidUpdate={async form => {
                                     if (noReadonlyMode && save) {
-                                        await save(form.values as any, {});
+                                        // Only auto-save when the form values actually changed. When a save
+                                        // updates the parent, the `values` prop changes and the effect above
+                                        // calls setAllValues(values), which re-fires formDidUpdate with the
+                                        // already-saved values. Without this guard those echoes trigger another
+                                        // save, feeding back into `values` and re-triggering the sync — an
+                                        // infinite render loop ("Maximum update depth exceeded"), see #29097.
+                                        if (JSON.stringify(form.values) !== JSON.stringify(values)) {
+                                            await save(form.values as any, {});
+                                        }
                                     }
                                 }}
                                 onSubmit={handleSubmit}


### PR DESCRIPTION
## What / Why

Fixes #29097.

In the **New App** panel, typing quickly into a source field while in **multi-source** mode drives the UI into an infinite render loop — the console fills with React's `Maximum update depth exceeded` and the panel has to be closed and reopened.

## Root cause

`EditablePanel` (`ui/src/app/shared/components/editable-panel/editable-panel.tsx`) auto-saves in `noReadonlyMode` by calling `save(form.values)` inside `formDidUpdate`. It fired on **every** form update — including the *programmatic* ones — with no check that anything actually changed.

The New App panel's `save` prop mirrors state back into the parent create-panel form:

```tsx
// create-panel-source-type-parameters.tsx
save={async updatedApp => {
    props.formApi.setAllValues(updatedApp);
}}
```

That `setAllValues` changes the `values` prop of the inner `EditablePanel`, whose sync effect then calls `formApiRef.current.setAllValues(values)` on the inner form, which **re-fires** `formDidUpdate` → `save` → parent `setAllValues` → … an unconditional two-form echo loop.

With slow typing the values converge to a fixpoint and it settles; under fast typing a new keystroke keeps changing the values before it converges, so the loop never terminates and React aborts with `Maximum update depth exceeded`. The same auto-save wiring exists in the single-source path, which matches the reporter's note that it is not strictly multi-source specific.

Stack trace from the issue confirms the path: `children.save (application-parameters.tsx)` ← `formDidUpdate (editable-panel.tsx)`.

## Fix

Guard the `formDidUpdate` auto-save so it only calls `save` when the form values actually differ from the current `values` prop:

```tsx
if (JSON.stringify(form.values) !== JSON.stringify(values)) {
    await save(form.values as any, {});
}
```

When the effect echoes the parent's value back into the form via `setAllValues(values)`, the resulting `formDidUpdate` sees `form.values === values` and skips the save, so the feedback loop cannot sustain. Genuine user edits always differ from `values` and still auto-save exactly as before. This mirrors the JSON.stringify comparison already used by the sync effect a few lines above, so it introduces no new comparison semantics.

Minimal and scoped to the auto-save path — the readonly/Save-button path (`handleSubmit`) is untouched.

## Testing

- Added a regression test in `editable-panel.test.tsx`: syncing an externally updated `values` prop must not trigger `save` (verified it **fails** without the fix and **passes** with it).
- `pnpm jest src/app/shared/components/editable-panel` → 15/15 pass.
- `tsc --noEmit --project ./src/app` → clean.
- `eslint` on the changed source file → clean.

Caveat: I verified via type/lint/unit tests and code reasoning rather than reproducing the live loop in a browser.

Checklist:

* [x] Either (a) I've created an enhancement proposal and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the Title of the PR.
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. (N/A — UI-only bug fix)
* [x] Does this PR require documentation updates? (No)
* [x] I've updated documentation as required by this PR. (N/A)
* [x] I have signed off all my commits as required by DCO.
* [x] I have written unit and/or e2e tests for my change.
* [x] My build is green.
* [x] My new feature complies with the feature status guidelines. (N/A — bug fix)
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into: affects 3.5.0 and 3.6.0 per the report; safe to cherry-pick to the corresponding release branches.
