### PR TITLE
fix(health): treat WaitForFirstConsumer PVC as Healthy not Progressing

### DIFF
--- a/gitops-engine/pkg/health/health_pvc.go
+++ b/gitops-engine/pkg/health/health_pvc.go
@@ -26,16 +26,25 @@ func getPVCHealth(obj *unstructured.Unstructured) (*HealthStatus, error) {
 }
 
 func getCorev1PVCHealth(pvc *corev1.PersistentVolumeClaim) (*HealthStatus, error) {
-	var status HealthStatusCode
 	switch pvc.Status.Phase {
 	case corev1.ClaimLost:
-		status = HealthStatusDegraded
+		return &HealthStatus{Status: HealthStatusDegraded}, nil
 	case corev1.ClaimPending:
-		status = HealthStatusProgressing
+		// A PVC with WaitForFirstConsumer binding mode stays Pending until a pod
+		// is scheduled that consumes it. This is an expected steady state, not
+		// progress toward a goal, so report Healthy instead of Progressing.
+		for _, condition := range pvc.Status.Conditions {
+			if condition.Reason == "WaitForFirstConsumer" {
+				return &HealthStatus{
+					Status:  HealthStatusHealthy,
+					Message: "Waiting for first consumer",
+				}, nil
+			}
+		}
+		return &HealthStatus{Status: HealthStatusProgressing}, nil
 	case corev1.ClaimBound:
-		status = HealthStatusHealthy
+		return &HealthStatus{Status: HealthStatusHealthy}, nil
 	default:
-		status = HealthStatusUnknown
+		return &HealthStatus{Status: HealthStatusUnknown}, nil
 	}
-	return &HealthStatus{Status: status}, nil
 }

--- a/gitops-engine/pkg/health/health_test.go
+++ b/gitops-engine/pkg/health/health_test.go
@@ -55,6 +55,7 @@ func TestDaemonSetOnDeleteHealth(t *testing.T) {
 func TestPVCHealth(t *testing.T) {
 	assertAppHealth(t, "./testdata/pvc-bound.yaml", HealthStatusHealthy)
 	assertAppHealth(t, "./testdata/pvc-pending.yaml", HealthStatusProgressing)
+	assertAppHealth(t, "./testdata/pvc-pending-wait-for-consumer.yaml", HealthStatusHealthy)
 }
 
 func TestServiceHealth(t *testing.T) {

--- a/gitops-engine/pkg/health/testdata/pvc-pending-wait-for-consumer.yaml
+++ b/gitops-engine/pkg/health/testdata/pvc-pending-wait-for-consumer.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: testpvc-wait-for-consumer
+  namespace: argocd
+  labels:
+    app.kubernetes.io/instance: working-pvc
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: wait-for-consumer-sc
+status:
+  phase: Pending
+  conditions:
+  - type: FileSystemResizePending
+    status: "False"
+    reason: WaitForFirstConsumer
+    message: waiting for first consumer to be created before binding


### PR DESCRIPTION
## Summary

Fixes #29201

A PVC bound to a StorageClass with `volumeBindingMode: WaitForFirstConsumer` stays in `Pending` phase indefinitely until a consumer Pod is scheduled. This is an **expected steady state**, not transient progress toward `Bound` — so reporting it as `Progressing` causes a perpetual spinner in the Argo CD UI with no actionable meaning.

## Root cause

`getCorev1PVCHealth` in `gitops-engine/pkg/health/health_pvc.go` maps `Pending` phase unconditionally to `Progressing`, without checking whether the PVC is intentionally waiting for a consumer.

## Fix

When a PVC is `Pending`, check `pvc.status.conditions` for a condition with `reason: WaitForFirstConsumer`. Kubernetes sets this condition on the PVC when a `WaitForFirstConsumer` StorageClass is used and no pod has consumed the volume yet. If present, return `Healthy` with message `"Waiting for first consumer"` instead of `Progressing`.

The existing `Progressing` result for a regular `Pending` PVC (no such condition) is unchanged.

## Changes

| File | Change |
|------|--------|
| `gitops-engine/pkg/health/health_pvc.go` | Check for `WaitForFirstConsumer` condition before returning `Progressing` |
| `gitops-engine/pkg/health/health_test.go` | Add test case asserting `Healthy` for WaitForFirstConsumer PVC |
| `gitops-engine/pkg/health/testdata/pvc-pending-wait-for-consumer.yaml` | New fixture with `Pending` phase + `WaitForFirstConsumer` condition |

## Testing

```
cd gitops-engine && go test ./pkg/health/... -run TestPVCHealth -v
=== RUN   TestPVCHealth
--- PASS: TestPVCHealth (0.00s)
```

All 3 cases pass: `Bound` → `Healthy`, regular `Pending` → `Progressing`, `WaitForFirstConsumer Pending` → `Healthy`.