### PR TITLE
fix(ui): remove kind filter from appset page (#29310)

### DIFF
--- a/ui/src/app/applications/components/application-details/application-details.tsx
+++ b/ui/src/app/applications/components/application-details/application-details.tsx
@@ -28,7 +28,7 @@ import * as AppUtils from '../utils';
 import {ApplicationResourceList, ApplicationResourceParentRef} from './application-resource-list';
 import {APPLICATION_DETAILS_SORT_KEY, ApplicationResourceSortKey, compareApplicationResource, GROUPED_NODES_DETAILS_SORT_KEY} from './application-resource-sort';
 import {useListSort} from '../../../shared/hooks/use-list-sort';
-import {Filters, FiltersProps, withoutKindResourceFilters} from './application-resource-filter';
+import {Filters, FiltersProps, getEffectiveResourceFilter} from './application-resource-filter';
 import {getAppDefaultSource, getAppCurrentVersion, urlPattern} from '../utils';
 import {ChartDetails, OCIMetadata} from '../../../shared/models';
 import {ApplicationsDetailsAppDropdown} from './application-details-app-dropdown';
@@ -678,20 +678,13 @@ Are you sure you want to disable auto-sync and rollback application '${props.mat
                         {({application, tree, pref}: {application: appModels.AbstractApplication; tree: appModels.ApplicationTree; pref: AppDetailsPreferences}) => {
                             tree.nodes = tree.nodes || [];
                             const isApplication = isApp(application);
-                            const effectiveResourceFilter = isApplication ? pref.resourceFilter || [] : withoutKindResourceFilters(pref.resourceFilter);
+                            const effectiveResourceFilter = getEffectiveResourceFilter(isApplication, pref.resourceFilter);
                             const treeFilter = getTreeFilter(effectiveResourceFilter);
                             const setFilter = (items: string[]) => {
                                 appContext.navigation.goto('.', {resource: items.join(',')}, {replace: true});
                                 services.viewPreferences.updatePreferences({appDetails: {...pref, resourceFilter: items}});
                             };
-                            const clearFilter = () => {
-                                if (isApplication) {
-                                    setFilter([]);
-                                    return;
-                                }
-                                const kindFilters = (pref.resourceFilter || []).filter(f => f.startsWith('kind:'));
-                                setFilter(kindFilters);
-                            };
+                            const clearFilter = () => setFilter([]);
                             const refreshing = application.metadata.annotations && application.metadata.annotations[appModels.AnnotationRefreshKey];
                             const appNodesByName = isApplication ? groupAppNodesByKey(application as appModels.Application, tree) : new Map();
                             // For ApplicationSets, add the appset itself to the map

--- a/ui/src/app/applications/components/application-details/application-details.tsx
+++ b/ui/src/app/applications/components/application-details/application-details.tsx
@@ -1039,6 +1039,7 @@ Are you sure you want to disable auto-sync and rollback application '${props.mat
                                                                     onClearFilter={clearFilter}
                                                                     collapsed={viewPref.hideSidebar}
                                                                     resourceNodes={state.filteredGraph}
+                                                                    hideKindFilter={!isApplication}
                                                                 />
                                                             )}
                                                         </DataLoader>
@@ -1144,6 +1145,7 @@ Are you sure you want to disable auto-sync and rollback application '${props.mat
                                                                         onClearFilter={clearFilter}
                                                                         collapsed={viewPref.hideSidebar}
                                                                         resourceNodes={filteredRes}
+                                                                        hideKindFilter={!isApplication}
                                                                     />
                                                                 )}
                                                             </DataLoader>

--- a/ui/src/app/applications/components/application-details/application-details.tsx
+++ b/ui/src/app/applications/components/application-details/application-details.tsx
@@ -28,7 +28,7 @@ import * as AppUtils from '../utils';
 import {ApplicationResourceList, ApplicationResourceParentRef} from './application-resource-list';
 import {APPLICATION_DETAILS_SORT_KEY, ApplicationResourceSortKey, compareApplicationResource, GROUPED_NODES_DETAILS_SORT_KEY} from './application-resource-sort';
 import {useListSort} from '../../../shared/hooks/use-list-sort';
-import {Filters, FiltersProps} from './application-resource-filter';
+import {Filters, FiltersProps, withoutKindResourceFilters} from './application-resource-filter';
 import {getAppDefaultSource, getAppCurrentVersion, urlPattern} from '../utils';
 import {ChartDetails, OCIMetadata} from '../../../shared/models';
 import {ApplicationsDetailsAppDropdown} from './application-details-app-dropdown';
@@ -678,12 +678,20 @@ Are you sure you want to disable auto-sync and rollback application '${props.mat
                         {({application, tree, pref}: {application: appModels.AbstractApplication; tree: appModels.ApplicationTree; pref: AppDetailsPreferences}) => {
                             tree.nodes = tree.nodes || [];
                             const isApplication = isApp(application);
-                            const treeFilter = getTreeFilter(pref.resourceFilter);
+                            const effectiveResourceFilter = isApplication ? pref.resourceFilter || [] : withoutKindResourceFilters(pref.resourceFilter);
+                            const treeFilter = getTreeFilter(effectiveResourceFilter);
                             const setFilter = (items: string[]) => {
                                 appContext.navigation.goto('.', {resource: items.join(',')}, {replace: true});
                                 services.viewPreferences.updatePreferences({appDetails: {...pref, resourceFilter: items}});
                             };
-                            const clearFilter = () => setFilter([]);
+                            const clearFilter = () => {
+                                if (isApplication) {
+                                    setFilter([]);
+                                    return;
+                                }
+                                const kindFilters = (pref.resourceFilter || []).filter(f => f.startsWith('kind:'));
+                                setFilter(kindFilters);
+                            };
                             const refreshing = application.metadata.annotations && application.metadata.annotations[appModels.AnnotationRefreshKey];
                             const appNodesByName = isApplication ? groupAppNodesByKey(application as appModels.Application, tree) : new Map();
                             // For ApplicationSets, add the appset itself to the map
@@ -767,7 +775,7 @@ Are you sure you want to disable auto-sync and rollback application '${props.mat
                                     appContext: {...appContext, apis: appContext} as unknown as AppContext,
                                     nameDirection: state.truncateNameOnRight,
                                     nameWrap: state.showFullNodeName,
-                                    filters: pref.resourceFilter,
+                                    filters: pref.resourceFilter || [],
                                     setTreeFilterGraph: setFilterGraph,
                                     updateUsrHelpTipMsgs: updateHelpTipState,
                                     setShowCompactNodes,
@@ -1038,7 +1046,7 @@ Are you sure you want to disable auto-sync and rollback application '${props.mat
                                                                     onSetFilter={setFilter}
                                                                     onClearFilter={clearFilter}
                                                                     collapsed={viewPref.hideSidebar}
-                                                                    resourceNodes={state.filteredGraph}
+                                                                    resourceNodes={filteredRes}
                                                                     hideKindFilter={!isApplication}
                                                                 />
                                                             )}

--- a/ui/src/app/applications/components/application-details/application-resource-filter.test.ts
+++ b/ui/src/app/applications/components/application-details/application-resource-filter.test.ts
@@ -1,0 +1,9 @@
+import {getEffectiveResourceFilter} from './application-resource-filter';
+
+test('ApplicationSet ignores kind filters when applying resource filters', () => {
+    expect(getEffectiveResourceFilter(false, ['kind:Deployment', 'sync:OutOfSync'])).toEqual(['sync:OutOfSync']);
+});
+
+test('Application still applies kind filters', () => {
+    expect(getEffectiveResourceFilter(true, ['kind:Deployment', 'sync:OutOfSync'])).toEqual(['kind:Deployment', 'sync:OutOfSync']);
+});

--- a/ui/src/app/applications/components/application-details/application-resource-filter.tsx
+++ b/ui/src/app/applications/components/application-details/application-resource-filter.tsx
@@ -18,6 +18,10 @@ export function withoutKindResourceFilters(filters: string[]): string[] {
     return (filters || []).filter(f => !f.startsWith('kind:'));
 }
 
+export function getEffectiveResourceFilter(isApplication: boolean, resourceFilter?: string[]): string[] {
+    return isApplication ? resourceFilter || [] : withoutKindResourceFilters(resourceFilter);
+}
+
 export interface FiltersProps {
     children?: React.ReactNode;
     pref: AppDetailsPreferences;

--- a/ui/src/app/applications/components/application-details/application-resource-filter.tsx
+++ b/ui/src/app/applications/components/application-details/application-resource-filter.tsx
@@ -22,12 +22,13 @@ export interface FiltersProps {
     onSetFilter: (items: string[]) => void;
     onClearFilter: () => void;
     collapsed?: boolean;
+    hideKindFilter?: boolean;
 }
 
 export const Filters = (props: FiltersProps) => {
     const ctx = React.useContext(Context);
 
-    const {pref, tree, onSetFilter} = props;
+    const {pref, tree, onSetFilter, hideKindFilter} = props;
 
     const onClearFilter = () => {
         setLoading(true);
@@ -127,16 +128,17 @@ export const Filters = (props: FiltersProps) => {
     return (
         <FiltersGroup title='Resource filters' content={props.children} appliedFilter={pref.resourceFilter} onClearFilter={onClearFilter} collapsed={props.collapsed}>
             {ResourceFilter({label: 'NAME', prefix: 'name', options: names.map(toOption), field: true})}
-            {ResourceFilter({
-                label: 'KINDS',
-                prefix: 'kind',
-                options: kinds.map(label => ({
-                    label,
-                    count: getOptionCount(label, 'Kind')
-                })),
-                abbreviations: resources,
-                field: true
-            })}
+            {!hideKindFilter &&
+                ResourceFilter({
+                    label: 'KINDS',
+                    prefix: 'kind',
+                    options: kinds.map(label => ({
+                        label,
+                        count: getOptionCount(label, 'Kind')
+                    })),
+                    abbreviations: resources,
+                    field: true
+                })}
             {ResourceFilter({
                 label: 'SYNC STATUS',
                 prefix: 'sync',

--- a/ui/src/app/applications/components/application-details/application-resource-filter.tsx
+++ b/ui/src/app/applications/components/application-details/application-resource-filter.tsx
@@ -14,6 +14,10 @@ function toOption(label: string) {
     return {label};
 }
 
+export function withoutKindResourceFilters(filters: string[]): string[] {
+    return (filters || []).filter(f => !f.startsWith('kind:'));
+}
+
 export interface FiltersProps {
     children?: React.ReactNode;
     pref: AppDetailsPreferences;
@@ -126,7 +130,12 @@ export const Filters = (props: FiltersProps) => {
     };
 
     return (
-        <FiltersGroup title='Resource filters' content={props.children} appliedFilter={pref.resourceFilter} onClearFilter={onClearFilter} collapsed={props.collapsed}>
+        <FiltersGroup
+            title='Resource filters'
+            content={props.children}
+            appliedFilter={hideKindFilter ? withoutKindResourceFilters(resourceFilter) : pref.resourceFilter}
+            onClearFilter={onClearFilter}
+            collapsed={props.collapsed}>
             {ResourceFilter({label: 'NAME', prefix: 'name', options: names.map(toOption), field: true})}
             {!hideKindFilter &&
                 ResourceFilter({


### PR DESCRIPTION
Hide the "kind" filter on the AppSet page, since the only Kind will ever be Application. 

Fixes #29310

**Before:**


https://github.com/user-attachments/assets/61a35105-aced-4358-b276-21fc93b0e981

**After:**


https://github.com/user-attachments/assets/a3692419-5b3d-40ce-8c89-997d9820fab8

