### PR TITLE
fix(ui): truncate top bar breadcrumbs instead of overlapping the page title (#29292)

### DIFF
--- a/ui/src/app/shared/components/page/page.scss
+++ b/ui/src/app/shared/components/page/page.scss
@@ -48,6 +48,35 @@
     }
 }
 
+// The top bar's first row lays the breadcrumb column and the page title out as flex items.
+// The breadcrumb column is `white-space: nowrap` with visible overflow, so once the row is
+// narrower than the breadcrumb text, that text leaves its column and paints over the
+// right-aligned title (issue #29292). Let the column shrink and truncate instead.
+.page__top-bar .top-bar > .row {
+    > .top-bar__left-side {
+        min-width: 0;
+    }
+
+    .top-bar__breadcrumbs {
+        min-width: 0;
+        max-width: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    // The last crumb is an inline-block, and `text-overflow` treats an inline-block as one
+    // atomic box: the container drops the whole crumb and renders a bare ellipsis. Inline
+    // puts its text back in the container's inline flow so the ellipsis lands mid-text.
+    .top-bar__breadcrumbs-last-item {
+        display: inline;
+    }
+
+    > .top-bar__title {
+        min-width: 0;
+    }
+}
+
 .login-logout-button {
     border-radius: 3px;
     @include themify($themes) {


### PR DESCRIPTION
Closes #29292. Supersedes #29406.

@choejwoo thanks for the review on #29406, you were right on both counts. I had verified that with `getBoundingClientRect` and stopped at "the boxes no longer overlap", which is not the same thing as looking at it. When I actually rendered it, that fix was bad: the last breadcrumb collapsed to a bare ellipsis and the title was clipped mid-word. This is a different fix, and the screenshots below are from the rendered page rather than from measurements.

## Root cause

The first row of the top bar lays the breadcrumb column and the page title out as flex items:

```html
<div class="row">
  <div class="columns top-bar__left-side">…breadcrumbs…</div>
  <div class="top-bar__title text-truncate top-bar__right-side">TITLE</div>
</div>
```

`.top-bar__left-side` is `white-space: nowrap` with visible overflow, so once the row is narrower than the breadcrumb text, that text leaves its column and paints over the title.

## The fix

Four declarations in `ui/src/app/shared/components/page/page.scss`, scoped to `.page__top-bar .top-bar > .row` so it does not touch `flex-top-bar`:

- `min-width: 0` on the breadcrumb column and the title so they can shrink below their content width
- `overflow: hidden; text-overflow: ellipsis` on the breadcrumbs so the text truncates
- `display: inline` on `.top-bar__breadcrumbs-last-item`

That last one is the part I got wrong the first time and is worth calling out. The last crumb is an `inline-block`, and `text-overflow` treats an inline-block as a single atomic box: the container cannot truncate inside it, so it drops the whole crumb and renders a bare `…`. Making it `inline` puts its text back into the container's inline flow so the ellipsis lands mid-text.

No media queries and no title hiding, so nothing about the layout changes at widths where the row already fits.

## Test results

Rendered on this branch against `/settings/certs`, screenshotting the `.page__top-bar` element at four viewport widths.

**Before, 760px** - the two texts paint through each other:

<img src="https://raw.githubusercontent.com/devangpratap/argo-cd/pr-assets/pr29412/topbar-before.png" alt="Top bar at 760px before the fix: the breadcrumb text and the page title paint over each other" width="760">

**After, 760px** - breadcrumb truncates, title fully readable:

<img src="https://raw.githubusercontent.com/devangpratap/argo-cd/pr-assets/pr29412/topbar-760-v4.png" alt="Top bar at 760px after the fix: the breadcrumb truncates with an ellipsis and the title is fully readable" width="760">

**After, 420px** - argo-cd's existing `max-width: medium` rule already hides the title here; the crumb still ellipsizes cleanly:

<img src="https://raw.githubusercontent.com/devangpratap/argo-cd/pr-assets/pr29412/topbar-420-v4.png" alt="Top bar at 420px after the fix: the breadcrumb ellipsizes cleanly" width="420">

**After, 1400px** - byte-identical to current behaviour, the rule is inert when the row fits:

<img src="https://raw.githubusercontent.com/devangpratap/argo-cd/pr-assets/pr29412/topbar-1400-v4.png" alt="Top bar at 1400px after the fix: identical to current behaviour" width="1400">

Measured box geometry alongside the renders, for the record:

| viewport | overlap before | overlap after |
| --- | --- | --- |
| 1400px | none | unchanged |
| 980px | none | unchanged |
| 760px | 142px overlap | 19px gap |
| 660px | 242px overlap | 19px gap |

I also confirmed the SCSS compiles to exactly the CSS I tested in the browser.

## Note on tests

There is no styling test harness in the repo, so there is no unit test here. If you would rather this came with an automated regression test, say which harness you would accept and I will add it.

## Checklist

* [x] (b) this is a bug fix
* [x] The title of the PR states what changed and the related issues number
* [x] The title of the PR conforms to the Title of the PR
* [x] I've included "Closes #29292"
* [ ] I've updated both the CLI and UI to expose my feature - N/A, UI-only bug fix
* [ ] Does this PR require documentation updates? - No
* [x] I have signed off all my commits as required by DCO
* [ ] I have written unit and/or e2e tests for my change - see the note above
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves

**Release notes**

fix(ui): truncate long top bar breadcrumbs instead of overlapping the page title

