### PR TITLE
fix: recover AuthReconcile visitor panics (#29436)

### DIFF
--- a/gitops-engine/pkg/utils/kube/resource_ops.go
+++ b/gitops-engine/pkg/utils/kube/resource_ops.go
@@ -111,7 +111,23 @@ func (f *realKubectlOptionsRunner) AuthReconcile(opts *auth.ReconcileOptions) (r
 			retErr = fmt.Errorf("error running kubectl auth reconcile: %v", r)
 		}
 	}()
+	opts.Visitor = panicRecoveringVisitor{Visitor: opts.Visitor}
 	return opts.RunReconcile()
+}
+
+type panicRecoveringVisitor struct {
+	resource.Visitor
+}
+
+func (v panicRecoveringVisitor) Visit(fn resource.VisitorFunc) error {
+	return v.Visitor.Visit(func(info *resource.Info, err error) (retErr error) {
+		defer func() {
+			if r := recover(); r != nil {
+				retErr = fmt.Errorf("error running kubectl auth reconcile: %v", r)
+			}
+		}()
+		return fn(info, err)
+	})
 }
 
 func (f *realKubectlOptionsRunner) processKubectlRun(cmd string) (CleanupFunc, error) {

--- a/gitops-engine/pkg/utils/kube/resource_ops.go
+++ b/gitops-engine/pkg/utils/kube/resource_ops.go
@@ -111,6 +111,7 @@ func (f *realKubectlOptionsRunner) AuthReconcile(opts *auth.ReconcileOptions) (r
 			retErr = fmt.Errorf("error running kubectl auth reconcile: %v", r)
 		}
 	}()
+	// TODO(#29484): Remove this wrapper after the upstream kubectl panic fix is available in Argo CD.
 	opts.Visitor = panicRecoveringVisitor{Visitor: opts.Visitor}
 	return opts.RunReconcile()
 }

--- a/gitops-engine/pkg/utils/kube/resource_ops_test.go
+++ b/gitops-engine/pkg/utils/kube/resource_ops_test.go
@@ -2,10 +2,10 @@ package kube
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/argoproj/argo-cd/gitops-engine/v3/pkg/utils/kube/mocks"
-	"k8s.io/kubectl/pkg/cmd/auth"
 	testingutils "github.com/argoproj/argo-cd/gitops-engine/v3/pkg/utils/testing"
 	"github.com/argoproj/argo-cd/gitops-engine/v3/pkg/utils/tracing"
 	"github.com/go-logr/logr"
@@ -14,10 +14,12 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/printers"
+	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/kubernetes"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
 	"k8s.io/kubectl/pkg/cmd/apply"
+	"k8s.io/kubectl/pkg/cmd/auth"
 	"k8s.io/kubectl/pkg/cmd/create"
 	"k8s.io/kubectl/pkg/cmd/replace"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -561,4 +563,39 @@ func TestRealKubectlOptionsRunner_AuthReconcile_PanicRecovery(t *testing.T) {
 	err := runner.AuthReconcile((*auth.ReconcileOptions)(nil))
 	require.Error(t, err, "AuthReconcile must return an error rather than propagating the panic")
 	assert.Contains(t, err.Error(), "error running kubectl auth reconcile")
+}
+
+type concurrentTestVisitor struct {
+	info *resource.Info
+	err  error
+}
+
+func (v concurrentTestVisitor) Visit(fn resource.VisitorFunc) error {
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- fn(v.info, v.err)
+	}()
+	return <-errCh
+}
+
+func TestRealKubectlOptionsRunner_AuthReconcile_ConcurrentVisitorPanicRecovery(t *testing.T) {
+	t.Parallel()
+	runner := &realKubectlOptionsRunner{}
+	opts := auth.NewReconcileOptions(genericclioptions.IOStreams{})
+	opts.Visitor = concurrentTestVisitor{}
+
+	err := runner.AuthReconcile(opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "error running kubectl auth reconcile")
+}
+
+func TestRealKubectlOptionsRunner_AuthReconcile_VisitorError(t *testing.T) {
+	t.Parallel()
+	runner := &realKubectlOptionsRunner{}
+	expectedErr := errors.New("visit failed")
+	opts := auth.NewReconcileOptions(genericclioptions.IOStreams{})
+	opts.Visitor = concurrentTestVisitor{err: expectedErr}
+
+	err := runner.AuthReconcile(opts)
+	require.ErrorIs(t, err, expectedErr)
 }


### PR DESCRIPTION
Fixes #29436

`kubectl auth reconcile` visits multiple RBAC manifests concurrently. Its visitor callback can panic when an impersonated service account is forbidden, and the existing recovery at the `AuthReconcile` entry point cannot catch a panic in those child goroutines.

This wraps the reconcile visitor so each callback converts a panic into the same `SyncFailed` error used by the existing outer recovery. Ordinary visitor errors are returned unchanged. Regression coverage executes the callback in a child goroutine and verifies both panic recovery and error preservation.

AI assistance was used to investigate, implement, and test this change. I reviewed the complete diff and take responsibility for the contribution.

Checklist:

* [x] This is a bug fix.
* [x] The title states what changed and includes the related issue number.
* [x] The title conforms to the semantic PR title policy.
* [x] The description includes `Fixes #29436`.
* [x] CLI/UI exposure is not applicable to this controller crash fix.
* [x] This bug fix does not require documentation updates.
* [x] Documentation updates are not applicable.
* [x] All commits are signed off per DCO.
* [x] Unit tests cover concurrent callback recovery and ordinary visitor errors.
* [x] Focused package tests, race tests, vet, formatting, and diff checks pass.
* [x] Feature-status requirements are not applicable to this bug fix.
* [x] The rationale and behavior are described above.
* [x] Organization listing is not applicable.
* [x] This regression affects v3.5.2; maintainers may consider a 3.5 cherry-pick based on release policy.

Validation on the final head:

```console
$ cd gitops-engine && /home/ubuntu/.local/go/bin/go test ./pkg/utils/kube -count=1
ok github.com/argoproj/argo-cd/gitops-engine/v3/pkg/utils/kube 0.067s

$ cd gitops-engine && /home/ubuntu/.local/go/bin/go test -race ./pkg/utils/kube -run 'TestRealKubectlOptionsRunner_AuthReconcile_(PanicRecovery|ConcurrentVisitorPanicRecovery|VisitorError)$' -count=10
ok github.com/argoproj/argo-cd/gitops-engine/v3/pkg/utils/kube 1.305s

$ cd gitops-engine && /home/ubuntu/.local/go/bin/go vet ./pkg/utils/kube
# no output; exit 0

$ git diff --check upstream/master...HEAD
# no output; exit 0
```

The required containerized `make build` was attempted after the test-tools image built successfully, but this non-interactive cron environment cannot attach stdin to the Makefile's hard-coded `docker run -it`; focused build-equivalent package tests and vet pass above.
