### PR TITLE
feat(perf): count apps per cluster in a single pass

### DIFF
--- a/controller/clusterinfoupdater.go
+++ b/controller/clusterinfoupdater.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/argoproj/argo-cd/v3/common"
@@ -100,10 +99,22 @@ func (c *clusterInfoUpdater) updateClusters() {
 			}
 		}
 	}
+	// Nothing to update, so don't walk the applications.
+	var appCountByServer map[string]int64
+	if len(clustersFiltered) > 0 {
+		apps, err := c.appLister.List(labels.Everything())
+		if err != nil {
+			log.Warnf("Failed to fetch the apps list to save clusters info: %v", err)
+			return
+		}
+		// Resolve every application's destination once per tick, not once per cluster.
+		appCountByServer = c.countAppsByDestinationServer(ctx, apps)
+	}
+
 	_ = kube.RunAllAsync(len(clustersFiltered), func(i int) error {
 		cluster := clustersFiltered[i]
 		clusterInfo := infoByServer[cluster.Server]
-		if err := c.updateClusterInfo(ctx, cluster, clusterInfo); err != nil {
+		if err := c.updateClusterInfo(cluster, clusterInfo, appCountByServer[cluster.Server]); err != nil {
 			log.Warnf("Failed to save cluster info: %v", err)
 		} else if err := updateClusterLabels(ctx, clusterInfo, cluster, c.db.UpdateCluster); err != nil {
 			log.Warnf("Failed to update cluster labels: %v", err)
@@ -113,18 +124,11 @@ func (c *clusterInfoUpdater) updateClusters() {
 	log.Debugf("Successfully saved info of %d clusters", len(clustersFiltered))
 }
 
-func (c *clusterInfoUpdater) updateClusterInfo(ctx context.Context, cluster appv1.Cluster, info *cache.ClusterInfo) error {
-	apps, err := c.appLister.List(labels.Everything())
-	if err != nil {
-		return fmt.Errorf("error while fetching the apps list: %w", err)
-	}
-
-	updated := c.getUpdatedClusterInfo(ctx, apps, cluster, info, metav1.Now())
-	return c.cache.SetClusterInfo(cluster.Server, &updated)
-}
-
-func (c *clusterInfoUpdater) getUpdatedClusterInfo(ctx context.Context, apps []*appv1.Application, cluster appv1.Cluster, info *cache.ClusterInfo, now metav1.Time) appv1.ClusterInfo {
-	var appCount int64
+// countAppsByDestinationServer returns the number of applications targeting each destination
+// server. An application is skipped if its project can't be resolved, the project doesn't permit
+// its namespace, or the destination doesn't resolve.
+func (c *clusterInfoUpdater) countAppsByDestinationServer(ctx context.Context, apps []*appv1.Application) map[string]int64 {
+	appCountByServer := make(map[string]int64)
 	for _, a := range apps {
 		if c.projGetter != nil {
 			proj, err := c.projGetter(a)
@@ -136,10 +140,17 @@ func (c *clusterInfoUpdater) getUpdatedClusterInfo(ctx context.Context, apps []*
 		if err != nil {
 			continue
 		}
-		if destServer == cluster.Server {
-			appCount++
-		}
+		appCountByServer[destServer]++
 	}
+	return appCountByServer
+}
+
+func (c *clusterInfoUpdater) updateClusterInfo(cluster appv1.Cluster, info *cache.ClusterInfo, appCount int64) error {
+	updated := getUpdatedClusterInfo(appCount, info, metav1.Now())
+	return c.cache.SetClusterInfo(cluster.Server, &updated)
+}
+
+func getUpdatedClusterInfo(appCount int64, info *cache.ClusterInfo, now metav1.Time) appv1.ClusterInfo {
 	clusterInfo := appv1.ClusterInfo{
 		ConnectionState:   appv1.ConnectionState{ModifiedAt: &now},
 		ApplicationsCount: appCount,

--- a/controller/clusterinfoupdater_test.go
+++ b/controller/clusterinfoupdater_test.go
@@ -9,6 +9,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/argoproj/argo-cd/v3/common"
 
@@ -86,7 +87,7 @@ func TestClusterSecretUpdater(t *testing.T) {
 		lister := applisters.NewApplicationLister(appInformer.GetIndexer()).Applications(fakeNamespace)
 		updater := NewClusterInfoUpdater(nil, argoDB, lister, appCache, nil, nil, fakeNamespace)
 
-		err = updater.updateClusterInfo(t.Context(), *cluster, info)
+		err = updater.updateClusterInfo(*cluster, info, 0)
 		require.NoError(t, err, "Invoking updateClusterInfo failed.")
 
 		var clusterInfo v1alpha1.ClusterInfo
@@ -141,7 +142,8 @@ func TestGetUpdatedClusterInfo_AppCount(t *testing.T) {
 	updater := &clusterInfoUpdater{db: argoDB, namespace: fakeNamespace}
 	cluster := v1alpha1.Cluster{Server: clusterServer}
 
-	info := updater.getUpdatedClusterInfo(t.Context(), apps, cluster, nil, metav1.Now())
+	appCountByServer := updater.countAppsByDestinationServer(t.Context(), apps)
+	info := getUpdatedClusterInfo(appCountByServer[cluster.Server], nil, metav1.Now())
 
 	assert.Equal(t, int64(2), info.ApplicationsCount)
 }
@@ -195,7 +197,8 @@ func TestGetUpdatedClusterInfo_AmbiguousName(t *testing.T) {
 	updater := &clusterInfoUpdater{db: argoDB, namespace: fakeNamespace}
 	cluster := v1alpha1.Cluster{Server: clusterServer}
 
-	info := updater.getUpdatedClusterInfo(t.Context(), apps, cluster, nil, metav1.Now())
+	appCountByServer := updater.countAppsByDestinationServer(t.Context(), apps)
+	info := getUpdatedClusterInfo(appCountByServer[cluster.Server], nil, metav1.Now())
 
 	assert.Equal(t, int64(0), info.ApplicationsCount, "ambiguous name should not count app")
 }
@@ -285,6 +288,373 @@ func TestUpdateClusterLabels(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.wantErr(t, updateClusterLabels(t.Context(), tt.clusterInfo, tt.cluster, tt.updateCluster), fmt.Sprintf("updateClusterLabels(%v, %v, %v)", t.Context(), tt.clusterInfo, tt.cluster))
+		})
+	}
+}
+
+// TestCountAppsByDestinationServer covers the destination shapes and the skip rules: server and
+// name based destinations, a trailing slash, a namespace the project denies, a project lookup that
+// fails, and destinations that don't resolve.
+func TestCountAppsByDestinationServer(t *testing.T) {
+	const (
+		fakeNamespace  = "fake-ns"
+		allowedNs      = "allowed-ns"
+		deniedNs       = "denied-ns"
+		prodServer     = "https://prod.example.com"
+		stagingServer  = "https://staging.example.com"
+		ambiguous1     = "https://ambiguous-1.example.com"
+		ambiguous2     = "https://ambiguous-2.example.com"
+		emptyServer    = "https://empty.example.com"
+		unknownServer  = "https://unknown.example.com"
+		prodName       = "prod"
+		stagingName    = "staging"
+		ambiguousName  = "ambiguous"
+		missingProject = "missing"
+	)
+
+	emptyArgoCDConfigMap := &corev1.ConfigMap{
+		Name:      common.ArgoCDConfigMapName,
+		Namespace: fakeNamespace,
+		Labels:    map[string]string{"app.kubernetes.io/part-of": "argocd"},
+		Data:      map[string]string{},
+	}
+	argoCDSecret := &corev1.Secret{
+		Name:      common.ArgoCDSecretName,
+		Namespace: fakeNamespace,
+		Labels:    map[string]string{"app.kubernetes.io/part-of": "argocd"},
+		Data:      map[string][]byte{"admin.password": nil, "server.secretkey": nil},
+	}
+	clusterSecret := func(secretName, name, server string) *corev1.Secret {
+		return &corev1.Secret{
+			Name:      secretName,
+			Namespace: fakeNamespace,
+			Labels:    map[string]string{common.LabelKeySecretType: common.LabelValueSecretTypeCluster},
+			Annotations: map[string]string{
+				common.AnnotationKeyManagedBy: common.AnnotationValueManagedByArgoCD,
+			},
+			Data: map[string][]byte{
+				"name":   []byte(name),
+				"server": []byte(server),
+				"config": []byte("{}"),
+			},
+		}
+	}
+
+	kubeclientset := fake.NewClientset(
+		emptyArgoCDConfigMap, argoCDSecret,
+		clusterSecret("prod-cluster", prodName, prodServer),
+		clusterSecret("staging-cluster", stagingName, stagingServer),
+		// Two secrets share a name, so that name doesn't resolve.
+		clusterSecret("ambiguous-cluster-1", ambiguousName, ambiguous1),
+		clusterSecret("ambiguous-cluster-2", ambiguousName, ambiguous2),
+		clusterSecret("empty-cluster", "empty", emptyServer),
+	)
+	settingsManager := settings.NewSettingsManager(t.Context(), kubeclientset, fakeNamespace)
+	argoDB := db.NewDB(fakeNamespace, settingsManager, kubeclientset)
+
+	app := func(name, namespace, project string, dest v1alpha1.ApplicationDestination) *v1alpha1.Application {
+		return &v1alpha1.Application{
+			Name:      name,
+			Namespace: namespace,
+			Spec:      v1alpha1.ApplicationSpec{Project: project, Destination: dest},
+		}
+	}
+	apps := []*v1alpha1.Application{
+		// Server based destinations.
+		app("server-prod", fakeNamespace, "default", v1alpha1.ApplicationDestination{Server: prodServer}),
+		app("server-prod-trailing-slash", fakeNamespace, "default", v1alpha1.ApplicationDestination{Server: prodServer + "/"}),
+		app("server-staging", fakeNamespace, "default", v1alpha1.ApplicationDestination{Server: stagingServer}),
+		// Name based destinations.
+		app("name-prod", fakeNamespace, "default", v1alpha1.ApplicationDestination{Name: prodName}),
+		app("name-staging", fakeNamespace, "default", v1alpha1.ApplicationDestination{Name: stagingName}),
+		// Permitted source namespace.
+		app("allowed-ns-prod", allowedNs, "default", v1alpha1.ApplicationDestination{Server: prodServer}),
+		// Project does not permit the application namespace.
+		app("denied-ns-prod", deniedNs, "default", v1alpha1.ApplicationDestination{Server: prodServer}),
+		// projGetter returns an error.
+		app("missing-project-prod", fakeNamespace, missingProject, v1alpha1.ApplicationDestination{Server: prodServer}),
+		// Unresolvable destinations.
+		app("both-name-and-server", fakeNamespace, "default", v1alpha1.ApplicationDestination{Name: prodName, Server: prodServer}),
+		app("empty-destination", fakeNamespace, "default", v1alpha1.ApplicationDestination{}),
+		app("unknown-name", fakeNamespace, "default", v1alpha1.ApplicationDestination{Name: "does-not-exist"}),
+		app("ambiguous-name", fakeNamespace, "default", v1alpha1.ApplicationDestination{Name: ambiguousName}),
+	}
+
+	syncTime := time.Now()
+	syncErr := errors.New("sync failed")
+	clusters := []v1alpha1.Cluster{
+		{Server: prodServer, Name: prodName},
+		{Server: stagingServer, Name: stagingName},
+		{Server: ambiguous1, Name: ambiguousName},
+		{Server: emptyServer, Name: "empty"},
+		{Server: unknownServer, Name: "unknown"},
+	}
+	infoByServer := map[string]*clustercache.ClusterInfo{
+		prodServer:    {Server: prodServer, K8SVersion: "1.31", LastCacheSyncTime: &syncTime, APIsCount: 3, ResourcesCount: 7},
+		stagingServer: {Server: stagingServer, K8SVersion: "1.30", LastCacheSyncTime: &syncTime, SyncError: syncErr},
+		ambiguous1:    {Server: ambiguous1, K8SVersion: "1.29"},
+		// emptyServer and unknownServer have no cluster cache info.
+	}
+
+	projGetter := func(a *v1alpha1.Application) (*v1alpha1.AppProject, error) {
+		if a.Spec.Project == missingProject {
+			return nil, errors.New("project not found")
+		}
+		return &v1alpha1.AppProject{
+			Name:      a.Spec.Project,
+			Namespace: fakeNamespace,
+			Spec:      v1alpha1.AppProjectSpec{SourceNamespaces: []string{allowedNs}},
+		}, nil
+	}
+
+	tests := []struct {
+		name       string
+		projGetter func(app *v1alpha1.Application) (*v1alpha1.AppProject, error)
+		wantCounts map[string]int64
+	}{
+		{
+			name:       "with project getter",
+			projGetter: projGetter,
+			wantCounts: map[string]int64{
+				prodServer:    4,
+				stagingServer: 2,
+				ambiguous1:    0,
+				emptyServer:   0,
+				unknownServer: 0,
+			},
+		},
+		{
+			// A nil projGetter skips the project and namespace checks, so those apps get counted.
+			name:       "nil project getter",
+			projGetter: nil,
+			wantCounts: map[string]int64{
+				prodServer:    6,
+				stagingServer: 2,
+				ambiguous1:    0,
+				emptyServer:   0,
+				unknownServer: 0,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			updater := &clusterInfoUpdater{db: argoDB, namespace: fakeNamespace, projGetter: tt.projGetter}
+			now := metav1.Now()
+
+			appCountByServer := updater.countAppsByDestinationServer(t.Context(), apps)
+
+			for _, cluster := range clusters {
+				got := getUpdatedClusterInfo(appCountByServer[cluster.Server], infoByServer[cluster.Server], now)
+
+				assert.Equal(t, tt.wantCounts[cluster.Server], got.ApplicationsCount, "unexpected app count for %s", cluster.Server)
+			}
+		})
+	}
+}
+
+type fakeClusterInfoSource struct {
+	infos []clustercache.ClusterInfo
+}
+
+func (f *fakeClusterInfoSource) GetClustersInfo() []clustercache.ClusterInfo {
+	return f.infos
+}
+
+// listOnlyDB implements just enough of db.ArgoDB for the benchmark, everything else panics.
+// GetClusterServersByName does what the real one does for an ordinary name: a by-name index
+// lookup plus a slice of the matches.
+type listOnlyDB struct {
+	db.ArgoDB
+	clusters      *v1alpha1.ClusterList
+	byNameIndexer cache.Indexer
+}
+
+func (l *listOnlyDB) ListClusters(_ context.Context) (*v1alpha1.ClusterList, error) {
+	return l.clusters, nil
+}
+
+func (l *listOnlyDB) GetClusterServersByName(_ context.Context, name string) ([]string, error) {
+	items, err := l.byNameIndexer.ByIndex(benchClusterByNameIndexer, name)
+	if err != nil {
+		return nil, err
+	}
+	servers := make([]string, 0, len(items))
+	for _, item := range items {
+		cluster, ok := item.(*v1alpha1.Cluster)
+		if !ok {
+			continue
+		}
+		servers = append(servers, cluster.Server)
+	}
+	return servers, nil
+}
+
+const benchClusterByNameIndexer = "byClusterName"
+
+// BenchmarkClusterInfoUpdater_updateClusters measures one full tick. Both destination shapes
+// are covered since a server resolves with a strings.TrimRight and a name costs an index lookup.
+func BenchmarkClusterInfoUpdater_updateClusters(b *testing.B) {
+	for _, byName := range []bool{false, true} {
+		shape := "destinationByServer"
+		if byName {
+			shape = "destinationByName"
+		}
+		b.Run(shape, func(b *testing.B) {
+			benchmarkUpdateClusters(b, byName)
+		})
+	}
+}
+
+func benchmarkUpdateClusters(b *testing.B, byName bool) {
+	b.Helper()
+	const (
+		benchNamespace   = "argocd"
+		benchNumClusters = 50
+		benchNumApps     = 35000
+	)
+
+	syncTime := time.Now()
+	clusters := &v1alpha1.ClusterList{}
+	infos := make([]clustercache.ClusterInfo, 0, benchNumClusters)
+	clusterIndexer := cache.NewIndexer(
+		func(obj any) (string, error) { return obj.(*v1alpha1.Cluster).Server, nil },
+		cache.Indexers{benchClusterByNameIndexer: func(obj any) ([]string, error) {
+			return []string{obj.(*v1alpha1.Cluster).Name}, nil
+		}},
+	)
+	for i := range benchNumClusters {
+		server := fmt.Sprintf("https://cluster-%d.example.com", i)
+		name := fmt.Sprintf("cluster-%d", i)
+		clusters.Items = append(clusters.Items, v1alpha1.Cluster{Server: server, Name: name})
+		require.NoError(b, clusterIndexer.Add(&v1alpha1.Cluster{Server: server, Name: name}))
+		infos = append(infos, clustercache.ClusterInfo{
+			Server:            server,
+			K8SVersion:        "1.31",
+			LastCacheSyncTime: &syncTime,
+			APIsCount:         100,
+			ResourcesCount:    5000,
+		})
+	}
+
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	for i := range benchNumApps {
+		dest := v1alpha1.ApplicationDestination{}
+		if byName {
+			dest.Name = fmt.Sprintf("cluster-%d", i%benchNumClusters)
+		} else {
+			dest.Server = fmt.Sprintf("https://cluster-%d.example.com", i%benchNumClusters)
+		}
+		app := &v1alpha1.Application{
+			Name:      fmt.Sprintf("app-%d", i),
+			Namespace: benchNamespace,
+			Spec: v1alpha1.ApplicationSpec{
+				Project:     "default",
+				Destination: dest,
+			},
+		}
+		require.NoError(b, indexer.Add(app))
+	}
+	lister := applisters.NewApplicationLister(indexer).Applications(benchNamespace)
+
+	proj := &v1alpha1.AppProject{Name: "default", Namespace: benchNamespace}
+	projGetter := func(_ *v1alpha1.Application) (*v1alpha1.AppProject, error) { return proj, nil }
+
+	appCache := appstate.NewCache(cacheutil.NewCache(cacheutil.NewInMemoryCache(time.Hour)), time.Hour)
+	updater := NewClusterInfoUpdater(
+		&fakeClusterInfoSource{infos: infos},
+		&listOnlyDB{clusters: clusters, byNameIndexer: clusterIndexer},
+		lister,
+		appCache,
+		nil,
+		projGetter,
+		benchNamespace,
+	)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		// updateClusters is a no-op unless a full interval has elapsed since the last tick.
+		updater.lastUpdated = time.Time{}
+		updater.updateClusters()
+	}
+}
+
+// countingAppLister records how many times updateClusters lists Applications.
+type countingAppLister struct {
+	applisters.ApplicationNamespaceLister
+	calls int
+}
+
+func (l *countingAppLister) List(selector labels.Selector) ([]*v1alpha1.Application, error) {
+	l.calls++
+	return l.ApplicationNamespaceLister.List(selector)
+}
+
+// TestUpdateClusters_EmptyShardDoesNotListApplications asserts a shard managing no clusters never
+// lists the applications. updateClusters runs every 10s.
+func TestUpdateClusters_EmptyShardDoesNotListApplications(t *testing.T) {
+	const (
+		fakeNamespace = "fake-ns"
+		shardServer   = "https://shard.example.com"
+		otherServer   = "https://other.example.com"
+	)
+
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	for i := range 3 {
+		require.NoError(t, indexer.Add(&v1alpha1.Application{
+			Name:      fmt.Sprintf("app-%d", i),
+			Namespace: fakeNamespace,
+			Spec: v1alpha1.ApplicationSpec{
+				Project:     "default",
+				Destination: v1alpha1.ApplicationDestination{Server: shardServer},
+			},
+		}))
+	}
+
+	tests := []struct {
+		name          string
+		clusters      []v1alpha1.Cluster
+		clusterFilter func(cluster *v1alpha1.Cluster) bool
+		wantListCalls int
+	}{
+		{
+			name:          "no clusters at all",
+			clusters:      nil,
+			wantListCalls: 0,
+		},
+		{
+			name:          "every cluster filtered out",
+			clusters:      []v1alpha1.Cluster{{Server: shardServer}, {Server: otherServer}},
+			clusterFilter: func(_ *v1alpha1.Cluster) bool { return false },
+			wantListCalls: 0,
+		},
+		{
+			// Positive control, otherwise the two cases above pass with the listing removed.
+			name:          "one cluster owned by this shard",
+			clusters:      []v1alpha1.Cluster{{Server: shardServer}, {Server: otherServer}},
+			clusterFilter: func(c *v1alpha1.Cluster) bool { return c.Server == shardServer },
+			wantListCalls: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lister := &countingAppLister{
+				ApplicationNamespaceLister: applisters.NewApplicationLister(indexer).Applications(fakeNamespace),
+			}
+			appCache := appstate.NewCache(cacheutil.NewCache(cacheutil.NewInMemoryCache(time.Minute)), time.Minute)
+			updater := NewClusterInfoUpdater(
+				&fakeClusterInfoSource{},
+				&listOnlyDB{clusters: &v1alpha1.ClusterList{Items: tt.clusters}},
+				lister,
+				appCache,
+				tt.clusterFilter,
+				nil,
+				fakeNamespace,
+			)
+
+			updater.updateClusters()
+
+			assert.Equal(t, tt.wantListCalls, lister.calls)
 		})
 	}
 }


### PR DESCRIPTION
`updateClusters` did the per application work once per cluster. Every 10s each cluster the shard owns called `appLister.List(labels.Everything())`, which allocates a fresh slice of every Application, then walked all of them calling `projGetter`, `IsAppNamespacePermitted` and `GetDestinationServer` just to count the ones pointing at that one cluster. 35k apps and 50 clusters per shard is 50 full lists and 1.75M per app visits every tick.

The list and the destination resolution happen once now, into a `map[server]int64`, and each cluster reads its count out of the map. The per cluster work still runs under `kube.RunAllAsync`.

`BenchmarkClusterInfoUpdater_updateClusters`, 35k apps, 50 clusters, one full tick per iteration.

| destination | | time | bytes | allocs |
|---|---|---|---|---|
| `destination.server` | before | 514ms | 93.6MB | 3,273 |
| `destination.server` | after | 14.5ms | 2.07MB | 2,004 |
| `destination.name` | before | 783ms | 149.6MB | 3,503,275 |
| `destination.name` | after | 18.8ms | 3.19MB | 72,004 |

A smaller behavior change, the lister errors the tick logs once and returns instead of logging once per cluster. Nothing is written to the cache either way.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
