### PR TITLE
fix: handle negative-polarity FolderUIDMismatch condition in GrafanaFolder health

### DIFF
--- a/resource_customizations/grafana.integreatly.org/GrafanaFolder/health.lua
+++ b/resource_customizations/grafana.integreatly.org/GrafanaFolder/health.lua
@@ -1,10 +1,22 @@
 -- Reference CRD can be found here:
 -- https://grafana.github.io/grafana-operator/docs/api/#grafanafolder
 
+-- Negative-polarity condition types: `status: "False"` means the check
+-- passed (no problem), while `status: "True"` indicates a real problem.
+-- grafana-operator v5.25.0 introduced FolderUIDMismatch with this
+-- polarity (reason: ConsistentUID when there is no mismatch), which must
+-- not mark the resource as Degraded.
+-- See https://github.com/grafana/grafana-operator/issues/2918
+local negativePolarityTypes = {
+  FolderUIDMismatch = true,
+}
+
 function getStatusFromConditions(obj, hs)
   if obj.status ~= nil and obj.status.conditions ~= nil then
       for i, condition in ipairs(obj.status.conditions) do
           if condition.status ~= nil then
+            local isNegativePolarity = condition.type ~= nil and negativePolarityTypes[condition.type] == true
+
             if hs.message ~= "" then
               hs.message = hs.message .. ", "
             end
@@ -20,11 +32,22 @@ function getStatusFromConditions(obj, hs)
             end
 
             if condition.status == "False" then
-              hs.status = "Degraded"
-              return hs
+              if isNegativePolarity then
+                -- The check passed; treat like a successful condition.
+                hs.status = "Healthy"
+              else
+                hs.status = "Degraded"
+                return hs
+              end
             end
 
             if condition.status == "True" then
+              if isNegativePolarity then
+                -- A triggered negative-polarity condition is a real problem.
+                hs.status = "Degraded"
+                return hs
+              end
+
               hs.status = "Healthy"
             end
           end

--- a/resource_customizations/grafana.integreatly.org/GrafanaFolder/health_test.yaml
+++ b/resource_customizations/grafana.integreatly.org/GrafanaFolder/health_test.yaml
@@ -14,3 +14,13 @@ tests:
 
       - grafana-operator/grafana: Get "https://dashboards.grafana.com/api/folders?limit=10000&page=1": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
   inputPath: testdata/degraded.yaml
+- healthStatus:
+    status: Healthy
+    message: >-
+      ApplySuccessful for FolderSynchronized because Folder was successfully applied to 1 instances, ConsistentUID for FolderUIDMismatch because Folder UID is consistent with the referenced parent folder
+  inputPath: testdata/healthy_uid_mismatch_false.yaml
+- healthStatus:
+    status: Degraded
+    message: >-
+      ApplySuccessful for FolderSynchronized because Folder was successfully applied to 1 instances, ParentFolderUIDMismatch for FolderUIDMismatch because Folder UID does not match the UID of the referenced parent folder
+  inputPath: testdata/degraded_folder_uid_mismatch.yaml

--- a/resource_customizations/grafana.integreatly.org/GrafanaFolder/testdata/degraded_folder_uid_mismatch.yaml
+++ b/resource_customizations/grafana.integreatly.org/GrafanaFolder/testdata/degraded_folder_uid_mismatch.yaml
@@ -1,0 +1,41 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaFolder
+metadata:
+  annotations:
+    argocd.argoproj.io/installation-id: argocd.com
+    argocd.argoproj.io/tracking-id: >-
+      foo:grafana.integreatly.org/GrafanaFolder:grafana-operator/bar
+  creationTimestamp: '2025-03-26T14:50:23Z'
+  finalizers:
+    - operator.grafana.com/finalizer
+  generation: 2
+  labels:
+    argocd.argoproj.io/instance: foo
+  name: bar
+  namespace: grafana-operator
+  resourceVersion: '185974150'
+  uid: 226a9af3-4a5d-4ebb-9705-ddfec0f6db47
+spec:
+  allowCrossNamespaceImport: false
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  parentFolderRef: baz
+  resyncPeriod: 10m0s
+  title: Bar-Folder
+status:
+  conditions:
+    - lastTransitionTime: '2025-03-26T14:50:23Z'
+      message: Folder was successfully applied to 1 instances
+      observedGeneration: 2
+      reason: ApplySuccessful
+      status: 'True'
+      type: FolderSynchronized
+    - lastTransitionTime: '2025-03-26T15:30:24Z'
+      message: Folder UID does not match the UID of the referenced parent folder
+      observedGeneration: 2
+      reason: ParentFolderUIDMismatch
+      status: 'True'
+      type: FolderUIDMismatch
+  hash: f929c3bb9a96dbba11dd9ecf049ab28f98d7f8fbf5403aee0877c2c7b6f2547f
+  lastResync: '2025-03-26T15:30:24Z'

--- a/resource_customizations/grafana.integreatly.org/GrafanaFolder/testdata/healthy_uid_mismatch_false.yaml
+++ b/resource_customizations/grafana.integreatly.org/GrafanaFolder/testdata/healthy_uid_mismatch_false.yaml
@@ -1,0 +1,41 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaFolder
+metadata:
+  annotations:
+    argocd.argoproj.io/installation-id: argocd.com
+    argocd.argoproj.io/tracking-id: >-
+      foo:grafana.integreatly.org/GrafanaFolder:grafana-operator/bar
+  creationTimestamp: '2025-03-26T14:50:23Z'
+  finalizers:
+    - operator.grafana.com/finalizer
+  generation: 2
+  labels:
+    argocd.argoproj.io/instance: foo
+  name: bar
+  namespace: grafana-operator
+  resourceVersion: '185974149'
+  uid: 226a9af3-4a5d-4ebb-9705-ddfec0f6db47
+spec:
+  allowCrossNamespaceImport: false
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  parentFolderRef: baz
+  resyncPeriod: 10m0s
+  title: Bar-Folder
+status:
+  conditions:
+    - lastTransitionTime: '2025-03-26T14:50:23Z'
+      message: Folder was successfully applied to 1 instances
+      observedGeneration: 2
+      reason: ApplySuccessful
+      status: 'True'
+      type: FolderSynchronized
+    - lastTransitionTime: '2025-03-26T15:30:24Z'
+      message: Folder UID is consistent with the referenced parent folder
+      observedGeneration: 2
+      reason: ConsistentUID
+      status: 'False'
+      type: FolderUIDMismatch
+  hash: f929c3bb9a96dbba11dd9ecf049ab28f98d7f8fbf5403aee0877c2c7b6f2547f
+  lastResync: '2025-03-26T15:30:24Z'


### PR DESCRIPTION
Fixes #29395

## Root cause

grafana-operator v5.25.0 introduced a negative-polarity condition: FolderUIDMismatch is set with status: "False" / eason: ConsistentUID when there is **no** mismatch (see [grafana-operator#2918](https://github.com/grafana/grafana-operator/issues/2918)).

The GrafanaFolder health script marked the resource Degraded on *any* condition with status == "False", so every folder CR started reporting Degraded after the operator upgrade.

## Changes

- health.lua: add a negative-polarity condition table (FolderUIDMismatch). For these types, False means the check passed (Healthy) and True indicates a real problem (Degraded). Message construction and all other behaviors are unchanged.
- health_test.yaml + 2 new fixtures:
  - healthy_uid_mismatch_false.yaml - v5.25.0 steady state (FolderSynchronized=True, FolderUIDMismatch=False) ? expected **Healthy**
  - degraded_folder_uid_mismatch.yaml - triggered mismatch (FolderUIDMismatch=True) ? expected **Degraded**

## Validation

- All 5 test cases (3 pre-existing + 2 new) pass with exact status/message strings via a faithful port of the script logic
- Note: I could not run TestLuaHealthScript reliably locally - the embedded Lua VM produces empty/flaky results on this Windows machine even on unmodified main (verified by stashing my changes). Upstream CI should be authoritative here.

Happy to adjust if maintainers prefer a different polarity-handling approach (e.g., an allowlist of reasons instead of types).