### PR TITLE
fix(notification-controller): deep-copy before mutating object from a shared cache

### DIFF
--- a/notification_controller/controller/controller.go
+++ b/notification_controller/controller/controller.go
@@ -226,6 +226,8 @@ func getAppProj(app *unstructured.Unstructured, appProjInformer cache.SharedInde
 	if !ok {
 		return nil
 	}
+	// Informer cache objects are shared; deep-copy before mutating.
+	proj = proj.DeepCopy()
 	if proj.GetAnnotations() == nil {
 		proj.SetAnnotations(map[string]string{})
 	}

--- a/notification_controller/controller/controller_test.go
+++ b/notification_controller/controller/controller_test.go
@@ -152,6 +152,38 @@ func TestGetAppProj_defaultsToDefaultProject(t *testing.T) {
 	assert.Equal(t, "default", result.GetName())
 }
 
+func TestGetAppProj_doesNotMutateCachedObject(t *testing.T) {
+	// Informer cache objects are shared among goroutines; getAppProj must
+	// return a copy so callers can't mutate the indexed AppProject.
+	proj := &unstructured.Unstructured{}
+	proj.SetGroupVersionKind(v1alpha1.AppProjectSchemaGroupVersionKind)
+	proj.SetName("my-proj")
+	proj.SetNamespace("argocd")
+
+	informer := cache.NewSharedIndexInformer(&cache.ListWatch{}, &unstructured.Unstructured{}, 0,
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	require.NoError(t, informer.GetIndexer().Add(proj))
+
+	app := &unstructured.Unstructured{
+		Object: map[string]any{
+			"metadata": map[string]any{"name": "my-app", "namespace": "argocd"},
+			"spec":     map[string]any{"project": "my-proj"},
+		},
+	}
+
+	result := getAppProj(app, informer, "argocd")
+	require.NotNil(t, result)
+	assert.NotSame(t, proj, result)
+
+	// Mutating the returned object must not leak into the indexed object.
+	result.SetAnnotations(map[string]string{"mutated": "true"})
+
+	cached, ok, err := informer.GetIndexer().GetByKey("argocd/my-proj")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Nil(t, cached.(*unstructured.Unstructured).GetAnnotations(), "indexed AppProject must remain unchanged")
+}
+
 func TestInit(t *testing.T) {
 	scheme := runtime.NewScheme()
 	err := v1alpha1.SchemeBuilder.AddToScheme(scheme)


### PR DESCRIPTION
Follow up on #28815

Possible mutation of a shared AppProject object from a shared informer cache.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
