### PR TITLE
fix: create a fresh gRPC connection on every dial attempt in BlockingNewClient

### DIFF
--- a/util/grpc/grpc.go
+++ b/util/grpc/grpc.go
@@ -36,18 +36,18 @@ func LoggerRecoveryHandler(log *logrus.Entry) recovery.RecoveryHandlerFunc {
 // connection will be insecure (plain-text).
 // Lifted from: https://github.com/fullstorydev/grpcurl/blob/master/grpcurl.go
 func BlockingNewClient(ctx context.Context, network, address string, creds credentials.TransportCredentials, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
-	rawConn, err := proxy.Dial(ctx, network, address)
-	if err != nil {
-		return nil, fmt.Errorf("error dial proxy: %w", err)
-	}
-
-	if creds != nil {
-		rawConn, _, err = creds.ClientHandshake(ctx, address, rawConn)
+	customDialer := func(dialCtx context.Context, _ string) (net.Conn, error) {
+		rawConn, err := proxy.Dial(dialCtx, network, address)
 		if err != nil {
-			return nil, fmt.Errorf("error creating connection: %w", err)
+			return nil, fmt.Errorf("error dial proxy: %w", err)
 		}
-	}
-	customDialer := func(_ context.Context, _ string) (net.Conn, error) {
+
+		if creds != nil {
+			rawConn, _, err = creds.ClientHandshake(dialCtx, address, rawConn)
+			if err != nil {
+				return nil, fmt.Errorf("error creating connection: %w", err)
+			}
+		}
 		return rawConn, nil
 	}
 

--- a/util/grpc/grpc_test.go
+++ b/util/grpc/grpc_test.go
@@ -2,11 +2,16 @@ package grpc
 
 import (
 	"context"
+	"net"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	grpcgo "google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 var proxyEnvKeys = []string{"ALL_PROXY", "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"}
@@ -112,4 +117,59 @@ func TestBlockingNewClient_CancelledContextAbortsDial(t *testing.T) {
 	cancel()
 	_, err := BlockingNewClient(ctx, "tcp", "10.255.255.1:443", nil)
 	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestBlockingNewClientReconnectsAfterIdle(t *testing.T) {
+	clearProxyEnv(t)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := grpcgo.NewServer()
+	healthpb.RegisterHealthServer(server, health.NewServer())
+
+	go func() {
+		_ = server.Serve(listener)
+	}()
+	t.Cleanup(server.Stop)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	conn, err := BlockingNewClient(
+		ctx,
+		"tcp",
+		listener.Addr().String(),
+		nil,
+		// Default is 30 minutes
+		grpcgo.WithIdleTimeout(200*time.Millisecond),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = conn.Close()
+	})
+
+	client := healthpb.NewHealthClient(conn)
+
+	// The initial transport works.
+	_, err = client.Check(ctx, &healthpb.HealthCheckRequest{})
+	require.NoError(t, err)
+
+	// Wait for idle.
+	require.Eventually(t, func() bool {
+		return conn.GetState() == connectivity.Idle
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// This must create a new transport using the same ClientConn.
+	rpcCtx, rpcCancel := context.WithTimeout(
+		t.Context(),
+		2*time.Second,
+	)
+	defer rpcCancel()
+
+	_, err = client.Check(
+		rpcCtx,
+		&healthpb.HealthCheckRequest{},
+		grpcgo.WaitForReady(true),
+	)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
### Problem

`util/grpc.BlockingNewClient` opens one network connection and returns that **same** connection for every dial attempt via the `customDialer`:

```go
customDialer := func(_ context.Context, _ string) (net.Conn, error) {
    return rawConn, nil
}
```

When grpc-go tears down the underlying transport (e.g. after the client enters idle mode), it calls the custom dialer to reconnect. Because the dialer always returns the already-closed `rawConn`, the client can never recover, and subsequent RPCs fail with:

```
transport: failed to write client preface: write tcp ...: use of closed network connection
```

This is a regression from #24188.

### Fix

Move the `proxy.Dial` + `creds.ClientHandshake` logic **inside** the custom dialer so that every transport attempt creates (and, when configured, performs TLS on) a fresh connection:

```go
customDialer := func(dialCtx context.Context, _ string) (net.Conn, error) {
    rawConn, err := proxy.Dial(dialCtx, network, address)
    if err != nil {
        return nil, fmt.Errorf("error dial proxy: %w", err)
    }
    if creds != nil {
        rawConn, _, err = creds.ClientHandshake(dialCtx, address, rawConn)
        if err != nil {
            return nil, fmt.Errorf("error creating connection: %w", err)
        }
    }
    return rawConn, nil
}
```

### Test

Added `TestBlockingNewClientReconnectsAfterIdle`, which verifies that a client recovers and issues a successful RPC after the connection goes idle and grpc-go tears the transport down.

Fixes #29392
