### PR TITLE
fix: prevent New App form update loop (#29097)

### DIFF
--- a/ui/src/app/shared/components/editable-panel/__tests__/editable-panel.test.tsx
+++ b/ui/src/app/shared/components/editable-panel/__tests__/editable-panel.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {render as rtlRender, screen, fireEvent} from '@testing-library/react';
+import {render as rtlRender, screen, fireEvent, waitFor} from '@testing-library/react';
 import {act} from 'react';
 
 // helpTip is imported by editable-panel from applications/components/utils,
@@ -185,13 +185,137 @@ describe('EditablePanel – noReadonlyMode', () => {
             />
         );
 
+        await waitFor(() => expect(capturedFormApi).not.toBeNull());
+        save.mockClear();
+
         // Trigger a value change via the captured FormApi
         await act(async () => {
             capturedFormApi?.setValue('name', 'bob');
         });
 
-        // save() should have been called at least once via formDidUpdate
-        expect(save).toHaveBeenCalled();
+        await waitFor(() => expect(save).toHaveBeenCalledTimes(1));
+        expect(save).toHaveBeenLastCalledWith({name: 'bob'}, {});
+    });
+
+    test('saves a user change once and does not save the parent echo', async () => {
+        const save = jest.fn().mockResolvedValue(undefined);
+        let capturedFormApi: FormApi | null = null;
+        const editItems: EditablePanelItem[] = [
+            {
+                title: 'Name',
+                view: <span />,
+                edit: (api: FormApi) => {
+                    capturedFormApi = api;
+                    return <span data-testid='form-value'>{api.values.name}</span>;
+                }
+            }
+        ];
+
+        const {rerender} = renderPanel(<EditablePanel values={{name: 'alice'}} items={editItems} save={save} noReadonlyMode />);
+
+        await waitFor(() => expect(capturedFormApi).not.toBeNull());
+        save.mockClear();
+
+        await act(async () => {
+            capturedFormApi?.setValue('name', 'bob');
+        });
+
+        await waitFor(() => expect(save).toHaveBeenCalledTimes(1));
+        expect(save).toHaveBeenLastCalledWith({name: 'bob'}, {});
+
+        rerender(
+            <Wrapper>
+                <EditablePanel values={{name: 'bob'}} items={editItems} save={save} noReadonlyMode />
+            </Wrapper>
+        );
+
+        await waitFor(() => expect(screen.getByTestId('form-value')).toHaveTextContent('bob'));
+        expect(save).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not save values synchronized from the parent', async () => {
+        const save = jest.fn().mockResolvedValue(undefined);
+        const editItems: EditablePanelItem[] = [
+            {
+                title: 'Name',
+                view: <span />,
+                edit: (api: FormApi) => <span data-testid='form-value'>{api.values.name}</span>
+            }
+        ];
+
+        const {rerender} = renderPanel(<EditablePanel values={{name: 'v1'}} items={editItems} save={save} noReadonlyMode />);
+
+        await waitFor(() => expect(screen.getByTestId('form-value')).toHaveTextContent('v1'));
+        save.mockClear();
+
+        rerender(
+            <Wrapper>
+                <EditablePanel values={{name: 'v2'}} items={editItems} save={save} noReadonlyMode />
+            </Wrapper>
+        );
+
+        await waitFor(() => expect(screen.getByTestId('form-value')).toHaveTextContent('v2'));
+        expect(save).not.toHaveBeenCalled();
+    });
+
+    test('does not save touched or error-only form updates', async () => {
+        const save = jest.fn().mockResolvedValue(undefined);
+        let capturedFormApi: FormApi | null = null;
+        const editItems: EditablePanelItem[] = [
+            {
+                title: 'Name',
+                view: <span />,
+                edit: (api: FormApi) => {
+                    capturedFormApi = api;
+                    return <span />;
+                }
+            }
+        ];
+
+        renderPanel(<EditablePanel values={{name: 'alice'}} items={editItems} save={save} noReadonlyMode />);
+
+        await waitFor(() => expect(capturedFormApi).not.toBeNull());
+        save.mockClear();
+
+        await act(async () => {
+            capturedFormApi?.setTouched('name', true);
+        });
+        await act(async () => {
+            capturedFormApi?.setError('name', 'Required');
+        });
+
+        expect(save).not.toHaveBeenCalled();
+    });
+
+    test('saves every distinct user value while earlier saves are pending', async () => {
+        const save = jest.fn().mockImplementation(() => new Promise(() => undefined));
+        let capturedFormApi: FormApi | null = null;
+        const editItems: EditablePanelItem[] = [
+            {
+                title: 'Name',
+                view: <span />,
+                edit: (api: FormApi) => {
+                    capturedFormApi = api;
+                    return <span />;
+                }
+            }
+        ];
+
+        renderPanel(<EditablePanel values={{name: ''}} items={editItems} save={save} noReadonlyMode />);
+
+        await waitFor(() => expect(capturedFormApi).not.toBeNull());
+        save.mockClear();
+
+        await act(async () => {
+            capturedFormApi?.setValue('name', 'a');
+        });
+        await waitFor(() => expect(save).toHaveBeenCalledTimes(1));
+
+        await act(async () => {
+            capturedFormApi?.setValue('name', 'ab');
+        });
+        await waitFor(() => expect(save).toHaveBeenCalledTimes(2));
+        expect(save).toHaveBeenLastCalledWith({name: 'ab'}, {});
     });
 });
 

--- a/ui/src/app/shared/components/editable-panel/__tests__/editable-section.test.tsx
+++ b/ui/src/app/shared/components/editable-panel/__tests__/editable-section.test.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+import {render, screen, waitFor} from '@testing-library/react';
+import {act} from 'react';
+import {FormApi} from 'argo-ui';
+
+jest.mock('../../../../applications/components/utils', () => ({
+    helpTip: (text: string) => React.createElement('span', {title: text}, '?')
+}));
+
+import {EditableSection} from '../editable-section';
+import {EditablePanelItem} from '../editable-panel';
+
+const ctx = {
+    notifications: {
+        show: jest.fn()
+    }
+} as any;
+
+describe('EditableSection – noReadonlyMode', () => {
+    test('saves a user change once and does not save the parent echo', async () => {
+        const save = jest.fn().mockResolvedValue(undefined);
+        let capturedFormApi: FormApi | null = null;
+        const items: EditablePanelItem[] = [
+            {
+                title: 'Path',
+                view: <span />,
+                edit: (api: FormApi) => {
+                    capturedFormApi = api;
+                    return <span data-testid='form-value'>{api.values.path}</span>;
+                }
+            }
+        ];
+
+        const {rerender} = render(
+            <EditableSection uniqueId='source' values={{path: 'apps'}} items={items} save={save} noReadonlyMode ctx={ctx} />
+        );
+
+        await waitFor(() => expect(capturedFormApi).not.toBeNull());
+        save.mockClear();
+
+        await act(async () => {
+            capturedFormApi?.setValue('path', 'apps/demo');
+        });
+
+        await waitFor(() => expect(save).toHaveBeenCalledTimes(1));
+        expect(save).toHaveBeenLastCalledWith({path: 'apps/demo'}, {});
+
+        rerender(<EditableSection uniqueId='source' values={{path: 'apps/demo'}} items={items} save={save} noReadonlyMode ctx={ctx} />);
+
+        await waitFor(() => expect(screen.getByTestId('form-value')).toHaveTextContent('apps/demo'));
+        expect(save).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not save values synchronized from the parent', async () => {
+        const save = jest.fn().mockResolvedValue(undefined);
+        const items: EditablePanelItem[] = [
+            {
+                title: 'Path',
+                view: <span />,
+                edit: (api: FormApi) => <span data-testid='form-value'>{api.values.path}</span>
+            }
+        ];
+
+        const {rerender} = render(<EditableSection uniqueId='source' values={{path: 'v1'}} items={items} save={save} noReadonlyMode ctx={ctx} />);
+
+        await waitFor(() => expect(screen.getByTestId('form-value')).toHaveTextContent('v1'));
+        save.mockClear();
+
+        rerender(<EditableSection uniqueId='source' values={{path: 'v2'}} items={items} save={save} noReadonlyMode ctx={ctx} />);
+
+        await waitFor(() => expect(screen.getByTestId('form-value')).toHaveTextContent('v2'));
+        expect(save).not.toHaveBeenCalled();
+    });
+});

--- a/ui/src/app/shared/components/editable-panel/editable-panel.tsx
+++ b/ui/src/app/shared/components/editable-panel/editable-panel.tsx
@@ -1,11 +1,12 @@
 import {ErrorNotification, HelpIcon, NotificationType} from 'argo-ui';
 import classNames from 'classnames';
 import * as React from 'react';
-import {type ReactNode, useCallback, useContext, useEffect, useRef, useState, Fragment} from 'react';
+import {type ReactNode, useCallback, useContext, useState, Fragment} from 'react';
 import {Form, type FormApi} from 'argo-ui';
 import {helpTip} from '../../../applications/components/utils';
 import {Context} from '../../context';
 import {Spinner} from '../spinner';
+import {useAutoSaveForm} from './use-auto-save-form';
 
 import './editable-panel.scss';
 
@@ -71,8 +72,7 @@ function EditablePanel<T extends {} = {}>({
     const [isCollapsed, setIsCollapsed] = useState<boolean>(collapsedProp);
     const [prevCollapsedProp, setPrevCollapsedProp] = useState<boolean>(collapsedProp);
     const ctx = useContext(Context);
-    const formApiRef = useRef<FormApi | null>(null);
-    const initialValuesRef = useRef<T>(values);
+    const {formApiRef, onFormDidUpdate} = useAutoSaveForm(values, noReadonlyMode, save);
 
     // Sync the collapsed state when the controlling prop changes, adjusting
     // during render instead of in an effect to avoid a cascading re-render.
@@ -80,20 +80,6 @@ function EditablePanel<T extends {} = {}>({
         setPrevCollapsedProp(collapsedProp);
         setIsCollapsed(collapsedProp);
     }
-
-    useEffect(() => {
-        const initialValuesString = JSON.stringify(initialValuesRef.current);
-        const valuesString = JSON.stringify(values);
-
-        if (formApiRef.current && initialValuesString !== valuesString) {
-            if (noReadonlyMode) {
-                formApiRef.current.setAllValues(values);
-            }
-            initialValuesRef.current = values;
-        } else if (initialValuesString !== valuesString) {
-            initialValuesRef.current = values;
-        }
-    }, [values, noReadonlyMode]);
 
     const onModeSwitch = useCallback(() => {
         if (onModeSwitchProp) {
@@ -231,11 +217,7 @@ function EditablePanel<T extends {} = {}>({
                         ) : (
                             <Form
                                 getApi={api => (formApiRef.current = api)}
-                                formDidUpdate={async form => {
-                                    if (noReadonlyMode && save) {
-                                        await save(form.values as any, {});
-                                    }
-                                }}
+                                formDidUpdate={onFormDidUpdate}
                                 onSubmit={handleSubmit}
                                 defaultValues={values}
                                 validateError={validate}>

--- a/ui/src/app/shared/components/editable-panel/editable-section.tsx
+++ b/ui/src/app/shared/components/editable-panel/editable-section.tsx
@@ -1,12 +1,13 @@
 import {ErrorNotification, NotificationType} from 'argo-ui';
 import * as React from 'react';
-import {useState, useRef, useEffect, Fragment, useCallback} from 'react';
-import type {FormApi, FormState} from 'argo-ui';
+import {useState, Fragment, useCallback} from 'react';
+import type {FormApi} from 'argo-ui';
 import {Form} from 'argo-ui';
 import {ContextApis} from '../../context';
 import {EditablePanelItem} from './editable-panel';
 import {Spinner} from '../spinner';
 import {helpTip} from '../../../applications/components/utils';
+import {useAutoSaveForm} from './use-auto-save-form';
 
 export interface EditableSectionProps<T> {
     title?: string | React.ReactNode;
@@ -50,24 +51,7 @@ function EditableSection<T extends {} = {}>({
 }: EditableSectionProps<T>) {
     const [isEditing, setIsEditing] = useState<boolean>(!!noReadonlyMode);
     const [isSaving, setIsSaving] = useState<boolean>(false);
-    const formApiRef = useRef<FormApi | null>(null);
-    const prevValuesRef = useRef<T>(values);
-
-    useEffect(() => {
-        if (formApiRef.current && JSON.stringify(prevValuesRef.current) !== JSON.stringify(values) && noReadonlyMode) {
-            formApiRef.current.setAllValues(values);
-        }
-        prevValuesRef.current = values;
-    }, [values, noReadonlyMode]);
-
-    const onFormDidUpdate = useCallback(
-        async (form: FormState) => {
-            if (noReadonlyMode && save) {
-                await save(form.values as any, {});
-            }
-        },
-        [noReadonlyMode, save]
-    );
+    const {formApiRef, onFormDidUpdate} = useAutoSaveForm(values, noReadonlyMode, save);
 
     const onFormSubmit = useCallback<<K extends T>(data: K) => Promise<void>>(
         async input => {

--- a/ui/src/app/shared/components/editable-panel/use-auto-save-form.ts
+++ b/ui/src/app/shared/components/editable-panel/use-auto-save-form.ts
@@ -1,0 +1,44 @@
+import {FormApi, FormState} from 'argo-ui';
+import {useCallback, useEffect, useRef} from 'react';
+
+type Save<T> = (input: T, query: {validate?: boolean}) => Promise<any>;
+
+function serializeValues(values: unknown): string {
+    return JSON.stringify(values);
+}
+
+export function useAutoSaveForm<T extends {}>(values: T, noReadonlyMode?: boolean, save?: Save<T>) {
+    const formApiRef = useRef<FormApi | null>(null);
+    // Form.formDidUpdate also runs after programmatic value synchronization and
+    // touched/error updates. Track the last inbound or saved value snapshot so
+    // only a new user value is propagated to the parent form.
+    const lastHandledValuesRef = useRef(serializeValues(values));
+
+    useEffect(() => {
+        const valuesString = serializeValues(values);
+        lastHandledValuesRef.current = valuesString;
+
+        if (noReadonlyMode && formApiRef.current && serializeValues(formApiRef.current.values) !== valuesString) {
+            formApiRef.current.setAllValues(values);
+        }
+    }, [values, noReadonlyMode]);
+
+    const onFormDidUpdate = useCallback(
+        async (form: FormState) => {
+            if (!noReadonlyMode || !save) {
+                return;
+            }
+
+            const valuesString = serializeValues(form.values);
+            if (valuesString === lastHandledValuesRef.current) {
+                return;
+            }
+
+            lastHandledValuesRef.current = valuesString;
+            await save(form.values as T, {});
+        },
+        [noReadonlyMode, save]
+    );
+
+    return {formApiRef, onFormDidUpdate};
+}


### PR DESCRIPTION
## Summary

Fixes #29097.

The New App panel renders source-type parameters through `EditablePanel` and `EditableSection` with `noReadonlyMode` enabled. Their `formDidUpdate` callbacks previously called the parent `save` function for every form update, including updates caused by synchronizing new parent values back into the child form. That parent/child echo could become an infinite render loop while editing a multi-source Application.

This change:

- introduces a shared `useAutoSaveForm` hook for both editable components;
- tracks the last inbound or saved value snapshot and ignores programmatic value echoes and touched/error-only updates;
- continues to save each distinct user value, including edits made while an earlier save promise is still pending;
- adds regression coverage for both `EditablePanel` and `EditableSection`.

This PR is intentionally based on current `master` and does not contain the multi-source creation changes from #28690.

## Testing

- Focused Jest suites: 2 suites, 20 tests passed.
- Full UI test suite: 27 suites, 304 tests, and 32 snapshots passed.
- `make build`
- `make codegen` (no generated changes)
- `make lint`
- `make lint-ui` (0 errors; 11 pre-existing warnings outside this change)
- `make test` (8,270 tests passed; 5 upstream-native skips)
- `make cli`
- Manual browser regression against a production build in a local three-node k3s cluster:
  - added Source 2 in the New App panel;
  - exercised rapid and interval-based Path edits;
  - exercised Path + Ref, ref-only, and repeated source-type unmount/remount transitions;
  - verified the final repository, Path, and Ref values were retained and the form remained responsive;
  - observed no `Maximum update depth exceeded` messages or runtime exceptions.

## Documentation

No documentation update is required. This restores the intended behavior of an existing UI form and does not change the API, CLI, CRDs, or user-facing configuration.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes. This is a bug fix tracked by #29097.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. Not applicable: this fixes existing UI behavior and adds no CLI or API surface.
* [x] Does this PR require documentation updates? No; the existing behavior and configuration are unchanged.
* [x] I've updated documentation as required by this PR. Not applicable for this behavioral bug fix.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal).
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines. Not applicable: this is not a new feature.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md. Not applicable.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity). The affected patch branches may take this isolated UI fix at the maintainers' discretion.

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
