### PR TITLE
chore: fix typos in comments and two user-facing messages

### DIFF
--- a/controller/sharding/cache.go
+++ b/controller/sharding/cache.go
@@ -252,7 +252,7 @@ func (sharding *ClusterSharding) UpdateApp(a *v1alpha1.Application) {
 	}
 }
 
-// GetAppDistribution should be not be called from a DestributionFunction because
+// GetAppDistribution should be not be called from a DistributionFunction because
 // it could cause a deadlock when updateDistribution is called.
 func (sharding *ClusterSharding) GetAppDistribution() map[string]int {
 	sharding.lock.RLock()

--- a/controller/sharding/sharding.go
+++ b/controller/sharding/sharding.go
@@ -81,7 +81,7 @@ func GetClusterFilter(_ db.ArgoDB, distributionFunction DistributionFunction, re
 }
 
 // GetDistributionFunction returns which DistributionFunction should be used based on the passed algorithm and
-// the current datas.
+// the current data.
 func GetDistributionFunction(clusters clusterAccessor, apps appAccessor, shardingAlgorithm string, replicasCount int) DistributionFunction {
 	log.Debugf("Using filter function:  %s", shardingAlgorithm)
 	distributionFunction := LegacyDistributionFunction(replicasCount)


### PR DESCRIPTION
Spelling fixes I picked up while reading through the applicationset and sharding code:

- comments: `lables`, `trigerred`, `vaildation`, `atleast`, `triggerd`, `patten`
- `argocd app` error text: `needs atleast repoUrl` -> `needs at least repoUrl`
- sharding warning log: `is greated than` -> `is greater than`

I left the exported `common.PasswordPatten` identifier alone and only corrected the trailing word in its doc comment, since renaming it would be an API change.

No functional change.