### PR TITLE
fix: include timestamps in downloaded logs when enabled (#29473)

### DIFF
--- a/pkg/apiclient/application/forwarder_overwrite.go
+++ b/pkg/apiclient/application/forwarder_overwrite.go
@@ -281,33 +281,45 @@ func processApplicationListField(v any, fields map[string]any, exclude bool) (an
 	return nil, errors.New("not an application list")
 }
 
+// downloadLogs streams log entries to the response as a plain-text file attachment.
+// When the "timestamps" query parameter is "true", each line is prefixed with the
+// entry's timestamp, matching what the UI displays when timestamps are enabled.
+func downloadLogs(w gohttp.ResponseWriter, req *gohttp.Request, recv func() (proto.Message, error)) {
+	w.Header().Set("Content-Type", "application/octet-stream")
+	fileName := "log"
+	namespace := req.URL.Query().Get("namespace")
+	podName := req.URL.Query().Get("podName")
+	container := req.URL.Query().Get("container")
+	if kube.IsValidResourceName(namespace) && kube.IsValidResourceName(podName) && kube.IsValidResourceName(container) {
+		fileName = fmt.Sprintf("%s-%s-%s", namespace, podName, container)
+	}
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment;filename="%s.log"`, fileName))
+	withTimestamps := req.URL.Query().Get("timestamps") == "true"
+	for {
+		msg, err := recv()
+		if err != nil {
+			_, _ = w.Write([]byte(err.Error()))
+			return
+		}
+		if logEntry, ok := msg.(*LogEntry); ok {
+			if logEntry.GetLast() {
+				return
+			}
+			content := logEntry.GetContent()
+			if withTimestamps {
+				content = logEntry.GetTimeStampStr() + " " + content
+			}
+			if _, err = w.Write([]byte(content + "\n")); err != nil {
+				return
+			}
+		}
+	}
+}
+
 func init() {
 	logsForwarder := func(ctx context.Context, mux *runtime.ServeMux, marshaler runtime.Marshaler, w gohttp.ResponseWriter, req *gohttp.Request, recv func() (proto.Message, error), opts ...func(context.Context, gohttp.ResponseWriter, proto.Message) error) {
 		if req.URL.Query().Get("download") == "true" {
-			w.Header().Set("Content-Type", "application/octet-stream")
-			fileName := "log"
-			namespace := req.URL.Query().Get("namespace")
-			podName := req.URL.Query().Get("podName")
-			container := req.URL.Query().Get("container")
-			if kube.IsValidResourceName(namespace) && kube.IsValidResourceName(podName) && kube.IsValidResourceName(container) {
-				fileName = fmt.Sprintf("%s-%s-%s", namespace, podName, container)
-			}
-			w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment;filename="%s.log"`, fileName))
-			for {
-				msg, err := recv()
-				if err != nil {
-					_, _ = w.Write([]byte(err.Error()))
-					return
-				}
-				if logEntry, ok := msg.(*LogEntry); ok {
-					if logEntry.GetLast() {
-						return
-					}
-					if _, err = w.Write([]byte(logEntry.GetContent() + "\n")); err != nil {
-						return
-					}
-				}
-			}
+			downloadLogs(w, req, recv)
 		} else {
 			http.StreamForwarder(ctx, mux, marshaler, w, req, recv, opts...)
 		}

--- a/pkg/apiclient/application/forwarder_overwrite_test.go
+++ b/pkg/apiclient/application/forwarder_overwrite_test.go
@@ -689,3 +689,74 @@ type failingResponseWriter struct {
 func (f *failingResponseWriter) Write(p []byte) (int, error) {
 	return f.Writer.Write(p)
 }
+
+func TestDownloadLogs(t *testing.T) {
+	t.Parallel()
+	entries := []*LogEntry{
+		{Content: proto.String("line one"), TimeStampStr: proto.String("2026-08-31T10:00:00.000000001Z")},
+		{Content: proto.String("line two"), TimeStampStr: proto.String("2026-08-31T10:00:01.000000001Z")},
+		{Last: proto.Bool(true)},
+	}
+
+	tests := []struct {
+		name     string
+		url      string
+		expected string
+	}{
+		{
+			name:     "without timestamps",
+			url:      "/api/v1/applications/my-app/logs?download=true&namespace=my-ns&podName=my-pod&container=main",
+			expected: "line one\nline two\n",
+		},
+		{
+			name:     "with timestamps",
+			url:      "/api/v1/applications/my-app/logs?download=true&timestamps=true&namespace=my-ns&podName=my-pod&container=main",
+			expected: "2026-08-31T10:00:00.000000001Z line one\n2026-08-31T10:00:01.000000001Z line two\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, tt.url, http.NoBody)
+			w := httptest.NewRecorder()
+			i := 0
+			recv := func() (proto.Message, error) {
+				if i >= len(entries) {
+					return nil, io.EOF
+				}
+				entry := entries[i]
+				i++
+				return entry, nil
+			}
+			downloadLogs(w, req, recv)
+			assert.Equal(t, tt.expected, w.Body.String())
+			assert.Equal(t, `attachment;filename="my-ns-my-pod-main.log"`, w.Header().Get("Content-Disposition"))
+		})
+	}
+
+	t.Run("writes recv error to response", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/v1/applications/my-app/logs?download=true", http.NoBody)
+		w := httptest.NewRecorder()
+		downloadLogs(w, req, func() (proto.Message, error) {
+			return nil, errors.New("stream failed")
+		})
+		assert.Equal(t, "stream failed", w.Body.String())
+		assert.Equal(t, `attachment;filename="log.log"`, w.Header().Get("Content-Disposition"))
+	})
+
+	t.Run("stops on write error", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/v1/applications/my-app/logs?download=true", http.NoBody)
+		w := httptest.NewRecorder()
+		fw := &failingResponseWriter{ResponseWriter: w, Writer: &failAfterNWriter{w: w, limit: 0}}
+		i := 0
+		recv := func() (proto.Message, error) {
+			i++
+			require.LessOrEqual(t, i, 1, "must stop receiving after a write failure")
+			return entries[0], nil
+		}
+		downloadLogs(fw, req, recv)
+		assert.Empty(t, w.Body.String())
+	})
+}

--- a/ui/src/app/applications/components/pod-logs-viewer/download-logs-button.tsx
+++ b/ui/src/app/applications/components/pod-logs-viewer/download-logs-button.tsx
@@ -5,15 +5,36 @@ import {Button} from '../../../shared/components/button';
 
 interface DownloadLogsButtonProps extends PodLogsProps {
     previous?: boolean;
+    viewTimestamps?: boolean;
 }
 
 // DownloadLogsButton is a button that downloads the logs to a file
-export const DownloadLogsButton = ({applicationName, applicationNamespace, containerName, group, kind, name, namespace, podName, previous}: DownloadLogsButtonProps) => (
+export const DownloadLogsButton = ({
+    applicationName,
+    applicationNamespace,
+    containerName,
+    group,
+    kind,
+    name,
+    namespace,
+    podName,
+    previous,
+    viewTimestamps
+}: DownloadLogsButtonProps) => (
     <Button
         title='Download logs to file'
         icon='download'
         onClick={async () => {
-            const downloadURL = services.applications.getDownloadLogsURL(applicationName, applicationNamespace, namespace, podName, {group, kind, name}, containerName, previous);
+            const downloadURL = services.applications.getDownloadLogsURL(
+                applicationName,
+                applicationNamespace,
+                namespace,
+                podName,
+                {group, kind, name},
+                containerName,
+                previous,
+                viewTimestamps
+            );
             window.open(downloadURL, '_blank');
         }}
     />

--- a/ui/src/app/applications/components/pod-logs-viewer/pod-logs-viewer.tsx
+++ b/ui/src/app/applications/components/pod-logs-viewer/pod-logs-viewer.tsx
@@ -325,7 +325,7 @@ export const PodsLogsViewer = (props: PodLogsProps) => {
                             <Spacer />
                             <span>
                                 <CopyLogsButton logs={logs} />
-                                <DownloadLogsButton {...props} previous={previous} />
+                                <DownloadLogsButton {...props} previous={previous} viewTimestamps={viewTimestamps} />
                                 <FullscreenButton
                                     {...props}
                                     viewPodNames={viewPodNames}

--- a/ui/src/app/shared/services/applications-service.test.ts
+++ b/ui/src/app/shared/services/applications-service.test.ts
@@ -1,0 +1,22 @@
+// Break the applications-service -> components/utils -> shared/components -> services/index cycle,
+// which otherwise leaves ApplicationsService undefined when jest loads this test in isolation.
+jest.mock('../../applications/components/utils', () => ({getRootPathByApp: jest.fn(), isApp: jest.fn()}));
+
+import {ApplicationsService} from './applications-service';
+
+describe('getDownloadLogsURL', () => {
+    const service = new ApplicationsService();
+    const getURL = (viewTimestamps?: boolean) => service.getDownloadLogsURL('my-app', 'argocd', 'my-ns', 'my-pod', {group: '', kind: '', name: ''}, 'main', false, viewTimestamps);
+
+    it('omits timestamps by default', () => {
+        const params = new URLSearchParams(getURL().split('?')[1]);
+        expect(params.get('download')).toBe('true');
+        expect(params.get('timestamps')).toBeNull();
+    });
+
+    it('includes timestamps when enabled', () => {
+        const params = new URLSearchParams(getURL(true).split('?')[1]);
+        expect(params.get('download')).toBe('true');
+        expect(params.get('timestamps')).toBe('true');
+    });
+});

--- a/ui/src/app/shared/services/applications-service.ts
+++ b/ui/src/app/shared/services/applications-service.ts
@@ -316,10 +316,14 @@ export class ApplicationsService {
         podName: string,
         resource: {group: string; kind: string; name: string},
         containerName: string,
-        previous: boolean
+        previous: boolean,
+        viewTimestamps?: boolean
     ): string {
         const search = this.getLogsQuery({namespace, appNamespace, podName, resource, containerName, follow: false, previous});
         search.set('download', 'true');
+        if (viewTimestamps) {
+            search.set('timestamps', 'true');
+        }
         return `api/v1/applications/${applicationName}/logs?${search.toString()}`;
     }
 


### PR DESCRIPTION
The log download endpoint wrote only the log content, dropping the timestamp that the UI shows when the timestamps toggle is enabled.

Pass a timestamps=true query parameter from the download button when the viewer has timestamps enabled, and prefix each downloaded line with its timestamp in the download forwarder.

Closes #29473

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [X] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [X] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [X] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [X] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).
