### PR TITLE
chore: fix typos in comments and two user-facing messages

### DIFF
--- a/applicationset/generators/pull_request.go
+++ b/applicationset/generators/pull_request.go
@@ -112,7 +112,7 @@ func (g *PullRequestGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha
 			"author":             pull.Author,
 		}
 
-		// PR lables will only be supported for Go Template appsets, since fasttemplate will be deprecated.
+		// PR labels will only be supported for Go Template appsets, since fasttemplate will be deprecated.
 		if applicationSetInfo != nil && applicationSetInfo.Spec.GoTemplate {
 			paramMap["labels"] = pull.Labels
 		}

--- a/applicationset/progressivesync/progressive_sync.go
+++ b/applicationset/progressivesync/progressive_sync.go
@@ -502,7 +502,7 @@ func (m *Manager) UpdateApplicationSetApplicationStatus(ctx context.Context, log
 			if currentAppStatus.Status == argov1alpha1.ProgressiveSyncPending {
 				// No need to evaluate status health further if the application did not change since our last transition
 				if app.Status.ReconciledAt == nil || (newAppStatus.LastTransitionTime != nil && app.Status.ReconciledAt.After(newAppStatus.LastTransitionTime.Time)) {
-					// Validate that at least one sync was trigerred after the pending transition time
+					// Validate that at least one sync was triggered after the pending transition time
 					if app.Status.OperationState != nil && app.Status.OperationState.StartedAt.After(currentAppStatus.LastTransitionTime.Time) {
 						statusLogCtx = statusLogCtx.WithField("app.operation", app.Status.OperationState.Phase)
 						newAppStatus.LastTransitionTime = &now

--- a/applicationset/progressivesync/validation_issues.go
+++ b/applicationset/progressivesync/validation_issues.go
@@ -111,7 +111,7 @@ func (v *ValidationIssues) formatEmptyStepsMessage() string {
 	return fmt.Sprintf("Steps %v have no applications matching their criteria", stepNums)
 }
 
-// getConditionMessage formats condition message for the first validation Issue found. If appset has multiple vaildation issues, condition message only reports one of highest priority
+// getConditionMessage formats condition message for the first validation Issue found. If appset has multiple validation issues, condition message only reports one of highest priority
 func (v *ValidationIssues) getConditionMessage() string {
 	var rolloutMessage string
 	switch {

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -2206,7 +2206,7 @@ func getResourceStates(app *argoappv1.Application, selectedResources []*argoappv
 	return states
 }
 
-// filterAppResources selects the app resources that match atleast one of the resource filters.
+// filterAppResources selects the app resources that match at least one of the resource filters.
 func filterAppResources(app *argoappv1.Application, selectedResources []*argoappv1.SyncOperationResource) []*argoappv1.SyncOperationResource {
 	var filteredResources []*argoappv1.SyncOperationResource
 	if app != nil && len(selectedResources) > 0 {
@@ -3124,7 +3124,7 @@ func NewApplicationAddSourceCommand(clientOpts *argocdclient.ClientOptions) *cob
 			errors.CheckError(err)
 
 			if c.Flags() == nil {
-				errors.Fatal(errors.ErrorGeneric, "ApplicationSource needs atleast repoUrl, path or chart or ref field. No source to add.")
+				errors.Fatal(errors.ErrorGeneric, "ApplicationSource needs at least repoUrl, path or chart or ref field. No source to add.")
 			}
 
 			if len(app.Spec.Sources) > 0 {

--- a/commitserver/commit/commit.go
+++ b/commitserver/commit/commit.go
@@ -39,7 +39,7 @@ func NewService(gitCredsStore git.CredsStore, metricsServer *metrics.Server) *Se
 // This struct is used to serialize/deserialize commit metadata (such as the dry run SHA)
 // stored in the custom note namespace by the hydrator.
 type CommitNote struct {
-	DrySHA string `json:"drySha"` // SHA of original commit that triggerd the hydrator
+	DrySHA string `json:"drySha"` // SHA of original commit that triggered the hydrator
 }
 
 // CommitHydratedManifests handles a commit request. It clones the repository, checks out the sync branch, checks out

--- a/common/common.go
+++ b/common/common.go
@@ -141,7 +141,7 @@ const (
 	// SP tokens are valid for 60 minutes, so cache for 59 minutes to avoid issues with token expiration when taking the cleanup interval of 1 minute into account
 	AzureServicePrincipalCredsExpirationDuration = time.Minute * 59
 
-	// PasswordPatten is the default password patten
+	// PasswordPatten is the default password pattern
 	PasswordPatten = `^.{8,32}$`
 
 	// LegacyShardingAlgorithm is the default value for Sharding Algorithm it uses an `uid` based distribution (non-uniform)

--- a/controller/sharding/sharding.go
+++ b/controller/sharding/sharding.go
@@ -501,7 +501,7 @@ func GetClusterSharding(kubeClient kubernetes.Interface, settingsMgr *settings.S
 				errors.CheckError(err)
 			}
 			if shardNumber > replicasCount {
-				log.Warnf("Calculated shard number %d is greated than the number of replicas count. Defaulting to 0", shardNumber)
+				log.Warnf("Calculated shard number %d is greater than the number of replicas count. Defaulting to 0", shardNumber)
 				shardNumber = 0
 			}
 		}


### PR DESCRIPTION
Spelling fixes I picked up while reading through the applicationset and sharding code:

- comments: `lables`, `trigerred`, `vaildation`, `atleast`, `triggerd`, `patten`
- `argocd app` error text: `needs atleast repoUrl` -> `needs at least repoUrl`
- sharding warning log: `is greated than` -> `is greater than`

I left the exported `common.PasswordPatten` identifier alone and only corrected the trailing word in its doc comment, since renaming it would be an API change.

No functional change.

(Supersedes #29509, which I opened from the wrong branch.)