### PR TITLE
fix(appset): populate createdAt in ApplicationSet resource tree

### DIFF
--- a/server/applicationset/applicationset.go
+++ b/server/applicationset/applicationset.go
@@ -61,6 +61,7 @@ type Server struct {
 	client                   client.Client
 	repoClientSet            repoapiclient.Clientset
 	appclientset             appclientset.Interface
+	appLister                applisters.ApplicationLister
 	appsetInformer           cache.SharedIndexInformer
 	appsetLister             applisters.ApplicationSetLister
 	appSetBroadcaster        broadcast.Broadcaster[v1alpha1.ApplicationSetWatchEvent]
@@ -176,6 +177,7 @@ func NewServer(
 	enf *rbac.Enforcer,
 	repoClientSet repoapiclient.Clientset,
 	appclientset appclientset.Interface,
+	appLister applisters.ApplicationLister,
 	appsetInformer cache.SharedIndexInformer,
 	appsetLister applisters.ApplicationSetLister,
 	appSetBroadcaster broadcast.Broadcaster[v1alpha1.ApplicationSetWatchEvent],
@@ -214,6 +216,7 @@ func NewServer(
 		k8sClient:                kubeclientset,
 		repoClientSet:            repoClientSet,
 		appclientset:             appclientset,
+		appLister:                appLister,
 		appsetInformer:           appsetInformer,
 		appsetLister:             appsetLister,
 		appSetBroadcaster:        appSetBroadcaster,
@@ -510,6 +513,19 @@ func (s *Server) buildApplicationSetTree(a *v1alpha1.ApplicationSet) (*v1alpha1.
 
 	apps := a.Status.Resources
 	for _, app := range apps {
+		// The generated Application may not be in the informer cache yet (e.g. it was just created); in that case createdAt stays unset.
+		var createdAt *metav1.Time
+		namespace := app.Namespace
+		if namespace == "" {
+			namespace = a.Namespace
+		}
+		generatedApp, err := s.appLister.Applications(namespace).Get(app.Name)
+		switch {
+		case err == nil:
+			createdAt = generatedApp.CreationTimestamp.DeepCopy()
+		case !apierrors.IsNotFound(err):
+			log.WithField("applicationset", a.Name).Warnf("failed to get generated Application %s/%s: %v", namespace, app.Name, err)
+		}
 		tree.Nodes = append(tree.Nodes, v1alpha1.ResourceNode{
 			Health:     app.Health,
 			Name:       app.Name,
@@ -518,6 +534,7 @@ func (s *Server) buildApplicationSetTree(a *v1alpha1.ApplicationSet) (*v1alpha1.
 			Kind:       app.Kind,
 			Namespace:  a.Namespace,
 			ParentRefs: parentRefs,
+			CreatedAt:  createdAt,
 		})
 	}
 	tree.Normalize()

--- a/server/applicationset/applicationset_test.go
+++ b/server/applicationset/applicationset_test.go
@@ -3,6 +3,7 @@ package applicationset
 import (
 	"sort"
 	"testing"
+	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	cr_fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -195,6 +196,7 @@ func newTestAppSetServerWithEnforcerConfigure(t *testing.T, f func(*rbac.Enforce
 		enforcer,
 		nil,
 		fakeAppsClientset,
+		factory.Argoproj().V1alpha1().Applications().Lister(),
 		appsetInformer,
 		factory.Argoproj().V1alpha1().ApplicationSets().Lister(),
 		nil,
@@ -729,6 +731,51 @@ func TestResourceTree(t *testing.T) {
 
 		_, err := appSetServer.ResourceTree(t.Context(), &appsetQuery)
 		assert.EqualError(t, err, "namespace 'NOT-ALLOWED' is not permitted")
+	})
+
+	t.Run("ResourceTree sets createdAt from the generated Application", func(t *testing.T) {
+		createdAt := metav1.NewTime(time.Date(2026, 6, 22, 13, 37, 43, 0, time.UTC))
+		app1 := &appsv1.Application{
+			Name:              "app1",
+			Namespace:         "default",
+			CreationTimestamp: createdAt,
+		}
+		appSetServer := newTestAppSetServer(t, appSet1, appSet2, appSet3, app1)
+
+		appsetQuery := applicationset.ApplicationSetTreeQuery{Name: "AppSet1"}
+
+		res, err := appSetServer.ResourceTree(t.Context(), &appsetQuery)
+		require.NoError(t, err)
+		require.Len(t, res.Nodes, 1)
+		require.NotNil(t, res.Nodes[0].CreatedAt)
+		assert.Equal(t, createdAt, *res.Nodes[0].CreatedAt)
+	})
+
+	t.Run("ResourceTree falls back to the AppSet namespace and leaves createdAt unset without a matching Application", func(t *testing.T) {
+		createdAt := metav1.NewTime(time.Date(2026, 6, 22, 13, 37, 43, 0, time.UTC))
+		appSet4 := newTestAppSet(func(appset *appsv1.ApplicationSet) {
+			appset.Name = "AppSet4"
+			appset.Status.Resources = []appsv1.ResourceStatus{
+				// No namespace set: must fall back to the ApplicationSet namespace.
+				{Name: "app-without-namespace", Kind: "Application", Group: "argoproj.io", Version: "v1alpha1"},
+				{Name: "app-missing", Kind: "Application", Group: "argoproj.io", Version: "v1alpha1", Namespace: "default"},
+			}
+		})
+		app := &appsv1.Application{Name: "app-without-namespace", Namespace: testNamespace, CreationTimestamp: createdAt}
+		appSetServer := newTestAppSetServer(t, appSet4, app)
+
+		res, err := appSetServer.ResourceTree(t.Context(), &applicationset.ApplicationSetTreeQuery{Name: "AppSet4"})
+		require.NoError(t, err)
+		require.Len(t, res.Nodes, 2)
+		nodesByName := map[string]appsv1.ResourceNode{}
+		for _, node := range res.Nodes {
+			nodesByName[node.Name] = node
+		}
+		require.Contains(t, nodesByName, "app-without-namespace")
+		require.NotNil(t, nodesByName["app-without-namespace"].CreatedAt)
+		assert.Equal(t, createdAt, *nodesByName["app-without-namespace"].CreatedAt)
+		require.Contains(t, nodesByName, "app-missing")
+		assert.Nil(t, nodesByName["app-missing"].CreatedAt)
 	})
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -1076,6 +1076,7 @@ func newArgoCDServiceSet(a *ArgoCDServer) *ArgoCDServiceSet {
 		a.enf,
 		a.RepoClientset,
 		a.AppClientset,
+		a.appLister,
 		a.appsetInformer,
 		a.appsetLister,
 		nil,

--- a/ui/src/app/shared/services/applications-service.ts
+++ b/ui/src/app/shared/services/applications-service.ts
@@ -1,6 +1,6 @@
 import * as deepMerge from 'deepmerge';
 import {Observable} from 'rxjs';
-import {filter, map, repeat, retry} from 'rxjs/operators';
+import {auditTime, filter, map, repeat, retry, switchMap} from 'rxjs/operators';
 
 import * as models from '../models';
 import {isValidURL} from '../utils';
@@ -123,24 +123,30 @@ export class ApplicationsService {
 
     public watchResourceTree(name: string, appNamespace: string, objectListKind: string): Observable<models.ApplicationTree> {
         const isApplication = objectListKind === 'application';
-        // ApplicationSet has no dedicated streaming resource-tree endpoint.
-        // Derive the tree from status.resources via the existing AppSet watch stream.
+        // ApplicationSet has no streaming resource-tree endpoint: re-fetch it on watch events (rate-limited, as
+        // status.resources updates can be frequent) to keep server-side fields such as createdAt, falling back
+        // to a tree derived from status.resources when the fetch fails.
         if (!isApplication) {
             return this.watch(objectListKind, {name, appNamespace}).pipe(
-                map(watchEvent => {
-                    const appset = watchEvent.application;
-                    return {
-                        nodes: (appset.status?.resources || []).map(res => ({
-                            ...res,
-                            parentRefs: [] as models.ResourceRef[],
-                            info: [] as models.InfoItem[],
-                            resourceVersion: '',
-                            uid: ''
-                        })),
-                        orphanedNodes: [],
-                        hosts: []
-                    } as models.ApplicationTree;
-                })
+                filter(watchEvent => watchEvent.type !== 'DELETED'),
+                auditTime(1000),
+                switchMap(
+                    watchEvent =>
+                        this.resourceTree(name, appNamespace, objectListKind).catch(
+                            () =>
+                                ({
+                                    nodes: (watchEvent.application.status?.resources || []).map(res => ({
+                                        ...res,
+                                        parentRefs: [] as models.ResourceRef[],
+                                        info: [] as models.InfoItem[],
+                                        resourceVersion: '',
+                                        uid: ''
+                                    })),
+                                    orphanedNodes: [],
+                                    hosts: []
+                                }) as models.ApplicationTree
+                        ) as Promise<models.ApplicationTree>
+                )
             );
         }
         return requests


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Fixes #29445

Set each node's `createdAt` from the generated Application creation timestamp via the informer-backed lister, and make the UI re-fetch the server-side tree on watch events.

The re-fetch is rate-limited on the UI side, and the tree derived from `status.resources` is used only as a fallback when the fetch fails. As a side effect, every emission is now the real server-side tree, so the Tree view no longer loses parent references after the first watch event.

<img width="1283" height="572" alt="스크린샷 2026-08-30 오후 1 06 00" src="https://github.com/user-attachments/assets/a4b88677-2a56-4148-8d08-b5cc94ce9dd4" />

<img width="1283" height="470" alt="스크린샷 2026-08-30 오후 1 12 43" src="https://github.com/user-attachments/assets/165d0704-3b54-43ee-9e5d-cc8e25f25346" />


Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
