### PR TITLE
fix: fall back to normal diff when ServerSideDiff fails on Force/Replace annotated resources

### DIFF
--- a/gitops-engine/pkg/diff/diff.go
+++ b/gitops-engine/pkg/diff/diff.go
@@ -141,6 +141,21 @@ func ServerSideDiff(ctx context.Context, config, live *unstructured.Unstructured
 	if live != nil && config != nil {
 		result, err := serverSideDiff(ctx, config, live, opts...)
 		if err != nil {
+			// When a resource is annotated with Force=true,Replace=true sync-options
+			// (e.g., a Job with an immutable spec.template field), the server-side
+			// dry-run apply fails with an error like "field is immutable". Fall back
+			// to the regular diff instead of failing the comparison, since the resource
+			// will be recreated on sync anyway.
+			syncOptAnnotation := "argocd.argoproj.io/sync-options"
+			if resource.HasAnnotationOption(config, syncOptAnnotation, "Force=true") &&
+				resource.HasAnnotationOption(config, syncOptAnnotation, "Replace=true") {
+				fallbackOpts := make([]Option, 0, len(opts)+1)
+				fallbackOpts = append(fallbackOpts, opts...)
+				fallbackOpts = append(fallbackOpts, func(o *options) {
+					o.serverSideDiff = false
+				})
+				return Diff(ctx, config, live, fallbackOpts...)
+			}
 			return nil, fmt.Errorf("serverSideDiff error: %w", err)
 		}
 		return result, nil

--- a/gitops-engine/pkg/diff/diff_test.go
+++ b/gitops-engine/pkg/diff/diff_test.go
@@ -1333,6 +1333,63 @@ func TestServerSideDiff(t *testing.T) {
 		assert.NotContains(t, string(result.NormalizedLive), annotationOnlySecret,
 			"NormalizedLive must not contain secret values embedded only in last-applied-configuration")
 	})
+	t.Run("will fall back to normal diff when dry-run fails on immutable field with ForceReplace", func(t *testing.T) {
+		t.Parallel()
+
+		dryRunner := mocks.NewServerSideDryRunner(t)
+		dryRunner.EXPECT().Run(mock.Anything, mock.AnythingOfType("*unstructured.Unstructured"), "argocd-controller").
+			Return("", fmt.Errorf("Job.batch \"test-job\" is invalid: spec.template: field is immutable"))
+
+		gvkParser := buildGVKParser(t)
+		manager := "argocd-controller"
+
+		config := StrToUnstructured(`
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: test-job
+  annotations:
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
+spec:
+  template:
+    spec:
+      containers:
+      - name: test
+        image: test:v2
+      restartPolicy: Never
+  backoffLimit: 4
+`)
+
+		live := StrToUnstructured(`
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: test-job
+spec:
+  template:
+    spec:
+      containers:
+      - name: test
+        image: test:v1
+      restartPolicy: Never
+  backoffLimit: 4
+`)
+
+		opts := []Option{
+			WithGVKParser(gvkParser),
+			WithManager(manager),
+			WithServerSideDryRunner(dryRunner),
+		}
+
+		// when
+		result, err := ServerSideDiff(t.Context(), config, live, opts...)
+
+		// then
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.True(t, result.Modified)
+	})
+
 }
 
 // mustMarshalUnstructured marshals an unstructured object to a JSON string, failing the test on error.


### PR DESCRIPTION
Fixes #29348

When a resource is annotated with `argocd.argoproj.io/sync-options: Force=true,Replace=true` (e.g., a Job with an immutable `spec.template` field), the server-side dry-run apply fails with `"field is immutable"`, causing a `ComparisonError`. This prevents the sync from proceeding.

This fix checks if the resource has `Force=true,Replace=true` sync-options before returning the error. If both conditions are met, it falls back to the regular (non-server-side) diff, which correctly handles the comparison. The resource will be recreated during sync anyway, so the server-side diff is not needed.

**Changes:**
- `gitops-engine/pkg/diff/diff.go`: In `ServerSideDiff()`, when `serverSideDiff()` fails, check for `Force=true,Replace=true` sync-options and fall back to normal diff.

**Testing:**
- Manual verification: the fix follows the existing pattern where `Diff()` has fallback logic (ThreeWayDiff → TwoWayDiff).