### PR TITLE
docs: clarify core resource health checks

### DIFF
--- a/docs/operator-manual/health.md
+++ b/docs/operator-manual/health.md
@@ -118,6 +118,12 @@ Custom health checks can be defined in
 ```
 field of `argocd-cm`. If you are using argocd-operator, this is overridden by [the argocd-operator resourceCustomizations](https://argocd-operator.readthedocs.io/en/latest/reference/argocd/#resource-customizations).
 
+> [!NOTE]
+> The `<group>_` prefix is used for resources that belong to an API group (for example, `resource.customizations.health.batch_Job` for `batch/Job`).
+> Core Kubernetes resources (such as `PersistentVolumeClaim`, `Pod`, or `Service`) do not belong to an API group. For core resources, omit the `<group>_` prefix and use the resource kind directly:
+>
+> `resource.customizations.health.PersistentVolumeClaim`
+
 The following example demonstrates a health check for `cert-manager.io/Certificate`.
 
 ```yaml


### PR DESCRIPTION
## Description

Clarifies how custom health check keys should be configured for Kubernetes core resources.

Resources belonging to an API group use the `<group>_<kind>` format, while core Kubernetes resources do not have an API group and should omit the `<group>_` prefix.

For example:

- `resource.customizations.health.batch_Job`
- `resource.customizations.health.PersistentVolumeClaim`

This addresses the documentation confusion described in #29249.

## Related issue

Fixes #29249

## Testing

- `git diff --check`
- Documentation build could not be run locally because MkDocs is not installed in the environment.