### PR TITLE
fix: GoogleCloudCreds GetUserInfo should return client_email for both username and email

### DIFF
--- a/util/git/creds.go
+++ b/util/git/creds.go
@@ -849,11 +849,11 @@ func NewGoogleCloudCreds(jsonData string, store CredsStore) GoogleCloudCreds {
 // GetUserInfo returns the username and email address for the credentials, if they're available.
 // For service accounts, client_email is used as both.
 func (c GoogleCloudCreds) GetUserInfo(_ context.Context) (string, string, error) {
-	username, err := c.getUsername()
+	clientEmail, err := c.getUsername()
 	if err != nil {
-		return "", "", fmt.Errorf("failed to get username from creds: %w", err)
+		return "", "", fmt.Errorf("failed to get client email from creds: %w", err)
 	}
-	return username, username, nil
+	return clientEmail, clientEmail, nil
 }
 
 func (c GoogleCloudCreds) Environ() (io.Closer, []string, error) {

--- a/util/git/creds.go
+++ b/util/git/creds.go
@@ -847,13 +847,13 @@ func NewGoogleCloudCreds(jsonData string, store CredsStore) GoogleCloudCreds {
 }
 
 // GetUserInfo returns the username and email address for the credentials, if they're available.
-// TODO: implement getting email instead of just username.
+// For service accounts, client_email is used as both.
 func (c GoogleCloudCreds) GetUserInfo(_ context.Context) (string, string, error) {
 	username, err := c.getUsername()
 	if err != nil {
 		return "", "", fmt.Errorf("failed to get username from creds: %w", err)
 	}
-	return username, "", nil
+	return username, username, nil
 }
 
 func (c GoogleCloudCreds) Environ() (io.Closer, []string, error) {

--- a/util/git/creds_test.go
+++ b/util/git/creds_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	_ "embed"
 	"encoding/base64"
 	"encoding/json"
@@ -414,6 +415,21 @@ func TestGoogleCloudCreds_Environ_cleanup(t *testing.T) {
 	credsLenBefore := len(store.creds)
 	utilio.Close(closer)
 	assert.Len(t, store.creds, credsLenBefore-1)
+}
+
+func TestGoogleCloudCreds_GetUserInfo(t *testing.T) {
+	store := &memoryCredsStore{creds: make(map[string]cred)}
+	googleCloudCreds := GoogleCloudCreds{&google.Credentials{
+		ProjectID: "my-google-project",
+		JSON:      []byte(gcpServiceAccountKeyJSON),
+	}, store}
+
+	username, email, err := googleCloudCreds.GetUserInfo(context.Background())
+	require.NoError(t, err)
+
+	expected := "argocd-service-account@my-google-project.iam.gserviceaccount.com"
+	assert.Equal(t, expected, username)
+	assert.Equal(t, expected, email)
 }
 
 func TestAzureWorkloadIdentityCreds_Environ(t *testing.T) {


### PR DESCRIPTION
### What this PR does
`GoogleCloudCreds.GetUserInfo` previously returned the service account's username but left the email field empty (marked with a `TODO: implement getting email instead of just username`). For Google Cloud Source Repository service account credentials, the client_email field from the credentials JSON is the only identity value available so this PR uses it for both the username and email return values instead of leaving email blank.

This fixes commit-authorship/attribution downstream where an empty email was previously being passed through (e.g for Argo CD's git commit metadata when using Google Cloud Source Repos with service-account creds).

### Changes
- `util/git/creds.go`: GoogleCloudCreds.GetUserInfo now returns username, username, nil (previously username, "", nil), sourced from client_email in the service account JSON. Updated the doc comment accordingly.
- `util/git/creds_test.go`: added TestGoogleCloudCreds_GetUserInfo, which asserts both username and email equal the client_email value from the test fixture's service account JSON.