### PR TITLE
fix(ui): hide the pod highlight button when there is only one pod (#29252)

### DIFF
--- a/ui/src/app/applications/components/pod-logs-viewer/pod-logs-viewer.highlight.test.tsx
+++ b/ui/src/app/applications/components/pod-logs-viewer/pod-logs-viewer.highlight.test.tsx
@@ -1,0 +1,93 @@
+import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+import * as React from 'react';
+import {MemoryRouter} from 'react-router-dom';
+import {of} from 'rxjs';
+
+import {ARGO_WARNING_COLOR} from '../../../shared/components/colors';
+import * as models from '../../../shared/models';
+import {PodsLogsViewer} from './pod-logs-viewer';
+
+const getContainerLogs = jest.fn();
+
+jest.mock('../../../shared/services', () => ({
+    services: {
+        applications: {
+            getContainerLogs: (...args: unknown[]) => getContainerLogs(...args)
+        },
+        viewPreferences: {
+            getPreferences: () => require('rxjs').of({appDetails: {darkMode: false, wrapLines: false}})
+        }
+    }
+}));
+
+// @tippy.js/react logs a React 19 ref deprecation the moment it renders, and tooltips have nothing
+// to do with what is under test here, so draw them as a plain pass-through.
+jest.mock('argo-ui', () => ({
+    ...jest.requireActual('argo-ui'),
+    Tooltip: ({children}: {children: React.ReactNode}) => children
+}));
+
+const logEntry = (podName: string, lineNum: number): models.LogEntry => ({
+    content: `line ${lineNum} from ${podName}`,
+    timeStamp: '2026-01-01T00:00:00Z' as unknown as models.LogEntry['timeStamp'],
+    timeStampStr: '2026-01-01T00:00:00Z',
+    podName,
+    last: false
+});
+
+const streamLogsFrom = (podNames: string[]) => getContainerLogs.mockReturnValue(of(...podNames.map(logEntry)));
+
+const viewer = (containerName: string) => (
+    <MemoryRouter>
+        <PodsLogsViewer applicationName='app' applicationNamespace='argocd' namespace='argocd' containerName={containerName} kind='Pod' name='pod-a' podName='pod-a' />
+    </MemoryRouter>
+);
+
+const renderViewer = (podNames: string[]) => {
+    streamLogsFrom(podNames);
+    return render(viewer('main'));
+};
+
+// The highlight button is the only toolbar button drawn with the highlighter icon.
+const highlightButton = (container: HTMLElement) => container.querySelector('.fa-highlighter')?.closest('button');
+
+const waitForHighlightButton = (container: HTMLElement) => waitFor(() => expect(highlightButton(container)).toBeInTheDocument());
+
+beforeEach(() => getContainerLogs.mockReset());
+
+test('offers the pod highlight button when the logs come from several pods', async () => {
+    const {container} = renderViewer(['pod-a', 'pod-b']);
+
+    await waitForHighlightButton(container);
+});
+
+test('hides the pod highlight button when the logs come from a single pod', async () => {
+    const {container} = renderViewer(['pod-a', 'pod-a']);
+
+    await waitFor(() => expect(screen.getByText(/line 1 from pod-a/)).toBeInTheDocument());
+    expect(highlightButton(container)).toBeUndefined();
+});
+
+test('hides the pod highlight button before any logs have arrived', async () => {
+    const {container} = renderViewer([]);
+
+    // The follow button is always present, so it marks the toolbar as rendered.
+    await waitFor(() => expect(container.querySelector('.fa-angles-down')).toBeInTheDocument());
+    expect(highlightButton(container)).toBeUndefined();
+});
+
+test('drops the highlight when the logs it was pointing at are discarded', async () => {
+    const {container, rerender} = renderViewer(['pod-a', 'pod-b']);
+    await waitForHighlightButton(container);
+
+    fireEvent.click(highlightButton(container));
+    fireEvent.click(screen.getByText('pod-a'));
+    expect(highlightButton(container)).toHaveStyle({backgroundColor: ARGO_WARNING_COLOR});
+
+    // Switching container restarts the log stream, so the highlighted pod may no longer be in view.
+    streamLogsFrom(['pod-c', 'pod-d']);
+    rerender(viewer('sidecar'));
+
+    await waitForHighlightButton(container);
+    expect(highlightButton(container)).not.toHaveStyle({backgroundColor: ARGO_WARNING_COLOR});
+});

--- a/ui/src/app/applications/components/pod-logs-viewer/pod-logs-viewer.tsx
+++ b/ui/src/app/applications/components/pod-logs-viewer/pod-logs-viewer.tsx
@@ -170,6 +170,9 @@ export const PodsLogsViewer = (props: PodLogsProps) => {
         setPrevQueryKey(queryKey);
         setLogs([]);
         setReceivedLogs([]);
+        // The highlighted pod may be absent from the new logs, and the button that clears the
+        // highlight is only shown while several pods are in view, so drop the highlight with them.
+        setSelectedPod(null);
     }
 
     useEffect(() => {
@@ -306,8 +309,12 @@ export const PodsLogsViewer = (props: PodLogsProps) => {
                                 {follow && <AutoScrollButton scrollToBottom={scrollToBottom} setScrollToBottom={setScrollToBottom} />}
                                 <ShowPreviousLogsToggleButton setPreviousLogs={setPreviousLogsWithQueryParams} showPreviousLogs={previous} />
                                 <Spacer />
-                                <PodHighlightButton selectedPod={selectedPod} setSelectedPod={setSelectedPod} pods={uniquePods} darkMode={prefs.appDetails.darkMode} />
-                                <Spacer />
+                                {uniquePods.length > 1 && (
+                                    <>
+                                        <PodHighlightButton selectedPod={selectedPod} setSelectedPod={setSelectedPod} pods={uniquePods} darkMode={prefs.appDetails.darkMode} />
+                                        <Spacer />
+                                    </>
+                                )}
                                 <ContainerSelector containerGroups={containerGroups} containerName={containerName} onClickContainer={onClickContainer} />
                                 <Spacer />
                                 {!follow && (


### PR DESCRIPTION
Fixes #29252

## What was wrong

The pod highlight button in the logs viewer picks one pod out of several and shades its log lines. When the logs come from a single pod for example when a pod is opened directly from the resource tree there is nothing to tell apart, but the button is still there offering to "Select a pod to highlight its logs" when there is no pod to select.

Per @jsoref in the issue: the button doesn't apply in that case, so it should be hidden.

## What this changes

The button is only rendered while more than one pod is in view:

```tsx
{uniquePods.length > 1 && (
    <>
        <PodHighlightButton ... />
        <Spacer />
    </>
)}
```

`uniquePods` is derived from the log entries themselves, so this covers both the reported case and a workload running a single replica the button is equally useless there. 

Two details worth calling out.

**The `<Spacer />` moves with the button.** `.pod-logs-viewer__settings` is `display: flex` and `Spacer` is a fixed 16px span. The button sits between two of them, so returning `null` from inside `PodHighlightButton` would leave a 32px gap in exactly the single-pod toolbar this is meant to tidy. Hiding at the call site keeps the spacing correct and matches the `{!follow && (<>...</>)}` pattern a few lines below.

**The highlight is cleared when the log stream restarts.** Hiding the button would otherwise strand a highlight that is still applied. Reproduction: highlight a pod on a multi-pod view, then change the container or add a message filter. The logs are discarded and refetched, and if the new set has one pod the shading is still painted while the control that removes it is gone. The one remaining escape hatch clicking the pod name in a log line needs `viewPodNames`, which is off by default. So the highlight is dropped in the same place the logs are, using the previous-value pattern the component already uses for its other resets.

## Behaviour as the pod count changes

Log entries are only ever appended (`previousLogs.concat(log)`), so within one stream the distinct pod count can rise but never fall. The button can appear, but it cannot vanish while it is in use.

| Situation | Button | Why |
| --- | --- | --- |
| Logs still loading, none received | hidden | `uniquePods` is empty, nothing to highlight yet |
| One pod | hidden | the reported bug |
| Deployment running a single replica | hidden | counted from the logs, not the route |
| A second pod starts logging later | appears | within one 100ms buffer of its first line |
| Pods stop logging | stays | entries accumulate; the count cannot fall |
| Highlight active, then filter/container/tail changes | highlight cleared | logs are discarded and refetched |
| Dropdown open when a new pod arrives | list grows | rendered from `pods` each render |
| Dropdown open when the stream restarts | closes with the button | the logs it referred to are gone |

## Alternatives considered

**Reword the tooltip** ("Highlight this pod in the logs") was the smaller change, but it keeps a control that cannot do anything useful.

**Disable the button** does not work: `Button` puts `disabled` on a CSS class only. It never sets the DOM attribute or guards `onClick`. So a disabled-looking button would still open its dropdown.

**Hide based on `props.podName`** is stable but only knows how the user navigated, not what is in the stream, so a single-replica Deployment keeps the useless button.

**Derive instead of clearing** (`uniquePods.length > 1 ? selectedPod : null`) avoids touching state but leaves a stale selection behind the hidden button. Since the pod count only rises, that selection lights up on its own when a second pod logs. Clearing at the stream boundary makes that unreachable.

## Testing

Added `pod-logs-viewer.test.tsx`. Neither file in this directory had test coverage before.

| Test | Covers |
| --- | --- |
| offers the button when the logs come from several pods | the button still appears when it applies |
| hides the button when the logs come from a single pod | the reported bug |
| hides the button before any logs have arrived | the empty-log window, where `uniquePods` is `[]` |
| drops the highlight when the logs it was pointing at are discarded | the stranded-highlight case above |

Each test was checked against a mutated build to confirm it fails without the corresponding change. None of them pass vacuously.

```
$ cd ui && pnpm test
Test Suites: 26 passed, 26 total
Tests:       300 passed, 300 total
Snapshots:   32 passed, 32 total

$ cd ui && pnpm lint
✖ 11 problems (0 errors, 11 warnings)   # all pre-existing react-hooks/exhaustive-deps warnings in unrelated files
```

Coverage of `pod-logs-viewer.tsx` goes from 0% to ~77% of statements.

## Screenshots

Single pod, before the highlighter is the fourth button:
<img width="979" height="646" alt="image" src="https://github.com/user-attachments/assets/5d060232-ba62-4538-8452-15b17f1a075f" />

Single pod, after the button and its spacer are gone:
<img width="979" height="646" alt="image" src="https://github.com/user-attachments/assets/92682f04-e30d-492e-ad1d-3851dc4dec77" />



Several pods, after unchanged, the button is still there:
<img width="979" height="646" alt="image" src="https://github.com/user-attachments/assets/7a00149a-6e7a-4957-88c7-eef7e1f91c51" />


> Captured from the UI dev server running against a stub API that streams synthetic pod logs. Same components and stylesheet, only the log data is fabricated.

## Checklist

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates? No — the button is not documented behaviour.
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- end of PR body -->
