### PR TITLE
fix(ui): improve pod log highlight button

### DIFF
--- a/ui/src/app/applications/components/pod-logs-viewer/pod-logs-highlight-button.tsx
+++ b/ui/src/app/applications/components/pod-logs-viewer/pod-logs-highlight-button.tsx
@@ -27,10 +27,18 @@ export const PodHighlightButton = ({
         document.addEventListener('mousedown', handleClickOutside);
         return () => document.removeEventListener('mousedown', handleClickOutside);
     }, []);
+    const isDisabled = pods.length <= 1;
 
     return (
         <div ref={dropdownRef} style={{position: 'relative'}}>
-            <ToggleButton title='Select a pod to highlight its logs' onToggle={() => setIsOpen(!isOpen)} icon='highlighter' toggled={selectedPod !== null} />
+            <ToggleButton
+                title={isDisabled ? 'Highlighting only applies when viewing multiple pods' : 'Select a pod to highlight its logs'}
+                onToggle={() => !isDisabled && setIsOpen(!isOpen)}
+                icon='highlighter'
+                toggled={selectedPod !== null}
+                disabled={isDisabled}
+            />
+
             {isOpen && (
                 <div className={`select-container ${darkMode ? 'dark-mode' : ''}`} style={{position: 'absolute', top: '100%', left: 0, zIndex: 1}}>
                     <div className='select-options'>

--- a/ui/src/app/applications/components/pod-logs-viewer/pod-logs-viewer.scss
+++ b/ui/src/app/applications/components/pod-logs-viewer/pod-logs-viewer.scss
@@ -3,6 +3,7 @@
 
 $pod-background-light: $argo-color-teal-3;
 $pod-background-dark: $dark-theme-background-2;
+
 :root {
     --pod-background-light: #{$pod-background-light};
     --pod-background-dark: #{$pod-background-dark};
@@ -33,19 +34,21 @@ $pod-background-dark: $dark-theme-background-2;
             border: none !important;
             width: 12px;
             margin-right: 8px;
+
             input:checked + span,
             input + span {
                 border: none;
                 width: 12px !important;
                 background-color: transparent;
             }
+
             .fa {
                 display: none;
             }
         }
 
         .argo-field {
-            @include themify($themes){
+            @include themify($themes) {
                 background-color: themed('background-2');
             }
         }
@@ -82,6 +85,7 @@ $pod-background-dark: $dark-theme-background-2;
         display: flex;
         margin-bottom: 1em;
         padding-left: 10px;
+
         .page-info {
             margin-left: auto;
             margin-right: auto;
@@ -89,6 +93,7 @@ $pod-background-dark: $dark-theme-background-2;
             text-overflow: clip;
             white-space: nowrap;
         }
+
         .nav-container {
             display: flex;
             align-self: flex-start;
@@ -99,15 +104,18 @@ $pod-background-dark: $dark-theme-background-2;
             justify-content: center;
             border: 1px solid black;
             margin: 0 2px;
+
             &:hover {
                 background-color: black;
                 color: white;
             }
+
             &.disabled {
                 opacity: 0.5;
                 cursor: not-allowed;
             }
         }
+
         i {
             margin-left: 5px;
         }
@@ -115,6 +123,7 @@ $pod-background-dark: $dark-theme-background-2;
         &--inverted {
             i {
                 border-color: white;
+
                 &:hover {
                     background-color: white;
                     color: black;
@@ -138,9 +147,11 @@ $pod-background-dark: $dark-theme-background-2;
             opacity: 0;
             flex-shrink: 0;
             box-shadow: 0 0 0 1px red inset;
+
             &--visible {
                 opacity: 1;
             }
+
             &:hover {
                 color: red;
             }
@@ -152,6 +163,7 @@ $pod-background-dark: $dark-theme-background-2;
             margin-right: 2ch;
             opacity: 0.5;
             cursor: pointer;
+
             &:hover {
                 opacity: 1;
             }
@@ -160,22 +172,27 @@ $pod-background-dark: $dark-theme-background-2;
         &__pod {
             padding-left: 5px;
             padding-right: 5px;
+
             span {
                 display: none;
                 text-overflow: ellipsis;
                 overflow: hidden;
             }
+
             width: 3ch;
             min-width: 3ch;
         }
+
         &__timestamp {
             padding-left: 5px;
             padding-right: 5px;
+
             span {
                 display: none;
                 text-overflow: ellipsis;
                 overflow: hidden;
             }
+
             width: 3ch;
             min-width: 3ch;
         }
@@ -186,21 +203,26 @@ $pod-background-dark: $dark-theme-background-2;
             span {
                 display: inherit;
             }
+
             i {
                 display: none;
             }
+
             width: 30ch;
             min-width: 30ch;
         }
     }
+
     &--pod-timestamp-visible {
         .pod-logs-viewer__line__timestamp {
             span {
                 display: inherit;
             }
+
             i {
                 display: none;
             }
+
             width: 30ch;
             min-width: 30ch;
         }
@@ -217,6 +239,7 @@ $pod-background-dark: $dark-theme-background-2;
     .pod-name-link {
         cursor: pointer;
         transition: opacity 0.2s ease;
+
         &:hover {
             text-decoration: underline;
             opacity: 0.8;
@@ -231,42 +254,49 @@ $pod-background-dark: $dark-theme-background-2;
     background: white;
     border: 1px solid #ccc;
     border-radius: 4px;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
     z-index: 1000;
-    min-width: 200px;  // Ensure dropdown is wide enough for pod names
+    min-width: 200px; // Ensure dropdown is wide enough for pod names
 
     &.dark-mode {
-        background: #333; /* Dark background for dark mode */
-        border: 1px solid #555; /* Subtle border for dark mode */
-        color: #eee; /* Light text for dark mode */
+        background: #333;
+        /* Dark background for dark mode */
+        border: 1px solid #555;
+        /* Subtle border for dark mode */
+        color: #eee;
+        /* Light text for dark mode */
     }
 }
 
 .select-options {
     max-height: 200px;
     overflow-y: auto;
-    
+
     .select-option {
         padding: 8px 10px;
         cursor: pointer;
-        white-space: nowrap;  // Prevent pod names from wrapping
-        
+        white-space: nowrap; // Prevent pod names from wrapping
+
         &:hover {
             background-color: #f5f5f5;
         }
 
         &.dark-mode {
-            background-color: #444; /* Hover effect in dark mode */
+            background-color: #444;
+
+            /* Hover effect in dark mode */
             &:hover {
                 background-color: #555;
             }
         }
-        
+
         &.selected {
             background-color: #e6f3ff;
         }
+
         &.dark-mode.selected {
-            background-color: #666; /* Selection highlight in dark mode */
+            background-color: #666;
+            /* Selection highlight in dark mode */
         }
     }
 }
@@ -277,7 +307,7 @@ $pod-background-dark: $dark-theme-background-2;
     text-align: center;
     color: #1750d3;
     cursor: pointer;
-    
+
     &:hover {
         background-color: #f0f0f0;
     }
@@ -285,6 +315,7 @@ $pod-background-dark: $dark-theme-background-2;
     &.dark-mode {
         border-top: 1px solid #555;
         color: #5a9bd3;
+
         &:hover {
             background-color: #333;
         }
@@ -295,10 +326,12 @@ $pod-background-dark: $dark-theme-background-2;
     // ARGO_SUCCESS_COLOR
     background-color: #18be94 !important;
 }
+
 .copyFailure {
     // ARGO_FAILED_COLOR
     background-color: #e96d76 !important;
 }
+
 .copyStandard {
     background-color: #6d7f8b !important;
 }
@@ -328,6 +361,16 @@ code {
 
 /* Hide scrollbar for IE, Edge and Firefox */
 .noscroll {
-    -ms-overflow-style: none;  /* IE and Edge */
-    scrollbar-width: none;  /* Firefox */
+    -ms-overflow-style: none;
+    /* IE and Edge */
+    scrollbar-width: none;
+    /* Firefox */
+}
+
+.pod-highlight-button {
+    .argo-button.disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+        pointer-events: none;
+    }
 }

--- a/ui/src/app/applications/components/pod-logs-viewer/pod-logs-viewer.tsx
+++ b/ui/src/app/applications/components/pod-logs-viewer/pod-logs-viewer.tsx
@@ -167,6 +167,7 @@ export const PodsLogsViewer = (props: PodLogsProps) => {
     if (prevQueryKey !== queryKey) {
         setPrevQueryKey(queryKey);
         setLogs([]);
+        setSelectedPod(null);
     }
 
     useEffect(() => {


### PR DESCRIPTION
## What does this PR do?

Fixes #29252

The pod log highlight button currently shows the tooltip "Select a pod to highlight its logs" even when only one pod is available, where pod highlighting does not apply.

This change:

* Disables the highlight button when there is only one pod or no pods.
* Updates the tooltip to explain why highlighting is unavailable.
* Resets the selected pod when the log query changes so stale highlighting is not retained.
* Adds disabled-state styling for the button.

## Why disable instead of hide?

I chose to disable the button rather than hide it so the log viewer toolbar keeps a stable layout when pod availability changes while logs are being viewed.

Removing the button can cause the surrounding toolbar controls to reflow when the pod count changes. Keeping the control in place avoids that layout shift, while the disabled state clearly communicates that the action is currently unavailable. The tooltip also provides context instead of suggesting that the user select a pod when there is only one pod.

I understand that hiding the button was suggested during the issue discussion, so I am open to changing this behavior if the maintainers prefer the button to be removed entirely.

## Validation

* `pnpm lint` — passed with 0 errors
* Prettier check — passed
* Local `PodHighlightButton` tests — 5/5 passed

## Checklist

* [x] This is a bug fix.
* [x] The PR title states what changed and includes the related issue number.
* [x] The PR title conforms to the requested format.
* [x] `Fixes #29252` is included above.
* [x] This change is UI-only; no CLI changes are required.
* [ ] Does this PR require documentation updates?
* [ ] I have signed off all my commits as required by DCO.
* [ ] I have written unit and/or e2e tests for my change.
* [ ] My build is green.
* [ ] My new feature complies with the feature status guidelines.
* [x] I have included a description of why this PR is necessary and what it solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, indicate older releases for cherry-picking if appropriate.
