### PR TITLE
fix: handle GrafanaFolder negative-polarity condition (#29395)

### DIFF
--- a/resource_customizations/grafana.integreatly.org/GrafanaFolder/health.lua
+++ b/resource_customizations/grafana.integreatly.org/GrafanaFolder/health.lua
@@ -19,7 +19,9 @@ function getStatusFromConditions(obj, hs)
               end
             end
 
-            if condition.status == "False" then
+            -- FolderUIDMismatch is a negative-polarity condition: False means
+            -- the UIDs are consistent, not that the resource is unhealthy.
+            if condition.status == "False" and condition.type ~= "FolderUIDMismatch" then
               hs.status = "Degraded"
               return hs
             end

--- a/resource_customizations/grafana.integreatly.org/GrafanaFolder/health.lua
+++ b/resource_customizations/grafana.integreatly.org/GrafanaFolder/health.lua
@@ -21,6 +21,11 @@ function getStatusFromConditions(obj, hs)
 
             -- FolderUIDMismatch is a negative-polarity condition: False means
             -- the UIDs are consistent, not that the resource is unhealthy.
+            if condition.status == "True" and condition.type == "FolderUIDMismatch" then
+              hs.status = "Degraded"
+              return hs
+            end
+
             if condition.status == "False" and condition.type ~= "FolderUIDMismatch" then
               hs.status = "Degraded"
               return hs

--- a/resource_customizations/grafana.integreatly.org/GrafanaFolder/health_test.yaml
+++ b/resource_customizations/grafana.integreatly.org/GrafanaFolder/health_test.yaml
@@ -14,3 +14,8 @@ tests:
 
       - grafana-operator/grafana: Get "https://dashboards.grafana.com/api/folders?limit=10000&page=1": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
   inputPath: testdata/degraded.yaml
+- healthStatus:
+    status: Healthy
+    message: >-
+      ApplySuccessful for FolderSynchronized because Folder was successfully applied to 1 instances, ConsistentUID for FolderUIDMismatch because UIDs consistent across all 1 instances
+  inputPath: testdata/healthy-negative-polarity-condition.yaml

--- a/resource_customizations/grafana.integreatly.org/GrafanaFolder/health_test.yaml
+++ b/resource_customizations/grafana.integreatly.org/GrafanaFolder/health_test.yaml
@@ -19,3 +19,10 @@ tests:
     message: >-
       ApplySuccessful for FolderSynchronized because Folder was successfully applied to 1 instances, ConsistentUID for FolderUIDMismatch because UIDs consistent across all 1 instances
   inputPath: testdata/healthy-negative-polarity-condition.yaml
+- healthStatus:
+    status: Degraded
+    message: >-
+      ApplySuccessful for FolderSynchronized because Folder was successfully applied to 1 instances, FolderUIDInferred for FolderUIDMismatch because UID was inferred for 1 out of 1 instances:
+
+      - grafana-operator/grafana: inferred bar-folder
+  inputPath: testdata/degraded-folder-uid-mismatch.yaml

--- a/resource_customizations/grafana.integreatly.org/GrafanaFolder/testdata/degraded-folder-uid-mismatch.yaml
+++ b/resource_customizations/grafana.integreatly.org/GrafanaFolder/testdata/degraded-folder-uid-mismatch.yaml
@@ -1,0 +1,44 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaFolder
+metadata:
+  annotations:
+    argocd.argoproj.io/installation-id: argocd.com
+    argocd.argoproj.io/tracking-id: >-
+      foo:grafana.integreatly.org/GrafanaFolder:grafana-operator/bar
+  creationTimestamp: '2025-03-26T14:50:23Z'
+  finalizers:
+    - operator.grafana.com/finalizer
+  generation: 1
+  labels:
+    argocd.argoproj.io/instance: foo
+  name: bar
+  namespace: grafana-operator
+  resourceVersion: '185974148'
+  uid: 226a9af3-4a5d-4ebb-9705-ddfec0f6db47
+spec:
+  allowCrossNamespaceImport: false
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  parentFolderRef: baz
+  resyncPeriod: 10m0s
+  title: Bar-Folder
+status:
+  conditions:
+    - lastTransitionTime: '2025-03-26T14:50:23Z'
+      message: Folder was successfully applied to 1 instances
+      observedGeneration: 1
+      reason: ApplySuccessful
+      status: 'True'
+      type: FolderSynchronized
+    - lastTransitionTime: '2026-08-25T09:00:00Z'
+      message: >-
+        UID was inferred for 1 out of 1 instances:
+
+        - grafana-operator/grafana: inferred bar-folder
+      observedGeneration: 1
+      reason: FolderUIDInferred
+      status: 'True'
+      type: FolderUIDMismatch
+  hash: f929c3bb9a96dbba11dd9ecf049ab28f98d7f8fbf5403aee0877c2c7b6f2547f
+  lastResync: '2025-03-26T15:30:24Z'

--- a/resource_customizations/grafana.integreatly.org/GrafanaFolder/testdata/healthy-negative-polarity-condition.yaml
+++ b/resource_customizations/grafana.integreatly.org/GrafanaFolder/testdata/healthy-negative-polarity-condition.yaml
@@ -1,0 +1,41 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaFolder
+metadata:
+  annotations:
+    argocd.argoproj.io/installation-id: argocd.com
+    argocd.argoproj.io/tracking-id: >-
+      foo:grafana.integreatly.org/GrafanaFolder:grafana-operator/bar
+  creationTimestamp: '2025-03-26T14:50:23Z'
+  finalizers:
+    - operator.grafana.com/finalizer
+  generation: 1
+  labels:
+    argocd.argoproj.io/instance: foo
+  name: bar
+  namespace: grafana-operator
+  resourceVersion: '185974148'
+  uid: 226a9af3-4a5d-4ebb-9705-ddfec0f6db47
+spec:
+  allowCrossNamespaceImport: false
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  parentFolderRef: baz
+  resyncPeriod: 10m0s
+  title: Bar-Folder
+status:
+  conditions:
+    - lastTransitionTime: '2025-03-26T14:50:23Z'
+      message: Folder was successfully applied to 1 instances
+      observedGeneration: 1
+      reason: ApplySuccessful
+      status: 'True'
+      type: FolderSynchronized
+    - lastTransitionTime: '2026-08-25T09:00:00Z'
+      message: UIDs consistent across all 1 instances
+      observedGeneration: 1
+      reason: ConsistentUID
+      status: 'False'
+      type: FolderUIDMismatch
+  hash: f929c3bb9a96dbba11dd9ecf049ab28f98d7f8fbf5403aee0877c2c7b6f2547f
+  lastResync: '2025-03-26T15:30:24Z'


### PR DESCRIPTION
Fixes #29395

Grafana Operator v5.25.0 adds a `FolderUIDMismatch` condition with negative polarity: `False` with reason `ConsistentUID` means the folder is healthy, while `True` means a UID mismatch is present. The existing customization treated all false conditions as degraded and all true conditions as healthy.

Handle both states explicitly while retaining existing behavior for failures such as `FolderSynchronized=False`. Tests include realistic v5.25-style fixtures for both consistent and mismatched folder UIDs.

Upstream context: https://github.com/grafana/grafana-operator/issues/2918#issuecomment-5409806774

Tested on the final head with:

```console
/home/ubuntu/.local/go/bin/go test ./util/lua -count=1
# ok github.com/argoproj/argo-cd/v3/util/lua 1.881s
git diff --check 376213737f3023686fe5623c45229a0ba4fb96c0...HEAD
```

Checklist:

* [x] This is a bug fix.
* [x] The title states what changed and includes the related issue number.
* [x] The title conforms to the semantic PR title policy.
* [x] The description includes `Fixes #29395`.
* [x] CLI/UI exposure is not applicable to this resource health customization.
* [x] This bug fix does not require documentation updates.
* [x] Documentation updates are not applicable.
* [x] All commits are signed off per DCO.
* [x] Unit health fixtures cover both negative-condition polarities.
* [x] Hosted CI was green before the corrective commit; focused local tests pass on the final head.
* [x] Feature-status requirements are not applicable to this bug fix.
* [x] The rationale and behavior are described above.
* [x] Organization listing is not applicable.
* [x] No cherry-pick target is requested; maintainers may choose based on release policy.
