### PR TITLE
fix(applicationset): validate Application status freshness using ComparedTo in progressive sync

### DIFF
--- a/applicationset/controllers/progressive_sync_dependencies_test.go
+++ b/applicationset/controllers/progressive_sync_dependencies_test.go
@@ -872,6 +872,321 @@ func TestUpdateApplicationSetApplicationStatus(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "delayed status update: does not move waiting app to healthy when ComparedTo is stale for git revision",
+			appSet: newDefaultAppSet(2, []v1alpha1.ApplicationSetApplicationStatus{
+				{
+					Application:        "app1",
+					Message:            "",
+					Status:             v1alpha1.ProgressiveSyncHealthy,
+					Step:               "1",
+					TargetRevisions:    []string{"v1.0.0"},
+					LastTransitionTime: &nowMinus5,
+				},
+			}),
+			apps: []v1alpha1.Application{
+				{
+					Name: "app1",
+					Spec: v1alpha1.ApplicationSpec{
+						Source: &v1alpha1.ApplicationSource{
+							RepoURL:        "https://example.com/repo.git",
+							TargetRevision: "v1.0.0",
+						},
+						Destination: v1alpha1.ApplicationDestination{
+							Server:    "https://kubernetes.default.svc",
+							Namespace: "default",
+						},
+					},
+					Status: v1alpha1.ApplicationStatus{
+						ReconciledAt: &metav1.Time{Time: time.Now()},
+						Health: v1alpha1.AppHealthStatus{
+							Status: health.HealthStatusHealthy,
+						},
+						Sync: v1alpha1.SyncStatus{
+							Status:   v1alpha1.SyncStatusCodeSynced,
+							Revision: "v1.0.0",
+							ComparedTo: v1alpha1.ComparedTo{
+								Source: v1alpha1.ApplicationSource{
+									RepoURL:        "https://example.com/repo.git",
+									TargetRevision: "v1.0.0", // Stale: points to v1.0.0
+								},
+								Destination: v1alpha1.ApplicationDestination{
+									Server:    "https://kubernetes.default.svc",
+									Namespace: "default",
+								},
+							},
+						},
+					},
+				},
+			},
+			desiredApps: []v1alpha1.Application{
+				{
+					Name: "app1",
+					Spec: v1alpha1.ApplicationSpec{
+						Source: &v1alpha1.ApplicationSource{
+							RepoURL:        "https://example.com/repo.git",
+							TargetRevision: "v2.0.0", // Desired target revision
+						},
+						Destination: v1alpha1.ApplicationDestination{
+							Server:    "https://kubernetes.default.svc",
+							Namespace: "default",
+						},
+					},
+				},
+			},
+			appStepMap: map[string]int{
+				"app1": 0,
+			},
+			expectedAppStatus: []v1alpha1.ApplicationSetApplicationStatus{
+				{
+					Application:     "app1",
+					Message:         specChangedMsg,
+					Status:          v1alpha1.ProgressiveSyncWaiting,
+					Step:            "1",
+					TargetRevisions: []string{"v1.0.0"},
+				},
+			},
+		},
+		{
+			name: "delayed status update: does not move waiting app to healthy when ComparedTo is stale for helm parameter",
+			appSet: newDefaultAppSet(2, []v1alpha1.ApplicationSetApplicationStatus{
+				{
+					Application:        "app1",
+					Message:            "",
+					Status:             v1alpha1.ProgressiveSyncHealthy,
+					Step:               "1",
+					TargetRevisions:    []string{"main"},
+					LastTransitionTime: &nowMinus5,
+				},
+			}),
+			apps: []v1alpha1.Application{
+				{
+					Name: "app1",
+					Spec: v1alpha1.ApplicationSpec{
+						Source: &v1alpha1.ApplicationSource{
+							RepoURL:        "https://example.com/repo.git",
+							TargetRevision: "main",
+							Helm: &v1alpha1.ApplicationSourceHelm{
+								Parameters: []v1alpha1.HelmParameter{
+									{Name: "image.tag", Value: "v1.0.0"},
+								},
+							},
+						},
+						Destination: v1alpha1.ApplicationDestination{
+							Server:    "https://kubernetes.default.svc",
+							Namespace: "default",
+						},
+					},
+					Status: v1alpha1.ApplicationStatus{
+						ReconciledAt: &metav1.Time{Time: time.Now()},
+						Health: v1alpha1.AppHealthStatus{
+							Status: health.HealthStatusHealthy,
+						},
+						Sync: v1alpha1.SyncStatus{
+							Status:   v1alpha1.SyncStatusCodeSynced,
+							Revision: "main",
+							ComparedTo: v1alpha1.ComparedTo{
+								Source: v1alpha1.ApplicationSource{
+									RepoURL:        "https://example.com/repo.git",
+									TargetRevision: "main",
+									Helm: &v1alpha1.ApplicationSourceHelm{
+										Parameters: []v1alpha1.HelmParameter{
+											{Name: "image.tag", Value: "v1.0.0"}, // Stale parameter value
+										},
+									},
+								},
+								Destination: v1alpha1.ApplicationDestination{
+									Server:    "https://kubernetes.default.svc",
+									Namespace: "default",
+								},
+							},
+						},
+					},
+				},
+			},
+			desiredApps: []v1alpha1.Application{
+				{
+					Name: "app1",
+					Spec: v1alpha1.ApplicationSpec{
+						Source: &v1alpha1.ApplicationSource{
+							RepoURL:        "https://example.com/repo.git",
+							TargetRevision: "main",
+							Helm: &v1alpha1.ApplicationSourceHelm{
+								Parameters: []v1alpha1.HelmParameter{
+									{Name: "image.tag", Value: "v2.0.0"},
+								},
+							},
+						},
+						Destination: v1alpha1.ApplicationDestination{
+							Server:    "https://kubernetes.default.svc",
+							Namespace: "default",
+						},
+					},
+				},
+			},
+			appStepMap: map[string]int{
+				"app1": 0,
+			},
+			expectedAppStatus: []v1alpha1.ApplicationSetApplicationStatus{
+				{
+					Application:     "app1",
+					Message:         specChangedMsg,
+					Status:          v1alpha1.ProgressiveSyncWaiting,
+					Step:            "1",
+					TargetRevisions: []string{"main"},
+				},
+			},
+		},
+		{
+			name: "delayed status update: does not move progressing app to healthy when ComparedTo is stale",
+			appSet: newDefaultAppSet(2, []v1alpha1.ApplicationSetApplicationStatus{
+				{
+					Application:        "app1",
+					Message:            "",
+					Status:             v1alpha1.ProgressiveSyncProgressing,
+					Step:               "1",
+					TargetRevisions:    []string{"v2.0.0"},
+					LastTransitionTime: &nowMinus5,
+				},
+			}),
+			apps: []v1alpha1.Application{
+				{
+					Name: "app1",
+					Spec: v1alpha1.ApplicationSpec{
+						Source: &v1alpha1.ApplicationSource{
+							RepoURL:        "https://example.com/repo.git",
+							TargetRevision: "v2.0.0",
+						},
+						Destination: v1alpha1.ApplicationDestination{
+							Server:    "https://kubernetes.default.svc",
+							Namespace: "default",
+						},
+					},
+					Status: v1alpha1.ApplicationStatus{
+						ReconciledAt: &metav1.Time{Time: time.Now()},
+						Health: v1alpha1.AppHealthStatus{
+							Status: health.HealthStatusHealthy,
+						},
+						Sync: v1alpha1.SyncStatus{
+							Status:   v1alpha1.SyncStatusCodeSynced,
+							Revision: "v2.0.0",
+							ComparedTo: v1alpha1.ComparedTo{
+								Source: v1alpha1.ApplicationSource{
+									RepoURL:        "https://example.com/repo.git",
+									TargetRevision: "v1.0.0", // Stale
+								},
+								Destination: v1alpha1.ApplicationDestination{
+									Server:    "https://kubernetes.default.svc",
+									Namespace: "default",
+								},
+							},
+						},
+					},
+				},
+			},
+			desiredApps: []v1alpha1.Application{
+				{
+					Name: "app1",
+					Spec: v1alpha1.ApplicationSpec{
+						Source: &v1alpha1.ApplicationSource{
+							RepoURL:        "https://example.com/repo.git",
+							TargetRevision: "v2.0.0",
+						},
+						Destination: v1alpha1.ApplicationDestination{
+							Server:    "https://kubernetes.default.svc",
+							Namespace: "default",
+						},
+					},
+				},
+			},
+			appStepMap: map[string]int{
+				"app1": 0,
+			},
+			expectedAppStatus: []v1alpha1.ApplicationSetApplicationStatus{
+				{
+					Application:     "app1",
+					Message:         "",
+					Status:          v1alpha1.ProgressiveSyncProgressing,
+					Step:            "1",
+					TargetRevisions: []string{"v2.0.0"},
+				},
+			},
+		},
+		{
+			name: "fresh status update: moves waiting app to healthy when ComparedTo matches desired revision",
+			appSet: newDefaultAppSet(2, []v1alpha1.ApplicationSetApplicationStatus{
+				{
+					Application:        "app1",
+					Message:            "",
+					Status:             v1alpha1.ProgressiveSyncWaiting,
+					Step:               "1",
+					TargetRevisions:    []string{"v1.0.0"},
+					LastTransitionTime: &nowMinus5,
+				},
+			}),
+			apps: []v1alpha1.Application{
+				{
+					Name: "app1",
+					Spec: v1alpha1.ApplicationSpec{
+						Source: &v1alpha1.ApplicationSource{
+							RepoURL:        "https://example.com/repo.git",
+							TargetRevision: "v2.0.0",
+						},
+						Destination: v1alpha1.ApplicationDestination{
+							Server:    "https://kubernetes.default.svc",
+							Namespace: "default",
+						},
+					},
+					Status: v1alpha1.ApplicationStatus{
+						ReconciledAt: &metav1.Time{Time: time.Now()},
+						Health: v1alpha1.AppHealthStatus{
+							Status: health.HealthStatusHealthy,
+						},
+						Sync: v1alpha1.SyncStatus{
+							Status:   v1alpha1.SyncStatusCodeSynced,
+							Revision: "v2.0.0",
+							ComparedTo: v1alpha1.ComparedTo{
+								Source: v1alpha1.ApplicationSource{
+									RepoURL:        "https://example.com/repo.git",
+									TargetRevision: "v2.0.0", // Fresh: matches desired v2.0.0
+								},
+								Destination: v1alpha1.ApplicationDestination{
+									Server:    "https://kubernetes.default.svc",
+									Namespace: "default",
+								},
+							},
+						},
+					},
+				},
+			},
+			desiredApps: []v1alpha1.Application{
+				{
+					Name: "app1",
+					Spec: v1alpha1.ApplicationSpec{
+						Source: &v1alpha1.ApplicationSource{
+							RepoURL:        "https://example.com/repo.git",
+							TargetRevision: "v2.0.0",
+						},
+						Destination: v1alpha1.ApplicationDestination{
+							Server:    "https://kubernetes.default.svc",
+							Namespace: "default",
+						},
+					},
+				},
+			},
+			appStepMap: map[string]int{
+				"app1": 0,
+			},
+			expectedAppStatus: []v1alpha1.ApplicationSetApplicationStatus{
+				{
+					Application:     "app1",
+					Message:         "Application resource has synced, updating status to Healthy",
+					Status:          v1alpha1.ProgressiveSyncHealthy,
+					Step:            "1",
+					TargetRevisions: []string{"v2.0.0"},
+				},
+			},
+		},
 	} {
 		t.Run(cc.name, func(t *testing.T) {
 			t.Parallel()

--- a/applicationset/progressivesync/progressive_sync.go
+++ b/applicationset/progressivesync/progressive_sync.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/argoproj/argo-cd/v3/applicationset/utils"
 	argov1alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v3/util/argo"
 	"github.com/argoproj/argo-cd/v3/util/argo/normalizers"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -414,12 +415,7 @@ func (m *Manager) UpdateApplicationSetApplicationStatus(ctx context.Context, log
 		appHealthStatus := app.Status.Health.Status
 		appSyncStatus := app.Status.Sync.Status
 
-		desiredSpec := app.Spec
-		if desiredApp, ok := desiredAppsMap[app.Name]; ok {
-			desiredSpec = desiredApp.Spec
-		}
-		desiredComparedTo := desiredSpec.BuildComparedToStatus(desiredSpec.GetSources())
-		statusIsFresh := desiredComparedTo.Equals(&app.Status.Sync.ComparedTo)
+		var statusIsFresh bool
 
 		currentAppStatus := argov1alpha1.ApplicationSetApplicationStatus{}
 		idx := utils.FindApplicationStatusIndex(applicationSet.Status.ApplicationStatus, app.Name)
@@ -469,9 +465,25 @@ func (m *Manager) UpdateApplicationSetApplicationStatus(ctx context.Context, log
 				// Failures here are persistent (for example a malformed jsonPointer), so reporting
 				// "changed" would loop forever. Leave the status alone and surface it.
 				statusLogCtx.WithError(cmpErr).Warn("could not compare desired and live specs; leaving progressive sync status unchanged")
+				statusIsFresh = false
 			} else {
 				specChanged = !equivalent
+				if equivalent {
+					// The live spec matches the desired spec (after normalization and ignoreApplicationDifferences).
+					// Ensure the Application controller has reconciled this live spec by checking if it matches the recorded ComparedTo.
+					normalizedLiveSpec := *argo.NormalizeApplicationSpec(app.Spec.DeepCopy())
+					expectedComparedTo := normalizedLiveSpec.BuildComparedToStatus(normalizedLiveSpec.GetSources())
+					statusIsFresh = expectedComparedTo.Equals(&app.Status.Sync.ComparedTo)
+				} else {
+					// If they are not equivalent, the live app is stale by definition.
+					statusIsFresh = false
+				}
 			}
+		} else {
+			// If not in desiredAppsMap, default to checking freshness against the live app's own spec
+			normalizedLiveSpec := *argo.NormalizeApplicationSpec(app.Spec.DeepCopy())
+			expectedComparedTo := normalizedLiveSpec.BuildComparedToStatus(normalizedLiveSpec.GetSources())
+			statusIsFresh = expectedComparedTo.Equals(&app.Status.Sync.ComparedTo)
 		}
 
 		if revisionsChanged || specChanged {

--- a/applicationset/progressivesync/progressive_sync.go
+++ b/applicationset/progressivesync/progressive_sync.go
@@ -414,6 +414,13 @@ func (m *Manager) UpdateApplicationSetApplicationStatus(ctx context.Context, log
 		appHealthStatus := app.Status.Health.Status
 		appSyncStatus := app.Status.Sync.Status
 
+		desiredSpec := app.Spec
+		if desiredApp, ok := desiredAppsMap[app.Name]; ok {
+			desiredSpec = desiredApp.Spec
+		}
+		desiredComparedTo := desiredSpec.BuildComparedToStatus(desiredSpec.GetSources())
+		statusIsFresh := desiredComparedTo.Equals(&app.Status.Sync.ComparedTo)
+
 		currentAppStatus := argov1alpha1.ApplicationSetApplicationStatus{}
 		idx := utils.FindApplicationStatusIndex(applicationSet.Status.ApplicationStatus, app.Name)
 		if idx == -1 {
@@ -486,7 +493,7 @@ func (m *Manager) UpdateApplicationSetApplicationStatus(ctx context.Context, log
 			// App has changed to waiting because the TargetRevisions changed or it is a new selected app
 			// This does not mean we should always sync the app. The app may not be OutOfSync
 			// and may not require a sync if it does not have differences.
-			if appSyncStatus == argov1alpha1.SyncStatusCodeSynced {
+			if appSyncStatus == argov1alpha1.SyncStatusCodeSynced && statusIsFresh {
 				if app.Status.Health.Status == health.HealthStatusHealthy {
 					newAppStatus.LastTransitionTime = &now
 					newAppStatus.Status = argov1alpha1.ProgressiveSyncHealthy
@@ -530,7 +537,7 @@ func (m *Manager) UpdateApplicationSetApplicationStatus(ctx context.Context, log
 			if currentAppStatus.Status == argov1alpha1.ProgressiveSyncProgressing {
 				// If the status has reached progressing, we know a sync has been triggered. No matter the result of that operation,
 				// we want an the app to reach the Healthy state for the current revision.
-				if appHealthStatus == health.HealthStatusHealthy && appSyncStatus == argov1alpha1.SyncStatusCodeSynced {
+				if appHealthStatus == health.HealthStatusHealthy && appSyncStatus == argov1alpha1.SyncStatusCodeSynced && statusIsFresh {
 					newAppStatus.LastTransitionTime = &now
 					newAppStatus.Status = argov1alpha1.ProgressiveSyncHealthy
 					newAppStatus.Message = "Application resource became Healthy, updating status from Progressing to Healthy"

--- a/applicationset/progressivesync/progressive_sync_test.go
+++ b/applicationset/progressivesync/progressive_sync_test.go
@@ -1801,3 +1801,216 @@ func TestDelayedStatusUpdateComparedToRegression(t *testing.T) {
 		"stale ComparedTo must not be trusted as Healthy for new desired revision")
 }
 
+func TestProgressiveSyncQodoFinding1_IgnoreDifferences(t *testing.T) {
+	t.Parallel()
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+
+	// AppSet declares IgnoreApplicationDifferences for targetRevision.
+	// The generated desired app has a different targetRevision from the live app.
+	// SpecsEquivalent sees them as equivalent (because the difference is ignored), so
+	// the write path will never correct targetRevision. The freshness check must use the
+	// same ignore rule via diffConfig so it does not report a permanent stale status.
+	appSet := v1alpha1.ApplicationSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-appset",
+			Namespace: "argocd",
+		},
+		Spec: v1alpha1.ApplicationSetSpec{
+			IgnoreApplicationDifferences: v1alpha1.ApplicationSetIgnoreDifferences{
+				{JSONPointers: []string{"/spec/source/targetRevision"}},
+			},
+			Strategy: &v1alpha1.ApplicationSetStrategy{
+				Type: "RollingSync",
+				RollingSync: &v1alpha1.ApplicationSetRolloutStrategy{
+					Steps: []v1alpha1.ApplicationSetRolloutStep{
+						{
+							MatchExpressions: []v1alpha1.ApplicationMatchExpression{
+								{Key: "env", Operator: "In", Values: []string{"dev"}},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: v1alpha1.ApplicationSetStatus{
+			ApplicationStatus: []v1alpha1.ApplicationSetApplicationStatus{
+				{
+					Application:     "app-dev",
+					Status:          v1alpha1.ProgressiveSyncWaiting,
+					Step:            "1",
+					TargetRevisions: []string{"v1.0.0"},
+				},
+			},
+		},
+	}
+
+	liveApp := v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "app-dev",
+			Namespace: "argocd",
+			Labels:    map[string]string{"env": "dev"},
+		},
+		Spec: v1alpha1.ApplicationSpec{
+			Source: &v1alpha1.ApplicationSource{
+				RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
+				Path:           "guestbook",
+				TargetRevision: "v1.0.0",
+			},
+			Destination: v1alpha1.ApplicationDestination{
+				Server:    "https://kubernetes.default.svc",
+				Namespace: "default",
+			},
+		},
+		Status: v1alpha1.ApplicationStatus{
+			Health: v1alpha1.AppHealthStatus{Status: health.HealthStatusHealthy},
+			Sync: v1alpha1.SyncStatus{
+				Status:   v1alpha1.SyncStatusCodeSynced,
+				Revision: "v1.0.0",
+				ComparedTo: v1alpha1.ComparedTo{
+					Source: v1alpha1.ApplicationSource{
+						RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
+						Path:           "guestbook",
+						TargetRevision: "v1.0.0",
+					},
+					Destination: v1alpha1.ApplicationDestination{
+						Server:    "https://kubernetes.default.svc",
+						Namespace: "default",
+					},
+				},
+			},
+		},
+	}
+
+	// Desired has a different targetRevision, but the AppSet ignore rule covers that field.
+	desiredApp := *liveApp.DeepCopy()
+	desiredApp.Spec.Source.TargetRevision = "v2.0.0"
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&appSet).WithStatusSubresource(&appSet).Build()
+	m := NewManager(c, c, regressionDeps{})
+
+	statuses, err := m.UpdateApplicationSetApplicationStatus(
+		t.Context(),
+		log.NewEntry(log.New()),
+		&appSet,
+		[]v1alpha1.Application{liveApp},
+		[]v1alpha1.Application{desiredApp},
+		map[string]int{"app-dev": 0},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, statuses, 1)
+
+	// IgnoreApplicationDifferences ignores the targetRevision field on the AppSet level.
+	// SpecsEquivalent sees the live and desired apps as equivalent. The freshness check must
+	// then use the live app's normalized spec (targetRevision=v1.0.0) against ComparedTo
+	// (which also records v1.0.0), so statusIsFresh=true and the app advances to Healthy.
+	// Without the fix, the raw desired spec (v2.0.0) would not match ComparedTo (v1.0.0),
+	// leaving the app permanently stuck in Waiting.
+	assert.Equal(t, v1alpha1.ProgressiveSyncHealthy, statuses[0].Status,
+		"a field covered by IgnoreApplicationDifferences must not cause a false stale-status: %s", statuses[0].Message)
+}
+
+func TestProgressiveSyncQodoFinding2_Normalization(t *testing.T) {
+	t.Parallel()
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+
+	// The generated desired app has an empty-but-present Kustomize struct (kustomize: {}).
+	// NormalizeApplicationSpec collapses it to nil before writing to ComparedTo.
+	// The freshness check must normalize before building expectedComparedTo so it matches the
+	// Application controller's recorded nil ComparedTo.Source.Kustomize.
+	appSet := v1alpha1.ApplicationSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-appset",
+			Namespace: "argocd",
+		},
+		Spec: v1alpha1.ApplicationSetSpec{
+			Strategy: &v1alpha1.ApplicationSetStrategy{
+				Type: "RollingSync",
+				RollingSync: &v1alpha1.ApplicationSetRolloutStrategy{
+					Steps: []v1alpha1.ApplicationSetRolloutStep{
+						{
+							MatchExpressions: []v1alpha1.ApplicationMatchExpression{
+								{Key: "env", Operator: "In", Values: []string{"dev"}},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: v1alpha1.ApplicationSetStatus{
+			ApplicationStatus: []v1alpha1.ApplicationSetApplicationStatus{
+				{
+					Application:     "app-dev",
+					Status:          v1alpha1.ProgressiveSyncWaiting,
+					Step:            "1",
+					TargetRevisions: []string{"v1.0.0"},
+				},
+			},
+		},
+	}
+
+	// Live app has nil Kustomize (as the Application controller stored it).
+	liveApp := v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "app-dev",
+			Namespace: "argocd",
+			Labels:    map[string]string{"env": "dev"},
+		},
+		Spec: v1alpha1.ApplicationSpec{
+			Source: &v1alpha1.ApplicationSource{
+				RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
+				Path:           "guestbook",
+				TargetRevision: "v1.0.0",
+			},
+			Destination: v1alpha1.ApplicationDestination{
+				Server:    "https://kubernetes.default.svc",
+				Namespace: "default",
+			},
+		},
+		Status: v1alpha1.ApplicationStatus{
+			Health: v1alpha1.AppHealthStatus{Status: health.HealthStatusHealthy},
+			Sync: v1alpha1.SyncStatus{
+				Status:   v1alpha1.SyncStatusCodeSynced,
+				Revision: "v1.0.0",
+				ComparedTo: v1alpha1.ComparedTo{
+					Source: v1alpha1.ApplicationSource{
+						RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
+						Path:           "guestbook",
+						TargetRevision: "v1.0.0",
+					},
+					Destination: v1alpha1.ApplicationDestination{
+						Server:    "https://kubernetes.default.svc",
+						Namespace: "default",
+					},
+				},
+			},
+		},
+	}
+
+	desiredApp := *liveApp.DeepCopy()
+	// Generated desired app has an unnormalized empty Kustomize struct.
+	desiredApp.Spec.Source.Kustomize = &v1alpha1.ApplicationSourceKustomize{}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&appSet).WithStatusSubresource(&appSet).Build()
+	m := NewManager(c, c, regressionDeps{})
+
+	statuses, err := m.UpdateApplicationSetApplicationStatus(
+		t.Context(),
+		log.NewEntry(log.New()),
+		&appSet,
+		[]v1alpha1.Application{liveApp},
+		[]v1alpha1.Application{desiredApp},
+		map[string]int{"app-dev": 0},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, statuses, 1)
+
+	// After NormalizeApplicationSpec, the empty Kustomize struct becomes nil, making the desired
+	// spec identical to the live spec. The freshness check normalizes before comparing to
+	// ComparedTo, so statusIsFresh=true and the app advances to Healthy instead of staying Waiting.
+	assert.Equal(t, v1alpha1.ProgressiveSyncHealthy, statuses[0].Status,
+		"unnormalized empty struct (kustomize: {}) must not cause a permanent ComparedTo mismatch: %s", statuses[0].Message)
+}

--- a/applicationset/progressivesync/progressive_sync_test.go
+++ b/applicationset/progressivesync/progressive_sync_test.go
@@ -16,6 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
+	"github.com/argoproj/argo-cd/gitops-engine/v3/pkg/health"
+
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 )
 
@@ -1702,3 +1704,100 @@ func TestPerformReverseDeletionTerminatingApp(t *testing.T) {
 		})
 	}
 }
+
+func TestDelayedStatusUpdateComparedToRegression(t *testing.T) {
+	t.Parallel()
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+
+	appSet := v1alpha1.ApplicationSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-appset",
+			Namespace: "argocd",
+		},
+		Spec: v1alpha1.ApplicationSetSpec{
+			Strategy: &v1alpha1.ApplicationSetStrategy{
+				Type: "RollingSync",
+				RollingSync: &v1alpha1.ApplicationSetRolloutStrategy{
+					Steps: []v1alpha1.ApplicationSetRolloutStep{
+						{
+							MatchExpressions: []v1alpha1.ApplicationMatchExpression{
+								{Key: "env", Operator: "In", Values: []string{"dev"}},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: v1alpha1.ApplicationSetStatus{
+			ApplicationStatus: []v1alpha1.ApplicationSetApplicationStatus{
+				{
+					Application:     "app-dev",
+					Status:          v1alpha1.ProgressiveSyncHealthy,
+					Step:            "1",
+					TargetRevisions: []string{"v1.0.0"},
+				},
+			},
+		},
+	}
+
+	liveApp := v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "app-dev",
+			Namespace: "argocd",
+			Labels:    map[string]string{"env": "dev"},
+		},
+		Spec: v1alpha1.ApplicationSpec{
+			Source: &v1alpha1.ApplicationSource{
+				RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
+				Path:           "guestbook",
+				TargetRevision: "v1.0.0",
+			},
+			Destination: v1alpha1.ApplicationDestination{
+				Server:    "https://kubernetes.default.svc",
+				Namespace: "default",
+			},
+		},
+		Status: v1alpha1.ApplicationStatus{
+			Health: v1alpha1.AppHealthStatus{Status: health.HealthStatusHealthy},
+			Sync: v1alpha1.SyncStatus{
+				Status:   v1alpha1.SyncStatusCodeSynced,
+				Revision: "v1.0.0",
+				ComparedTo: v1alpha1.ComparedTo{
+					Source: v1alpha1.ApplicationSource{
+						RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
+						Path:           "guestbook",
+						TargetRevision: "v1.0.0",
+					},
+					Destination: v1alpha1.ApplicationDestination{
+						Server:    "https://kubernetes.default.svc",
+						Namespace: "default",
+					},
+				},
+			},
+		},
+	}
+
+	desiredApp := *liveApp.DeepCopy()
+	desiredApp.Spec.Source.TargetRevision = "v2.0.0"
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&appSet).WithStatusSubresource(&appSet).Build()
+	m := NewManager(c, c, regressionDeps{})
+
+	statuses, err := m.UpdateApplicationSetApplicationStatus(
+		t.Context(),
+		log.NewEntry(log.New()),
+		&appSet,
+		[]v1alpha1.Application{liveApp},
+		[]v1alpha1.Application{desiredApp},
+		map[string]int{"app-dev": 0},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, statuses, 1)
+
+	// With Option A fix: stale status prevents premature progression to Healthy
+	assert.Equal(t, v1alpha1.ProgressiveSyncWaiting, statuses[0].Status,
+		"stale ComparedTo must not be trusted as Healthy for new desired revision")
+}
+

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -1331,7 +1331,7 @@ func (spec *ApplicationSpec) BuildComparedToStatus(sources []ApplicationSource) 
 	}
 	if spec.HasMultipleSources() {
 		ct.Sources = sources
-	} else {
+	} else if len(sources) > 0 {
 		ct.Source = sources[0]
 	}
 	return ct
@@ -1942,6 +1942,29 @@ type ComparedTo struct {
 	Sources ApplicationSources `json:"sources,omitempty" protobuf:"bytes,3,opt,name=sources"`
 	// IgnoreDifferences is a reference to the application's ignored differences used for comparison
 	IgnoreDifferences IgnoreDifferences `json:"ignoreDifferences,omitempty" protobuf:"bytes,4,opt,name=ignoreDifferences"`
+}
+
+// Equals compares two instances of ComparedTo and returns true if instances are equal.
+func (c *ComparedTo) Equals(other *ComparedTo) bool {
+	if c == nil && other == nil {
+		return true
+	}
+	if c == nil || other == nil {
+		return false
+	}
+	if !c.Source.Equals(&other.Source) {
+		return false
+	}
+	if !c.Sources.Equals(other.Sources) {
+		return false
+	}
+	if !reflect.DeepEqual(c.Destination, other.Destination) {
+		return false
+	}
+	if !c.IgnoreDifferences.Equals(other.IgnoreDifferences) {
+		return false
+	}
+	return true
 }
 
 // SyncStatus contains information about the currently observed live and desired states of an application


### PR DESCRIPTION
## Problem

When using the ApplicationSet Progressive Sync strategy (RollingSync), an asynchronous reconciliation window exists where a step's applications can be marked complete based on pre-existing Synced/Healthy status from a previous revision. UpdateApplicationSetApplicationStatus detected spec changes and set the application to Waiting, but immediately checked the live application status. Because the live status had not yet refreshed and was still Synced/Healthy for the old revision, the step was prematurely marked complete. This allowed subsequent progressive sync steps to trigger before the current step had synced the new revision, breaking step isolation and canary safety.

## Solution

This fix validates that pp.Status.Sync.ComparedTo matches the newly generated desired Application spec before treating Synced/Healthy as the completion state. 
- Added ComparedTo.Equals in pkg/apis/application/v1alpha1 and hardened BuildComparedToStatus.
- In UpdateApplicationSetApplicationStatus, we construct a desiredComparedTo from the desired application spec.
- We guard both Waiting -> Healthy/Progressing and Progressing -> Healthy transitions by requiring desiredComparedTo.Equals(&app.Status.Sync.ComparedTo).

## Testing

- The regression test fails without the fix (expected "Waiting", actual "Healthy").
- The regression test passes with the fix.
- Validated via table-driven tests in progressive_sync_dependencies_test.go and standalone regression in progressive_sync_test.go.
- The pplicationset/progressivesync package tests pass.

Fixes #29410
