### PR TITLE
fix(ui): allow GitHub App credential templates (#18741)

### DIFF
--- a/docs/user-guide/private-repositories.md
+++ b/docs/user-guide/private-repositories.md
@@ -134,7 +134,7 @@ Using the UI:
 
     ![connect repo overview](../assets/repo-add-overview.png)
 
-2. Click `Connect Repo using GitHub App` button, choose type: `GitHub` or `GitHub Enterprise`, enter the URL, App Id, Installation Id (optional), and the app's private key.
+2. Click `Connect Repo using GitHub App` button, choose type: `GitHub` or `GitHub Enterprise`, and enter the URL. For a read repository, either enter the App ID, Installation ID (optional), and the app's private key, or leave the GitHub App and TLS client authentication fields empty to use a matching credentials template.
 
 > [!NOTE]
 > Enter the GitHub Enterprise Base URL for type `GitHub Enterprise`.

--- a/ui/src/app/settings/components/repos-list/repos-list.tsx
+++ b/ui/src/app/settings/components/repos-list/repos-list.tsx
@@ -41,6 +41,7 @@ import {
     isWrite,
     isTemplate
 } from './repos-filter';
+import {validateGitHubAppCredentials} from './repos-validation';
 
 // Helper functions to convert to UnifiedRepo
 const repoToUnified = (repo: models.Repository, isWriteFlag: boolean): UnifiedRepo => (isWriteFlag ? {writeRepo: repo} : {readRepo: repo});
@@ -357,8 +358,7 @@ export const ReposList = ({match, location}: RouteComponentProps) => {
                 const githubAppValues = params as NewGitHubAppRepoParams;
                 return {
                     url: (!githubAppValues.url && 'Repository URL is required') || (credsTemplate && !isHTTPOrHTTPSUrl(githubAppValues.url) && 'Not a valid HTTP/HTTPS URL'),
-                    githubAppId: !githubAppValues.githubAppId && 'GitHub App ID is required',
-                    githubAppPrivateKey: !githubAppValues.githubAppPrivateKey && 'GitHub App private Key is required',
+                    ...validateGitHubAppCredentials(githubAppValues, credsTemplate.current || githubAppValues.write),
                     depth: githubAppValues.depth != undefined && githubAppValues.depth < 0 && 'Depth must be a non-negative number'
                 };
             }
@@ -549,10 +549,11 @@ export const ReposList = ({match, location}: RouteComponentProps) => {
 
     // Connect a new repository or create a repository credentials for GitHub App repositories
     const connectGitHubAppRepo = async (params: NewGitHubAppRepoParams) => {
+        const normalizedParams = {...params, githubAppPrivateKey: params.githubAppPrivateKey?.trim() ? params.githubAppPrivateKey : ''};
         if (credsTemplate.current) {
             createGitHubAppCreds({
                 url: params.url,
-                githubAppPrivateKey: params.githubAppPrivateKey,
+                githubAppPrivateKey: normalizedParams.githubAppPrivateKey,
                 githubAppId: params.githubAppId,
                 githubAppInstallationId: params.githubAppInstallationId,
                 githubAppEnterpriseBaseURL: params.githubAppEnterpriseBaseURL,
@@ -566,9 +567,9 @@ export const ReposList = ({match, location}: RouteComponentProps) => {
             setConnecting(true);
             try {
                 if (params.write) {
-                    await services.repos.createGitHubAppWrite(params);
+                    await services.repos.createGitHubAppWrite(normalizedParams);
                 } else {
-                    await services.repos.createGitHubApp(params);
+                    await services.repos.createGitHubApp(normalizedParams);
                 }
                 repoLoader.current.reload();
                 setConnectRepo(false);
@@ -1248,6 +1249,7 @@ export const ReposList = ({match, location}: RouteComponentProps) => {
                                                 <div className='argo-form-row'>
                                                     <FormField formApi={formApi} label='Repository URL' field='url' component={Text} />
                                                 </div>
+                                                <p>For read repositories, leave all credential fields empty to use a matching credentials template.</p>
                                                 <div className='argo-form-row'>
                                                     <FormField formApi={formApi} label='GitHub App ID' field='githubAppId' component={NumberField} />
                                                 </div>

--- a/ui/src/app/settings/components/repos-list/repos-validation.test.ts
+++ b/ui/src/app/settings/components/repos-list/repos-validation.test.ts
@@ -1,0 +1,45 @@
+import {validateGitHubAppCredentials} from './repos-validation';
+
+describe('validateGitHubAppCredentials', () => {
+    const requiredErrors = {
+        githubAppId: 'GitHub App ID is required',
+        githubAppPrivateKey: 'GitHub App private Key is required'
+    };
+    test('allows all credential fields to be empty so a matching template can be used', () => {
+        expect(validateGitHubAppCredentials({})).toEqual({});
+    });
+
+    test('requires credentials when requested', () => {
+        expect(validateGitHubAppCredentials({}, true)).toEqual(requiredErrors);
+    });
+
+    test('accepts directly supplied GitHub App credentials', () => {
+        expect(
+            validateGitHubAppCredentials({
+                githubAppId: 123n,
+                githubAppInstallationId: 456n,
+                githubAppPrivateKey: 'private-key'
+            })
+        ).toEqual({githubAppId: false, githubAppPrivateKey: false});
+    });
+
+    test.each([
+        [{githubAppPrivateKey: 'private-key'}, {githubAppId: 'GitHub App ID is required', githubAppPrivateKey: false}],
+        [{githubAppId: 123n}, {githubAppId: false, githubAppPrivateKey: 'GitHub App private Key is required'}],
+        [{githubAppInstallationId: 456n}, requiredErrors]
+    ])('requires complete direct credentials: %p', (values, expected) => {
+        expect(validateGitHubAppCredentials(values)).toEqual(expected);
+    });
+
+    test.each([{githubAppId: 0}, {githubAppInstallationId: 0}])('does not treat a zero ID as empty credentials: %p', values => {
+        expect(validateGitHubAppCredentials(values)).toEqual(requiredErrors);
+    });
+
+    test.each([{githubAppId: Number.NaN}, {githubAppInstallationId: Number.NaN}])('treats an unnormalized numeric field as empty: %p', values => {
+        expect(validateGitHubAppCredentials(values)).toEqual({});
+    });
+
+    test('treats a whitespace-only private key as empty', () => {
+        expect(validateGitHubAppCredentials({githubAppPrivateKey: '  \n'})).toEqual({});
+    });
+});

--- a/ui/src/app/settings/components/repos-list/repos-validation.ts
+++ b/ui/src/app/settings/components/repos-list/repos-validation.ts
@@ -1,0 +1,18 @@
+interface GitHubAppCredentialValues {
+    githubAppId?: bigint | number | null;
+    githubAppInstallationId?: bigint | number | null;
+    githubAppPrivateKey?: string;
+}
+
+export const validateGitHubAppCredentials = (values: GitHubAppCredentialValues, requireCredentials = false) => {
+    const hasDirectCredentials =
+        [values.githubAppId, values.githubAppInstallationId].some(value => value != null && !Number.isNaN(value)) || Boolean(values.githubAppPrivateKey?.trim());
+    if (!requireCredentials && !hasDirectCredentials) {
+        return {};
+    }
+
+    return {
+        githubAppId: !values.githubAppId && 'GitHub App ID is required',
+        githubAppPrivateKey: !values.githubAppPrivateKey?.trim() && 'GitHub App private Key is required'
+    };
+};

--- a/ui/src/app/shared/components/number-field.test.tsx
+++ b/ui/src/app/shared/components/number-field.test.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import {fireEvent, render, screen} from '@testing-library/react';
+import {Form, FormApi} from 'argo-ui';
+import {NumberField} from './number-field';
+
+describe('NumberField', () => {
+    let formApi: FormApi;
+
+    beforeEach(() => {
+        render(
+            <Form defaultValues={{value: 123}} getApi={api => (formApi = api)}>
+                {() => <NumberField field='value' />}
+            </Form>
+        );
+    });
+
+    test('sets undefined when cleared', () => {
+        fireEvent.change(screen.getByRole('spinbutton'), {target: {value: ''}});
+        expect(formApi.values.value).toBeUndefined();
+    });
+
+    test('preserves zero as a numeric value', () => {
+        fireEvent.change(screen.getByRole('spinbutton'), {target: {value: '0'}});
+        expect(formApi.values.value).toBe(0);
+    });
+});

--- a/ui/src/app/shared/components/number-field.tsx
+++ b/ui/src/app/shared/components/number-field.tsx
@@ -8,5 +8,14 @@ export const NumberField = ReactForm.FormField((props: {fieldApi: ReactForm.Fiel
         ...rest
     } = props;
 
-    return <input {...rest} className={props.className} type='number' value={getValue()} onChange={el => setValue(parseInt(el.target.value, 10))} onBlur={onBlur} />;
+    return (
+        <input
+            {...rest}
+            className={props.className}
+            type='number'
+            value={getValue() ?? ''}
+            onChange={el => setValue(el.target.value === '' ? undefined : parseInt(el.target.value, 10))}
+            onBlur={onBlur}
+        />
+    );
 });


### PR DESCRIPTION
## Summary

When connecting a repository via **GitHub App**, the UI currently requires an App ID and private key even when a matching credentials template already contains them. This prevents the server's existing URL-based credential inheritance from being used.

This change:

- allows all GitHub App credential fields to remain empty so a matching credentials template can be used;
- keeps App ID, installation ID, and private key validation when any credential is entered directly;
- normalizes cleared number fields and rejects invalid zero or `NaN` credential IDs;
- adds inline guidance and user documentation for matching credentials templates.

Fixes #18741

## Screenshots

### Before

GitHub App credentials were treated as required even when a matching credentials template could provide them:

![GitHub App repository form before the fix](https://github.com/user-attachments/assets/c6af0332-9de8-453f-858f-24fce37c0fdd)

### After

The form now explains that credentials may be inherited from a matching template and accepts the repository URL with all GitHub App credential fields left empty:

![GitHub App repository form after the fix](https://raw.githubusercontent.com/SHINMH/argo-cd/pr-assets/screenshots/18741-github-app-credentials-after.png)

## Test plan

- `pnpm --dir ui exec jest --runInBand src/app/settings/components/repos-list/repos-validation.test.ts src/app/shared/components/number-field.test.tsx` (13 tests passed across 2 suites; existing `ts-jest` `isolatedModules` deprecation warning)
- `pnpm --dir ui lint` (0 errors; 11 existing React Hooks warnings)
- `make lint-ui` (0 errors; 11 existing React Hooks warnings)
- `make build-docs`
- `git diff --check`
- `make build`, `make lint`, `make test`, and `make cli` currently stop on an upstream `master` vendoring mismatch: the AWS SDK versions in `go.mod` do not match `vendor/modules.txt`. This branch does not modify either file.

Focused unit tests cover template-based authentication, complete and incomplete direct credentials, zero and `NaN` IDs, whitespace-only private keys, and cleared-number normalization.

## Checklist

* [x] Either (a) I've created an [enhancement proposal](https://argo-cd.readthedocs.io/en/stable/proposals/) and discussed it with the community, (b) this is a bug fix, or (c) this is a small feature that doesn't require an enhancement proposal.
* [x] The title of this PR states what changed and the related issues number (used for the release note).
* [x] I've included "Fixes [ISSUE_NUM]" or "Closes [ISSUE_NUM]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] I've updated documentation and example manifests as appropriate for this change.


