### PR TITLE
feat: accept repository-style Azure keys in repo-creds (#29414)

### DIFF
--- a/docs/operator-manual/declarative-setup.md
+++ b/docs/operator-manual/declarative-setup.md
@@ -401,6 +401,16 @@ The following keys are valid to refer to credential secrets:
 * `githubAppEnterpriseBaseUrl` refers to the base api URL for GitHub Enterprise (e.g. `https://ghe.example.com/api/v3`)
 * `tlsClientCertData` and `tlsClientCertKey` refer to secrets where a TLS client certificate (`tlsClientCertData`) and the corresponding private key `tlsClientCertKey` are stored for accessing GitHub Enterprise if custom certificates are used.
 
+#### Azure Service Principal repositories
+
+* `azureServicePrincipalClientID` or `azureServicePrincipalClientId` refers to the client ID.
+* `azureServicePrincipalTenantID` or `azureServicePrincipalTenantId` refers to the tenant ID.
+* `azureServicePrincipalClientSecret` refers to the client secret.
+* `azureActiveDirectoryEndpoint` optionally specifies the Microsoft Entra authority endpoint.
+
+> [!NOTE]
+> If both forms of a client or tenant ID key are set, the uppercase-`ID` form takes precedence.
+
 #### Helm Chart repositories
 
 See the [Helm](#helm) section for the properties that apply to Helm repositories and charts sourced from OCI registries.

--- a/docs/operator-manual/declarative-setup.md
+++ b/docs/operator-manual/declarative-setup.md
@@ -409,7 +409,7 @@ The following keys are valid to refer to credential secrets:
 * `azureActiveDirectoryEndpoint` optionally specifies the Microsoft Entra authority endpoint.
 
 > [!NOTE]
-> If both forms of a client or tenant ID key are set, the uppercase-`ID` form takes precedence.
+> If both forms of a client or tenant ID key have values, the uppercase-`ID` form takes precedence.
 
 #### Helm Chart repositories
 

--- a/util/db/repository_secrets.go
+++ b/util/db/repository_secrets.go
@@ -462,12 +462,12 @@ func (s *secretsRepositoryBackend) repositoryToSecret(repository *appsv1.Reposit
 
 func (s *secretsRepositoryBackend) secretToRepoCred(secret *corev1.Secret) (*appsv1.RepoCreds, error) {
 	secretCopy := secret.DeepCopy()
-	azureServicePrincipalClientID, ok := secretCopy.Data["azureServicePrincipalClientID"]
-	if !ok {
+	azureServicePrincipalClientID := secretCopy.Data["azureServicePrincipalClientID"]
+	if len(azureServicePrincipalClientID) == 0 {
 		azureServicePrincipalClientID = secretCopy.Data["azureServicePrincipalClientId"]
 	}
-	azureServicePrincipalTenantID, ok := secretCopy.Data["azureServicePrincipalTenantID"]
-	if !ok {
+	azureServicePrincipalTenantID := secretCopy.Data["azureServicePrincipalTenantID"]
+	if len(azureServicePrincipalTenantID) == 0 {
 		azureServicePrincipalTenantID = secretCopy.Data["azureServicePrincipalTenantId"]
 	}
 

--- a/util/db/repository_secrets.go
+++ b/util/db/repository_secrets.go
@@ -462,6 +462,14 @@ func (s *secretsRepositoryBackend) repositoryToSecret(repository *appsv1.Reposit
 
 func (s *secretsRepositoryBackend) secretToRepoCred(secret *corev1.Secret) (*appsv1.RepoCreds, error) {
 	secretCopy := secret.DeepCopy()
+	azureServicePrincipalClientID, ok := secretCopy.Data["azureServicePrincipalClientID"]
+	if !ok {
+		azureServicePrincipalClientID = secretCopy.Data["azureServicePrincipalClientId"]
+	}
+	azureServicePrincipalTenantID, ok := secretCopy.Data["azureServicePrincipalTenantID"]
+	if !ok {
+		azureServicePrincipalTenantID = secretCopy.Data["azureServicePrincipalTenantId"]
+	}
 
 	repository := &appsv1.RepoCreds{
 		URL:                               string(secretCopy.Data["url"]),
@@ -477,9 +485,9 @@ func (s *secretsRepositoryBackend) secretToRepoCred(secret *corev1.Secret) (*app
 		GCPServiceAccountKey:              string(secretCopy.Data["gcpServiceAccountKey"]),
 		Proxy:                             string(secretCopy.Data["proxy"]),
 		NoProxy:                           string(secretCopy.Data["noProxy"]),
-		AzureServicePrincipalClientId:     string(secretCopy.Data["azureServicePrincipalClientID"]),
+		AzureServicePrincipalClientId:     string(azureServicePrincipalClientID),
 		AzureServicePrincipalClientSecret: string(secretCopy.Data["azureServicePrincipalClientSecret"]),
-		AzureServicePrincipalTenantId:     string(secretCopy.Data["azureServicePrincipalTenantID"]),
+		AzureServicePrincipalTenantId:     string(azureServicePrincipalTenantID),
 		AzureActiveDirectoryEndpoint:      string(secretCopy.Data["azureActiveDirectoryEndpoint"]),
 	}
 

--- a/util/db/repository_secrets_test.go
+++ b/util/db/repository_secrets_test.go
@@ -686,15 +686,6 @@ func TestSecretToRepoCred_AzureServicePrincipalKeyAliases(t *testing.T) {
 			clientID: "existing-client",
 			tenantID: "existing-tenant",
 		},
-		{
-			name: "empty existing keys take precedence",
-			data: map[string][]byte{
-				"azureServicePrincipalClientID": nil,
-				"azureServicePrincipalClientId": []byte("alias-client"),
-				"azureServicePrincipalTenantID": nil,
-				"azureServicePrincipalTenantId": []byte("alias-tenant"),
-			},
-		},
 	}
 
 	for _, tt := range tests {

--- a/util/db/repository_secrets_test.go
+++ b/util/db/repository_secrets_test.go
@@ -659,6 +659,55 @@ func TestSecretsRepositoryBackend_GetRepoCreds(t *testing.T) {
 	}
 }
 
+func TestSecretToRepoCred_AzureServicePrincipalKeyAliases(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     map[string][]byte
+		clientID string
+		tenantID string
+	}{
+		{
+			name: "repository-style aliases",
+			data: map[string][]byte{
+				"azureServicePrincipalClientId": []byte("alias-client"),
+				"azureServicePrincipalTenantId": []byte("alias-tenant"),
+			},
+			clientID: "alias-client",
+			tenantID: "alias-tenant",
+		},
+		{
+			name: "existing keys take precedence",
+			data: map[string][]byte{
+				"azureServicePrincipalClientID": []byte("existing-client"),
+				"azureServicePrincipalClientId": []byte("alias-client"),
+				"azureServicePrincipalTenantID": []byte("existing-tenant"),
+				"azureServicePrincipalTenantId": []byte("alias-tenant"),
+			},
+			clientID: "existing-client",
+			tenantID: "existing-tenant",
+		},
+		{
+			name: "empty existing keys take precedence",
+			data: map[string][]byte{
+				"azureServicePrincipalClientID": nil,
+				"azureServicePrincipalClientId": []byte("alias-client"),
+				"azureServicePrincipalTenantID": nil,
+				"azureServicePrincipalTenantId": []byte("alias-tenant"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			creds, err := (&secretsRepositoryBackend{}).secretToRepoCred(&corev1.Secret{Data: tt.data})
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.clientID, creds.AzureServicePrincipalClientId)
+			assert.Equal(t, tt.tenantID, creds.AzureServicePrincipalTenantId)
+		})
+	}
+}
+
 func TestSecretsRepositoryBackend_ListRepoCreds(t *testing.T) {
 	repoCredSecrets := []runtime.Object{
 		&corev1.Secret{


### PR DESCRIPTION
## What changed

`repository` Secrets accept the Azure client and tenant ID keys with `Id`, but `repo-creds` Secrets only read the older `ID` spelling. That makes the same Azure credentials behave differently depending on which Secret type is used.

This change lets `repo-creds` read both spellings. The existing uppercase-`ID` keys still take precedence when both have values, so current configurations keep the same behavior. I also added unit coverage for the aliases and precedence rule, plus a short note in the declarative setup docs.

Closes #29414

## Testing

Passed locally:

* `GOFLAGS=-mod=mod go test ./util/db -count=1`
* `GOFLAGS=-mod=mod make build-local`
* `golangci-lint v2.13.1 run --verbose` (0 issues)
* `GOFLAGS=-mod=mod make cli-local`
* `make lint-ui-local` (0 errors; 11 existing warnings)

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. (Not applicable; this only changes declarative Secret parsing.)
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
