### PR TITLE
fix(controller): show retry wait time in unambiguous format

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -1683,7 +1683,7 @@ func (ctrl *ApplicationController) processRequestedAppOperation(app *appv1.Appli
 				state.Phase = synccommon.OperationRunning
 				state.FinishedAt = &now
 				state.RetryCount++
-				state.Message = fmt.Sprintf("%s. Retrying attempt #%d at %s.", state.Message, state.RetryCount, retryAt.Format(time.Kitchen))
+				state.Message = fmt.Sprintf("%s. Retrying attempt #%d in %s (at %s).", state.Message, state.RetryCount, retryAt.Sub(now.Time).Round(time.Second), retryAt.UTC().Format(time.RFC3339))
 			}
 		} else {
 			if terminating && terminatingCause != "" {

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -1683,7 +1683,7 @@ func (ctrl *ApplicationController) processRequestedAppOperation(app *appv1.Appli
 				state.Phase = synccommon.OperationRunning
 				state.FinishedAt = &now
 				state.RetryCount++
-				state.Message = fmt.Sprintf("%s. Retrying attempt #%d in %s (at %s).", state.Message, state.RetryCount, retryAt.Sub(now.Time).Round(time.Second), retryAt.UTC().Format(time.RFC3339))
+				state.Message = fmt.Sprintf("%s. Retrying attempt #%d at %s.", state.Message, state.RetryCount, retryAt.UTC().Format(time.RFC3339))
 			}
 		} else {
 			if terminating && terminatingCause != "" {

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -2941,6 +2942,38 @@ func TestProcessRequestedAppOperation_FailedHasRetries(t *testing.T) {
 	assert.Equal(t, synccommon.OperationRunning, patchedApp.Status.OperationState.Phase)
 	assert.Contains(t, patchedApp.Status.OperationState.Message, "Failed to load application project: error getting app project \"invalid-project\": appproject.argoproj.io \"invalid-project\" not found. Retrying attempt #1")
 	assert.EqualValues(t, 1, patchedApp.Status.OperationState.RetryCount)
+}
+
+func TestProcessRequestedAppOperation_FailedRetryMessageTime(t *testing.T) {
+	app := newFakeApp()
+	app.Spec.Project = "invalid-project"
+	app.Operation = &v1alpha1.Operation{
+		Sync: &v1alpha1.SyncOperation{},
+		Retry: v1alpha1.RetryStrategy{
+			Limit:   1,
+			Backoff: &v1alpha1.Backoff{Duration: "2m", MaxDuration: "1h"},
+		},
+	}
+	ctrl := newFakeController(t.Context(), &fakeData{apps: []runtime.Object{app}}, nil)
+	start := time.Now()
+
+	ctrl.processRequestedAppOperation(app)
+
+	patchedApp, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(app.Namespace).Get(t.Context(), app.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, patchedApp.Status.OperationState)
+	message := patchedApp.Status.OperationState.Message
+
+	// The relative delta tells the user how long the wait actually is, without any clock arithmetic.
+	assert.Contains(t, message, "Retrying attempt #1 in 2m0s (at ")
+
+	// The absolute time must be unambiguous, so it can't be mistaken for the reader's local time.
+	match := regexp.MustCompile(`\(at ([^)]+)\)`).FindStringSubmatch(message)
+	require.Len(t, match, 2)
+	retryAt, err := time.Parse(time.RFC3339, match[1])
+	require.NoError(t, err)
+	assert.Equal(t, time.UTC, retryAt.Location())
+	assert.WithinDuration(t, start.Add(2*time.Minute), retryAt, time.Minute)
 }
 
 func TestProcessRequestedAppOperation_RunningPreviouslyFailed(t *testing.T) {

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -2964,14 +2964,15 @@ func TestProcessRequestedAppOperation_FailedRetryMessageTime(t *testing.T) {
 	require.NotNil(t, patchedApp.Status.OperationState)
 	message := patchedApp.Status.OperationState.Message
 
-	// The relative delta tells the user how long the wait actually is, without any clock arithmetic.
-	assert.Contains(t, message, "Retrying attempt #1 in 2m0s (at ")
+	assert.Contains(t, message, "Retrying attempt #1 at ")
 
-	// The absolute time must be unambiguous, so it can't be mistaken for the reader's local time.
-	match := regexp.MustCompile(`\(at ([^)]+)\)`).FindStringSubmatch(message)
+	// The retry time is absolute rather than relative, because the message is persisted once and
+	// never rewritten until the next attempt fails, so a relative delta would go stale on the object.
+	match := regexp.MustCompile(`Retrying attempt #1 at (\S+)\.`).FindStringSubmatch(message)
 	require.Len(t, match, 2)
 	retryAt, err := time.Parse(time.RFC3339, match[1])
 	require.NoError(t, err)
+	// RFC3339 in UTC, so the time can't be mistaken for the reader's local time.
 	assert.Equal(t, time.UTC, retryAt.Location())
 	assert.WithinDuration(t, start.Add(2*time.Minute), retryAt, time.Minute)
 }


### PR DESCRIPTION
Closes https://github.com/argoproj/argo-cd/issues/29535

When a sync operation fails and is scheduled for retry, the operation message rendered the next attempt time with `time.Kitchen`:

  > ComparisonError: Failed to load target state: failed to generate manifest for
  > source 1 of 1: rpc error: code = Unavailable desc = connection error: desc =
  > "transport: Error while dialing: dial tcp 10.0.9.23:8081: connect: connection
  > refused". Retrying attempt #2 at 4:04PM.

`4:04PM` has no date and no timezone, so you can't tell what day it refers to, whether it's the controller's clock or your own, or how long the wait actually is. This PR adds the relative wait and prints the absolute time as RFC3339 in UTC:

  > ... connection refused. Retrying attempt #2 in 2m0s (at 2026-09-03T16:04:00Z).

More details here - https://cloud-native.slack.com/archives/C020XM04CUW/p1788278865234229

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
