### PR TITLE
feat(ui): show pod status counts in pods view (#25130)

### DIFF
--- a/ui/src/app/applications/components/application-pod-view/pod-view.scss
+++ b/ui/src/app/applications/components/application-pod-view/pod-view.scss
@@ -82,10 +82,10 @@ $pod-age-icon-clr: #ffce25;
             color: $argo-color-gray-6;
             max-height: 100px;
             overflow: auto;
-             &__item {
+            &__item {
                 line-height: 20px;
                 display: flex;
-         
+
                 &__name {
                     max-width: 60%;
                     overflow: hidden;

--- a/ui/src/app/applications/components/application-pod-view/pod-view.scss
+++ b/ui/src/app/applications/components/application-pod-view/pod-view.scss
@@ -268,3 +268,26 @@ $pod-age-icon-clr: #ffce25;
 .tippy-content {
     text-align: left;
 }
+
+.pod-view__node__pod-summary {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-top: 4px;
+
+    &__item {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+    }
+
+    &__icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 18px;
+        height: 18px;
+        border-radius: 3px;
+        color: white;
+    }
+}

--- a/ui/src/app/applications/components/application-pod-view/pod-view.test.ts
+++ b/ui/src/app/applications/components/application-pod-view/pod-view.test.ts
@@ -1,0 +1,49 @@
+import {Pod} from '../../../shared/models';
+
+import {getPodHealthCounts} from './pod-view';
+
+describe('getPodHealthCounts', () => {
+    it('counts healthy, degraded, and progressing pods', () => {
+        const pods = [
+            {health: 'Healthy'},
+            {health: 'Healthy'},
+            {health: 'Degraded'},
+            {health: 'Progressing'},
+            {health: 'Progressing'}
+        ] as Pod[];
+
+        expect(getPodHealthCounts(pods)).toEqual({
+            healthy: 2,
+            degraded: 1,
+            progressing: 2
+        });
+    });
+
+    it('counts suspended pods as healthy', () => {
+        const pods = [{health: 'Healthy'}, {health: 'Suspended'}, {health: 'Suspended'}] as Pod[];
+
+        expect(getPodHealthCounts(pods)).toEqual({
+            healthy: 3,
+            degraded: 0,
+            progressing: 0
+        });
+    });
+
+    it('returns zero counts for an empty pod list', () => {
+        expect(getPodHealthCounts([])).toEqual({
+            healthy: 0,
+            degraded: 0,
+            progressing: 0
+        });
+    });
+
+    it('ignores pod health states that do not use summary icons', () => {
+        const pods = [{health: 'Unknown'}, {health: 'Missing'}] as Pod[];
+
+        expect(getPodHealthCounts(pods)).toEqual({
+            healthy: 0,
+            degraded: 0,
+            progressing: 0
+        });
+    });
+});

--- a/ui/src/app/applications/components/application-pod-view/pod-view.test.ts
+++ b/ui/src/app/applications/components/application-pod-view/pod-view.test.ts
@@ -4,13 +4,7 @@ import {getPodHealthCounts} from './pod-view';
 
 describe('getPodHealthCounts', () => {
     it('counts healthy, degraded, and progressing pods', () => {
-        const pods = [
-            {health: 'Healthy'},
-            {health: 'Healthy'},
-            {health: 'Degraded'},
-            {health: 'Progressing'},
-            {health: 'Progressing'}
-        ] as Pod[];
+        const pods = [{health: 'Healthy'}, {health: 'Healthy'}, {health: 'Degraded'}, {health: 'Progressing'}, {health: 'Progressing'}] as Pod[];
 
         expect(getPodHealthCounts(pods)).toEqual({
             healthy: 2,

--- a/ui/src/app/applications/components/application-pod-view/pod-view.tsx
+++ b/ui/src/app/applications/components/application-pod-view/pod-view.tsx
@@ -46,7 +46,7 @@ export interface PodGroup extends Partial<ResourceNode> {
     hostLabels?: {[name: string]: string};
 }
 
-function getPodHealthCounts(pods: Pod[]) {
+export function getPodHealthCounts(pods: Pod[]) {
     return pods.reduce(
         (counts, pod) => {
             switch (pod.health) {

--- a/ui/src/app/applications/components/application-pod-view/pod-view.tsx
+++ b/ui/src/app/applications/components/application-pod-view/pod-view.tsx
@@ -46,6 +46,32 @@ export interface PodGroup extends Partial<ResourceNode> {
     hostLabels?: {[name: string]: string};
 }
 
+function getPodHealthCounts(pods: Pod[]) {
+    return pods.reduce(
+        (counts, pod) => {
+            switch (pod.health) {
+                case 'Healthy':
+                case 'Suspended':
+                    counts.healthy++;
+                    break;
+                case 'Degraded':
+                    counts.degraded++;
+                    break;
+                case 'Progressing':
+                    counts.progressing++;
+                    break;
+            }
+
+            return counts;
+        },
+        {
+            healthy: 0,
+            degraded: 0,
+            progressing: 0
+        }
+    );
+}
+
 export function PodView(props: PodViewProps) {
     const ctx = useContext(Context);
 
@@ -118,6 +144,7 @@ export function PodView(props: PodViewProps) {
                                     if (group.type === 'node' && group.name === 'Unschedulable' && podPrefs.hideUnschedulable) {
                                         return null;
                                     }
+                                    const podHealthCounts = getPodHealthCounts(group.pods);
                                     return (
                                         <div className={`pod-view__node white-box ${group.kind === 'node' && 'pod-view__node--large'}`} key={group.fullName || group.name}>
                                             <div
@@ -132,13 +159,41 @@ export function PodView(props: PodViewProps) {
                                                     </div>
                                                     <div style={{lineHeight: '15px'}}>
                                                         <b style={{wordWrap: 'break-word'}}>{group.name || 'Unknown'}</b>
+
+                                                        <div className='pod-view__node__pod-summary'>
+                                                            {podHealthCounts.healthy > 0 && (
+                                                                <span className='pod-view__node__pod-summary__item'>
+                                                                    <span className='pod-view__node__pod-summary__icon pod-view__node__pod--healthy'>
+                                                                        <PodHealthIcon state={{status: 'Healthy', message: ''}} />
+                                                                    </span>
+                                                                    {podHealthCounts.healthy}
+                                                                </span>
+                                                            )}
+
+                                                            {podHealthCounts.degraded > 0 && (
+                                                                <span className='pod-view__node__pod-summary__item'>
+                                                                    <span className='pod-view__node__pod-summary__icon pod-view__node__pod--degraded'>
+                                                                        <PodHealthIcon state={{status: 'Degraded', message: ''}} />
+                                                                    </span>
+                                                                    {podHealthCounts.degraded}
+                                                                </span>
+                                                            )}
+
+                                                            {podHealthCounts.progressing > 0 && (
+                                                                <span className='pod-view__node__pod-summary__item'>
+                                                                    <span className='pod-view__node__pod-summary__icon pod-view__node__pod--progressing'>
+                                                                        <PodHealthIcon state={{status: 'Progressing', message: ''}} />
+                                                                    </span>
+                                                                    {podHealthCounts.progressing}
+                                                                </span>
+                                                            )}
+                                                        </div>
+
                                                         {group.resourceStatus && (
                                                             <div>
                                                                 {group.resourceStatus.health && <HealthStatusIcon state={group.resourceStatus.health} />}
                                                                 &nbsp;
-                                                                {group.resourceStatus.status && (
-                                                                    <ComparisonStatusIcon status={group.resourceStatus.status} resource={group.resourceStatus} />
-                                                                )}
+                                                                {group.resourceStatus.status && <ComparisonStatusIcon status={group.resourceStatus.status} resource={group.resourceStatus} />}
                                                             </div>
                                                         )}
                                                     </div>

--- a/ui/src/app/applications/components/application-pod-view/pod-view.tsx
+++ b/ui/src/app/applications/components/application-pod-view/pod-view.tsx
@@ -193,7 +193,9 @@ export function PodView(props: PodViewProps) {
                                                             <div>
                                                                 {group.resourceStatus.health && <HealthStatusIcon state={group.resourceStatus.health} />}
                                                                 &nbsp;
-                                                                {group.resourceStatus.status && <ComparisonStatusIcon status={group.resourceStatus.status} resource={group.resourceStatus} />}
+                                                                {group.resourceStatus.status && (
+                                                                    <ComparisonStatusIcon status={group.resourceStatus.status} resource={group.resourceStatus} />
+                                                                )}
                                                             </div>
                                                         )}
                                                     </div>


### PR DESCRIPTION
## What does this PR do?

Adds summary counts for pod health states in the Pods view, addressing #25130.

The pod group header now displays counts for:
- Healthy/Suspended pods using the existing check icon
- Degraded pods using the existing failure icon
- Progressing pods using the existing spinner icon

The summary reuses the existing `PodHealthIcon` and pod health styling so that the summary indicators visually match the individual pod indicators shown in the Pods view.

This makes it easier to understand the overall pod health of groups containing many pods without manually counting individual pod indicators.

## Testing

Tested locally using Argo CD with a Kind Kubernetes cluster.

Verified the Pods view with:
- 8 healthy pods
- 3 degraded pods
- 2 progressing pods

Confirmed that:
- Summary counts match the individual pods.
- Healthy, degraded, and progressing indicators use the corresponding existing pod health colors/icons.
- Counts update according to pod health state.

Fixes #25130

Checklist:

* [x] Either (a) I've created an enhancement proposal and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the Title of the PR guidelines.
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by DCO.
* [x] I have written unit and/or e2e tests for my change.
* [ ] My build is green.
* [ ] My new feature complies with the feature status guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into.