### PR TITLE
fix(ui): stop the top bar breadcrumbs from overlapping the page title (#29292)

### DIFF
--- a/ui/src/app/shared/components/page/page.scss
+++ b/ui/src/app/shared/components/page/page.scss
@@ -48,6 +48,28 @@
     }
 }
 
+// The top bar's first row lays out the breadcrumbs and the page title as flex items. The
+// breadcrumb column is `white-space: nowrap` with visible overflow, so on a narrow window a long
+// breadcrumb runs out of its column and underneath the right-aligned title instead of shrinking
+// (issue #29292). Let both sides shrink and ellipsize, and cap the title so the breadcrumbs keep
+// a usable share of the row.
+.page__top-bar .top-bar > .row {
+    > .top-bar__left-side {
+        min-width: 0;
+    }
+
+    .top-bar__breadcrumbs {
+        max-width: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    > .top-bar__title {
+        min-width: 0;
+        max-width: 50%;
+    }
+}
+
 .login-logout-button {
     border-radius: 3px;
     @include themify($themes) {


### PR DESCRIPTION
Closes #29292

## What

The top bar's first row lays out the breadcrumb column and the page title as flex items:

```html
<div class="row">
  <div class="columns top-bar__left-side">…breadcrumbs…</div>
  <div class="top-bar__title text-truncate top-bar__right-side">TITLE</div>
</div>
```

`.top-bar__left-side` is `white-space: nowrap` with visible overflow, so once the row is narrower than the breadcrumb text, the text leaves its column and runs underneath the right-aligned title instead of shrinking.

Measured on https://cd.apps.argoproj.io/settings/certs at a 760px viewport: the breadcrumbs box ends at x=551 while the title box starts at x=409, so the two texts overlap by 142px. At 660px it is 242px.

## The fix

Three declarations in `ui/src/app/shared/components/page/page.scss`:

- `min-width: 0` on the breadcrumb column so it can shrink below its content width
- `overflow: hidden; text-overflow: ellipsis` on the breadcrumbs so the clipped text ellipsizes
- `min-width: 0; max-width: 50%` on the title so the breadcrumbs keep a usable share of the row rather than being crushed to a few characters

It is scoped to `.page__top-bar .top-bar > .row`, so it does not touch the `flex-top-bar` used elsewhere.

## Testing

Verified against the live demo by injecting the compiled rule and measuring the boxes at several viewport widths:

| viewport | overlap before | overlap after | breadcrumb width after |
|---|---|---|---|
| 1600px | none (-698px gap) | unchanged | 310px, not clipped |
| 980px | none (-78px gap) | unchanged | 310px, not clipped |
| 760px | **142px overlap** | 19px gap | ellipsized |
| 660px | **242px overlap** | 19px gap | 185px, ellipsized |

The rule is inert at widths where the row already fits, and the title keeps its existing `text-truncate` behaviour.

This is a CSS-only change to a shared layout rule, so it applies to every page that uses the `Page` top bar, not just the certificates settings page. There is no unit or e2e test here because the repo has no styling test harness.
