### PR TITLE
feat(health): add health check for CloudNativePG Database CRD

### DIFF
--- a/docs/operator-manual/upgrading/3.5-3.6.md
+++ b/docs/operator-manual/upgrading/3.5-3.6.md
@@ -94,3 +94,10 @@ One specific change to be aware of: `otelgrpc` now sets the `server.address`/`se
 attributes from the gRPC dial target rather than the resolved peer IP. If a dashboard or alert
 keys on `server.address` expecting a literal pod/service IP for internal Argo CD gRPC calls
 (`argocd-server` ↔ `repo-server` ↔ `cmp-server`), it may need updating.
+
+## Custom Healthchecks Added
+
+- A bundled health check for CloudNativePG's `postgresql.cnpg.io/Database` resource. It reports
+  `Healthy` only once the operator has applied the current generation (`status.applied` with a
+  matching `status.observedGeneration`), so a sync wave acts as a real dependency barrier for it
+  instead of treating the not-yet-applied Database as healthy.

--- a/resource_customizations/postgresql.cnpg.io/Database/health.lua
+++ b/resource_customizations/postgresql.cnpg.io/Database/health.lua
@@ -7,36 +7,38 @@ if obj.status == nil then
   return hs
 end
 
--- CloudNativePG only advances status.observedGeneration on a *successful*
--- reconcile: SetAsFailed sets applied=false and a message but leaves
--- observedGeneration untouched, whereas SetAsReady sets applied=true and
--- advances observedGeneration to the current generation. See database_funcs.go:
+-- CloudNativePG only advances status.observedGeneration on a successful
+-- reconcile (SetAsReady); SetAsFailed and SetAsUnknown leave it untouched. So
+-- observedGeneration == metadata.generation means the current spec generation
+-- has been reconciled at least once. See database_funcs.go:
 -- https://github.com/cloudnative-pg/cloudnative-pg/blob/v1.30.0/api/v1/database_funcs.go
--- A failed reconcile must therefore be evaluated before the observedGeneration
--- guard below, otherwise a permanently failing Database would report
--- Progressing forever instead of Degraded.
-if obj.status.applied == false then
-  hs.status = "Degraded"
-  hs.message = obj.status.message or "CloudNativePG failed to apply the Database"
-  return hs
-end
+local generationObserved =
+  obj.metadata == nil or obj.metadata.generation == nil or
+  obj.status.observedGeneration == obj.metadata.generation
 
--- A new spec generation that CNPG has not observed yet: keep the previous
--- successful state from blocking, but do not report Healthy until the current
--- generation has actually been applied.
-if obj.metadata ~= nil and obj.metadata.generation ~= nil and
-   obj.status.observedGeneration ~= obj.metadata.generation then
-  hs.message = "Waiting for CloudNativePG to observe the current Database generation"
-  return hs
-end
-
-if obj.status.applied == true then
+if obj.status.applied == true and generationObserved then
   hs.status = "Healthy"
   hs.message = obj.status.message or ""
   return hs
 end
 
-if obj.status.message ~= nil then
+-- A failed reconcile of the generation CloudNativePG has already observed is a
+-- genuine regression of a Database that was previously applied -> Degraded.
+if obj.status.applied == false and generationObserved then
+  hs.status = "Degraded"
+  hs.message = obj.status.message or "CloudNativePG failed to apply the Database"
+  return hs
+end
+
+-- Otherwise the current generation has not been applied yet: a first reconcile,
+-- a pending spec change, or a failure that happened before the current
+-- generation was ever observed. Report Progressing (NOT Degraded) so the sync
+-- wave waits. On first adoption the Database's owner role may not exist yet, so
+-- CloudNativePG's first reconcile fails (applied=false) and only succeeds on a
+-- retry; Argo CD turns a Degraded non-hook resource into a failed sync
+-- operation, so degrading this self-healing state would fail the very sync this
+-- health check is meant to gate.
+if obj.status.message ~= nil and obj.status.message ~= "" then
   hs.message = obj.status.message
 end
 return hs

--- a/resource_customizations/postgresql.cnpg.io/Database/health.lua
+++ b/resource_customizations/postgresql.cnpg.io/Database/health.lua
@@ -1,0 +1,42 @@
+local hs = {
+  status = "Progressing",
+  message = "Waiting for CloudNativePG to reconcile Database"
+}
+
+if obj.status == nil then
+  return hs
+end
+
+-- CloudNativePG only advances status.observedGeneration on a *successful*
+-- reconcile: SetAsFailed sets applied=false and a message but leaves
+-- observedGeneration untouched, whereas SetAsReady sets applied=true and
+-- advances observedGeneration to the current generation. See database_funcs.go:
+-- https://github.com/cloudnative-pg/cloudnative-pg/blob/v1.30.0/api/v1/database_funcs.go
+-- A failed reconcile must therefore be evaluated before the observedGeneration
+-- guard below, otherwise a permanently failing Database would report
+-- Progressing forever instead of Degraded.
+if obj.status.applied == false then
+  hs.status = "Degraded"
+  hs.message = obj.status.message or "CloudNativePG failed to apply the Database"
+  return hs
+end
+
+-- A new spec generation that CNPG has not observed yet: keep the previous
+-- successful state from blocking, but do not report Healthy until the current
+-- generation has actually been applied.
+if obj.metadata ~= nil and obj.metadata.generation ~= nil and
+   obj.status.observedGeneration ~= obj.metadata.generation then
+  hs.message = "Waiting for CloudNativePG to observe the current Database generation"
+  return hs
+end
+
+if obj.status.applied == true then
+  hs.status = "Healthy"
+  hs.message = obj.status.message or ""
+  return hs
+end
+
+if obj.status.message ~= nil then
+  hs.message = obj.status.message
+end
+return hs

--- a/resource_customizations/postgresql.cnpg.io/Database/health_test.yaml
+++ b/resource_customizations/postgresql.cnpg.io/Database/health_test.yaml
@@ -15,3 +15,7 @@ tests:
     status: Progressing
     message: "Waiting for CloudNativePG to reconcile Database"
   inputPath: testdata/database_progressing_no_status.yaml
+- healthStatus:
+    status: Progressing
+    message: "unable to determine database status: connection refused"
+  inputPath: testdata/database_progressing_applied_unset.yaml

--- a/resource_customizations/postgresql.cnpg.io/Database/health_test.yaml
+++ b/resource_customizations/postgresql.cnpg.io/Database/health_test.yaml
@@ -5,12 +5,8 @@ tests:
   inputPath: testdata/database_healthy.yaml
 - healthStatus:
     status: Progressing
-    message: "Waiting for CloudNativePG to observe the current Database generation"
+    message: "Waiting for CloudNativePG to reconcile Database"
   inputPath: testdata/database_progressing.yaml
-- healthStatus:
-    status: Degraded
-    message: 'failed to reconcile database "app": role "app" does not exist (SQLSTATE 42704)'
-  inputPath: testdata/database_degraded.yaml
 - healthStatus:
     status: Progressing
     message: "Waiting for CloudNativePG to reconcile Database"
@@ -19,3 +15,11 @@ tests:
     status: Progressing
     message: "unable to determine database status: connection refused"
   inputPath: testdata/database_progressing_applied_unset.yaml
+- healthStatus:
+    status: Progressing
+    message: 'failed to reconcile database "app": role "app" does not exist (SQLSTATE 42704)'
+  inputPath: testdata/database_progressing_failed_first_reconcile.yaml
+- healthStatus:
+    status: Degraded
+    message: 'failed to reconcile database "app": permission denied to create database (SQLSTATE 42501)'
+  inputPath: testdata/database_degraded.yaml

--- a/resource_customizations/postgresql.cnpg.io/Database/health_test.yaml
+++ b/resource_customizations/postgresql.cnpg.io/Database/health_test.yaml
@@ -1,0 +1,17 @@
+tests:
+- healthStatus:
+    status: Healthy
+    message: ""
+  inputPath: testdata/database_healthy.yaml
+- healthStatus:
+    status: Progressing
+    message: "Waiting for CloudNativePG to observe the current Database generation"
+  inputPath: testdata/database_progressing.yaml
+- healthStatus:
+    status: Degraded
+    message: 'failed to reconcile database "app": role "app" does not exist (SQLSTATE 42704)'
+  inputPath: testdata/database_degraded.yaml
+- healthStatus:
+    status: Progressing
+    message: "Waiting for CloudNativePG to reconcile Database"
+  inputPath: testdata/database_progressing_no_status.yaml

--- a/resource_customizations/postgresql.cnpg.io/Database/testdata/database_degraded.yaml
+++ b/resource_customizations/postgresql.cnpg.io/Database/testdata/database_degraded.yaml
@@ -1,0 +1,22 @@
+# A failed reconcile: CloudNativePG's SetAsFailed sets applied=false and a
+# message, and does NOT advance observedGeneration. This is why the health
+# check evaluates applied==false before the observedGeneration guard.
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  creationTimestamp: "2026-09-02T12:00:00Z"
+  finalizers:
+  - cnpg.io/deleteDatabase
+  generation: 1
+  name: database-example
+  namespace: default
+spec:
+  cluster:
+    name: cluster-example
+  databaseReclaimPolicy: retain
+  ensure: present
+  name: app
+  owner: app
+status:
+  applied: false
+  message: 'failed to reconcile database "app": role "app" does not exist (SQLSTATE 42704)'

--- a/resource_customizations/postgresql.cnpg.io/Database/testdata/database_degraded.yaml
+++ b/resource_customizations/postgresql.cnpg.io/Database/testdata/database_degraded.yaml
@@ -1,6 +1,7 @@
-# A failed reconcile: CloudNativePG's SetAsFailed sets applied=false and a
-# message, and does NOT advance observedGeneration. This is why the health
-# check evaluates applied==false before the observedGeneration guard.
+# A regression: CloudNativePG had already applied the current generation
+# (observedGeneration == generation), and a later reconcile of that same
+# generation now fails (applied=false). This is a genuine failure of an
+# already-applied Database, not a first-adoption transient, so it is Degraded.
 apiVersion: postgresql.cnpg.io/v1
 kind: Database
 metadata:
@@ -19,4 +20,5 @@ spec:
   owner: app
 status:
   applied: false
-  message: 'failed to reconcile database "app": role "app" does not exist (SQLSTATE 42704)'
+  observedGeneration: 1
+  message: 'failed to reconcile database "app": permission denied to create database (SQLSTATE 42501)'

--- a/resource_customizations/postgresql.cnpg.io/Database/testdata/database_healthy.yaml
+++ b/resource_customizations/postgresql.cnpg.io/Database/testdata/database_healthy.yaml
@@ -1,0 +1,19 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  creationTimestamp: "2026-09-02T12:00:00Z"
+  finalizers:
+  - cnpg.io/deleteDatabase
+  generation: 1
+  name: database-example
+  namespace: default
+spec:
+  cluster:
+    name: cluster-example
+  databaseReclaimPolicy: retain
+  ensure: present
+  name: app
+  owner: app
+status:
+  applied: true
+  observedGeneration: 1

--- a/resource_customizations/postgresql.cnpg.io/Database/testdata/database_progressing.yaml
+++ b/resource_customizations/postgresql.cnpg.io/Database/testdata/database_progressing.yaml
@@ -1,0 +1,23 @@
+# A new spec generation (2) that CloudNativePG has not observed yet: the
+# previous successful reconcile still shows applied=true with the old
+# observedGeneration (1), so the Database must report Progressing until the
+# current generation is applied.
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  creationTimestamp: "2026-09-02T12:00:00Z"
+  finalizers:
+  - cnpg.io/deleteDatabase
+  generation: 2
+  name: database-example
+  namespace: default
+spec:
+  cluster:
+    name: cluster-example
+  databaseReclaimPolicy: retain
+  ensure: present
+  name: app
+  owner: app
+status:
+  applied: true
+  observedGeneration: 1

--- a/resource_customizations/postgresql.cnpg.io/Database/testdata/database_progressing_applied_unset.yaml
+++ b/resource_customizations/postgresql.cnpg.io/Database/testdata/database_progressing_applied_unset.yaml
@@ -1,0 +1,23 @@
+# SetAsUnknown: CloudNativePG could not determine the database state (e.g. a
+# transient connection error while reconciling). It sets a message and leaves
+# status.applied unset, keeping the previously observed generation -> the health
+# check falls through to Progressing and surfaces the operator's message.
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  creationTimestamp: "2026-09-02T12:00:00Z"
+  finalizers:
+  - cnpg.io/deleteDatabase
+  generation: 1
+  name: database-example
+  namespace: default
+spec:
+  cluster:
+    name: cluster-example
+  databaseReclaimPolicy: retain
+  ensure: present
+  name: app
+  owner: app
+status:
+  observedGeneration: 1
+  message: "unable to determine database status: connection refused"

--- a/resource_customizations/postgresql.cnpg.io/Database/testdata/database_progressing_failed_first_reconcile.yaml
+++ b/resource_customizations/postgresql.cnpg.io/Database/testdata/database_progressing_failed_first_reconcile.yaml
@@ -1,0 +1,25 @@
+# First adoption: CloudNativePG's first reconcile of a brand-new Database fails
+# (e.g. the owner role has not been created yet) and will succeed on retry.
+# SetAsFailed sets applied=false but does not set observedGeneration, so the
+# current generation has never been observed. This must be Progressing, NOT
+# Degraded: Argo CD treats a Degraded non-hook resource as a failed sync, which
+# would turn this self-healing race into a failed sync.
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  creationTimestamp: "2026-09-02T12:00:00Z"
+  finalizers:
+  - cnpg.io/deleteDatabase
+  generation: 1
+  name: database-example
+  namespace: default
+spec:
+  cluster:
+    name: cluster-example
+  databaseReclaimPolicy: retain
+  ensure: present
+  name: app
+  owner: app
+status:
+  applied: false
+  message: 'failed to reconcile database "app": role "app" does not exist (SQLSTATE 42704)'

--- a/resource_customizations/postgresql.cnpg.io/Database/testdata/database_progressing_no_status.yaml
+++ b/resource_customizations/postgresql.cnpg.io/Database/testdata/database_progressing_no_status.yaml
@@ -1,0 +1,16 @@
+# Freshly created Database the operator has not reconciled yet: no status
+# subresource at all, so the health check reports Progressing.
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  creationTimestamp: "2026-09-02T12:00:00Z"
+  generation: 1
+  name: database-example
+  namespace: default
+spec:
+  cluster:
+    name: cluster-example
+  databaseReclaimPolicy: retain
+  ensure: present
+  name: app
+  owner: app


### PR DESCRIPTION
# feat(health): add health check for CloudNativePG Database CRD

## What

Adds a bundled custom health check for CloudNativePG's `postgresql.cnpg.io/Database`
resource under `resource_customizations/postgresql.cnpg.io/Database/`.

## Why

Argo CD already bundles a health check for the CNPG `Cluster` CRD, but not for
`Database`. Without a health assessment Argo CD falls back to "exists = Healthy",
so a sync wave advances past a `Database` that CloudNativePG has not applied to
PostgreSQL yet. With this check the `Database` only reports `Healthy` once it has
actually been applied, which lets a sync wave act as a real dependency barrier
(e.g. for a schema-migration Job that must not run before the database exists).

## How it works

The Lua script reads the `Database` status. CloudNativePG only advances
`status.observedGeneration` on a **successful** reconcile (`SetAsReady`);
`SetAsFailed` and `SetAsUnknown` leave it untouched
([database_funcs.go @ v1.30.0](https://github.com/cloudnative-pg/cloudnative-pg/blob/v1.30.0/api/v1/database_funcs.go)),
so `observedGeneration == metadata.generation` means "the current spec generation
has been reconciled at least once".

- `status.applied == true` **and** current generation observed → `Healthy`
- `status.applied == false` **and** current generation observed → `Degraded`
  (a regression of a Database that was already applied)
- everything else → `Progressing` (no status yet, a pending spec change, or a
  reconcile failure before the current generation was ever observed)

`status.applied == false` is only reported `Degraded` when the failing generation
has already been observed. This is deliberate: Argo CD turns a `Degraded`
**non-hook** resource into a failed sync operation (`OperationFailed`), while a
`Progressing` one makes the sync wait. On first adoption a `Database`'s owner role
may not exist yet, so CloudNativePG's first reconcile fails (`applied == false`)
and succeeds on a retry within a minute — reporting that self-healing state as
`Degraded` would fail the very sync this health check is meant to gate, so it
stays `Progressing`.

## Tests

Adds `health_test.yaml` with six cases and the matching `testdata/` fixtures:
healthy; progressing on a pending (unobserved) generation; progressing with no
status; progressing with a status but `applied` unset (`SetAsUnknown`);
progressing on a first-reconcile failure that has not been observed yet; and
degraded on a failure of an already-observed generation. `go test ./util/lua/`
passes.

## Notes

- Field names/semantics verified against a live CloudNativePG v1.30.0 cluster.
- Context: CNPG previously contributed the `Cluster` health check
  (cloudnative-pg/cloudnative-pg#7436); happy to loop in CNPG maintainers for
  review of the `Database` status semantics if useful.

---

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes. — a bundled health check, added per the [Contribute a Custom Health Check](https://argo-cd.readthedocs.io/en/latest/operator-manual/health/) guide; an upgrade note is included.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue. — N/A: self-contained health-check contribution, no tracking issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. — N/A: bundled resource customization, no CLI/UI surface.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR. — `docs/operator-manual/upgrading/3.5-3.6.md` (Custom Healthchecks Added).
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged. — `health_test.yaml` + fixtures, run by `go test ./util/lua/`.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines. — N/A: bundled health check, not a gated feature.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
