### PR TITLE
feat: share cross-component configbus static keys

### DIFF
--- a/docs/developer-guide/architecture/configbus.md
+++ b/docs/developer-guide/architecture/configbus.md
@@ -109,6 +109,20 @@ flags win by chain position.
 - Later with CRD: `[StaticOverride?, CRD, StaticFallback, SettingsManager, Env]`
 - CRD-only: `[StaticOverride?, CRD]`
 
+### Shared getters
+
+Some settings are process-wide rather than component-prefixed. They have a
+**single owning leaf** (today: `StaticProvider` fields captured at construction):
+
+| Getter | Owner | Notes |
+| --- | --- | --- |
+| `ApplicationNamespaces` | `StaticProvider` | Shared by API server and notifications. |
+| `HydratorEnabled` | `StaticProvider` | Shared (API server captures it today). |
+
+`NotificationsApplicationNamespaces` is a generated **alias** of
+`ApplicationNamespaces` for older call sites; do not add a second Static field
+for it.
+
 ### Testing with mockery
 
 Prefer **`mocks.Provider`** for consumer unit tests that stub one or a few

--- a/notification_controller/controller/config_provider.go
+++ b/notification_controller/controller/config_provider.go
@@ -11,7 +11,7 @@ func (c *notificationController) InitConfigProvider() {
 	c.configProvider = configbus.NewChainProvider(
 		&configbus.StaticProvider{Fields: configbus.StaticFields{
 			NotificationsAppLabelSelector:        configbus.Ptr(c.appLabelSelector),
-			NotificationsApplicationNamespaces:   configbus.Ptr(c.applicationNamespaces),
+			ApplicationNamespaces:                 configbus.Ptr(c.applicationNamespaces),
 			NotificationsConfigMapName:           configbus.Ptr(c.configMapName),
 			NotificationsSecretName:              configbus.Ptr(c.secretName),
 			NotificationsSelfserviceEnabled:      configbus.Ptr(c.selfServiceNotificationEnabled),

--- a/notification_controller/controller/controller.go
+++ b/notification_controller/controller/controller.go
@@ -67,7 +67,7 @@ type notificationController struct {
 
 	// Deprecated: use configProvider.NotificationsSelfserviceEnabled.
 	selfServiceNotificationEnabled bool
-	// Deprecated: use configProvider.NotificationsApplicationNamespaces.
+	// Deprecated: use configProvider.ApplicationNamespaces.
 	applicationNamespaces []string
 	// Deprecated: use configProvider.NotificationsConfigMapName.
 	configMapName string
@@ -99,7 +99,7 @@ func NewController(
 	}
 	res.InitConfigProvider()
 
-	applicationNamespacesCfg, err := res.configProvider.NotificationsApplicationNamespaces(context.Background())
+	applicationNamespacesCfg, err := res.configProvider.ApplicationNamespaces(context.Background())
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve notifications application namespaces: %w", err)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -500,6 +500,25 @@ func NewServer(ctx context.Context, opts ArgoCDServerOpts, appsetOpts Applicatio
 	return a
 }
 
+// ensureConfigProvider lazily wires a Static/Env chain. Production always
+// constructs the provider in NewServer; unit tests that build ArgoCDServer
+// directly hit this path so configProvider getters remain usable.
+func (a *ArgoCDServer) ensureConfigProvider() {
+	if a.configProvider != nil {
+		return
+	}
+	//nolint:staticcheck // SA1019: StaticFields capture construction-time opts once at wire-up
+	a.configProvider = configbus.NewChainProvider(
+		&configbus.StaticProvider{Fields: configbus.StaticFields{
+			ApplicationNamespaces: configbus.Ptr(a.ApplicationNamespaces),
+			BaseHRef:              configbus.Ptr(a.BaseHRef),
+			HydratorEnabled:       configbus.Ptr(a.HydratorEnabled),
+			RootPath:              configbus.Ptr(a.RootPath),
+		}},
+		configbus.NewEnvProvider(),
+	)
+}
+
 const (
 	// catches corrupted informer state; see https://github.com/argoproj/argo-cd/issues/4960 for more information
 	notObjectErrMsg = "object does not implement the Object interfaces"
@@ -1274,6 +1293,7 @@ func (server *ArgoCDServer) setTokenCookie(token string, w http.ResponseWriter) 
 }
 
 func withRootPath(handler http.Handler, a *ArgoCDServer) (http.Handler, error) {
+	a.ensureConfigProvider()
 	rootPath, err := a.configProvider.RootPath(context.Background())
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve root path: %w", err)

--- a/util/configbus/components.go
+++ b/util/configbus/components.go
@@ -1,0 +1,13 @@
+package configbus
+
+// Component name constants label Argo CD processes in docs, metrics, and logs.
+// They are not wired into Provider construction (no ForComponent).
+const (
+	ComponentController     = "controller"
+	ComponentServer         = "server"
+	ComponentReposerver     = "reposerver"
+	ComponentApplicationset = "applicationset"
+	ComponentNotifications  = "notifications"
+	ComponentCommitserver   = "commitserver"
+	ComponentShared         = "shared"
+)

--- a/util/configbus/provider_test.go
+++ b/util/configbus/provider_test.go
@@ -105,3 +105,31 @@ func TestChainProviderSkipsErrNotConfigured(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 120*time.Second, d)
 }
+
+func TestApplicationNamespaces_SharedAlias(t *testing.T) {
+	p := &StaticProvider{Fields: StaticFields{
+		ApplicationNamespaces: Ptr([]string{"app-ns"}),
+	}}
+	ns, err := p.ApplicationNamespaces(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"app-ns"}, ns)
+
+	ns, err = p.NotificationsApplicationNamespaces(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"app-ns"}, ns, "NotificationsApplicationNamespaces aliases ApplicationNamespaces")
+
+	chain := NewChainProvider(p)
+	ns, err = chain.NotificationsApplicationNamespaces(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"app-ns"}, ns)
+}
+
+func TestHydratorEnabled_StaticOwned(t *testing.T) {
+	p := &StaticProvider{Fields: StaticFields{HydratorEnabled: Ptr(true)}}
+	enabled, err := p.HydratorEnabled(context.Background())
+	require.NoError(t, err)
+	assert.True(t, enabled)
+
+	_, err = NewEnvProvider().HydratorEnabled(context.Background())
+	assert.ErrorIs(t, err, ErrNotConfigured)
+}


### PR DESCRIPTION
Part of the configbus stacked PR series (layers 00–08).

Related issue: https://github.com/argoproj/argo-cd/issues/5721

**Stack position:** Layer 07 — stacks on layer 06.

**What this layer owns:** Share cross-component configbus static keys and resolver coverage metric.

**Non-goals:** No CRD install, no legacy config removal.

**Test plan:**
- [x] `make build-local`
- [x] `go test ./util/configbus/...`

Checklist:

* [x] Enhancement proposal tracked in #5721.
* [x] Semantic PR title.
* [x] Unit tests included.
* [x] Build green locally.
