### PR TITLE
fix(ci): strip v prefix for helm and git-lfs renovate checksum tasks

### DIFF
--- a/hack/tool-versions.sh
+++ b/hack/tool-versions.sh
@@ -16,13 +16,13 @@
 # add-kustomize-checksums.sh, and add-git-lfs-checksums.sh to help download
 # checksums.
 ###############################################################################
-# renovate: datasource=github-releases depName=helm/helm packageName=helm/helm
+# renovate: datasource=github-releases depName=helm/helm packageName=helm/helm extractVersion=^v(?<version>.*)$
 HELM_VERSION=4.2.3
 # renovate: datasource=github-releases depName=kubernetes-sigs/kustomize packageName=kubernetes-sigs/kustomize extractVersion=^kustomize/v(?<version>.*)$
 KUSTOMIZE_VERSION=5.8.1
 protoc_version=29.3
 oras_version=1.2.0
-# renovate: datasource=github-releases depName=git-lfs/git-lfs packageName=git-lfs/git-lfs
+# renovate: datasource=github-releases depName=git-lfs/git-lfs packageName=git-lfs/git-lfs extractVersion=^v(?<version>.*)$
 GIT_LFS_VERSION=3.7.1
 # renovate: datasource=github-releases depName=github/gh-aw packageName=github/gh-aw
 GH_AW_VERSION=0.81.6


### PR DESCRIPTION
Renovate postUpgradeTasks pass {{newVersion}} from GitHub release tags (v4.2.4), but add-helm-checksums.sh and add-git-lfs-checksums.sh expect bare semver (4.2.4). Add extractVersion to match the kustomize pattern so checksum refresh commands receive the correct version.

This will help version bumps like this pass CI: https://github.com/argoproj/argo-cd/pull/29187