### PR TITLE
feat: support filtering out managed resources using label selector

### DIFF
--- a/controller/state.go
+++ b/controller/state.go
@@ -31,6 +31,7 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -811,6 +812,17 @@ func (m *appStateManager) CompareAppState(ctx context.Context, app *v1alpha1.App
 				Message:            fmt.Sprintf("Resource %s/%s %s is excluded in the settings", gvk.Group, gvk.Kind, targetObj.GetName()),
 				LastTransitionTime: &now,
 			})
+		} else if selectorStr := resFilter.GetLabelSelector(gvk.Group, gvk.Kind, destCluster.Server); selectorStr != "" {
+			// the selector is validated when the settings are loaded, so it is expected to parse
+			if selector, err := labels.Parse(selectorStr); err == nil && !selector.Matches(labels.Set(targetObj.GetLabels())) {
+				// the resource stays managed, but Argo CD does not watch it, so it never has a live
+				// state to compare the target state against
+				conditions = append(conditions, v1alpha1.ApplicationCondition{
+					Type:               v1alpha1.ApplicationConditionExcludedResourceWarning,
+					Message:            fmt.Sprintf("Resource %s/%s %s does not match the resource selector %q in the settings and will not be watched; it will appear as OutOfSync", gvk.Group, gvk.Kind, targetObj.GetName(), selectorStr),
+					LastTransitionTime: &now,
+				})
+			}
 		}
 
 		// If we reach this path, this means that a namespace has been both defined in Git, as well in the

--- a/controller/state_test.go
+++ b/controller/state_test.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -517,6 +518,74 @@ func TestCompareAppStateMissing(t *testing.T) {
 	assert.Len(t, compRes.resources, 1)
 	assert.Len(t, compRes.managedResources, 1)
 	assert.Empty(t, app.Status.Conditions)
+}
+
+// TestCompareAppStateResourceSelector tests that a managed resource filtered out by a configured
+// resource selector is reported with an ExcludedResourceWarning, as it will never have a live state
+func TestCompareAppStateResourceSelector(t *testing.T) {
+	labeledPodManifest := `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"my-pod","labels":{"app":"my-app"}}}`
+
+	compare := func(t *testing.T, manifest string, selector string) (*comparisonResult, *v1alpha1.Application) {
+		t.Helper()
+		app := newFakeApp()
+		data := fakeData{
+			apps: []runtime.Object{app},
+			manifestResponse: &apiclient.ManifestResponse{
+				Manifests: []string{manifest},
+				Namespace: test.FakeDestNamespace,
+				Server:    test.FakeClusterURL,
+				Revision:  "abc123",
+			},
+			managedLiveObjs: make(map[kube.ResourceKey]*unstructured.Unstructured),
+			configMapData: map[string]string{
+				"resource.selectors": fmt.Sprintf("- kinds: [\"Pod\"]\n  selector: %q\n", selector),
+			},
+		}
+		ctrl := newFakeController(t.Context(), &data, nil)
+		compRes, err := ctrl.appStateManager.CompareAppState(t.Context(), app, &defaultProj, []string{""}, []v1alpha1.ApplicationSource{app.Spec.GetSource()}, false, false, nil, false)
+		require.NoError(t, err)
+		return compRes, app
+	}
+
+	t.Run("resource not matching the selector is reported", func(t *testing.T) {
+		// PodManifest has no labels, so it does not match
+		compRes, app := compare(t, PodManifest, "app=my-app")
+
+		require.Len(t, app.Status.Conditions, 1)
+		assert.Equal(t, v1alpha1.ApplicationConditionExcludedResourceWarning, app.Status.Conditions[0].Type)
+		assert.Contains(t, app.Status.Conditions[0].Message, `Resource /Pod my-pod does not match the resource selector "app=my-app" in the settings`)
+		// the resource stays managed, it is only unwatched
+		assert.Len(t, compRes.resources, 1)
+		assert.Len(t, compRes.managedResources, 1)
+	})
+
+	t.Run("resource matching the selector is not reported", func(t *testing.T) {
+		compRes, app := compare(t, labeledPodManifest, "app=my-app")
+
+		assert.Empty(t, app.Status.Conditions)
+		assert.Len(t, compRes.resources, 1)
+	})
+
+	t.Run("selector of another kind is ignored", func(t *testing.T) {
+		app := newFakeApp()
+		data := fakeData{
+			apps: []runtime.Object{app},
+			manifestResponse: &apiclient.ManifestResponse{
+				Manifests: []string{PodManifest},
+				Namespace: test.FakeDestNamespace,
+				Server:    test.FakeClusterURL,
+				Revision:  "abc123",
+			},
+			managedLiveObjs: make(map[kube.ResourceKey]*unstructured.Unstructured),
+			configMapData: map[string]string{
+				"resource.selectors": "- kinds: [\"Service\"]\n  selector: \"app=my-app\"\n",
+			},
+		}
+		ctrl := newFakeController(t.Context(), &data, nil)
+		_, err := ctrl.appStateManager.CompareAppState(t.Context(), app, &defaultProj, []string{""}, []v1alpha1.ApplicationSource{app.Spec.GetSource()}, false, false, nil, false)
+		require.NoError(t, err)
+		assert.Empty(t, app.Status.Conditions)
+	})
 }
 
 // TestCompareAppStateExtra tests when there is an extra object in live but not defined in git

--- a/docs/operator-manual/argocd-cm.yaml
+++ b/docs/operator-manual/argocd-cm.yaml
@@ -228,6 +228,18 @@ data:
       clusters:
       - "*.local"
 
+  # By default all the objects of an included group/kind are watched. The resource.selectors setting
+  # allows narrowing down the watched objects to the ones matching a label selector. The selector is
+  # passed to the Kubernetes API server, so it is a label selector in its string form.
+  resource.selectors: |
+    - apiGroups:
+      - ""
+      kinds:
+      - Pod
+      clusters:
+      - "*.local"
+      selector: "!argocd.argoproj.io/instance"
+
   # An optional comma-separated list of annotation keys to mask in UI/CLI on secrets
   resource.sensitive.mask.annotations: openshift.io/token-secret.value,api-key
 

--- a/docs/operator-manual/declarative-setup.md
+++ b/docs/operator-manual/declarative-setup.md
@@ -1442,10 +1442,6 @@ Notes:
 
 * Selectors of all the matching rules are ANDed together.
 * An invalid selector is rejected when the config map is loaded.
-* Objects filtered out by a selector are not in the controller cache, so they are not shown in the resource tree and
-  managed objects that no longer match appear as `OutOfSync`.
-* Some filtered out objects may already be in the controller cache. A restart of the controller will be necessary to
-  remove them from the Application View.
 
 ## Mask sensitive Annotations on Secrets
 

--- a/docs/operator-manual/declarative-setup.md
+++ b/docs/operator-manual/declarative-setup.md
@@ -1405,12 +1405,47 @@ kind: ConfigMap
 The `resource.inclusions` and `resource.exclusions` might be used together. The final list of resources includes group/kinds specified in `resource.inclusions` minus group/kinds
 specified in `resource.exclusions` setting.
 
+## Filtering resources with a label selector
+
+While `resource.inclusions` and `resource.exclusions` work at the group/kind level, the `resource.selectors` setting
+narrows down which *objects* of a group/kind Argo CD watches. The selector is sent to the Kubernetes API server as part
+of the list/watch call, so the filtered out objects never reach Argo CD:
+
+```yaml
+apiVersion: v1
+data:
+  resource.selectors: |
+    - apiGroups:
+      - ""
+      kinds:
+      - Pod
+      clusters:
+      - https://192.168.0.20
+      selector: "!argocd.argoproj.io/instance"
+kind: ConfigMap
+```
+
+The `resource.selectors` node is a list of objects. Each object can have:
+
+* `apiGroups` A list of globs to match the API group.
+* `kinds` A list of kinds to match. Can be `"*"` to match all.
+* `clusters` A list of globs to match the cluster URL.
+* `selector` A [label selector](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors)
+  in its string form, e.g. `tier=backend`, `tier in (backend,frontend)` or `!tier`.
+
+If `apiGroups`, `kinds` and `clusters` all match, the selector is applied when listing and watching that resource. The
+example above makes Argo CD watch, in cluster `https://192.168.0.20`, only the Pods that do not have the
+`argocd.argoproj.io/instance` label. Omitting `apiGroups`, `kinds` or `clusters` matches all of them, so a rule with only
+a `selector` applies the selector to every watched resource.
+
 Notes:
 
-* Quote globs in your YAML to avoid parsing errors.
-* Invalid globs result in the whole rule being ignored.
-* If you add a rule that matches existing resources, these will appear in the interface as `OutOfSync`.
-* Some excluded objects may already be in the controller cache. A restart of the controller will be necessary to remove them from the Application View.
+* Selectors of all the matching rules are ANDed together.
+* An invalid selector is rejected when the config map is loaded.
+* Objects filtered out by a selector are not in the controller cache, so they are not shown in the resource tree and
+  managed objects that no longer match appear as `OutOfSync`.
+* Some filtered out objects may already be in the controller cache. A restart of the controller will be necessary to
+  remove them from the Application View.
 
 ## Mask sensitive Annotations on Secrets
 

--- a/gitops-engine/pkg/cache/cluster.go
+++ b/gitops-engine/pkg/cache/cluster.go
@@ -769,7 +769,7 @@ func (c *clusterCache) loadInitialState(ctx context.Context, api kube.APIResourc
 		// Use the WithAlloc variant: newResource may retain the object (as Resource.Resource, or via the
 		// Info returned by the OnPopulateResourceInfoHandler). Plain EachListItem yields &list.Items[i],
 		// so retaining one item keeps the page's whole backing array, and every manifest in it, reachable.
-		return listPager.EachListItemWithAlloc(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+		return listPager.EachListItemWithAlloc(ctx, metav1.ListOptions{LabelSelector: api.LabelSelector}, func(obj runtime.Object) error {
 			if un, ok := obj.(*unstructured.Unstructured); !ok {
 				return fmt.Errorf("object %s/%s has an unexpected type", un.GroupVersionKind().String(), un.GetName())
 			} else {
@@ -810,6 +810,7 @@ func (c *clusterCache) watchEvents(ctx context.Context, api kube.APIResourceInfo
 
 		w, err := watchutil.NewRetryWatcherWithContext(ctx, resourceVersion, &cache.ListWatch{
 			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				options.LabelSelector = api.LabelSelector
 				res, err := resClient.Watch(ctx, options)
 				if apierrors.IsNotFound(err) {
 					c.stopWatching(api.GroupKind, ns)
@@ -883,6 +884,7 @@ func (c *clusterCache) watchEvents(ctx context.Context, api kube.APIResourceInfo
 								Version:      v.Name,
 								ShortNames:   crd.Spec.Names.ShortNames,
 							},
+							LabelSelector: c.settings.ResourcesFilter.GetLabelSelector(crd.Spec.Group, crd.Spec.Names.Kind, c.config.Host),
 						})
 					}
 
@@ -1190,7 +1192,7 @@ func (c *clusterCache) sync() (err error) {
 				// Use the WithAlloc variant: newResource may retain the object (as Resource.Resource, or via the
 				// Info returned by the OnPopulateResourceInfoHandler). Plain EachListItem yields &list.Items[i],
 				// so retaining one item keeps the page's whole backing array, and every manifest in it, reachable.
-				return listPager.EachListItemWithAlloc(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+				return listPager.EachListItemWithAlloc(ctx, metav1.ListOptions{LabelSelector: api.LabelSelector}, func(obj runtime.Object) error {
 					if un, ok := obj.(*unstructured.Unstructured); !ok {
 						return fmt.Errorf("object %s/%s has an unexpected type", un.GroupVersionKind().String(), un.GetName())
 					} else {

--- a/gitops-engine/pkg/cache/cluster_test.go
+++ b/gitops-engine/pkg/cache/cluster_test.go
@@ -2857,3 +2857,38 @@ func BenchmarkIncrementalIndexBuild(b *testing.B) {
 		})
 	}
 }
+
+func TestAPIResourceLabelSelectorIsAppliedToList(t *testing.T) {
+	matching := strToUnstructured(`
+  apiVersion: v1
+  kind: Pod
+  metadata:
+    name: matching
+    namespace: default
+    uid: "1"
+    labels:
+      foo: bar`)
+	notMatching := strToUnstructured(`
+  apiVersion: v1
+  kind: Pod
+  metadata:
+    name: not-matching
+    namespace: default
+    uid: "2"`)
+
+	cluster := newCluster(t, matching, notMatching)
+	apiResources := cluster.kubectl.(*kubetest.MockKubectlCmd).APIResources
+	for i := range apiResources {
+		if apiResources[i].GroupKind.Kind == "Pod" {
+			apiResources[i].LabelSelector = "foo=bar"
+		}
+	}
+
+	require.NoError(t, cluster.EnsureSynced())
+
+	resources := cluster.FindResources("default", func(r *Resource) bool {
+		return r.ResourceKey().Kind == "Pod"
+	})
+	assert.Len(t, resources, 1)
+	assert.Contains(t, resources, kube.NewResourceKey("", "Pod", "default", "matching"))
+}

--- a/gitops-engine/pkg/cache/settings.go
+++ b/gitops-engine/pkg/cache/settings.go
@@ -27,6 +27,10 @@ func (f *noopSettings) IsExcludedResource(_, _, _ string) bool {
 	return false
 }
 
+func (f *noopSettings) GetLabelSelector(_, _, _ string) string {
+	return ""
+}
+
 // Settings caching customizations
 type Settings struct {
 	// ResourceHealthOverride contains health assessment overrides

--- a/gitops-engine/pkg/utils/kube/ctl.go
+++ b/gitops-engine/pkg/utils/kube/ctl.go
@@ -55,6 +55,9 @@ type APIResourceInfo struct {
 	GroupKind            schema.GroupKind
 	Meta                 metav1.APIResource
 	GroupVersionResource schema.GroupVersionResource
+	// LabelSelector holds the label selector that must be applied to the list/watch calls of the
+	// resource. An empty string means that every object of the resource must be listed.
+	LabelSelector string
 }
 
 type filterFunc func(apiResource *metav1.APIResource) bool
@@ -99,6 +102,7 @@ func (k *KubectlCmd) filterAPIResources(config *rest.Config, preferred bool, res
 					GroupKind:            schema.GroupKind{Group: gv.Group, Kind: apiResource.Kind},
 					Meta:                 apiResource,
 					GroupVersionResource: resource,
+					LabelSelector:        resourceFilter.GetLabelSelector(gv.Group, apiResource.Kind, config.Host),
 				}
 				apiResIfs = append(apiResIfs, apiResIf)
 			}

--- a/gitops-engine/pkg/utils/kube/resource_filter.go
+++ b/gitops-engine/pkg/utils/kube/resource_filter.go
@@ -2,4 +2,7 @@ package kube
 
 type ResourceFilter interface {
 	IsExcludedResource(group, kind, cluster string) bool
+	// GetLabelSelector returns the label selector that must be applied to list/watch calls of the
+	// given resource. An empty string means that every object of the resource must be listed.
+	GetLabelSelector(group, kind, cluster string) string
 }

--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -1629,6 +1629,45 @@ func TestExcludedResource(t *testing.T) {
 		Expect(Condition(ApplicationConditionExcludedResourceWarning, "Resource apps/Deployment guestbook-ui is excluded in the settings"))
 }
 
+// TestResourceSelector makes sure that a label selector configured via resource.selectors removes the
+// matching resources from the cluster cache, while leaving them running in the cluster.
+func TestResourceSelector(t *testing.T) {
+	isDeploymentPod := func(node ResourceNode) bool {
+		return node.Kind == kube.PodKind && node.Group == ""
+	}
+	isDeploymentPodInCluster := func(pod corev1.Pod) bool {
+		return pod.Labels["my-label"] == "whatever"
+	}
+
+	Given(t).
+		Path("one-deployment").
+		When().
+		CreateApp().
+		Sync().
+		Then().
+		Expect(SyncStatusIs(SyncStatusCodeSynced)).
+		Expect(HealthIs(health.HealthStatusHealthy)).
+		Expect(Pod(isDeploymentPodInCluster)).
+		// the pod is part of the application resource tree
+		Expect(ResourceTreeNode(isDeploymentPod)).
+		When().
+		// filter out the pods of the deployment
+		SetResourceFilter(settings.ResourcesFilter{
+			ResourceSelectors: []settings.FilteredResource{{
+				APIGroups: []string{""},
+				Kinds:     []string{kube.PodKind},
+				Selector:  "my-label!=whatever",
+			}},
+		}).
+		Refresh(RefreshTypeHard).
+		Then().
+		// the pod is gone from the resource tree ...
+		Expect(NotResourceTreeNode(isDeploymentPod)).
+		// ... but is still running in the cluster
+		Expect(Pod(isDeploymentPodInCluster)).
+		Expect(HealthIs(health.HealthStatusHealthy))
+}
+
 func TestRevisionHistoryLimit(t *testing.T) {
 	Given(t).
 		Path("config-map").

--- a/test/e2e/fixture/app/actions.go
+++ b/test/e2e/fixture/app/actions.go
@@ -21,6 +21,7 @@ import (
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v3/test/e2e/fixture"
 	"github.com/argoproj/argo-cd/v3/util/grpc"
+	"github.com/argoproj/argo-cd/v3/util/settings"
 )
 
 // this implements the "when" part of given/when/then
@@ -532,6 +533,12 @@ func (a *Actions) Wait(args ...string) *Actions {
 func (a *Actions) SetParamInSettingConfigMap(key, value string) *Actions {
 	a.context.T().Helper()
 	require.NoError(a.context.T(), fixture.SetParamInSettingConfigMap(key, value))
+	return a
+}
+
+func (a *Actions) SetResourceFilter(filter settings.ResourcesFilter) *Actions {
+	a.context.T().Helper()
+	require.NoError(a.context.T(), fixture.SetResourceFilter(filter))
 	return a
 }
 

--- a/test/e2e/fixture/app/consequences.go
+++ b/test/e2e/fixture/app/consequences.go
@@ -117,6 +117,19 @@ func (c *Consequences) get() (*v1alpha1.Application, error) {
 	return fixture.AppClientset.ArgoprojV1alpha1().Applications(c.context.AppNamespace()).Get(context.Background(), c.context.AppName(), metav1.GetOptions{})
 }
 
+func (c *Consequences) resourceTree() (*v1alpha1.ApplicationTree, error) {
+	closer, client, err := fixture.ArgoCDClientset.NewApplicationClient()
+	if err != nil {
+		return nil, err
+	}
+	defer utilio.Close(closer)
+	return client.ResourceTree(context.Background(), &applicationpkg.ResourcesQuery{
+		ApplicationName: new(c.context.AppName()),
+		Project:         new(c.context.project),
+		AppNamespace:    new(c.context.appNamespace),
+	})
+}
+
 func (c *Consequences) resource(kind, name, namespace string) v1alpha1.ResourceStatus {
 	c.context.T().Helper()
 	closer, client, err := fixture.ArgoCDClientset.NewApplicationClient()

--- a/test/e2e/fixture/app/expectation.go
+++ b/test/e2e/fixture/app/expectation.go
@@ -403,22 +403,17 @@ func NotPod(predicate func(p corev1.Pod) bool) Expectation {
 
 // ResourceTreeNode checks that the app resource tree has a node matching the predicate
 func ResourceTreeNode(predicate func(node v1alpha1.ResourceNode) bool) Expectation {
-	return func(c *Consequences) (state, string) {
-		tree, err := c.resourceTree()
-		if err != nil {
-			return failed, err.Error()
-		}
-		for _, node := range tree.Nodes {
-			if predicate(node) {
-				return succeeded, fmt.Sprintf("resource tree node predicate matched node named '%s'", node.Name)
-			}
-		}
-		return pending, "resource tree node predicate does not match any node"
-	}
+	return resourceTreeNode(predicate, succeeded, pending)
 }
 
 // NotResourceTreeNode checks that the app resource tree has no node matching the predicate
 func NotResourceTreeNode(predicate func(node v1alpha1.ResourceNode) bool) Expectation {
+	return resourceTreeNode(predicate, pending, succeeded)
+}
+
+// resourceTreeNode looks for a node matching the predicate in the app resource tree and reports
+// whenMatched if one is found, whenNotMatched otherwise.
+func resourceTreeNode(predicate func(node v1alpha1.ResourceNode) bool, whenMatched, whenNotMatched state) Expectation {
 	return func(c *Consequences) (state, string) {
 		tree, err := c.resourceTree()
 		if err != nil {
@@ -426,10 +421,10 @@ func NotResourceTreeNode(predicate func(node v1alpha1.ResourceNode) bool) Expect
 		}
 		for _, node := range tree.Nodes {
 			if predicate(node) {
-				return pending, fmt.Sprintf("resource tree node predicate matched node named '%s'", node.Name)
+				return whenMatched, fmt.Sprintf("resource tree node predicate matched node named '%s'", node.Name)
 			}
 		}
-		return succeeded, "resource tree node predicate did not match any node"
+		return whenNotMatched, "resource tree node predicate did not match any node"
 	}
 }
 

--- a/test/e2e/fixture/app/expectation.go
+++ b/test/e2e/fixture/app/expectation.go
@@ -401,6 +401,38 @@ func NotPod(predicate func(p corev1.Pod) bool) Expectation {
 	}
 }
 
+// ResourceTreeNode checks that the app resource tree has a node matching the predicate
+func ResourceTreeNode(predicate func(node v1alpha1.ResourceNode) bool) Expectation {
+	return func(c *Consequences) (state, string) {
+		tree, err := c.resourceTree()
+		if err != nil {
+			return failed, err.Error()
+		}
+		for _, node := range tree.Nodes {
+			if predicate(node) {
+				return succeeded, fmt.Sprintf("resource tree node predicate matched node named '%s'", node.Name)
+			}
+		}
+		return pending, "resource tree node predicate does not match any node"
+	}
+}
+
+// NotResourceTreeNode checks that the app resource tree has no node matching the predicate
+func NotResourceTreeNode(predicate func(node v1alpha1.ResourceNode) bool) Expectation {
+	return func(c *Consequences) (state, string) {
+		tree, err := c.resourceTree()
+		if err != nil {
+			return failed, err.Error()
+		}
+		for _, node := range tree.Nodes {
+			if predicate(node) {
+				return pending, fmt.Sprintf("resource tree node predicate matched node named '%s'", node.Name)
+			}
+		}
+		return succeeded, "resource tree node predicate did not match any node"
+	}
+}
+
 func pods(namespace string) (*corev1.PodList, error) {
 	pods, err := fixture.KubeClientset.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{})
 	return pods, err

--- a/test/e2e/fixture/fixture.go
+++ b/test/e2e/fixture/fixture.go
@@ -575,8 +575,13 @@ func SetResourceFilter(filters settings.ResourcesFilter) error {
 		if err != nil {
 			return err
 		}
+		selectors, err := yaml.Marshal(filters.ResourceSelectors)
+		if err != nil {
+			return err
+		}
 		cm.Data["resource.exclusions"] = string(exclusions)
 		cm.Data["resource.inclusions"] = string(inclusions)
+		cm.Data["resource.selectors"] = string(selectors)
 		return nil
 	})
 }

--- a/util/settings/filtered_resource.go
+++ b/util/settings/filtered_resource.go
@@ -6,6 +6,10 @@ type FilteredResource struct {
 	APIGroups []string `json:"apiGroups,omitempty"`
 	Kinds     []string `json:"kinds,omitempty"`
 	Clusters  []string `json:"clusters,omitempty"`
+	// Selector narrows the filter down to the resources whose labels match the selector. The value
+	// is a label selector in its string form, e.g. `foo=bar,!baz`, and is passed as is to the
+	// list/watch calls. An empty selector matches every resource.
+	Selector string `json:"selector,omitempty"`
 }
 
 func (r FilteredResource) matchGroup(apiGroup string) bool {

--- a/util/settings/resources_filter.go
+++ b/util/settings/resources_filter.go
@@ -1,5 +1,7 @@
 package settings
 
+import "strings"
+
 // The core exclusion list are K8s resources that we assume will never be managed by operators,
 // and are never child objects of managed resources that need to be presented in the resource tree.
 // This list contains high volume and  high churn metadata objects which we exclude for performance
@@ -15,6 +17,9 @@ type ResourcesFilter struct {
 	ResourceExclusions []FilteredResource
 	// ResourceInclusions holds the only api groups, kinds per cluster that Argo CD will watch
 	ResourceInclusions []FilteredResource
+	// ResourceSelectors holds the label selectors, per api group, kind and cluster, that narrow
+	// down the objects Argo CD will watch
+	ResourceSelectors []FilteredResource
 }
 
 func (rf *ResourcesFilter) getExcludedResources() []FilteredResource {
@@ -81,4 +86,19 @@ func (rf *ResourcesFilter) IsExcludedResource(apiGroup, kind, cluster string) bo
 
 	// if no inclusion rules defined for cluster, default is allow
 	return false
+}
+
+// GetLabelSelector returns the label selector that must be applied to the list/watch calls of the
+// given resource so that the API server only returns the objects Argo CD is interested in. The
+// selectors of all the matching ResourceSelectors rules are ANDed together. An empty string is
+// returned if no rule matches, in which case all the objects of the resource are listed.
+func (rf *ResourcesFilter) GetLabelSelector(apiGroup, kind, cluster string) string {
+	selectors := make([]string, 0)
+	for _, resourceSelector := range rf.ResourceSelectors {
+		if resourceSelector.Selector == "" || !resourceSelector.Match(apiGroup, kind, cluster) {
+			continue
+		}
+		selectors = append(selectors, resourceSelector.Selector)
+	}
+	return strings.Join(selectors, ",")
 }

--- a/util/settings/resources_filter.go
+++ b/util/settings/resources_filter.go
@@ -95,10 +95,11 @@ func (rf *ResourcesFilter) IsExcludedResource(apiGroup, kind, cluster string) bo
 func (rf *ResourcesFilter) GetLabelSelector(apiGroup, kind, cluster string) string {
 	selectors := make([]string, 0)
 	for _, resourceSelector := range rf.ResourceSelectors {
-		if resourceSelector.Selector == "" || !resourceSelector.Match(apiGroup, kind, cluster) {
+		selector := strings.TrimSpace(resourceSelector.Selector)
+		if selector == "" || !resourceSelector.Match(apiGroup, kind, cluster) {
 			continue
 		}
-		selectors = append(selectors, resourceSelector.Selector)
+		selectors = append(selectors, selector)
 	}
 	return strings.Join(selectors, ",")
 }

--- a/util/settings/resources_filter_test.go
+++ b/util/settings/resources_filter_test.go
@@ -64,3 +64,46 @@ func TestResourceInclusionsExclusionMultiCluster(t *testing.T) {
 	assert.True(t, filter.IsExcludedResource("whitelisted-resource", "", "cluster-two"))
 	assert.False(t, filter.IsExcludedResource("whitelisted-resource", "", "cluster-three"))
 }
+
+func TestGetLabelSelector(t *testing.T) {
+	t.Run("no selectors configured", func(t *testing.T) {
+		filter := &ResourcesFilter{}
+		assert.Empty(t, filter.GetLabelSelector("", "Pod", "cluster-one"))
+	})
+
+	t.Run("selector of the matching rule is returned", func(t *testing.T) {
+		filter := &ResourcesFilter{
+			ResourceSelectors: []FilteredResource{
+				{Kinds: []string{"Pod"}, Clusters: []string{"cluster-one"}, Selector: "!foo"},
+			},
+		}
+		assert.Equal(t, "!foo", filter.GetLabelSelector("", "Pod", "cluster-one"))
+		assert.Empty(t, filter.GetLabelSelector("", "Service", "cluster-one"))
+		assert.Empty(t, filter.GetLabelSelector("", "Pod", "cluster-two"))
+	})
+
+	t.Run("rule without group, kind and cluster matches everything", func(t *testing.T) {
+		filter := &ResourcesFilter{
+			ResourceSelectors: []FilteredResource{{Selector: "foo=bar"}},
+		}
+		assert.Equal(t, "foo=bar", filter.GetLabelSelector("apps", "Deployment", "cluster-one"))
+	})
+
+	t.Run("selectors of matching rules are ANDed", func(t *testing.T) {
+		filter := &ResourcesFilter{
+			ResourceSelectors: []FilteredResource{
+				{Selector: "foo=bar"},
+				{Kinds: []string{"Pod"}, Selector: "!baz"},
+				{Kinds: []string{"Service"}, Selector: "ignored=true"},
+			},
+		}
+		assert.Equal(t, "foo=bar,!baz", filter.GetLabelSelector("", "Pod", "cluster-one"))
+	})
+
+	t.Run("rule without a selector is skipped", func(t *testing.T) {
+		filter := &ResourcesFilter{
+			ResourceSelectors: []FilteredResource{{Kinds: []string{"Pod"}}},
+		}
+		assert.Empty(t, filter.GetLabelSelector("", "Pod", "cluster-one"))
+	})
+}

--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -493,6 +493,8 @@ const (
 	resourceExclusionsKey = "resource.exclusions"
 	// resourceInclusions is the key to the list of explicitly watched resources
 	resourceInclusionsKey = "resource.inclusions"
+	// resourceSelectorsKey is the key to the list of label selectors that narrow down the watched resources
+	resourceSelectorsKey = "resource.selectors"
 	// resourceIgnoreResourceUpdatesEnabledKey is the key to a boolean determining whether the resourceIgnoreUpdates feature is enabled
 	resourceIgnoreResourceUpdatesEnabledKey = "resource.ignoreResourceUpdatesEnabled"
 	// resourceSensitiveAnnotationsKey is the key to list of annotations to mask in secret resource
@@ -899,6 +901,20 @@ func (mgr *SettingsManager) GetResourcesFilter() (*ResourcesFilter, error) {
 			return nil, fmt.Errorf("error unmarshalling excluded resources %w", err)
 		}
 		rf.ResourceExclusions = excludedResources
+	}
+
+	if value, ok := argoCDCM.Data[resourceSelectorsKey]; ok {
+		resourceSelectors := make([]FilteredResource, 0)
+		err := yaml.Unmarshal([]byte(value), &resourceSelectors)
+		if err != nil {
+			return nil, fmt.Errorf("error unmarshalling resource selectors %w", err)
+		}
+		for _, resourceSelector := range resourceSelectors {
+			if _, err := labels.Parse(resourceSelector.Selector); err != nil {
+				return nil, fmt.Errorf("error parsing resource selector %q: %w", resourceSelector.Selector, err)
+			}
+		}
+		rf.ResourceSelectors = resourceSelectors
 	}
 	return rf, nil
 }

--- a/util/settings/settings_test.go
+++ b/util/settings/settings_test.go
@@ -149,6 +149,7 @@ func TestGetResourceFilter(t *testing.T) {
 	data := map[string]string{
 		"resource.exclusions": "\n  - apiGroups: [\"group1\"]\n    kinds: [\"kind1\"]\n    clusters: [\"cluster1\"]\n",
 		"resource.inclusions": "\n  - apiGroups: [\"group2\"]\n    kinds: [\"kind2\"]\n    clusters: [\"cluster2\"]\n",
+		"resource.selectors":  "\n  - apiGroups: [\"group3\"]\n    kinds: [\"kind3\"]\n    clusters: [\"cluster3\"]\n    selector: \"foo=bar,!baz\"\n",
 	}
 	_, settingsManager := fixtures(t.Context(), data)
 	filter, err := settingsManager.GetResourcesFilter()
@@ -156,7 +157,28 @@ func TestGetResourceFilter(t *testing.T) {
 	assert.Equal(t, &ResourcesFilter{
 		ResourceExclusions: []FilteredResource{{APIGroups: []string{"group1"}, Kinds: []string{"kind1"}, Clusters: []string{"cluster1"}}},
 		ResourceInclusions: []FilteredResource{{APIGroups: []string{"group2"}, Kinds: []string{"kind2"}, Clusters: []string{"cluster2"}}},
+		ResourceSelectors:  []FilteredResource{{APIGroups: []string{"group3"}, Kinds: []string{"kind3"}, Clusters: []string{"cluster3"}, Selector: "foo=bar,!baz"}},
 	}, filter)
+}
+
+// the e2e fixture marshals an empty ResourceSelectors list into the config map, make sure it parses
+func TestGetResourceFilterNullSelectors(t *testing.T) {
+	data := map[string]string{
+		"resource.selectors": "null\n",
+	}
+	_, settingsManager := fixtures(t.Context(), data)
+	filter, err := settingsManager.GetResourcesFilter()
+	require.NoError(t, err)
+	assert.Empty(t, filter.ResourceSelectors)
+}
+
+func TestGetResourceFilterInvalidSelector(t *testing.T) {
+	data := map[string]string{
+		"resource.selectors": "\n  - kinds: [\"Pod\"]\n    selector: \"foo=~bar\"\n",
+	}
+	_, settingsManager := fixtures(t.Context(), data)
+	_, err := settingsManager.GetResourcesFilter()
+	require.ErrorContains(t, err, "error parsing resource selector")
 }
 
 func TestInClusterServerAddressEnabled(t *testing.T) {


### PR DESCRIPTION
PR partially implements https://github.com/argoproj/argo-cd/issues/14994:

Adds a `resource.selectors` key to `argocd-cm` that attaches a Kubernetes label selector to the list/watch calls Argo CD makes for a given API group/kind/cluster. Objects that don't match are filtered out by the API server and never enter the cluster cache.

```yaml
resource.selectors: |
  - apiGroups:
    - ""
    kinds:
    - Pod
    clusters:
    - "*"
    selector: "app.kubernetes.io/name!=some-noisy-workload"
```

* `apiGroups` / `kinds` / `clusters` are matched exactly as they are for the existing
  `resource.exclusions` and `resource.inclusions` rules; omitting a field matches everything, so a rule with only a `selector` applies it to every watched resource.
* `selector` is a label selector in its string form (`tier=backend`, `tier in (backend,frontend)`, `!tier`), passed verbatim to the API server.
* Selectors of all matching rules are ANDed together. With no matching rule the resource is listed unfiltered, exactly as today.
