### PR TITLE
docs: clarify hook caveats in the database migration example

### DIFF
--- a/docs/user-guide/sync-waves.md
+++ b/docs/user-guide/sync-waves.md
@@ -14,7 +14,7 @@ Argo CD has the following hook types:
 | `PreDelete`  | Executes before Application resources are deleted. Only runs when the entire Application is being deleted, not during normal sync operations (even with pruning enabled. ) |
 | `PostDelete` | Executes after all Application resources are deleted. _Available starting in v2.10._                                                                                       |
 
-Adding the argocd.argoproj.io/hook annotation to a resource will assign it to a specific phase. During a Sync operation, Argo CD will apply the resource during the appropriate phase of the deployment. Hooks can be any type of Kubernetes resource kind, but tend to be Pod, Job or Argo Workflows. Multiple hooks can be specified as a comma separated list.
+Adding the argocd.argoproj.io/hook annotation to a resource will assign it to a specific phase. During a Sync operation, Argo CD will apply the resource during the appropriate phase of the deployment. Hooks can be any type of Kubernetes resource kind, but tend to be Pod, Job, or Argo Workflows. Multiple hooks can be specified as a comma separated list.
 
 ## How phases work?
 
@@ -51,6 +51,11 @@ This can take the following values:
 | `BeforeHookCreation` | Any existing hook resource is deleted before the new one is created (since v1.3). It is meant to be used with `/metadata/name`.                  |
 
 Note that if no deletion policy is specified, Argo CD will automatically assume `BeforeHookCreation` rules.
+
+> [!WARNING]
+> Stick to the hook-delete-policy annotation for cleaning up hooks and avoid `ttlSecondsAfterFinished`
+> on hook Jobs. Argo CD needs to read the Job to find out how the phase went, and if Kubernetes deletes
+> it first, the sync can end up waiting for a hook that is not there any more.
 
 When Helm hook annotations are mapped onto Argo CD hooks, delete-policy evaluation still follows Argo CD sync phases and sync result semantics rather than Helm's per-hook-event lifecycle. For example, a `PreSync` resource mapped from Helm may remain available until later phases finish, and passive resources such as `ServiceAccount` do not have a completion state like `Job` or `Workflow`.
 
@@ -202,7 +207,6 @@ metadata:
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
     argocd.argoproj.io/sync-wave: '-1'
 spec:
-  ttlSecondsAfterFinished: 360
   template:
     spec:
       containers:
@@ -211,7 +215,10 @@ spec:
           imagePullPolicy: Always
           env:
             - name: PGPASSWORD
-              value: admin
+              valueFrom:
+                secretKeyRef:
+                  name: db-migrate-credentials
+                  key: password
             - name: POSTGRES_HOST
               value: my_postgresql_db
           command:
@@ -222,6 +229,28 @@ spec:
       restartPolicy: Never
   backoffLimit: 1
 ```
+
+#### Things to keep in mind
+
+Hooks that talk to something outside the cluster, like a database, come with a few drawbacks.
+
+A PreSync hook is applied before everything in the Sync phase, and that includes any Secret, ConfigMap, or ServiceAccount that belongs to the same Application. 
+So a hook that reads its password from a Secret in that same Application gets the old value or fails outright if the Secret is not there yet. 
+You will usually notice this the first time you rotate the password, so you should either keep the credentials for your hooks outside the Application, 
+or make the Secret a hook as well and give it a lower sync-wave so it lands first.
+
+Hooks also run on every sync, not only when something they care about has changed. 
+A self-heal, a manual sync from the UI, or a change to a completely unrelated part of the Application will all run them again, so whatever the hook does has to be safe to run twice. 
+Most migration tools keep track of what they have already applied and are fine here, so make sure that your manual scripts do the same.
+
+Keep in mind that Argo CD only looks at the hook resource to decide whether the phase worked. 
+A Job that exits with 0 marks the phase as successful, and the next waves go ahead, even if the database ended up in a different state than your application expects. 
+If you want Argo CD to track that state, you need a custom resource with a controller behind it and a [custom health check](../operator-manual/health.md#custom-health-checks), 
+so that the next wave waits for `Healthy` instead of waiting for a process to exit.
+
+Finally, the sync operation stays open for as long as the hook runs, and the Application's status is `Progressing` the whole time. 
+If the migration task takes more time, the operation can hit its timeout while the hook is still going, and terminating the operation does not stop whatever the hook already started. 
+Long or multi-step jobs are usually better handled by a controller or a workflow engine that can report progress on its own.
 
 ### Work around ArgoCD sync failure
 


### PR DESCRIPTION
The "[Initialize or migrate a database](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/#initialize-or-migrate-a-database)" example on the sync waves page shows a PreSync hook Job, but says nothing about the things people need to be aware of. 

The credentials one is the least obvious. A PreSync hook is applied before the Secrets in the same Application, so it reads the previous value, or fails if the Secret does not exist yet (#9891). That is presumably why the example had a hardcoded `PGPASSWORD: admin` in the first place. I swapped it for a secretKeyRef and explained the ordering constraint, so people copying the example do not get a surprise the first time they rotate a password.

The example also set `ttlSecondsAfterFinished: 360`, which is redundant next to hook-delete-policy: HookSucceeded and is the field behind the stuck hook reports in #21055 (fixed in argoproj/gitops-engine#646). Removed it from the example, and added a short warning in the hook cleanup section explaining why Argo CD needs the resource to stick around.

The rest of the changes is mainly a "Things to watch out for" section covering hooks re-running on every sync (#3837), and the fact that Argo CD only looks at the hook resource and not at whatever the hook talked to, mentioning also the idea of custom health checks for people who need a later wave to actually wait for the database.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
