### PR TITLE
fix(hydrator): resolve dry source repo for revision metadata when sync repo differs

### DIFF
--- a/server/application/application.go
+++ b/server/application/application.go
@@ -1756,6 +1756,25 @@ func (s *Server) GetOCIMetadata(ctx context.Context, q *application.RevisionMeta
 // version ID. If the version ID is not found, we return an error. If the source index is out of bounds for whichever
 // source we choose (configured sources or sources for a specific version), we return an error.
 func getAppSourceBySourceIndexAndVersionId(a *v1alpha1.Application, sourceIndexMaybe *int32, versionIdMaybe *int32) (v1alpha1.ApplicationSource, error) {
+	// Start by assuming we want the first source.
+	sourceIndex := 0
+
+	// If the user specified a source index, use that instead.
+	if sourceIndexMaybe != nil {
+		sourceIndex = int(*sourceIndexMaybe)
+	}
+
+	// A negative index is only meaningful for source hydrator apps, where it refers to the dry source. The dry
+	// source is not tracked in the app's revision history (RevisionHistory only ever records the sync source), so
+	// always resolve it from the current spec, regardless of whether a version ID was requested. Otherwise, a
+	// negative index would incorrectly be looked up against the sync source's repo.
+	if sourceIndex < 0 {
+		if a.Spec.SourceHydrator == nil {
+			return v1alpha1.ApplicationSource{}, fmt.Errorf("source index %d not found because there are only %d sources", sourceIndex, len(a.Spec.GetSources()))
+		}
+		return a.Spec.SourceHydrator.GetDrySource(), nil
+	}
+
 	// Start with all the app's configured sources.
 	sources := a.Spec.GetSources()
 
@@ -1769,18 +1788,11 @@ func getAppSourceBySourceIndexAndVersionId(a *v1alpha1.Application, sourceIndexM
 		}
 	}
 
-	// Start by assuming we want the first source.
-	sourceIndex := 0
-
-	// If the user specified a source index, use that instead.
-	if sourceIndexMaybe != nil {
-		sourceIndex = int(*sourceIndexMaybe)
-		if sourceIndex >= len(sources) {
-			if len(sources) == 1 {
-				return v1alpha1.ApplicationSource{}, fmt.Errorf("source index %d not found because there is only 1 source", sourceIndex)
-			}
-			return v1alpha1.ApplicationSource{}, fmt.Errorf("source index %d not found because there are only %d sources", sourceIndex, len(sources))
+	if sourceIndex >= len(sources) {
+		if len(sources) == 1 {
+			return v1alpha1.ApplicationSource{}, fmt.Errorf("source index %d not found because there is only 1 source", sourceIndex)
 		}
+		return v1alpha1.ApplicationSource{}, fmt.Errorf("source index %d not found because there are only %d sources", sourceIndex, len(sources))
 	}
 
 	source := sources[sourceIndex]

--- a/server/application/application_test.go
+++ b/server/application/application_test.go
@@ -2813,6 +2813,61 @@ func TestGetManifests_SourceHydrator(t *testing.T) {
 	mockRepoServiceClient.AssertExpectations(t)
 }
 
+// TestRevisionMetadata_SourceHydrator_CrossRepo covers https://github.com/argoproj/argo-cd/issues/29218: when the
+// hydrator's syncSource.repoURL points to a different repo than drySource.repoURL, requesting revision metadata for
+// the dry source SHA (sourceIndex -1) must resolve against the dry source's repo, not the sync source's repo.
+func TestRevisionMetadata_SourceHydrator_CrossRepo(t *testing.T) {
+	testApp := newTestApp()
+	testApp.Spec.SourceHydrator = &v1alpha1.SourceHydrator{
+		DrySource: v1alpha1.DrySource{
+			RepoURL:        "https://github.com/org/dry-repo",
+			Path:           "manifests/dry",
+			TargetRevision: "main",
+		},
+		SyncSource: v1alpha1.SyncSource{
+			RepoURL:      "https://github.com/org/sync-repo",
+			Path:         "manifests/sync",
+			TargetBranch: "env/prod",
+		},
+	}
+	testApp.Status.History = []v1alpha1.RevisionHistory{
+		{
+			ID:       1,
+			Source:   testApp.Spec.SourceHydrator.GetSyncSource(),
+			Revision: "sync-revision",
+		},
+	}
+
+	testCases := []struct {
+		name      string
+		versionId *int32
+	}{
+		{name: "no version ID"},
+		{name: "with version ID", versionId: new(int32(1))},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			appServer := newTestAppServer(t, testApp)
+
+			mockRepoServiceClient := mocks.RepoServerServiceClient{}
+			mockRepoServiceClient.On("GetRevisionMetadata", mock.Anything, mock.MatchedBy(func(mr *apiclient.RepoServerRevisionMetadataRequest) bool {
+				return mr.Repo.Repo == "https://github.com/org/dry-repo" && mr.Revision == "dry-revision"
+			})).Return(&v1alpha1.RevisionMetadata{}, nil)
+			appServer.repoClientset = &mocks.Clientset{RepoServerServiceClient: &mockRepoServiceClient}
+
+			_, err := appServer.RevisionMetadata(t.Context(), &application.RevisionMetadataQuery{
+				Name:        &testApp.Name,
+				Revision:    new("dry-revision"),
+				SourceIndex: new(int32(-1)),
+				VersionId:   tc.versionId,
+			})
+			require.NoError(t, err)
+			mockRepoServiceClient.AssertExpectations(t)
+		})
+	}
+}
+
 func TestRollbackApp(t *testing.T) {
 	testApp := newTestApp()
 	testApp.Status.History = []v1alpha1.RevisionHistory{{

--- a/ui/src/app/applications/components/application-status-panel/application-status-panel.tsx
+++ b/ui/src/app/applications/components/application-status-panel/application-status-panel.tsx
@@ -267,6 +267,7 @@ export const ApplicationStatusPanel = ({application, showDiff, showOperation, sh
                                 type={''}
                                 revision={application.status.sourceHydrator.currentOperation.drySHA}
                                 versionId={utils.getAppCurrentVersion(application)}
+                                sourceIndex={-1}
                             />
                         )}
                     </div>

--- a/ui/src/app/applications/components/application-status-panel/revision-metadata-panel.tsx
+++ b/ui/src/app/applications/components/application-status-panel/revision-metadata-panel.tsx
@@ -3,13 +3,16 @@ import * as React from 'react';
 import {Timestamp} from '../../../shared/components/timestamp';
 import {services} from '../../../shared/services';
 
-export const RevisionMetadataPanel = (props: {appName: string; appNamespace: string; type: string; revision: string; versionId: number}) => {
+export const RevisionMetadataPanel = (props: {appName: string; appNamespace: string; type: string; revision: string; versionId: number; sourceIndex?: number}) => {
+    const sourceIndex = props.sourceIndex ?? 0;
     if (props.type === 'helm') {
         return null;
     }
     if (props.type === 'oci') {
         return (
-            <DataLoader load={() => services.applications.ociMetadata(props.appName, props.appNamespace, props.revision, 0, props.versionId)} errorRenderer={() => <div />}>
+            <DataLoader
+                load={() => services.applications.ociMetadata(props.appName, props.appNamespace, props.revision, sourceIndex, props.versionId)}
+                errorRenderer={() => <div />}>
                 {m => (
                     <Tooltip
                         popperOptions={{
@@ -53,7 +56,7 @@ export const RevisionMetadataPanel = (props: {appName: string; appNamespace: str
     return (
         <DataLoader
             key={props.revision}
-            load={() => services.applications.revisionMetadata(props.appName, props.appNamespace, props.revision, 0, props.versionId)}
+            load={() => services.applications.revisionMetadata(props.appName, props.appNamespace, props.revision, sourceIndex, props.versionId)}
             errorRenderer={() => <div />}>
             {m => (
                 <Tooltip


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

Fixes [ISSUE #29218]

This fixes the "not our ref" UI error popup reported for hydrator apps whose `syncSource.repoURL` differs from `drySource.repoURL`. Should be safe to cherry-pick into any actively maintained release branch that has the source hydrator feature, since it is a self-contained fix scoped to the revision-metadata lookup path.

CI on this repo requires a maintainer to add `ok-to-test` — happy to address anything it surfaces.

Fixes #29218