### PR TITLE
fix: use current source for sync status revision metadata

### DIFF
--- a/ui/src/app/applications/components/application-status-panel/application-status-panel.test.tsx
+++ b/ui/src/app/applications/components/application-status-panel/application-status-panel.test.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+import {render} from '@testing-library/react';
+import * as models from '../../../shared/models';
+import {ApplicationStatusPanel} from './application-status-panel';
+
+jest.mock('./revision-metadata-panel', () => ({
+    RevisionMetadataPanel: (props: any) => (
+        <div data-testid='revision-metadata-panel' data-version-id={props.versionId === null ? 'null' : props.versionId}>
+            {props.revision}
+        </div>
+    )
+}));
+
+jest.mock('../../../shared/services', () => ({
+    services: {
+        extensions: {
+            getStatusPanelExtensions: jest.fn(() => [])
+        },
+        applications: {
+            getApplicationSyncWindowState: jest.fn(() => Promise.resolve({}))
+        }
+    }
+}));
+
+describe('ApplicationStatusPanel', () => {
+    it('uses current source for sync status revision metadata and historical version for last sync', () => {
+        const application = {
+            metadata: {
+                name: 'test-app',
+                namespace: 'default'
+            },
+            spec: {
+                source: {
+                    repoURL: 'oci://new-repo',
+                    targetRevision: 'latest'
+                },
+                syncPolicy: {
+                    automated: {
+                        enabled: false
+                    }
+                }
+            },
+            status: {
+                health: {
+                    status: models.HealthStatuses.Healthy
+                },
+                sync: {
+                    status: models.SyncStatuses.Synced,
+                    revision: 'BBBB'
+                },
+                history: [
+                    {
+                        id: 1,
+                        revision: 'AAAA',
+                        source: {
+                            repoURL: 'oci://old-repo',
+                            targetRevision: 'AAAA'
+                        },
+                        deployedAt: '2026-01-01T00:00:00Z'
+                    }
+                ],
+                conditions: [],
+                operationState: {
+                    phase: models.OperationPhases.Succeeded,
+                    syncResult: {
+                        revision: 'AAAA'
+                    },
+                    finishedAt: '2026-01-01T00:00:00Z'
+                }
+            }
+        } as models.Application;
+
+        render(<ApplicationStatusPanel application={application} />);
+
+        const panels = document.querySelectorAll('[data-testid="revision-metadata-panel"]');
+
+        expect(panels).toHaveLength(2);
+
+        // SYNC STATUS: current revision must use the current source.
+        expect(panels[0]).toHaveAttribute('data-version-id', 'null');
+        expect(panels[0]).toHaveTextContent('BBBB');
+
+        // LAST SYNC: historical revision must continue using its historical version.
+        expect(panels[1]).toHaveAttribute('data-version-id', '1');
+        expect(panels[1]).toHaveTextContent('AAAA');
+    });
+});

--- a/ui/src/app/applications/components/application-status-panel/application-status-panel.tsx
+++ b/ui/src/app/applications/components/application-status-panel/application-status-panel.tsx
@@ -306,7 +306,9 @@ export const ApplicationStatusPanel = ({application, showDiff, showOperation, sh
                                 appNamespace={application.metadata.namespace}
                                 type={revisionType}
                                 revision={revision}
-                                versionId={utils.getAppCurrentVersion(application)}
+                                // Sync Status uses the current revision and current application source.
+                                // The historical version ID belongs to the last sync and must not be used here.
+                                versionId={null}
                             />
                         </div>
                     )}

--- a/ui/src/app/applications/components/application-status-panel/revision-metadata-panel.test.tsx
+++ b/ui/src/app/applications/components/application-status-panel/revision-metadata-panel.test.tsx
@@ -60,4 +60,16 @@ describe('RevisionMetadataPanel', () => {
         render(<RevisionMetadataPanel {...defaultProps} type='git' />);
         expect(services.applications.revisionMetadata).toHaveBeenCalledWith('test-app', 'default', 'abc123', 0, 1);
     });
+
+    it('passes null versionId to revisionMetadata', () => {
+        const {services} = require('../../../shared/services');
+        render(
+            <RevisionMetadataPanel
+                {...defaultProps}
+                type='git'
+                versionId={null}
+            />
+        );
+        expect(services.applications.revisionMetadata).toHaveBeenCalledWith('test-app', 'default', 'abc123', 0, null);
+    });
 });

--- a/ui/src/app/applications/components/application-status-panel/revision-metadata-panel.tsx
+++ b/ui/src/app/applications/components/application-status-panel/revision-metadata-panel.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import {Timestamp} from '../../../shared/components/timestamp';
 import {services} from '../../../shared/services';
 
-export const RevisionMetadataPanel = (props: {appName: string; appNamespace: string; type: string; revision: string; versionId: number}) => {
+export const RevisionMetadataPanel = (props: {appName: string; appNamespace: string; type: string; revision: string; versionId: number | null}) => {
     if (props.type === 'helm') {
         return null;
     }

--- a/ui/src/app/shared/services/applications-service.ts
+++ b/ui/src/app/shared/services/applications-service.ts
@@ -79,7 +79,7 @@ export class ApplicationsService {
             .then(res => res.body as models.ApplicationSyncWindowState);
     }
 
-    public ociMetadata(name: string, appNamespace: string, revision: string, sourceIndex: number, versionId: number): Promise<models.OCIMetadata> {
+    public ociMetadata(name: string, appNamespace: string, revision: string, sourceIndex: number, versionId: number | null): Promise<models.OCIMetadata> {
         let r = requests.get(`/applications/${name}/revisions/${revision || 'HEAD'}/ocimetadata`).query({appNamespace});
         if (sourceIndex !== null) {
             r = r.query({sourceIndex});


### PR DESCRIPTION
## What does this PR do?

When an application's source changes without a new sync operation, `status.sync.revision` reflects the current revision while `getAppCurrentVersion()` still points to the latest historical sync.

For Sync Status revision metadata, passing this historical `versionId` causes the backend to resolve the current revision against the historical source. This can result in revision metadata being reported as not found.

This PR fixes the issue by using the application's current source for the Sync Status revision metadata lookup instead of the historical `versionId`.

LAST SYNC continues to use the historical version ID because its revision and source belong to the same historical sync operation.

## Testing

Added regression coverage verifying:

- Sync Status uses the current revision with `versionId=null`.
- Last Sync continues using the historical revision and version ID.
- `RevisionMetadataPanel` correctly forwards a null version ID.

Testing performed:

- `pnpm test src/app/applications/components/application-status-panel/revision-metadata-panel.test.tsx --runInBand`
- `pnpm test src/app/applications/components/application-status-panel/application-status-panel.test.tsx --runInBand`
- `pnpm test --runInBand`
- All UI tests passed: 28 suites, 308 tests, 32 snapshots.

Checklist:

- [x] Either (a) I've created an enhancement proposal and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [x] The title of the PR conforms to the "Title of the PR".
- [x] I've included "Closes [ISSUE]" or "Fixes [ISSUE]" in the description to automatically close the associated issue.
- [x] Does this PR require documentation updates?
- [x] I've updated documentation as required by this PR.
- [x] I have signed off all my commits as required by DCO.
- [x] I have written unit and/or e2e tests for my changes. PRs without these are unlikely to be merged.
- [ ] My build is green (troubleshooting builds).
- [x] My new feature complies with the feature status guidelines.
- [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
- [ ] Optional. My organization is added to USERS.md.
- [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

Fixes #29513