### PR TITLE
fix: recover AuthReconcile visitor panics (cherry-pick #29440 for 3.5)

### DIFF
--- a/gitops-engine/pkg/utils/kube/resource_ops.go
+++ b/gitops-engine/pkg/utils/kube/resource_ops.go
@@ -111,7 +111,24 @@ func (f *realKubectlOptionsRunner) AuthReconcile(opts *auth.ReconcileOptions) (r
 			retErr = fmt.Errorf("error running kubectl auth reconcile: %v", r)
 		}
 	}()
+	// TODO(#29484): Remove this wrapper after the upstream kubectl panic fix is available in Argo CD.
+	opts.Visitor = panicRecoveringVisitor{Visitor: opts.Visitor}
 	return opts.RunReconcile()
+}
+
+type panicRecoveringVisitor struct {
+	resource.Visitor
+}
+
+func (v panicRecoveringVisitor) Visit(fn resource.VisitorFunc) error {
+	return v.Visitor.Visit(func(info *resource.Info, err error) (retErr error) {
+		defer func() {
+			if r := recover(); r != nil {
+				retErr = fmt.Errorf("error running kubectl auth reconcile: %v", r)
+			}
+		}()
+		return fn(info, err)
+	})
 }
 
 func (f *realKubectlOptionsRunner) processKubectlRun(cmd string) (CleanupFunc, error) {

--- a/gitops-engine/pkg/utils/kube/resource_ops_test.go
+++ b/gitops-engine/pkg/utils/kube/resource_ops_test.go
@@ -3,6 +3,7 @@ package kube
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/argoproj/argo-cd/gitops-engine/pkg/utils/kube/mocks"
@@ -14,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/printers"
+	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/kubernetes"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
@@ -562,4 +564,39 @@ func TestRealKubectlOptionsRunner_AuthReconcile_PanicRecovery(t *testing.T) {
 	err := runner.AuthReconcile((*auth.ReconcileOptions)(nil))
 	require.Error(t, err, "AuthReconcile must return an error rather than propagating the panic")
 	assert.Contains(t, err.Error(), "error running kubectl auth reconcile")
+}
+
+type concurrentTestVisitor struct {
+	info *resource.Info
+	err  error
+}
+
+func (v concurrentTestVisitor) Visit(fn resource.VisitorFunc) error {
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- fn(v.info, v.err)
+	}()
+	return <-errCh
+}
+
+func TestRealKubectlOptionsRunner_AuthReconcile_ConcurrentVisitorPanicRecovery(t *testing.T) {
+	t.Parallel()
+	runner := &realKubectlOptionsRunner{}
+	opts := auth.NewReconcileOptions(genericclioptions.IOStreams{})
+	opts.Visitor = concurrentTestVisitor{}
+
+	err := runner.AuthReconcile(opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "error running kubectl auth reconcile")
+}
+
+func TestRealKubectlOptionsRunner_AuthReconcile_VisitorError(t *testing.T) {
+	t.Parallel()
+	runner := &realKubectlOptionsRunner{}
+	expectedErr := errors.New("visit failed")
+	opts := auth.NewReconcileOptions(genericclioptions.IOStreams{})
+	opts.Visitor = concurrentTestVisitor{err: expectedErr}
+
+	err := runner.AuthReconcile(opts)
+	require.ErrorIs(t, err, expectedErr)
 }


### PR DESCRIPTION
Backport of #29440 to `release-3.5`.

The automated cherry-pick failed because the release branch still uses the pre-v3 `gitops-engine` module path and has an additional `context` import in the test file. This resolves only that import-block conflict; the production change is unchanged.

Validation:

```console
$ cd gitops-engine && /home/ubuntu/.local/go/bin/go test ./pkg/utils/kube -count=1
ok github.com/argoproj/argo-cd/gitops-engine/pkg/utils/kube 0.082s

$ cd gitops-engine && /home/ubuntu/.local/go/bin/go test -race ./pkg/utils/kube -run "TestRealKubectlOptionsRunner_AuthReconcile_(PanicRecovery|ConcurrentVisitorPanicRecovery|VisitorError)$" -count=10
ok github.com/argoproj/argo-cd/gitops-engine/pkg/utils/kube 1.395s

$ cd gitops-engine && /home/ubuntu/.local/go/bin/go vet ./pkg/utils/kube
# no output; exit 0

$ git diff --check upstream/release-3.5...HEAD
# no output; exit 0
```