### PR TITLE
fix(ui): render annotations as records and hide empty expand toggle

### DIFF
--- a/ui/src/app/applications/components/application-summary/application-summary.scss
+++ b/ui/src/app/applications/components/application-summary/application-summary.scss
@@ -21,6 +21,28 @@
         margin-right: 2px;
     }
 
+    &__annotations {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+    }
+
+    &__annotation {
+        display: flex;
+        flex-wrap: wrap;
+        word-break: break-all;
+
+        &-key {
+            font-weight: 500;
+            margin-right: 4px;
+
+            &::after {
+                content: '=';
+                margin-left: 4px;
+            }
+        }
+    }
+
     &__sort-icon {
         cursor: pointer;
         position: absolute;

--- a/ui/src/app/applications/components/application-summary/application-summary.tsx
+++ b/ui/src/app/applications/components/application-summary/application-summary.tsx
@@ -112,9 +112,14 @@ export const ApplicationSummary = (props: ApplicationSummaryProps) => {
             title: 'ANNOTATIONS',
             view: (
                 <Expandable height={48}>
-                    {Object.keys(app.metadata.annotations || {})
-                        .map(annotation => `${annotation}=${app.metadata.annotations[annotation]}`)
-                        .join(' ')}
+                    <div className='application-summary__annotations'>
+                        {Object.keys(app.metadata.annotations || {}).map(annotation => (
+                            <div className='application-summary__annotation' key={annotation}>
+                                <span className='application-summary__annotation-key'>{annotation}</span>
+                                <span className='application-summary__annotation-value'>{app.metadata.annotations[annotation]}</span>
+                            </div>
+                        ))}
+                    </div>
                 </Expandable>
             ),
             edit: (formApi: FormApi) => <EditAnnotations formApi={formApi} app={app} />

--- a/ui/src/app/applications/components/resource-details/appset-resource-details.tsx
+++ b/ui/src/app/applications/components/resource-details/appset-resource-details.tsx
@@ -73,9 +73,14 @@ export const AppSetResourceDetails = (props: AppSetResourceDetailsProps) => {
                                 <SummaryItem title='ANNOTATIONS'>
                                     {Object.keys(appSet.metadata.annotations || {}).length > 0 ? (
                                         <Expandable height={48}>
-                                            {Object.entries(appSet.metadata.annotations || {})
-                                                .map(([k, v]) => `${k}=${v}`)
-                                                .join(' ')}
+                                            <div className='resource-details__annotations'>
+                                                {Object.entries(appSet.metadata.annotations || {}).map(([k, v]) => (
+                                                    <div className='resource-details__annotation' key={k}>
+                                                        <span className='resource-details__annotation-key'>{k}</span>
+                                                        <span className='resource-details__annotation-value'>{v}</span>
+                                                    </div>
+                                                ))}
+                                            </div>
                                         </Expandable>
                                     ) : (
                                         ''

--- a/ui/src/app/applications/components/resource-details/resource-details.scss
+++ b/ui/src/app/applications/components/resource-details/resource-details.scss
@@ -19,6 +19,30 @@
     }
 }
 
+.resource-details {
+    &__annotations {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+    }
+
+    &__annotation {
+        display: flex;
+        flex-wrap: wrap;
+        word-break: break-all;
+
+        &-key {
+            font-weight: 500;
+            margin-right: 4px;
+
+            &::after {
+                content: '=';
+                margin-left: 4px;
+            }
+        }
+    }
+}
+
 .appset-resource-node-preview__synced-icon {
     margin-right: 6px;
     color: $argo-success-color;

--- a/ui/src/app/shared/components/expandable/expandable.test.tsx
+++ b/ui/src/app/shared/components/expandable/expandable.test.tsx
@@ -43,4 +43,42 @@ describe('Expandable', () => {
         expect(container.querySelector('.expandable__handle')?.classList.contains('fa-chevron-up')).toBe(true);
         expect(container.querySelector('.expandable--collapsed')).toBeNull();
     });
+
+    it('detects overflow on mount even when ResizeObserver is unavailable', () => {
+        // jsdom has no ResizeObserver; explicitly assert the non-RO fallback path so the
+        // toggle is driven by the on-mount measurement rather than an observer callback.
+        const original = (global as any).ResizeObserver;
+        (global as any).ResizeObserver = undefined;
+        try {
+            mockScrollHeight(200);
+            const {container} = render(<Expandable height={48}>a lot of content that overflows without a ResizeObserver</Expandable>);
+
+            expect(container.querySelector('.expandable__handle')).not.toBeNull();
+            expect(container.querySelector('.expandable--collapsed')).not.toBeNull();
+        } finally {
+            (global as any).ResizeObserver = original;
+        }
+    });
+
+    it('keeps max-height numeric in both states so the CSS transition can animate', () => {
+        mockScrollHeight(200);
+        const {container} = render(<Expandable height={48}>a lot of content that overflows</Expandable>);
+
+        const root = container.querySelector('.expandable') as HTMLElement;
+        // Collapsed: max-height pinned to the collapsed height.
+        expect(root.style.maxHeight).toBe('48px');
+
+        fireEvent.click(container.querySelector('.expandable a') as HTMLElement);
+        // Expanded: max-height is the measured content height (a concrete number), not
+        // `none`/`auto`, so `transition: max-height` still animates.
+        expect(root.style.maxHeight).toBe('200px');
+    });
+
+    it('does not constrain max-height when content fits within the collapsed height', () => {
+        mockScrollHeight(20);
+        const {container} = render(<Expandable height={48}>short annotation</Expandable>);
+
+        const root = container.querySelector('.expandable') as HTMLElement;
+        expect(root.style.maxHeight).toBe('');
+    });
 });

--- a/ui/src/app/shared/components/expandable/expandable.test.tsx
+++ b/ui/src/app/shared/components/expandable/expandable.test.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import {render, fireEvent, cleanup} from '@testing-library/react';
+import {Expandable} from './expandable';
+
+// jsdom does not perform layout, so scrollHeight is always 0. Mock it to simulate
+// content that either fits within, or overflows, the collapsed height.
+function mockScrollHeight(value: number) {
+    return jest.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockReturnValue(value);
+}
+
+afterEach(() => {
+    jest.restoreAllMocks();
+    cleanup();
+});
+
+describe('Expandable', () => {
+    it('does not render the expand toggle when content fits within the collapsed height', () => {
+        mockScrollHeight(20);
+        const {container} = render(<Expandable height={48}>short annotation</Expandable>);
+
+        expect(container.querySelector('.expandable__handle')).toBeNull();
+        expect(container.querySelector('.expandable--collapsed')).toBeNull();
+    });
+
+    it('renders the expand toggle when content overflows the collapsed height', () => {
+        mockScrollHeight(200);
+        const {container} = render(<Expandable height={48}>a lot of content that overflows</Expandable>);
+
+        const handle = container.querySelector('.expandable__handle');
+        expect(handle).not.toBeNull();
+        // collapsed by default -> chevron points down
+        expect(handle?.classList.contains('fa-chevron-down')).toBe(true);
+        expect(container.querySelector('.expandable--collapsed')).not.toBeNull();
+    });
+
+    it('toggles the expanded state when the handle is clicked', () => {
+        mockScrollHeight(200);
+        const {container} = render(<Expandable height={48}>a lot of content that overflows</Expandable>);
+
+        const toggle = container.querySelector('.expandable a') as HTMLElement;
+        fireEvent.click(toggle);
+
+        expect(container.querySelector('.expandable__handle')?.classList.contains('fa-chevron-up')).toBe(true);
+        expect(container.querySelector('.expandable--collapsed')).toBeNull();
+    });
+});

--- a/ui/src/app/shared/components/expandable/expandable.tsx
+++ b/ui/src/app/shared/components/expandable/expandable.tsx
@@ -26,12 +26,26 @@ export const Expandable = (props: Props) => {
 
         // Re-measure when the content resizes (e.g. async data loads or the window resizes)
         // so the toggle appears/disappears as the actual overflow changes.
-        let observer: ResizeObserver | undefined;
+        const cleanups: Array<() => void> = [];
         if (typeof ResizeObserver !== 'undefined' && contentEl.current) {
-            observer = new ResizeObserver(() => measure());
+            const observer = new ResizeObserver(() => measure());
             observer.observe(contentEl.current);
+            cleanups.push(() => observer.disconnect());
+        } else {
+            // Fallback for environments without ResizeObserver: watch DOM mutations
+            // (async content changes) and window resizes (wrap-driven height changes)
+            // so overflow detection stays accurate beyond the initial measurement.
+            if (typeof MutationObserver !== 'undefined' && contentEl.current) {
+                const mutationObserver = new MutationObserver(() => measure());
+                mutationObserver.observe(contentEl.current, {childList: true, subtree: true, characterData: true});
+                cleanups.push(() => mutationObserver.disconnect());
+            }
+            if (typeof window !== 'undefined') {
+                window.addEventListener('resize', measure);
+                cleanups.push(() => window.removeEventListener('resize', measure));
+            }
         }
-        return () => observer?.disconnect();
+        return () => cleanups.forEach(cleanup => cleanup());
     }, [props.children]);
 
     // Only offer the expand/collapse toggle when the content actually overflows the
@@ -40,9 +54,13 @@ export const Expandable = (props: Props) => {
     const overflowing = contentHeight > collapsedHeight;
     const collapsed = overflowing && !expanded;
 
+    // Drive the `transition: max-height` in expandable.scss by keeping max-height a
+    // concrete number in both states while overflowing: collapse to the fixed height,
+    // expand to the measured content height. CSS cannot animate to/from `none`, so the
+    // expanded state must use an explicit height rather than leaving max-height unset.
     const style: React.CSSProperties = {};
-    if (collapsed) {
-        style.maxHeight = collapsedHeight;
+    if (overflowing) {
+        style.maxHeight = collapsed ? collapsedHeight : contentHeight;
     }
 
     return (

--- a/ui/src/app/shared/components/expandable/expandable.tsx
+++ b/ui/src/app/shared/components/expandable/expandable.tsx
@@ -9,29 +9,50 @@ export interface Props {
 }
 
 export const Expandable = (props: Props) => {
+    const collapsedHeight = props.height || 100;
     const [expanded, setExpanded] = React.useState(false);
     const [contentHeight, setContentHeight] = React.useState(0);
     const contentEl = React.useRef<HTMLDivElement>(null);
 
     React.useLayoutEffect(() => {
-        if (expanded && contentEl.current) {
-            setContentHeight(contentEl.current.clientHeight);
+        const measure = () => {
+            if (contentEl.current) {
+                // The inner element is never height-constrained, so scrollHeight is the
+                // full natural height of the content regardless of the collapsed state.
+                setContentHeight(contentEl.current.scrollHeight);
+            }
+        };
+        measure();
+
+        // Re-measure when the content resizes (e.g. async data loads or the window resizes)
+        // so the toggle appears/disappears as the actual overflow changes.
+        let observer: ResizeObserver | undefined;
+        if (typeof ResizeObserver !== 'undefined' && contentEl.current) {
+            observer = new ResizeObserver(() => measure());
+            observer.observe(contentEl.current);
         }
-    }, [expanded]);
+        return () => observer?.disconnect();
+    }, [props.children]);
+
+    // Only offer the expand/collapse toggle when the content actually overflows the
+    // collapsed height. A single short value (e.g. one short annotation) renders in full
+    // with no near-invisible toggle. See https://github.com/argoproj/argo-cd/issues/29315.
+    const overflowing = contentHeight > collapsedHeight;
+    const collapsed = overflowing && !expanded;
 
     const style: React.CSSProperties = {};
-    if (!expanded) {
-        style.maxHeight = props.height || 100;
-    } else {
-        style.maxHeight = contentHeight || 10000;
+    if (collapsed) {
+        style.maxHeight = collapsedHeight;
     }
 
     return (
-        <div style={style} className={classNames('expandable', {'expandable--collapsed': !expanded})}>
+        <div style={style} className={classNames('expandable', {'expandable--collapsed': collapsed})}>
             <div ref={contentEl}>{props.children}</div>
-            <a onClick={() => setExpanded(!expanded)}>
-                <i className={classNames('expandable__handle fa', {'fa-chevron-down': !expanded, 'fa-chevron-up': expanded})} />
-            </a>
+            {overflowing && (
+                <a onClick={() => setExpanded(!expanded)}>
+                    <i className={classNames('expandable__handle fa', {'fa-chevron-down': !expanded, 'fa-chevron-up': expanded})} />
+                </a>
+            )}
         </div>
     );
 };


### PR DESCRIPTION
Fixes #29315
Fixes #29316

## What changed

Two related annotations-rendering fixes in the resource / application detail views.

### #29315 — near-invisible expand toggle for a single short annotation

The shared `Expandable` component (`ui/src/app/shared/components/expandable/expandable.tsx`) always rendered its chevron toggle, even when the content already fit within the collapsed height. For a single short annotation this produced a tiny, near-invisible up/down chevron that toggled nothing useful.

It now measures the actual content height (via `scrollHeight`, kept in sync with a `ResizeObserver` for async/resize cases) and only renders the expand/collapse affordance — and the fade gradient — when the content genuinely overflows the collapsed height. A short value renders in full with no toggle. This also benefits the other `Expandable` consumers (application parameters, application summary).

### #29316 — annotations rendered as a run-on string

Annotations were rendered with `Object.entries(...).map(([k,v]) => `${k}=${v}`).join(' ')`, concatenating every annotation into one unreadable run-on string. They are now rendered as individual `key=value` records, one per line, with long values wrapping. Applied in both:
- `resource-details/appset-resource-details.tsx`
- `application-summary/application-summary.tsx`

## Testing

- Added unit tests (`expandable.test.tsx`) covering: no toggle when content fits, toggle shown when content overflows, and expand/collapse on click.
- `pnpm exec jest src/app/shared/components/expandable` → 3 passed
- `pnpm exec jest .../application-summary .../resource-details` → 6 passed (no regressions)
- `pnpm exec tsc --noEmit --project ./src/app` → clean
- `pnpm exec eslint` on changed files → 0 errors

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).
