### PR TITLE
chore: rxjs retry when migration

### DIFF
--- a/ui/src/app/applications/components/application-details/application-details.tsx
+++ b/ui/src/app/applications/components/application-details/application-details.tsx
@@ -5,7 +5,7 @@ import * as ReactDOM from 'react-dom';
 import * as models from '../../../shared/models';
 import {RouteComponentProps} from 'react-router';
 import {BehaviorSubject, combineLatest, from, merge, Observable} from 'rxjs';
-import {delay, filter, map, mergeMap, repeat, retryWhen} from 'rxjs/operators';
+import {filter, map, mergeMap, repeat, retry} from 'rxjs/operators';
 
 import {DataLoader, EmptyState, ErrorNotification, ObservableQuery, Page, Paginate, Revision, Timestamp} from '../../../shared/components';
 import {AppContext, Context, ContextApis} from '../../../shared/context';
@@ -1537,7 +1537,7 @@ Are you sure you want to disable auto-sync and rollback application '${props.mat
                                             })
                                         )
                                         .pipe(repeat())
-                                        .pipe(retryWhen(errors => errors.pipe(delay(500))))
+                                        .pipe(retry({delay: 500}))
                                 )
                             ),
                             merge(
@@ -1547,7 +1547,7 @@ Are you sure you want to disable auto-sync and rollback application '${props.mat
                                     services.applications
                                         .watchResourceTree(name, appNamespace, objectListKind)
                                         .pipe(repeat())
-                                        .pipe(retryWhen(errors => errors.pipe(delay(500))))
+                                        .pipe(retry({delay: 500}))
                                 )
                             )
                         );

--- a/ui/src/app/applications/components/applications-list/application-sets-list.tsx
+++ b/ui/src/app/applications/components/applications-list/application-sets-list.tsx
@@ -4,7 +4,7 @@ import * as ReactDOM from 'react-dom';
 import {Key, KeybindingContext, KeybindingProvider, NumKey, NumKeyToNumber, NumPadKey, useNav} from 'argo-ui/v2';
 import {RouteComponentProps} from 'react-router';
 import {combineLatest, from, merge, Observable} from 'rxjs';
-import {bufferTime, delay, filter, map, mergeMap, repeat, retryWhen} from 'rxjs/operators';
+import {bufferTime, filter, map, mergeMap, repeat, retry} from 'rxjs/operators';
 import {DataLoader, EmptyState, Page, Paginate, SearchBar} from '../../../shared/components';
 import {AuthSettingsCtx, Consumer, Context, ContextApis} from '../../../shared/context';
 import * as models from '../../../shared/models';
@@ -54,7 +54,7 @@ function loadApplicationSets(projects: string[]): Observable<models.ApplicationS
                 services.applications
                     .watch('applicationset', {projects, resourceVersion: applicationsList.metadata.resourceVersion}, {fields: APPSET_WATCH_FIELDS})
                     .pipe(repeat())
-                    .pipe(retryWhen(errors => errors.pipe(delay(WATCH_RETRY_TIMEOUT))))
+                    .pipe(retry({delay: WATCH_RETRY_TIMEOUT}))
                     .pipe(bufferTime(EVENTS_BUFFER_TIMEOUT))
                     .pipe(
                         map(appChanges => {

--- a/ui/src/app/applications/components/applications-list/applications-list.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-list.tsx
@@ -4,7 +4,7 @@ import * as ReactDOM from 'react-dom';
 import {KeybindingProvider} from 'argo-ui/v2';
 import {RouteComponentProps} from 'react-router';
 import {combineLatest, from, merge, Observable} from 'rxjs';
-import {bufferTime, delay, filter, map, mergeMap, repeat, retryWhen} from 'rxjs/operators';
+import {bufferTime, filter, map, mergeMap, repeat, retry} from 'rxjs/operators';
 import {ClusterCtx, DataLoader, EmptyState, Page, Paginate, SearchBar, Spinner} from '../../../shared/components';
 import {AuthSettingsCtx, Consumer, ContextApis} from '../../../shared/context';
 import * as models from '../../../shared/models';
@@ -69,7 +69,7 @@ function loadApplications(projects: string[], appNamespace: string): Observable<
                 services.applications
                     .watch('application', {projects, resourceVersion: applicationsList.metadata.resourceVersion}, {fields: APP_WATCH_FIELDS})
                     .pipe(repeat())
-                    .pipe(retryWhen(errors => errors.pipe(delay(WATCH_RETRY_TIMEOUT))))
+                    .pipe(retry({delay: WATCH_RETRY_TIMEOUT}))
                     // batch events to avoid constant re-rendering and improve UI performance
                     .pipe(bufferTime(EVENTS_BUFFER_TIMEOUT))
                     .pipe(

--- a/ui/src/app/applications/components/pod-logs-viewer/pod-logs-viewer.tsx
+++ b/ui/src/app/applications/components/pod-logs-viewer/pod-logs-viewer.tsx
@@ -2,7 +2,7 @@ import {DataLoader} from 'argo-ui';
 import classNames from 'classnames';
 import * as React from 'react';
 import {useEffect, useMemo, useState, useRef} from 'react';
-import {bufferTime, catchError, delay, retryWhen} from 'rxjs/operators';
+import {bufferTime, catchError, retry} from 'rxjs/operators';
 
 import {LogEntry} from '../../../shared/models';
 import {services, ViewPreferences} from '../../../shared/services';
@@ -205,7 +205,7 @@ export const PodsLogsViewer = (props: PodLogsProps) => {
                         }
                     }
                 }),
-                retryWhen(errors => errors.pipe(delay(500)))
+                retry({delay: 500})
             )
             .subscribe(log => {
                 if (log.length) {

--- a/ui/src/app/resources/components/resources-list/resources-details-panel.tsx
+++ b/ui/src/app/resources/components/resources-list/resources-details-panel.tsx
@@ -1,7 +1,7 @@
 import {SlidingPanel} from 'argo-ui';
 import * as React from 'react';
 import {combineLatest, from, merge} from 'rxjs';
-import {delay, map, mergeMap, repeat, retryWhen} from 'rxjs/operators';
+import {map, mergeMap, repeat, retry} from 'rxjs/operators';
 import {DataLoader} from '../../../shared/components';
 import {AppContext, Context} from '../../../shared/context';
 import * as appModels from '../../../shared/models';
@@ -73,7 +73,7 @@ export const ResourcesDetailsPanel = (props: {node: string | null; detailsApp: s
                             services.applications
                                 .watchResourceTree(appName, appNamespace, 'application')
                                 .pipe(repeat())
-                                .pipe(retryWhen(errors => errors.pipe(delay(500))))
+                                .pipe(retry({delay: 500}))
                         )
                     )
                 ]).pipe(map(([app, tree]) => ({application: app, tree: tree || fallbackTree})));

--- a/ui/src/app/resources/components/resources-list/resources-list.tsx
+++ b/ui/src/app/resources/components/resources-list/resources-list.tsx
@@ -4,7 +4,7 @@ import * as ReactDOM from 'react-dom';
 import {KeybindingProvider} from 'argo-ui/v2';
 import {RouteComponentProps} from 'react-router';
 import {combineLatest, from, merge, Observable} from 'rxjs';
-import {bufferTime, delay, filter, map, mergeMap, repeat, retryWhen} from 'rxjs/operators';
+import {bufferTime, filter, map, mergeMap, repeat, retry} from 'rxjs/operators';
 import {ClusterCtx, DataLoader, EmptyState, FlexTopBar, Page, Paginate, Query, SearchBar} from '../../../shared/components';
 import {Consumer, ContextApis} from '../../../shared/context';
 import {useObservableQuery} from '../../../shared/hooks/query';
@@ -45,7 +45,7 @@ function loadApplications(projects: string[], appNamespace: string): Observable<
                 services.applications
                     .watch('application', {projects, resourceVersion: applicationsList.metadata.resourceVersion}, {fields: APP_WATCH_FIELDS})
                     .pipe(repeat())
-                    .pipe(retryWhen(errors => errors.pipe(delay(WATCH_RETRY_TIMEOUT))))
+                    .pipe(retry({delay: WATCH_RETRY_TIMEOUT}))
                     // batch events to avoid constant re-rendering and improve UI performance
                     .pipe(bufferTime(EVENTS_BUFFER_TIMEOUT))
                     .pipe(


### PR DESCRIPTION
  The `retryWhen` operator was **deprecated in rxjs v7** and is **scheduled for removal in v8** ([rxjs docs — Breaking changes → retryWhen](https://rxjs.dev/deprecations/breaking-changes#retrywhen)). All six
  existing call sites use the same simple pattern — "retry indefinitely with a fixed delay after every error" — which maps one-to-one onto rxjs 7's `retry({ delay: N })`: