### PR TITLE
fix: CMP tar should only pack annotation paths when use-manifest-generate-paths is enabled

### DIFF
--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -2371,10 +2371,12 @@ func runConfigManagementPluginSidecars(ctx context.Context, appPath, repoPath, p
 	defer utilio.Close(conn)
 
 	rootPath := repoPath
+	var includeRels []string
 	if useManifestGeneratePaths {
-		// Transmit the files under the common root path for all paths related to the manifest generate paths annotation.
+		// Transmit files under the common root, further filtered to annotation paths.
 		rootPath = getApplicationRootPath(q, appPath, repoPath)
-		log.Debugf("common root path calculated for application %s: %s", q.AppName, rootPath)
+		includeRels = getManifestGenerateIncludeRels(q, appPath, rootPath, repoPath)
+		log.Debugf("common root path calculated for application %s: %s (includes=%v)", q.AppName, rootPath, includeRels)
 	}
 
 	pluginConfigResponse, err := cmpClient.CheckPluginConfiguration(ctx, &emptypb.Empty{})
@@ -2394,7 +2396,7 @@ func runConfigManagementPluginSidecars(ctx context.Context, appPath, repoPath, p
 	}
 
 	// generate manifests using commands provided in plugin config file in detected cmp-server sidecar
-	cmpManifests, err := generateManifestsCMP(ctx, appPath, rootPath, env, cmpClient, tarDoneCh, tarExcludedGlobs)
+	cmpManifests, err := generateManifestsCMP(ctx, appPath, rootPath, env, cmpClient, tarDoneCh, tarExcludedGlobs, includeRels)
 	if err != nil {
 		return nil, fmt.Errorf("error generating manifests in cmp: %w", err)
 	}
@@ -2417,7 +2419,7 @@ func runConfigManagementPluginSidecars(ctx context.Context, appPath, repoPath, p
 // generateManifestsCMP will send the appPath files to the cmp-server over a gRPC stream.
 // The cmp-server will generate the manifests. Returns a response object with the generated
 // manifests.
-func generateManifestsCMP(ctx context.Context, appPath, rootPath string, env []string, cmpClient pluginclient.ConfigManagementPluginServiceClient, tarDoneCh chan<- bool, tarExcludedGlobs []string) (*pluginclient.ManifestResponse, error) {
+func generateManifestsCMP(ctx context.Context, appPath, rootPath string, env []string, cmpClient pluginclient.ConfigManagementPluginServiceClient, tarDoneCh chan<- bool, tarExcludedGlobs []string, includeRels []string) (*pluginclient.ManifestResponse, error) {
 	ctx, span := tracer.Start(ctx, "repository.generateManifestsCMP")
 	defer span.End()
 
@@ -2427,6 +2429,9 @@ func generateManifestsCMP(ctx context.Context, appPath, rootPath string, env []s
 	}
 	opts := []cmp.SenderOption{
 		cmp.WithTarDoneChan(tarDoneCh),
+	}
+	if len(includeRels) > 0 {
+		opts = append(opts, cmp.WithInclusions(includeRels))
 	}
 
 	// Use the request context (ctx) rather than stream.Context() to avoid prematurely sending into a stream whose

--- a/reposerver/repository/utils.go
+++ b/reposerver/repository/utils.go
@@ -83,3 +83,30 @@ func getPaths(q *apiclient.ManifestRequest, appPath, repoPath string) []string {
 	}
 	return paths
 }
+// getManifestGenerateIncludeRels returns paths relative to rootPath that should be
+// packed into the CMP tar when use-manifest-generate-paths is enabled.
+// Returns nil when the annotation is empty (no extra filtering beyond rootPath).
+func getManifestGenerateIncludeRels(q *apiclient.ManifestRequest, appPath, rootPath, repoPath string) []string {
+	paths := getPaths(q, appPath, repoPath)
+	if len(paths) == 0 {
+		return nil
+	}
+
+	// Always include the application path so the plugin working directory exists.
+	candidates := append([]string{appPath}, paths...)
+	seen := map[string]struct{}{}
+	var rels []string
+	for _, p := range candidates {
+		rel, err := files.RelativePath(p, rootPath)
+		if err != nil {
+			log.Errorf("error building include relative path for %q under %q: %v", p, rootPath, err)
+			continue
+		}
+		if _, ok := seen[rel]; ok {
+			continue
+		}
+		seen[rel] = struct{}{}
+		rels = append(rels, rel)
+	}
+	return rels
+}

--- a/util/cmp/stream.go
+++ b/util/cmp/stream.go
@@ -78,6 +78,7 @@ type SenderOption func(*senderOption)
 type senderOption struct {
 	chunkSize   int
 	tarDoneChan chan<- bool
+	inclusions  []string
 }
 
 func newSenderOption(opts ...SenderOption) *senderOption {
@@ -93,6 +94,14 @@ func newSenderOption(opts ...SenderOption) *senderOption {
 func WithTarDoneChan(ch chan<- bool) SenderOption {
 	return func(opt *senderOption) {
 		opt.tarDoneChan = ch
+	}
+}
+
+// WithInclusions limits the CMP tar to the given paths relative to rootPath.
+// Directory paths include all files beneath them; file paths include only that file.
+func WithInclusions(inclusions []string) SenderOption {
+	return func(opt *senderOption) {
+		opt.inclusions = inclusions
 	}
 }
 
@@ -131,8 +140,12 @@ func SendRepoStream(ctx context.Context, appPath, rootPath string, sender Stream
 }
 
 func GetCompressedRepoAndMetadata(rootPath string, appPath string, env []string, excludedGlobs []string, opt *senderOption) (*os.File, *pluginclient.AppStreamRequest, error) {
-	// compress all files in rootPath in tgz
-	tgz, filesWritten, checksum, err := tgzstream.CompressFiles(rootPath, nil, excludedGlobs)
+	var inclusions []string
+	if opt != nil {
+		inclusions = opt.inclusions
+	}
+	// compress files in rootPath in tgz (optionally filtered by inclusions)
+	tgz, filesWritten, checksum, err := tgzstream.CompressFiles(rootPath, inclusions, excludedGlobs)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error compressing repo files: %w", err)
 	}

--- a/util/io/files/tar.go
+++ b/util/io/files/tar.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -184,6 +185,58 @@ func untar(dstPath string, r io.Reader, preserveFileMode bool) error {
 	return nil
 }
 
+// pathMatchesInclusion reports whether relativePath is selected by pattern.
+// Patterns are matched against the path relative to the tar root (not basename):
+// exact match, directory prefix, or filepath.Match glob.
+func pathMatchesInclusion(relativePath, pattern string) bool {
+	if pattern == "" || pattern == "." {
+		return true
+	}
+	if relativePath == pattern {
+		return true
+	}
+	sep := string(filepath.Separator)
+	if strings.HasPrefix(relativePath, pattern+sep) {
+		return true
+	}
+	if matched, err := filepath.Match(pattern, relativePath); err == nil && matched {
+		return true
+	}
+	return false
+}
+
+// dirMayContainInclusion returns false when no inclusion can exist under dirRel,
+// allowing the walk to SkipDir and avoid scanning unrelated trees (e.g. monorepo bulk dirs).
+func dirMayContainInclusion(dirRel string, inclusions []string) bool {
+	if dirRel == "." || len(inclusions) == 0 {
+		return true
+	}
+	sep := string(filepath.Separator)
+	for _, pattern := range inclusions {
+		if pattern == "" || pattern == "." {
+			return true
+		}
+		if strings.ContainsAny(pattern, "*?[") {
+			// Globs are hard to prune precisely; only skip when the literal directory
+			// prefix before the first meta character cannot match this dir.
+			metaIdx := strings.IndexAny(pattern, "*?[")
+			literal := pattern
+			if metaIdx >= 0 {
+				literal = pattern[:metaIdx]
+				literal = strings.TrimSuffix(literal, sep)
+			}
+			if literal == "" || dirRel == literal || strings.HasPrefix(dirRel, literal+sep) || strings.HasPrefix(literal, dirRel+sep) {
+				return true
+			}
+			continue
+		}
+		if dirRel == pattern || strings.HasPrefix(pattern, dirRel+sep) || strings.HasPrefix(dirRel, pattern+sep) {
+			return true
+		}
+	}
+	return false
+}
+
 // tgzFile is used as a filepath.WalkFunc implementing the logic to write
 // the given file in the tgz.tarWriter applying the exclusion pattern defined
 // in tgz.exclusions, or the inclusion pattern defined in tgz.inclusions.
@@ -193,27 +246,27 @@ func (t *tgz) tgzFile(path string, fi os.FileInfo, err error) error {
 		return fmt.Errorf("error walking in %q: %w", t.srcPath, err)
 	}
 
-	base := filepath.Base(path)
-
 	relativePath, err := RelativePath(path, t.srcPath)
 	if err != nil {
 		return fmt.Errorf("relative path error: %w", err)
 	}
 
-	if t.inclusions != nil && base != "." && !fi.IsDir() {
-		included := false
-		for _, inclusionPattern := range t.inclusions {
-			found, err := filepath.Match(inclusionPattern, base)
-			if err != nil {
-				return fmt.Errorf("error verifying inclusion pattern %q: %w", inclusionPattern, err)
+	if t.inclusions != nil && relativePath != "." {
+		if fi.IsDir() {
+			if !dirMayContainInclusion(relativePath, t.inclusions) {
+				return filepath.SkipDir
 			}
-			if found {
-				included = true
-				break
+		} else {
+			included := false
+			for _, inclusionPattern := range t.inclusions {
+				if pathMatchesInclusion(relativePath, inclusionPattern) {
+					included = true
+					break
+				}
 			}
-		}
-		if !included {
-			return nil
+			if !included {
+				return nil
+			}
 		}
 	}
 	if t.exclusions != nil {


### PR DESCRIPTION
### Bug

With `--plugin-use-manifest-generate-paths` enabled, the repo-server still packs the **entire common-root directory** of `argocd.argoproj.io/manifest-generate-paths` and streams it to the CMP sidecar, instead of sending only the annotation paths. In large monorepos this causes tar/gRPC/untar overhead proportional to the entire common-root tree, leading to `GenerateManifest` timeouts (~250× latency increase shown in reporter benchmarks).

### Fix

1. **`util/io/files/tar.go`**: Replace basename-based `inclusions` matching with path-based matching (`pathMatchesInclusion` / `dirMayContainInclusion`) so annotations like `.;../../infra` only include the paths specified, and `SkipDir` prunes unrelated trees.
2. **`util/cmp/stream.go`**: Add `WithInclusions` option to `SenderOption`; pass it to `CompressFiles` instead of `nil`.
3. **`reposerver/repository/utils.go`**: Add `getManifestGenerateIncludeRels` to compute relative inclusion paths from annotation.
4. **`reposerver/repository/repository.go`**: Wire `includeRels` from `runConfigManagementPluginSidecars` through `generateManifestsCMP` to the CMP stream.

Fixes #29309