### PR TITLE
feat: wire application-controller through configbus

### DIFF
--- a/cmd/argocd-application-controller/commands/argocd_application_controller.go
+++ b/cmd/argocd-application-controller/commands/argocd_application_controller.go
@@ -32,6 +32,7 @@ import (
 	cacheutil "github.com/argoproj/argo-cd/v3/util/cache"
 	appstatecache "github.com/argoproj/argo-cd/v3/util/cache/appstate"
 	"github.com/argoproj/argo-cd/v3/util/cli"
+	"github.com/argoproj/argo-cd/v3/util/configbus"
 	"github.com/argoproj/argo-cd/v3/util/env"
 	"github.com/argoproj/argo-cd/v3/util/errors"
 	kubeutil "github.com/argoproj/argo-cd/v3/util/kube"
@@ -137,6 +138,7 @@ func NewCommand() *cobra.Command {
 
 			kubeClient := kubernetes.NewForConfigOrDie(config)
 			appClient := appclientset.NewForConfigOrDie(config)
+			crdSource := configbus.NewOptionalInformerCRDSource(ctx, appClient, namespace)
 
 			hardResyncDuration := time.Duration(appHardResyncPeriod) * time.Second
 
@@ -193,6 +195,7 @@ func NewCommand() *cobra.Command {
 			appController, err = controller.NewApplicationController(
 				namespace,
 				settingsMgr,
+				crdSource,
 				kubeClient,
 				appClient,
 				repoClientset,

--- a/cmd/argocd/commands/admin/app.go
+++ b/cmd/argocd/commands/admin/app.go
@@ -41,6 +41,7 @@ import (
 	appstatecache "github.com/argoproj/argo-cd/v3/util/cache/appstate"
 	"github.com/argoproj/argo-cd/v3/util/cli"
 	"github.com/argoproj/argo-cd/v3/util/config"
+	"github.com/argoproj/argo-cd/v3/util/configbus"
 	"github.com/argoproj/argo-cd/v3/util/db"
 	"github.com/argoproj/argo-cd/v3/util/errors"
 	utilio "github.com/argoproj/argo-cd/v3/util/io"
@@ -365,11 +366,30 @@ func reconcileApplications(
 	namespace string,
 	repoServerClient reposerverclient.Clientset,
 	selector string,
-	createLiveStateCache func(argoDB db.ArgoDB, appInformer kubecache.SharedIndexInformer, settingsMgr *settings.SettingsManager, server *metrics.MetricsServer) cache.LiveStateCache,
+	createLiveStateCache func(argoDB db.ArgoDB, appInformer kubecache.SharedIndexInformer, namespace string, configProvider configbus.Provider, server *metrics.MetricsServer) cache.LiveStateCache,
 	serverSideDiff bool,
 	ignoreNormalizerOpts normalizers.IgnoreNormalizerOpts,
 ) ([]appReconcileResult, error) {
 	settingsMgr := settings.NewSettingsManager(ctx, kubeClientset, namespace)
+	// CLI flags override Diff-related settings via a leading StaticProvider.
+	// Temporary: once config is fully CRD-backed these admin flags go away.
+	// Trailing Static mirrors the former admin NewAppStateManager literals
+	// (persistResourceHealth=false, statusRefreshTimeout=1s, repoErrorGracePeriod=0)
+	// so reconcile behavior matches pre-configbus admin.
+	configProvider := configbus.NewChainProvider(
+		&configbus.StaticProvider{Fields: configbus.StaticFields{
+			IgnoreNormalizerJQTimeout: configbus.Ptr(ignoreNormalizerOpts.JQExecutionTimeout),
+			ServerSideDiff:            configbus.Ptr(serverSideDiff),
+		}},
+		configbus.NewCRDProvider(nil),
+		configbus.NewSettingsManagerProvider(settingsMgr),
+		configbus.NewEnvProvider(),
+		&configbus.StaticProvider{Fields: configbus.StaticFields{
+			PersistResourceHealth: configbus.Ptr(false),
+			ReconciliationTimeout: configbus.Ptr(time.Second),
+			RepoErrorGracePeriod:  configbus.Ptr(time.Duration(0)),
+		}},
+	)
 	argoDB := db.NewDB(namespace, settingsMgr, kubeClientset)
 	appInformerFactory := appinformers.NewSharedInformerFactoryWithOptions(
 		appClientset,
@@ -396,7 +416,7 @@ func reconcileApplications(
 	if err != nil {
 		return nil, fmt.Errorf("error starting new metrics server: %w", err)
 	}
-	stateCache := createLiveStateCache(argoDB, appInformer, settingsMgr, server)
+	stateCache := createLiveStateCache(argoDB, appInformer, namespace, configProvider, server)
 	if err := stateCache.Init(); err != nil {
 		return nil, fmt.Errorf("error initializing state cache: %w", err)
 	}
@@ -415,16 +435,11 @@ func reconcileApplications(
 		func(_ string) (kube.CleanupFunc, error) {
 			return func() {}, nil
 		},
-		settingsMgr,
+		configProvider,
 		stateCache,
 		server,
 		cache,
-		time.Second,
 		argo.NewResourceTracking(),
-		false,
-		0,
-		serverSideDiff,
-		ignoreNormalizerOpts,
 	)
 
 	appsList, err := appClientset.ArgoprojV1alpha1().Applications(namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
@@ -479,6 +494,6 @@ func reconcileApplications(
 	return items, nil
 }
 
-func newLiveStateCache(argoDB db.ArgoDB, appInformer kubecache.SharedIndexInformer, settingsMgr *settings.SettingsManager, server *metrics.MetricsServer) cache.LiveStateCache {
-	return cache.NewLiveStateCache(argoDB, appInformer, settingsMgr, server, func(_ map[string]bool, _ corev1.ObjectReference) {}, &sharding.ClusterSharding{}, argo.NewResourceTracking())
+func newLiveStateCache(argoDB db.ArgoDB, appInformer kubecache.SharedIndexInformer, namespace string, configProvider configbus.Provider, server *metrics.MetricsServer) cache.LiveStateCache {
+	return cache.NewLiveStateCache(argoDB, appInformer, namespace, configProvider, server, func(_ map[string]bool, _ corev1.ObjectReference) {}, &sharding.ClusterSharding{}, argo.NewResourceTracking())
 }

--- a/cmd/argocd/commands/admin/app_test.go
+++ b/cmd/argocd/commands/admin/app_test.go
@@ -25,8 +25,8 @@ import (
 	"github.com/argoproj/argo-cd/v3/reposerver/apiclient/mocks"
 	"github.com/argoproj/argo-cd/v3/test"
 	"github.com/argoproj/argo-cd/v3/util/argo/normalizers"
+	"github.com/argoproj/argo-cd/v3/util/configbus"
 	"github.com/argoproj/argo-cd/v3/util/db"
-	"github.com/argoproj/argo-cd/v3/util/settings"
 )
 
 func TestGetReconcileResults(t *testing.T) {
@@ -123,7 +123,7 @@ func TestGetReconcileResults_Refresh(t *testing.T) {
 	liveStateCache.EXPECT().IsNamespaced(mock.Anything, mock.Anything).Return(true, nil)
 
 	result, err := reconcileApplications(ctx, kubeClientset, appClientset, "default", repoServerClientset, "",
-		func(_ db.ArgoDB, _ cache.SharedIndexInformer, _ *settings.SettingsManager, _ *metrics.MetricsServer) statecache.LiveStateCache {
+		func(_ db.ArgoDB, _ cache.SharedIndexInformer, _ string, _ configbus.Provider, _ *metrics.MetricsServer) statecache.LiveStateCache {
 			return liveStateCache
 		},
 		false,

--- a/cmd/argocd/commands/admin/settings.go
+++ b/cmd/argocd/commands/admin/settings.go
@@ -1,3 +1,4 @@
+//nolint:staticcheck // SA1019: admin settings CLI intentionally uses SettingsManager; remaining getters deprecate on later layers
 package admin
 
 import (

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -61,6 +61,7 @@ import (
 	"github.com/argoproj/argo-cd/v3/util/argo"
 	argodiff "github.com/argoproj/argo-cd/v3/util/argo/diff"
 	"github.com/argoproj/argo-cd/v3/util/argo/normalizers"
+	"github.com/argoproj/argo-cd/v3/util/configbus"
 	"github.com/argoproj/argo-cd/v3/util/env"
 	"github.com/argoproj/argo-cd/v3/util/stats"
 
@@ -135,23 +136,15 @@ type ApplicationController struct {
 	projInformer                  cache.SharedIndexInformer
 	appStateManager               AppStateManager
 	stateCache                    statecache.LiveStateCache
-	statusRefreshTimeout          time.Duration
-	statusHardRefreshTimeout      time.Duration
-	statusRefreshJitter           time.Duration
-	selfHealTimeout               time.Duration
-	selfHealBackoff               *wait.Backoff
-	syncTimeout                   time.Duration
 	db                            db.ArgoDB
-	settingsMgr                   *settings_util.SettingsManager
+	configProvider                configbus.Provider
 	refreshRequestedApps          map[string]CompareWith
 	refreshRequestedAppsMutex     *sync.Mutex
 	metricsServer                 *metrics.MetricsServer
-	metricsClusterLabels          []string
 	kubectlSemaphore              *semaphore.Weighted
 	clusterSharding               sharding.ClusterShardingCache
 	projByNameCache               sync.Map
 	applicationNamespaces         []string
-	ignoreNormalizerOpts          normalizers.IgnoreNormalizerOpts
 
 	// dynamicClusterDistributionEnabled if disabled deploymentInformer is never initialized
 	dynamicClusterDistributionEnabled bool
@@ -161,6 +154,7 @@ type ApplicationController struct {
 }
 
 // NewApplicationController creates new instance of ApplicationController.
+// The config provider is wired from the controller itself as the legacy source.
 func NewApplicationController(
 	namespace string,
 	settingsMgr *settings_util.SettingsManager,
@@ -212,23 +206,31 @@ func NewApplicationController(
 		appHydrateQueue:                   workqueue.NewTypedRateLimitingQueueWithConfig(ratelimiter.NewCustomAppControllerRateLimiter[string](rateLimiterConfig), workqueue.TypedRateLimitingQueueConfig[string]{Name: "app_hydration_queue"}),
 		hydrationQueue:                    workqueue.NewTypedRateLimitingQueueWithConfig(ratelimiter.NewCustomAppControllerRateLimiter[hydratortypes.HydrationQueueKey](rateLimiterConfig), workqueue.TypedRateLimitingQueueConfig[hydratortypes.HydrationQueueKey]{Name: "manifest_hydration_queue"}),
 		db:                                db,
-		statusRefreshTimeout:              appResyncPeriod,
-		statusHardRefreshTimeout:          appHardResyncPeriod,
-		statusRefreshJitter:               appResyncJitter,
 		refreshRequestedApps:              make(map[string]CompareWith),
 		refreshRequestedAppsMutex:         &sync.Mutex{},
 		auditLogger:                       argo.NewAuditLogger(kubeClientset, namespace, common.CommandApplicationController, enableK8sEvent),
-		settingsMgr:                       settingsMgr,
-		selfHealTimeout:                   selfHealTimeout,
-		selfHealBackoff:                   selfHealBackoff,
-		syncTimeout:                       syncTimeout,
 		clusterSharding:                   clusterSharding,
 		projByNameCache:                   sync.Map{},
 		applicationNamespaces:             applicationNamespaces,
 		dynamicClusterDistributionEnabled: dynamicClusterDistributionEnabled,
-		ignoreNormalizerOpts:              ignoreNormalizerOpts,
-		metricsClusterLabels:              metricsClusterLabels,
 	}
+	ctrl.configProvider = configbus.NewChainProvider(
+		&configbus.StaticProvider{Fields: configbus.StaticFields{
+			HardReconciliationTimeout: configbus.Ptr(appHardResyncPeriod),
+			IgnoreNormalizerJQTimeout: configbus.Ptr(ignoreNormalizerOpts.JQExecutionTimeout),
+			MetricsClusterLabels:      configbus.Ptr(metricsClusterLabels),
+			PersistResourceHealth:     configbus.Ptr(persistResourceHealth),
+			ReconciliationJitter:      configbus.Ptr(appResyncJitter),
+			ReconciliationTimeout:     configbus.Ptr(appResyncPeriod),
+			RepoErrorGracePeriod:      configbus.Ptr(repoErrorGracePeriod),
+			SelfHealRetry:             configbus.Ptr(configbus.SelfHealRetry{Backoff: selfHealBackoff}),
+			SelfHealTimeout:           configbus.Ptr(selfHealTimeout),
+			ServerSideDiff:            configbus.Ptr(serverSideDiff),
+			SyncTimeout:               configbus.Ptr(syncTimeout),
+		}},
+		configbus.NewSettingsManagerProvider(settingsMgr),
+		configbus.NewEnvProvider(),
+	)
 	if hydratorEnabled {
 		ctrl.hydrator = hydrator.NewHydrator(&ctrl, appResyncPeriod, commitClientset, repoClientset, db)
 	}
@@ -236,10 +238,12 @@ func NewApplicationController(
 		ctrl.kubectlSemaphore = semaphore.NewWeighted(kubectlParallelismLimit)
 	}
 	kubectl.SetOnKubectlRun(ctrl.onKubectlRun)
-	appInformer, appLister := ctrl.newApplicationInformerAndLister()
+	appInformer, appLister, err := ctrl.newApplicationInformerAndLister()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create application informer and lister: %w", err)
+	}
 	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
 	projInformer := v1alpha1.NewAppProjectInformer(applicationClientset, namespace, appResyncPeriod, indexers)
-	var err error
 	_, err = projInformer.AddEventHandler(ctrl.appProjectEventHandlerFuncs())
 	if err != nil {
 		return nil, err
@@ -312,8 +316,8 @@ func NewApplicationController(
 			return nil, err
 		}
 	}
-	stateCache := statecache.NewLiveStateCache(db, appInformer, ctrl.settingsMgr, ctrl.metricsServer, ctrl.handleObjectUpdated, clusterSharding, argo.NewResourceTracking())
-	appStateManager := NewAppStateManager(db, applicationClientset, repoClientset, namespace, kubectl, ctrl.onKubectlRun, ctrl.settingsMgr, stateCache, ctrl.metricsServer, argoCache, ctrl.statusRefreshTimeout, argo.NewResourceTracking(), persistResourceHealth, repoErrorGracePeriod, serverSideDiff, ignoreNormalizerOpts)
+	stateCache := statecache.NewLiveStateCache(db, appInformer, ctrl.namespace, ctrl.configProvider, ctrl.metricsServer, ctrl.handleObjectUpdated, clusterSharding, argo.NewResourceTracking())
+	appStateManager := NewAppStateManager(db, applicationClientset, repoClientset, namespace, kubectl, ctrl.onKubectlRun, ctrl.configProvider, stateCache, ctrl.metricsServer, argoCache, argo.NewResourceTracking())
 	ctrl.appInformer = appInformer
 	ctrl.appLister = appLister
 	ctrl.projInformer = projInformer
@@ -387,7 +391,7 @@ func (projCache *appProjCache) GetAppProject(ctx context.Context) (*appv1.AppPro
 	if projCache.appProj != nil {
 		return projCache.appProj, nil
 	}
-	proj, err := argo.GetAppProjectByName(ctx, projCache.name, applisters.NewAppProjectLister(projCache.ctrl.projInformer.GetIndexer()), projCache.ctrl.namespace, projCache.ctrl.settingsMgr, projCache.ctrl.db)
+	proj, err := argo.GetAppProjectByName(ctx, projCache.name, applisters.NewAppProjectLister(projCache.ctrl.projInformer.GetIndexer()), projCache.ctrl.namespace, projCache.ctrl.configProvider, projCache.ctrl.db)
 	if err != nil {
 		return nil, err
 	}
@@ -781,7 +785,10 @@ func (ctrl *ApplicationController) getAppHosts(destCluster *appv1.Cluster, a *ap
 			return resourcesInfo[i].ResourceName < resourcesInfo[j].ResourceName
 		})
 
-		allowedNodeLabels := ctrl.settingsMgr.GetAllowedNodeLabels()
+		allowedNodeLabels, err := ctrl.configProvider.AllowedNodeLabels(context.Background())
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve allowed node labels: %w", err)
+		}
 		nodeLabels := make(map[string]string)
 		for _, label := range allowedNodeLabels {
 			if val, ok := node.Labels[label]; ok {
@@ -813,8 +820,11 @@ func (ctrl *ApplicationController) hideSecretData(ctx context.Context, destClust
 		resDiff := res.Diff
 		if res.Kind == kube.SecretKind && res.Group == "" {
 			var err error
-			hideAnnots := ctrl.settingsMgr.GetSensitiveAnnotations()
-			target, live, err = diff.HideSecretData(res.Target, res.Live, hideAnnots)
+			sensitiveAnnotations, err := ctrl.configProvider.SensitiveAnnotations(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("error getting sensitive annotations: %w", err)
+			}
+			target, live, err = diff.HideSecretData(res.Target, res.Live, sensitiveAnnotations)
 			if err != nil {
 				return nil, fmt.Errorf("error hiding secret data: %w", err)
 			}
@@ -839,7 +849,7 @@ func (ctrl *ApplicationController) hideSecretData(ctx context.Context, destClust
 						return nil, fmt.Errorf("error unmarshaling normalized live for secret masking: %w", err)
 					}
 				}
-				predicted, normalized, err = diff.HideSecretData(predicted, normalized, hideAnnots)
+				predicted, normalized, err = diff.HideSecretData(predicted, normalized, sensitiveAnnotations)
 				if err != nil {
 					return nil, fmt.Errorf("error hiding secret data in diff result: %w", err)
 				}
@@ -857,19 +867,19 @@ func (ctrl *ApplicationController) hideSecretData(ctx context.Context, destClust
 				}
 			}
 			if !useSSDResult {
-				compareOptions, err := ctrl.settingsMgr.GetResourceCompareOptions()
+				compareOptions, err := ctrl.configProvider.ResourceCompareOptions(ctx)
 				if err != nil {
 					return nil, fmt.Errorf("error getting resource compare options: %w", err)
 				}
-				resourceOverrides, err := ctrl.settingsMgr.GetResourceOverrides()
+				resourceOverrides, err := ctrl.configProvider.ResourceOverrides(ctx)
 				if err != nil {
 					return nil, fmt.Errorf("error getting resource overrides: %w", err)
 				}
-				appLabelKey, err := ctrl.settingsMgr.GetAppInstanceLabelKey()
+				appLabelKey, err := ctrl.configProvider.AppInstanceLabelKey(ctx)
 				if err != nil {
 					return nil, fmt.Errorf("error getting app instance label key: %w", err)
 				}
-				trackingMethod, err := ctrl.settingsMgr.GetTrackingMethod()
+				trackingMethod, err := ctrl.configProvider.TrackingMethod(ctx)
 				if err != nil {
 					return nil, fmt.Errorf("error getting tracking method: %w", err)
 				}
@@ -878,8 +888,12 @@ func (ctrl *ApplicationController) hideSecretData(ctx context.Context, destClust
 				if err != nil {
 					return nil, fmt.Errorf("error getting cluster cache: %w", err)
 				}
+				ignoreNormalizerJQTimeout, err := ctrl.configProvider.IgnoreNormalizerJQTimeout(ctx)
+				if err != nil {
+					return nil, fmt.Errorf("failed to resolve ignore normalizer JQ timeout: %w", err)
+				}
 				diffConfig, err := argodiff.NewDiffConfigBuilder().
-					WithDiffSettings(app.Spec.IgnoreDifferences, resourceOverrides, compareOptions.IgnoreAggregatedRoles, ctrl.ignoreNormalizerOpts).
+					WithDiffSettings(app.Spec.IgnoreDifferences, resourceOverrides, compareOptions.IgnoreAggregatedRoles, normalizers.IgnoreNormalizerOpts{JQExecutionTimeout: ignoreNormalizerJQTimeout}).
 					WithTracking(appLabelKey, trackingMethod).
 					WithNoCache().
 					WithLogger(logutils.NewLogrusLogger(logutils.NewWithCurrentConfig())).
@@ -949,7 +963,11 @@ func (ctrl *ApplicationController) Run(ctx context.Context, statusProcessors int
 	defer ctrl.hydrationQueue.ShutDown()
 
 	ctrl.RegisterClusterSecretUpdater(ctx)
-	ctrl.metricsServer.RegisterClustersInfoSource(ctx, ctrl.stateCache, ctrl.db, ctrl.metricsClusterLabels)
+	metricsClusterLabels, err := ctrl.configProvider.MetricsClusterLabels(ctx)
+	if err != nil {
+		log.WithError(err).Fatal("failed to resolve metrics cluster labels")
+	}
+	ctrl.metricsServer.RegisterClustersInfoSource(ctx, ctrl.stateCache, ctrl.db, metricsClusterLabels)
 
 	if ctrl.dynamicClusterDistributionEnabled {
 		// only start deployment informer if dynamic distribution is enabled
@@ -1581,12 +1599,13 @@ func (ctrl *ApplicationController) processRequestedAppOperation(app *appv1.Appli
 		}
 	}()
 
+	syncTimeout, syncTimeoutErr := ctrl.configProvider.SyncTimeout(ctx)
 	requeueAfter := appOperationMaxRequeueInterval
 	defer func() {
 		// Re-enqueue the app onto the operation queue to keep polling the in-progress sync.
 		// Cap the delay by the remaining sync timeout so a timeout is enforced promptly.
-		if ctrl.syncTimeout > 0 && state != nil && state.Phase != synccommon.OperationTerminating {
-			if remaining := time.Until(state.StartedAt.Add(ctrl.syncTimeout)); remaining < requeueAfter {
+		if syncTimeoutErr == nil && syncTimeout > 0 && state != nil && state.Phase != synccommon.OperationTerminating {
+			if remaining := time.Until(state.StartedAt.Add(syncTimeout)); remaining < requeueAfter {
 				requeueAfter = remaining
 			}
 		}
@@ -1599,12 +1618,12 @@ func (ctrl *ApplicationController) processRequestedAppOperation(app *appv1.Appli
 		switch {
 		case state.Phase == synccommon.OperationTerminating:
 			logCtx.Infof("Resuming in-progress operation. phase: %s, message: %s", state.Phase, state.Message)
-		case ctrl.syncTimeout != time.Duration(0) && time.Now().After(state.StartedAt.Add(ctrl.syncTimeout)):
+		case syncTimeoutErr == nil && syncTimeout != time.Duration(0) && time.Now().After(state.StartedAt.Add(syncTimeout)):
 			state.Phase = synccommon.OperationTerminating
 			state.Message = "operation is terminating due to timeout"
 			terminatingCause = "controller sync timeout"
 			ctrl.setOperationState(ctx, app, state)
-			logCtx.Infof("Terminating in-progress operation due to timeout. Started at: %v, timeout: %v", state.StartedAt, ctrl.syncTimeout)
+			logCtx.Infof("Terminating in-progress operation due to timeout. Started at: %v, timeout: %v", state.StartedAt, syncTimeout)
 		case state.Phase == synccommon.OperationRunning && state.FinishedAt != nil:
 			// Failed operation with retry strategy might be in-progress and has completion time
 			retryAt, err := app.Status.OperationState.Operation.Retry.NextRetryAt(state.FinishedAt.Time, state.RetryCount)
@@ -1647,6 +1666,13 @@ func (ctrl *ApplicationController) processRequestedAppOperation(app *appv1.Appli
 		logCtx.Infof("Initialized new operation: %v", *app.Operation)
 	}
 	ts.AddCheckpoint("initial_operation_stage_ms")
+
+	if syncTimeoutErr != nil {
+		state.Phase = synccommon.OperationError
+		state.Message = fmt.Sprintf("failed to resolve SyncTimeout: %v", syncTimeoutErr)
+		ctrl.setOperationState(ctx, app, state)
+		return
+	}
 
 	terminating := state.Phase == synccommon.OperationTerminating
 
@@ -1852,7 +1878,17 @@ func (ctrl *ApplicationController) processAppRefreshQueueItem() (processNext boo
 		return processNext
 	}
 	origApp = origApp.DeepCopy()
-	needRefresh, refreshType, comparisonLevel := ctrl.needRefreshAppStatus(origApp, ctrl.statusRefreshTimeout, ctrl.statusHardRefreshTimeout)
+	refreshTimeout, err := ctrl.configProvider.ReconciliationTimeout(context.Background())
+	if err != nil {
+		log.WithField("appkey", appKey).WithError(err).Error("Failed to resolve reconciliation timeout")
+		return processNext
+	}
+	hardRefreshTimeout, err := ctrl.configProvider.HardReconciliationTimeout(context.Background())
+	if err != nil {
+		log.WithField("appkey", appKey).WithError(err).Error("Failed to resolve hard reconciliation timeout")
+		return processNext
+	}
+	needRefresh, refreshType, comparisonLevel := ctrl.needRefreshAppStatus(origApp, refreshTimeout, hardRefreshTimeout)
 
 	if !needRefresh {
 		return processNext
@@ -2609,8 +2645,16 @@ func (ctrl *ApplicationController) autoSync(ctx context.Context, app *appv1.Appl
 			op.Sync.SelfHealAttemptsCount = app.Status.OperationState.Operation.Sync.SelfHealAttemptsCount
 		}
 
-		if remainingTime := ctrl.selfHealRemainingBackoff(app, int(op.Sync.SelfHealAttemptsCount)); remainingTime > 0 {
-			logCtx.Infof("Skipping auto-sync: already attempted sync to %s with timeout %v (retrying in %v)", lastAttemptedRevisions, ctrl.selfHealTimeout, remainingTime)
+		remainingTime, err := ctrl.selfHealRemainingBackoff(app, int(op.Sync.SelfHealAttemptsCount))
+		if err != nil {
+			return &appv1.ApplicationCondition{Type: appv1.ApplicationConditionSyncError, Message: err.Error()}, 0
+		}
+		if remainingTime > 0 {
+			selfHealTimeout, err := ctrl.configProvider.SelfHealTimeout(ctx)
+			if err != nil {
+				return &appv1.ApplicationCondition{Type: appv1.ApplicationConditionSyncError, Message: err.Error()}, 0
+			}
+			logCtx.Infof("Skipping auto-sync: already attempted sync to %s with timeout %v (retrying in %v)", lastAttemptedRevisions, selfHealTimeout, remainingTime)
 			ctrl.requestAppRefresh(app.QualifiedName(), CompareWithLatest.Pointer(), &remainingTime)
 			return nil, 0
 		}
@@ -2708,9 +2752,9 @@ func alreadyAttemptedSync(app *appv1.Application, desiredRevisions []string, new
 	return reflect.DeepEqual(app.Spec.GetSource(), app.Status.OperationState.SyncResult.Source), []string{app.Status.OperationState.SyncResult.Revision}, app.Status.OperationState.Phase
 }
 
-func (ctrl *ApplicationController) selfHealRemainingBackoff(app *appv1.Application, selfHealAttemptsCount int) time.Duration {
+func (ctrl *ApplicationController) selfHealRemainingBackoff(app *appv1.Application, selfHealAttemptsCount int) (time.Duration, error) {
 	if app.Status.OperationState == nil {
-		return time.Duration(0)
+		return time.Duration(0), nil
 	}
 
 	var timeSinceOperation *time.Duration
@@ -2718,15 +2762,23 @@ func (ctrl *ApplicationController) selfHealRemainingBackoff(app *appv1.Applicati
 		timeSinceOperation = new(time.Since(app.Status.OperationState.FinishedAt.Time))
 	}
 
+	selfHealTimeout, err := ctrl.configProvider.SelfHealTimeout(context.Background())
+	if err != nil {
+		return 0, fmt.Errorf("failed to resolve self heal timeout: %w", err)
+	}
+	selfHealRetry, err := ctrl.configProvider.SelfHealRetry(context.Background())
+	if err != nil {
+		return 0, fmt.Errorf("failed to resolve SelfHealRetry: %w", err)
+	}
 	var retryAfter time.Duration
-	if ctrl.selfHealBackoff == nil {
+	if selfHealRetry.Backoff == nil {
 		if timeSinceOperation == nil {
-			retryAfter = ctrl.selfHealTimeout
+			retryAfter = selfHealTimeout
 		} else {
-			retryAfter = ctrl.selfHealTimeout - *timeSinceOperation
+			retryAfter = selfHealTimeout - *timeSinceOperation
 		}
 	} else {
-		backOff := *ctrl.selfHealBackoff
+		backOff := *selfHealRetry.Backoff
 		backOff.Steps = selfHealAttemptsCount
 		var delay time.Duration
 		steps := backOff.Steps
@@ -2739,7 +2791,7 @@ func (ctrl *ApplicationController) selfHealRemainingBackoff(app *appv1.Applicati
 			retryAfter = delay - *timeSinceOperation
 		}
 	}
-	return retryAfter
+	return retryAfter, nil
 }
 
 // isAppNamespaceAllowed returns whether the application is allowed in the
@@ -2781,16 +2833,23 @@ func (ctrl *ApplicationController) canProcessApp(obj any) bool {
 	return ctrl.clusterSharding.IsManagedCluster(destCluster)
 }
 
-func (ctrl *ApplicationController) newApplicationInformerAndLister() (cache.SharedIndexInformer, applisters.ApplicationLister) {
+func (ctrl *ApplicationController) newApplicationInformerAndLister() (cache.SharedIndexInformer, applisters.ApplicationLister, error) {
 	watchNamespace := ctrl.namespace
 	// If we have at least one additional namespace configured, we need to
 	// watch on them all.
 	if len(ctrl.applicationNamespaces) > 0 {
 		watchNamespace = ""
 	}
-	refreshTimeout := ctrl.statusRefreshTimeout
-	if ctrl.statusHardRefreshTimeout.Seconds() != 0 && (ctrl.statusHardRefreshTimeout < ctrl.statusRefreshTimeout) {
-		refreshTimeout = ctrl.statusHardRefreshTimeout
+	refreshTimeout, err := ctrl.configProvider.ReconciliationTimeout(context.Background())
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to resolve reconciliation timeout: %w", err)
+	}
+	hardRefreshTimeout, err := ctrl.configProvider.HardReconciliationTimeout(context.Background())
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to resolve hard reconciliation timeout: %w", err)
+	}
+	if hardRefreshTimeout.Seconds() != 0 && (hardRefreshTimeout < refreshTimeout) {
+		refreshTimeout = hardRefreshTimeout
 	}
 	informer := cache.NewSharedIndexInformer(
 		&cache.ListWatch{
@@ -2844,11 +2903,11 @@ func (ctrl *ApplicationController) newApplicationInformerAndLister() (cache.Shar
 		},
 	)
 	lister := applisters.NewApplicationLister(informer.GetIndexer())
-	_, err := informer.AddEventHandler(ctrl.applicationEventHandlerFuncs())
+	_, err = informer.AddEventHandler(ctrl.applicationEventHandlerFuncs())
 	if err != nil {
-		return nil, nil
+		return nil, nil, err
 	}
-	return informer, lister
+	return informer, lister, nil
 }
 
 // appProjectEventHandlerFuncs returns the informer event handlers for AppProject
@@ -2930,10 +2989,17 @@ func (ctrl *ApplicationController) applicationEventHandlerFuncs() cache.Resource
 					log.WithFields(applog.GetAppLogFields(newApp)).Info("Enabled automated sync")
 					compareWith = CompareWithLatest.Pointer()
 				}
-				if ctrl.statusRefreshJitter != 0 && oldApp.ResourceVersion == newApp.ResourceVersion {
+				if oldApp.ResourceVersion == newApp.ResourceVersion {
 					// Handler is refreshing the apps, add a random jitter to spread the load and avoid spikes
-					jitter := time.Duration(float64(ctrl.statusRefreshJitter) * rand.Float64())
-					delay = &jitter
+					statusRefreshJitter, err := ctrl.configProvider.ReconciliationJitter(context.Background())
+					if err != nil {
+						log.WithFields(applog.GetAppLogFields(newApp)).WithError(err).Error("Failed to resolve reconciliation jitter")
+						return
+					}
+					if statusRefreshJitter != 0 {
+						jitter := time.Duration(float64(statusRefreshJitter) * rand.Float64())
+						delay = &jitter
+					}
 				}
 			}
 			ctrl.requestAppRefresh(newApp.QualifiedName(), compareWith, delay)
@@ -3056,12 +3122,12 @@ func (ctrl *ApplicationController) getAppList(options metav1.ListOptions) (*appv
 }
 
 func (ctrl *ApplicationController) logAppEvent(ctx context.Context, a *appv1.Application, eventInfo argo.EventInfo, message string) {
-	eventLabels := argo.GetAppEventLabels(ctx, a, applisters.NewAppProjectLister(ctrl.projInformer.GetIndexer()), ctrl.namespace, ctrl.settingsMgr, ctrl.db)
+	eventLabels := argo.GetAppEventLabels(ctx, a, applisters.NewAppProjectLister(ctrl.projInformer.GetIndexer()), ctrl.namespace, ctrl.configProvider, ctrl.db)
 	ctrl.auditLogger.LogAppEvent(a, eventInfo, message, "", eventLabels)
 }
 
 func (ctrl *ApplicationController) applyImpersonationConfig(config *rest.Config, proj *appv1.AppProject, app *appv1.Application, destCluster *appv1.Cluster) error {
-	impersonationEnabled, err := ctrl.settingsMgr.IsImpersonationEnabled()
+	impersonationEnabled, err := ctrl.configProvider.IsImpersonationEnabled(context.Background())
 	if err != nil {
 		return fmt.Errorf("error getting impersonation setting: %w", err)
 	}

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -57,6 +57,8 @@ import (
 	"github.com/argoproj/argo-cd/v3/util/argo/normalizers"
 	cacheutil "github.com/argoproj/argo-cd/v3/util/cache"
 	appstatecache "github.com/argoproj/argo-cd/v3/util/cache/appstate"
+	"github.com/argoproj/argo-cd/v3/util/configbus"
+	configbusmocks "github.com/argoproj/argo-cd/v3/util/configbus/mocks"
 	"github.com/argoproj/argo-cd/v3/util/settings"
 	utilTest "github.com/argoproj/argo-cd/v3/util/test"
 )
@@ -88,6 +90,9 @@ type fakeData struct {
 	// persistResourceHealth controls whether managed resource health is stored
 	// inline on the Application. When nil it defaults to true.
 	persistResourceHealth *bool
+	// configProviderOverride, if set, is chained ahead of the controller's
+	// default provider before informers start (safe under -race).
+	configProviderOverride configbus.Provider
 }
 
 type MockKubectl struct {
@@ -265,6 +270,9 @@ func newFakeControllerWithResync(ctx context.Context, data *fakeData, appResyncP
 	ctrl.clusterSharding = sharding.NewClusterSharding(db, 0, 1, common.DefaultShardingAlgorithm)
 	if err != nil {
 		panic(err)
+	}
+	if data.configProviderOverride != nil {
+		ctrl.configProvider = configbus.NewChainProvider(data.configProviderOverride, ctrl.configProvider)
 	}
 	cancelProj := test.StartInformer(ctrl.projInformer)
 	defer cancelProj()
@@ -3197,14 +3205,18 @@ func TestProcessRequestedAppOperation_SyncTimeout(t *testing.T) {
 					Revision: "HEAD",
 				},
 			}
+			override := configbusmocks.NewProvider(t)
+			override.EXPECT().SyncTimeout(mock.Anything).Return(tc.syncTimeout, nil)
+			override.EXPECT().GlobalProjectsSettings(mock.Anything).Return(nil, configbus.ErrNotConfigured).Maybe()
+			override.EXPECT().IncludeEventLabelKeys(mock.Anything).Return(nil, configbus.ErrNotConfigured).Maybe()
+			override.EXPECT().ExcludeEventLabelKeys(mock.Anything).Return(nil, configbus.ErrNotConfigured).Maybe()
 			ctrl := newFakeController(t.Context(), &fakeData{
 				apps: []runtime.Object{app, &defaultProj},
 				manifestResponses: []*apiclient.ManifestResponse{{
 					Manifests: []string{},
 				}},
+				configProviderOverride: override,
 			}, nil)
-
-			ctrl.syncTimeout = tc.syncTimeout
 			app.Status.OperationState = &v1alpha1.OperationState{
 				Operation: *app.Operation,
 				Phase:     tc.currentPhase,
@@ -3254,13 +3266,19 @@ func TestProcessRequestedAppOperation_RequeuesOperation(t *testing.T) {
 		app.Operation = &v1alpha1.Operation{
 			Sync: &v1alpha1.SyncOperation{Revision: "HEAD"},
 		}
+		syncTimeout := 10 * time.Second
+		override := configbusmocks.NewProvider(t)
+		override.EXPECT().SyncTimeout(mock.Anything).Return(syncTimeout, nil)
+		override.EXPECT().GlobalProjectsSettings(mock.Anything).Return(nil, configbus.ErrNotConfigured).Maybe()
+		override.EXPECT().IncludeEventLabelKeys(mock.Anything).Return(nil, configbus.ErrNotConfigured).Maybe()
+		override.EXPECT().ExcludeEventLabelKeys(mock.Anything).Return(nil, configbus.ErrNotConfigured).Maybe()
 		ctrl := newFakeController(t.Context(), &fakeData{
 			apps: []runtime.Object{app, &defaultProj},
 			manifestResponses: []*apiclient.ManifestResponse{{
 				Manifests: []string{},
 			}},
+			configProviderOverride: override,
 		}, nil)
-		ctrl.syncTimeout = 10 * time.Second
 		app.Status.OperationState = &v1alpha1.OperationState{
 			Operation: *app.Operation,
 			Phase:     synccommon.OperationRunning,
@@ -3274,7 +3292,9 @@ func TestProcessRequestedAppOperation_RequeuesOperation(t *testing.T) {
 		require.Len(t, rq.calls, 1)
 		assert.Equal(t, ctrl.toAppKey(app.QualifiedName()), rq.calls[0].item)
 		assert.Positive(t, rq.calls[0].delay)
-		assert.LessOrEqual(t, rq.calls[0].delay, ctrl.syncTimeout)
+		syncTimeout, err := ctrl.configProvider.SyncTimeout(context.Background())
+		require.NoError(t, err)
+		assert.LessOrEqual(t, rq.calls[0].delay, syncTimeout)
 		assert.Less(t, rq.calls[0].delay, appOperationMaxRequeueInterval)
 	})
 
@@ -4003,12 +4023,17 @@ func assertDurationAround(t *testing.T, expected time.Duration, actual time.Dura
 }
 
 func TestSelfHealRemainingBackoff(t *testing.T) {
-	ctrl := newFakeController(t.Context(), &fakeData{}, nil)
-	ctrl.selfHealBackoff = &wait.Backoff{
+	backoff := &wait.Backoff{
 		Factor:   3,
 		Duration: 2 * time.Second,
 		Cap:      2 * time.Minute,
 	}
+	override := configbusmocks.NewProvider(t)
+	// Unstubbed mock methods panic; return ErrNotConfigured so Chain falls through
+	// to the real provider for getters this test does not override.
+	override.EXPECT().SelfHealTimeout(mock.Anything).Return(time.Duration(0), configbus.ErrNotConfigured)
+	override.EXPECT().SelfHealRetry(mock.Anything).Return(configbus.SelfHealRetry{Backoff: backoff}, nil)
+	ctrl := newFakeController(t.Context(), &fakeData{configProviderOverride: override}, nil)
 	app := &v1alpha1.Application{
 		Status: v1alpha1.ApplicationStatus{
 			OperationState: &v1alpha1.OperationState{
@@ -4075,7 +4100,8 @@ func TestSelfHealRemainingBackoff(t *testing.T) {
 		tc := testCases[i]
 		t.Run(fmt.Sprintf("test case %d", i), func(t *testing.T) {
 			app.Status.OperationState.FinishedAt = tc.finishedAt
-			duration := ctrl.selfHealRemainingBackoff(app, tc.attempts)
+			duration, err := ctrl.selfHealRemainingBackoff(app, tc.attempts)
+			require.NoError(t, err)
 			shouldSelfHeal := duration <= 0
 			require.Equal(t, tc.shouldSelfHeal, shouldSelfHeal)
 			assertDurationAround(t, tc.expectedDuration, duration)

--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -36,6 +36,7 @@ import (
 	appv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v3/util/argo"
 	"github.com/argoproj/argo-cd/v3/util/argo/normalizers"
+	"github.com/argoproj/argo-cd/v3/util/configbus"
 	"github.com/argoproj/argo-cd/v3/util/db"
 	"github.com/argoproj/argo-cd/v3/util/env"
 	logutils "github.com/argoproj/argo-cd/v3/util/log"
@@ -189,7 +190,8 @@ type ResourceInfo struct {
 func NewLiveStateCache(
 	db db.ArgoDB,
 	appInformer cache.SharedIndexInformer,
-	settingsMgr *settings.SettingsManager,
+	namespace string,
+	configProvider configbus.Provider,
 	metricsServer *metrics.MetricsServer,
 	onObjectUpdated ObjectUpdatedHandler,
 	clusterSharding sharding.ClusterShardingCache,
@@ -200,7 +202,8 @@ func NewLiveStateCache(
 		db:               db,
 		clusters:         make(map[string]clustercache.ClusterCache),
 		onObjectUpdated:  onObjectUpdated,
-		settingsMgr:      settingsMgr,
+		namespace:        namespace,
+		configProvider:   configProvider,
 		metricsServer:    metricsServer,
 		clusterSharding:  clusterSharding,
 		resourceTracking: resourceTracking,
@@ -217,17 +220,21 @@ type cacheSettings struct {
 
 	// ignoreResourceUpdates is a flag to enable resource-ignore rules.
 	ignoreResourceUpdatesEnabled bool
+
+	// ignoreNormalizerJQTimeout is resolved once with other cache settings. Not hot-reloaded
+	// independently of loadCacheSettings / invalidate.
+	ignoreNormalizerJQTimeout time.Duration
 }
 
 type liveStateCache struct {
-	db                   db.ArgoDB
-	appInformer          cache.SharedIndexInformer
-	onObjectUpdated      ObjectUpdatedHandler
-	settingsMgr          *settings.SettingsManager
-	metricsServer        *metrics.MetricsServer
-	clusterSharding      sharding.ClusterShardingCache
-	resourceTracking     argo.ResourceTracking
-	ignoreNormalizerOpts normalizers.IgnoreNormalizerOpts
+	db               db.ArgoDB
+	appInformer      cache.SharedIndexInformer
+	onObjectUpdated  ObjectUpdatedHandler
+	namespace        string
+	configProvider   configbus.Provider
+	metricsServer    *metrics.MetricsServer
+	clusterSharding  sharding.ClusterShardingCache
+	resourceTracking argo.ResourceTracking
 
 	clusters      map[string]clustercache.ClusterCache
 	cacheSettings cacheSettings
@@ -235,40 +242,52 @@ type liveStateCache struct {
 }
 
 func (c *liveStateCache) loadCacheSettings() (*cacheSettings, error) {
-	appInstanceLabelKey, err := c.settingsMgr.GetAppInstanceLabelKey()
+	appInstanceLabelKey, err := c.configProvider.AppInstanceLabelKey(context.Background())
 	if err != nil {
 		return nil, err
 	}
-	trackingMethod, err := c.settingsMgr.GetTrackingMethod()
+	trackingMethod, err := c.configProvider.TrackingMethod(context.Background())
 	if err != nil {
 		return nil, err
 	}
-	installationID, err := c.settingsMgr.GetInstallationID()
+	installationID, err := c.configProvider.InstallationID(context.Background())
 	if err != nil {
 		return nil, err
 	}
-	resourceUpdatesOverrides, err := c.settingsMgr.GetIgnoreResourceUpdatesOverrides()
+	resourceUpdatesOverrides, err := c.configProvider.IgnoreResourceUpdatesOverrides(context.Background())
 	if err != nil {
 		return nil, err
 	}
-	ignoreResourceUpdatesEnabled, err := c.settingsMgr.GetIsIgnoreResourceUpdatesEnabled()
+	ignoreResourceUpdatesEnabled, err := c.configProvider.IsIgnoreResourceUpdatesEnabled(context.Background())
 	if err != nil {
 		return nil, err
 	}
-	resourcesFilter, err := c.settingsMgr.GetResourcesFilter()
+	resourcesFilter, err := c.configProvider.ResourcesFilter(context.Background())
 	if err != nil {
 		return nil, err
 	}
-	resourceOverrides, err := c.settingsMgr.GetResourceOverrides()
+	resourceOverrides, err := c.configProvider.ResourceOverrides(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	ignoreNormalizerJQTimeout, err := c.configProvider.IgnoreNormalizerJQTimeout(context.Background())
 	if err != nil {
 		return nil, err
 	}
 	clusterSettings := clustercache.Settings{
 		ResourceHealthOverride: lua.ResourceHealthOverrides(resourceOverrides),
-		ResourcesFilter:        resourcesFilter,
+		ResourcesFilter:        &resourcesFilter,
 	}
 
-	return &cacheSettings{clusterSettings, appInstanceLabelKey, appv1.TrackingMethod(trackingMethod), installationID, resourceUpdatesOverrides, ignoreResourceUpdatesEnabled}, nil
+	return &cacheSettings{
+		clusterSettings:              clusterSettings,
+		appInstanceLabelKey:          appInstanceLabelKey,
+		trackingMethod:               appv1.TrackingMethod(trackingMethod),
+		installationID:               installationID,
+		resourceOverrides:            resourceUpdatesOverrides,
+		ignoreResourceUpdatesEnabled: ignoreResourceUpdatesEnabled,
+		ignoreNormalizerJQTimeout:    ignoreNormalizerJQTimeout,
+	}, nil
 }
 
 func asResourceNode(r *clustercache.Resource, namespaceResources map[kube.ResourceKey]*clustercache.Resource) appv1.ResourceNode {
@@ -513,12 +532,12 @@ func (c *liveStateCache) getCluster(cluster *appv1.Cluster) (clustercache.Cluste
 		return nil, fmt.Errorf("controller is configured to ignore cluster %s", cluster.Server)
 	}
 
-	resourceCustomLabels, err := c.settingsMgr.GetResourceCustomLabels()
+	resourceCustomLabels, err := c.configProvider.ResourceCustomLabels(context.Background())
 	if err != nil {
 		return nil, fmt.Errorf("error getting custom label: %w", err)
 	}
 
-	respectRBAC, err := c.settingsMgr.RespectRBAC()
+	respectRBAC, err := c.configProvider.RespectRBAC(context.Background())
 	if err != nil {
 		return nil, fmt.Errorf("error getting value for %v: %w", settings.RespectRBAC, err)
 	}
@@ -567,7 +586,7 @@ func (c *liveStateCache) getCluster(cluster *appv1.Cluster) (clustercache.Cluste
 			gvk := un.GroupVersionKind()
 
 			if cacheSettings.ignoreResourceUpdatesEnabled && shouldHashManifest(appName, gvk, un) {
-				hash, err := generateManifestHash(un, nil, cacheSettings.resourceOverrides, c.ignoreNormalizerOpts)
+				hash, err := generateManifestHash(un, nil, cacheSettings.resourceOverrides, normalizers.IgnoreNormalizerOpts{JQExecutionTimeout: cacheSettings.ignoreNormalizerJQTimeout})
 				if err != nil {
 					log.Errorf("Failed to generate manifest hash: %v", err)
 				} else {
@@ -730,7 +749,7 @@ func (c *liveStateCache) GetManagedLiveObjs(destCluster *appv1.Cluster, a *appv1
 		return nil, fmt.Errorf("failed to get cluster info for %q: %w", destCluster.Server, err)
 	}
 	return clusterInfo.GetManagedLiveObjs(targetObjs, func(r *clustercache.Resource) bool {
-		return resInfo(r).AppName == a.InstanceName(c.settingsMgr.GetNamespace())
+		return resInfo(r).AppName == a.InstanceName(c.namespace)
 	})
 }
 
@@ -762,7 +781,7 @@ func (c *liveStateCache) isClusterHasApps(apps []any, cluster *appv1.Cluster) bo
 
 func (c *liveStateCache) watchSettings(ctx context.Context) {
 	updateCh := make(chan *settings.ArgoCDSettings, 1)
-	c.settingsMgr.Subscribe(updateCh)
+	c.configProvider.Subscribe(updateCh)
 
 	done := false
 	for !done {
@@ -789,7 +808,7 @@ func (c *liveStateCache) watchSettings(ctx context.Context) {
 		}
 	}
 	log.Info("shutting down settings watch")
-	c.settingsMgr.Unsubscribe(updateCh)
+	c.configProvider.Unsubscribe(updateCh)
 	close(updateCh)
 }
 

--- a/controller/cache/cache_test.go
+++ b/controller/cache/cache_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/argoproj/argo-cd/v3/controller/sharding"
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application"
 	appv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v3/util/configbus"
 	dbmocks "github.com/argoproj/argo-cd/v3/util/db/mocks"
 	argosettings "github.com/argoproj/argo-cd/v3/util/settings"
 )
@@ -105,7 +106,6 @@ func TestHandleModEvent_ClusterExcluded(t *testing.T) {
 		appInformer: nil,
 		onObjectUpdated: func(_ map[string]bool, _ corev1.ObjectReference) {
 		},
-		settingsMgr:   &argosettings.SettingsManager{},
 		metricsServer: &metrics.MetricsServer{},
 		// returns a shard that never process any cluster
 		clusterSharding:  sharding.NewClusterSharding(db, 0, 1, common.DefaultShardingAlgorithm),
@@ -173,15 +173,12 @@ func TestHandleDeleteEvent_CacheDeadlock(t *testing.T) {
 	}
 	db := &dbmocks.ArgoDB{}
 	db.EXPECT().GetApplicationControllerReplicas().Return(1)
-	fakeClient := fake.NewClientset()
-	settingsMgr := argosettings.NewSettingsManager(t.Context(), fakeClient, "argocd")
 	gitopsEngineClusterCache := &mocks.ClusterCache{}
 	clustersCache := liveStateCache{
 		clusters: map[string]cache.ClusterCache{
 			testCluster.Server: gitopsEngineClusterCache,
 		},
 		clusterSharding: sharding.NewClusterSharding(db, 0, 1, common.DefaultShardingAlgorithm),
-		settingsMgr:     settingsMgr,
 		lock:            sync.RWMutex{},
 	}
 	channel := make(chan string)
@@ -813,12 +810,19 @@ func TestLoadCacheSettings(t *testing.T) {
 		"application.resourceTrackingMethod": string(appv1.TrackingMethodLabel),
 		"installationID":                     "123456789",
 	})
+	jqTimeout := 2 * time.Second
 	ch := liveStateCache{
-		settingsMgr: settingsManager,
+		namespace: "argocd",
+		configProvider: configbus.NewChainProvider(
+			&configbus.StaticProvider{Fields: configbus.StaticFields{
+				IgnoreNormalizerJQTimeout: configbus.Ptr(jqTimeout),
+			}},
+			configbus.NewSettingsManagerProvider(settingsManager),
+		),
 	}
-	label, err := settingsManager.GetAppInstanceLabelKey()
+	label, err := ch.configProvider.AppInstanceLabelKey(t.Context())
 	require.NoError(t, err)
-	trackingMethod, err := settingsManager.GetTrackingMethod()
+	trackingMethod, err := ch.configProvider.TrackingMethod(t.Context())
 	require.NoError(t, err)
 	res, err := ch.loadCacheSettings()
 	require.NoError(t, err)
@@ -826,6 +830,7 @@ func TestLoadCacheSettings(t *testing.T) {
 	assert.Equal(t, label, res.appInstanceLabelKey)
 	assert.Equal(t, string(appv1.TrackingMethodLabel), trackingMethod)
 	assert.Equal(t, "123456789", res.installationID)
+	assert.Equal(t, jqTimeout, res.ignoreNormalizerJQTimeout)
 
 	// By default the values won't be nil
 	assert.NotNil(t, res.resourceOverrides)

--- a/controller/hook.go
+++ b/controller/hook.go
@@ -100,15 +100,15 @@ func (ctrl *ApplicationController) executeHooks(ctx context.Context, hookType Ho
 	ctx, span := tracer.Start(ctx, "controller.executeHooks")
 	setAppTraceAttrs(span, app, attribute.String("argocd.hook.type", string(hookType)))
 	defer func() { traceutil.EndSpan(span, retErr) }()
-	appLabelKey, err := ctrl.settingsMgr.GetAppInstanceLabelKey()
+	appLabelKey, err := ctrl.configProvider.AppInstanceLabelKey(ctx)
 	if err != nil {
 		return false, err
 	}
-	trackingMethodStr, err := ctrl.settingsMgr.GetTrackingMethod()
+	trackingMethodStr, err := ctrl.configProvider.TrackingMethod(ctx)
 	if err != nil {
 		return false, err
 	}
-	installationID, err := ctrl.settingsMgr.GetInstallationID()
+	installationID, err := ctrl.configProvider.InstallationID(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -179,7 +179,7 @@ func (ctrl *ApplicationController) executeHooks(ctx context.Context, hookType Ho
 	}
 
 	// Check health of running hooks
-	resourceOverrides, err := ctrl.settingsMgr.GetResourceOverrides()
+	resourceOverrides, err := ctrl.configProvider.ResourceOverrides(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -245,7 +245,7 @@ func (ctrl *ApplicationController) cleanupHooks(ctx context.Context, hookType Ho
 	ctx, span := tracer.Start(ctx, "controller.cleanupHooks")
 	span.SetAttributes(attribute.String("argocd.hook.type", string(hookType)))
 	defer func() { traceutil.EndSpan(span, retErr) }()
-	resourceOverrides, err := ctrl.settingsMgr.GetResourceOverrides()
+	resourceOverrides, err := ctrl.configProvider.ResourceOverrides(ctx)
 	if err != nil {
 		return false, err
 	}

--- a/controller/hydrator_dependencies.go
+++ b/controller/hydrator_dependencies.go
@@ -53,7 +53,7 @@ func (ctrl *ApplicationController) GetRepoObjs(ctx context.Context, app *appv1.A
 	drySources := []appv1.ApplicationSource{drySource}
 	dryRevisions := []string{revision}
 
-	appLabelKey, err := ctrl.settingsMgr.GetAppInstanceLabelKey()
+	appLabelKey, err := ctrl.configProvider.AppInstanceLabelKey(ctx)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get app instance label key: %w", err)
 	}
@@ -64,7 +64,7 @@ func (ctrl *ApplicationController) GetRepoObjs(ctx context.Context, app *appv1.A
 		return nil, nil, fmt.Errorf("failed to get repo objects: %w", err)
 	}
 
-	trackingMethod, err := ctrl.settingsMgr.GetTrackingMethod()
+	trackingMethod, err := ctrl.configProvider.TrackingMethod(ctx)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get tracking method: %w", err)
 	}
@@ -109,7 +109,7 @@ func (ctrl *ApplicationController) AddHydrationQueueItem(key types.HydrationQueu
 }
 
 func (ctrl *ApplicationController) GetHydratorCommitMessageTemplate() (string, error) {
-	sourceHydratorCommitMessageKey, err := ctrl.settingsMgr.GetSourceHydratorCommitMessageTemplate()
+	sourceHydratorCommitMessageKey, err := ctrl.configProvider.SourceHydratorCommitMessageTemplate(context.Background())
 	if err != nil {
 		return "", fmt.Errorf("failed to get sourceHydrator commit message template key: %w", err)
 	}
@@ -118,7 +118,7 @@ func (ctrl *ApplicationController) GetHydratorCommitMessageTemplate() (string, e
 }
 
 func (ctrl *ApplicationController) GetHydratorReadmeMessageTemplate() (string, error) {
-	readmeTemplate, err := ctrl.settingsMgr.GetHydratorReadmeTemplate()
+	readmeTemplate, err := ctrl.configProvider.HydratorReadmeTemplate(context.Background())
 	if err != nil {
 		return "", fmt.Errorf("failed to get sourceHydrator README message template: %w", err)
 	}
@@ -127,7 +127,7 @@ func (ctrl *ApplicationController) GetHydratorReadmeMessageTemplate() (string, e
 }
 
 func (ctrl *ApplicationController) GetCommitAuthorName() (string, error) {
-	authorName, err := ctrl.settingsMgr.GetCommitAuthorName()
+	authorName, err := ctrl.configProvider.CommitAuthorName(context.Background())
 	if err != nil {
 		return "", fmt.Errorf("failed to get commit author name: %w", err)
 	}
@@ -135,7 +135,7 @@ func (ctrl *ApplicationController) GetCommitAuthorName() (string, error) {
 }
 
 func (ctrl *ApplicationController) GetCommitAuthorEmail() (string, error) {
-	authorEmail, err := ctrl.settingsMgr.GetCommitAuthorEmail()
+	authorEmail, err := ctrl.configProvider.CommitAuthorEmail(context.Background())
 	if err != nil {
 		return "", fmt.Errorf("failed to get commit author email: %w", err)
 	}

--- a/controller/state.go
+++ b/controller/state.go
@@ -46,6 +46,7 @@ import (
 	argodiff "github.com/argoproj/argo-cd/v3/util/argo/diff"
 	"github.com/argoproj/argo-cd/v3/util/argo/normalizers"
 	appstatecache "github.com/argoproj/argo-cd/v3/util/cache/appstate"
+	"github.com/argoproj/argo-cd/v3/util/configbus"
 	"github.com/argoproj/argo-cd/v3/util/db"
 	"github.com/argoproj/argo-cd/v3/util/git"
 	utilio "github.com/argoproj/argo-cd/v3/util/io"
@@ -130,23 +131,18 @@ func (res *comparisonResult) GetHealthStatus() health.HealthStatusCode {
 
 // appStateManager allows to compare applications to git
 type appStateManager struct {
-	metricsServer         *metrics.MetricsServer
-	db                    db.ArgoDB
-	settingsMgr           *settings.SettingsManager
-	appclientset          appclientset.Interface
-	kubectl               kubeutil.Kubectl
-	onKubectlRun          kubeutil.OnKubectlRunFunc
-	repoClientset         apiclient.Clientset
-	liveStateCache        statecache.LiveStateCache
-	cache                 *appstatecache.Cache
-	namespace             string
-	statusRefreshTimeout  time.Duration
-	resourceTracking      argo.ResourceTracking
-	persistResourceHealth bool
-	repoErrorCache        goSync.Map
-	repoErrorGracePeriod  time.Duration
-	serverSideDiff        bool
-	ignoreNormalizerOpts  normalizers.IgnoreNormalizerOpts
+	metricsServer    *metrics.MetricsServer
+	db               db.ArgoDB
+	configProvider   configbus.Provider
+	appclientset     appclientset.Interface
+	kubectl          kubeutil.Kubectl
+	onKubectlRun     kubeutil.OnKubectlRunFunc
+	repoClientset    apiclient.Clientset
+	liveStateCache   statecache.LiveStateCache
+	cache            *appstatecache.Cache
+	namespace        string
+	resourceTracking argo.ResourceTracking
+	repoErrorCache   goSync.Map
 }
 
 // EvaluateAppRevisionsChanges checks if any source revisions have changes without generating manifests.
@@ -155,17 +151,17 @@ type appStateManager struct {
 func (m *appStateManager) EvaluateAppRevisionsChanges(ctx context.Context, app *v1alpha1.Application, sources []v1alpha1.ApplicationSource, revisions []string, proj *v1alpha1.AppProject, sendRuntimeState bool, noRevisionCache bool) (bool, []string, error) {
 	hasChanges := false
 
-	appLabelKey, err := m.settingsMgr.GetAppInstanceLabelKey()
+	appLabelKey, err := m.configProvider.AppInstanceLabelKey(ctx)
 	if err != nil {
 		return false, nil, fmt.Errorf("failed to get app instance label key: %w", err)
 	}
 
-	trackingMethod, err := m.settingsMgr.GetTrackingMethod()
+	trackingMethod, err := m.configProvider.TrackingMethod(ctx)
 	if err != nil {
 		return false, nil, fmt.Errorf("failed to get trackingMethod: %w", err)
 	}
 
-	installationID, err := m.settingsMgr.GetInstallationID()
+	installationID, err := m.configProvider.InstallationID(ctx)
 	if err != nil {
 		return false, nil, fmt.Errorf("failed to get installation ID: %w", err)
 	}
@@ -269,28 +265,28 @@ func (m *appStateManager) GetRepoObjs(ctx context.Context, app *v1alpha1.Applica
 		return nil, nil, false, fmt.Errorf("failed to get permitted OCI credentials for project %q: %w", proj.Name, err)
 	}
 
-	enabledSourceTypes, err := m.settingsMgr.GetEnabledSourceTypes()
+	enabledSourceTypes, err := m.configProvider.EnabledSourceTypes(ctx)
 	if err != nil {
 		return nil, nil, false, fmt.Errorf("failed to get enabled source types: %w", err)
 	}
 	ts.AddCheckpoint("plugins_ms")
 
-	kustomizeSettings, err := m.settingsMgr.GetKustomizeSettings()
+	kustomizeSettings, err := m.configProvider.KustomizeSettings(ctx)
 	if err != nil {
 		return nil, nil, false, fmt.Errorf("failed to get Kustomize settings: %w", err)
 	}
 
-	helmOptions, err := m.settingsMgr.GetHelmSettings()
+	helmOptions, err := m.configProvider.HelmSettings(ctx)
 	if err != nil {
 		return nil, nil, false, fmt.Errorf("failed to get Helm settings: %w", err)
 	}
 
-	trackingMethod, err := m.settingsMgr.GetTrackingMethod()
+	trackingMethod, err := m.configProvider.TrackingMethod(ctx)
 	if err != nil {
 		return nil, nil, false, fmt.Errorf("failed to get trackingMethod: %w", err)
 	}
 
-	installationID, err := m.settingsMgr.GetInstallationID()
+	installationID, err := m.configProvider.InstallationID(ctx)
 	if err != nil {
 		return nil, nil, false, fmt.Errorf("failed to get installation ID: %w", err)
 	}
@@ -401,7 +397,7 @@ func (m *appStateManager) GetRepoObjs(ctx context.Context, app *v1alpha1.Applica
 				AppName:                         app.InstanceName(m.namespace),
 				Namespace:                       appNamespace,
 				ApplicationSource:               &source,
-				KustomizeOptions:                kustomizeSettings,
+				KustomizeOptions:                &kustomizeSettings,
 				KubeVersion:                     serverVersion,
 				ApiVersions:                     apiVersions,
 				SourceIntegrity:                 sourceIntegrity,
@@ -409,7 +405,7 @@ func (m *appStateManager) GetRepoObjs(ctx context.Context, app *v1alpha1.Applica
 				HelmRepoCreds:                   helmRepoCreds,
 				TrackingMethod:                  trackingMethod,
 				EnabledSourceTypes:              enabledSourceTypes,
-				HelmOptions:                     helmOptions,
+				HelmOptions:                     &helmOptions,
 				HasMultipleSources:              app.Spec.HasMultipleSources(),
 				RefSources:                      refSources,
 				ProjectName:                     proj.Name,
@@ -626,27 +622,27 @@ func NormalizeTargetObjects(namespace string, objs []*unstructured.Unstructured,
 // getComparisonSettings will return the system level settings related to the
 // diff/normalization process.
 func (m *appStateManager) getComparisonSettings() (string, map[string]v1alpha1.ResourceOverride, *settings.ResourcesFilter, string, string, error) {
-	resourceOverrides, err := m.settingsMgr.GetResourceOverrides()
+	resourceOverrides, err := m.configProvider.ResourceOverrides(context.Background())
 	if err != nil {
 		return "", nil, nil, "", "", err
 	}
-	appLabelKey, err := m.settingsMgr.GetAppInstanceLabelKey()
+	appLabelKey, err := m.configProvider.AppInstanceLabelKey(context.Background())
 	if err != nil {
 		return "", nil, nil, "", "", err
 	}
-	resFilter, err := m.settingsMgr.GetResourcesFilter()
+	resFilter, err := m.configProvider.ResourcesFilter(context.Background())
 	if err != nil {
 		return "", nil, nil, "", "", err
 	}
-	installationID, err := m.settingsMgr.GetInstallationID()
+	installationID, err := m.configProvider.InstallationID(context.Background())
 	if err != nil {
 		return "", nil, nil, "", "", err
 	}
-	trackingMethod, err := m.settingsMgr.GetTrackingMethod()
+	trackingMethod, err := m.configProvider.TrackingMethod(context.Background())
 	if err != nil {
 		return "", nil, nil, "", "", err
 	}
-	return appLabelKey, resourceOverrides, resFilter, installationID, trackingMethod, nil
+	return appLabelKey, resourceOverrides, &resFilter, installationID, trackingMethod, nil
 }
 
 func isManagedNamespace(ns *unstructured.Unstructured, app *v1alpha1.Application) bool {
@@ -749,7 +745,11 @@ func (m *appStateManager) CompareAppState(ctx context.Context, app *v1alpha1.App
 			msg := "Failed to load target state: " + err.Error()
 			conditions = append(conditions, v1alpha1.ApplicationCondition{Type: v1alpha1.ApplicationConditionComparisonError, Message: msg, LastTransitionTime: &now})
 			if firstSeen, ok := m.repoErrorCache.Load(app.Name); ok {
-				if time.Since(firstSeen.(time.Time)) <= m.repoErrorGracePeriod && !noRevisionCache {
+				repoErrorGracePeriod, graceErr := m.configProvider.RepoErrorGracePeriod(ctx)
+				if graceErr != nil {
+					return nil, fmt.Errorf("failed to resolve repo error grace period: %w", graceErr)
+				}
+				if time.Since(firstSeen.(time.Time)) <= repoErrorGracePeriod && !noRevisionCache {
 					// if first seen is less than grace period and it's not a Level 3 comparison,
 					// ignore error and short circuit
 					logCtx.Debugf("Ignoring repo error %v, already encountered error in grace period", err.Error())
@@ -901,9 +901,9 @@ func (m *appStateManager) CompareAppState(ctx context.Context, app *v1alpha1.App
 	reconciliation := sync.Reconcile(targetObjsForSync, liveObjByKey, app.Spec.Destination.Namespace, infoProvider)
 	ts.AddCheckpoint("live_ms")
 
-	compareOptions, err := m.settingsMgr.GetResourceCompareOptions()
+	compareOptions, err := m.configProvider.ResourceCompareOptions(ctx)
 	if err != nil {
-		log.Warnf("Could not get compare options from ConfigMap (assuming defaults): %v", err)
+		log.Warnf("Could not get compare options from config provider (assuming defaults): %v", err)
 		compareOptions = settings.GetDefaultDiffOptions()
 	}
 	manifestRevisions := make([]string, 0)
@@ -912,7 +912,11 @@ func (m *appStateManager) CompareAppState(ctx context.Context, app *v1alpha1.App
 		manifestRevisions = append(manifestRevisions, manifestInfo.Revision)
 	}
 
-	serverSideDiff := m.serverSideDiff ||
+	serverSideDiffCfg, err := m.configProvider.ServerSideDiff(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve server-side diff setting: %w", err)
+	}
+	serverSideDiff := serverSideDiffCfg ||
 		resourceutil.HasAnnotationOption(app, common.AnnotationCompareOptions, "ServerSideDiff=true")
 
 	// This allows turning SSD off for a given app if it is enabled at the
@@ -921,10 +925,18 @@ func (m *appStateManager) CompareAppState(ctx context.Context, app *v1alpha1.App
 		serverSideDiff = false
 	}
 
-	useDiffCache := useDiffCache(noCache, manifestInfos, sources, app, manifestRevisions, m.statusRefreshTimeout, serverSideDiff, logCtx)
+	reconciliationTimeout, err := m.configProvider.ReconciliationTimeout(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve reconciliation timeout: %w", err)
+	}
+	useDiffCache := useDiffCache(noCache, manifestInfos, sources, app, manifestRevisions, reconciliationTimeout, serverSideDiff, logCtx)
 
+	ignoreNormalizerJQTimeout, err := m.configProvider.IgnoreNormalizerJQTimeout(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve ignore normalizer JQ timeout: %w", err)
+	}
 	diffConfigBuilder := argodiff.NewDiffConfigBuilder().
-		WithDiffSettings(app.Spec.IgnoreDifferences, resourceOverrides, compareOptions.IgnoreAggregatedRoles, m.ignoreNormalizerOpts).
+		WithDiffSettings(app.Spec.IgnoreDifferences, resourceOverrides, compareOptions.IgnoreAggregatedRoles, normalizers.IgnoreNormalizerOpts{JQExecutionTimeout: ignoreNormalizerJQTimeout}).
 		WithTracking(appLabelKey, string(trackingMethod))
 
 	if useDiffCache {
@@ -1107,7 +1119,11 @@ func (m *appStateManager) CompareAppState(ctx context.Context, app *v1alpha1.App
 
 	ts.AddCheckpoint("sync_ms")
 
-	healthStatus, healthMessage, err := setApplicationHealth(managedResources, resourceSummaries, resourceOverrides, app, m.persistResourceHealth)
+	persistResourceHealth, err := m.configProvider.PersistResourceHealth(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve persist resource health setting: %w", err)
+	}
+	healthStatus, healthMessage, err := setApplicationHealth(managedResources, resourceSummaries, resourceOverrides, app, persistResourceHealth)
 	if err != nil {
 		conditions = append(conditions, v1alpha1.ApplicationCondition{Type: v1alpha1.ApplicationConditionComparisonError, Message: "error setting app health: " + err.Error(), LastTransitionTime: &now})
 	}
@@ -1308,34 +1324,24 @@ func NewAppStateManager(
 	namespace string,
 	kubectl kubeutil.Kubectl,
 	onKubectlRun kubeutil.OnKubectlRunFunc,
-	settingsMgr *settings.SettingsManager,
+	configProvider configbus.Provider,
 	liveStateCache statecache.LiveStateCache,
 	metricsServer *metrics.MetricsServer,
 	cache *appstatecache.Cache,
-	statusRefreshTimeout time.Duration,
 	resourceTracking argo.ResourceTracking,
-	persistResourceHealth bool,
-	repoErrorGracePeriod time.Duration,
-	serverSideDiff bool,
-	ignoreNormalizerOpts normalizers.IgnoreNormalizerOpts,
 ) AppStateManager {
 	return &appStateManager{
-		liveStateCache:        liveStateCache,
-		cache:                 cache,
-		db:                    db,
-		appclientset:          appclientset,
-		kubectl:               kubectl,
-		onKubectlRun:          onKubectlRun,
-		repoClientset:         repoClientset,
-		namespace:             namespace,
-		settingsMgr:           settingsMgr,
-		metricsServer:         metricsServer,
-		statusRefreshTimeout:  statusRefreshTimeout,
-		resourceTracking:      resourceTracking,
-		persistResourceHealth: persistResourceHealth,
-		repoErrorGracePeriod:  repoErrorGracePeriod,
-		serverSideDiff:        serverSideDiff,
-		ignoreNormalizerOpts:  ignoreNormalizerOpts,
+		liveStateCache:   liveStateCache,
+		cache:            cache,
+		db:               db,
+		appclientset:     appclientset,
+		kubectl:          kubectl,
+		onKubectlRun:     onKubectlRun,
+		repoClientset:    repoClientset,
+		namespace:        namespace,
+		configProvider:   configProvider,
+		metricsServer:    metricsServer,
+		resourceTracking: resourceTracking,
 	}
 }
 

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -95,7 +95,7 @@ func (m *appStateManager) getServerSideDiffDryRunApplier(cluster *v1alpha1.Clust
 func (m *appStateManager) applyDiffImpersonationConfig(config *rest.Config, project *v1alpha1.AppProject, app *v1alpha1.Application, destCluster *v1alpha1.Cluster) error {
 	logEntry := log.WithFields(applog.GetAppLogFields(app))
 
-	impersonationEnabled, err := m.settingsMgr.IsImpersonationEnabled()
+	impersonationEnabled, err := m.configProvider.IsImpersonationEnabled(context.Background())
 	if err != nil {
 		return fmt.Errorf("error getting impersonation setting: %w", err)
 	}
@@ -108,7 +108,7 @@ func (m *appStateManager) applyDiffImpersonationConfig(config *rest.Config, proj
 	}
 	if serviceAccountToImpersonate == "" {
 		// No matching service account found - check enforcement.
-		impersonationEnforced, err := m.settingsMgr.IsImpersonationEnforced()
+		impersonationEnforced, err := m.configProvider.IsImpersonationEnforced(context.Background())
 		if err != nil {
 			return fmt.Errorf("error getting impersonation enforcement setting: %w", err)
 		}
@@ -260,7 +260,7 @@ func (m *appStateManager) SyncAppState(ctx context.Context, app *v1alpha1.Applic
 	}
 	restConfig := metrics.AddMetricsTransportWrapper(m.metricsServer, app, clusterRESTConfig)
 
-	resourceOverrides, err := m.settingsMgr.GetResourceOverrides()
+	resourceOverrides, err := m.configProvider.ResourceOverrides(ctx)
 	if err != nil {
 		state.Phase = common.OperationError
 		state.Message = fmt.Sprintf("Failed to load resource overrides: %v", err)
@@ -321,18 +321,18 @@ func (m *appStateManager) SyncAppState(ctx context.Context, app *v1alpha1.Applic
 		reconciliationResult.Target = patchedTargets
 	}
 
-	installationID, err := m.settingsMgr.GetInstallationID()
+	installationID, err := m.configProvider.InstallationID(ctx)
 	if err != nil {
 		log.Errorf("Could not get installation ID: %v", err)
 		return
 	}
-	trackingMethod, err := m.settingsMgr.GetTrackingMethod()
+	trackingMethod, err := m.configProvider.TrackingMethod(ctx)
 	if err != nil {
 		log.Errorf("Could not get trackingMethod: %v", err)
 		return
 	}
 
-	impersonationEnabled, err := m.settingsMgr.IsImpersonationEnabled()
+	impersonationEnabled, err := m.configProvider.IsImpersonationEnabled(ctx)
 	if err != nil {
 		log.Errorf("could not get impersonation feature flag: %v", err)
 		return
@@ -347,7 +347,7 @@ func (m *appStateManager) SyncAppState(ctx context.Context, app *v1alpha1.Applic
 
 		if serviceAccountToImpersonate == "" {
 			// No matching service account found - check enforcement
-			impersonationEnforced, enforcedErr := m.settingsMgr.IsImpersonationEnforced()
+			impersonationEnforced, enforcedErr := m.configProvider.IsImpersonationEnforced(ctx)
 			if enforcedErr != nil {
 				log.Errorf("could not get impersonation enforcement flag: %v", enforcedErr)
 				state.Phase = common.OperationError

--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -27,6 +27,7 @@ import (
 	"github.com/argoproj/argo-cd/v3/pkg/client/clientset/versioned/typed/application/v1alpha1"
 	applicationsv1 "github.com/argoproj/argo-cd/v3/pkg/client/listers/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v3/reposerver/apiclient"
+	"github.com/argoproj/argo-cd/v3/util/configbus"
 	"github.com/argoproj/argo-cd/v3/util/db"
 	"github.com/argoproj/argo-cd/v3/util/git"
 	"github.com/argoproj/argo-cd/v3/util/glob"
@@ -314,7 +315,7 @@ func ValidateRepo(
 	db db.ArgoDB,
 	kubectl kube.Kubectl,
 	proj *argoappv1.AppProject,
-	settingsMgr *settings.SettingsManager,
+	configProvider configbus.Provider,
 ) ([]argoappv1.ApplicationCondition, error) {
 	spec := &app.Spec
 
@@ -327,10 +328,11 @@ func ValidateRepo(
 	}
 	defer utilio.Close(conn)
 
-	helmOptions, err := settingsMgr.GetHelmSettings()
+	helmOptions, err := configProvider.HelmSettings(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("error getting helm settings: %w", err)
+		return nil, fmt.Errorf("failed to resolve HelmSettings: %w", err)
 	}
+	helmOptionsPtr := &helmOptions
 
 	helmRepos, err := db.ListHelmRepositories(ctx)
 	if err != nil {
@@ -385,9 +387,9 @@ func ValidateRepo(
 	if err != nil {
 		return nil, fmt.Errorf("error getting API resources: %w", err)
 	}
-	enabledSourceTypes, err := settingsMgr.GetEnabledSourceTypes()
+	enabledSourceTypes, err := configProvider.EnabledSourceTypes(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("error getting enabled source types: %w", err)
+		return nil, fmt.Errorf("failed to resolve EnabledSourceTypes: %w", err)
 	}
 
 	sourceCondition, err := validateRepo(
@@ -398,14 +400,14 @@ func ValidateRepo(
 		repoClient,
 		permittedHelmRepos,
 		permittedOCIRepos,
-		helmOptions,
+		helmOptionsPtr,
 		destCluster,
 		apiGroups,
 		proj,
 		permittedHelmCredentials,
 		permittedOCICredentials,
 		enabledSourceTypes,
-		settingsMgr)
+		configProvider)
 	if err != nil {
 		return nil, err
 	}
@@ -451,7 +453,7 @@ func validateRepo(ctx context.Context,
 	permittedHelmCredentials []*argoappv1.RepoCreds,
 	permittedOCICredentials []*argoappv1.RepoCreds,
 	enabledSourceTypes map[string]bool,
-	settingsMgr *settings.SettingsManager,
+	configProvider configbus.Provider,
 ) ([]argoappv1.ApplicationCondition, error) {
 	conditions := []argoappv1.ApplicationCondition{}
 	errMessage := ""
@@ -518,7 +520,7 @@ func validateRepo(ctx context.Context,
 		permittedHelmCredentials,
 		permittedOCICredentials,
 		enabledSourceTypes,
-		settingsMgr,
+		configProvider,
 		refSources)...)
 
 	return conditions, nil
@@ -748,13 +750,13 @@ func APIResourcesToStrings(resources []kube.APIResourceInfo, includeKinds bool) 
 }
 
 // GetAppProjectWithScopedResources returns a project from an application with scoped resources
-func GetAppProjectWithScopedResources(ctx context.Context, name string, projLister applicationsv1.AppProjectLister, ns string, settingsManager *settings.SettingsManager, db db.ArgoDB) (*argoappv1.AppProject, argoappv1.Repositories, []*argoappv1.Cluster, error) {
+func GetAppProjectWithScopedResources(ctx context.Context, name string, projLister applicationsv1.AppProjectLister, ns string, configProvider configbus.Provider, db db.ArgoDB) (*argoappv1.AppProject, argoappv1.Repositories, []*argoappv1.Cluster, error) {
 	projOrig, err := projLister.AppProjects(ns).Get(name)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("error getting app project %q: %w", name, err)
 	}
 
-	project, err := GetAppVirtualProject(projOrig, projLister, settingsManager)
+	project, err := GetAppVirtualProject(ctx, projOrig, projLister, configProvider)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("error getting app virtual project: %w", err)
 	}
@@ -771,7 +773,7 @@ func GetAppProjectWithScopedResources(ctx context.Context, name string, projList
 }
 
 // GetAppProjectByName returns a project from an application based on name
-func GetAppProjectByName(ctx context.Context, name string, projLister applicationsv1.AppProjectLister, ns string, settingsManager *settings.SettingsManager, db db.ArgoDB) (*argoappv1.AppProject, error) {
+func GetAppProjectByName(ctx context.Context, name string, projLister applicationsv1.AppProjectLister, ns string, configProvider configbus.Provider, db db.ArgoDB) (*argoappv1.AppProject, error) {
 	projOrig, err := projLister.AppProjects(ns).Get(name)
 	if err != nil {
 		return nil, fmt.Errorf("error getting app project %q: %w", name, err)
@@ -797,13 +799,13 @@ func GetAppProjectByName(ctx context.Context, name string, projLister applicatio
 			}
 		}
 	}
-	return GetAppVirtualProject(project, projLister, settingsManager)
+	return GetAppVirtualProject(ctx, project, projLister, configProvider)
 }
 
 // GetAppProject returns a project from an application. It will also ensure
 // that the application is allowed to use the project.
-func GetAppProject(ctx context.Context, app *argoappv1.Application, projLister applicationsv1.AppProjectLister, ns string, settingsManager *settings.SettingsManager, db db.ArgoDB) (*argoappv1.AppProject, error) {
-	proj, err := GetAppProjectByName(ctx, app.Spec.GetProject(), projLister, ns, settingsManager, db)
+func GetAppProject(ctx context.Context, app *argoappv1.Application, projLister applicationsv1.AppProjectLister, ns string, configProvider configbus.Provider, db db.ArgoDB) (*argoappv1.AppProject, error) {
+	proj, err := GetAppProjectByName(ctx, app.Spec.GetProject(), projLister, ns, configProvider, db)
 	if err != nil {
 		return nil, err
 	}
@@ -829,12 +831,12 @@ func verifyGenerateManifests(
 	repositoryCredentials []*argoappv1.RepoCreds,
 	ociRepositoryCredentials []*argoappv1.RepoCreds,
 	enableGenerateManifests map[string]bool,
-	settingsMgr *settings.SettingsManager,
+	configProvider configbus.Provider,
 	refSources argoappv1.RefTargetRevisionMapping,
 ) []argoappv1.ApplicationCondition {
 	var conditions []argoappv1.ApplicationCondition
 	// If source is Kustomize add build options
-	kustomizeSettings, err := settingsMgr.GetKustomizeSettings()
+	kustomizeSettings, err := configProvider.KustomizeSettings(ctx)
 	if err != nil {
 		conditions = append(conditions, argoappv1.ApplicationCondition{
 			Type:    argoappv1.ApplicationConditionInvalidSpecError,
@@ -842,6 +844,7 @@ func verifyGenerateManifests(
 		})
 		return conditions // Can't perform the next check without settings.
 	}
+	kustomizeSettingsPtr := &kustomizeSettings
 
 	for _, source := range sources {
 		repoRes, err := db.GetRepository(ctx, source.RepoURL, proj.Name)
@@ -852,7 +855,7 @@ func verifyGenerateManifests(
 			})
 			continue
 		}
-		installationID, err := settingsMgr.GetInstallationID()
+		installationID, err := configProvider.InstallationID(ctx)
 		if err != nil {
 			conditions = append(conditions, argoappv1.ApplicationCondition{
 				Type:    argoappv1.ApplicationConditionInvalidSpecError,
@@ -861,7 +864,7 @@ func verifyGenerateManifests(
 			continue
 		}
 
-		appLabelKey, err := settingsMgr.GetAppInstanceLabelKey()
+		appLabelKey, err := configProvider.AppInstanceLabelKey(ctx)
 		if err != nil {
 			conditions = append(conditions, argoappv1.ApplicationCondition{
 				Type:    argoappv1.ApplicationConditionInvalidSpecError,
@@ -870,7 +873,7 @@ func verifyGenerateManifests(
 			continue
 		}
 
-		trackingMethod, err := settingsMgr.GetTrackingMethod()
+		trackingMethod, err := configProvider.TrackingMethod(ctx)
 		if err != nil {
 			conditions = append(conditions, argoappv1.ApplicationCondition{
 				Type:    argoappv1.ApplicationConditionInvalidSpecError,
@@ -905,7 +908,7 @@ func verifyGenerateManifests(
 			Namespace:                       app.Spec.Destination.Namespace,
 			ApplicationSource:               &source,
 			AppLabelKey:                     appLabelKey,
-			KustomizeOptions:                kustomizeSettings,
+			KustomizeOptions:                kustomizeSettingsPtr,
 			KubeVersion:                     kubeVersion,
 			ApiVersions:                     apiVersions,
 			HelmOptions:                     helmOptions,
@@ -1140,12 +1143,12 @@ func GetDestinationCluster(ctx context.Context, destination argoappv1.Applicatio
 	return cluster, nil
 }
 
-func GetGlobalProjects(proj *argoappv1.AppProject, projLister applicationsv1.AppProjectLister, settingsManager *settings.SettingsManager) []*argoappv1.AppProject {
-	gps, err := settingsManager.GetGlobalProjectsSettings()
+func GetGlobalProjects(ctx context.Context, proj *argoappv1.AppProject, projLister applicationsv1.AppProjectLister, configProvider configbus.Provider) []*argoappv1.AppProject {
+	gps, err := configProvider.GlobalProjectsSettings(ctx)
 	globalProjects := []*argoappv1.AppProject{}
 
 	if err != nil {
-		log.Warnf("Failed to get global project settings: %v", err)
+		log.Warnf("Failed to resolve GlobalProjectsSettings: %v", err)
 		return globalProjects
 	}
 
@@ -1184,9 +1187,9 @@ func GetGlobalProjects(proj *argoappv1.AppProject, projLister applicationsv1.App
 	return globalProjects
 }
 
-func GetAppVirtualProject(proj *argoappv1.AppProject, projLister applicationsv1.AppProjectLister, settingsManager *settings.SettingsManager) (*argoappv1.AppProject, error) {
+func GetAppVirtualProject(ctx context.Context, proj *argoappv1.AppProject, projLister applicationsv1.AppProjectLister, configProvider configbus.Provider) (*argoappv1.AppProject, error) {
 	virtualProj := proj.DeepCopy()
-	globalProjects := GetGlobalProjects(proj, projLister, settingsManager)
+	globalProjects := GetGlobalProjects(ctx, proj, projLister, configProvider)
 
 	for _, gp := range globalProjects {
 		virtualProj = mergeVirtualProject(virtualProj, gp)
@@ -1324,7 +1327,7 @@ func IsValidContainerName(name string) bool {
 // If matched, the corresponding labels are returned to be added to the generated event. In case of a conflict
 // between labels on the Application and AppProject, the Application label values are prioritized and added to the event.
 // Furthermore, labels specified in `resource.excludeEventLabelKeys` in argocd-cm are removed from the event labels, if they were included.
-func GetAppEventLabels(ctx context.Context, app *argoappv1.Application, projLister applicationsv1.AppProjectLister, ns string, settingsManager *settings.SettingsManager, db db.ArgoDB) map[string]string {
+func GetAppEventLabels(ctx context.Context, app *argoappv1.Application, projLister applicationsv1.AppProjectLister, ns string, configProvider configbus.Provider, db db.ArgoDB) map[string]string {
 	eventLabels := make(map[string]string)
 
 	// Get all app & app-project labels
@@ -1332,7 +1335,7 @@ func GetAppEventLabels(ctx context.Context, app *argoappv1.Application, projList
 	if labels == nil {
 		labels = make(map[string]string)
 	}
-	proj, err := GetAppProject(ctx, app, projLister, ns, settingsManager, db)
+	proj, err := GetAppProject(ctx, app, projLister, ns, configProvider, db)
 	if err == nil {
 		for k, v := range proj.Labels {
 			_, found := labels[k]
@@ -1345,20 +1348,28 @@ func GetAppEventLabels(ctx context.Context, app *argoappv1.Application, projList
 	}
 
 	// Filter out event labels to include
-	inKeys := settingsManager.GetIncludeEventLabelKeys()
-	for k, v := range labels {
-		found := glob.MatchStringInList(inKeys, k, glob.GLOB)
-		if found {
-			eventLabels[k] = v
+	inKeys, err := configProvider.IncludeEventLabelKeys(ctx)
+	if err != nil {
+		log.Warnf("Failed to resolve IncludeEventLabelKeys: %v", err)
+	} else {
+		for k, v := range labels {
+			found := glob.MatchStringInList(inKeys, k, glob.GLOB)
+			if found {
+				eventLabels[k] = v
+			}
 		}
 	}
 
 	// Remove excluded event labels
-	exKeys := settingsManager.GetExcludeEventLabelKeys()
-	for k := range eventLabels {
-		found := glob.MatchStringInList(exKeys, k, glob.GLOB)
-		if found {
-			delete(eventLabels, k)
+	exKeys, err := configProvider.ExcludeEventLabelKeys(ctx)
+	if err != nil {
+		log.Warnf("Failed to resolve ExcludeEventLabelKeys: %v", err)
+	} else {
+		for k := range eventLabels {
+			found := glob.MatchStringInList(exKeys, k, glob.GLOB)
+			if found {
+				delete(eventLabels, k)
+			}
 		}
 	}
 

--- a/util/argo/argo_test.go
+++ b/util/argo/argo_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/argoproj/argo-cd/v3/reposerver/apiclient"
 	"github.com/argoproj/argo-cd/v3/reposerver/apiclient/mocks"
 	"github.com/argoproj/argo-cd/v3/test"
+	"github.com/argoproj/argo-cd/v3/util/configbus"
 	"github.com/argoproj/argo-cd/v3/util/db"
 	dbmocks "github.com/argoproj/argo-cd/v3/util/db/mocks"
 	"github.com/argoproj/argo-cd/v3/util/settings"
@@ -124,7 +125,7 @@ func TestGetAppProjectWithNoProjDefined(t *testing.T) {
 	kubeClient := fake.NewClientset(&cm)
 	settingsMgr := settings.NewSettingsManager(t.Context(), kubeClient, test.FakeArgoCDNamespace)
 	argoDB := db.NewDB("default", settingsMgr, kubeClient)
-	proj, err := GetAppProject(ctx, &testApp, applisters.NewAppProjectLister(informer.GetIndexer()), namespace, settingsMgr, argoDB)
+	proj, err := GetAppProject(ctx, &testApp, applisters.NewAppProjectLister(informer.GetIndexer()), namespace, configbus.NewSettingsManagerProvider(settingsMgr), argoDB)
 	require.NoError(t, err)
 	assert.Equal(t, proj.Name, projName)
 }
@@ -495,8 +496,9 @@ func TestValidateRepo(t *testing.T) {
 
 	kubeClient := fake.NewClientset(&cm)
 	settingsMgr := settings.NewSettingsManager(t.Context(), kubeClient, test.FakeArgoCDNamespace)
+	configProvider := configbus.NewSettingsManagerProvider(settingsMgr)
 
-	conditions, err := ValidateRepo(t.Context(), app, repoClientSet, db, &kubetest.MockKubectlCmd{Version: kubeVersion, APIResources: apiResources}, proj, settingsMgr)
+	conditions, err := ValidateRepo(t.Context(), app, repoClientSet, db, &kubetest.MockKubectlCmd{Version: kubeVersion, APIResources: apiResources}, proj, configProvider)
 
 	require.NoError(t, err)
 	assert.Empty(t, conditions)
@@ -583,8 +585,9 @@ func TestValidateRepo_SourceHydrator(t *testing.T) {
 	}
 	kubeClient := fake.NewClientset(&cm)
 	settingsMgr := settings.NewSettingsManager(t.Context(), kubeClient, test.FakeArgoCDNamespace)
+	configProvider := configbus.NewSettingsManagerProvider(settingsMgr)
 
-	conditions, err := ValidateRepo(t.Context(), app, repoClientSet, db, &kubetest.MockKubectlCmd{Version: kubeVersion, APIResources: apiResources}, proj, settingsMgr)
+	conditions, err := ValidateRepo(t.Context(), app, repoClientSet, db, &kubetest.MockKubectlCmd{Version: kubeVersion, APIResources: apiResources}, proj, configProvider)
 
 	require.NoError(t, err)
 	assert.Empty(t, conditions)
@@ -1556,11 +1559,11 @@ func TestGetGlobalProjects(t *testing.T) {
 
 		projLister := applisters.NewAppProjectLister(informer.GetIndexer())
 
-		xGlobalProjects := GetGlobalProjects(isX, projLister, settingsMgr)
+		xGlobalProjects := GetGlobalProjects(t.Context(), isX, projLister, configbus.NewSettingsManagerProvider(settingsMgr))
 		assert.Len(t, xGlobalProjects, 1)
 		assert.Equal(t, "default-x", xGlobalProjects[0].Name)
 
-		nonXGlobalProjects := GetGlobalProjects(isNoX, projLister, settingsMgr)
+		nonXGlobalProjects := GetGlobalProjects(t.Context(), isNoX, projLister, configbus.NewSettingsManagerProvider(settingsMgr))
 		assert.Len(t, nonXGlobalProjects, 1)
 		assert.Equal(t, "default-non-x", nonXGlobalProjects[0].Name)
 	})
@@ -2242,7 +2245,7 @@ func TestGetAppEventLabels(t *testing.T) {
 			settingsMgr := settings.NewSettingsManager(t.Context(), kubeClient, test.FakeArgoCDNamespace)
 			argoDB := db.NewDB("default", settingsMgr, kubeClient)
 
-			eventLabels := GetAppEventLabels(ctx, &app, applisters.NewAppProjectLister(informer.GetIndexer()), test.FakeArgoCDNamespace, settingsMgr, argoDB)
+			eventLabels := GetAppEventLabels(ctx, &app, applisters.NewAppProjectLister(informer.GetIndexer()), test.FakeArgoCDNamespace, configbus.NewSettingsManagerProvider(settingsMgr), argoDB)
 			assert.Len(t, eventLabels, len(tt.expectedEventLabels))
 			for ek, ev := range tt.expectedEventLabels {
 				v, found := eventLabels[ek]

--- a/util/configbus/coverage_test.go
+++ b/util/configbus/coverage_test.go
@@ -1,0 +1,138 @@
+package configbus_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/argoproj/argo-cd/v3/common"
+	"github.com/argoproj/argo-cd/v3/util/configbus"
+	"github.com/argoproj/argo-cd/v3/util/settings"
+)
+
+// controllerResolvedMethods are Provider getters the application-controller
+// chain must resolve. Other-component methods may still return ErrNotConfigured
+// on this binary's chain.
+var controllerResolvedMethods = map[string]struct{}{
+	"AllowedNodeLabels":                   {},
+	"AppInstanceLabelKey":                 {},
+	"CommitAuthorEmail":                   {},
+	"CommitAuthorName":                    {},
+	"EnabledSourceTypes":                  {},
+	"GitRequestTimeout":                   {},
+	"HardReconciliationTimeout":           {},
+	"HelmSettings":                        {},
+	"HydratorReadmeTemplate":              {},
+	"IgnoreNormalizerJQTimeout":           {},
+	"IgnoreResourceUpdatesOverrides":      {},
+	"InstallationID":                      {},
+	"IsIgnoreResourceUpdatesEnabled":      {},
+	"IsImpersonationEnabled":              {},
+	"IsImpersonationEnforced":             {},
+	"KustomizeSettings":                   {},
+	"MetricsClusterLabels":                {},
+	"PersistResourceHealth":               {},
+	"ReconciliationJitter":                {},
+	"ReconciliationTimeout":               {},
+	"RepoErrorGracePeriod":                {},
+	"ResourceCompareOptions":              {},
+	"ResourceCustomLabels":                {},
+	"ResourceOverrides":                   {},
+	"ResourcesFilter":                     {},
+	"RespectRBAC":                         {},
+	"SelfHealRetry":                       {},
+	"SelfHealTimeout":                     {},
+	"SensitiveAnnotations":                {},
+	"ServerSideDiff":                      {},
+	"SourceHydratorCommitMessageTemplate": {},
+	"SyncTimeout":                         {},
+	"TrackingMethod":                      {},
+}
+
+// TestControllerChainResolvesAllFields asserts the application-controller
+// production chain resolves every controller-owned Provider field getter
+// without leaking ErrNotConfigured.
+func TestControllerChainResolvesAllFields(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      common.ArgoCDConfigMapName,
+			Namespace: "argocd",
+			Labels:    map[string]string{"app.kubernetes.io/part-of": "argocd"},
+		},
+		Data: map[string]string{},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      common.ArgoCDSecretName,
+			Namespace: "argocd",
+			Labels:    map[string]string{"app.kubernetes.io/part-of": "argocd"},
+		},
+		Data: map[string][]byte{
+			"admin.password":   []byte("test"),
+			"server.secretkey": []byte("test"),
+		},
+	}
+	kubeClient := fake.NewClientset(cm, secret)
+	settingsMgr := settings.NewSettingsManager(ctx, kubeClient, "argocd")
+	require.NoError(t, settingsMgr.ResyncInformers())
+
+	optsTimeout := 2 * time.Second
+	labels := []string{"team"}
+	var backoff *wait.Backoff
+	chain := configbus.NewChainProvider(
+		&configbus.StaticProvider{Fields: configbus.StaticFields{
+			HardReconciliationTimeout: configbus.Ptr(time.Hour),
+			IgnoreNormalizerJQTimeout: configbus.Ptr(optsTimeout),
+			MetricsClusterLabels:      configbus.Ptr(labels),
+			PersistResourceHealth:     configbus.Ptr(true),
+			ReconciliationJitter:      configbus.Ptr(time.Second),
+			ReconciliationTimeout:     configbus.Ptr(time.Minute),
+			RepoErrorGracePeriod:      configbus.Ptr(90 * time.Second),
+			SelfHealRetry:             configbus.Ptr(configbus.SelfHealRetry{Backoff: backoff}),
+			SelfHealTimeout:           configbus.Ptr(30 * time.Second),
+			ServerSideDiff:            configbus.Ptr(false),
+			SyncTimeout:               configbus.Ptr(5 * time.Minute),
+		}},
+		configbus.NewSettingsManagerProvider(settingsMgr),
+		configbus.NewEnvProvider(),
+	)
+
+	assertProviderResolves(t, chain, controllerResolvedMethods)
+}
+
+func assertProviderResolves(t *testing.T, p configbus.Provider, required map[string]struct{}) {
+	t.Helper()
+	pv := reflect.ValueOf(p)
+	ctx := context.Background()
+	for name := range required {
+		method := pv.MethodByName(name)
+		require.True(t, method.IsValid(), name)
+		in := make([]reflect.Value, method.Type().NumIn())
+		for j := range method.Type().NumIn() {
+			argType := method.Type().In(j)
+			if argType.String() == "context.Context" {
+				in[j] = reflect.ValueOf(ctx)
+				continue
+			}
+			in[j] = reflect.Zero(argType)
+		}
+		out := method.Call(in)
+		require.NotEmpty(t, out, name)
+		errVal := out[len(out)-1]
+		if errVal.IsNil() {
+			continue
+		}
+		err, ok := errVal.Interface().(error)
+		require.True(t, ok, name)
+		require.NotErrorIs(t, err, configbus.ErrNotConfigured, "%s leaked ErrNotConfigured: %v", name, err)
+	}
+}

--- a/util/configbus/env_provider.go
+++ b/util/configbus/env_provider.go
@@ -1,5 +1,13 @@
 package configbus
 
+import (
+	"context"
+	"math"
+	"time"
+
+	"github.com/argoproj/argo-cd/v3/util/env"
+)
+
 // EnvProvider resolves process environment variables. Unowned field getters
 // return ErrNotConfigured via the embedded empty ChainProvider.
 type EnvProvider struct {
@@ -16,3 +24,7 @@ func NewEnvProvider() *EnvProvider {
 
 // Ensure EnvProvider implements Provider.
 var _ Provider = (*EnvProvider)(nil)
+
+func (p *EnvProvider) GitRequestTimeout(_ context.Context) (time.Duration, error) {
+	return env.ParseDurationFromEnv("ARGOCD_GIT_REQUEST_TIMEOUT", 15*time.Second, 0, math.MaxInt64), nil
+}

--- a/util/configbus/mocks/Provider.go
+++ b/util/configbus/mocks/Provider.go
@@ -5,6 +5,11 @@
 package mocks
 
 import (
+	"context"
+	"time"
+
+	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v3/util/configbus"
 	"github.com/argoproj/argo-cd/v3/util/settings"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -34,6 +39,2066 @@ type Provider_Expecter struct {
 
 func (_m *Provider) EXPECT() *Provider_Expecter {
 	return &Provider_Expecter{mock: &_m.Mock}
+}
+
+// AllowedNodeLabels provides a mock function for the type Provider
+func (_mock *Provider) AllowedNodeLabels(ctx context.Context) ([]string, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AllowedNodeLabels")
+	}
+
+	var r0 []string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) ([]string, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) []string); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Provider_AllowedNodeLabels_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AllowedNodeLabels'
+type Provider_AllowedNodeLabels_Call struct {
+	*mock.Call
+}
+
+// AllowedNodeLabels is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Provider_Expecter) AllowedNodeLabels(ctx any) *Provider_AllowedNodeLabels_Call {
+	return &Provider_AllowedNodeLabels_Call{Call: _e.mock.On("AllowedNodeLabels", ctx)}
+}
+
+func (_c *Provider_AllowedNodeLabels_Call) Run(run func(ctx context.Context)) *Provider_AllowedNodeLabels_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Provider_AllowedNodeLabels_Call) Return(strings []string, err error) *Provider_AllowedNodeLabels_Call {
+	_c.Call.Return(strings, err)
+	return _c
+}
+
+func (_c *Provider_AllowedNodeLabels_Call) RunAndReturn(run func(ctx context.Context) ([]string, error)) *Provider_AllowedNodeLabels_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// AppInstanceLabelKey provides a mock function for the type Provider
+func (_mock *Provider) AppInstanceLabelKey(ctx context.Context) (string, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AppInstanceLabelKey")
+	}
+
+	var r0 string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (string, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) string); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Provider_AppInstanceLabelKey_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AppInstanceLabelKey'
+type Provider_AppInstanceLabelKey_Call struct {
+	*mock.Call
+}
+
+// AppInstanceLabelKey is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Provider_Expecter) AppInstanceLabelKey(ctx any) *Provider_AppInstanceLabelKey_Call {
+	return &Provider_AppInstanceLabelKey_Call{Call: _e.mock.On("AppInstanceLabelKey", ctx)}
+}
+
+func (_c *Provider_AppInstanceLabelKey_Call) Run(run func(ctx context.Context)) *Provider_AppInstanceLabelKey_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Provider_AppInstanceLabelKey_Call) Return(s string, err error) *Provider_AppInstanceLabelKey_Call {
+	_c.Call.Return(s, err)
+	return _c
+}
+
+func (_c *Provider_AppInstanceLabelKey_Call) RunAndReturn(run func(ctx context.Context) (string, error)) *Provider_AppInstanceLabelKey_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CommitAuthorEmail provides a mock function for the type Provider
+func (_mock *Provider) CommitAuthorEmail(ctx context.Context) (string, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CommitAuthorEmail")
+	}
+
+	var r0 string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (string, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) string); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Provider_CommitAuthorEmail_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CommitAuthorEmail'
+type Provider_CommitAuthorEmail_Call struct {
+	*mock.Call
+}
+
+// CommitAuthorEmail is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Provider_Expecter) CommitAuthorEmail(ctx any) *Provider_CommitAuthorEmail_Call {
+	return &Provider_CommitAuthorEmail_Call{Call: _e.mock.On("CommitAuthorEmail", ctx)}
+}
+
+func (_c *Provider_CommitAuthorEmail_Call) Run(run func(ctx context.Context)) *Provider_CommitAuthorEmail_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Provider_CommitAuthorEmail_Call) Return(s string, err error) *Provider_CommitAuthorEmail_Call {
+	_c.Call.Return(s, err)
+	return _c
+}
+
+func (_c *Provider_CommitAuthorEmail_Call) RunAndReturn(run func(ctx context.Context) (string, error)) *Provider_CommitAuthorEmail_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CommitAuthorName provides a mock function for the type Provider
+func (_mock *Provider) CommitAuthorName(ctx context.Context) (string, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CommitAuthorName")
+	}
+
+	var r0 string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (string, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) string); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Provider_CommitAuthorName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CommitAuthorName'
+type Provider_CommitAuthorName_Call struct {
+	*mock.Call
+}
+
+// CommitAuthorName is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Provider_Expecter) CommitAuthorName(ctx any) *Provider_CommitAuthorName_Call {
+	return &Provider_CommitAuthorName_Call{Call: _e.mock.On("CommitAuthorName", ctx)}
+}
+
+func (_c *Provider_CommitAuthorName_Call) Run(run func(ctx context.Context)) *Provider_CommitAuthorName_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Provider_CommitAuthorName_Call) Return(s string, err error) *Provider_CommitAuthorName_Call {
+	_c.Call.Return(s, err)
+	return _c
+}
+
+func (_c *Provider_CommitAuthorName_Call) RunAndReturn(run func(ctx context.Context) (string, error)) *Provider_CommitAuthorName_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// EnabledSourceTypes provides a mock function for the type Provider
+func (_mock *Provider) EnabledSourceTypes(ctx context.Context) (map[string]bool, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for EnabledSourceTypes")
+	}
+
+	var r0 map[string]bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (map[string]bool, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) map[string]bool); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]bool)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Provider_EnabledSourceTypes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'EnabledSourceTypes'
+type Provider_EnabledSourceTypes_Call struct {
+	*mock.Call
+}
+
+// EnabledSourceTypes is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Provider_Expecter) EnabledSourceTypes(ctx any) *Provider_EnabledSourceTypes_Call {
+	return &Provider_EnabledSourceTypes_Call{Call: _e.mock.On("EnabledSourceTypes", ctx)}
+}
+
+func (_c *Provider_EnabledSourceTypes_Call) Run(run func(ctx context.Context)) *Provider_EnabledSourceTypes_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Provider_EnabledSourceTypes_Call) Return(stringToBool map[string]bool, err error) *Provider_EnabledSourceTypes_Call {
+	_c.Call.Return(stringToBool, err)
+	return _c
+}
+
+func (_c *Provider_EnabledSourceTypes_Call) RunAndReturn(run func(ctx context.Context) (map[string]bool, error)) *Provider_EnabledSourceTypes_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ExcludeEventLabelKeys provides a mock function for the type Provider
+func (_mock *Provider) ExcludeEventLabelKeys(ctx context.Context) ([]string, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ExcludeEventLabelKeys")
+	}
+
+	var r0 []string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) ([]string, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) []string); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Provider_ExcludeEventLabelKeys_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ExcludeEventLabelKeys'
+type Provider_ExcludeEventLabelKeys_Call struct {
+	*mock.Call
+}
+
+// ExcludeEventLabelKeys is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Provider_Expecter) ExcludeEventLabelKeys(ctx any) *Provider_ExcludeEventLabelKeys_Call {
+	return &Provider_ExcludeEventLabelKeys_Call{Call: _e.mock.On("ExcludeEventLabelKeys", ctx)}
+}
+
+func (_c *Provider_ExcludeEventLabelKeys_Call) Run(run func(ctx context.Context)) *Provider_ExcludeEventLabelKeys_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Provider_ExcludeEventLabelKeys_Call) Return(strings []string, err error) *Provider_ExcludeEventLabelKeys_Call {
+	_c.Call.Return(strings, err)
+	return _c
+}
+
+func (_c *Provider_ExcludeEventLabelKeys_Call) RunAndReturn(run func(ctx context.Context) ([]string, error)) *Provider_ExcludeEventLabelKeys_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GitRequestTimeout provides a mock function for the type Provider
+func (_mock *Provider) GitRequestTimeout(ctx context.Context) (time.Duration, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GitRequestTimeout")
+	}
+
+	var r0 time.Duration
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (time.Duration, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) time.Duration); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(time.Duration)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Provider_GitRequestTimeout_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GitRequestTimeout'
+type Provider_GitRequestTimeout_Call struct {
+	*mock.Call
+}
+
+// GitRequestTimeout is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Provider_Expecter) GitRequestTimeout(ctx any) *Provider_GitRequestTimeout_Call {
+	return &Provider_GitRequestTimeout_Call{Call: _e.mock.On("GitRequestTimeout", ctx)}
+}
+
+func (_c *Provider_GitRequestTimeout_Call) Run(run func(ctx context.Context)) *Provider_GitRequestTimeout_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Provider_GitRequestTimeout_Call) Return(duration time.Duration, err error) *Provider_GitRequestTimeout_Call {
+	_c.Call.Return(duration, err)
+	return _c
+}
+
+func (_c *Provider_GitRequestTimeout_Call) RunAndReturn(run func(ctx context.Context) (time.Duration, error)) *Provider_GitRequestTimeout_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GlobalProjectsSettings provides a mock function for the type Provider
+func (_mock *Provider) GlobalProjectsSettings(ctx context.Context) ([]settings.GlobalProjectSettings, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GlobalProjectsSettings")
+	}
+
+	var r0 []settings.GlobalProjectSettings
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) ([]settings.GlobalProjectSettings, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) []settings.GlobalProjectSettings); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]settings.GlobalProjectSettings)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Provider_GlobalProjectsSettings_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GlobalProjectsSettings'
+type Provider_GlobalProjectsSettings_Call struct {
+	*mock.Call
+}
+
+// GlobalProjectsSettings is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Provider_Expecter) GlobalProjectsSettings(ctx any) *Provider_GlobalProjectsSettings_Call {
+	return &Provider_GlobalProjectsSettings_Call{Call: _e.mock.On("GlobalProjectsSettings", ctx)}
+}
+
+func (_c *Provider_GlobalProjectsSettings_Call) Run(run func(ctx context.Context)) *Provider_GlobalProjectsSettings_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Provider_GlobalProjectsSettings_Call) Return(globalProjectSettingss []settings.GlobalProjectSettings, err error) *Provider_GlobalProjectsSettings_Call {
+	_c.Call.Return(globalProjectSettingss, err)
+	return _c
+}
+
+func (_c *Provider_GlobalProjectsSettings_Call) RunAndReturn(run func(ctx context.Context) ([]settings.GlobalProjectSettings, error)) *Provider_GlobalProjectsSettings_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// HardReconciliationTimeout provides a mock function for the type Provider
+func (_mock *Provider) HardReconciliationTimeout(ctx context.Context) (time.Duration, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for HardReconciliationTimeout")
+	}
+
+	var r0 time.Duration
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (time.Duration, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) time.Duration); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(time.Duration)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Provider_HardReconciliationTimeout_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'HardReconciliationTimeout'
+type Provider_HardReconciliationTimeout_Call struct {
+	*mock.Call
+}
+
+// HardReconciliationTimeout is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Provider_Expecter) HardReconciliationTimeout(ctx any) *Provider_HardReconciliationTimeout_Call {
+	return &Provider_HardReconciliationTimeout_Call{Call: _e.mock.On("HardReconciliationTimeout", ctx)}
+}
+
+func (_c *Provider_HardReconciliationTimeout_Call) Run(run func(ctx context.Context)) *Provider_HardReconciliationTimeout_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Provider_HardReconciliationTimeout_Call) Return(duration time.Duration, err error) *Provider_HardReconciliationTimeout_Call {
+	_c.Call.Return(duration, err)
+	return _c
+}
+
+func (_c *Provider_HardReconciliationTimeout_Call) RunAndReturn(run func(ctx context.Context) (time.Duration, error)) *Provider_HardReconciliationTimeout_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// HelmSettings provides a mock function for the type Provider
+func (_mock *Provider) HelmSettings(ctx context.Context) (v1alpha1.HelmOptions, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for HelmSettings")
+	}
+
+	var r0 v1alpha1.HelmOptions
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (v1alpha1.HelmOptions, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) v1alpha1.HelmOptions); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(v1alpha1.HelmOptions)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Provider_HelmSettings_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'HelmSettings'
+type Provider_HelmSettings_Call struct {
+	*mock.Call
+}
+
+// HelmSettings is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Provider_Expecter) HelmSettings(ctx any) *Provider_HelmSettings_Call {
+	return &Provider_HelmSettings_Call{Call: _e.mock.On("HelmSettings", ctx)}
+}
+
+func (_c *Provider_HelmSettings_Call) Run(run func(ctx context.Context)) *Provider_HelmSettings_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Provider_HelmSettings_Call) Return(helmOptions v1alpha1.HelmOptions, err error) *Provider_HelmSettings_Call {
+	_c.Call.Return(helmOptions, err)
+	return _c
+}
+
+func (_c *Provider_HelmSettings_Call) RunAndReturn(run func(ctx context.Context) (v1alpha1.HelmOptions, error)) *Provider_HelmSettings_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// HydratorReadmeTemplate provides a mock function for the type Provider
+func (_mock *Provider) HydratorReadmeTemplate(ctx context.Context) (string, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for HydratorReadmeTemplate")
+	}
+
+	var r0 string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (string, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) string); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Provider_HydratorReadmeTemplate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'HydratorReadmeTemplate'
+type Provider_HydratorReadmeTemplate_Call struct {
+	*mock.Call
+}
+
+// HydratorReadmeTemplate is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Provider_Expecter) HydratorReadmeTemplate(ctx any) *Provider_HydratorReadmeTemplate_Call {
+	return &Provider_HydratorReadmeTemplate_Call{Call: _e.mock.On("HydratorReadmeTemplate", ctx)}
+}
+
+func (_c *Provider_HydratorReadmeTemplate_Call) Run(run func(ctx context.Context)) *Provider_HydratorReadmeTemplate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Provider_HydratorReadmeTemplate_Call) Return(s string, err error) *Provider_HydratorReadmeTemplate_Call {
+	_c.Call.Return(s, err)
+	return _c
+}
+
+func (_c *Provider_HydratorReadmeTemplate_Call) RunAndReturn(run func(ctx context.Context) (string, error)) *Provider_HydratorReadmeTemplate_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// IgnoreNormalizerJQTimeout provides a mock function for the type Provider
+func (_mock *Provider) IgnoreNormalizerJQTimeout(ctx context.Context) (time.Duration, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IgnoreNormalizerJQTimeout")
+	}
+
+	var r0 time.Duration
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (time.Duration, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) time.Duration); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(time.Duration)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Provider_IgnoreNormalizerJQTimeout_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IgnoreNormalizerJQTimeout'
+type Provider_IgnoreNormalizerJQTimeout_Call struct {
+	*mock.Call
+}
+
+// IgnoreNormalizerJQTimeout is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Provider_Expecter) IgnoreNormalizerJQTimeout(ctx any) *Provider_IgnoreNormalizerJQTimeout_Call {
+	return &Provider_IgnoreNormalizerJQTimeout_Call{Call: _e.mock.On("IgnoreNormalizerJQTimeout", ctx)}
+}
+
+func (_c *Provider_IgnoreNormalizerJQTimeout_Call) Run(run func(ctx context.Context)) *Provider_IgnoreNormalizerJQTimeout_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Provider_IgnoreNormalizerJQTimeout_Call) Return(duration time.Duration, err error) *Provider_IgnoreNormalizerJQTimeout_Call {
+	_c.Call.Return(duration, err)
+	return _c
+}
+
+func (_c *Provider_IgnoreNormalizerJQTimeout_Call) RunAndReturn(run func(ctx context.Context) (time.Duration, error)) *Provider_IgnoreNormalizerJQTimeout_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// IgnoreResourceUpdatesOverrides provides a mock function for the type Provider
+func (_mock *Provider) IgnoreResourceUpdatesOverrides(ctx context.Context) (map[string]v1alpha1.ResourceOverride, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IgnoreResourceUpdatesOverrides")
+	}
+
+	var r0 map[string]v1alpha1.ResourceOverride
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (map[string]v1alpha1.ResourceOverride, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) map[string]v1alpha1.ResourceOverride); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]v1alpha1.ResourceOverride)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Provider_IgnoreResourceUpdatesOverrides_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IgnoreResourceUpdatesOverrides'
+type Provider_IgnoreResourceUpdatesOverrides_Call struct {
+	*mock.Call
+}
+
+// IgnoreResourceUpdatesOverrides is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Provider_Expecter) IgnoreResourceUpdatesOverrides(ctx any) *Provider_IgnoreResourceUpdatesOverrides_Call {
+	return &Provider_IgnoreResourceUpdatesOverrides_Call{Call: _e.mock.On("IgnoreResourceUpdatesOverrides", ctx)}
+}
+
+func (_c *Provider_IgnoreResourceUpdatesOverrides_Call) Run(run func(ctx context.Context)) *Provider_IgnoreResourceUpdatesOverrides_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Provider_IgnoreResourceUpdatesOverrides_Call) Return(stringToResourceOverride map[string]v1alpha1.ResourceOverride, err error) *Provider_IgnoreResourceUpdatesOverrides_Call {
+	_c.Call.Return(stringToResourceOverride, err)
+	return _c
+}
+
+func (_c *Provider_IgnoreResourceUpdatesOverrides_Call) RunAndReturn(run func(ctx context.Context) (map[string]v1alpha1.ResourceOverride, error)) *Provider_IgnoreResourceUpdatesOverrides_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// IncludeEventLabelKeys provides a mock function for the type Provider
+func (_mock *Provider) IncludeEventLabelKeys(ctx context.Context) ([]string, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IncludeEventLabelKeys")
+	}
+
+	var r0 []string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) ([]string, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) []string); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Provider_IncludeEventLabelKeys_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IncludeEventLabelKeys'
+type Provider_IncludeEventLabelKeys_Call struct {
+	*mock.Call
+}
+
+// IncludeEventLabelKeys is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Provider_Expecter) IncludeEventLabelKeys(ctx any) *Provider_IncludeEventLabelKeys_Call {
+	return &Provider_IncludeEventLabelKeys_Call{Call: _e.mock.On("IncludeEventLabelKeys", ctx)}
+}
+
+func (_c *Provider_IncludeEventLabelKeys_Call) Run(run func(ctx context.Context)) *Provider_IncludeEventLabelKeys_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Provider_IncludeEventLabelKeys_Call) Return(strings []string, err error) *Provider_IncludeEventLabelKeys_Call {
+	_c.Call.Return(strings, err)
+	return _c
+}
+
+func (_c *Provider_IncludeEventLabelKeys_Call) RunAndReturn(run func(ctx context.Context) ([]string, error)) *Provider_IncludeEventLabelKeys_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// InstallationID provides a mock function for the type Provider
+func (_mock *Provider) InstallationID(ctx context.Context) (string, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for InstallationID")
+	}
+
+	var r0 string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (string, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) string); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Provider_InstallationID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'InstallationID'
+type Provider_InstallationID_Call struct {
+	*mock.Call
+}
+
+// InstallationID is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Provider_Expecter) InstallationID(ctx any) *Provider_InstallationID_Call {
+	return &Provider_InstallationID_Call{Call: _e.mock.On("InstallationID", ctx)}
+}
+
+func (_c *Provider_InstallationID_Call) Run(run func(ctx context.Context)) *Provider_InstallationID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Provider_InstallationID_Call) Return(s string, err error) *Provider_InstallationID_Call {
+	_c.Call.Return(s, err)
+	return _c
+}
+
+func (_c *Provider_InstallationID_Call) RunAndReturn(run func(ctx context.Context) (string, error)) *Provider_InstallationID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// IsIgnoreResourceUpdatesEnabled provides a mock function for the type Provider
+func (_mock *Provider) IsIgnoreResourceUpdatesEnabled(ctx context.Context) (bool, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsIgnoreResourceUpdatesEnabled")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (bool, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) bool); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Provider_IsIgnoreResourceUpdatesEnabled_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsIgnoreResourceUpdatesEnabled'
+type Provider_IsIgnoreResourceUpdatesEnabled_Call struct {
+	*mock.Call
+}
+
+// IsIgnoreResourceUpdatesEnabled is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Provider_Expecter) IsIgnoreResourceUpdatesEnabled(ctx any) *Provider_IsIgnoreResourceUpdatesEnabled_Call {
+	return &Provider_IsIgnoreResourceUpdatesEnabled_Call{Call: _e.mock.On("IsIgnoreResourceUpdatesEnabled", ctx)}
+}
+
+func (_c *Provider_IsIgnoreResourceUpdatesEnabled_Call) Run(run func(ctx context.Context)) *Provider_IsIgnoreResourceUpdatesEnabled_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Provider_IsIgnoreResourceUpdatesEnabled_Call) Return(b bool, err error) *Provider_IsIgnoreResourceUpdatesEnabled_Call {
+	_c.Call.Return(b, err)
+	return _c
+}
+
+func (_c *Provider_IsIgnoreResourceUpdatesEnabled_Call) RunAndReturn(run func(ctx context.Context) (bool, error)) *Provider_IsIgnoreResourceUpdatesEnabled_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// IsImpersonationEnabled provides a mock function for the type Provider
+func (_mock *Provider) IsImpersonationEnabled(ctx context.Context) (bool, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsImpersonationEnabled")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (bool, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) bool); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Provider_IsImpersonationEnabled_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsImpersonationEnabled'
+type Provider_IsImpersonationEnabled_Call struct {
+	*mock.Call
+}
+
+// IsImpersonationEnabled is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Provider_Expecter) IsImpersonationEnabled(ctx any) *Provider_IsImpersonationEnabled_Call {
+	return &Provider_IsImpersonationEnabled_Call{Call: _e.mock.On("IsImpersonationEnabled", ctx)}
+}
+
+func (_c *Provider_IsImpersonationEnabled_Call) Run(run func(ctx context.Context)) *Provider_IsImpersonationEnabled_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Provider_IsImpersonationEnabled_Call) Return(b bool, err error) *Provider_IsImpersonationEnabled_Call {
+	_c.Call.Return(b, err)
+	return _c
+}
+
+func (_c *Provider_IsImpersonationEnabled_Call) RunAndReturn(run func(ctx context.Context) (bool, error)) *Provider_IsImpersonationEnabled_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// IsImpersonationEnforced provides a mock function for the type Provider
+func (_mock *Provider) IsImpersonationEnforced(ctx context.Context) (bool, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsImpersonationEnforced")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (bool, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) bool); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Provider_IsImpersonationEnforced_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsImpersonationEnforced'
+type Provider_IsImpersonationEnforced_Call struct {
+	*mock.Call
+}
+
+// IsImpersonationEnforced is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Provider_Expecter) IsImpersonationEnforced(ctx any) *Provider_IsImpersonationEnforced_Call {
+	return &Provider_IsImpersonationEnforced_Call{Call: _e.mock.On("IsImpersonationEnforced", ctx)}
+}
+
+func (_c *Provider_IsImpersonationEnforced_Call) Run(run func(ctx context.Context)) *Provider_IsImpersonationEnforced_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Provider_IsImpersonationEnforced_Call) Return(b bool, err error) *Provider_IsImpersonationEnforced_Call {
+	_c.Call.Return(b, err)
+	return _c
+}
+
+func (_c *Provider_IsImpersonationEnforced_Call) RunAndReturn(run func(ctx context.Context) (bool, error)) *Provider_IsImpersonationEnforced_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// KustomizeSettings provides a mock function for the type Provider
+func (_mock *Provider) KustomizeSettings(ctx context.Context) (v1alpha1.KustomizeOptions, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for KustomizeSettings")
+	}
+
+	var r0 v1alpha1.KustomizeOptions
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (v1alpha1.KustomizeOptions, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) v1alpha1.KustomizeOptions); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(v1alpha1.KustomizeOptions)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Provider_KustomizeSettings_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'KustomizeSettings'
+type Provider_KustomizeSettings_Call struct {
+	*mock.Call
+}
+
+// KustomizeSettings is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Provider_Expecter) KustomizeSettings(ctx any) *Provider_KustomizeSettings_Call {
+	return &Provider_KustomizeSettings_Call{Call: _e.mock.On("KustomizeSettings", ctx)}
+}
+
+func (_c *Provider_KustomizeSettings_Call) Run(run func(ctx context.Context)) *Provider_KustomizeSettings_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Provider_KustomizeSettings_Call) Return(kustomizeOptions v1alpha1.KustomizeOptions, err error) *Provider_KustomizeSettings_Call {
+	_c.Call.Return(kustomizeOptions, err)
+	return _c
+}
+
+func (_c *Provider_KustomizeSettings_Call) RunAndReturn(run func(ctx context.Context) (v1alpha1.KustomizeOptions, error)) *Provider_KustomizeSettings_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// MetricsClusterLabels provides a mock function for the type Provider
+func (_mock *Provider) MetricsClusterLabels(ctx context.Context) ([]string, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MetricsClusterLabels")
+	}
+
+	var r0 []string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) ([]string, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) []string); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Provider_MetricsClusterLabels_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MetricsClusterLabels'
+type Provider_MetricsClusterLabels_Call struct {
+	*mock.Call
+}
+
+// MetricsClusterLabels is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Provider_Expecter) MetricsClusterLabels(ctx any) *Provider_MetricsClusterLabels_Call {
+	return &Provider_MetricsClusterLabels_Call{Call: _e.mock.On("MetricsClusterLabels", ctx)}
+}
+
+func (_c *Provider_MetricsClusterLabels_Call) Run(run func(ctx context.Context)) *Provider_MetricsClusterLabels_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Provider_MetricsClusterLabels_Call) Return(strings []string, err error) *Provider_MetricsClusterLabels_Call {
+	_c.Call.Return(strings, err)
+	return _c
+}
+
+func (_c *Provider_MetricsClusterLabels_Call) RunAndReturn(run func(ctx context.Context) ([]string, error)) *Provider_MetricsClusterLabels_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// PersistResourceHealth provides a mock function for the type Provider
+func (_mock *Provider) PersistResourceHealth(ctx context.Context) (bool, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PersistResourceHealth")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (bool, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) bool); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Provider_PersistResourceHealth_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PersistResourceHealth'
+type Provider_PersistResourceHealth_Call struct {
+	*mock.Call
+}
+
+// PersistResourceHealth is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Provider_Expecter) PersistResourceHealth(ctx any) *Provider_PersistResourceHealth_Call {
+	return &Provider_PersistResourceHealth_Call{Call: _e.mock.On("PersistResourceHealth", ctx)}
+}
+
+func (_c *Provider_PersistResourceHealth_Call) Run(run func(ctx context.Context)) *Provider_PersistResourceHealth_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Provider_PersistResourceHealth_Call) Return(b bool, err error) *Provider_PersistResourceHealth_Call {
+	_c.Call.Return(b, err)
+	return _c
+}
+
+func (_c *Provider_PersistResourceHealth_Call) RunAndReturn(run func(ctx context.Context) (bool, error)) *Provider_PersistResourceHealth_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ReconciliationJitter provides a mock function for the type Provider
+func (_mock *Provider) ReconciliationJitter(ctx context.Context) (time.Duration, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ReconciliationJitter")
+	}
+
+	var r0 time.Duration
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (time.Duration, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) time.Duration); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(time.Duration)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Provider_ReconciliationJitter_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ReconciliationJitter'
+type Provider_ReconciliationJitter_Call struct {
+	*mock.Call
+}
+
+// ReconciliationJitter is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Provider_Expecter) ReconciliationJitter(ctx any) *Provider_ReconciliationJitter_Call {
+	return &Provider_ReconciliationJitter_Call{Call: _e.mock.On("ReconciliationJitter", ctx)}
+}
+
+func (_c *Provider_ReconciliationJitter_Call) Run(run func(ctx context.Context)) *Provider_ReconciliationJitter_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Provider_ReconciliationJitter_Call) Return(duration time.Duration, err error) *Provider_ReconciliationJitter_Call {
+	_c.Call.Return(duration, err)
+	return _c
+}
+
+func (_c *Provider_ReconciliationJitter_Call) RunAndReturn(run func(ctx context.Context) (time.Duration, error)) *Provider_ReconciliationJitter_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ReconciliationTimeout provides a mock function for the type Provider
+func (_mock *Provider) ReconciliationTimeout(ctx context.Context) (time.Duration, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ReconciliationTimeout")
+	}
+
+	var r0 time.Duration
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (time.Duration, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) time.Duration); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(time.Duration)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Provider_ReconciliationTimeout_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ReconciliationTimeout'
+type Provider_ReconciliationTimeout_Call struct {
+	*mock.Call
+}
+
+// ReconciliationTimeout is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Provider_Expecter) ReconciliationTimeout(ctx any) *Provider_ReconciliationTimeout_Call {
+	return &Provider_ReconciliationTimeout_Call{Call: _e.mock.On("ReconciliationTimeout", ctx)}
+}
+
+func (_c *Provider_ReconciliationTimeout_Call) Run(run func(ctx context.Context)) *Provider_ReconciliationTimeout_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Provider_ReconciliationTimeout_Call) Return(duration time.Duration, err error) *Provider_ReconciliationTimeout_Call {
+	_c.Call.Return(duration, err)
+	return _c
+}
+
+func (_c *Provider_ReconciliationTimeout_Call) RunAndReturn(run func(ctx context.Context) (time.Duration, error)) *Provider_ReconciliationTimeout_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// RepoErrorGracePeriod provides a mock function for the type Provider
+func (_mock *Provider) RepoErrorGracePeriod(ctx context.Context) (time.Duration, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RepoErrorGracePeriod")
+	}
+
+	var r0 time.Duration
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (time.Duration, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) time.Duration); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(time.Duration)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Provider_RepoErrorGracePeriod_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RepoErrorGracePeriod'
+type Provider_RepoErrorGracePeriod_Call struct {
+	*mock.Call
+}
+
+// RepoErrorGracePeriod is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Provider_Expecter) RepoErrorGracePeriod(ctx any) *Provider_RepoErrorGracePeriod_Call {
+	return &Provider_RepoErrorGracePeriod_Call{Call: _e.mock.On("RepoErrorGracePeriod", ctx)}
+}
+
+func (_c *Provider_RepoErrorGracePeriod_Call) Run(run func(ctx context.Context)) *Provider_RepoErrorGracePeriod_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Provider_RepoErrorGracePeriod_Call) Return(duration time.Duration, err error) *Provider_RepoErrorGracePeriod_Call {
+	_c.Call.Return(duration, err)
+	return _c
+}
+
+func (_c *Provider_RepoErrorGracePeriod_Call) RunAndReturn(run func(ctx context.Context) (time.Duration, error)) *Provider_RepoErrorGracePeriod_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ResourceCompareOptions provides a mock function for the type Provider
+func (_mock *Provider) ResourceCompareOptions(ctx context.Context) (settings.ArgoCDDiffOptions, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ResourceCompareOptions")
+	}
+
+	var r0 settings.ArgoCDDiffOptions
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (settings.ArgoCDDiffOptions, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) settings.ArgoCDDiffOptions); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(settings.ArgoCDDiffOptions)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Provider_ResourceCompareOptions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ResourceCompareOptions'
+type Provider_ResourceCompareOptions_Call struct {
+	*mock.Call
+}
+
+// ResourceCompareOptions is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Provider_Expecter) ResourceCompareOptions(ctx any) *Provider_ResourceCompareOptions_Call {
+	return &Provider_ResourceCompareOptions_Call{Call: _e.mock.On("ResourceCompareOptions", ctx)}
+}
+
+func (_c *Provider_ResourceCompareOptions_Call) Run(run func(ctx context.Context)) *Provider_ResourceCompareOptions_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Provider_ResourceCompareOptions_Call) Return(argoCDDiffOptions settings.ArgoCDDiffOptions, err error) *Provider_ResourceCompareOptions_Call {
+	_c.Call.Return(argoCDDiffOptions, err)
+	return _c
+}
+
+func (_c *Provider_ResourceCompareOptions_Call) RunAndReturn(run func(ctx context.Context) (settings.ArgoCDDiffOptions, error)) *Provider_ResourceCompareOptions_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ResourceCustomLabels provides a mock function for the type Provider
+func (_mock *Provider) ResourceCustomLabels(ctx context.Context) ([]string, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ResourceCustomLabels")
+	}
+
+	var r0 []string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) ([]string, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) []string); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Provider_ResourceCustomLabels_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ResourceCustomLabels'
+type Provider_ResourceCustomLabels_Call struct {
+	*mock.Call
+}
+
+// ResourceCustomLabels is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Provider_Expecter) ResourceCustomLabels(ctx any) *Provider_ResourceCustomLabels_Call {
+	return &Provider_ResourceCustomLabels_Call{Call: _e.mock.On("ResourceCustomLabels", ctx)}
+}
+
+func (_c *Provider_ResourceCustomLabels_Call) Run(run func(ctx context.Context)) *Provider_ResourceCustomLabels_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Provider_ResourceCustomLabels_Call) Return(strings []string, err error) *Provider_ResourceCustomLabels_Call {
+	_c.Call.Return(strings, err)
+	return _c
+}
+
+func (_c *Provider_ResourceCustomLabels_Call) RunAndReturn(run func(ctx context.Context) ([]string, error)) *Provider_ResourceCustomLabels_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ResourceOverrides provides a mock function for the type Provider
+func (_mock *Provider) ResourceOverrides(ctx context.Context) (map[string]v1alpha1.ResourceOverride, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ResourceOverrides")
+	}
+
+	var r0 map[string]v1alpha1.ResourceOverride
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (map[string]v1alpha1.ResourceOverride, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) map[string]v1alpha1.ResourceOverride); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]v1alpha1.ResourceOverride)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Provider_ResourceOverrides_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ResourceOverrides'
+type Provider_ResourceOverrides_Call struct {
+	*mock.Call
+}
+
+// ResourceOverrides is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Provider_Expecter) ResourceOverrides(ctx any) *Provider_ResourceOverrides_Call {
+	return &Provider_ResourceOverrides_Call{Call: _e.mock.On("ResourceOverrides", ctx)}
+}
+
+func (_c *Provider_ResourceOverrides_Call) Run(run func(ctx context.Context)) *Provider_ResourceOverrides_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Provider_ResourceOverrides_Call) Return(stringToResourceOverride map[string]v1alpha1.ResourceOverride, err error) *Provider_ResourceOverrides_Call {
+	_c.Call.Return(stringToResourceOverride, err)
+	return _c
+}
+
+func (_c *Provider_ResourceOverrides_Call) RunAndReturn(run func(ctx context.Context) (map[string]v1alpha1.ResourceOverride, error)) *Provider_ResourceOverrides_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ResourcesFilter provides a mock function for the type Provider
+func (_mock *Provider) ResourcesFilter(ctx context.Context) (settings.ResourcesFilter, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ResourcesFilter")
+	}
+
+	var r0 settings.ResourcesFilter
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (settings.ResourcesFilter, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) settings.ResourcesFilter); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(settings.ResourcesFilter)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Provider_ResourcesFilter_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ResourcesFilter'
+type Provider_ResourcesFilter_Call struct {
+	*mock.Call
+}
+
+// ResourcesFilter is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Provider_Expecter) ResourcesFilter(ctx any) *Provider_ResourcesFilter_Call {
+	return &Provider_ResourcesFilter_Call{Call: _e.mock.On("ResourcesFilter", ctx)}
+}
+
+func (_c *Provider_ResourcesFilter_Call) Run(run func(ctx context.Context)) *Provider_ResourcesFilter_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Provider_ResourcesFilter_Call) Return(resourcesFilter settings.ResourcesFilter, err error) *Provider_ResourcesFilter_Call {
+	_c.Call.Return(resourcesFilter, err)
+	return _c
+}
+
+func (_c *Provider_ResourcesFilter_Call) RunAndReturn(run func(ctx context.Context) (settings.ResourcesFilter, error)) *Provider_ResourcesFilter_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// RespectRBAC provides a mock function for the type Provider
+func (_mock *Provider) RespectRBAC(ctx context.Context) (int, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RespectRBAC")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (int, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) int); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Provider_RespectRBAC_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RespectRBAC'
+type Provider_RespectRBAC_Call struct {
+	*mock.Call
+}
+
+// RespectRBAC is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Provider_Expecter) RespectRBAC(ctx any) *Provider_RespectRBAC_Call {
+	return &Provider_RespectRBAC_Call{Call: _e.mock.On("RespectRBAC", ctx)}
+}
+
+func (_c *Provider_RespectRBAC_Call) Run(run func(ctx context.Context)) *Provider_RespectRBAC_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Provider_RespectRBAC_Call) Return(n int, err error) *Provider_RespectRBAC_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *Provider_RespectRBAC_Call) RunAndReturn(run func(ctx context.Context) (int, error)) *Provider_RespectRBAC_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// SelfHealRetry provides a mock function for the type Provider
+func (_mock *Provider) SelfHealRetry(ctx context.Context) (configbus.SelfHealRetry, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SelfHealRetry")
+	}
+
+	var r0 configbus.SelfHealRetry
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (configbus.SelfHealRetry, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) configbus.SelfHealRetry); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(configbus.SelfHealRetry)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Provider_SelfHealRetry_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SelfHealRetry'
+type Provider_SelfHealRetry_Call struct {
+	*mock.Call
+}
+
+// SelfHealRetry is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Provider_Expecter) SelfHealRetry(ctx any) *Provider_SelfHealRetry_Call {
+	return &Provider_SelfHealRetry_Call{Call: _e.mock.On("SelfHealRetry", ctx)}
+}
+
+func (_c *Provider_SelfHealRetry_Call) Run(run func(ctx context.Context)) *Provider_SelfHealRetry_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Provider_SelfHealRetry_Call) Return(selfHealRetry configbus.SelfHealRetry, err error) *Provider_SelfHealRetry_Call {
+	_c.Call.Return(selfHealRetry, err)
+	return _c
+}
+
+func (_c *Provider_SelfHealRetry_Call) RunAndReturn(run func(ctx context.Context) (configbus.SelfHealRetry, error)) *Provider_SelfHealRetry_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// SelfHealTimeout provides a mock function for the type Provider
+func (_mock *Provider) SelfHealTimeout(ctx context.Context) (time.Duration, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SelfHealTimeout")
+	}
+
+	var r0 time.Duration
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (time.Duration, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) time.Duration); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(time.Duration)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Provider_SelfHealTimeout_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SelfHealTimeout'
+type Provider_SelfHealTimeout_Call struct {
+	*mock.Call
+}
+
+// SelfHealTimeout is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Provider_Expecter) SelfHealTimeout(ctx any) *Provider_SelfHealTimeout_Call {
+	return &Provider_SelfHealTimeout_Call{Call: _e.mock.On("SelfHealTimeout", ctx)}
+}
+
+func (_c *Provider_SelfHealTimeout_Call) Run(run func(ctx context.Context)) *Provider_SelfHealTimeout_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Provider_SelfHealTimeout_Call) Return(duration time.Duration, err error) *Provider_SelfHealTimeout_Call {
+	_c.Call.Return(duration, err)
+	return _c
+}
+
+func (_c *Provider_SelfHealTimeout_Call) RunAndReturn(run func(ctx context.Context) (time.Duration, error)) *Provider_SelfHealTimeout_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// SensitiveAnnotations provides a mock function for the type Provider
+func (_mock *Provider) SensitiveAnnotations(ctx context.Context) (map[string]bool, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SensitiveAnnotations")
+	}
+
+	var r0 map[string]bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (map[string]bool, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) map[string]bool); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]bool)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Provider_SensitiveAnnotations_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SensitiveAnnotations'
+type Provider_SensitiveAnnotations_Call struct {
+	*mock.Call
+}
+
+// SensitiveAnnotations is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Provider_Expecter) SensitiveAnnotations(ctx any) *Provider_SensitiveAnnotations_Call {
+	return &Provider_SensitiveAnnotations_Call{Call: _e.mock.On("SensitiveAnnotations", ctx)}
+}
+
+func (_c *Provider_SensitiveAnnotations_Call) Run(run func(ctx context.Context)) *Provider_SensitiveAnnotations_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Provider_SensitiveAnnotations_Call) Return(stringToBool map[string]bool, err error) *Provider_SensitiveAnnotations_Call {
+	_c.Call.Return(stringToBool, err)
+	return _c
+}
+
+func (_c *Provider_SensitiveAnnotations_Call) RunAndReturn(run func(ctx context.Context) (map[string]bool, error)) *Provider_SensitiveAnnotations_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ServerSideDiff provides a mock function for the type Provider
+func (_mock *Provider) ServerSideDiff(ctx context.Context) (bool, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ServerSideDiff")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (bool, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) bool); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Provider_ServerSideDiff_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ServerSideDiff'
+type Provider_ServerSideDiff_Call struct {
+	*mock.Call
+}
+
+// ServerSideDiff is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Provider_Expecter) ServerSideDiff(ctx any) *Provider_ServerSideDiff_Call {
+	return &Provider_ServerSideDiff_Call{Call: _e.mock.On("ServerSideDiff", ctx)}
+}
+
+func (_c *Provider_ServerSideDiff_Call) Run(run func(ctx context.Context)) *Provider_ServerSideDiff_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Provider_ServerSideDiff_Call) Return(b bool, err error) *Provider_ServerSideDiff_Call {
+	_c.Call.Return(b, err)
+	return _c
+}
+
+func (_c *Provider_ServerSideDiff_Call) RunAndReturn(run func(ctx context.Context) (bool, error)) *Provider_ServerSideDiff_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// SourceHydratorCommitMessageTemplate provides a mock function for the type Provider
+func (_mock *Provider) SourceHydratorCommitMessageTemplate(ctx context.Context) (string, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SourceHydratorCommitMessageTemplate")
+	}
+
+	var r0 string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (string, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) string); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Provider_SourceHydratorCommitMessageTemplate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SourceHydratorCommitMessageTemplate'
+type Provider_SourceHydratorCommitMessageTemplate_Call struct {
+	*mock.Call
+}
+
+// SourceHydratorCommitMessageTemplate is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Provider_Expecter) SourceHydratorCommitMessageTemplate(ctx any) *Provider_SourceHydratorCommitMessageTemplate_Call {
+	return &Provider_SourceHydratorCommitMessageTemplate_Call{Call: _e.mock.On("SourceHydratorCommitMessageTemplate", ctx)}
+}
+
+func (_c *Provider_SourceHydratorCommitMessageTemplate_Call) Run(run func(ctx context.Context)) *Provider_SourceHydratorCommitMessageTemplate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Provider_SourceHydratorCommitMessageTemplate_Call) Return(s string, err error) *Provider_SourceHydratorCommitMessageTemplate_Call {
+	_c.Call.Return(s, err)
+	return _c
+}
+
+func (_c *Provider_SourceHydratorCommitMessageTemplate_Call) RunAndReturn(run func(ctx context.Context) (string, error)) *Provider_SourceHydratorCommitMessageTemplate_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // Subscribe provides a mock function for the type Provider
@@ -73,6 +2138,126 @@ func (_c *Provider_Subscribe_Call) Return() *Provider_Subscribe_Call {
 
 func (_c *Provider_Subscribe_Call) RunAndReturn(run func(subCh chan<- *settings.ArgoCDSettings)) *Provider_Subscribe_Call {
 	_c.Run(run)
+	return _c
+}
+
+// SyncTimeout provides a mock function for the type Provider
+func (_mock *Provider) SyncTimeout(ctx context.Context) (time.Duration, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SyncTimeout")
+	}
+
+	var r0 time.Duration
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (time.Duration, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) time.Duration); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(time.Duration)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Provider_SyncTimeout_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SyncTimeout'
+type Provider_SyncTimeout_Call struct {
+	*mock.Call
+}
+
+// SyncTimeout is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Provider_Expecter) SyncTimeout(ctx any) *Provider_SyncTimeout_Call {
+	return &Provider_SyncTimeout_Call{Call: _e.mock.On("SyncTimeout", ctx)}
+}
+
+func (_c *Provider_SyncTimeout_Call) Run(run func(ctx context.Context)) *Provider_SyncTimeout_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Provider_SyncTimeout_Call) Return(duration time.Duration, err error) *Provider_SyncTimeout_Call {
+	_c.Call.Return(duration, err)
+	return _c
+}
+
+func (_c *Provider_SyncTimeout_Call) RunAndReturn(run func(ctx context.Context) (time.Duration, error)) *Provider_SyncTimeout_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// TrackingMethod provides a mock function for the type Provider
+func (_mock *Provider) TrackingMethod(ctx context.Context) (string, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for TrackingMethod")
+	}
+
+	var r0 string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (string, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) string); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Provider_TrackingMethod_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'TrackingMethod'
+type Provider_TrackingMethod_Call struct {
+	*mock.Call
+}
+
+// TrackingMethod is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Provider_Expecter) TrackingMethod(ctx any) *Provider_TrackingMethod_Call {
+	return &Provider_TrackingMethod_Call{Call: _e.mock.On("TrackingMethod", ctx)}
+}
+
+func (_c *Provider_TrackingMethod_Call) Run(run func(ctx context.Context)) *Provider_TrackingMethod_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Provider_TrackingMethod_Call) Return(s string, err error) *Provider_TrackingMethod_Call {
+	_c.Call.Return(s, err)
+	return _c
+}
+
+func (_c *Provider_TrackingMethod_Call) RunAndReturn(run func(ctx context.Context) (string, error)) *Provider_TrackingMethod_Call {
+	_c.Call.Return(run)
 	return _c
 }
 

--- a/util/configbus/provider.go
+++ b/util/configbus/provider.go
@@ -1,15 +1,25 @@
 package configbus
 
 import (
+	"context"
 	"errors"
+	"time"
 
+	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v3/util/settings"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 // ErrNotConfigured is returned by a leaf Provider when it does not own / does
 // not have a value for a field. ChainProvider skips links that return this
 // sentinel and continues to the next link.
 var ErrNotConfigured = errors.New("config: not configured")
+
+// SelfHealRetry is the self-heal retry policy. A nil Backoff means use a flat
+// SelfHealTimeout rather than exponential backoff.
+type SelfHealRetry struct {
+	Backoff *wait.Backoff
+}
 
 // Provider is the typed config API for one Argo CD process.
 //
@@ -27,9 +37,45 @@ var ErrNotConfigured = errors.New("config: not configured")
 // SettingsManagerProvider / Env; CRD is inserted once wired). Tests typically
 // inject mocks.Provider from mockery, or a StaticProvider literal.
 type Provider interface {
+	AllowedNodeLabels(ctx context.Context) ([]string, error)
+	AppInstanceLabelKey(ctx context.Context) (string, error)
+	CommitAuthorEmail(ctx context.Context) (string, error)
+	CommitAuthorName(ctx context.Context) (string, error)
+	EnabledSourceTypes(ctx context.Context) (map[string]bool, error)
+	ExcludeEventLabelKeys(ctx context.Context) ([]string, error)
+	GitRequestTimeout(ctx context.Context) (time.Duration, error)
+	GlobalProjectsSettings(ctx context.Context) ([]settings.GlobalProjectSettings, error)
+	HardReconciliationTimeout(ctx context.Context) (time.Duration, error)
+	HelmSettings(ctx context.Context) (v1alpha1.HelmOptions, error)
+	HydratorReadmeTemplate(ctx context.Context) (string, error)
+	IgnoreNormalizerJQTimeout(ctx context.Context) (time.Duration, error)
+	IgnoreResourceUpdatesOverrides(ctx context.Context) (map[string]v1alpha1.ResourceOverride, error)
+	IncludeEventLabelKeys(ctx context.Context) ([]string, error)
+	InstallationID(ctx context.Context) (string, error)
+	IsIgnoreResourceUpdatesEnabled(ctx context.Context) (bool, error)
+	IsImpersonationEnabled(ctx context.Context) (bool, error)
+	IsImpersonationEnforced(ctx context.Context) (bool, error)
+	KustomizeSettings(ctx context.Context) (v1alpha1.KustomizeOptions, error)
+	MetricsClusterLabels(ctx context.Context) ([]string, error)
+	PersistResourceHealth(ctx context.Context) (bool, error)
+	ReconciliationJitter(ctx context.Context) (time.Duration, error)
+	ReconciliationTimeout(ctx context.Context) (time.Duration, error)
+	RepoErrorGracePeriod(ctx context.Context) (time.Duration, error)
+	ResourceCompareOptions(ctx context.Context) (settings.ArgoCDDiffOptions, error)
+	ResourceCustomLabels(ctx context.Context) ([]string, error)
+	ResourceOverrides(ctx context.Context) (map[string]v1alpha1.ResourceOverride, error)
+	ResourcesFilter(ctx context.Context) (settings.ResourcesFilter, error)
+	RespectRBAC(ctx context.Context) (int, error)
+	SelfHealRetry(ctx context.Context) (SelfHealRetry, error)
+	SelfHealTimeout(ctx context.Context) (time.Duration, error)
+	SensitiveAnnotations(ctx context.Context) (map[string]bool, error)
+	ServerSideDiff(ctx context.Context) (bool, error)
+	SourceHydratorCommitMessageTemplate(ctx context.Context) (string, error)
 	// Subscribe registers for argocd-cm/secret change notifications when the
 	// backing implementation supports it (SettingsManagerProvider / ChainProvider).
 	Subscribe(subCh chan<- *settings.ArgoCDSettings)
+	SyncTimeout(ctx context.Context) (time.Duration, error)
+	TrackingMethod(ctx context.Context) (string, error)
 	// Unsubscribe unregisters a settings change subscriber.
 	Unsubscribe(subCh chan<- *settings.ArgoCDSettings)
 }

--- a/util/configbus/provider_test.go
+++ b/util/configbus/provider_test.go
@@ -1,13 +1,107 @@
 package configbus
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
+
+func TestEnvProviderGitRequestTimeoutDefault(t *testing.T) {
+	t.Setenv("ARGOCD_GIT_REQUEST_TIMEOUT", "")
+	p := NewEnvProvider()
+	d, err := p.GitRequestTimeout(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 15*time.Second, d)
+
+	t.Setenv("ARGOCD_GIT_REQUEST_TIMEOUT", "30s")
+	d, err = p.GitRequestTimeout(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 30*time.Second, d)
+}
+
+func TestEnvProviderUnownedReturnsErrNotConfigured(t *testing.T) {
+	p := NewEnvProvider()
+	_, err := p.SyncTimeout(context.Background())
+	require.ErrorIs(t, err, ErrNotConfigured)
+}
 
 func TestSettingsManagerProviderRequiresMgr(t *testing.T) {
 	assert.Panics(t, func() {
 		NewSettingsManagerProvider(nil)
 	})
+}
+
+func TestStaticProviderRoundTrip(t *testing.T) {
+	syncTimeout := 5 * time.Minute
+	labels := []string{"team"}
+	backoff := &wait.Backoff{Duration: time.Second}
+	p := &StaticProvider{Fields: StaticFields{
+		SyncTimeout:               &syncTimeout,
+		MetricsClusterLabels:      &labels,
+		IgnoreNormalizerJQTimeout: Ptr(2 * time.Second),
+		ServerSideDiff:            Ptr(true),
+		SelfHealRetry:             Ptr(SelfHealRetry{Backoff: backoff}),
+	}}
+
+	d, err := p.SyncTimeout(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 5*time.Minute, d)
+
+	gotLabels, err := p.MetricsClusterLabels(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"team"}, gotLabels)
+
+	jqTimeout, err := p.IgnoreNormalizerJQTimeout(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 2*time.Second, jqTimeout)
+
+	b, err := p.ServerSideDiff(context.Background())
+	require.NoError(t, err)
+	assert.True(t, b)
+
+	gotRetry, err := p.SelfHealRetry(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, backoff, gotRetry.Backoff)
+
+	_, err = p.AppInstanceLabelKey(context.Background())
+	require.ErrorIs(t, err, ErrNotConfigured)
+}
+
+func TestStaticProviderConfiguredNilSelfHealBackoff(t *testing.T) {
+	p := &StaticProvider{Fields: StaticFields{SelfHealRetry: Ptr(SelfHealRetry{Backoff: nil})}}
+	got, err := p.SelfHealRetry(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, got.Backoff)
+}
+
+func TestChainProviderPrecedence(t *testing.T) {
+	overrideTimeout := 10 * time.Second
+	fallbackTimeout := 90 * time.Second
+	override := &StaticProvider{Fields: StaticFields{SyncTimeout: &overrideTimeout}}
+	fallback := &StaticProvider{Fields: StaticFields{SyncTimeout: &fallbackTimeout, SelfHealTimeout: Ptr(30 * time.Second)}}
+	chain := NewChainProvider(override, fallback, NewEnvProvider())
+
+	d, err := chain.SyncTimeout(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 10*time.Second, d, "override Static must beat fallback")
+
+	d, err = chain.SelfHealTimeout(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 30*time.Second, d, "fallback Static supplies unset override fields")
+
+	d, err = chain.GitRequestTimeout(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 15*time.Second, d, "EnvProvider supplies env-only fields")
+}
+
+func TestChainProviderSkipsErrNotConfigured(t *testing.T) {
+	unset := &StaticProvider{}
+	chain := NewChainProvider(unset, &StaticProvider{Fields: StaticFields{ReconciliationTimeout: Ptr(120 * time.Second)}})
+	d, err := chain.ReconciliationTimeout(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 120*time.Second, d)
 }

--- a/util/configbus/settings_manager_provider.go
+++ b/util/configbus/settings_manager_provider.go
@@ -2,6 +2,9 @@
 package configbus
 
 import (
+	"context"
+
+	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v3/util/settings"
 )
 
@@ -29,8 +32,115 @@ func NewSettingsManagerProvider(mgr *settings.SettingsManager) *SettingsManagerP
 // Ensure SettingsManagerProvider implements Provider.
 var _ Provider = (*SettingsManagerProvider)(nil)
 
+func (p *SettingsManagerProvider) AllowedNodeLabels(_ context.Context) ([]string, error) {
+	return withMgr(p, func(mgr *settings.SettingsManager) ([]string, error) {
+		return mgr.GetAllowedNodeLabels(), nil
+	})
+}
+func (p *SettingsManagerProvider) AppInstanceLabelKey(_ context.Context) (string, error) {
+	return withMgr(p, (*settings.SettingsManager).GetAppInstanceLabelKey)
+}
+func (p *SettingsManagerProvider) CommitAuthorEmail(_ context.Context) (string, error) {
+	return withMgr(p, (*settings.SettingsManager).GetCommitAuthorEmail)
+}
+func (p *SettingsManagerProvider) CommitAuthorName(_ context.Context) (string, error) {
+	return withMgr(p, (*settings.SettingsManager).GetCommitAuthorName)
+}
+func (p *SettingsManagerProvider) EnabledSourceTypes(_ context.Context) (map[string]bool, error) {
+	return withMgr(p, (*settings.SettingsManager).GetEnabledSourceTypes)
+}
+func (p *SettingsManagerProvider) ExcludeEventLabelKeys(_ context.Context) ([]string, error) {
+	return withMgr(p, func(mgr *settings.SettingsManager) ([]string, error) {
+		return mgr.GetExcludeEventLabelKeys(), nil
+	})
+}
+func (p *SettingsManagerProvider) GlobalProjectsSettings(_ context.Context) ([]settings.GlobalProjectSettings, error) {
+	return withMgr(p, (*settings.SettingsManager).GetGlobalProjectsSettings)
+}
+func (p *SettingsManagerProvider) HelmSettings(_ context.Context) (v1alpha1.HelmOptions, error) {
+	return withMgr(p, func(mgr *settings.SettingsManager) (v1alpha1.HelmOptions, error) {
+		opts, err := mgr.GetHelmSettings()
+		if err != nil {
+			return v1alpha1.HelmOptions{}, err
+		}
+		if opts == nil {
+			return v1alpha1.HelmOptions{}, nil
+		}
+		return *opts, nil
+	})
+}
+func (p *SettingsManagerProvider) HydratorReadmeTemplate(_ context.Context) (string, error) {
+	return withMgr(p, (*settings.SettingsManager).GetHydratorReadmeTemplate)
+}
+func (p *SettingsManagerProvider) IgnoreResourceUpdatesOverrides(_ context.Context) (map[string]v1alpha1.ResourceOverride, error) {
+	return withMgr(p, (*settings.SettingsManager).GetIgnoreResourceUpdatesOverrides)
+}
+func (p *SettingsManagerProvider) IncludeEventLabelKeys(_ context.Context) ([]string, error) {
+	return withMgr(p, func(mgr *settings.SettingsManager) ([]string, error) {
+		return mgr.GetIncludeEventLabelKeys(), nil
+	})
+}
+func (p *SettingsManagerProvider) InstallationID(_ context.Context) (string, error) {
+	return withMgr(p, (*settings.SettingsManager).GetInstallationID)
+}
+func (p *SettingsManagerProvider) IsIgnoreResourceUpdatesEnabled(_ context.Context) (bool, error) {
+	return withMgr(p, (*settings.SettingsManager).GetIsIgnoreResourceUpdatesEnabled)
+}
+func (p *SettingsManagerProvider) IsImpersonationEnabled(_ context.Context) (bool, error) {
+	return withMgr(p, (*settings.SettingsManager).IsImpersonationEnabled)
+}
+func (p *SettingsManagerProvider) IsImpersonationEnforced(_ context.Context) (bool, error) {
+	return withMgr(p, (*settings.SettingsManager).IsImpersonationEnforced)
+}
+func (p *SettingsManagerProvider) KustomizeSettings(_ context.Context) (v1alpha1.KustomizeOptions, error) {
+	return withMgr(p, func(mgr *settings.SettingsManager) (v1alpha1.KustomizeOptions, error) {
+		opts, err := mgr.GetKustomizeSettings()
+		if err != nil {
+			return v1alpha1.KustomizeOptions{}, err
+		}
+		if opts == nil {
+			return v1alpha1.KustomizeOptions{}, nil
+		}
+		return *opts, nil
+	})
+}
+func (p *SettingsManagerProvider) ResourceCompareOptions(_ context.Context) (settings.ArgoCDDiffOptions, error) {
+	return withMgr(p, (*settings.SettingsManager).GetResourceCompareOptions)
+}
+func (p *SettingsManagerProvider) ResourceCustomLabels(_ context.Context) ([]string, error) {
+	return withMgr(p, (*settings.SettingsManager).GetResourceCustomLabels)
+}
+func (p *SettingsManagerProvider) ResourceOverrides(_ context.Context) (map[string]v1alpha1.ResourceOverride, error) {
+	return withMgr(p, (*settings.SettingsManager).GetResourceOverrides)
+}
+func (p *SettingsManagerProvider) ResourcesFilter(_ context.Context) (settings.ResourcesFilter, error) {
+	return withMgr(p, func(mgr *settings.SettingsManager) (settings.ResourcesFilter, error) {
+		f, err := mgr.GetResourcesFilter()
+		if err != nil {
+			return settings.ResourcesFilter{}, err
+		}
+		if f == nil {
+			return settings.ResourcesFilter{}, nil
+		}
+		return *f, nil
+	})
+}
+func (p *SettingsManagerProvider) RespectRBAC(_ context.Context) (int, error) {
+	return withMgr(p, (*settings.SettingsManager).RespectRBAC)
+}
+func (p *SettingsManagerProvider) SensitiveAnnotations(_ context.Context) (map[string]bool, error) {
+	return withMgr(p, func(mgr *settings.SettingsManager) (map[string]bool, error) {
+		return mgr.GetSensitiveAnnotations(), nil
+	})
+}
+func (p *SettingsManagerProvider) SourceHydratorCommitMessageTemplate(_ context.Context) (string, error) {
+	return withMgr(p, (*settings.SettingsManager).GetSourceHydratorCommitMessageTemplate)
+}
 func (p *SettingsManagerProvider) Subscribe(subCh chan<- *settings.ArgoCDSettings) {
 	p.mgr.Subscribe(subCh)
+}
+func (p *SettingsManagerProvider) TrackingMethod(_ context.Context) (string, error) {
+	return withMgr(p, (*settings.SettingsManager).GetTrackingMethod)
 }
 func (p *SettingsManagerProvider) Unsubscribe(subCh chan<- *settings.ArgoCDSettings) {
 	p.mgr.Unsubscribe(subCh)

--- a/util/configbus/zz_generated.chain_provider.go
+++ b/util/configbus/zz_generated.chain_provider.go
@@ -3,6 +3,10 @@
 package configbus
 
 import (
+	"context"
+	"time"
+
+	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v3/util/settings"
 )
 
@@ -26,10 +30,226 @@ func NewChainProvider(links ...Provider) *ChainProvider {
 // Ensure ChainProvider implements Provider.
 var _ Provider = (*ChainProvider)(nil)
 
+func (c *ChainProvider) AllowedNodeLabels(ctx context.Context) ([]string, error) {
+	return firstConfigured(func(p Provider) ([]string, error) {
+		return p.AllowedNodeLabels(ctx)
+	}, c.links)
+}
+
+func (c *ChainProvider) AppInstanceLabelKey(ctx context.Context) (string, error) {
+	return firstConfigured(func(p Provider) (string, error) {
+		return p.AppInstanceLabelKey(ctx)
+	}, c.links)
+}
+
+func (c *ChainProvider) CommitAuthorEmail(ctx context.Context) (string, error) {
+	return firstConfigured(func(p Provider) (string, error) {
+		return p.CommitAuthorEmail(ctx)
+	}, c.links)
+}
+
+func (c *ChainProvider) CommitAuthorName(ctx context.Context) (string, error) {
+	return firstConfigured(func(p Provider) (string, error) {
+		return p.CommitAuthorName(ctx)
+	}, c.links)
+}
+
+func (c *ChainProvider) EnabledSourceTypes(ctx context.Context) (map[string]bool, error) {
+	return firstConfigured(func(p Provider) (map[string]bool, error) {
+		return p.EnabledSourceTypes(ctx)
+	}, c.links)
+}
+
+func (c *ChainProvider) ExcludeEventLabelKeys(ctx context.Context) ([]string, error) {
+	return firstConfigured(func(p Provider) ([]string, error) {
+		return p.ExcludeEventLabelKeys(ctx)
+	}, c.links)
+}
+
+func (c *ChainProvider) GitRequestTimeout(ctx context.Context) (time.Duration, error) {
+	return firstConfigured(func(p Provider) (time.Duration, error) {
+		return p.GitRequestTimeout(ctx)
+	}, c.links)
+}
+
+func (c *ChainProvider) GlobalProjectsSettings(ctx context.Context) ([]settings.GlobalProjectSettings, error) {
+	return firstConfigured(func(p Provider) ([]settings.GlobalProjectSettings, error) {
+		return p.GlobalProjectsSettings(ctx)
+	}, c.links)
+}
+
+func (c *ChainProvider) HardReconciliationTimeout(ctx context.Context) (time.Duration, error) {
+	return firstConfigured(func(p Provider) (time.Duration, error) {
+		return p.HardReconciliationTimeout(ctx)
+	}, c.links)
+}
+
+func (c *ChainProvider) HelmSettings(ctx context.Context) (v1alpha1.HelmOptions, error) {
+	return firstConfigured(func(p Provider) (v1alpha1.HelmOptions, error) {
+		return p.HelmSettings(ctx)
+	}, c.links)
+}
+
+func (c *ChainProvider) HydratorReadmeTemplate(ctx context.Context) (string, error) {
+	return firstConfigured(func(p Provider) (string, error) {
+		return p.HydratorReadmeTemplate(ctx)
+	}, c.links)
+}
+
+func (c *ChainProvider) IgnoreNormalizerJQTimeout(ctx context.Context) (time.Duration, error) {
+	return firstConfigured(func(p Provider) (time.Duration, error) {
+		return p.IgnoreNormalizerJQTimeout(ctx)
+	}, c.links)
+}
+
+func (c *ChainProvider) IgnoreResourceUpdatesOverrides(ctx context.Context) (map[string]v1alpha1.ResourceOverride, error) {
+	return firstConfigured(func(p Provider) (map[string]v1alpha1.ResourceOverride, error) {
+		return p.IgnoreResourceUpdatesOverrides(ctx)
+	}, c.links)
+}
+
+func (c *ChainProvider) IncludeEventLabelKeys(ctx context.Context) ([]string, error) {
+	return firstConfigured(func(p Provider) ([]string, error) {
+		return p.IncludeEventLabelKeys(ctx)
+	}, c.links)
+}
+
+func (c *ChainProvider) InstallationID(ctx context.Context) (string, error) {
+	return firstConfigured(func(p Provider) (string, error) {
+		return p.InstallationID(ctx)
+	}, c.links)
+}
+
+func (c *ChainProvider) IsIgnoreResourceUpdatesEnabled(ctx context.Context) (bool, error) {
+	return firstConfigured(func(p Provider) (bool, error) {
+		return p.IsIgnoreResourceUpdatesEnabled(ctx)
+	}, c.links)
+}
+
+func (c *ChainProvider) IsImpersonationEnabled(ctx context.Context) (bool, error) {
+	return firstConfigured(func(p Provider) (bool, error) {
+		return p.IsImpersonationEnabled(ctx)
+	}, c.links)
+}
+
+func (c *ChainProvider) IsImpersonationEnforced(ctx context.Context) (bool, error) {
+	return firstConfigured(func(p Provider) (bool, error) {
+		return p.IsImpersonationEnforced(ctx)
+	}, c.links)
+}
+
+func (c *ChainProvider) KustomizeSettings(ctx context.Context) (v1alpha1.KustomizeOptions, error) {
+	return firstConfigured(func(p Provider) (v1alpha1.KustomizeOptions, error) {
+		return p.KustomizeSettings(ctx)
+	}, c.links)
+}
+
+func (c *ChainProvider) MetricsClusterLabels(ctx context.Context) ([]string, error) {
+	return firstConfigured(func(p Provider) ([]string, error) {
+		return p.MetricsClusterLabels(ctx)
+	}, c.links)
+}
+
+func (c *ChainProvider) PersistResourceHealth(ctx context.Context) (bool, error) {
+	return firstConfigured(func(p Provider) (bool, error) {
+		return p.PersistResourceHealth(ctx)
+	}, c.links)
+}
+
+func (c *ChainProvider) ReconciliationJitter(ctx context.Context) (time.Duration, error) {
+	return firstConfigured(func(p Provider) (time.Duration, error) {
+		return p.ReconciliationJitter(ctx)
+	}, c.links)
+}
+
+func (c *ChainProvider) ReconciliationTimeout(ctx context.Context) (time.Duration, error) {
+	return firstConfigured(func(p Provider) (time.Duration, error) {
+		return p.ReconciliationTimeout(ctx)
+	}, c.links)
+}
+
+func (c *ChainProvider) RepoErrorGracePeriod(ctx context.Context) (time.Duration, error) {
+	return firstConfigured(func(p Provider) (time.Duration, error) {
+		return p.RepoErrorGracePeriod(ctx)
+	}, c.links)
+}
+
+func (c *ChainProvider) ResourceCompareOptions(ctx context.Context) (settings.ArgoCDDiffOptions, error) {
+	return firstConfigured(func(p Provider) (settings.ArgoCDDiffOptions, error) {
+		return p.ResourceCompareOptions(ctx)
+	}, c.links)
+}
+
+func (c *ChainProvider) ResourceCustomLabels(ctx context.Context) ([]string, error) {
+	return firstConfigured(func(p Provider) ([]string, error) {
+		return p.ResourceCustomLabels(ctx)
+	}, c.links)
+}
+
+func (c *ChainProvider) ResourceOverrides(ctx context.Context) (map[string]v1alpha1.ResourceOverride, error) {
+	return firstConfigured(func(p Provider) (map[string]v1alpha1.ResourceOverride, error) {
+		return p.ResourceOverrides(ctx)
+	}, c.links)
+}
+
+func (c *ChainProvider) ResourcesFilter(ctx context.Context) (settings.ResourcesFilter, error) {
+	return firstConfigured(func(p Provider) (settings.ResourcesFilter, error) {
+		return p.ResourcesFilter(ctx)
+	}, c.links)
+}
+
+func (c *ChainProvider) RespectRBAC(ctx context.Context) (int, error) {
+	return firstConfigured(func(p Provider) (int, error) {
+		return p.RespectRBAC(ctx)
+	}, c.links)
+}
+
+func (c *ChainProvider) SelfHealRetry(ctx context.Context) (SelfHealRetry, error) {
+	return firstConfigured(func(p Provider) (SelfHealRetry, error) {
+		return p.SelfHealRetry(ctx)
+	}, c.links)
+}
+
+func (c *ChainProvider) SelfHealTimeout(ctx context.Context) (time.Duration, error) {
+	return firstConfigured(func(p Provider) (time.Duration, error) {
+		return p.SelfHealTimeout(ctx)
+	}, c.links)
+}
+
+func (c *ChainProvider) SensitiveAnnotations(ctx context.Context) (map[string]bool, error) {
+	return firstConfigured(func(p Provider) (map[string]bool, error) {
+		return p.SensitiveAnnotations(ctx)
+	}, c.links)
+}
+
+func (c *ChainProvider) ServerSideDiff(ctx context.Context) (bool, error) {
+	return firstConfigured(func(p Provider) (bool, error) {
+		return p.ServerSideDiff(ctx)
+	}, c.links)
+}
+
+func (c *ChainProvider) SourceHydratorCommitMessageTemplate(ctx context.Context) (string, error) {
+	return firstConfigured(func(p Provider) (string, error) {
+		return p.SourceHydratorCommitMessageTemplate(ctx)
+	}, c.links)
+}
+
 func (c *ChainProvider) Subscribe(subCh chan<- *settings.ArgoCDSettings) {
 	for _, l := range c.links {
 		l.Subscribe(subCh)
 	}
+}
+
+func (c *ChainProvider) SyncTimeout(ctx context.Context) (time.Duration, error) {
+	return firstConfigured(func(p Provider) (time.Duration, error) {
+		return p.SyncTimeout(ctx)
+	}, c.links)
+}
+
+func (c *ChainProvider) TrackingMethod(ctx context.Context) (string, error) {
+	return firstConfigured(func(p Provider) (string, error) {
+		return p.TrackingMethod(ctx)
+	}, c.links)
 }
 
 func (c *ChainProvider) Unsubscribe(subCh chan<- *settings.ArgoCDSettings) {

--- a/util/configbus/zz_generated.static_provider.go
+++ b/util/configbus/zz_generated.static_provider.go
@@ -2,6 +2,14 @@
 
 package configbus
 
+import (
+	"context"
+	"time"
+
+	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v3/util/settings"
+)
+
 // StaticFields holds in-memory nilable config values for StaticProvider.
 // Construct a literal with only the fields this call site owns; unset fields
 // return ErrNotConfigured so ChainProvider can fall through to later links.
@@ -13,6 +21,42 @@ package configbus
 //     policy struct) instead of *U when “configured nil” is a product meaning.
 //   - Method returning ([]T, error) or (map[K]V, error) → field *[]T / *map[K]V
 type StaticFields struct {
+	AllowedNodeLabels                   *[]string
+	AppInstanceLabelKey                 *string
+	CommitAuthorEmail                   *string
+	CommitAuthorName                    *string
+	EnabledSourceTypes                  *map[string]bool
+	ExcludeEventLabelKeys               *[]string
+	GitRequestTimeout                   *time.Duration
+	GlobalProjectsSettings              *[]settings.GlobalProjectSettings
+	HardReconciliationTimeout           *time.Duration
+	HelmSettings                        *v1alpha1.HelmOptions
+	HydratorReadmeTemplate              *string
+	IgnoreNormalizerJQTimeout           *time.Duration
+	IgnoreResourceUpdatesOverrides      *map[string]v1alpha1.ResourceOverride
+	IncludeEventLabelKeys               *[]string
+	InstallationID                      *string
+	IsIgnoreResourceUpdatesEnabled      *bool
+	IsImpersonationEnabled              *bool
+	IsImpersonationEnforced             *bool
+	KustomizeSettings                   *v1alpha1.KustomizeOptions
+	MetricsClusterLabels                *[]string
+	PersistResourceHealth               *bool
+	ReconciliationJitter                *time.Duration
+	ReconciliationTimeout               *time.Duration
+	RepoErrorGracePeriod                *time.Duration
+	ResourceCompareOptions              *settings.ArgoCDDiffOptions
+	ResourceCustomLabels                *[]string
+	ResourceOverrides                   *map[string]v1alpha1.ResourceOverride
+	ResourcesFilter                     *settings.ResourcesFilter
+	RespectRBAC                         *int
+	SelfHealRetry                       *SelfHealRetry
+	SelfHealTimeout                     *time.Duration
+	SensitiveAnnotations                *map[string]bool
+	ServerSideDiff                      *bool
+	SourceHydratorCommitMessageTemplate *string
+	SyncTimeout                         *time.Duration
+	TrackingMethod                      *string
 }
 
 // StaticProvider is a leaf Provider backed by StaticFields.
@@ -27,3 +71,255 @@ type StaticProvider struct {
 
 // Ensure StaticProvider implements Provider.
 var _ Provider = (*StaticProvider)(nil)
+
+func (p *StaticProvider) AllowedNodeLabels(_ context.Context) ([]string, error) {
+	if p == nil || p.Fields.AllowedNodeLabels == nil {
+		return nil, ErrNotConfigured
+	}
+	return *p.Fields.AllowedNodeLabels, nil
+}
+
+func (p *StaticProvider) AppInstanceLabelKey(_ context.Context) (string, error) {
+	if p == nil || p.Fields.AppInstanceLabelKey == nil {
+		return "", ErrNotConfigured
+	}
+	return *p.Fields.AppInstanceLabelKey, nil
+}
+
+func (p *StaticProvider) CommitAuthorEmail(_ context.Context) (string, error) {
+	if p == nil || p.Fields.CommitAuthorEmail == nil {
+		return "", ErrNotConfigured
+	}
+	return *p.Fields.CommitAuthorEmail, nil
+}
+
+func (p *StaticProvider) CommitAuthorName(_ context.Context) (string, error) {
+	if p == nil || p.Fields.CommitAuthorName == nil {
+		return "", ErrNotConfigured
+	}
+	return *p.Fields.CommitAuthorName, nil
+}
+
+func (p *StaticProvider) EnabledSourceTypes(_ context.Context) (map[string]bool, error) {
+	if p == nil || p.Fields.EnabledSourceTypes == nil {
+		return nil, ErrNotConfigured
+	}
+	return *p.Fields.EnabledSourceTypes, nil
+}
+
+func (p *StaticProvider) ExcludeEventLabelKeys(_ context.Context) ([]string, error) {
+	if p == nil || p.Fields.ExcludeEventLabelKeys == nil {
+		return nil, ErrNotConfigured
+	}
+	return *p.Fields.ExcludeEventLabelKeys, nil
+}
+
+func (p *StaticProvider) GitRequestTimeout(_ context.Context) (time.Duration, error) {
+	if p == nil || p.Fields.GitRequestTimeout == nil {
+		return 0, ErrNotConfigured
+	}
+	return *p.Fields.GitRequestTimeout, nil
+}
+
+func (p *StaticProvider) GlobalProjectsSettings(_ context.Context) ([]settings.GlobalProjectSettings, error) {
+	if p == nil || p.Fields.GlobalProjectsSettings == nil {
+		return nil, ErrNotConfigured
+	}
+	return *p.Fields.GlobalProjectsSettings, nil
+}
+
+func (p *StaticProvider) HardReconciliationTimeout(_ context.Context) (time.Duration, error) {
+	if p == nil || p.Fields.HardReconciliationTimeout == nil {
+		return 0, ErrNotConfigured
+	}
+	return *p.Fields.HardReconciliationTimeout, nil
+}
+
+func (p *StaticProvider) HelmSettings(_ context.Context) (v1alpha1.HelmOptions, error) {
+	if p == nil || p.Fields.HelmSettings == nil {
+		return v1alpha1.HelmOptions{}, ErrNotConfigured
+	}
+	return *p.Fields.HelmSettings, nil
+}
+
+func (p *StaticProvider) HydratorReadmeTemplate(_ context.Context) (string, error) {
+	if p == nil || p.Fields.HydratorReadmeTemplate == nil {
+		return "", ErrNotConfigured
+	}
+	return *p.Fields.HydratorReadmeTemplate, nil
+}
+
+func (p *StaticProvider) IgnoreNormalizerJQTimeout(_ context.Context) (time.Duration, error) {
+	if p == nil || p.Fields.IgnoreNormalizerJQTimeout == nil {
+		return 0, ErrNotConfigured
+	}
+	return *p.Fields.IgnoreNormalizerJQTimeout, nil
+}
+
+func (p *StaticProvider) IgnoreResourceUpdatesOverrides(_ context.Context) (map[string]v1alpha1.ResourceOverride, error) {
+	if p == nil || p.Fields.IgnoreResourceUpdatesOverrides == nil {
+		return nil, ErrNotConfigured
+	}
+	return *p.Fields.IgnoreResourceUpdatesOverrides, nil
+}
+
+func (p *StaticProvider) IncludeEventLabelKeys(_ context.Context) ([]string, error) {
+	if p == nil || p.Fields.IncludeEventLabelKeys == nil {
+		return nil, ErrNotConfigured
+	}
+	return *p.Fields.IncludeEventLabelKeys, nil
+}
+
+func (p *StaticProvider) InstallationID(_ context.Context) (string, error) {
+	if p == nil || p.Fields.InstallationID == nil {
+		return "", ErrNotConfigured
+	}
+	return *p.Fields.InstallationID, nil
+}
+
+func (p *StaticProvider) IsIgnoreResourceUpdatesEnabled(_ context.Context) (bool, error) {
+	if p == nil || p.Fields.IsIgnoreResourceUpdatesEnabled == nil {
+		return false, ErrNotConfigured
+	}
+	return *p.Fields.IsIgnoreResourceUpdatesEnabled, nil
+}
+
+func (p *StaticProvider) IsImpersonationEnabled(_ context.Context) (bool, error) {
+	if p == nil || p.Fields.IsImpersonationEnabled == nil {
+		return false, ErrNotConfigured
+	}
+	return *p.Fields.IsImpersonationEnabled, nil
+}
+
+func (p *StaticProvider) IsImpersonationEnforced(_ context.Context) (bool, error) {
+	if p == nil || p.Fields.IsImpersonationEnforced == nil {
+		return false, ErrNotConfigured
+	}
+	return *p.Fields.IsImpersonationEnforced, nil
+}
+
+func (p *StaticProvider) KustomizeSettings(_ context.Context) (v1alpha1.KustomizeOptions, error) {
+	if p == nil || p.Fields.KustomizeSettings == nil {
+		return v1alpha1.KustomizeOptions{}, ErrNotConfigured
+	}
+	return *p.Fields.KustomizeSettings, nil
+}
+
+func (p *StaticProvider) MetricsClusterLabels(_ context.Context) ([]string, error) {
+	if p == nil || p.Fields.MetricsClusterLabels == nil {
+		return nil, ErrNotConfigured
+	}
+	return *p.Fields.MetricsClusterLabels, nil
+}
+
+func (p *StaticProvider) PersistResourceHealth(_ context.Context) (bool, error) {
+	if p == nil || p.Fields.PersistResourceHealth == nil {
+		return false, ErrNotConfigured
+	}
+	return *p.Fields.PersistResourceHealth, nil
+}
+
+func (p *StaticProvider) ReconciliationJitter(_ context.Context) (time.Duration, error) {
+	if p == nil || p.Fields.ReconciliationJitter == nil {
+		return 0, ErrNotConfigured
+	}
+	return *p.Fields.ReconciliationJitter, nil
+}
+
+func (p *StaticProvider) ReconciliationTimeout(_ context.Context) (time.Duration, error) {
+	if p == nil || p.Fields.ReconciliationTimeout == nil {
+		return 0, ErrNotConfigured
+	}
+	return *p.Fields.ReconciliationTimeout, nil
+}
+
+func (p *StaticProvider) RepoErrorGracePeriod(_ context.Context) (time.Duration, error) {
+	if p == nil || p.Fields.RepoErrorGracePeriod == nil {
+		return 0, ErrNotConfigured
+	}
+	return *p.Fields.RepoErrorGracePeriod, nil
+}
+
+func (p *StaticProvider) ResourceCompareOptions(_ context.Context) (settings.ArgoCDDiffOptions, error) {
+	if p == nil || p.Fields.ResourceCompareOptions == nil {
+		return settings.ArgoCDDiffOptions{}, ErrNotConfigured
+	}
+	return *p.Fields.ResourceCompareOptions, nil
+}
+
+func (p *StaticProvider) ResourceCustomLabels(_ context.Context) ([]string, error) {
+	if p == nil || p.Fields.ResourceCustomLabels == nil {
+		return nil, ErrNotConfigured
+	}
+	return *p.Fields.ResourceCustomLabels, nil
+}
+
+func (p *StaticProvider) ResourceOverrides(_ context.Context) (map[string]v1alpha1.ResourceOverride, error) {
+	if p == nil || p.Fields.ResourceOverrides == nil {
+		return nil, ErrNotConfigured
+	}
+	return *p.Fields.ResourceOverrides, nil
+}
+
+func (p *StaticProvider) ResourcesFilter(_ context.Context) (settings.ResourcesFilter, error) {
+	if p == nil || p.Fields.ResourcesFilter == nil {
+		return settings.ResourcesFilter{}, ErrNotConfigured
+	}
+	return *p.Fields.ResourcesFilter, nil
+}
+
+func (p *StaticProvider) RespectRBAC(_ context.Context) (int, error) {
+	if p == nil || p.Fields.RespectRBAC == nil {
+		return 0, ErrNotConfigured
+	}
+	return *p.Fields.RespectRBAC, nil
+}
+
+func (p *StaticProvider) SelfHealRetry(_ context.Context) (SelfHealRetry, error) {
+	if p == nil || p.Fields.SelfHealRetry == nil {
+		return SelfHealRetry{}, ErrNotConfigured
+	}
+	return *p.Fields.SelfHealRetry, nil
+}
+
+func (p *StaticProvider) SelfHealTimeout(_ context.Context) (time.Duration, error) {
+	if p == nil || p.Fields.SelfHealTimeout == nil {
+		return 0, ErrNotConfigured
+	}
+	return *p.Fields.SelfHealTimeout, nil
+}
+
+func (p *StaticProvider) SensitiveAnnotations(_ context.Context) (map[string]bool, error) {
+	if p == nil || p.Fields.SensitiveAnnotations == nil {
+		return nil, ErrNotConfigured
+	}
+	return *p.Fields.SensitiveAnnotations, nil
+}
+
+func (p *StaticProvider) ServerSideDiff(_ context.Context) (bool, error) {
+	if p == nil || p.Fields.ServerSideDiff == nil {
+		return false, ErrNotConfigured
+	}
+	return *p.Fields.ServerSideDiff, nil
+}
+
+func (p *StaticProvider) SourceHydratorCommitMessageTemplate(_ context.Context) (string, error) {
+	if p == nil || p.Fields.SourceHydratorCommitMessageTemplate == nil {
+		return "", ErrNotConfigured
+	}
+	return *p.Fields.SourceHydratorCommitMessageTemplate, nil
+}
+
+func (p *StaticProvider) SyncTimeout(_ context.Context) (time.Duration, error) {
+	if p == nil || p.Fields.SyncTimeout == nil {
+		return 0, ErrNotConfigured
+	}
+	return *p.Fields.SyncTimeout, nil
+}
+
+func (p *StaticProvider) TrackingMethod(_ context.Context) (string, error) {
+	if p == nil || p.Fields.TrackingMethod == nil {
+		return "", ErrNotConfigured
+	}
+	return *p.Fields.TrackingMethod, nil
+}

--- a/util/notification/argocd/service.go
+++ b/util/notification/argocd/service.go
@@ -1,3 +1,4 @@
+//nolint:staticcheck // SA1019: notification service not yet on configbus.Provider
 package service
 
 import (

--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -669,6 +669,7 @@ func (mgr *SettingsManager) onRepoOrClusterChanged() {
 	}
 }
 
+// Deprecated: use configbus.Provider.RespectRBAC instead.
 func (mgr *SettingsManager) RespectRBAC() (int, error) {
 	cm, err := mgr.getConfigMap()
 	if err != nil {
@@ -869,6 +870,7 @@ func (mgr *SettingsManager) getSecrets() ([]*corev1.Secret, error) {
 	return secretList, nil
 }
 
+// Deprecated: use configbus.Provider.HydratorReadmeTemplate instead.
 func (mgr *SettingsManager) GetHydratorReadmeTemplate() (string, error) {
 	argoCDCM, err := mgr.getConfigMap()
 	if err != nil {
@@ -881,6 +883,7 @@ func (mgr *SettingsManager) GetHydratorReadmeTemplate() (string, error) {
 	return readmeTemplate, nil
 }
 
+// Deprecated: use configbus.Provider.ResourcesFilter instead.
 func (mgr *SettingsManager) GetResourcesFilter() (*ResourcesFilter, error) {
 	argoCDCM, err := mgr.getConfigMap()
 	if err != nil {
@@ -907,6 +910,7 @@ func (mgr *SettingsManager) GetResourcesFilter() (*ResourcesFilter, error) {
 	return rf, nil
 }
 
+// Deprecated: use configbus.Provider.AppInstanceLabelKey instead.
 func (mgr *SettingsManager) GetAppInstanceLabelKey() (string, error) {
 	argoCDCM, err := mgr.getConfigMap()
 	if err != nil {
@@ -919,6 +923,7 @@ func (mgr *SettingsManager) GetAppInstanceLabelKey() (string, error) {
 	return label, nil
 }
 
+// Deprecated: use configbus.Provider.TrackingMethod instead.
 func (mgr *SettingsManager) GetTrackingMethod() (string, error) {
 	argoCDCM, err := mgr.getConfigMap()
 	if err != nil {
@@ -931,6 +936,7 @@ func (mgr *SettingsManager) GetTrackingMethod() (string, error) {
 	return tm, nil
 }
 
+// Deprecated: use configbus.Provider.InstallationID instead.
 func (mgr *SettingsManager) GetInstallationID() (string, error) {
 	argoCDCM, err := mgr.getConfigMap()
 	if err != nil {
@@ -939,6 +945,7 @@ func (mgr *SettingsManager) GetInstallationID() (string, error) {
 	return argoCDCM.Data[settingsInstallationID], nil
 }
 
+// Deprecated: use configbus.Provider.PasswordPattern instead.
 func (mgr *SettingsManager) GetPasswordPattern() (string, error) {
 	argoCDCM, err := mgr.getConfigMap()
 	if err != nil {
@@ -951,6 +958,7 @@ func (mgr *SettingsManager) GetPasswordPattern() (string, error) {
 	return label, nil
 }
 
+// Deprecated: use configbus.Provider.ApplicationFineGrainedRBACInheritanceDisabled instead.
 func (mgr *SettingsManager) ApplicationFineGrainedRBACInheritanceDisabled() (bool, error) {
 	argoCDCM, err := mgr.getConfigMap()
 	if err != nil {
@@ -977,6 +985,7 @@ func (mgr *SettingsManager) GetServerRBACRollbackEnforceEnable() (bool, error) {
 	return strconv.ParseBool(argoCDCM.Data[settingsServerRBACRollbackEnforceEnableKey])
 }
 
+// Deprecated: use configbus.Provider.MaxPodLogsToRender instead.
 func (mgr *SettingsManager) GetMaxPodLogsToRender() (int64, error) {
 	argoCDCM, err := mgr.getConfigMap()
 	if err != nil {
@@ -990,6 +999,7 @@ func (mgr *SettingsManager) GetMaxPodLogsToRender() (int64, error) {
 	return strconv.ParseInt(argoCDCM.Data[settingsMaxPodLogsToRender], 10, 64)
 }
 
+// Deprecated: use configbus.Provider.ApplicationDeepLinks / ProjectDeepLinks / ResourceDeepLinks instead.
 func (mgr *SettingsManager) GetDeepLinks(deeplinkType string) ([]DeepLink, error) {
 	argoCDCM, err := mgr.getConfigMap()
 	if err != nil {
@@ -1005,6 +1015,7 @@ func (mgr *SettingsManager) GetDeepLinks(deeplinkType string) ([]DeepLink, error
 	return deepLinks, nil
 }
 
+// Deprecated: use configbus.Provider.EnabledSourceTypes instead.
 func (mgr *SettingsManager) GetEnabledSourceTypes() (map[string]bool, error) {
 	argoCDCM, err := mgr.getConfigMap()
 	if err != nil {
@@ -1024,12 +1035,15 @@ func (mgr *SettingsManager) GetEnabledSourceTypes() (map[string]bool, error) {
 	return res, nil
 }
 
+// Deprecated: use configbus.Provider.IgnoreResourceUpdatesOverrides instead.
 func (mgr *SettingsManager) GetIgnoreResourceUpdatesOverrides() (map[string]v1alpha1.ResourceOverride, error) {
+	//nolint:staticcheck // SA1019: SettingsManager still composes deprecated product getters internally.
 	compareOptions, err := mgr.GetResourceCompareOptions()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get compare options: %w", err)
 	}
 
+	//nolint:staticcheck // SA1019: SettingsManager still composes deprecated product getters internally.
 	resourceOverrides, err := mgr.GetResourceOverrides()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get resource overrides: %w", err)
@@ -1059,6 +1073,7 @@ func (mgr *SettingsManager) GetIgnoreResourceUpdatesOverrides() (map[string]v1al
 	return resourceOverrides, nil
 }
 
+// Deprecated: use configbus.Provider.IsIgnoreResourceUpdatesEnabled instead.
 func (mgr *SettingsManager) GetIsIgnoreResourceUpdatesEnabled() (bool, error) {
 	argoCDCM, err := mgr.getConfigMap()
 	if err != nil {
@@ -1073,6 +1088,8 @@ func (mgr *SettingsManager) GetIsIgnoreResourceUpdatesEnabled() (bool, error) {
 }
 
 // GetResourceOverrides loads Resource Overrides from argocd-cm ConfigMap
+//
+// Deprecated: use configbus.Provider.ResourceOverrides instead.
 func (mgr *SettingsManager) GetResourceOverrides() (map[string]v1alpha1.ResourceOverride, error) {
 	argoCDCM, err := mgr.getConfigMap()
 	if err != nil {
@@ -1091,7 +1108,7 @@ func (mgr *SettingsManager) GetResourceOverrides() (map[string]v1alpha1.Resource
 		return nil, err
 	}
 
-	diffOptions, err := mgr.GetResourceCompareOptions()
+	diffOptions, err := mgr.GetResourceCompareOptions() //nolint:staticcheck // SA1019: GetResourceOverrides still composes compare options.
 	if err != nil {
 		return nil, fmt.Errorf("failed to get compare options: %w", err)
 	}
@@ -1118,6 +1135,7 @@ func (mgr *SettingsManager) GetResourceOverrides() (map[string]v1alpha1.Resource
 	return resourceOverrides, nil
 }
 
+// Deprecated: use configbus.Provider.SourceHydratorCommitMessageTemplate instead.
 func (mgr *SettingsManager) GetSourceHydratorCommitMessageTemplate() (string, error) {
 	argoCDCM, err := mgr.getConfigMap()
 	if err != nil {
@@ -1130,6 +1148,7 @@ func (mgr *SettingsManager) GetSourceHydratorCommitMessageTemplate() (string, er
 	return argoCDCM.Data[settingsSourceHydratorCommitMessageTemplateKey], nil
 }
 
+// Deprecated: use configbus.Provider.CommitAuthorName instead.
 func (mgr *SettingsManager) GetCommitAuthorName() (string, error) {
 	argoCDCM, err := mgr.getConfigMap()
 	if err != nil {
@@ -1138,6 +1157,7 @@ func (mgr *SettingsManager) GetCommitAuthorName() (string, error) {
 	return argoCDCM.Data[settingsCommitAuthorNameKey], nil
 }
 
+// Deprecated: use configbus.Provider.CommitAuthorEmail instead.
 func (mgr *SettingsManager) GetCommitAuthorEmail() (string, error) {
 	argoCDCM, err := mgr.getConfigMap()
 	if err != nil {
@@ -1253,6 +1273,8 @@ func GetDefaultDiffOptions() ArgoCDDiffOptions {
 }
 
 // GetResourceCompareOptions loads the resource compare options settings from the ConfigMap
+//
+// Deprecated: use configbus.Provider.ResourceCompareOptions instead.
 func (mgr *SettingsManager) GetResourceCompareOptions() (ArgoCDDiffOptions, error) {
 	// We have a sane set of default diff options
 	diffOptions := GetDefaultDiffOptions()
@@ -1273,6 +1295,8 @@ func (mgr *SettingsManager) GetResourceCompareOptions() (ArgoCDDiffOptions, erro
 }
 
 // GetHelmSettings returns helm settings
+//
+// Deprecated: use configbus.Provider.HelmSettings instead.
 func (mgr *SettingsManager) GetHelmSettings() (*v1alpha1.HelmOptions, error) {
 	argoCDCM, err := mgr.getConfigMap()
 	if err != nil {
@@ -1292,6 +1316,8 @@ func (mgr *SettingsManager) GetHelmSettings() (*v1alpha1.HelmOptions, error) {
 }
 
 // GetKustomizeSettings loads the kustomize settings from argocd-cm ConfigMap
+//
+// Deprecated: use configbus.Provider.KustomizeSettings instead.
 func (mgr *SettingsManager) GetKustomizeSettings() (*v1alpha1.KustomizeOptions, error) {
 	argoCDCM, err := mgr.getConfigMap()
 	if err != nil {
@@ -1351,6 +1377,7 @@ func addKustomizeVersion(prefix, name, path string, kvMap map[string]v1alpha1.Ku
 	return nil
 }
 
+// Deprecated: use configbus.Provider.GoogleAnalytics instead.
 func (mgr *SettingsManager) GetGoogleAnalytics() (*GoogleAnalytics, error) {
 	argoCDCM, err := mgr.getConfigMap()
 	if err != nil {
@@ -1362,6 +1389,7 @@ func (mgr *SettingsManager) GetGoogleAnalytics() (*GoogleAnalytics, error) {
 	}, nil
 }
 
+// Deprecated: use configbus.Provider.Help instead.
 func (mgr *SettingsManager) GetHelp() (*Help, error) {
 	argoCDCM, err := mgr.getConfigMap()
 	if err != nil {
@@ -1382,6 +1410,7 @@ func (mgr *SettingsManager) GetHelp() (*Help, error) {
 	}, nil
 }
 
+// Deprecated: use configbus.Provider.RequireOverridePrivilegeForRevisionSync instead.
 func (mgr *SettingsManager) RequireOverridePrivilegeForRevisionSync() (bool, error) {
 	argoCDCM, err := mgr.getConfigMap()
 	if err != nil {
@@ -2702,6 +2731,8 @@ func isUnresolvedEnvVarReference(val string, secretValues map[string]string) boo
 }
 
 // GetGlobalProjectsSettings loads the global project settings from argocd-cm ConfigMap
+//
+// Deprecated: use configbus.Provider.GlobalProjectsSettings instead.
 func (mgr *SettingsManager) GetGlobalProjectsSettings() ([]GlobalProjectSettings, error) {
 	argoCDCM, err := mgr.getConfigMap()
 	if err != nil {
@@ -2723,6 +2754,7 @@ func (mgr *SettingsManager) GetNamespace() string {
 	return mgr.namespace
 }
 
+// Deprecated: use configbus.Provider.ResourceCustomLabels instead.
 func (mgr *SettingsManager) GetResourceCustomLabels() ([]string, error) {
 	argoCDCM, err := mgr.getConfigMap()
 	if err != nil {
@@ -2735,6 +2767,7 @@ func (mgr *SettingsManager) GetResourceCustomLabels() ([]string, error) {
 	return []string{}, nil
 }
 
+// Deprecated: use configbus.Provider.IncludeEventLabelKeys instead.
 func (mgr *SettingsManager) GetIncludeEventLabelKeys() []string {
 	labelKeys := []string{}
 	argoCDCM, err := mgr.getConfigMap()
@@ -2751,6 +2784,7 @@ func (mgr *SettingsManager) GetIncludeEventLabelKeys() []string {
 	return labelKeys
 }
 
+// Deprecated: use configbus.Provider.ExcludeEventLabelKeys instead.
 func (mgr *SettingsManager) GetExcludeEventLabelKeys() []string {
 	labelKeys := []string{}
 	argoCDCM, err := mgr.getConfigMap()
@@ -2767,6 +2801,7 @@ func (mgr *SettingsManager) GetExcludeEventLabelKeys() []string {
 	return labelKeys
 }
 
+// Deprecated: use configbus.Provider.SensitiveAnnotations instead.
 func (mgr *SettingsManager) GetSensitiveAnnotations() map[string]bool {
 	annotationKeys := make(map[string]bool)
 
@@ -2788,6 +2823,7 @@ func (mgr *SettingsManager) GetSensitiveAnnotations() map[string]bool {
 	return annotationKeys
 }
 
+// Deprecated: use configbus.Provider.MaxWebhookPayloadSize instead.
 func (mgr *SettingsManager) GetMaxWebhookPayloadSize() int64 {
 	argoCDCM, err := mgr.getConfigMap()
 	if err != nil {
@@ -2807,6 +2843,7 @@ func (mgr *SettingsManager) GetMaxWebhookPayloadSize() int64 {
 	return maxPayloadSizeMB * 1024 * 1024
 }
 
+// Deprecated: use configbus.Provider.WebhookRefreshJitter instead.
 func (mgr *SettingsManager) GetWebhookRefreshJitter() time.Duration {
 	argoCDCM, err := mgr.getConfigMap()
 	if err != nil {
@@ -2827,6 +2864,7 @@ func (mgr *SettingsManager) GetWebhookRefreshJitter() time.Duration {
 	return *jitter
 }
 
+// Deprecated: use configbus.Provider.WebhookRefreshJitterThreshold instead.
 func (mgr *SettingsManager) GetWebhookRefreshJitterThreshold() int {
 	argoCDCM, err := mgr.getConfigMap()
 	if err != nil {
@@ -2853,6 +2891,8 @@ func (mgr *SettingsManager) GetWebhookRefreshJitterThreshold() int {
 }
 
 // IsImpersonationEnabled returns true if application sync with impersonation feature is enabled in argocd-cm configmap
+//
+// Deprecated: use configbus.Provider.IsImpersonationEnabled instead.
 func (mgr *SettingsManager) IsImpersonationEnabled() (bool, error) {
 	cm, err := mgr.getConfigMap()
 	if err != nil {
@@ -2862,6 +2902,8 @@ func (mgr *SettingsManager) IsImpersonationEnabled() (bool, error) {
 }
 
 // IsImpersonationEnforced returns true if impersonation enforcement is enabled (requires service account to be configured)
+//
+// Deprecated: use configbus.Provider.IsImpersonationEnforced instead.
 func (mgr *SettingsManager) IsImpersonationEnforced() (bool, error) {
 	cm, err := mgr.getConfigMap()
 	if err != nil {
@@ -2873,6 +2915,7 @@ func (mgr *SettingsManager) IsImpersonationEnforced() (bool, error) {
 	return defaultImpersonationEnforcedFlag, nil
 }
 
+// Deprecated: use configbus.Provider.AllowedNodeLabels instead.
 func (mgr *SettingsManager) GetAllowedNodeLabels() []string {
 	labelKeys := []string{}
 	argoCDCM, err := mgr.getConfigMap()
@@ -2897,6 +2940,8 @@ func (mgr *SettingsManager) GetAllowedNodeLabels() []string {
 }
 
 // IsInClusterEnabled returns false if in-cluster is explicitly disabled in argocd-cm configmap, true otherwise
+//
+// Deprecated: use configbus.Provider.InClusterEnabled instead.
 func (mgr *SettingsManager) IsInClusterEnabled() (bool, error) {
 	argoCDCM, err := mgr.getConfigMap()
 	if err != nil {

--- a/util/settings/settings_test.go
+++ b/util/settings/settings_test.go
@@ -1,3 +1,4 @@
+//nolint:staticcheck // SA1019: tests exercise deprecated SettingsManager product getters until removed.
 package settings
 
 import (


### PR DESCRIPTION
Part of the configbus stacked PR series (layers 00–08).

Related issue: https://github.com/argoproj/argo-cd/issues/5721

**Stack position:** Layer 01 — stacks on #29363 (`configbus/00-foundation`).

**What this layer owns:** Wire application-controller through `configbus.ChainProvider`.

**Non-goals:** No server/repo wiring, no CRD, no legacy config removal.

**Test plan:**
- [x] `make build-local`
- [x] `go test ./controller/...`

Checklist:

* [x] Enhancement proposal tracked in #5721.
* [x] Semantic PR title.
* [x] Unit tests included.
* [x] Build green locally.
