### PR TITLE
fix: hide argocd.argoproj.io/tracking-id annotation when Hide Managed Fields is enabled (#29424)

### DIFF
--- a/ui/src/app/applications/components/application-node-info/application-node-info.test.tsx
+++ b/ui/src/app/applications/components/application-node-info/application-node-info.test.tsx
@@ -1,0 +1,67 @@
+import {stripManagedFields} from './application-node-info';
+
+describe('stripManagedFields', () => {
+    it('removes metadata.managedFields', () => {
+        const resource = {
+            metadata: {
+                name: 'my-deployment',
+                managedFields: [{manager: 'argocd-controller', operation: 'Update'}]
+            }
+        };
+
+        const result = stripManagedFields(resource);
+
+        expect(result.metadata.managedFields).toBeUndefined();
+    });
+
+    it('removes the argocd.argoproj.io/tracking-id annotation', () => {
+        const resource = {
+            metadata: {
+                name: 'my-deployment',
+                annotations: {
+                    'argocd.argoproj.io/tracking-id': 'my-app:apps/Deployment:default/my-deployment',
+                    'some-other/annotation': 'keep-me'
+                }
+            }
+        };
+
+        const result = stripManagedFields(resource);
+
+        expect(result.metadata.annotations['argocd.argoproj.io/tracking-id']).toBeUndefined();
+        expect(result.metadata.annotations['some-other/annotation']).toBe('keep-me');
+    });
+
+    it('leaves annotations untouched when there is nothing to hide', () => {
+        const resource = {
+            metadata: {
+                name: 'my-deployment',
+                annotations: {'some-other/annotation': 'keep-me'}
+            }
+        };
+
+        const result = stripManagedFields(resource);
+
+        expect(result.metadata.annotations).toEqual({'some-other/annotation': 'keep-me'});
+    });
+
+    it('does not mutate the original resource', () => {
+        const resource = {
+            metadata: {
+                name: 'my-deployment',
+                managedFields: [{manager: 'argocd-controller'}],
+                annotations: {'argocd.argoproj.io/tracking-id': 'my-app:apps/Deployment:default/my-deployment'}
+            }
+        };
+
+        stripManagedFields(resource);
+
+        expect(resource.metadata.managedFields).toBeDefined();
+        expect(resource.metadata.annotations['argocd.argoproj.io/tracking-id']).toBeDefined();
+    });
+
+    it('returns the input unchanged when there is no metadata', () => {
+        const resource = {kind: 'Deployment'};
+
+        expect(stripManagedFields(resource)).toBe(resource);
+    });
+});

--- a/ui/src/app/applications/components/application-node-info/application-node-info.tsx
+++ b/ui/src/app/applications/components/application-node-info/application-node-info.tsx
@@ -15,6 +15,24 @@ import './application-node-info.scss';
 import {ReadinessGatesNotPassedWarning} from './readiness-gates-not-passed-warning';
 import Moment from 'react-moment';
 
+// Annotations that Argo CD injects into live resources for its own bookkeeping. These are hidden, alongside
+// metadata.managedFields, when the "Hide Managed Fields" checkbox is enabled.
+export const ArgoCDManagedAnnotations = ['argocd.argoproj.io/tracking-id'];
+
+export const stripManagedFields = (resource: any): any => {
+    if (!resource?.metadata) {
+        return resource;
+    }
+    const metadata = {...resource.metadata};
+    delete metadata.managedFields;
+    if (metadata.annotations && ArgoCDManagedAnnotations.some(key => key in metadata.annotations)) {
+        const annotations = {...metadata.annotations};
+        ArgoCDManagedAnnotations.forEach(key => delete annotations[key]);
+        metadata.annotations = annotations;
+    }
+    return {...resource, metadata};
+};
+
 const RenderContainerState = (props: {container: any}) => {
     const state = (props.container.state?.waiting && 'waiting') || (props.container.state?.terminated && 'terminated') || (props.container.state?.running && 'running');
     const status = props.container.state.waiting?.reason || props.container.state.terminated?.reason || props.container.state.running?.reason;
@@ -246,14 +264,7 @@ export const ApplicationNodeInfo = (props: {
                         const merged = deepMerge(props.live, {}) as any;
                         const showLiveState = Object.keys(merged).length !== 0;
 
-                        const live =
-                            merged?.metadata?.managedFields && pref.appDetails.hideManagedFields
-                                ? (() => {
-                                      const metadata = {...merged.metadata};
-                                      delete metadata.managedFields;
-                                      return {...merged, metadata};
-                                  })()
-                                : merged;
+                        const live = pref.appDetails.hideManagedFields ? stripManagedFields(merged) : merged;
                         return (
                             <React.Fragment>
                                 {showLiveState ? (


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

## Why this PR is necessary

Fixes #29424.

The "Hide Managed Fields" checkbox on the "Live Manifest" tab of a resource only stripped `metadata.managedFields` from the displayed YAML. Argo CD's own `argocd.argoproj.io/tracking-id` bookkeeping annotation (injected into every live, annotation-tracked resource) is stored under `metadata.annotations`, not `managedFields`, so it was left behind — defeating the purpose of the toggle for users who want to see their own manifest without Argo CD's internal bookkeeping.

## What changed

* Extracted the ad-hoc field-stripping logic in `application-node-info.tsx` into a small, pure, exported `stripManagedFields()` helper.
* The helper now also removes Argo CD-managed annotations (currently just `argocd.argoproj.io/tracking-id`, tracked in an exported `ArgoCDManagedAnnotations` list) alongside `metadata.managedFields`, only when the "Hide Managed Fields" checkbox is checked. No behavior change when the checkbox is unchecked.
* Added unit tests (`application-node-info.test.tsx`) covering: removing `managedFields`, removing the tracking-id annotation while preserving other annotations, no-op when nothing to hide, non-mutation of the input, and passthrough when there's no metadata.

## Testing

* Added unit tests, `pnpm test` passes (5/5 new tests, no regressions in existing suite run).
* `pnpm run lint` (`tsc --noEmit` + `eslint`) passes with no new errors/warnings introduced by this change.

## Screenshots

Verified interactively by rendering the actual `ApplicationNodeInfo` component with a fake `Deployment` resource carrying both `metadata.managedFields` and the `argocd.argoproj.io/tracking-id` annotation, then toggling the checkbox in a real browser.

### Before
<img width="619" height="358" alt="image" src="https://github.com/user-attachments/assets/a9d82359-9bb0-4f76-ab4d-fceae19b7d26" />

### After
<img width="631" height="352" alt="image" src="https://github.com/user-attachments/assets/a92f64e1-9593-4451-abbb-969635d116a9" />

