### PR TITLE
fix: skip URL validation for secret references in OIDC config

### DIFF
--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -2132,20 +2132,29 @@ func unmarshalOIDCConfig(configStr string) (oidcConfig, error) {
 	return config, err
 }
 
+// isSecretReference reports whether the value is a secret key reference
+// (e.g. $my-secret:key). References are resolved at use time, so they
+// cannot be validated as URLs here.
+func isSecretReference(val string) bool {
+	return strings.HasPrefix(val, "$")
+}
+
 func ValidateOIDCConfig(configStr string) error {
 	settings, err := unmarshalOIDCConfig(configStr)
 	if err != nil {
 		return err
 	}
-	err = ValidateExternalURL(settings.Issuer)
-	if err != nil {
-		return err
+	if !isSecretReference(settings.Issuer) {
+		if err := ValidateExternalURL(settings.Issuer); err != nil {
+			return err
+		}
 	}
-	err = ValidateExternalURL(settings.UserInfoBaseURL)
-	if err != nil {
-		return err
+	if !isSecretReference(settings.UserInfoBaseURL) {
+		if err := ValidateExternalURL(settings.UserInfoBaseURL); err != nil {
+			return err
+		}
 	}
-	if settings.Azure != nil && settings.Azure.GraphAPIEndpoint != "" {
+	if settings.Azure != nil && settings.Azure.GraphAPIEndpoint != "" && !isSecretReference(settings.Azure.GraphAPIEndpoint) {
 		if err := ValidateAzureGraphAPIEndpoint(settings.Azure.GraphAPIEndpoint); err != nil {
 			return err
 		}

--- a/util/settings/settings_test.go
+++ b/util/settings/settings_test.go
@@ -1048,6 +1048,15 @@ func TestValidateOIDCConfig(t *testing.T) {
 			config: "name: Test\nissuer: $oidc-secret:issuer\nuserInfoBaseURL: $oidc-secret:userInfoBaseURL",
 		},
 		{
+			name:   "azure graph API endpoint secret reference is skipped",
+			config: "name: Test\nissuer: https://idp.example.com\nazure:\n  graphAPIEndpoint: $oidc-secret:graphAPIEndpoint",
+		},
+		{
+			name:      "invalid literal azure graph API endpoint",
+			config:    "name: Test\nissuer: https://idp.example.com\nazure:\n  graphAPIEndpoint: http://graph.microsoft.com",
+			expectErr: "must use https",
+		},
+		{
 			name:      "invalid literal issuer",
 			config:    "name: Test\nissuer: idp_internal:9999/path",
 			expectErr: "failed to parse URL",

--- a/util/settings/settings_test.go
+++ b/util/settings/settings_test.go
@@ -1033,6 +1033,43 @@ func TestSettingsManager_GetSettings(t *testing.T) {
 	})
 }
 
+func TestValidateOIDCConfig(t *testing.T) {
+	testCases := []struct {
+		name      string
+		config    string
+		expectErr string
+	}{
+		{
+			name:   "literal URLs",
+			config: "name: Test\nissuer: https://idp.example.com\nuserInfoPath: /userinfo\nenableUserInfoGroups: true\nuserInfoCacheExpiration: 5m\nuserInfoBaseURL: https://idp.example.com",
+		},
+		{
+			name:   "secret references are skipped",
+			config: "name: Test\nissuer: $oidc-secret:issuer\nuserInfoBaseURL: $oidc-secret:userInfoBaseURL",
+		},
+		{
+			name:      "invalid literal issuer",
+			config:    "name: Test\nissuer: idp_internal:9999/path",
+			expectErr: "failed to parse URL",
+		},
+		{
+			name:      "issuer without scheme",
+			config:    "name: Test\nissuer: idp.example.com",
+			expectErr: "URL must include http or https protocol",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateOIDCConfig(tc.config)
+			if tc.expectErr == "" {
+				require.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tc.expectErr)
+			}
+		})
+	}
+}
+
 func TestGetOIDCConfig(t *testing.T) {
 	testCases := []struct {
 		name          string


### PR DESCRIPTION
## What does this PR do?

`ValidateOIDCConfig` runs against the raw `oidc.config` string during settings reload, before `$secret:key` references are substituted (substitution happens at use time in `oidcConfig()` via `ReplaceMapSecrets`). When `issuer` or `userInfoBaseURL` is a secret reference, every settings reload logs a spurious warning:

```
Failed to validate OIDC config: failed to parse URL: parse "$argocd-secret:issuer": first path segment in URL cannot contain colon
```

This PR skips URL validation for `$`-prefixed values (the same convention `replaceStringSecret` uses to detect references) for `issuer`, `userInfoBaseURL`, and `azure.graphAPIEndpoint`. Literal values keep the existing validation.

## How is it tested?

Added `TestValidateOIDCConfig` covering literal URLs (pass), secret references (skipped), an unparseable literal issuer, and a literal issuer without scheme. `go test ./util/settings/` passes.

## Checklist
- [x] The title of the PR conforms to conventional commit spec
- [x] Commits are signed off (DCO)
- [x] Tests added