### PR TITLE
fix: retry server-side apply on transient conflict (#21085)

### DIFF
--- a/gitops-engine/pkg/utils/kube/resource_ops.go
+++ b/gitops-engine/pkg/utils/kube/resource_ops.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/kubectl/pkg/cmd/apply"
 	"k8s.io/kubectl/pkg/cmd/auth"
 	"k8s.io/kubectl/pkg/cmd/create"
@@ -398,15 +399,35 @@ func (k *kubectlResourceOperations) ApplyResource(ctx context.Context, obj *unst
 	}
 
 	return k.runResourceCommand(ctx, obj, func(ioStreams genericiooptions.IOStreams, fileName string) error {
-		applyOpts, err := k.newApplyOptions(ioStreams, obj, fileName, validate, force, serverSideApply, dryRunStrategy, manager)
-		if err != nil {
-			return err
-		}
-		_, err = ioStreams.Out.Write([]byte(outReconcile))
-		if err != nil {
+		if _, err := ioStreams.Out.Write([]byte(outReconcile)); err != nil {
 			return fmt.Errorf("error writing reconcile output to stdout: %w", err)
 		}
-		return k.optionsRunner.Apply(applyOpts)
+
+		applyOnce := func() error {
+			applyOpts, err := k.newApplyOptions(ioStreams, obj, fileName, validate, force, serverSideApply, dryRunStrategy, manager)
+			if err != nil {
+				return err
+			}
+			return k.optionsRunner.Apply(applyOpts)
+		}
+
+		if !serverSideApply {
+			return applyOnce()
+		}
+
+		// A server-side apply PATCH is sent to the apiserver exactly once by
+		// kubectl. Unlike client-side apply's three-way merge patch, which
+		// kubectl retries itself on conflict (see Patcher.Patch), a conflict
+		// on the server-side apply request is returned straight to the
+		// caller. Because the request always carries our full desired state
+		// rather than a patch computed against a possibly-stale read, a
+		// conflict here just means some other writer (e.g. an HPA or KEDA
+		// controller updating status/replicas) modified the object between
+		// when we built the request and when it reached the apiserver.
+		// Resending the identical request is safe and frequently succeeds,
+		// so retry instead of failing the sync outright.
+		// See https://github.com/argoproj/argo-cd/issues/21085.
+		return retry.RetryOnConflict(retry.DefaultRetry, applyOnce)
 	})
 }
 

--- a/gitops-engine/pkg/utils/kube/resource_ops_test.go
+++ b/gitops-engine/pkg/utils/kube/resource_ops_test.go
@@ -2,22 +2,26 @@ package kube
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/argoproj/argo-cd/gitops-engine/v3/pkg/utils/kube/mocks"
-	"k8s.io/kubectl/pkg/cmd/auth"
 	testingutils "github.com/argoproj/argo-cd/gitops-engine/v3/pkg/utils/testing"
 	"github.com/argoproj/argo-cd/gitops-engine/v3/pkg/utils/tracing"
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/client-go/kubernetes"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/kubectl/pkg/cmd/apply"
+	"k8s.io/kubectl/pkg/cmd/auth"
 	"k8s.io/kubectl/pkg/cmd/create"
 	"k8s.io/kubectl/pkg/cmd/replace"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -561,4 +565,77 @@ func TestRealKubectlOptionsRunner_AuthReconcile_PanicRecovery(t *testing.T) {
 	err := runner.AuthReconcile((*auth.ReconcileOptions)(nil))
 	require.Error(t, err, "AuthReconcile must return an error rather than propagating the panic")
 	assert.Contains(t, err.Error(), "error running kubectl auth reconcile")
+}
+
+// TestApplyResource_ServerSideApplyConflict reproduces
+// https://github.com/argoproj/argo-cd/issues/21085: when a resource is
+// mutated very frequently by another controller (e.g. an HPA whose
+// `status`/`spec.replicas` a HPA controller or KEDA writes every few
+// seconds), the server can return a transient 409 conflict for a
+// server-side apply patch even though no field ownership conflict exists,
+// simply because the object changed between when the patch was built and
+// when it landed. `kubectl apply --server-side` only sends the patch once;
+// unlike its client-side apply counterpart (which retries via
+// Patcher.Patch's built-in RetryOnConflict loop), it does not retry the
+// request on conflict. ApplyResource now retries such conflicts for
+// server-side apply, since resending the identical desired state is safe.
+func TestApplyResource_ServerSideApplyConflict(t *testing.T) {
+	t.Parallel()
+
+	newConflictErr := func() error {
+		return apierrors.NewConflict(
+			schema.GroupResource{Group: "autoscaling", Resource: "horizontalpodautoscalers"},
+			"my-hpa",
+			errors.New("the object has been modified; please apply your changes to the latest version and try again"),
+		)
+	}
+
+	t.Run("a transient conflict is retried and can succeed", func(t *testing.T) {
+		t.Parallel()
+		k, cmdMocks := newTestKubectlResourceOperations(t)
+
+		// Simulate what kubectl's server-side apply branch returns on the
+		// first attempt: the raw apiserver conflict, exactly as it would be
+		// after a second writer (e.g. the HPA controller) updated the object
+		// in between. The retry then succeeds, as it would against a real
+		// apiserver once the transient write race has cleared.
+		cmdMocks.On("Apply", mock.Anything).Return(newConflictErr()).Once()
+		cmdMocks.On("Apply", mock.Anything).Return(nil).Once()
+
+		obj := testingutils.NewPod()
+		_, err := k.ApplyResource(t.Context(), obj, cmdutil.DryRunNone, false, false, true, "argocd-controller")
+
+		require.NoError(t, err, "a transient conflict should be retried instead of failing the sync outright")
+		cmdMocks.AssertNumberOfCalls(t, "Apply", 2)
+	})
+
+	t.Run("a persistent conflict still fails after retries are exhausted", func(t *testing.T) {
+		t.Parallel()
+		k, cmdMocks := newTestKubectlResourceOperations(t)
+
+		cmdMocks.On("Apply", mock.Anything).Return(newConflictErr())
+
+		obj := testingutils.NewPod()
+		_, err := k.ApplyResource(t.Context(), obj, cmdutil.DryRunNone, false, false, true, "argocd-controller")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "the object has been modified")
+		cmdMocks.AssertNumberOfCalls(t, "Apply", retry.DefaultRetry.Steps)
+	})
+
+	t.Run("client-side apply conflicts are not retried by ApplyResource itself", func(t *testing.T) {
+		t.Parallel()
+		// kubectl's client-side apply path (Patcher.Patch) already retries
+		// conflicts on its own; ApplyResource must not add a second,
+		// redundant retry loop on top of it for the non-SSA path.
+		k, cmdMocks := newTestKubectlResourceOperations(t)
+
+		cmdMocks.On("Apply", mock.Anything).Return(newConflictErr()).Once()
+
+		obj := testingutils.NewPod()
+		_, err := k.ApplyResource(t.Context(), obj, cmdutil.DryRunNone, false, false, false, "argocd-controller")
+
+		require.Error(t, err)
+		cmdMocks.AssertNumberOfCalls(t, "Apply", 1)
+	})
 }


### PR DESCRIPTION
Fixes #21085

## What this PR does

`kubectl apply --server-side` sends the Apply-typed PATCH to the apiserver exactly once. Its client-side apply counterpart retries on 409 conflicts internally (`Patcher.Patch`'s built-in retry loop), but the server-side apply code path (`k8s.io/kubectl/pkg/cmd/apply`, the `o.ServerSideApply` branch) does not — a conflict is returned straight to the caller.

For a resource that another controller mutates very frequently (e.g. an `HorizontalPodAutoscaler` or KEDA `ScaledObject` whose status/spec the autoscaler writes every few seconds), the apiserver's own internal optimistic-concurrency handling can occasionally lose that race and return:

```
Operation cannot be fulfilled on horizontalpodautoscalers.autoscaling "my-hpa":
the object has been modified; please apply your changes to the latest version and try again
```

This happens even when field ownership is correct and no `resourceVersion` precondition was sent by the client — I traced this end to end (`createManifestFile` → `json.Marshal(obj)` → kubectl's SSA branch encodes that object verbatim with no preceding `Get()`) and confirmed Argo CD's sync path does not include `metadata.resourceVersion` in the object it server-side applies for the normal (non-CRD/Namespace-replace) case. The `--force-conflicts` guidance kubectl appends to *any* conflict error (see `apply.go`) is what makes the message read like a field-ownership problem when it isn't; `ApplyResource` already sets `ForceConflicts: true` whenever server-side apply is enabled, so field-manager conflicts are not the cause here.

Since `ApplyResource` has no retry of its own, a single transient conflict fails the whole sync.

## The fix

Retry the server-side apply request on conflict with `client-go`'s default backoff (`retry.RetryOnConflict`), mirroring the retry kubectl already performs for client-side apply, and matching the same pattern used elsewhere in this codebase for a similar class of bug (#28970). Resending the identical desired state is safe here — server-side apply doesn't need a fresh read between attempts, unlike a diff-based patch. Client-side apply is untouched, since kubectl already retries that path itself.

## Testing

Added `TestApplyResource_ServerSideApplyConflict` in `gitops-engine/pkg/utils/kube/resource_ops_test.go`:
- a transient conflict is retried and the apply succeeds
- a persistent conflict still fails once `retry.DefaultRetry`'s attempts are exhausted
- client-side apply conflicts are *not* retried a second time by `ApplyResource` (kubectl already retries those itself)

`go build`, `go vet`, and the full `pkg/utils/kube`, `pkg/sync`, and `pkg/diff` suites in `gitops-engine` pass locally.

Checklist:

* [x] This is a bug fix.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. — N/A, no user-facing surface change.
* [x] Does this PR require documentation updates? — No, this is an internal reliability fix with no new user-facing option.
* [ ] I've updated documentation as required by this PR. — N/A per above.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). — pending CI.
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines. — N/A, bug fix only.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into. — This is a low-risk, narrowly-scoped reliability fix; safe to cherry-pick to any currently-supported release branch that includes server-side apply support.
