### PR TITLE
fix: persist ApplicationSet RollingSync operations via JSON patch

### DIFF
--- a/applicationset/utils/createOrUpdate.go
+++ b/applicationset/utils/createOrUpdate.go
@@ -25,6 +25,8 @@ import (
 	"github.com/argoproj/argo-cd/v3/util/argo/normalizers"
 )
 
+const AppSetControllerUsername = "applicationset-controller"
+
 var appEquality = conversion.EqualitiesOrDie(
 	func(a, b resource.Quantity) bool {
 		// Ignore formatting, only care that numeric value stayed the same.
@@ -143,8 +145,8 @@ func CreateOrUpdate(ctx context.Context, logCtx *log.Entry, c client.Client, dif
 	// keeps the leftover filter. Never send Operation through MergeFrom.
 	obj.Operation = cacheOp
 
-	alreadyFullAppSet := cacheOp != nil && cacheOp.InitiatedBy.Username == "applicationset-controller" && cacheOp.Sync != nil && len(cacheOp.Sync.Resources) == 0
-	shouldWriteOp := generatedAssigned && desiredOp != nil && (cacheOp == nil || cacheOp.InitiatedBy.Username == "applicationset-controller") && !alreadyFullAppSet
+	alreadyFullAppSet := cacheOp != nil && cacheOp.InitiatedBy.Username == AppSetControllerUsername && cacheOp.Sync != nil && len(cacheOp.Sync.Resources) == 0
+	shouldWriteOp := generatedAssigned && desiredOp != nil && (cacheOp == nil || cacheOp.InitiatedBy.Username == AppSetControllerUsername) && !alreadyFullAppSet
 
 	// Normalize the live spec to avoid spurious diffs from unimportant differences (e.g. nil vs
 	// empty SyncPolicy). obj.Spec is already normalized by the caller; only the live side needs it.

--- a/applicationset/utils/createOrUpdate.go
+++ b/applicationset/utils/createOrUpdate.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -103,6 +104,13 @@ func SpecsEquivalent(diffConfig argodiff.DiffConfig, live, desired *argov1alpha1
 // cluster is normalized internally.
 //
 // The MutateFn is called regardless of creating or updating an object.
+// When generating an Operation, MutateFn must assign a new Operation pointer to
+// obj.Operation; it must not mutate the existing Operation in place. Operation is
+// excluded from MergeFrom and written only via a JSON-patch add when desiredOp !=
+// cacheOp.
+//
+// MergeFrom and the optional Operation JSON-patch are not atomic; a failed second
+// write leaves a partial update until the next reconcile retries.
 //
 // It returns the executed operation and an error.
 func CreateOrUpdate(ctx context.Context, logCtx *log.Entry, c client.Client, diffConfig argodiff.DiffConfig, obj *argov1alpha1.Application, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
@@ -120,12 +128,23 @@ func CreateOrUpdate(ctx context.Context, logCtx *log.Entry, c client.Client, dif
 		return controllerutil.OperationResultCreated, nil
 	}
 
+	cacheOp := obj.Operation
 	normalizedLive := obj.DeepCopy()
 
 	// Mutate the live object to match the desired state.
 	if err := mutate(f, key, obj); err != nil {
 		return controllerutil.OperationResultNone, err
 	}
+
+	desiredOp := obj.Operation
+	generatedAssigned := desiredOp != cacheOp
+	// MergeFrom is RFC 7386. A stale Get (Operation==nil) while the API object
+	// already has sync.resources produces a patch with no resources key and
+	// keeps the leftover filter. Never send Operation through MergeFrom.
+	obj.Operation = cacheOp
+
+	alreadyFullAppSet := cacheOp != nil && cacheOp.InitiatedBy.Username == "applicationset-controller" && cacheOp.Sync != nil && len(cacheOp.Sync.Resources) == 0
+	shouldWriteOp := generatedAssigned && desiredOp != nil && (cacheOp == nil || cacheOp.InitiatedBy.Username == "applicationset-controller") && !alreadyFullAppSet
 
 	// Normalize the live spec to avoid spurious diffs from unimportant differences (e.g. nil vs
 	// empty SyncPolicy). obj.Spec is already normalized by the caller; only the live side needs it.
@@ -138,22 +157,33 @@ func CreateOrUpdate(ctx context.Context, logCtx *log.Entry, c client.Client, dif
 		return controllerutil.OperationResultNone, fmt.Errorf("failed to apply ignore differences: %w", err)
 	}
 
-	// Note: if the informer cache holds a stale entry for an application that no longer exists on
-	// the API server, DeepEqual may match against that stale entry and we skip Patch here. The
-	// eviction in cacheSyncingClient only runs on NotFound from a write operation, so this edge
-	// case is not covered and relies on Kubernetes propagating the delete event to the informer.
-	if appEquality.DeepEqual(normalizedLive, obj) {
-		return controllerutil.OperationResultNone, nil
+	result := controllerutil.OperationResultNone
+	if !appEquality.DeepEqual(normalizedLive, obj) {
+		patch := client.MergeFrom(normalizedLive)
+		if log.IsLevelEnabled(log.DebugLevel) {
+			LogPatch(logCtx, patch, obj)
+		}
+		if err := c.Patch(ctx, obj, patch); err != nil {
+			return controllerutil.OperationResultNone, err
+		}
+		result = controllerutil.OperationResultUpdated
 	}
 
-	patch := client.MergeFrom(normalizedLive)
-	if log.IsLevelEnabled(log.DebugLevel) {
-		LogPatch(logCtx, patch, obj)
+	if shouldWriteOp {
+		patch, err := json.Marshal([]map[string]any{
+			{"op": "add", "path": "/operation", "value": desiredOp},
+		})
+		if err != nil {
+			return result, fmt.Errorf("marshal operation patch: %w", err)
+		}
+		if err := c.Patch(ctx, obj, client.RawPatch(types.JSONPatchType, patch)); err != nil {
+			return result, err
+		}
+		obj.Operation = desiredOp
+		result = controllerutil.OperationResultUpdated
 	}
-	if err := c.Patch(ctx, obj, patch); err != nil {
-		return controllerutil.OperationResultNone, err
-	}
-	return controllerutil.OperationResultUpdated, nil
+
+	return result, nil
 }
 
 func LogPatch(logCtx *log.Entry, patch client.Patch, obj *argov1alpha1.Application) {

--- a/applicationset/utils/createOrUpdate_test.go
+++ b/applicationset/utils/createOrUpdate_test.go
@@ -385,15 +385,13 @@ func (s staleGetClient) Get(ctx context.Context, key client.ObjectKey, obj clien
 }
 
 func testApp(name string, op *v1alpha1.Operation) *v1alpha1.Application {
-	return &v1alpha1.Application{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "argoproj.io/v1alpha1",
-			Kind:       "Application",
-		},
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "argocd"},
-		Spec:       v1alpha1.ApplicationSpec{Project: "default"},
-		Operation:  op,
+	app := &v1alpha1.Application{
+		Spec:      v1alpha1.ApplicationSpec{Project: "default"},
+		Operation: op,
 	}
+	app.Name = name
+	app.Namespace = "argocd"
+	return app
 }
 
 func fullAppSetOp() *v1alpha1.Operation {

--- a/applicationset/utils/createOrUpdate_test.go
+++ b/applicationset/utils/createOrUpdate_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"testing"
 
 	log "github.com/sirupsen/logrus"
@@ -364,4 +365,181 @@ func TestCreateOrUpdateDoesNotRevertIgnoredKustomizeImagesMultiSource(t *testing
 	require.NoError(t, c.Get(t.Context(), client.ObjectKeyFromObject(live), persisted))
 	require.NotNil(t, persisted.Spec.Sources[1].Kustomize, "the ignored kustomize.images override must survive in the cluster")
 	require.Equal(t, live.Spec.Sources[1].Kustomize.Images, persisted.Spec.Sources[1].Kustomize.Images)
+}
+
+// staleGetClient returns an older snapshot from Get while Patch/Create apply to
+// the inner client's stored object. Models AppSet's cache-backed Get lagging
+// the API server (spec Test 1).
+type staleGetClient struct {
+	client.Client
+	stale *v1alpha1.Application
+}
+
+func (s staleGetClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	app, ok := obj.(*v1alpha1.Application)
+	if !ok {
+		return s.Client.Get(ctx, key, obj, opts...)
+	}
+	s.stale.DeepCopyInto(app)
+	return nil
+}
+
+func testApp(name string, op *v1alpha1.Operation) *v1alpha1.Application {
+	return &v1alpha1.Application{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "argoproj.io/v1alpha1",
+			Kind:       "Application",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "argocd"},
+		Spec:       v1alpha1.ApplicationSpec{Project: "default"},
+		Operation:  op,
+	}
+}
+
+func fullAppSetOp() *v1alpha1.Operation {
+	return &v1alpha1.Operation{
+		InitiatedBy: v1alpha1.OperationInitiator{Username: "applicationset-controller", Automated: true},
+		Info: []*v1alpha1.Info{{
+			Name:  "Reason",
+			Value: "ApplicationSet RollingSync triggered a sync of this Application resource",
+		}},
+		Sync:  &v1alpha1.SyncOperation{},
+		Retry: v1alpha1.RetryStrategy{Limit: 5},
+	}
+}
+
+func filteredOp(username string) *v1alpha1.Operation {
+	return &v1alpha1.Operation{
+		InitiatedBy: v1alpha1.OperationInitiator{Username: username, Automated: username == "applicationset-controller"},
+		Sync: &v1alpha1.SyncOperation{
+			Resources: []v1alpha1.SyncOperationResource{{
+				Group: "batch", Kind: "Job", Name: "cilium-post-sync", Namespace: "kube-system",
+			}},
+		},
+	}
+}
+
+// Covers the stale-Get window (Operation==nil in cache while the API already has a
+// filtered op): AppSet must overwrite. That is not the user-op preserve guarantee
+// (OperationGuard case 5).
+func TestCreateOrUpdate_StaleBaseClearsFilteredOperation(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+
+	stored := testApp("demo", filteredOp("admin"))
+	stale := testApp("demo", nil) // Get predates the filtered op
+
+	inner := fake.NewClientBuilder().WithScheme(scheme).WithObjects(stored.DeepCopy()).Build()
+	c := staleGetClient{Client: inner, stale: stale}
+
+	obj := testApp("demo", nil)
+	logCtx := log.NewEntry(log.New())
+	_, err := CreateOrUpdate(t.Context(), logCtx, c, nil, obj, func() error {
+		obj.Spec = stored.Spec
+		obj.Operation = fullAppSetOp()
+		return nil
+	})
+	require.NoError(t, err)
+
+	got := &v1alpha1.Application{}
+	require.NoError(t, inner.Get(t.Context(), client.ObjectKeyFromObject(stored), got))
+	require.NotNil(t, got.Operation)
+	require.NotNil(t, got.Operation.Sync)
+	assert.Empty(t, got.Operation.Sync.Resources)
+	assert.Equal(t, "applicationset-controller", got.Operation.InitiatedBy.Username)
+}
+
+func TestCreateOrUpdate_OperationGuard(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+
+	tests := []struct {
+		name           string
+		liveOp         *v1alpha1.Operation
+		desiredOp      *v1alpha1.Operation
+		wantUser       string
+		wantRes        int
+		wantResult     controllerutil.OperationResult
+		checkResult    bool
+		wantRetryLimit int64
+		checkRetry     bool
+	}{
+		{
+			name:      "2 live nil generated set -> live gets generated",
+			liveOp:    nil,
+			desiredOp: fullAppSetOp(),
+			wantUser:  "applicationset-controller",
+			wantRes:   0,
+		},
+		{
+			name:      "3 generated nil live user op -> live user op unchanged",
+			liveOp:    filteredOp("admin"),
+			desiredOp: nil,
+			wantUser:  "admin",
+			wantRes:   1,
+		},
+		{
+			name:      "4 live AppSet-initiated filtered + generated full -> filter gone",
+			liveOp:    filteredOp("applicationset-controller"),
+			desiredOp: fullAppSetOp(),
+			wantUser:  "applicationset-controller",
+			wantRes:   0,
+		},
+		{
+			name:      "5 live user-initiated + generated full -> live user op unchanged",
+			liveOp:    filteredOp("admin"),
+			desiredOp: fullAppSetOp(),
+			wantUser:  "admin",
+			wantRes:   1,
+		},
+		{
+			name: "6 live already-full AppSet op + generated full -> do not re-add",
+			liveOp: fullAppSetOp(),
+			desiredOp: func() *v1alpha1.Operation {
+				op := fullAppSetOp()
+				op.Retry.Limit = 9
+				return op
+			}(),
+			wantUser:       "applicationset-controller",
+			wantRes:        0,
+			wantResult:     controllerutil.OperationResultNone,
+			checkResult:    true,
+			wantRetryLimit: 5,
+			checkRetry:     true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			live := testApp("demo", tc.liveOp)
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(live.DeepCopy()).Build()
+			obj := testApp("demo", nil)
+			result, err := CreateOrUpdate(t.Context(), log.NewEntry(log.New()), c, nil, obj, func() error {
+				obj.Spec = live.Spec
+				if tc.desiredOp != nil {
+					obj.Operation = tc.desiredOp
+				}
+				return nil
+			})
+			require.NoError(t, err)
+			if tc.checkResult {
+				assert.Equal(t, tc.wantResult, result)
+			}
+
+			got := &v1alpha1.Application{}
+			require.NoError(t, c.Get(t.Context(), client.ObjectKeyFromObject(live), got))
+			require.NotNil(t, got.Operation)
+			assert.Equal(t, tc.wantUser, got.Operation.InitiatedBy.Username)
+			require.NotNil(t, got.Operation.Sync)
+			assert.Len(t, got.Operation.Sync.Resources, tc.wantRes)
+			if tc.checkRetry {
+				assert.Equal(t, tc.wantRetryLimit, got.Operation.Retry.Limit)
+			}
+		})
+	}
 }

--- a/applicationset/utils/createOrUpdate_test.go
+++ b/applicationset/utils/createOrUpdate_test.go
@@ -398,7 +398,7 @@ func testApp(name string, op *v1alpha1.Operation) *v1alpha1.Application {
 
 func fullAppSetOp() *v1alpha1.Operation {
 	return &v1alpha1.Operation{
-		InitiatedBy: v1alpha1.OperationInitiator{Username: "applicationset-controller", Automated: true},
+		InitiatedBy: v1alpha1.OperationInitiator{Username: AppSetControllerUsername, Automated: true},
 		Info: []*v1alpha1.Info{{
 			Name:  "Reason",
 			Value: "ApplicationSet RollingSync triggered a sync of this Application resource",
@@ -410,7 +410,7 @@ func fullAppSetOp() *v1alpha1.Operation {
 
 func filteredOp(username string) *v1alpha1.Operation {
 	return &v1alpha1.Operation{
-		InitiatedBy: v1alpha1.OperationInitiator{Username: username, Automated: username == "applicationset-controller"},
+		InitiatedBy: v1alpha1.OperationInitiator{Username: username, Automated: username == AppSetControllerUsername},
 		Sync: &v1alpha1.SyncOperation{
 			Resources: []v1alpha1.SyncOperationResource{{
 				Group: "batch", Kind: "Job", Name: "cilium-post-sync", Namespace: "kube-system",
@@ -448,7 +448,7 @@ func TestCreateOrUpdate_StaleBaseClearsFilteredOperation(t *testing.T) {
 	require.NotNil(t, got.Operation)
 	require.NotNil(t, got.Operation.Sync)
 	assert.Empty(t, got.Operation.Sync.Resources)
-	assert.Equal(t, "applicationset-controller", got.Operation.InitiatedBy.Username)
+	assert.Equal(t, AppSetControllerUsername, got.Operation.InitiatedBy.Username)
 }
 
 func TestCreateOrUpdate_OperationGuard(t *testing.T) {
@@ -472,7 +472,7 @@ func TestCreateOrUpdate_OperationGuard(t *testing.T) {
 			name:      "2 live nil generated set -> live gets generated",
 			liveOp:    nil,
 			desiredOp: fullAppSetOp(),
-			wantUser:  "applicationset-controller",
+			wantUser:  AppSetControllerUsername,
 			wantRes:   0,
 		},
 		{
@@ -484,9 +484,9 @@ func TestCreateOrUpdate_OperationGuard(t *testing.T) {
 		},
 		{
 			name:      "4 live AppSet-initiated filtered + generated full -> filter gone",
-			liveOp:    filteredOp("applicationset-controller"),
+			liveOp:    filteredOp(AppSetControllerUsername),
 			desiredOp: fullAppSetOp(),
-			wantUser:  "applicationset-controller",
+			wantUser:  AppSetControllerUsername,
 			wantRes:   0,
 		},
 		{
@@ -497,14 +497,14 @@ func TestCreateOrUpdate_OperationGuard(t *testing.T) {
 			wantRes:   1,
 		},
 		{
-			name: "6 live already-full AppSet op + generated full -> do not re-add",
+			name:   "6 live already-full AppSet op + generated full -> do not re-add",
 			liveOp: fullAppSetOp(),
 			desiredOp: func() *v1alpha1.Operation {
 				op := fullAppSetOp()
 				op.Retry.Limit = 9
 				return op
 			}(),
-			wantUser:       "applicationset-controller",
+			wantUser:       AppSetControllerUsername,
 			wantRes:        0,
 			wantResult:     controllerutil.OperationResultNone,
 			checkResult:    true,

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -766,7 +766,7 @@ func TestAutoSyncMultiSourceWithoutSelfHeal(t *testing.T) {
 			Status:    v1alpha1.SyncStatusCodeOutOfSync,
 			Revisions: []string{"a", "b", "c"},
 		}
-		cond, _ := ctrl.autoSync(app, &syncStatus, []v1alpha1.ResourceStatus{{Name: "guestbook-1", Kind: kube.DeploymentKind, Status: v1alpha1.SyncStatusCodeOutOfSync}}, false)
+		cond, _ := ctrl.autoSync(t.Context(), app, &syncStatus, []v1alpha1.ResourceStatus{{Name: "guestbook-1", Kind: kube.DeploymentKind, Status: v1alpha1.SyncStatusCodeOutOfSync}}, false)
 		assert.Nil(t, cond)
 		app, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(test.FakeArgoCDNamespace).Get(t.Context(), "my-app", metav1.GetOptions{})
 		require.NoError(t, err)


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

Fixes #29280

## Why

ApplicationSet RollingSync writes a full `Application.operation` (`sync: {}`, no `resources`) through `CreateOrUpdate`. That helper two-way-merges against the object from `Get`. If the Get is stale (`operation` missing) while the API object already has a leftover filtered `operation.sync.resources` list, RFC 7386 merge does not replace `/operation`. The subset filter stays, and RollingSync keeps re-triggering subset syncs (for example repeatedly deleting and recreating a post-sync Job).

## What

- Snapshot the cache-visible `Operation` after `Get`.
- Restore it before `DeepEqual` / `MergeFrom` so spec/metadata patches never carry `/operation`.
- Persist a generated full RollingSync operation with RFC 6902 `add` `/operation` when the MutateFn assigned a new pointer, the cache op is nil or AppSet-initiated, and it is not already a full AppSet op.
- Leave user-initiated operations alone when they are still cache-visible.

## Tests

`go test ./applicationset/utils/ -count=1`

- Stale Get vs stored filtered op (leftover `sync.resources` cleared).
- Guard table: generated set, user op preserved, AppSet filter replaced, already-full AppSet op not re-added.
