### PR TITLE
fix: set dedicated FieldManager for application status write paths (#29253)

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -126,6 +126,8 @@ const (
 	ArgoCDUserAgentName = "argocd-client"
 	// ArgoCDSSAManager is the default argocd manager name used by server-side apply syncs
 	ArgoCDSSAManager = "argocd-controller"
+	// ArgoCDStatusManager is the default argocd manager name used for application status updates
+	ArgoCDStatusManager = "argocd-controller-status"
 	// AuthCookieName is the HTTP cookie name where we store our auth token
 	AuthCookieName = "argocd.token"
 	// StateCookieName is the HTTP cookie name that holds temporary nonce tokens for CSRF protection

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -2472,7 +2472,7 @@ func (ctrl *ApplicationController) persistAppStatus(ctx context.Context, orig *a
 	defer func() {
 		patchDuration = time.Since(start)
 	}()
-	_, err = ctrl.PatchAppWithWriteBack(context.Background(), orig.Name, orig.Namespace, types.MergePatchType, patch, metav1.PatchOptions{})
+	_, err = ctrl.PatchAppWithWriteBack(context.Background(), orig.Name, orig.Namespace, types.MergePatchType, patch, metav1.PatchOptions{FieldManager: common.ArgoCDStatusManager})
 	if err != nil {
 		spanErr = err
 		if apierrors.IsRequestEntityTooLargeError(err) {
@@ -2503,7 +2503,7 @@ func (ctrl *ApplicationController) persistAppStatus(ctx context.Context, orig *a
 			if !modified {
 				return patchDuration
 			}
-			if _, fbErr := ctrl.PatchAppWithWriteBack(context.Background(), orig.Name, orig.Namespace, types.MergePatchType, fallbackPatch, metav1.PatchOptions{}); fbErr != nil {
+			if _, fbErr := ctrl.PatchAppWithWriteBack(context.Background(), orig.Name, orig.Namespace, types.MergePatchType, fallbackPatch, metav1.PatchOptions{FieldManager: common.ArgoCDStatusManager}); fbErr != nil {
 				logCtx.WithError(fbErr).Error("Error persisting fallback status with error condition")
 			}
 			return patchDuration

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -4463,3 +4463,47 @@ func TestHandleRefreshAnnotation(t *testing.T) {
 		}, capturedPatches[0], "patch without timestamp should only remove the refresh annotation, no test op")
 	})
 }
+
+func TestPersistAppStatus_UsesStatusFieldManager(t *testing.T) {
+	app := newFakeApp()
+	ctrl := newFakeController(t.Context(), &fakeData{apps: []runtime.Object{app}}, nil)
+	fakeAppCs := ctrl.applicationClientset.(*appclientset.Clientset)
+	fakeAppCs.ReactionChain = nil
+
+	var capturedFieldManager string
+	fakeAppCs.AddReactor("patch", "*", func(action kubetesting.Action) (bool, runtime.Object, error) {
+		if patchActionImpl, ok := action.(kubetesting.PatchActionImpl); ok {
+			capturedFieldManager = patchActionImpl.PatchOptions.FieldManager
+		}
+		return true, app, nil
+	})
+
+	newStatus := app.Status.DeepCopy()
+	newStatus.Sync.Status = v1alpha1.SyncStatusCodeOutOfSync
+	ctrl.persistAppStatus(t.Context(), app, newStatus)
+
+	assert.Equal(t, common.ArgoCDStatusManager, capturedFieldManager, "persistAppStatus must use ArgoCDStatusManager to prevent SSA field ownership collision")
+	assert.NotEqual(t, common.ArgoCDSSAManager, capturedFieldManager, "status field manager must differ from ArgoCDSSAManager")
+}
+
+func TestNormalizeApplication_DoesNotUseStatusFieldManager(t *testing.T) {
+	app := newFakeApp()
+	// Modify spec so normalizeApplication produces a diff and triggers PatchAppWithWriteBack
+	app.Spec.Source.RepoURL = "https://github.com/argoproj/argo-cd.git/"
+
+	ctrl := newFakeController(t.Context(), &fakeData{apps: []runtime.Object{app}}, nil)
+	fakeAppCs := ctrl.applicationClientset.(*appclientset.Clientset)
+	fakeAppCs.ReactionChain = nil
+
+	var capturedFieldManager string
+	fakeAppCs.AddReactor("patch", "*", func(action kubetesting.Action) (bool, runtime.Object, error) {
+		if patchActionImpl, ok := action.(kubetesting.PatchActionImpl); ok {
+			capturedFieldManager = patchActionImpl.PatchOptions.FieldManager
+		}
+		return true, app, nil
+	})
+
+	ctrl.normalizeApplication(app)
+
+	assert.NotEqual(t, common.ArgoCDStatusManager, capturedFieldManager, "spec normalization patch must not use status field manager")
+}

--- a/controller/state.go
+++ b/controller/state.go
@@ -1296,7 +1296,7 @@ func (m *appStateManager) persistRevisionHistory(
 	if err != nil {
 		return fmt.Errorf("error marshaling revision history patch: %w", err)
 	}
-	_, err = m.appclientset.ArgoprojV1alpha1().Applications(app.Namespace).Patch(context.Background(), app.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+	_, err = m.appclientset.ArgoprojV1alpha1().Applications(app.Namespace).Patch(context.Background(), app.Name, types.MergePatchType, patch, metav1.PatchOptions{FieldManager: common.ArgoCDStatusManager})
 	return err
 }
 


### PR DESCRIPTION
Fixes #29253

### Problem

When a parent Application uses `ServerSideApply=true` to sync child Applications in an app-of-apps setup, the child Application's `status.operationState` can be pruned while a sync operation is in progress.

This can leave the child operation stuck in `Running` even though the operation has completed.

### Root Cause

Application status updates and Server-Side Apply syncs were using the same field manager (`argocd-controller`).

Because the Application CRD does not define a `status` subresource, the SSA apply of a child Application could claim ownership of status fields and prune `status.operationState` when the field was absent from the applied manifest.

### Fix

Introduce a dedicated field manager:

`argocd-controller-status`

and use it for Application status write paths:

- `persistAppStatus`
- `persistRevisionHistory`

The existing SSA manager remains unchanged for resource synchronization.

This keeps controller-owned Application status fields separate from fields managed by Server-Side Apply.

### Tests

- `go test -v -run "TestPersistAppStatus|TestNormalizeApplication" ./controller`
- `go test -v ./common/...`
- `go vet ./common/... ./controller/...`
- `gofmt -s -d` on changed files
- `git diff --check`

`golangci-lint` and `make codegen-local` could not be run locally because the required tools were not installed. No generated files are affected by this change.