### PR TITLE
fix(ui): use hydrateTo branch name when set (cherry-pick #29562 for 3.4)

### DIFF
--- a/ui/src/app/applications/components/utils.test.tsx
+++ b/ui/src/app/applications/components/utils.test.tsx
@@ -17,7 +17,6 @@ import {
     ComparisonStatusIcon,
     getAppDrySource,
     getAppHydrateToSource,
-    getAppHydratorSyncSource,
     hydrationStatusMessage,
     getAppOperationState,
     getOperationType,
@@ -1011,31 +1010,16 @@ describe('appRBACName', () => {
     });
 });
 
-describe('getAppHydratorSyncSource', () => {
-    it('returns the sync source with resolved repo URL', () => {
-        expect(
-            getAppHydratorSyncSource({
-                drySource: {repoURL: 'https://github.com/example/dry.git', targetRevision: 'main', path: 'in'},
-                syncSource: {repoURL: 'https://github.com/example/hydrated.git', targetBranch: 'env/test', path: 'out'}
-            } as any)
-        ).toEqual({
-            repoURL: 'https://github.com/example/hydrated.git',
-            targetRevision: 'env/test',
-            path: 'out'
-        });
-    });
-});
-
 describe('getAppHydrateToSource', () => {
     it('uses hydrateTo.targetBranch when set', () => {
         expect(
             getAppHydrateToSource({
                 drySource: {repoURL: 'https://github.com/example/dry.git', targetRevision: 'main', path: 'in'},
-                syncSource: {repoURL: 'https://github.com/example/hydrated.git', targetBranch: 'env/test', path: 'out'},
+                syncSource: {targetBranch: 'env/test', path: 'out'},
                 hydrateTo: {targetBranch: 'env/test-hydrate'}
-            } as any)
+            })
         ).toEqual({
-            repoURL: 'https://github.com/example/hydrated.git',
+            repoURL: 'https://github.com/example/dry.git',
             targetRevision: 'env/test-hydrate',
             path: 'out'
         });

--- a/ui/src/app/applications/components/utils.test.tsx
+++ b/ui/src/app/applications/components/utils.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
+import {renderToStaticMarkup} from 'react-dom/server';
 import {
     Application,
     HealthStatus,
@@ -15,6 +16,9 @@ import {
     appRBACName,
     ComparisonStatusIcon,
     getAppDrySource,
+    getAppHydrateToSource,
+    getAppHydratorSyncSource,
+    hydrationStatusMessage,
     getAppOperationState,
     getOperationType,
     getPodStateReason,
@@ -24,6 +28,10 @@ import {
 } from './utils';
 
 const zero = new Date(0).toISOString();
+
+function renderMarkup(element: React.ReactElement) {
+    return renderToStaticMarkup(element);
+}
 
 test('getAppOperationState.DeletionTimestamp', () => {
     const state = getAppOperationState({metadata: {deletionTimestamp: zero}} as Application);
@@ -1000,5 +1008,73 @@ describe('appRBACName', () => {
         const result = appRBACName(app);
 
         expect(result).toBe('test-project/test-app');
+    });
+});
+
+describe('getAppHydratorSyncSource', () => {
+    it('returns the sync source with resolved repo URL', () => {
+        expect(
+            getAppHydratorSyncSource({
+                drySource: {repoURL: 'https://github.com/example/dry.git', targetRevision: 'main', path: 'in'},
+                syncSource: {repoURL: 'https://github.com/example/hydrated.git', targetBranch: 'env/test', path: 'out'}
+            } as any)
+        ).toEqual({
+            repoURL: 'https://github.com/example/hydrated.git',
+            targetRevision: 'env/test',
+            path: 'out'
+        });
+    });
+});
+
+describe('getAppHydrateToSource', () => {
+    it('uses hydrateTo.targetBranch when set', () => {
+        expect(
+            getAppHydrateToSource({
+                drySource: {repoURL: 'https://github.com/example/dry.git', targetRevision: 'main', path: 'in'},
+                syncSource: {repoURL: 'https://github.com/example/hydrated.git', targetBranch: 'env/test', path: 'out'},
+                hydrateTo: {targetBranch: 'env/test-hydrate'}
+            } as any)
+        ).toEqual({
+            repoURL: 'https://github.com/example/hydrated.git',
+            targetRevision: 'env/test-hydrate',
+            path: 'out'
+        });
+    });
+
+    it('falls back to the sync source branch when hydrateTo is unset', () => {
+        expect(
+            getAppHydrateToSource({
+                drySource: {repoURL: 'https://github.com/example/dry.git', targetRevision: 'main', path: 'in'},
+                syncSource: {targetBranch: 'env/test', path: 'out'}
+            })
+        ).toEqual({
+            repoURL: 'https://github.com/example/dry.git',
+            targetRevision: 'env/test',
+            path: 'out'
+        });
+    });
+});
+
+describe('hydrationStatusMessage', () => {
+    it('shows hydrateTo as the destination while hydrating', () => {
+        const html = renderMarkup(
+            hydrationStatusMessage({
+                status: {
+                    sourceHydrator: {
+                        currentOperation: {
+                            phase: 'Hydrating',
+                            sourceHydrator: {
+                                drySource: {repoURL: 'https://github.com/example/dry.git', targetRevision: 'main'},
+                                syncSource: {targetBranch: 'env/test', path: 'out'},
+                                hydrateTo: {targetBranch: 'env/test-hydrate'}
+                            }
+                        }
+                    }
+                }
+            } as Application)
+        );
+        expect(html).toContain('env/test-hydrate');
+        expect(html).not.toContain('env/test)');
+        expect(html).not.toMatch(/>env\/test</);
     });
 });

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -14,7 +14,6 @@ import {ResourceTreeNode} from './application-resource-tree/application-resource
 import {CheckboxField, COLORS, ErrorNotification, Revision} from '../../shared/components';
 import * as appModels from '../../shared/models';
 import {services} from '../../shared/services';
-import {ApplicationSource} from '../../shared/models';
 
 require('./utils.scss');
 
@@ -974,14 +973,10 @@ export function syncStatusMessage(app: appModels.Application) {
 }
 
 export function hydrationStatusMessage(app: appModels.Application) {
-    const drySource = app.status.sourceHydrator.currentOperation.sourceHydrator.drySource;
+    const sourceHydrator = app.status.sourceHydrator.currentOperation.sourceHydrator;
+    const drySource = sourceHydrator.drySource;
     const dryCommit = app.status.sourceHydrator.currentOperation.drySHA;
-    const syncSource: ApplicationSource = {
-        repoURL: drySource.repoURL,
-        targetRevision:
-            app.status.sourceHydrator.currentOperation.sourceHydrator.hydrateTo?.targetBranch || app.status.sourceHydrator.currentOperation.sourceHydrator.syncSource.targetBranch,
-        path: app.status.sourceHydrator.currentOperation.sourceHydrator.syncSource.path
-    };
+    const hydrateToSource = getAppHydrateToSource(sourceHydrator);
     const hydratedCommit = app.status.sourceHydrator.currentOperation.hydratedSHA || '';
 
     switch (app.status.sourceHydrator.currentOperation.phase) {
@@ -994,8 +989,8 @@ export function hydrationStatusMessage(app: appModels.Application) {
                     </Revision>
                     <br />
                     to{' '}
-                    <Revision repoUrl={syncSource.repoURL} revision={hydratedCommit}>
-                        {syncSource.targetRevision + ' (' + hydratedCommit.substr(0, 7) + ')'}
+                    <Revision repoUrl={hydrateToSource.repoURL} revision={hydratedCommit}>
+                        {hydrateToSource.targetRevision + ' (' + hydratedCommit.substr(0, 7) + ')'}
                     </Revision>
                 </span>
             );
@@ -1008,8 +1003,8 @@ export function hydrationStatusMessage(app: appModels.Application) {
                     </Revision>
                     <br />
                     to{' '}
-                    <Revision repoUrl={syncSource.repoURL} revision={syncSource.targetRevision}>
-                        {syncSource.targetRevision}
+                    <Revision repoUrl={hydrateToSource.repoURL} revision={hydrateToSource.targetRevision}>
+                        {hydrateToSource.targetRevision}
                     </Revision>
                 </span>
             );
@@ -1023,8 +1018,8 @@ export function hydrationStatusMessage(app: appModels.Application) {
                     </Revision>
                     <br />
                     to{' '}
-                    <Revision repoUrl={syncSource.repoURL} revision={syncSource.targetRevision}>
-                        {syncSource.targetRevision}
+                    <Revision repoUrl={hydrateToSource.repoURL} revision={hydrateToSource.targetRevision}>
+                        {hydrateToSource.targetRevision}
                     </Revision>
                 </span>
             );
@@ -1479,6 +1474,27 @@ export function getAppDrySource(app?: appModels.Application): appModels.Applicat
         return {repoURL, targetRevision, path};
     }
     return getAppDefaultSource(app);
+}
+
+export function getHydratorSyncSourceRepoURL(sourceHydrator?: appModels.SourceHydrator): string {
+    return sourceHydrator?.syncSource?.repoURL || sourceHydrator?.drySource?.repoURL || '';
+}
+
+export function getAppHydratorSyncSource(sourceHydrator?: appModels.SourceHydrator): appModels.ApplicationSource {
+    return {
+        repoURL: getHydratorSyncSourceRepoURL(sourceHydrator),
+        targetRevision: sourceHydrator?.syncSource?.targetBranch || '',
+        path: sourceHydrator?.syncSource?.path || ''
+    };
+}
+
+// Destination of a hydration push: hydrateTo.targetBranch when set, otherwise the sync source branch.
+export function getAppHydrateToSource(sourceHydrator?: appModels.SourceHydrator): appModels.ApplicationSource {
+    const syncSource = getAppHydratorSyncSource(sourceHydrator);
+    return {
+        ...syncSource,
+        targetRevision: sourceHydrator?.hydrateTo?.targetBranch || syncSource.targetRevision
+    };
 }
 
 // getAppDefaultSyncRevision gets the first app revisions from `status.sync.revisions` or, if that list is missing or empty, the `revision`

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -1476,24 +1476,13 @@ export function getAppDrySource(app?: appModels.Application): appModels.Applicat
     return getAppDefaultSource(app);
 }
 
-export function getHydratorSyncSourceRepoURL(sourceHydrator?: appModels.SourceHydrator): string {
-    return sourceHydrator?.syncSource?.repoURL || sourceHydrator?.drySource?.repoURL || '';
-}
-
-export function getAppHydratorSyncSource(sourceHydrator?: appModels.SourceHydrator): appModels.ApplicationSource {
-    return {
-        repoURL: getHydratorSyncSourceRepoURL(sourceHydrator),
-        targetRevision: sourceHydrator?.syncSource?.targetBranch || '',
-        path: sourceHydrator?.syncSource?.path || ''
-    };
-}
-
 // Destination of a hydration push: hydrateTo.targetBranch when set, otherwise the sync source branch.
+// On 3.4 the destination repo is always the dry source repo (syncSource.repoURL is 3.5+).
 export function getAppHydrateToSource(sourceHydrator?: appModels.SourceHydrator): appModels.ApplicationSource {
-    const syncSource = getAppHydratorSyncSource(sourceHydrator);
     return {
-        ...syncSource,
-        targetRevision: sourceHydrator?.hydrateTo?.targetBranch || syncSource.targetRevision
+        repoURL: sourceHydrator?.drySource?.repoURL || '',
+        targetRevision: sourceHydrator?.hydrateTo?.targetBranch || sourceHydrator?.syncSource?.targetBranch || '',
+        path: sourceHydrator?.syncSource?.path || ''
     };
 }
 

--- a/ui/src/app/shared/models.ts
+++ b/ui/src/app/shared/models.ts
@@ -272,6 +272,7 @@ export interface DrySource {
 export interface SyncSource {
     targetBranch: string;
     path: string;
+    repoURL?: string;
 }
 
 export interface HydrateTo {

--- a/ui/src/app/shared/models.ts
+++ b/ui/src/app/shared/models.ts
@@ -272,7 +272,6 @@ export interface DrySource {
 export interface SyncSource {
     targetBranch: string;
     path: string;
-    repoURL?: string;
 }
 
 export interface HydrateTo {


### PR DESCRIPTION
## Summary
- Backport of #29562 (`#29554`) to `release-3.4`.
- Automated cherry-pick failed on conflicts in `utils.tsx` / `utils.test.tsx`. This version already used `hydrateTo` for the destination branch; the backport adds `getAppHydrateToSource` (and tests) so destination repo URL matches later releases.

## Test plan
- [ ] UI unit tests for `getAppHydrateToSource` / `hydrationStatusMessage`
- [ ] Confirm the Source Hydrator panel shows `hydrateTo` rather than the sync source branch


Made with [Cursor](https://cursor.com)