### PR TITLE
chore: fix typos in sharding comments

### DIFF
--- a/controller/sharding/cache.go
+++ b/controller/sharding/cache.go
@@ -252,7 +252,7 @@ func (sharding *ClusterSharding) UpdateApp(a *v1alpha1.Application) {
 	}
 }
 
-// GetAppDistribution should be not be called from a DestributionFunction because
+// GetAppDistribution should be not be called from a DistributionFunction because
 // it could cause a deadlock when updateDistribution is called.
 func (sharding *ClusterSharding) GetAppDistribution() map[string]int {
 	sharding.lock.RLock()

--- a/controller/sharding/sharding.go
+++ b/controller/sharding/sharding.go
@@ -81,7 +81,7 @@ func GetClusterFilter(_ db.ArgoDB, distributionFunction DistributionFunction, re
 }
 
 // GetDistributionFunction returns which DistributionFunction should be used based on the passed algorithm and
-// the current datas.
+// the current data.
 func GetDistributionFunction(clusters clusterAccessor, apps appAccessor, shardingAlgorithm string, replicasCount int) DistributionFunction {
 	log.Debugf("Using filter function:  %s", shardingAlgorithm)
 	distributionFunction := LegacyDistributionFunction(replicasCount)


### PR DESCRIPTION
Two comment-only fixes in `controller/sharding`:

- `DestributionFunction` -> `DistributionFunction` (the comment on `GetAppDistribution` refers to the real type name)
- `the current datas` -> `the current data` (comment on `GetDistributionFunction`)

No code changes. Signed off per DCO.