### PR TITLE
chore(ci): group interdependent upgrades

### DIFF
--- a/renovate-presets/devtool.json5
+++ b/renovate-presets/devtool.json5
@@ -96,15 +96,19 @@
       "enabled": true
     },
     {
-      "description": "Group golang-version packages",
+      "description": "Group Go toolchain with golangci-lint and mockery. These are tightly coupled (especially on major Go bumps) but go.mod is intentionally excluded so library consumers are not forced to upgrade.",
       "groupName": "group golang",
       "matchDatasources": [
         "docker",
-        "golang-version"
+        "golang-version",
+        "go"
       ],
       "matchPackageNames": [
-        "/(?:^|/)golang$/"
-      ]
+        "/(?:^|/)golang$/",
+        "github.com/golangci/golangci-lint/v2",
+        "github.com/vektra/mockery/v3"
+      ],
+      "separateMajorMinor": false
     },
     {
       "description": "Group node-version packages across production, CI, and test-tools image",


### PR DESCRIPTION
Major go upgrades are tightly coupled to lint and mockery upgrades. Grouping them means that, even if the initial PR doesn't succeed, eventually it'll include all the upgrades necessary to pass and merge.

Fixing problem PRs such as this one: https://github.com/argoproj/argo-cd/pull/29268