### PR TITLE
fix: recover from kubectl panic in AuthReconcile when SA is forbidden (cherry-pick #28669 for 3.5)

### DIFF
--- a/gitops-engine/pkg/utils/kube/resource_ops.go
+++ b/gitops-engine/pkg/utils/kube/resource_ops.go
@@ -96,12 +96,21 @@ func (f *realKubectlOptionsRunner) Replace(opts *replace.ReplaceOptions, fact cm
 }
 
 // AuthReconcile will perform https://kubernetes.io/docs/reference/kubectl/generated/kubectl_auth/kubectl_auth_reconcile/
-func (f *realKubectlOptionsRunner) AuthReconcile(opts *auth.ReconcileOptions) error {
+func (f *realKubectlOptionsRunner) AuthReconcile(opts *auth.ReconcileOptions) (retErr error) {
 	cleanup, err := f.processKubectlRun("auth")
 	if err != nil {
 		return err
 	}
 	defer cleanup()
+	// kubectl panics instead of returning an error when the impersonated
+	// ServiceAccount is forbidden (see GitHub #28607, k8s#140338). Catch
+	// any panic so the controller can surface a SyncFailed status rather
+	// than crashing.
+	defer func() {
+		if r := recover(); r != nil {
+			retErr = fmt.Errorf("error running kubectl auth reconcile: %v", r)
+		}
+	}()
 	return opts.RunReconcile()
 }
 

--- a/gitops-engine/pkg/utils/kube/resource_ops_test.go
+++ b/gitops-engine/pkg/utils/kube/resource_ops_test.go
@@ -18,6 +18,7 @@ import (
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
 	"k8s.io/kubectl/pkg/cmd/apply"
+	"k8s.io/kubectl/pkg/cmd/auth"
 	"k8s.io/kubectl/pkg/cmd/create"
 	"k8s.io/kubectl/pkg/cmd/replace"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -547,4 +548,18 @@ func TestReplaceOptionsConfiguration(t *testing.T) {
 			})
 		}
 	})
+}
+
+// TestRealKubectlOptionsRunner_AuthReconcile_PanicRecovery verifies that the
+// recover() wrapper in realKubectlOptionsRunner.AuthReconcile converts a panic
+// inside kubectl into a returned error instead of crashing the controller
+// (see GitHub #28607).
+func TestRealKubectlOptionsRunner_AuthReconcile_PanicRecovery(t *testing.T) {
+	t.Parallel()
+	runner := &realKubectlOptionsRunner{}
+	// A nil *auth.ReconcileOptions panics at opts.RunReconcile() — the same
+	// class of panic that occurs when the impersonated SA is forbidden.
+	err := runner.AuthReconcile((*auth.ReconcileOptions)(nil))
+	require.Error(t, err, "AuthReconcile must return an error rather than propagating the panic")
+	assert.Contains(t, err.Error(), "error running kubectl auth reconcile")
 }


### PR DESCRIPTION
Cherry-picks #28669 into the 3.5 release to resolve the panics introduced in 3.5

Manually resolved a conflict in `gitops-engine/pkg/utils/kube/resource_ops_test.go` for some conflicting package imports

Signed-off-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
Co-authored-by: ppapapetrou76 <1743100+ppapapetrou76@users.noreply.github.com>
