### PR TITLE
fix: handle already deleted resources

### DIFF
--- a/ui/src/app/applications/components/utils.test.tsx
+++ b/ui/src/app/applications/components/utils.test.tsx
@@ -25,8 +25,11 @@ import {
     HealthStatusIcon,
     nameConfirmationError,
     OperationState,
+    deletePopup,
     ResourceResultIcon
 } from './utils';
+import {NotificationType} from 'argo-ui';
+import {services} from '../../shared/services';
 
 const zero = new Date(0).toISOString();
 
@@ -1107,5 +1110,134 @@ describe('getApplicationDetailsContainerClass', () => {
         expect(classes).toContain('user-app-login');
         // ...and must NOT emit a bare `login` class that would pull in the login page's `.login` styles.
         expect(classes).not.toContain('login');
+    });
+});
+
+describe('deletePopup', () => {
+    const application = {
+        kind: 'Application',
+        metadata: {
+            name: 'test-app',
+            namespace: 'default'
+        }
+    } as Application;
+
+    const resource = {
+        kind: 'Deployment',
+        name: 'test-deployment',
+        namespace: 'default',
+        group: 'apps',
+        version: 'v1'
+    } as any;
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('shows a success notification and closes on 404 (already deleted)', async () => {
+        const notifications = {show: jest.fn()};
+        let submit: any;
+
+        const ctx = {
+            notifications,
+            popup: {
+                prompt: jest.fn((_title: any, _content: any, options: any) => {
+                    submit = options.submit;
+                })
+            }
+        } as any;
+
+        jest.spyOn(services.applications, 'deleteResource').mockRejectedValueOnce({status: 404});
+
+        await deletePopup(ctx, resource, application, true, []);
+
+        const close = jest.fn();
+
+        await submit({}, {}, close);
+
+        expect(notifications.show).toHaveBeenCalledWith({
+            content: 'Resource already deleted',
+            type: NotificationType.Success
+        });
+        expect(close).toHaveBeenCalled();
+    });
+
+    it('shows an error notification on non-404 failures', async () => {
+        const notifications = {show: jest.fn()};
+        let submit: any;
+
+        const ctx = {
+            notifications,
+            popup: {
+                prompt: jest.fn((_title: any, _content: any, options: any) => {
+                    submit = options.submit;
+                })
+            }
+        } as any;
+
+        jest.spyOn(services.applications, 'deleteResource').mockRejectedValueOnce({status: 500});
+
+        await deletePopup(ctx, resource, application, true, []);
+
+        const close = jest.fn();
+
+        await submit({}, {}, close);
+
+        expect(notifications.show).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: NotificationType.Error
+            })
+        );
+        expect(close).not.toHaveBeenCalled();
+    });
+});
+
+describe('deletePopup for unmanaged Pods', () => {
+    const application = {
+        kind: 'Application',
+        metadata: {
+            name: 'test-app',
+            namespace: 'default'
+        }
+    } as Application;
+
+    const pod = {
+        kind: 'Pod',
+        name: 'test-pod',
+        namespace: 'default',
+        group: '',
+        version: 'v1'
+    } as any;
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('treats a 404 as already-deleted success', async () => {
+        const notifications = {show: jest.fn()};
+        let submit: any;
+
+        const ctx = {
+            notifications,
+            popup: {
+                prompt: jest.fn((_title: any, _content: any, options: any) => {
+                    submit = options.submit;
+                })
+            }
+        } as any;
+
+        jest.spyOn(services.applications, 'deleteResource').mockRejectedValueOnce({status: 404});
+
+        await deletePopup(ctx, pod, application, false, []);
+
+        const close = jest.fn();
+
+        await submit({force: false}, {}, close);
+
+        expect(notifications.show).toHaveBeenCalledWith({
+            content: 'Resource already deleted',
+            type: NotificationType.Success
+        });
+        expect(close).toHaveBeenCalled();
     });
 });

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -638,6 +638,14 @@ export const deletePopup = async (
                     }
                     close();
                 } catch (e) {
+                    if (e.status === 404) {
+                        ctx.notifications.show({
+                            content: 'Resource already deleted',
+                            type: NotificationType.Success
+                        });
+                        close();
+                        return;
+                    }
                     ctx.notifications.show({
                         content: <ErrorNotification title='Unable to delete resource' e={e} />,
                         type: NotificationType.Error

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -450,6 +450,16 @@ const deletePodAction = async (ctx: ContextApis, pod: appModels.ResourceNode, ap
                     await services.applications.deleteResource(app.metadata.name, app.metadata.namespace, pod, !!vals.force, false);
                     close();
                 } catch (e) {
+                    // A 404 means the resource is already gone, so treat the deletion as successful.
+                    if (e.status === 404) {
+                        ctx.notifications.show({
+                            content: 'Resource already deleted',
+                            type: NotificationType.Success
+                        });
+                        close();
+                        return;
+                    }
+
                     ctx.notifications.show({
                         content: <ErrorNotification title='Unable to delete resource' e={e} />,
                         type: NotificationType.Error
@@ -632,12 +642,8 @@ export const deletePopup = async (
                 const orphan = deleteOptions.option === 'orphan';
                 try {
                     await services.applications.deleteResource(application.metadata.name, application.metadata.namespace, resource, !!force, !!orphan);
-                    if (appChanged) {
-                        const objectListKind = isApp(application) ? 'application' : 'applicationset';
-                        appChanged.next(await services.applications.get(application.metadata.name, application.metadata.namespace, objectListKind));
-                    }
-                    close();
                 } catch (e) {
+                    // A 404 means the resource is already gone, so treat the deletion as successful.
                     if (e.status === 404) {
                         ctx.notifications.show({
                             content: 'Resource already deleted',
@@ -646,11 +652,27 @@ export const deletePopup = async (
                         close();
                         return;
                     }
+
                     ctx.notifications.show({
                         content: <ErrorNotification title='Unable to delete resource' e={e} />,
                         type: NotificationType.Error
                     });
+                    return;
                 }
+
+                if (appChanged) {
+                    try {
+                        const objectListKind = isApp(application) ? 'application' : 'applicationset';
+                        appChanged.next(await services.applications.get(application.metadata.name, application.metadata.namespace, objectListKind));
+                    } catch (e) {
+                        ctx.notifications.show({
+                            content: <ErrorNotification title='Unable to delete resource' e={e} />,
+                            type: NotificationType.Error
+                        });
+                        return;
+                    }
+                }
+                close();
             }
         },
         {name: 'argo-icon-warning', color: 'warning'},


### PR DESCRIPTION
## What does this PR do?

When a resource is deleted or recreated before the deletion is confirmed in the application resource tree, the UI can send a delete request using stale resource information. If the resource is already gone, the API returns `404 Not Found` and the UI currently reports this as an error.

This PR treats a `404 Not Found` response from the resource deletion request as an already-completed deletion.

The UI now:
- Treats `404 Not Found` responses during resource deletion as successful deletion.
- Shows a `Resource already deleted` success notification.
- Closes the delete confirmation popup.
- Preserves the existing error handling for other failures.
- Covers both regular resources and unmanaged Pods.

## Testing

Added regression tests covering:
- A resource deletion returning `404` is treated as already deleted.
- Non-`404` deletion failures still show an error notification.
- An unmanaged Pod deletion returning `404` is treated as already deleted.

Tested with:

- `pnpm exec jest --runInBand src/app/applications/components/utils.test.tsx`
- `pnpm lint`

## Checklist

- [x] Either (a) I've created an enhancement proposal and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be discussed.
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [x] The title of the PR conforms to the Title of the PR.
- [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
- [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
- [x] Does this PR require documentation updates?
- [ ] I've updated documentation as required by this PR.
- [x] I have signed off all my commits as required by DCO.
- [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
- [ ] My build is green (troubleshooting builds).
- [ ] My new feature complies with the feature status guidelines.
- [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
- [ ] Optional. My organization is added to USERS.md.
- [x] Optional. For bug fixes, I've indicated what older releases this should be cherry-picked into (this may or may not happen depending on risk/complexity).