### PR TITLE
feat(resource_customizations): support ignored status for victoriametrics healthcheck

### DIFF
--- a/resource_customizations/operator.victoriametrics.com/_/health.lua
+++ b/resource_customizations/operator.victoriametrics.com/_/health.lua
@@ -1,7 +1,7 @@
 -- Health check for VictoriaMetrics operator CRDs.
 -- Status field reference:
 --   https://github.com/VictoriaMetrics/operator/blob/master/api/operator/v1beta1/vmextra_types.go
--- UpdateStatus values: "expanding", "operational", "failed", "paused".
+-- UpdateStatus values: "expanding", "operational", "failed", "paused", "ignored".
 -- Request: https://github.com/VictoriaMetrics/operator/issues/1181
 
 local hs = { status = "Progressing", message = "Waiting for the operator to reconcile" }
@@ -24,6 +24,10 @@ local reason = obj.status.reason or ""
 if updateStatus == "operational" then
   hs.status = "Healthy"
   hs.message = "All components are operational"
+-- ignored => Healthy
+elseif updateStatus == "ignored" then
+  hs.status = "Healthy"
+  hs.message = "Resource was not picked by any parent object"
 -- expanding => reconciliation in progress
 elseif updateStatus == "expanding" then
   hs.status = "Progressing"

--- a/resource_customizations/operator.victoriametrics.com/_/health_test.yaml
+++ b/resource_customizations/operator.victoriametrics.com/_/health_test.yaml
@@ -4,6 +4,10 @@ tests:
       message: "All components are operational"
     inputPath: testdata/healthy.yaml
   - healthStatus:
+      status: Healthy
+      message: "Resource was not picked by any parent object"
+    inputPath: testdata/ignored.yaml
+  - healthStatus:
       status: Progressing
       message: "Reconciliation in progress"
     inputPath: testdata/progressing.yaml

--- a/resource_customizations/operator.victoriametrics.com/_/testdata/ignored.yaml
+++ b/resource_customizations/operator.victoriametrics.com/_/testdata/ignored.yaml
@@ -1,0 +1,17 @@
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMRule
+metadata:
+  finalizers:
+    - apps.victoriametrics.com/finalizer
+  generation: 1
+  name: example
+  namespace: demo
+spec:
+  groups:
+    - name: example
+      rules:
+        - alert: ExampleAlert
+          expr: vector(1)
+status:
+  observedGeneration: 1
+  updateStatus: ignored


### PR DESCRIPTION
Starting VictoriaMetrics operator 0.74.0 it supports additional `Ignored` status. Adding it's support to ArgoCD customizations