### PR TITLE
fix: Use `EachListItemWithAlloc` to prevent page retention 

### DIFF
--- a/gitops-engine/pkg/cache/cluster.go
+++ b/gitops-engine/pkg/cache/cluster.go
@@ -766,7 +766,10 @@ func (c *clusterCache) listResources(ctx context.Context, resClient dynamic.Reso
 func (c *clusterCache) loadInitialState(ctx context.Context, api kube.APIResourceInfo, resClient dynamic.ResourceInterface, ns string, lock bool) (string, error) {
 	var items []*Resource
 	resourceVersion, err := c.listResources(ctx, resClient, func(listPager *pager.ListPager) error {
-		return listPager.EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+		// Use the WithAlloc variant: newResource may retain the object (as Resource.Resource, or via the
+		// Info returned by the OnPopulateResourceInfoHandler). Plain EachListItem yields &list.Items[i],
+		// so retaining one item keeps the page's whole backing array, and every manifest in it, reachable.
+		return listPager.EachListItemWithAlloc(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
 			if un, ok := obj.(*unstructured.Unstructured); !ok {
 				return fmt.Errorf("object %s/%s has an unexpected type", un.GroupVersionKind().String(), un.GetName())
 			} else {
@@ -1184,7 +1187,10 @@ func (c *clusterCache) sync() (err error) {
 
 		return c.processApi(client, api, func(resClient dynamic.ResourceInterface, ns string) error {
 			resourceVersion, err := c.listResources(ctx, resClient, func(listPager *pager.ListPager) error {
-				return listPager.EachListItem(context.Background(), metav1.ListOptions{}, func(obj runtime.Object) error {
+				// Use the WithAlloc variant: newResource may retain the object (as Resource.Resource, or via the
+				// Info returned by the OnPopulateResourceInfoHandler). Plain EachListItem yields &list.Items[i],
+				// so retaining one item keeps the page's whole backing array, and every manifest in it, reachable.
+				return listPager.EachListItemWithAlloc(context.Background(), metav1.ListOptions{}, func(obj runtime.Object) error {
 					if un, ok := obj.(*unstructured.Unstructured); !ok {
 						return fmt.Errorf("object %s/%s has an unexpected type", un.GroupVersionKind().String(), un.GetName())
 					} else {

--- a/gitops-engine/pkg/cache/cluster.go
+++ b/gitops-engine/pkg/cache/cluster.go
@@ -1190,7 +1190,7 @@ func (c *clusterCache) sync() (err error) {
 				// Use the WithAlloc variant: newResource may retain the object (as Resource.Resource, or via the
 				// Info returned by the OnPopulateResourceInfoHandler). Plain EachListItem yields &list.Items[i],
 				// so retaining one item keeps the page's whole backing array, and every manifest in it, reachable.
-				return listPager.EachListItemWithAlloc(context.Background(), metav1.ListOptions{}, func(obj runtime.Object) error {
+				return listPager.EachListItemWithAlloc(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
 					if un, ok := obj.(*unstructured.Unstructured); !ok {
 						return fmt.Errorf("object %s/%s has an unexpected type", un.GroupVersionKind().String(), un.GetName())
 					} else {

--- a/gitops-engine/pkg/cache/cluster_page_retention_test.go
+++ b/gitops-engine/pkg/cache/cluster_page_retention_test.go
@@ -34,7 +34,7 @@ func (m *pagedListResourceInterface) List(_ context.Context, _ metav1.ListOption
 }
 
 // TestLoadInitialStateDoesNotRetainListPage asserts that caching a manifest does not pin the list
-// page it arrived in, which happens when using pager.EachListItem rather than poager.EachListItemWithAlloc
+// page it arrived in, which happens when using pager.EachListItem rather than pager.EachListItemWithAlloc
 func TestLoadInitialStateDoesNotRetainListPage(t *testing.T) {
 	t.Parallel()
 

--- a/gitops-engine/pkg/cache/cluster_page_retention_test.go
+++ b/gitops-engine/pkg/cache/cluster_page_retention_test.go
@@ -1,0 +1,98 @@
+package cache
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/semaphore"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2/textlogger"
+
+	"github.com/argoproj/argo-cd/gitops-engine/v3/pkg/utils/kube"
+)
+
+// pagedListResourceInterface serves a fixed set of objects and keeps a handle on every page it
+// returned, so tests can check whether the cache retained pointers into a page's backing array.
+type pagedListResourceInterface struct {
+	*mockResourceInterface
+	items []unstructured.Unstructured
+	pages []*unstructured.UnstructuredList
+}
+
+func (m *pagedListResourceInterface) List(_ context.Context, _ metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	page := &unstructured.UnstructuredList{Items: make([]unstructured.Unstructured, len(m.items))}
+	copy(page.Items, m.items)
+	page.SetResourceVersion("123")
+	m.pages = append(m.pages, page)
+	return page, nil
+}
+
+// TestLoadInitialStateDoesNotRetainListPage asserts that caching a manifest does not pin the list
+// page it arrived in, which happens when using pager.EachListItem rather than poager.EachListItemWithAlloc
+func TestLoadInitialStateDoesNotRetainListPage(t *testing.T) {
+	t.Parallel()
+
+	const (
+		pageSize = 10
+		// only this pod's manifest gets cached, so the other nine must not be retained with it
+		cachedPod = "pod-3"
+	)
+
+	items := make([]unstructured.Unstructured, pageSize)
+	for i := range items {
+		items[i] = unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]any{
+				"name":            fmt.Sprintf("pod-%d", i),
+				"namespace":       "default",
+				"uid":             fmt.Sprintf("uid-%d", i),
+				"resourceVersion": "123",
+			},
+		}}
+	}
+	resClient := &pagedListResourceInterface{mockResourceInterface: &mockResourceInterface{}, items: items}
+
+	cache := &clusterCache{
+		listSemaphore:       semaphore.NewWeighted(1),
+		listPageSize:        pageSize,
+		listPageBufferSize:  1,
+		listRetryLimit:      1,
+		listRetryFunc:       ListRetryFuncNever,
+		log:                 textlogger.NewLogger(textlogger.NewConfig()),
+		resources:           map[kube.ResourceKey]*Resource{},
+		nsIndex:             map[string]map[kube.ResourceKey]*Resource{},
+		parentUIDToChildren: map[types.UID]map[kube.ResourceKey]struct{}{},
+		populateResourceInfoHandler: func(un *unstructured.Unstructured, _ bool) (any, bool) {
+			return nil, un.GetName() == cachedPod
+		},
+	}
+
+	api := kube.APIResourceInfo{
+		GroupKind:            schema.GroupKind{Kind: "Pod"},
+		GroupVersionResource: schema.GroupVersionResource{Version: "v1", Resource: "pods"},
+		Meta:                 metav1.APIResource{Namespaced: true},
+	}
+	_, err := cache.loadInitialState(t.Context(), api, resClient, "default", false)
+	require.NoError(t, err)
+	require.Len(t, cache.resources, pageSize)
+	require.Len(t, resClient.pages, 1, "test assumes the objects arrive in a single page")
+
+	cached := cache.resources[kube.NewResourceKey("", "Pod", "default", cachedPod)]
+	require.NotNil(t, cached)
+	require.NotNil(t, cached.Resource, "expected the manifest for %s to be cached", cachedPod)
+
+	// Rather than test that we can run a GC sweep, it's easier to test that the cached manifest's pointer doesn't exist in the page
+	// therefore, it shouldn't be retained after a sweep
+	page := resClient.pages[0]
+	for i := range page.Items {
+		assert.NotSame(t, &page.Items[i], cached.Resource,
+			"cached manifest points into the list page's backing array, pinning all %d manifests in the page", pageSize)
+	}
+}

--- a/gitops-engine/pkg/cache/references.go
+++ b/gitops-engine/pkg/cache/references.go
@@ -71,10 +71,13 @@ func isStatefulSetChild(un *unstructured.Unstructured) (func(kube.ResourceKey) b
 	}
 
 	templates := sts.Spec.VolumeClaimTemplates
+	// Capture the name rather than un itself: this closure is retained for the lifetime of the
+	// cached Resource, and capturing un would keep the whole StatefulSet manifest alive with it.
+	name := un.GetName()
 	return func(key kube.ResourceKey) bool {
 		if key.Kind == kube.PersistentVolumeClaimKind && key.GroupKind().Group == "" {
 			for _, templ := range templates {
-				if match, _ := regexp.MatchString(fmt.Sprintf(`%s-%s-\d+$`, templ.Name, un.GetName()), key.Name); match {
+				if match, _ := regexp.MatchString(fmt.Sprintf(`%s-%s-\d+$`, templ.Name, name), key.Name); match {
 					return true
 				}
 			}

--- a/gitops-engine/pkg/cache/references_test.go
+++ b/gitops-engine/pkg/cache/references_test.go
@@ -104,3 +104,33 @@ func Test_isStatefulSetChild(t *testing.T) {
 		})
 	}
 }
+
+func Test_isStatefulSetChild_doesNotRetainManifest(t *testing.T) {
+	un, err := kube.ToUnstructured(&appsv1.StatefulSet{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "StatefulSet",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "sw-broker",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "emqx-data",
+					},
+				},
+			},
+		},
+	})
+	require.NoErrorf(t, err, "Failed to convert StatefulSet to unstructured: %v", err)
+
+	matches, err := isStatefulSetChild(un)
+	require.NoError(t, err)
+
+	// the closure outlives the cached Resource, so it must not hold the manifest
+	un.Object = nil
+	assert.True(t, matches(kube.ResourceKey{Kind: kube.PersistentVolumeClaimKind, Name: "emqx-data-sw-broker-0"}))
+	assert.False(t, matches(kube.ResourceKey{Kind: kube.PersistentVolumeClaimKind, Name: "emqx-data-sw-broker-internal-0"}))
+}


### PR DESCRIPTION
This PR fixes a small bug I found in the gitops-engine, where we use `EachListItem` instead of `EachListItemWithAlloc`. When using the original `EachListItem`, we would accidentally retain pages, causing unnecessary memory growth.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
