### PR TITLE
fix: preserve original Kustomize image name as override matcher (#29417)

### DIFF
--- a/ui/src/app/applications/components/application-parameters/kustomize.test.tsx
+++ b/ui/src/app/applications/components/application-parameters/kustomize.test.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import {render, screen, fireEvent} from '@testing-library/react';
+import {Form, FormApi} from 'argo-ui';
+
+import {ImageTagFieldEditor} from './kustomize';
+
+function renderEditor(metadataValue: string, defaultValues: any = {}) {
+    let api: FormApi | null = null;
+    render(
+        <Form
+            defaultValues={defaultValues}
+            getApi={a => {
+                api = a;
+            }}>
+            {() => <ImageTagFieldEditor field='images[0]' metadata={{value: metadataValue}} className='' />}
+        </Form>
+    );
+    return () => (api as unknown as FormApi).values.images[0];
+}
+
+test('editing tag of renamed image keeps original name as matcher', () => {
+    const getValue = renderEditor('my-image=ghcr.io/my-org/my-image:main');
+    fireEvent.change(screen.getByPlaceholderText('main'), {target: {value: 'abc123'}});
+    expect(getValue()).toBe('my-image=ghcr.io/my-org/my-image:abc123');
+});
+
+test('editing tag of plain image produces tag-only override', () => {
+    const getValue = renderEditor('nginx:1.15.4');
+    fireEvent.change(screen.getByPlaceholderText('1.15.4'), {target: {value: '1.16.0'}});
+    expect(getValue()).toBe('nginx:1.16.0');
+});
+
+test('editing tag of existing override keeps its new name', () => {
+    const getValue = renderEditor('my-image=ghcr.io/my-org/my-image:main', {images: ['my-image=ghcr.io/my-org/my-image:v1']});
+    fireEvent.change(screen.getByDisplayValue('v1'), {target: {value: 'v2'}});
+    expect(getValue()).toBe('my-image=ghcr.io/my-org/my-image:v2');
+});

--- a/ui/src/app/applications/components/application-parameters/kustomize.tsx
+++ b/ui/src/app/applications/components/application-parameters/kustomize.tsx
@@ -10,7 +10,8 @@ export const ImageTagFieldEditor = ReactFormField((props: {metadata: {value: str
     } = props;
     const origImage = parse(props.metadata.value);
     const val = getValue();
-    const image = val ? parse(val) : {name: origImage.name};
+    // keep the original rename target, otherwise a tag-only override would drop newName from the kustomize images entry
+    const image = val ? parse(val) : {name: origImage.name, newName: origImage.newName};
     const mustBeDigest = (image.digest || '').indexOf(':') > -1;
     return (
         <div>

--- a/util/kustomize/kustomize.go
+++ b/util/kustomize/kustomize.go
@@ -161,6 +161,9 @@ func (k *kustomize) Build(opts *v1alpha1.ApplicationSourceKustomize, kustomizeOp
 
 	env = append(env, environ...)
 
+	// capture rename entries before `kustomize edit set image` mutates the kustomization, so rendered images can be keyed by their original name
+	aliases := k.imageAliases(opts)
+
 	if opts != nil {
 		if opts.NamePrefix != "" {
 			cmd := exec.CommandContext(ctx, k.getBinaryPath(), "edit", "set", "nameprefix", "--", opts.NamePrefix)
@@ -406,7 +409,7 @@ func (k *kustomize) Build(opts *v1alpha1.ApplicationSourceKustomize, kustomizeOp
 		redactedCommands[i] = strings.ReplaceAll(c, k.repoRoot, ".")
 	}
 
-	return objs, getImageParameters(objs), redactedCommands, nil
+	return objs, restoreImageAliases(getImageParameters(objs), aliases), redactedCommands, nil
 }
 
 func parseKustomizeBuildOptions(ctx context.Context, k *kustomize, buildOptions string, buildOpts *BuildOpts) []string {
@@ -500,6 +503,89 @@ func versionWithBinaryPath(ctx context.Context, k *kustomize) (string, error) {
 	// remove extra 'kustomize/' before version
 	version = strings.TrimPrefix(version, "kustomize/")
 	return version, nil
+}
+
+// kustomizationImages captures only the images field of a kustomization file.
+type kustomizationImages struct {
+	Images []struct {
+		Name    string `json:"name"`
+		NewName string `json:"newName"`
+		NewTag  string `json:"newTag"`
+		Digest  string `json:"digest"`
+	} `json:"images"`
+}
+
+// imageAliases maps the reference kustomize renders for a renamed image back to the original images[].name it stays keyed by.
+// A reference claimed by more than one name is ambiguous and maps to an empty name, so it is reported as rendered.
+func (k *kustomize) imageAliases(opts *v1alpha1.ApplicationSourceKustomize) map[string]string {
+	aliases := map[string]string{}
+	add := func(name, ref string) {
+		if ref == "" || ref == name {
+			return
+		}
+		if claimed, taken := aliases[ref]; taken && claimed != name {
+			aliases[ref] = ""
+			return
+		}
+		aliases[ref] = name
+	}
+
+	if file := findKustomizeFile(k.path); file != "" {
+		var kust kustomizationImages
+		if data, err := os.ReadFile(filepath.Join(k.path, file)); err == nil && yaml.Unmarshal(data, &kust) == nil {
+			for _, image := range kust.Images {
+				switch {
+				case image.NewName == "":
+				case image.Digest != "":
+					add(image.Name, image.NewName+"@"+image.Digest)
+				case image.NewTag != "":
+					add(image.Name, image.NewName+":"+image.NewTag)
+				default:
+					add(image.Name, image.NewName)
+				}
+			}
+		}
+	}
+	if opts != nil {
+		for _, image := range opts.Images {
+			if name, newImage, found := strings.Cut(string(image), "="); found {
+				add(name, newImage)
+			}
+		}
+	}
+	return aliases
+}
+
+// restoreImageAliases rewrites renamed images as <name>=<image> so overrides stay keyed by the original kustomize image name.
+func restoreImageAliases(images []Image, aliases map[string]string) []Image {
+	if len(aliases) == 0 {
+		return images
+	}
+	perRepo := map[string]int{}
+	for _, image := range images {
+		perRepo[imageRepo(image)]++
+	}
+	for i, image := range images {
+		name, ok := aliases[image]
+		// a rename that sets no tag renders with the original one, so it can only be recognised by its repository
+		if !ok && perRepo[imageRepo(image)] == 1 {
+			name, ok = aliases[imageRepo(image)]
+		}
+		if ok && name != "" {
+			images[i] = name + "=" + image
+		}
+	}
+	sort.Strings(images)
+	return images
+}
+
+// imageRepo strips the tag and digest from a container image reference.
+func imageRepo(image string) string {
+	repo, _, _ := strings.Cut(image, "@")
+	if i := strings.LastIndex(repo, ":"); i > strings.LastIndex(repo, "/") {
+		repo = repo[:i]
+	}
+	return repo
 }
 
 func getImageParameters(objs []*unstructured.Unstructured) []Image {

--- a/util/kustomize/kustomize_test.go
+++ b/util/kustomize/kustomize_test.go
@@ -18,14 +18,16 @@ import (
 )
 
 const (
-	kustomization1 = "kustomization_yaml"
-	kustomization3 = "force_common"
-	kustomization4 = "custom_version"
-	kustomization5 = "kustomization_yaml_patches"
-	kustomization6 = "kustomization_yaml_components"
-	kustomization7 = "label_without_selector"
-	kustomization8 = "kustomization_yaml_patches_empty"
-	kustomization9 = "kustomization_yaml_components_monorepo"
+	kustomization1  = "kustomization_yaml"
+	kustomization3  = "force_common"
+	kustomization4  = "custom_version"
+	kustomization5  = "kustomization_yaml_patches"
+	kustomization6  = "kustomization_yaml_components"
+	kustomization7  = "label_without_selector"
+	kustomization8  = "kustomization_yaml_patches_empty"
+	kustomization9  = "kustomization_yaml_components_monorepo"
+	kustomization10 = "kustomization_image_matcher"
+	kustomization11 = "kustomization_image_alias_collision"
 )
 
 func testDataDir(tb testing.TB, testData string) (string, error) {
@@ -625,6 +627,83 @@ func TestKustomizeBuildComponentsNoFoundComponents(t *testing.T) {
 	for _, cmd := range commands {
 		assert.NotContains(t, cmd, "edit add component", "kustomize edit add component should not be invoked when foundComponents is empty")
 	}
+}
+
+func TestKustomizeBuildImagesPreserveOriginalName(t *testing.T) {
+	appPath, err := testDataDir(t, kustomization10)
+	require.NoError(t, err)
+	kustomize := NewKustomizeApp(appPath, appPath, git.NopCreds{}, "", "", "", "")
+
+	_, images, _, err := kustomize.Build(nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, []Image{
+		"mirrored=mirror.example.com/mirrored:1.0",
+		"my-image=ghcr.io/my-org/my-image:main",
+		"nginx:1.15.4",
+		"other-image=quay.io/my-org/other-image@sha256:24a0c4b4a4c0eb97a1aabb8e29f18e917d05abfe1b7a7c07857230879ce7d3d3",
+	}, images)
+}
+
+func TestKustomizeBuildImageOverrideByOriginalName(t *testing.T) {
+	appPath, err := testDataDir(t, kustomization10)
+	require.NoError(t, err)
+	kustomize := NewKustomizeApp(appPath, appPath, git.NopCreds{}, "", "", "", "")
+
+	kustomizeSource := v1alpha1.ApplicationSourceKustomize{
+		Images: v1alpha1.KustomizeImages{"my-image=ghcr.io/my-org/my-image:abc123"},
+	}
+	objs, images, _, err := kustomize.Build(&kustomizeSource, nil, &v1alpha1.Env{}, nil)
+	require.NoError(t, err)
+
+	require.Len(t, objs, 1)
+	containers, ok, err := unstructured.NestedSlice(objs[0].Object, "spec", "template", "spec", "containers")
+	require.NoError(t, err)
+	require.True(t, ok)
+	image, ok, err := unstructured.NestedString(containers[0].(map[string]any), "image")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "ghcr.io/my-org/my-image:abc123", image)
+
+	assert.Contains(t, images, Image("my-image=ghcr.io/my-org/my-image:abc123"))
+}
+
+func TestKustomizeBuildImageOverrideToDifferentRepo(t *testing.T) {
+	appPath, err := testDataDir(t, kustomization10)
+	require.NoError(t, err)
+	kustomize := NewKustomizeApp(appPath, appPath, git.NopCreds{}, "", "", "", "")
+
+	kustomizeSource := v1alpha1.ApplicationSourceKustomize{
+		Images: v1alpha1.KustomizeImages{"my-image=example.com:5000/elsewhere:v1"},
+	}
+	_, images, _, err := kustomize.Build(&kustomizeSource, nil, &v1alpha1.Env{}, nil)
+	require.NoError(t, err)
+
+	assert.Contains(t, images, Image("my-image=example.com:5000/elsewhere:v1"))
+}
+
+func TestKustomizeBuildImagesSharingOneNewName(t *testing.T) {
+	appPath, err := testDataDir(t, kustomization11)
+	require.NoError(t, err)
+	kustomize := NewKustomizeApp(appPath, appPath, git.NopCreds{}, "", "", "", "")
+
+	_, images, _, err := kustomize.Build(nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	assert.Contains(t, images, Image("my-image=ghcr.io/my-org/shared:v1"))
+	assert.Contains(t, images, Image("other-image=ghcr.io/my-org/shared:v2"))
+}
+
+func TestKustomizeBuildImagesLeaveUntransformedImagesAlone(t *testing.T) {
+	appPath, err := testDataDir(t, kustomization11)
+	require.NoError(t, err)
+	kustomize := NewKustomizeApp(appPath, appPath, git.NopCreds{}, "", "", "", "")
+
+	_, images, _, err := kustomize.Build(nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	assert.Contains(t, images, Image("nginx:1.15.4"))
+	assert.Contains(t, images, Image("aliased-nginx=nginx:v3"))
 }
 
 func Test_getImageParameters_sorted(t *testing.T) {

--- a/util/kustomize/testdata/kustomization_image_alias_collision/deployment.yaml
+++ b/util/kustomize/testdata/kustomization_image_alias_collision/deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-app
+  template:
+    metadata:
+      labels:
+        app: my-app
+    spec:
+      containers:
+        - name: main
+          image: my-image
+        - name: other
+          image: other-image
+        - name: aliased
+          image: aliased-nginx
+        - name: sidecar
+          image: nginx:1.15.4

--- a/util/kustomize/testdata/kustomization_image_alias_collision/kustomization.yaml
+++ b/util/kustomize/testdata/kustomization_image_alias_collision/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./deployment.yaml
+images:
+  - name: my-image
+    newName: ghcr.io/my-org/shared
+    newTag: v1
+  - name: other-image
+    newName: ghcr.io/my-org/shared
+    newTag: v2
+  - name: aliased-nginx
+    newName: nginx
+    newTag: v3

--- a/util/kustomize/testdata/kustomization_image_matcher/deployment.yaml
+++ b/util/kustomize/testdata/kustomization_image_matcher/deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-app
+  template:
+    metadata:
+      labels:
+        app: my-app
+    spec:
+      containers:
+        - name: main
+          image: my-image
+        - name: other
+          image: other-image
+        - name: sidecar
+          image: nginx:1.15.4
+        - name: mirrored
+          image: mirrored:1.0

--- a/util/kustomize/testdata/kustomization_image_matcher/kustomization.yaml
+++ b/util/kustomize/testdata/kustomization_image_matcher/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./deployment.yaml
+images:
+  - name: my-image
+    newName: ghcr.io/my-org/my-image
+    newTag: main
+  - name: other-image
+    newName: quay.io/my-org/other-image
+    digest: sha256:24a0c4b4a4c0eb97a1aabb8e29f18e917d05abfe1b7a7c07857230879ce7d3d3
+  - name: mirrored
+    newName: mirror.example.com/mirrored


### PR DESCRIPTION
The Parameters UI listed Kustomize images as rendered by `kustomize build`, so an entry declaring `name: my-image` with `newName: ghcr.io/my-org/my-image` was shown and keyed as `ghcr.io/my-org/my-image:main`. Overriding the tag from the UI then wrote a parameter keyed by the rewritten name, which Kustomize treats as a new image entry: `kustomize edit set image` appended a second, unused entry and the original `my-image` mapping kept winning. The override silently had no effect.

Kustomize build now records, for every renamed image, the reference Kustomize will render for it, and reports those rendered images as `<name>=<image>` so the app details response carries the matcher Kustomize actually keys on. The image tag editor keeps the existing `newName` when creating an override, so editing only the tag no longer drops the rename.

The resulting parameter matches the `argocd app set --kustomize-image` format, e.g. `my-image=ghcr.io/my-org/my-image:abc123`.

Closes #29417

## Changes

* `util/kustomize/kustomize.go` — before `kustomize edit set image` rewrites the kustomization, record the reference each renamed entry will render as (`newName:newTag`, `newName@digest`, or a bare `newName` when the entry sets no tag). Overrides already present in the app spec are recorded the same way. After the build, rendered images matching a recorded reference are reported as `<name>=<image>`.
* `ui/src/app/applications/components/application-parameters/kustomize.tsx` — seed the editor with the original `newName` so a tag-only edit no longer collapses the override to `my-image:<tag>`.

Matching is deliberately conservative, so an image never receives a matcher it does not belong to:

* Two entries rewriting to the same repository with different tags render as distinct references and keep their own matchers.
* A reference claimed by more than one original name is ambiguous and is reported as rendered.
* A rename that sets no tag renders with the container's original tag and can only be recognised by its repository, so that fallback applies only when exactly one rendered image has that repository.

Images whose `name` is not rewritten are unaffected and are still reported as plain `<image>:<tag>`.

## Verification

Reproduced against kustomize v5.8.1 (the version pinned in `hack/tool-versions.sh`) with the case from the issue. Before the change, overriding the tag appends a dead entry and `kustomize build` still renders `:main`:

```yaml
images:
- name: ghcr.io/my-org/my-image   # dead entry written by the UI
  newTag: abc123
- name: my-image                  # still wins
  newName: ghcr.io/my-org/my-image
  newTag: main
```

After the change the UI writes `my-image=ghcr.io/my-org/my-image:abc123`, kustomize updates the existing entry in place, and the rendered image becomes `ghcr.io/my-org/my-image:abc123`.

Tests added (each was confirmed to fail before the corresponding fix):

* `util/kustomize`, fixture `kustomization_image_matcher` — renamed images keep their original matcher in both the `newTag` and `digest` forms; a rename that sets no new tag is matched by its repository; an override keyed by the original name reaches the rendered manifests; an override pointing at a different registry, including one with a port (`example.com:5000/elsewhere:v1`), is parsed correctly.
* `util/kustomize`, fixture `kustomization_image_alias_collision` — two entries sharing one `newName` keep distinct matchers, and an untransformed image whose repository matches another entry's `newName` is left alone.
* `ui/.../kustomize.test.tsx` — editing the tag of a renamed image preserves the matcher, a plain image still produces a tag-only override, and an existing override keeps its `newName`.

Locally: `go build ./...`, `go test ./util/kustomize/` (23 passed), `go test ./reposerver/repository/ -run TestGetAppDetails` (14 passed), `golangci-lint run` (0 issues, v2.13.1 as pinned in CI), `gofmt`, `tsc --noEmit`, `eslint`, `prettier --check`, and the full UI jest suite (305 passed) are clean. `reposerver/repository` has one failing test, `TestGenerateManifestsHelmWithRefs_CachedNoLsRemote`, which fails identically on `master` and is unrelated to this change.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. — the CLI already used the correct `<name>=<image>` form via `argocd app set --kustomize-image`; this PR brings the UI in line with it, so no CLI change was needed.
* [ ] Does this PR require documentation updates? — no. `docs/user-guide/kustomize.md` already documents `images` as a list of Kustomize image overrides; this restores the documented behaviour rather than changing it.
* [ ] I've updated documentation as required by this PR. — not applicable, see above.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines. — not applicable, this is a bug fix rather than a new feature.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity). — the change is confined to Kustomize image reporting plus one UI editor line, so it should be safe to cherry-pick into `release-3.5` and `release-3.4` if maintainers agree.

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
