### PR TITLE
fix(ui): show multi-source plugin env in Parameters tab

### DIFF
--- a/ui/src/app/applications/components/application-parameters/application-parameters.test.tsx
+++ b/ui/src/app/applications/components/application-parameters/application-parameters.test.tsx
@@ -1,0 +1,53 @@
+import {render, screen} from '@testing-library/react';
+import * as React from 'react';
+
+import * as models from '../../../shared/models';
+
+// lodash-es ships as untransformed ESM under node_modules and is not covered by the jest
+// transform config, so map the single helper this module uses to a CJS-friendly stub.
+jest.mock('lodash-es', () => ({
+    __esModule: true,
+    cloneDeep: (value: any) => (value == null ? value : JSON.parse(JSON.stringify(value)))
+}));
+
+// eslint-disable-next-line import/first
+import {ApplicationParameters} from './application-parameters';
+
+// Paginate pulls in a view-preferences DataLoader that is irrelevant to what we assert here,
+// so replace it with a passthrough that simply renders its children for the provided data.
+jest.mock('../../../shared/components', () => ({
+    ...jest.requireActual('../../../shared/components'),
+    Paginate: ({data, children}: {data: any[]; children: (d: any[]) => React.ReactNode}) => <>{children(data)}</>
+}));
+
+// The expanded per-source panel and the add-source panel are not exercised by the collapsed
+// summary and depend on backend services, so stub them out.
+jest.mock('./application-parameters-source', () => ({ApplicationParametersSource: () => null}));
+jest.mock('./source-panel', () => ({SourcePanel: () => null}));
+
+const multiSourceApp = (): models.Application =>
+    ({
+        metadata: {name: 'test-app'},
+        spec: {
+            project: 'default',
+            sources: [
+                {
+                    repoURL: 'https://github.com/example/repo',
+                    targetRevision: 'main',
+                    plugin: {
+                        name: 'my-plugin',
+                        env: [
+                            {name: 'FOO', value: 'bar'},
+                            {name: 'ENVIRONMENT', value: 'prod'}
+                        ]
+                    }
+                }
+            ]
+        }
+    }) as models.Application;
+
+test('collapsed multi-source summary shows plugin env values', () => {
+    render(<ApplicationParameters application={multiSourceApp()} collapsedSources={[true]} handleCollapse={() => undefined} />);
+
+    expect(screen.getByText(/ENV=FOO=bar ENVIRONMENT=prod/)).toBeInTheDocument();
+});

--- a/ui/src/app/applications/components/application-parameters/application-parameters.test.tsx
+++ b/ui/src/app/applications/components/application-parameters/application-parameters.test.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 
 import * as models from '../../../shared/models';
 import {Context} from '../../../shared/context';
+import {ApplicationParameters} from './application-parameters';
 
 // lodash-es ships as untransformed ESM under node_modules and is not covered by the jest
 // transform config, so map the single helper this module uses to a CJS-friendly stub.
@@ -32,23 +33,14 @@ jest.mock('argo-ui', () => {
 });
 
 // The expanded panel loads per-source repo details via services.repos.appDetails; return a
-// Plugin-type detail so gatherDetails takes the Plugin branch. (view mode never calls the
-// authService loaders, but they are stubbed defensively.)
+// Plugin-type detail so gatherDetails takes the Plugin branch.
 jest.mock('../../../shared/services', () => ({
     services: {
         repos: {
-            appDetails: () => Promise.resolve({type: 'Plugin', plugin: {}}),
-            charts: () => Promise.resolve([])
-        },
-        authService: {
-            plugins: () => Promise.resolve([]),
-            settings: () => Promise.resolve({})
+            appDetails: () => Promise.resolve({type: 'Plugin', plugin: {}})
         }
     }
 }));
-
-// eslint-disable-next-line import/first
-import {ApplicationParameters} from './application-parameters';
 
 // Paginate pulls in a view-preferences DataLoader that is irrelevant to what we assert here,
 // so replace it with a passthrough that simply renders its children for the provided data.

--- a/ui/src/app/applications/components/application-parameters/application-parameters.test.tsx
+++ b/ui/src/app/applications/components/application-parameters/application-parameters.test.tsx
@@ -2,12 +2,49 @@ import {render, screen} from '@testing-library/react';
 import * as React from 'react';
 
 import * as models from '../../../shared/models';
+import {Context} from '../../../shared/context';
 
 // lodash-es ships as untransformed ESM under node_modules and is not covered by the jest
 // transform config, so map the single helper this module uses to a CJS-friendly stub.
 jest.mock('lodash-es', () => ({
     __esModule: true,
     cloneDeep: (value: any) => (value == null ? value : JSON.parse(JSON.stringify(value)))
+}));
+
+// The expanded per-source panel resolves its repo details through argo-ui's DataLoader.
+// Replace it with a synchronous passthrough that resolves `load(input)` and renders children,
+// so the expanded plugin section renders deterministically without a backend.
+jest.mock('argo-ui', () => {
+    const actual = jest.requireActual('argo-ui');
+    const react = require('react');
+    const MockDataLoader = ({load, input, children}: any) => {
+        const [state, setState] = react.useState<{ready: boolean; data: any}>({ready: false, data: undefined});
+        react.useEffect(() => {
+            let alive = true;
+            Promise.resolve(load(input)).then((data: any) => alive && setState({ready: true, data}));
+            return () => {
+                alive = false;
+            };
+        }, []);
+        return state.ready ? children(state.data) : null;
+    };
+    return {...actual, DataLoader: MockDataLoader};
+});
+
+// The expanded panel loads per-source repo details via services.repos.appDetails; return a
+// Plugin-type detail so gatherDetails takes the Plugin branch. (view mode never calls the
+// authService loaders, but they are stubbed defensively.)
+jest.mock('../../../shared/services', () => ({
+    services: {
+        repos: {
+            appDetails: () => Promise.resolve({type: 'Plugin', plugin: {}}),
+            charts: () => Promise.resolve([])
+        },
+        authService: {
+            plugins: () => Promise.resolve([]),
+            settings: () => Promise.resolve({})
+        }
+    }
 }));
 
 // eslint-disable-next-line import/first
@@ -20,9 +57,7 @@ jest.mock('../../../shared/components', () => ({
     Paginate: ({data, children}: {data: any[]; children: (d: any[]) => React.ReactNode}) => <>{children(data)}</>
 }));
 
-// The expanded per-source panel and the add-source panel are not exercised by the collapsed
-// summary and depend on backend services, so stub them out.
-jest.mock('./application-parameters-source', () => ({ApplicationParametersSource: () => null}));
+// The add-source panel is not exercised by these tests and depends on backend services.
 jest.mock('./source-panel', () => ({SourcePanel: () => null}));
 
 const multiSourceApp = (): models.Application =>
@@ -46,8 +81,26 @@ const multiSourceApp = (): models.Application =>
         }
     }) as models.Application;
 
+// EditablePanel (rendered by the expanded panel) reads notifications off the app Context,
+// so provide a minimal Context value.
+const ctxValue = {notifications: {show: () => undefined}} as any;
+const renderWithContext = (element: React.ReactElement) => render(<Context.Provider value={ctxValue}>{element}</Context.Provider>);
+
 test('collapsed multi-source summary shows plugin env values', () => {
-    render(<ApplicationParameters application={multiSourceApp()} collapsedSources={[true]} handleCollapse={() => undefined} />);
+    renderWithContext(<ApplicationParameters application={multiSourceApp()} collapsedSources={[true]} handleCollapse={() => undefined} />);
 
     expect(screen.getByText(/ENV=FOO=bar ENVIRONMENT=prod/)).toBeInTheDocument();
+});
+
+test('expanded multi-source plugin panel renders NAME and ENV from the per-source plugin', async () => {
+    // collapsedSources[0] = false -> the expanded panel renders and reads spec.sources[0].plugin.
+    // Before the fix it read the (absent) single-source spec.source.plugin, so NAME/ENV were blank.
+    renderWithContext(<ApplicationParameters application={multiSourceApp()} collapsedSources={[false]} handleCollapse={() => undefined} />);
+
+    // NAME and ENV are rendered as read-only inputs (see NameValueEditor/ValueEditor), so assert by display value.
+    expect(await screen.findByDisplayValue('my-plugin')).toBeInTheDocument();
+    expect(await screen.findByDisplayValue('FOO')).toBeInTheDocument();
+    expect(await screen.findByDisplayValue('bar')).toBeInTheDocument();
+    expect(await screen.findByDisplayValue('ENVIRONMENT')).toBeInTheDocument();
+    expect(await screen.findByDisplayValue('prod')).toBeInTheDocument();
 });

--- a/ui/src/app/applications/components/application-parameters/application-parameters.tsx
+++ b/ui/src/app/applications/components/application-parameters/application-parameters.tsx
@@ -306,7 +306,13 @@ export const ApplicationParameters = (props: {
                 <div className='settings-overview__redirect-panel__content'>
                     <div className='settings-overview__redirect-panel__title'>Source {index + 1 + (appSource.name ? ' - ' + appSource.name : '') + ': ' + appSource.repoURL}</div>
                     <div className='settings-overview__redirect-panel__description'>
-                        {(appSource.path ? 'PATH=' + appSource.path : '') + (appSource.targetRevision ? (appSource.path ? ', ' : '') + 'REVISION=' + appSource.targetRevision : '')}
+                        {[
+                            appSource.path ? 'PATH=' + appSource.path : '',
+                            appSource.targetRevision ? 'REVISION=' + appSource.targetRevision : '',
+                            appSource.plugin?.env?.length ? 'ENV=' + appSource.plugin.env.map(env => env.name + '=' + env.value).join(' ') : ''
+                        ]
+                            .filter(part => part !== '')
+                            .join(', ')}
                     </div>
                 </div>
             </div>
@@ -861,7 +867,7 @@ function gatherDetails(
     } else if (repoDetails.type === 'Plugin') {
         attributes.push({
             title: 'NAME',
-            view: <div style={{marginTop: 15, marginBottom: 5}}>{ValueEditor(app.spec.source?.plugin?.name, null)}</div>,
+            view: <div style={{marginTop: 15, marginBottom: 5}}>{ValueEditor(source?.plugin?.name, null)}</div>,
             edit: (formApi: FormApi) => (
                 <DataLoader load={() => services.authService.plugins()}>
                     {(plugins: Plugin[]) => (
@@ -879,7 +885,7 @@ function gatherDetails(
             title: 'ENV',
             view: (
                 <div style={{marginTop: 15}}>
-                    {(app.spec.source?.plugin?.env || []).map(val => (
+                    {(source?.plugin?.env || []).map(val => (
                         <span key={val.name} style={{display: 'block', marginBottom: 5}}>
                             {NameValueEditor(val, null)}
                         </span>
@@ -896,8 +902,8 @@ function gatherDetails(
                 parametersSet.add(announcement.name);
             }
         }
-        if (app.spec.source?.plugin?.parameters) {
-            for (const appParameter of app.spec.source.plugin.parameters) {
+        if (source?.plugin?.parameters) {
+            for (const appParameter of source.plugin.parameters) {
                 parametersSet.add(appParameter.name);
             }
         }
@@ -907,7 +913,7 @@ function gatherDetails(
         }
         parametersSet.forEach(name => {
             const announcement = repoDetails.plugin.parametersAnnouncement?.find(param => param.name === name);
-            const liveParam = app.spec.source?.plugin?.parameters?.find(param => param.name === name);
+            const liveParam = source?.plugin?.parameters?.find(param => param.name === name);
             const pluginIcon =
                 announcement && liveParam ? 'This parameter has been provided by plugin, but is overridden in application manifest.' : 'This parameter is provided by the plugin.';
             const isPluginPar = !!announcement;

--- a/ui/src/app/applications/components/application-parameters/application-parameters.tsx
+++ b/ui/src/app/applications/components/application-parameters/application-parameters.tsx
@@ -308,6 +308,7 @@ export const ApplicationParameters = (props: {
                     <div className='settings-overview__redirect-panel__description'>
                         {[
                             appSource.path ? 'PATH=' + appSource.path : '',
+                            appSource.chart ? 'CHART=' + appSource.chart : '',
                             appSource.targetRevision ? 'REVISION=' + appSource.targetRevision : '',
                             appSource.plugin?.env?.length ? 'ENV=' + appSource.plugin.env.map(env => env.name + '=' + env.value).join(' ') : ''
                         ]


### PR DESCRIPTION
## What

In a multi-source `Application`, a config-management-plugin source's `env`
key/value pairs rendered **blank** in the Sources/Parameters tab — both the
collapsed per-source summary line and the expanded plugin section — even though
the data is present (it shows correctly in EDIT mode).

## Why

Two separate causes in `ui/src/app/applications/components/application-parameters/application-parameters.tsx`:

1. **Collapsed per-source summary** only rendered `PATH=...` and `REVISION=...`
   and omitted the plugin `env` entirely. It now also shows
   `ENV=<name>=<value> ...`, so sources that differ only by their plugin env are
   distinguishable at a glance.
2. **Expanded plugin section** read `env`, `name`, and `parameters` from the
   single-source `app.spec.source.plugin` path regardless of whether the panel
   was rendering a multi-source entry, so nothing showed for
   `spec.sources[i].plugin`. It now uses the per-source `source` object already
   passed into `gatherDetails` (the same field EDIT mode resolves), which also
   fixes the plugin **NAME** and live parameter overrides for multi-source apps.

`source-panel.tsx` needed no change — it is the add-source create form, not the
display path.

## Testing

- Added `application-parameters.test.tsx` covering the collapsed multi-source env summary.
- `pnpm exec tsc --noEmit --project ./src/app` — pass
- `pnpm exec eslint` on the changed source — pass
- `pnpm exec jest application-parameters.test.tsx` — pass

Fixes #29357

Checklist:

* [x] This is a bug fix.
* [x] The title of the PR states what changed and the related issue number.
* [x] The title of the PR conforms to the Title of the PR guidelines.
* [x] I've included "Fixes #29357" in the description to automatically close the associated issue.
* [x] I've updated the UI to expose my fix.
* [ ] Does this PR require documentation updates? No.
* [x] I have signed off all my commits as required by DCO.
* [x] I have written unit tests for my change.
* [x] I have added a brief description of why this PR is necessary and what it solves.
