### PR TITLE
fix(resource_customizations): Crossplane MRs should report Progressing (not Healthy) whilst provisioning [ISSUE:  #29381]

### DIFF
--- a/resource_customizations/_.crossplane.io/_/health.lua
+++ b/resource_customizations/_.crossplane.io/_/health.lua
@@ -1,12 +1,13 @@
--- Health check copied from here: https://github.com/crossplane/docs/blob/9fe744889fc150ca71e5298d90b4133f79ea20f2/content/master/guides/crossplane-with-argo-cd.md
+-- Health check for Crossplane resources, adapted from
+-- https://github.com/crossplane/docs/blob/9fe744889fc150ca71e5298d90b4133f79ea20f2/content/master/guides/crossplane-with-argo-cd.md
 
 health_status = {
   status = "Progressing",
   message = "Provisioning ..."
 }
 
-local function contains (table, val)
-  for i, v in ipairs(table) do
+local function contains(list, val)
+  for _, v in ipairs(list) do
     if v == val then
       return true
     end
@@ -14,52 +15,50 @@ local function contains (table, val)
   return false
 end
 
-local has_no_status = {
+-- Kinds that never get status.conditions, so would sit at Progressing forever.
+-- Only consulted when there are none, so a kind that gains them can stay.
+local has_no_conditions = {
+  -- v1 and v2
   "Composition",
-  "CompositionRevision",
+  "CompositionRevision",      -- conditions only on releases that set ValidPipeline
   "DeploymentRuntimeConfig",
-  "ClusterProviderConfig",
+  "EnvironmentConfig",
+  "ImageConfig",
   "ProviderConfig",
   "ProviderConfigUsage",
-  "ControllerConfig" -- Added to ensure that healthcheck is backwards-compatible with Crossplane v1
+
+  -- v1 only
+  "ControllerConfig",
+  "StoreConfig",
+
+  -- v2 only
+  "ClusterProviderConfig",
+  "ClusterProviderConfigUsage"
 }
-if obj.status == nil or next(obj.status) == nil and contains(has_no_status, obj.kind) then
+
+if obj.status == nil or obj.status.conditions == nil or next(obj.status.conditions) == nil then
+  if contains(has_no_conditions, obj.kind) then
     health_status.status = "Healthy"
-    health_status.message = "Resource is up-to-date."
-  return health_status
-end
-
-if obj.status == nil or next(obj.status) == nil or obj.status.conditions == nil then
-  if (obj.kind == "ProviderConfig" or obj.kind == "ClusterProviderConfig") and obj.status.users ~= nil then
-    health_status.status = "Healthy"
-    health_status.message = "Resource is in use."
-    return health_status
-  end
-  return health_status
-end
-
-for i, condition in ipairs(obj.status.conditions) do
-  if condition.type == "LastAsyncOperation" then
-    if condition.status == "False" then
-      health_status.status = "Degraded"
-      health_status.message = condition.message
-      return health_status
-    end
-  end
-
-  if condition.type == "Synced" then
-    if condition.status == "False" then
-      health_status.status = "Degraded"
-      health_status.message = condition.message
-      return health_status
-    end
-  end
-
-  if contains({"Ready", "Healthy", "Offered", "Established", "ValidPipeline", "RevisionHealthy"}, condition.type) then
-    if condition.status == "True" then
-      health_status.status = "Healthy"
+    -- status.users affects the message, not the health status.
+    if obj.status ~= nil and obj.status.users ~= nil then
+      health_status.message = "Resource is in use."
+    else
       health_status.message = "Resource is up-to-date."
     end
+  end
+  return health_status
+end
+
+for _, condition in ipairs(obj.status.conditions) do
+  if contains({"LastAsyncOperation", "Synced"}, condition.type) and condition.status == "False" then
+    health_status.status = "Degraded"
+    health_status.message = condition.message
+    return health_status
+  end
+
+  if contains({"Ready", "Healthy", "Offered", "Established", "ValidPipeline", "RevisionHealthy"}, condition.type) and condition.status == "True" then
+    health_status.status = "Healthy"
+    health_status.message = "Resource is up-to-date."
   end
 end
 

--- a/resource_customizations/_.crossplane.io/_/health_test.yaml
+++ b/resource_customizations/_.crossplane.io/_/health_test.yaml
@@ -11,3 +11,35 @@ tests:
       status: Degraded
       message: "ActivePackageRevision UnhealthyPackageRevision"
     inputPath: testdata/provider_degraded.yaml
+  - healthStatus:
+      status: Healthy
+      message: "Resource is up-to-date."
+    inputPath: testdata/environmentconfig_healthy.yaml
+  - healthStatus:
+      status: Healthy
+      message: "Resource is up-to-date."
+    inputPath: testdata/imageconfig_healthy.yaml
+  - healthStatus:
+      status: Progressing
+      message: "Provisioning ..."
+    inputPath: testdata/compositeresourcedefinition_progressing.yaml
+  - healthStatus:
+      status: Healthy
+      message: "Resource is up-to-date."
+    inputPath: testdata/compositeresourcedefinition_healthy.yaml
+  - healthStatus:
+      status: Healthy
+      message: "Resource is up-to-date."
+    inputPath: testdata/clusterproviderconfigusage_healthy.yaml
+  - healthStatus:
+      status: Healthy
+      message: "Resource is in use."
+    inputPath: testdata/clusterproviderconfig_withusers_healthy.yaml
+  - healthStatus:
+      status: Healthy
+      message: "Resource is up-to-date."
+    inputPath: testdata/storeconfig_healthy.yaml
+  - healthStatus:
+      status: Healthy
+      message: "Resource is up-to-date."
+    inputPath: testdata/providerconfig_emptyconditions_healthy.yaml

--- a/resource_customizations/_.crossplane.io/_/testdata/clusterproviderconfig_withusers_healthy.yaml
+++ b/resource_customizations/_.crossplane.io/_/testdata/clusterproviderconfig_withusers_healthy.yaml
@@ -1,0 +1,10 @@
+# Non-empty status, no conditions: the case the kind list has to catch.
+apiVersion: helm.m.crossplane.io/v1beta1
+kind: ClusterProviderConfig
+metadata:
+  name: default
+spec:
+  credentials:
+    source: InjectedIdentity
+status:
+  users: 3

--- a/resource_customizations/_.crossplane.io/_/testdata/clusterproviderconfigusage_healthy.yaml
+++ b/resource_customizations/_.crossplane.io/_/testdata/clusterproviderconfigusage_healthy.yaml
@@ -1,0 +1,12 @@
+# v2 cluster scoped twin of ProviderConfigUsage. No status at all.
+apiVersion: helm.m.crossplane.io/v1beta1
+kind: ClusterProviderConfigUsage
+metadata:
+  name: 8f2a1c4e-7b3d-4f6a-9c2e-1d5b8a0f3e7c
+providerConfigRef:
+  kind: ClusterProviderConfig
+  name: default
+resourceRef:
+  apiVersion: helm.m.crossplane.io/v1beta1
+  kind: Release
+  name: sample-release

--- a/resource_customizations/_.crossplane.io/_/testdata/compositeresourcedefinition_healthy.yaml
+++ b/resource_customizations/_.crossplane.io/_/testdata/compositeresourcedefinition_healthy.yaml
@@ -1,0 +1,25 @@
+# The same kind once the controller has established it. Paired with
+# compositeresourcedefinition_progressing.yaml so the pair shows the
+# kind reaching Healthy rather than only ever Progressing.
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xpostgresqlinstances.example.org
+spec:
+  group: example.org
+  names:
+    kind: XPostgreSQLInstance
+    plural: xpostgresqlinstances
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+status:
+  conditions:
+    - lastTransitionTime: "2025-11-22T08:45:44Z"
+      reason: WatchingCompositeResource
+      status: "True"
+      type: Established

--- a/resource_customizations/_.crossplane.io/_/testdata/compositeresourcedefinition_progressing.yaml
+++ b/resource_customizations/_.crossplane.io/_/testdata/compositeresourcedefinition_progressing.yaml
@@ -1,0 +1,20 @@
+# Accepted by the API server, not yet reconciled: no status at all. This
+# is the case the has_no_conditions precedence governs -- a kind that will
+# get a status but has not yet must report Progressing, and reported
+# Healthy while the condition read as `A or (B and C)`.
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xpostgresqlinstances.example.org
+spec:
+  group: example.org
+  names:
+    kind: XPostgreSQLInstance
+    plural: xpostgresqlinstances
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object

--- a/resource_customizations/_.crossplane.io/_/testdata/environmentconfig_healthy.yaml
+++ b/resource_customizations/_.crossplane.io/_/testdata/environmentconfig_healthy.yaml
@@ -1,0 +1,11 @@
+# An EnvironmentConfig is data. It has no controller and no status
+# subresource, so nothing will ever write one -- it is only ever Healthy
+# via the has_no_conditions list.
+apiVersion: apiextensions.crossplane.io/v1beta1
+kind: EnvironmentConfig
+metadata:
+  name: example-environment
+data:
+  locations:
+    us: us-west-2
+    eu: eu-north-1

--- a/resource_customizations/_.crossplane.io/_/testdata/imageconfig_healthy.yaml
+++ b/resource_customizations/_.crossplane.io/_/testdata/imageconfig_healthy.yaml
@@ -1,0 +1,15 @@
+# An ImageConfig is configuration read by the package manager. Like
+# EnvironmentConfig it has no status subresource, so it reaches Healthy
+# only through the has_no_conditions list.
+apiVersion: pkg.crossplane.io/v1beta1
+kind: ImageConfig
+metadata:
+  name: acme-packages
+spec:
+  matchImages:
+    - prefix: registry1.com/acme-co/configuration-foo
+      type: Prefix
+  registry:
+    authentication:
+      pullSecretRef:
+        name: acme-registry-credentials

--- a/resource_customizations/_.crossplane.io/_/testdata/providerconfig_emptyconditions_healthy.yaml
+++ b/resource_customizations/_.crossplane.io/_/testdata/providerconfig_emptyconditions_healthy.yaml
@@ -1,0 +1,11 @@
+# An empty conditions array means the same as an absent one.
+apiVersion: helm.m.crossplane.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: default
+  namespace: default
+spec:
+  credentials:
+    source: InjectedIdentity
+status:
+  conditions: []

--- a/resource_customizations/_.crossplane.io/_/testdata/storeconfig_healthy.yaml
+++ b/resource_customizations/_.crossplane.io/_/testdata/storeconfig_healthy.yaml
@@ -1,0 +1,8 @@
+# v1 only. Has a ConditionedStatus but nothing ever writes to it.
+apiVersion: aws.crossplane.io/v1alpha1
+kind: StoreConfig
+metadata:
+  name: vault
+spec:
+  type: Vault
+  defaultScope: crossplane-system

--- a/resource_customizations/_.upbound.io/_/health.lua
+++ b/resource_customizations/_.upbound.io/_/health.lua
@@ -1,12 +1,13 @@
--- Health check copied from here: https://github.com/crossplane/docs/blob/9fe744889fc150ca71e5298d90b4133f79ea20f2/content/master/guides/crossplane-with-argo-cd.md
+-- Health check for Crossplane resources, adapted from
+-- https://github.com/crossplane/docs/blob/9fe744889fc150ca71e5298d90b4133f79ea20f2/content/master/guides/crossplane-with-argo-cd.md
 
 health_status = {
   status = "Progressing",
   message = "Provisioning ..."
 }
 
-local function contains (table, val)
-  for i, v in ipairs(table) do
+local function contains(list, val)
+  for _, v in ipairs(list) do
     if v == val then
       return true
     end
@@ -14,49 +15,44 @@ local function contains (table, val)
   return false
 end
 
-local has_no_status = {
-  "ClusterProviderConfig",
+-- Kinds that never get status.conditions, so would sit at Progressing forever.
+-- Only consulted when there are none, so a kind that gains them can stay.
+local has_no_conditions = {
+  -- v1 and v2
   "ProviderConfig",
-  "ProviderConfigUsage"
+  "ProviderConfigUsage",
+
+  -- v1 only
+  "StoreConfig",
+
+  -- v2 only
+  "ClusterProviderConfig",
+  "ClusterProviderConfigUsage"
 }
 
-if obj.status == nil or next(obj.status) == nil and contains(has_no_status, obj.kind) then
-  health_status.status = "Healthy"
-  health_status.message = "Resource is up-to-date."
-  return health_status
-end
-
-if obj.status == nil or next(obj.status) == nil or obj.status.conditions == nil then
-  if (obj.kind == "ProviderConfig" or obj.kind == "ClusterProviderConfig") and obj.status.users ~= nil then
+if obj.status == nil or obj.status.conditions == nil or next(obj.status.conditions) == nil then
+  if contains(has_no_conditions, obj.kind) then
     health_status.status = "Healthy"
-    health_status.message = "Resource is in use."
-    return health_status
-  end
-  return health_status
-end
-
-for i, condition in ipairs(obj.status.conditions) do
-  if condition.type == "LastAsyncOperation" then
-    if condition.status == "False" then
-      health_status.status = "Degraded"
-      health_status.message = condition.message
-      return health_status
-    end
-  end
-
-  if condition.type == "Synced" then
-    if condition.status == "False" then
-      health_status.status = "Degraded"
-      health_status.message = condition.message
-      return health_status
-    end
-  end
-
-  if condition.type == "Ready" then
-    if condition.status == "True" then
-      health_status.status = "Healthy"
+    -- status.users affects the message, not the health status.
+    if obj.status ~= nil and obj.status.users ~= nil then
+      health_status.message = "Resource is in use."
+    else
       health_status.message = "Resource is up-to-date."
     end
+  end
+  return health_status
+end
+
+for _, condition in ipairs(obj.status.conditions) do
+  if contains({"LastAsyncOperation", "Synced"}, condition.type) and condition.status == "False" then
+    health_status.status = "Degraded"
+    health_status.message = condition.message
+    return health_status
+  end
+
+  if condition.type == "Ready" and condition.status == "True" then
+    health_status.status = "Healthy"
+    health_status.message = "Resource is up-to-date."
   end
 end
 

--- a/resource_customizations/_.upbound.io/_/health_test.yaml
+++ b/resource_customizations/_.upbound.io/_/health_test.yaml
@@ -7,3 +7,27 @@ tests:
       status: Degraded
       message: "update failed: async update failed: refuse to update the external resource because the following update requires replacing it: cannot change the value of the argument \"location\" from \"westeurope\" to \"switzerlandnorth\""
     inputPath: testdata/managedresource_failedupdate_degraded.yaml
+  - healthStatus:
+      status: Progressing
+      message: "Provisioning ..."
+    inputPath: testdata/managedresource_provisioning_progressing.yaml
+  - healthStatus:
+      status: Healthy
+      message: "Resource is up-to-date."
+    inputPath: testdata/providerconfigusage_healthy.yaml
+  - healthStatus:
+      status: Healthy
+      message: "Resource is up-to-date."
+    inputPath: testdata/clusterproviderconfigusage_healthy.yaml
+  - healthStatus:
+      status: Healthy
+      message: "Resource is in use."
+    inputPath: testdata/providerconfig_withusers_healthy.yaml
+  - healthStatus:
+      status: Healthy
+      message: "Resource is up-to-date."
+    inputPath: testdata/storeconfig_healthy.yaml
+  - healthStatus:
+      status: Healthy
+      message: "Resource is up-to-date."
+    inputPath: testdata/providerconfig_emptyconditions_healthy.yaml

--- a/resource_customizations/_.upbound.io/_/testdata/clusterproviderconfigusage_healthy.yaml
+++ b/resource_customizations/_.upbound.io/_/testdata/clusterproviderconfigusage_healthy.yaml
@@ -1,0 +1,12 @@
+# v2 cluster scoped twin of ProviderConfigUsage. No status at all.
+apiVersion: aws.m.upbound.io/v1beta1
+kind: ClusterProviderConfigUsage
+metadata:
+  name: 8f2a1c4e-7b3d-4f6a-9c2e-1d5b8a0f3e7c
+providerConfigRef:
+  kind: ClusterProviderConfig
+  name: default
+resourceRef:
+  apiVersion: ec2.m.aws.upbound.io/v1beta1
+  kind: Instance
+  name: sample-instance

--- a/resource_customizations/_.upbound.io/_/testdata/managedresource_provisioning_progressing.yaml
+++ b/resource_customizations/_.upbound.io/_/testdata/managedresource_provisioning_progressing.yaml
@@ -1,0 +1,15 @@
+# A managed resource the provider has not reconciled yet: accepted by
+# the API server, no status written. This is the case the fix is for --
+# it reported Healthy while the condition read as `A or (B and C)`,
+# because the nil branch answered before has_no_conditions was consulted.
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: Instance
+metadata:
+  name: sample-instance
+spec:
+  forProvider:
+    region: us-west-1
+    instanceType: t2.micro
+    ami: ami-0d5ae304a0b933620
+  providerConfigRef:
+    name: default

--- a/resource_customizations/_.upbound.io/_/testdata/providerconfig_emptyconditions_healthy.yaml
+++ b/resource_customizations/_.upbound.io/_/testdata/providerconfig_emptyconditions_healthy.yaml
@@ -1,0 +1,10 @@
+# An empty conditions array means the same as an absent one.
+apiVersion: aws.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  credentials:
+    source: IRSA
+status:
+  conditions: []

--- a/resource_customizations/_.upbound.io/_/testdata/providerconfig_withusers_healthy.yaml
+++ b/resource_customizations/_.upbound.io/_/testdata/providerconfig_withusers_healthy.yaml
@@ -1,0 +1,11 @@
+# Non-empty status, no conditions: the case the kind list has to catch.
+apiVersion: aws.m.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: default
+  namespace: default
+spec:
+  credentials:
+    source: IRSA
+status:
+  users: 2

--- a/resource_customizations/_.upbound.io/_/testdata/providerconfigusage_healthy.yaml
+++ b/resource_customizations/_.upbound.io/_/testdata/providerconfigusage_healthy.yaml
@@ -1,0 +1,14 @@
+# A ProviderConfigUsage has no status subresource, so it is Healthy only
+# through the has_no_conditions list. Kept as a fixture because that list is
+# now the only thing standing between a status-less kind and a
+# permanent Progressing.
+apiVersion: aws.upbound.io/v1beta1
+kind: ProviderConfigUsage
+metadata:
+  name: 4d1b2c3d-5e6f-4a7b-8c9d-0e1f2a3b4c5d
+providerConfigRef:
+  name: default
+resourceRef:
+  apiVersion: ec2.aws.upbound.io/v1beta1
+  kind: Instance
+  name: sample-instance

--- a/resource_customizations/_.upbound.io/_/testdata/storeconfig_healthy.yaml
+++ b/resource_customizations/_.upbound.io/_/testdata/storeconfig_healthy.yaml
@@ -1,0 +1,8 @@
+# v1 only. Has a ConditionedStatus but nothing ever writes to it.
+apiVersion: aws.upbound.io/v1alpha1
+kind: StoreConfig
+metadata:
+  name: vault
+spec:
+  type: Vault
+  defaultScope: crossplane-system


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Closes [ISSUE #29381]. Necessary as confirmed by the OP of [PR #25386].

## The bug

Both `resource_customizations/_.crossplane.io/_/health.lua` and
`_.upbound.io/_/health.lua` guard the `has_no_status` allowlist with:

```lua
if obj.status == nil or next(obj.status) == nil and contains(has_no_status, obj.kind) then
```

`and` binds tighter than `or` in Lua, so this reads as
`(obj.status == nil) or (next(obj.status) == nil and contains(...))`. A resource
whose `.status` has not been written yet takes the first branch and reports
**Healthy**, before the allowlist is consulted.

The allowlist is therefore only reachable for a present-but-empty `status: {}`,
so the same resource grades differently depending on which spelling of "nothing
has happened yet" the API server holds:

```
fresh managed resource, no status yet  ->  Healthy      (wrong)
fresh managed resource, status: {}     ->  Progressing  (right)
```

A script whose default is `Progressing / "Provisioning ..."` cannot have
intended "no status at all -> Healthy". In practice a freshly applied managed
resource reports Healthy until its controller first reconciles - long enough for
a sync wave to advance, or a `kubectl wait --for=health.status=Healthy` to
return, before anything has been provisioned.

## The fix

Both scripts now ask one question - has the resource written any
`status.conditions` yet - and consult the allowlist only when it has not:

```lua
if obj.status == nil or obj.status.conditions == nil or next(obj.status.conditions) == nil then
  if contains(has_no_conditions, obj.kind) then
```

That replaces two overlapping blocks with one, so only kinds on the allowlist
short-circuit to Healthy. It also fixes a third spelling of "nothing has
happened yet": an explicit `conditions: []` used to fall through to a condition
loop with nothing to iterate and return Progressing by default.

The list is renamed `has_no_conditions`, since what it governs is the absence of
conditions rather than of a status - `ProviderConfig` and `ClusterProviderConfig`
do write `status.users`.

## Why the allowlist also changes

The guard alone regresses any kind that legitimately never carries a status
and is missing from the list: it becomes Progressing **permanently**, because
nothing will ever write the status it is now waiting for.

Membership is derivable rather than remembered. A kind can never carry a status
when no served version of its CRD declares a `status` subresource and none
declares a `status` property:

```bash
kubectl get crd -o json | jq -r '
  .items[]
  | select(.spec.group | endswith("crossplane.io"))
  | select([.spec.versions[] | select(.served)
      | ((.subresources // {}) | has("status"))
        or (((.schema.openAPIV3Schema.properties) // {}) | has("status"))] | any | not)
  | .spec.names.kind' | sort -u
```

Against Crossplane 2.4.0 that yields five kinds:

| kind | already listed? |
| --- | --- |
| `Composition` | yes |
| `DeploymentRuntimeConfig` | yes |
| `ProviderConfigUsage` | yes |
| `EnvironmentConfig` | **no - added** |
| `ImageConfig` | **no - added** |

Two further kinds are added to both files by the same rule, from the
crossplane-runtime types rather than from what a 2.4.0 cluster with these
providers happens to serve:

- `ClusterProviderConfigUsage` - the cluster scoped twin created when Crossplane
  2 made `ProviderConfigUsage` namespaced. On neither list, so it reads
  Progressing forever on v2.
- `StoreConfig` - external secret stores, v1 only and removed in v2. It declares
  a `ConditionedStatus` that nothing ever writes.

`ProviderConfig`, `ClusterProviderConfig` and `CompositionRevision` stay listed
despite having status subresources - an unused `ProviderConfig` legitimately has
an empty status forever, and listing it is what stops it reading as Progressing.
`ControllerConfig` is gone in Crossplane 2.x and is left for v1 clusters.

`_.upbound.io` keeps its narrower list, as upstream has it: the config kinds
above are the only additions, and the `*.crossplane.io` kinds cannot be served
in those groups.

## Tests

Fixtures added to both wildcard directories, all using kinds with no
more-specific customization directory so they genuinely exercise the changed
scripts.

Each half of the change is tested:

| variant | no-status MR / XRD fixtures | list-addition fixtures |
| --- | --- | --- |
| `master` - old guard, old list | **fail** (Healthy, expected Progressing) | pass |
| new guard only, list untouched | pass | **fail** (Progressing, expected Healthy) |
| this PR | pass | pass |

- `_.crossplane.io/_/testdata/compositeresourcedefinition_progressing.yaml` - no status, expects Progressing. Fails on `master`.
- `_.crossplane.io/_/testdata/compositeresourcedefinition_healthy.yaml` - same kind with `Established: True`, so the pair shows it still reaches Healthy.
- `_.crossplane.io/_/testdata/environmentconfig_healthy.yaml` - guards the first list addition.
- `_.crossplane.io/_/testdata/imageconfig_healthy.yaml` - guards the second.
- `_.upbound.io/_/testdata/managedresource_provisioning_progressing.yaml` - no status, expects Progressing. Fails on `master`.
- `_.upbound.io/_/testdata/providerconfigusage_healthy.yaml` - guards the short-circuit the guard now depends on.
- `clusterproviderconfigusage_healthy.yaml` and `storeconfig_healthy.yaml`, in both directories - guard the two further list additions.
- `providerconfig_emptyconditions_healthy.yaml`, in both directories - an empty conditions array reads the same as an absent one. Fails on `master`.
- `providerconfig_withusers_healthy.yaml` and `clusterproviderconfig_withusers_healthy.yaml` - cover the "Resource is in use." message, which had no fixture before.

```
go test ./util/lua/ -run TestLuaHealthScript
ok  github.com/argoproj/argo-cd/v3/util/lua
```

## Notes for reviewers

**The nil status hazard is gone.** The old second block dereferenced
`obj.status` on a line that was unreachable only because both `ProviderConfig`
kinds returned at the first block:

```lua
if (obj.kind == "ProviderConfig" or obj.kind == "ClusterProviderConfig") and obj.status.users ~= nil then
```

Removing either kind from the list - reasonable-looking, since both do have
status subresources - turned a wrong grade into a runtime error. With one block
there is no such coupling, and the `status.users` read is guarded.

**Scope of the derivation.** Checked against Crossplane 2.4.0 with
`provider-helm`, `provider-kubernetes` and the GCP provider family - 42 CRDs.
The upbound config kinds are upjet-generated and structurally identical across
families, so `ProviderConfigUsage` should be the only status-less one
everywhere, but I have not read the AWS or Azure CRDs.

**The list drifts with Crossplane releases.** `ControllerConfig` went;
`ImageConfig`, `ManagedResourceDefinition`, `ops.crossplane.io/*` and
`protection.crossplane.io/*` arrived. That drift is how these went missing and
nothing detects it. The list now carries a comment saying what it is for, and
that a kind which starts reporting conditions can stay in it.

**Unrelated observation.** `_.crossplane.io/_/testdata/provider_degraded.yaml`
does not exercise this script. `TestLuaHealthScript` resolves via
`vm.GetHealthScript(obj)`, by the object's group and kind, so a `Provider`
fixture runs `pkg.crossplane.io/Provider/health.lua` whatever directory it sits
in - and its expected message is a copy of that directory's `degraded_installed`
case. Left alone.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->