### PR TITLE
fix: enable refresh tokens via workload identity

### DIFF
--- a/util/oidc/oidc.go
+++ b/util/oidc/oidc.go
@@ -189,6 +189,14 @@ func (a *ClientApp) GetTokenSourceFromCache(ctx context.Context, oidcTokenCache 
 		return nil, err
 	}
 	baseTokenSource := config.TokenSource(ctx, oidcTokenCache.Token)
+	if a.useAzureWorkloadIdentity {
+		baseTokenSource = &azureRefreshTokenSource{
+			ctx:                ctx,
+			conf:               config,
+			getClientAssertion: a.azure.getFederatedServiceAccountToken,
+			refreshToken:       oidcTokenCache.Token.RefreshToken,
+		}
+	}
 	tokenRefresher := oauth2.ReuseTokenSourceWithExpiry(oidcTokenCache.Token, baseTokenSource, a.refreshTokenThreshold)
 	return tokenRefresher, nil
 }
@@ -562,7 +570,7 @@ func (a *ClientApp) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		}
 
 		options = []oauth2.AuthCodeOption{
-			oauth2.SetAuthURLParam("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"),
+			oauth2.SetAuthURLParam("client_assertion_type", clientAssertionType),
 			oauth2.SetAuthURLParam("client_assertion", clientAssertion),
 		}
 	}

--- a/util/oidc/oidc_azure_refresh.go
+++ b/util/oidc/oidc_azure_refresh.go
@@ -1,0 +1,68 @@
+package oidc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"golang.org/x/oauth2"
+)
+
+const clientAssertionType = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+
+var errAzureRefreshTokenMissing = errors.New("refresh token is not set")
+
+// azureRefreshTokenSource redeems a refresh token using a federated service
+// account token as the client assertion.
+//
+// The mutex makes the source safe for concurrent use and ensures that a
+// rotated refresh token is installed before another refresh begins.
+type azureRefreshTokenSource struct {
+	mu sync.Mutex
+
+	ctx                context.Context
+	conf               *oauth2.Config
+	getClientAssertion func(context.Context) (string, error)
+	refreshToken       string
+}
+
+func (s *azureRefreshTokenSource) Token() (*oauth2.Token, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.refreshToken == "" {
+		return nil, errAzureRefreshTokenMissing
+	}
+
+	clientAssertion, err := s.getClientAssertion(s.ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate client assertion: %w", err)
+	}
+
+	// Exchange applies AuthCodeOptions after its defaults. This allows the
+	// grant type to be changed while retaining oauth2's token response parsing
+	// and error handling.
+	token, err := s.conf.Exchange(
+		s.ctx,
+		"",
+		oauth2.SetAuthURLParam("grant_type", "refresh_token"),
+		oauth2.SetAuthURLParam("refresh_token", s.refreshToken),
+		oauth2.SetAuthURLParam("client_assertion_type", clientAssertionType),
+		oauth2.SetAuthURLParam("client_assertion", clientAssertion),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to refresh token using Azure workload identity: %w", err)
+	}
+
+	// OAuth servers may rotate the refresh token. If no replacement is
+	// returned, preserve the previous one so it is neither lost from the cache
+	// nor omitted from the next refresh request.
+	if token.RefreshToken == "" {
+		token.RefreshToken = s.refreshToken
+	} else {
+		s.refreshToken = token.RefreshToken
+	}
+
+	return token, nil
+}

--- a/util/oidc/oidc_azure_refresh_test.go
+++ b/util/oidc/oidc_azure_refresh_test.go
@@ -1,0 +1,149 @@
+package oidc
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+type azureRefreshRequest struct {
+	method        string
+	authorization string
+	form          url.Values
+}
+
+func TestAzureRefreshTokenSource(t *testing.T) {
+	requests := make(chan azureRefreshRequest, 3)
+	var requestCount atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		requests <- azureRefreshRequest{
+			method:        r.Method,
+			authorization: r.Header.Get("Authorization"),
+			form:          r.PostForm,
+		}
+
+		currentRequest := requestCount.Add(1)
+		response := map[string]any{
+			"access_token": fmt.Sprintf("access-token-%d", currentRequest),
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		}
+
+		// Rotate the token after the first request. Subsequent responses omit
+		// refresh_token to verify that the rotated token is preserved.
+		if currentRequest == 1 {
+			response["refresh_token"] = "refresh-token-2"
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}))
+	defer server.Close()
+
+	var assertionCount atomic.Int32
+	source := &azureRefreshTokenSource{
+		ctx: context.Background(),
+		conf: &oauth2.Config{
+			ClientID: "client-id",
+			Endpoint: oauth2.Endpoint{
+				TokenURL:  server.URL,
+				AuthStyle: oauth2.AuthStyleInParams,
+			},
+		},
+		getClientAssertion: func(context.Context) (string, error) {
+			currentAssertion := assertionCount.Add(1)
+			return fmt.Sprintf("client-assertion-%d", currentAssertion), nil
+		},
+		refreshToken: "refresh-token-1",
+	}
+
+	firstToken, err := source.Token()
+	require.NoError(t, err)
+	assert.Equal(t, "access-token-1", firstToken.AccessToken)
+	assert.Equal(t, "refresh-token-2", firstToken.RefreshToken)
+
+	secondToken, err := source.Token()
+	require.NoError(t, err)
+	assert.Equal(t, "access-token-2", secondToken.AccessToken)
+	assert.Equal(t, "refresh-token-2", secondToken.RefreshToken)
+
+	thirdToken, err := source.Token()
+	require.NoError(t, err)
+	assert.Equal(t, "access-token-3", thirdToken.AccessToken)
+	assert.Equal(t, "refresh-token-2", thirdToken.RefreshToken)
+
+	expectedRefreshTokens := []string{
+		"refresh-token-1",
+		"refresh-token-2",
+		"refresh-token-2",
+	}
+
+	for i, expectedRefreshToken := range expectedRefreshTokens {
+		request := <-requests
+
+		assert.Equal(t, http.MethodPost, request.method)
+		assert.Empty(t, request.authorization)
+		assert.Equal(t, "client-id", request.form.Get("client_id"))
+		assert.Equal(t, "refresh_token", request.form.Get("grant_type"))
+		assert.Equal(t, expectedRefreshToken, request.form.Get("refresh_token"))
+		assert.Equal(t, clientAssertionType, request.form.Get("client_assertion_type"))
+		assert.Equal(t, fmt.Sprintf("client-assertion-%d", i+1), request.form.Get("client_assertion"))
+		assert.Empty(t, request.form.Get("client_secret"))
+	}
+
+	assert.EqualValues(t, 3, assertionCount.Load())
+}
+
+func TestAzureRefreshTokenSourceRequiresRefreshToken(t *testing.T) {
+	assertionCalled := false
+	source := &azureRefreshTokenSource{
+		ctx:  context.Background(),
+		conf: &oauth2.Config{},
+		getClientAssertion: func(context.Context) (string, error) {
+			assertionCalled = true
+			return "client-assertion", nil
+		},
+	}
+
+	token, err := source.Token()
+
+	require.ErrorIs(t, err, errAzureRefreshTokenMissing)
+	assert.Nil(t, token)
+	assert.False(t, assertionCalled)
+}
+
+func TestAzureRefreshTokenSourceReturnsClientAssertionError(t *testing.T) {
+	expectedErr := errors.New("service account token unavailable")
+	source := &azureRefreshTokenSource{
+		ctx:          context.Background(),
+		conf:         &oauth2.Config{},
+		refreshToken: "refresh-token",
+		getClientAssertion: func(context.Context) (string, error) {
+			return "", expectedErr
+		},
+	}
+
+	token, err := source.Token()
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, expectedErr)
+	assert.Nil(t, token)
+}


### PR DESCRIPTION
If Microsoft Entra Workload Identity is used, no client_secret is configured. Instead the refresh request should carry the service account token as client_assertion.

Fixes https://github.com/argoproj/argo-cd/issues/29298