### PR TITLE
fix(ci): regenerate manifests in Renovate helm post-upgrade tasks

### DIFF
--- a/renovate-presets/production-binaries.json5
+++ b/renovate-presets/production-binaries.json5
@@ -19,7 +19,7 @@
       ]
     },
     {
-      "description": "Refresh helm checksum files after version bump",
+      "description": "Refresh helm checksum files and regenerate redis-ha manifests after version bump",
       "matchDatasources": [
         "github-releases"
       ],
@@ -28,10 +28,13 @@
       ],
       "postUpgradeTasks": {
         "commands": [
-          "hack/installers/checksums/add-helm-checksums.sh {{newVersion}}"
+          "hack/installers/checksums/add-helm-checksums.sh {{newVersion}}",
+          "env INSTALL_SUDO=env BIN=./dist ./hack/install.sh kustomize helm",
+          "sh -c PATH=`pwd`/dist:$PATH;./hack/update-manifests.sh"
         ],
         "fileFilters": [
-          "hack/installers/checksums/**"
+          "hack/installers/checksums/**",
+          "manifests/**"
         ],
         "executionMode": "branch"
       }


### PR DESCRIPTION
Helm template output can change across patch releases (e.g. YAML document spacing in 4.2.4), which breaks CI codegen checks on Renovate PRs. Run update-manifests.sh after installing the bumped helm binary, matching the existing redis image post-upgrade workflow.

Fixes stuck upgrades like this one: https://github.com/argoproj/argo-cd/actions/runs/32396058095/job/96513295703?pr=29187
