### PR TITLE
feat(perf): resolve the destination server without copying the cluster

### DIFF
--- a/cmd/argocd/commands/admin/app.go
+++ b/cmd/argocd/commands/admin/app.go
@@ -388,11 +388,11 @@ func reconcileApplications(
 
 	appLister := appInformerFactory.Argoproj().V1alpha1().Applications().Lister()
 	projLister := appInformerFactory.Argoproj().V1alpha1().AppProjects().Lister()
-	server, err := metrics.NewMetricsServer("", appLister, func(_ any) bool {
-		return true
+	server, err := metrics.NewMetricsServer("", appLister, func(_ any) (bool, string, error) {
+		return true, "", nil
 	}, func(_ *http.Request) error {
 		return nil
-	}, []string{}, []string{}, argoDB)
+	}, []string{}, []string{})
 	if err != nil {
 		return nil, fmt.Errorf("error starting new metrics server: %w", err)
 	}

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -303,7 +303,7 @@ func NewApplicationController(
 
 	metricsAddr := fmt.Sprintf("0.0.0.0:%d", metricsPort)
 
-	ctrl.metricsServer, err = metrics.NewMetricsServer(metricsAddr, appLister, ctrl.canProcessApp, readinessHealthCheck, metricsApplicationLabels, metricsApplicationConditions, ctrl.db)
+	ctrl.metricsServer, err = metrics.NewMetricsServer(metricsAddr, appLister, ctrl.canProcessAppWithDestination, readinessHealthCheck, metricsApplicationLabels, metricsApplicationConditions)
 	if err != nil {
 		return nil, err
 	}
@@ -2746,15 +2746,24 @@ func (ctrl *ApplicationController) isAppNamespaceAllowed(app *appv1.Application)
 }
 
 func (ctrl *ApplicationController) canProcessApp(obj any) bool {
+	canProcess, _, _ := ctrl.canProcessAppWithDestination(obj)
+	return canProcess
+}
+
+// canProcessAppWithDestination is canProcessApp plus the destination server it resolved and the
+// error that stopped it resolving, so the metrics collector doesn't have to resolve it again and
+// can still report the failure. Callers on the informer path drop the error, which is why nothing
+// logs per Application event.
+func (ctrl *ApplicationController) canProcessAppWithDestination(obj any) (bool, string, error) {
 	app, ok := obj.(*appv1.Application)
 	if !ok {
-		return false
+		return false, "", nil
 	}
 
 	// Only process given app if it exists in a watched namespace, or in the
 	// control plane's namespace.
 	if !ctrl.isAppNamespaceAllowed(app) {
-		return false
+		return false, "", nil
 	}
 
 	if annotations := app.GetAnnotations(); annotations != nil {
@@ -2763,7 +2772,7 @@ func (ctrl *ApplicationController) canProcessApp(obj any) bool {
 			if skipReconcile, err := strconv.ParseBool(skipVal); err == nil {
 				if skipReconcile {
 					logCtx.Debugf("Skipping Application reconcile based on annotation %s", common.AnnotationKeyAppSkipReconcile)
-					return false
+					return false, "", nil
 				}
 			} else {
 				logCtx.WithError(err).Debugf("Unable to determine if Application should skip reconcile based on annotation %s", common.AnnotationKeyAppSkipReconcile)
@@ -2771,11 +2780,23 @@ func (ctrl *ApplicationController) canProcessApp(obj any) bool {
 		}
 	}
 
+	destServer, err := argo.GetDestinationServer(context.Background(), app.Spec.Destination, ctrl.db)
+	if err != nil {
+		// Destination doesn't resolve to a server: both name and server set, neither set, an
+		// unknown name, or an ambiguous one. GetDestinationCluster returns this same error
+		// unwrapped, so the collector logs exactly what it always did.
+		return ctrl.clusterSharding.IsManagedCluster(nil), "", err
+	}
+	if managed, known := ctrl.clusterSharding.IsManagedClusterByServer(destServer); known {
+		return managed, destServer, nil
+	}
+	// Nothing in the sharding cache for this server, either there is no cluster secret or the cache
+	// hasn't caught up with a new one. Fall back to the full lookup.
 	destCluster, err := argo.GetDestinationCluster(context.Background(), app.Spec.Destination, ctrl.db)
 	if err != nil {
-		return ctrl.clusterSharding.IsManagedCluster(nil)
+		return ctrl.clusterSharding.IsManagedCluster(nil), "", err
 	}
-	return ctrl.clusterSharding.IsManagedCluster(destCluster)
+	return ctrl.clusterSharding.IsManagedCluster(destCluster), destCluster.Server, nil
 }
 
 func (ctrl *ApplicationController) newApplicationInformerAndLister() (cache.SharedIndexInformer, applisters.ApplicationLister) {

--- a/controller/canprocessapp_test.go
+++ b/controller/canprocessapp_test.go
@@ -1,0 +1,446 @@
+package controller
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/argoproj/argo-cd/v3/common"
+	"github.com/argoproj/argo-cd/v3/controller/sharding"
+	appv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v3/test"
+)
+
+// testCluster describes a cluster secret to seed the fake API server with.
+type testCluster struct {
+	secretName  string
+	clusterName string
+	server      string
+	shard       *int
+	annotations map[string]string
+	// config overrides the cluster secret's config blob. The benchmarks use a realistic size since
+	// that is what Cluster.DeepCopy charges for.
+	config []byte
+}
+
+func (c testCluster) secret() *corev1.Secret {
+	config := c.config
+	if config == nil {
+		config = []byte(`{"bearerToken":"fake","tlsClientConfig":{"insecure":true}}`)
+	}
+	data := map[string][]byte{
+		"name":   []byte(c.clusterName),
+		"server": []byte(c.server),
+		"config": config,
+	}
+	if c.shard != nil {
+		data["shard"] = []byte(strconv.Itoa(*c.shard))
+	}
+	return &corev1.Secret{
+		Name:        c.secretName,
+		Namespace:   test.FakeArgoCDNamespace,
+		UID:         types.UID(c.secretName),
+		Labels:      map[string]string{common.LabelKeySecretType: common.LabelValueSecretTypeCluster},
+		Annotations: c.annotations,
+		Data:        data,
+	}
+}
+
+// newShardedController builds a controller backed by the given cluster secrets, with the sharding
+// cache initialized from them the way ApplicationController.Run does.
+func newShardedController(ctx context.Context, tb testing.TB, shard, replicas int, inClusterEnabled bool, clusters []testCluster, apps []runtime.Object) *ApplicationController {
+	tb.Helper()
+
+	additionalObjs := make([]runtime.Object, 0, len(clusters))
+	for _, c := range clusters {
+		additionalObjs = append(additionalObjs, c.secret())
+	}
+	configMapData := map[string]string{}
+	if !inClusterEnabled {
+		configMapData["cluster.inClusterEnabled"] = "false"
+	}
+
+	ctrl := newFakeController(ctx, &fakeData{
+		apps:           apps,
+		additionalObjs: additionalObjs,
+		configMapData:  configMapData,
+	}, nil)
+
+	ctrl.clusterSharding = sharding.NewClusterSharding(nil, shard, replicas, common.DefaultShardingAlgorithm)
+	clusterList, err := ctrl.db.ListClusters(ctx)
+	require.NoError(tb, err)
+	ctrl.clusterSharding.Init(clusterList, &appv1.ApplicationList{})
+	return ctrl
+}
+
+func appWithDestination(name string, dest appv1.ApplicationDestination) *appv1.Application {
+	return &appv1.Application{
+		Name:      name,
+		Namespace: test.FakeArgoCDNamespace,
+		Spec: appv1.ApplicationSpec{
+			Project:     "default",
+			Destination: dest,
+			Source:      &appv1.ApplicationSource{RepoURL: "https://github.com/argoproj/argocd-example-apps.git", Path: "some/path"},
+		},
+	}
+}
+
+// canProcessWant is the answer canProcessAppWithDestination is expected to give. server is only
+// checked when process is true, which is when the collector uses it for the dest_server label.
+type canProcessWant struct {
+	process bool
+	server  string
+}
+
+// Test_canProcessApp_ShardAssignment covers every destination shape against a two shard layout:
+// resolvable by name and by server, a trailing slash, an ambiguous name, a cluster with no secret,
+// a cluster the sharding cache has not caught up with, the skip-reconcile annotation on both the
+// cluster and the Application, a disallowed namespace, and an object that is not an Application.
+func Test_canProcessApp_ShardAssignment(t *testing.T) {
+	shard0, shard1 := 0, 1
+	clusters := []testCluster{
+		{secretName: "cluster-a", clusterName: "cluster-a", server: "https://cluster-a", shard: &shard0},
+		{secretName: "cluster-b", clusterName: "cluster-b", server: "https://cluster-b", shard: &shard1},
+		{secretName: "cluster-skipped", clusterName: "cluster-skipped", server: "https://cluster-skipped", shard: &shard0, annotations: map[string]string{common.AnnotationKeyAppSkipReconcile: "true"}},
+		// Two secrets share a name, so the name is ambiguous.
+		{secretName: "dupe-1", clusterName: "dupe", server: "https://dupe-1", shard: &shard0},
+		{secretName: "dupe-2", clusterName: "dupe", server: "https://dupe-2", shard: &shard1},
+		{secretName: "cluster-forgotten", clusterName: "cluster-forgotten", server: "https://cluster-forgotten", shard: &shard1},
+	}
+
+	cases := []struct {
+		name   string
+		obj    any
+		shard0 canProcessWant
+		shard1 canProcessWant
+	}{
+		{
+			"destination by name",
+			appWithDestination("by-name-shard0", appv1.ApplicationDestination{Name: "cluster-a", Namespace: "default"}),
+			canProcessWant{true, "https://cluster-a"},
+			canProcessWant{false, ""},
+		},
+		{
+			"destination by name, other shard",
+			appWithDestination("by-name-shard1", appv1.ApplicationDestination{Name: "cluster-b", Namespace: "default"}),
+			canProcessWant{false, ""},
+			canProcessWant{true, "https://cluster-b"},
+		},
+		{
+			"destination by server",
+			appWithDestination("by-server", appv1.ApplicationDestination{Server: "https://cluster-b", Namespace: "default"}),
+			canProcessWant{false, ""},
+			canProcessWant{true, "https://cluster-b"},
+		},
+		{
+			"destination by server with trailing slash",
+			appWithDestination("by-server-slash", appv1.ApplicationDestination{Server: "https://cluster-b/", Namespace: "default"}),
+			canProcessWant{false, ""},
+			canProcessWant{true, "https://cluster-b"},
+		},
+		{
+			// An unresolvable destination is processed by every shard.
+			"both server and name set",
+			appWithDestination("both-set", appv1.ApplicationDestination{Server: "https://cluster-a", Name: "cluster-a", Namespace: "default"}),
+			canProcessWant{true, ""},
+			canProcessWant{true, ""},
+		},
+		{
+			"neither server nor name set",
+			appWithDestination("neither-set", appv1.ApplicationDestination{Namespace: "default"}),
+			canProcessWant{true, ""},
+			canProcessWant{true, ""},
+		},
+		{
+			"name of a cluster with no secret",
+			appWithDestination("unknown-name", appv1.ApplicationDestination{Name: "no-such-cluster", Namespace: "default"}),
+			canProcessWant{true, ""},
+			canProcessWant{true, ""},
+		},
+		{
+			"server of a cluster with no secret",
+			appWithDestination("unknown-server", appv1.ApplicationDestination{Server: "https://no-such-cluster", Namespace: "default"}),
+			canProcessWant{true, ""},
+			canProcessWant{true, ""},
+		},
+		{
+			"ambiguous name matching two clusters",
+			appWithDestination("ambiguous", appv1.ApplicationDestination{Name: "dupe", Namespace: "default"}),
+			canProcessWant{true, ""},
+			canProcessWant{true, ""},
+		},
+		{
+			"cluster with skip-reconcile annotation",
+			appWithDestination("skipped-cluster", appv1.ApplicationDestination{Name: "cluster-skipped", Namespace: "default"}),
+			canProcessWant{false, ""},
+			canProcessWant{false, ""},
+		},
+		{
+			// The sharding cache is made to forget this one below, which is the fallback path.
+			"cluster the sharding cache does not know about",
+			appWithDestination("forgotten-cluster", appv1.ApplicationDestination{Name: "cluster-forgotten", Namespace: "default"}),
+			canProcessWant{true, "https://cluster-forgotten"},
+			canProcessWant{false, ""},
+		},
+		{
+			"application with skip-reconcile annotation",
+			func() *appv1.Application {
+				app := appWithDestination("skipped-app", appv1.ApplicationDestination{Name: "cluster-a", Namespace: "default"})
+				app.Annotations = map[string]string{common.AnnotationKeyAppSkipReconcile: "true"}
+				return app
+			}(),
+			canProcessWant{false, ""},
+			canProcessWant{false, ""},
+		},
+		{
+			"application with unparsable skip-reconcile annotation",
+			func() *appv1.Application {
+				app := appWithDestination("bad-annotation-app", appv1.ApplicationDestination{Name: "cluster-a", Namespace: "default"})
+				app.Annotations = map[string]string{common.AnnotationKeyAppSkipReconcile: "not-a-bool"}
+				return app
+			}(),
+			canProcessWant{true, "https://cluster-a"},
+			canProcessWant{false, ""},
+		},
+		{
+			"application in a namespace that is not allowed",
+			func() *appv1.Application {
+				app := appWithDestination("wrong-namespace-app", appv1.ApplicationDestination{Name: "cluster-a", Namespace: "default"})
+				app.Namespace = "some-other-namespace"
+				return app
+			}(),
+			canProcessWant{false, ""},
+			canProcessWant{false, ""},
+		},
+		{
+			"object that is not an application",
+			&corev1.Secret{Name: "not-an-app"},
+			canProcessWant{false, ""},
+			canProcessWant{false, ""},
+		},
+	}
+
+	for _, shard := range []int{0, 1} {
+		ctrl := newShardedController(t.Context(), t, shard, 2, true, clusters, nil)
+		ctrl.clusterSharding.Delete("https://cluster-forgotten")
+		for _, tc := range cases {
+			t.Run(fmt.Sprintf("shard=%d/%s", shard, tc.name), func(t *testing.T) {
+				want := tc.shard0
+				if shard == 1 {
+					want = tc.shard1
+				}
+
+				got, gotServer, _ := ctrl.canProcessAppWithDestination(tc.obj)
+				assert.Equal(t, want.process, got)
+				assert.Equal(t, want.process, ctrl.canProcessApp(tc.obj), "canProcessApp disagrees with canProcessAppWithDestination")
+				if want.process {
+					assert.Equal(t, want.server, gotServer, "dest_server label")
+				}
+			})
+		}
+	}
+}
+
+// Test_canProcessApp_InCluster covers the in-cluster destination, whose answer depends on both the
+// shard and whether in-cluster is enabled.
+func Test_canProcessApp_InCluster(t *testing.T) {
+	shard0 := 0
+	clusters := []testCluster{
+		{secretName: "cluster-a", clusterName: "cluster-a", server: "https://cluster-a", shard: &shard0},
+	}
+
+	dests := map[string]appv1.ApplicationDestination{
+		"by server": {Server: appv1.KubernetesInternalAPIServerAddr, Namespace: "default"},
+		"by name":   {Name: appv1.KubernetesInClusterName, Namespace: "default"},
+	}
+	cases := []struct {
+		shard            int
+		inClusterEnabled bool
+		want             canProcessWant
+	}{
+		{0, true, canProcessWant{true, appv1.KubernetesInternalAPIServerAddr}},
+		{0, false, canProcessWant{true, ""}},
+		{1, true, canProcessWant{false, ""}},
+		{1, false, canProcessWant{true, ""}},
+	}
+
+	for _, tc := range cases {
+		ctrl := newShardedController(t.Context(), t, tc.shard, 2, tc.inClusterEnabled, clusters, nil)
+		for name, dest := range dests {
+			t.Run(fmt.Sprintf("shard=%d/inClusterEnabled=%t/%s", tc.shard, tc.inClusterEnabled, name), func(t *testing.T) {
+				got, gotServer, _ := ctrl.canProcessAppWithDestination(appWithDestination("in-cluster", dest))
+				assert.Equal(t, tc.want.process, got)
+				assert.Equal(t, tc.want.process, ctrl.canProcessApp(appWithDestination("in-cluster", dest)))
+				if tc.want.process {
+					assert.Equal(t, tc.want.server, gotServer, "dest_server label")
+				}
+			})
+		}
+	}
+}
+
+// perfClusters and perfApps build the 35k Application, 500 cluster fixture for the benchmarks.
+// Destinations are name based, the more expensive shape: a name index lookup on top of the
+// cluster lookup.
+const (
+	benchmarkClusters = 500
+	benchmarkApps     = 35000
+)
+
+// benchmarkClusterConfig returns a realistically sized config blob, a bearer token plus client
+// certs. The size is what Cluster.DeepCopy charged for on every canProcessApp call.
+func benchmarkClusterConfig() []byte {
+	pem := func(kind string, size int) string {
+		return base64.StdEncoding.EncodeToString([]byte("-----BEGIN " + kind + "-----\n" + strings.Repeat("A", size) + "\n-----END " + kind + "-----\n"))
+	}
+	return fmt.Appendf(nil, `{"bearerToken":%q,"tlsClientConfig":{"caData":%q,"certData":%q,"keyData":%q}}`,
+		strings.Repeat("t", 900), pem("CERTIFICATE", 1200), pem("CERTIFICATE", 1200), pem("RSA PRIVATE KEY", 1600))
+}
+
+func benchmarkFixture(b *testing.B) *ApplicationController {
+	b.Helper()
+
+	// Building the fixture logs a line per cluster, which drowns out the benchmark output.
+	previousLevel := log.GetLevel()
+	log.SetLevel(log.ErrorLevel)
+	b.Cleanup(func() { log.SetLevel(previousLevel) })
+
+	clusters := make([]testCluster, 0, benchmarkClusters)
+	for i := range benchmarkClusters {
+		name := fmt.Sprintf("cluster-%d", i)
+		clusters = append(clusters, testCluster{
+			secretName:  name,
+			clusterName: name,
+			server:      fmt.Sprintf("https://cluster-%d.example.com", i),
+			config:      benchmarkClusterConfig(),
+		})
+	}
+
+	apps := make([]runtime.Object, 0, benchmarkApps)
+	for i := range benchmarkApps {
+		apps = append(apps, appWithDestination(fmt.Sprintf("app-%d", i), appv1.ApplicationDestination{
+			Name:      fmt.Sprintf("cluster-%d", i%benchmarkClusters),
+			Namespace: "default",
+		}))
+	}
+
+	return newShardedController(b.Context(), b, 0, 1, true, clusters, apps)
+}
+
+// BenchmarkCanProcessApp measures the filter alone, one call per iteration, cycling through the
+// Applications so every cluster gets hit.
+func BenchmarkCanProcessApp(b *testing.B) {
+	ctrl := benchmarkFixture(b)
+
+	apps := make([]*appv1.Application, 0, benchmarkClusters)
+	for i := range benchmarkClusters {
+		apps = append(apps, appWithDestination(fmt.Sprintf("app-%d", i), appv1.ApplicationDestination{
+			Name:      fmt.Sprintf("cluster-%d", i),
+			Namespace: "default",
+		}))
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	i := 0
+	for b.Loop() {
+		if !ctrl.canProcessApp(apps[i%len(apps)]) {
+			b.Fatal("expected application to be processed by this shard")
+		}
+		i++
+	}
+}
+
+// BenchmarkAppCollector_Collect measures a full /metrics scrape over the 35k Application fixture,
+// which is what Prometheus does every 30s per shard.
+func BenchmarkAppCollector_Collect(b *testing.B) {
+	ctrl := benchmarkFixture(b)
+
+	req, err := http.NewRequestWithContext(b.Context(), http.MethodGet, "/metrics", http.NoBody)
+	require.NoError(b, err)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		ctrl.metricsServer.Handler.ServeHTTP(&discardResponseWriter{}, req)
+	}
+}
+
+// discardResponseWriter drops the scrape body so the benchmark measures collection and encoding,
+// not the response buffer.
+type discardResponseWriter struct {
+	header http.Header
+}
+
+func (w *discardResponseWriter) Header() http.Header {
+	if w.header == nil {
+		w.header = http.Header{}
+	}
+	return w.header
+}
+
+func (w *discardResponseWriter) Write(b []byte) (int, error) { return len(b), nil }
+
+func (w *discardResponseWriter) WriteHeader(int) {}
+
+// Test_canProcessAppWithDestination_ReportsResolutionError pins which destination shapes hand the
+// caller an error, which is what the metrics collector logs per scrape. Anything that resolves
+// reports nil, so a healthy fleet logs nothing. It also pins that the informer path stays silent:
+// canProcessApp drops the error, so a resolution failure costs one warning per scrape, not one per
+// Application event.
+func Test_canProcessAppWithDestination_ReportsResolutionError(t *testing.T) {
+	shard0 := 0
+	clusters := []testCluster{
+		{secretName: "cluster-a", clusterName: "cluster-a", server: "https://cluster-a", shard: &shard0},
+		{secretName: "dupe-1", clusterName: "dupe", server: "https://dupe-1", shard: &shard0},
+		{secretName: "dupe-2", clusterName: "dupe", server: "https://dupe-2", shard: &shard0},
+	}
+	ctrl := newShardedController(t.Context(), t, 0, 1, true, clusters, nil)
+
+	tests := []struct {
+		name    string
+		dest    appv1.ApplicationDestination
+		wantErr bool
+	}{
+		{"resolvable by name", appv1.ApplicationDestination{Name: "cluster-a", Namespace: "default"}, false},
+		{"resolvable by server", appv1.ApplicationDestination{Server: "https://cluster-a", Namespace: "default"}, false},
+		{"both name and server set", appv1.ApplicationDestination{Name: "cluster-a", Server: "https://cluster-a", Namespace: "default"}, true},
+		{"neither name nor server set", appv1.ApplicationDestination{Namespace: "default"}, true},
+		{"name of a cluster with no secret", appv1.ApplicationDestination{Name: "no-such-cluster", Namespace: "default"}, true},
+		{"server of a cluster with no secret", appv1.ApplicationDestination{Server: "https://no-such-cluster", Namespace: "default"}, true},
+		{"ambiguous name matching two clusters", appv1.ApplicationDestination{Name: "dupe", Namespace: "default"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := appWithDestination("app", tt.dest)
+
+			_, gotServer, err := ctrl.canProcessAppWithDestination(app)
+			if !tt.wantErr {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Empty(t, gotServer, "an unresolved destination exports an empty dest_server")
+
+			hook := logtest.NewGlobal()
+			defer hook.Reset()
+			ctrl.canProcessApp(app)
+			for _, entry := range hook.AllEntries() {
+				assert.NotEqual(t, log.WarnLevel, entry.Level,
+					"the informer path must not warn, or every Application event logs")
+			}
+		})
+	}
+}

--- a/controller/metrics/metrics.go
+++ b/controller/metrics/metrics.go
@@ -21,7 +21,6 @@ import (
 	"github.com/argoproj/argo-cd/v3/common"
 	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	applister "github.com/argoproj/argo-cd/v3/pkg/client/listers/application/v1alpha1"
-	"github.com/argoproj/argo-cd/v3/util/argo"
 	"github.com/argoproj/argo-cd/v3/util/db"
 	"github.com/argoproj/argo-cd/v3/util/git"
 	"github.com/argoproj/argo-cd/v3/util/healthz"
@@ -159,7 +158,7 @@ var (
 )
 
 // NewMetricsServer returns a new prometheus server which collects application metrics
-func NewMetricsServer(addr string, appLister applister.ApplicationLister, appFilter func(obj any) bool, healthCheck func(r *http.Request) error, appLabels []string, appConditions []string, db db.ArgoDB) (*MetricsServer, error) {
+func NewMetricsServer(addr string, appLister applister.ApplicationLister, appFilter AppFilter, healthCheck func(r *http.Request) error, appLabels []string, appConditions []string) (*MetricsServer, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
 		return nil, err
@@ -185,7 +184,7 @@ func NewMetricsServer(addr string, appLister applister.ApplicationLister, appFil
 	}
 
 	mux := http.NewServeMux()
-	registry := NewAppRegistry(appLister, appFilter, appLabels, appConditions, db)
+	registry := NewAppRegistry(appLister, appFilter, appLabels, appConditions)
 
 	mux.Handle(MetricsPath, promhttp.HandlerFor(prometheus.Gatherers{
 		// contains app controller specific metrics
@@ -354,29 +353,34 @@ func (m *MetricsServer) SetExpiration(cacheExpiration time.Duration) error {
 	return nil
 }
 
+// AppFilter reports whether an Application should be exported, and returns the destination server
+// it resolved on the way. Resolving isn't free, so the collector reuses this instead of resolving
+// again. destServer is empty and err is set when the destination doesn't resolve, which the
+// collector logs per scrape; keep is independent of err, an unresolvable destination is still
+// exported.
+type AppFilter func(obj any) (keep bool, destServer string, err error)
+
 type appCollector struct {
 	store         applister.ApplicationLister
-	appFilter     func(obj any) bool
+	appFilter     AppFilter
 	appLabels     []string
 	appConditions []string
-	db            db.ArgoDB
 }
 
 // NewAppCollector returns a prometheus collector for application metrics
-func NewAppCollector(appLister applister.ApplicationLister, appFilter func(obj any) bool, appLabels []string, appConditions []string, db db.ArgoDB) prometheus.Collector {
+func NewAppCollector(appLister applister.ApplicationLister, appFilter AppFilter, appLabels []string, appConditions []string) prometheus.Collector {
 	return &appCollector{
 		store:         appLister,
 		appFilter:     appFilter,
 		appLabels:     appLabels,
 		appConditions: appConditions,
-		db:            db,
 	}
 }
 
 // NewAppRegistry creates a new prometheus registry that collects applications
-func NewAppRegistry(appLister applister.ApplicationLister, appFilter func(obj any) bool, appLabels []string, appConditions []string, db db.ArgoDB) *prometheus.Registry {
+func NewAppRegistry(appLister applister.ApplicationLister, appFilter AppFilter, appLabels []string, appConditions []string) *prometheus.Registry {
 	registry := prometheus.NewRegistry()
-	registry.MustRegister(NewAppCollector(appLister, appFilter, appLabels, appConditions, db))
+	registry.MustRegister(NewAppCollector(appLister, appFilter, appLabels, appConditions))
 	return registry
 }
 
@@ -399,16 +403,12 @@ func (c *appCollector) Collect(ch chan<- prometheus.Metric) {
 		return
 	}
 	for _, app := range apps {
-		if !c.appFilter(app) {
+		keep, destServer, err := c.appFilter(app)
+		if !keep {
 			continue
 		}
-		destCluster, err := argo.GetDestinationCluster(context.Background(), app.Spec.Destination, c.db)
 		if err != nil {
 			log.Warnf("Failed to get destination cluster for application %s: %v", app.Name, err)
-		}
-		destServer := ""
-		if destCluster != nil {
-			destServer = destCluster.Server
 		}
 		c.collectApps(ch, app, destServer)
 	}

--- a/controller/metrics/metrics_test.go
+++ b/controller/metrics/metrics_test.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+	stderrors "errors"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -9,12 +10,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/mock"
-
-	"github.com/argoproj/argo-cd/v3/util/db/mocks"
-
 	gitopsCache "github.com/argoproj/argo-cd/gitops-engine/v3/pkg/cache"
 	"github.com/argoproj/argo-cd/gitops-engine/v3/pkg/sync/common"
+	"github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -272,8 +271,8 @@ var noOpHealthCheck = func(_ *http.Request) error {
 	return nil
 }
 
-var appFilter = func(_ any) bool {
-	return true
+var appFilter AppFilter = func(_ any) (bool, string, error) {
+	return true, "https://localhost:6443", nil
 }
 
 func init() {
@@ -355,10 +354,7 @@ func runTest(t *testing.T, cfg TestMetricServerConfig) {
 	t.Helper()
 	cancel, appLister := newFakeLister(t.Context(), cfg.FakeAppYAMLs...)
 	defer cancel()
-	mockDB := mocks.NewArgoDB(t)
-	mockDB.EXPECT().GetClusterServersByName(mock.Anything, "cluster1").Return([]string{"https://localhost:6443"}, nil).Maybe()
-	mockDB.EXPECT().GetCluster(mock.Anything, "https://localhost:6443").Return(&argoappv1.Cluster{Name: "cluster1", Server: "https://localhost:6443"}, nil).Maybe()
-	metricsServ, err := NewMetricsServer("localhost:8082", appLister, appFilter, noOpHealthCheck, cfg.AppLabels, cfg.AppConditions, mockDB)
+	metricsServ, err := NewMetricsServer("localhost:8082", appLister, appFilter, noOpHealthCheck, cfg.AppLabels, cfg.AppConditions)
 	require.NoError(t, err)
 
 	if len(cfg.ClustersInfo) > 0 {
@@ -523,8 +519,7 @@ argocd_app_condition{condition="ExcludedResourceWarning",name="my-app-4",namespa
 func TestMetricsSyncCounter(t *testing.T) {
 	cancel, appLister := newFakeLister(t.Context())
 	defer cancel()
-	mockDB := mocks.NewArgoDB(t)
-	metricsServ, err := NewMetricsServer("localhost:8082", appLister, appFilter, noOpHealthCheck, []string{}, []string{}, mockDB)
+	metricsServ, err := NewMetricsServer("localhost:8082", appLister, appFilter, noOpHealthCheck, []string{}, []string{})
 	require.NoError(t, err)
 
 	appSyncTotal := `
@@ -577,8 +572,7 @@ func assertMetricsNotPrinted(t *testing.T, expectedLines, body string) {
 func TestMetricsSyncDuration(t *testing.T) {
 	cancel, appLister := newFakeLister(t.Context())
 	defer cancel()
-	mockDB := mocks.NewArgoDB(t)
-	metricsServ, err := NewMetricsServer("localhost:8082", appLister, appFilter, noOpHealthCheck, []string{}, []string{}, mockDB)
+	metricsServ, err := NewMetricsServer("localhost:8082", appLister, appFilter, noOpHealthCheck, []string{}, []string{})
 	require.NoError(t, err)
 
 	t.Run("metric is not generated during Operation Running.", func(t *testing.T) {
@@ -618,8 +612,7 @@ argocd_app_sync_duration_seconds_total{dest_server="https://localhost:6443",name
 func TestReconcileMetrics(t *testing.T) {
 	cancel, appLister := newFakeLister(t.Context())
 	defer cancel()
-	mockDB := mocks.NewArgoDB(t)
-	metricsServ, err := NewMetricsServer("localhost:8082", appLister, appFilter, noOpHealthCheck, []string{}, []string{}, mockDB)
+	metricsServ, err := NewMetricsServer("localhost:8082", appLister, appFilter, noOpHealthCheck, []string{}, []string{})
 	require.NoError(t, err)
 
 	appReconcileMetrics := `
@@ -652,8 +645,7 @@ argocd_app_reconcile_count{dest_server="https://localhost:6443",namespace="argoc
 func TestOrphanedResourcesMetric(t *testing.T) {
 	cancel, appLister := newFakeLister(t.Context())
 	defer cancel()
-	mockDB := mocks.NewArgoDB(t)
-	metricsServ, err := NewMetricsServer("localhost:8082", appLister, appFilter, noOpHealthCheck, []string{}, []string{}, mockDB)
+	metricsServ, err := NewMetricsServer("localhost:8082", appLister, appFilter, noOpHealthCheck, []string{}, []string{})
 	require.NoError(t, err)
 
 	expectedMetrics := `
@@ -678,8 +670,7 @@ argocd_app_orphaned_resources_count{name="my-app-4",namespace="argocd",project="
 func TestMetricsReset(t *testing.T) {
 	cancel, appLister := newFakeLister(t.Context())
 	defer cancel()
-	mockDB := mocks.NewArgoDB(t)
-	metricsServ, err := NewMetricsServer("localhost:8082", appLister, appFilter, noOpHealthCheck, []string{}, []string{}, mockDB)
+	metricsServ, err := NewMetricsServer("localhost:8082", appLister, appFilter, noOpHealthCheck, []string{}, []string{})
 	require.NoError(t, err)
 
 	appSyncTotal := `
@@ -716,8 +707,7 @@ argocd_app_sync_total{dest_server="https://localhost:6443",dry_run="false",name=
 func TestWorkqueueMetrics(t *testing.T) {
 	cancel, appLister := newFakeLister(t.Context())
 	defer cancel()
-	mockDB := mocks.NewArgoDB(t)
-	metricsServ, err := NewMetricsServer("localhost:8082", appLister, appFilter, noOpHealthCheck, []string{}, []string{}, mockDB)
+	metricsServ, err := NewMetricsServer("localhost:8082", appLister, appFilter, noOpHealthCheck, []string{}, []string{})
 	require.NoError(t, err)
 
 	expectedMetrics := `
@@ -747,8 +737,7 @@ workqueue_unfinished_work_seconds{controller="test",name="test"}
 func TestGoMetrics(t *testing.T) {
 	cancel, appLister := newFakeLister(t.Context())
 	defer cancel()
-	mockDB := mocks.NewArgoDB(t)
-	metricsServ, err := NewMetricsServer("localhost:8082", appLister, appFilter, noOpHealthCheck, []string{}, []string{}, mockDB)
+	metricsServ, err := NewMetricsServer("localhost:8082", appLister, appFilter, noOpHealthCheck, []string{}, []string{})
 	require.NoError(t, err)
 
 	expectedMetrics := `
@@ -775,4 +764,42 @@ go_threads
 	body := rr.Body.String()
 	log.Println(body)
 	assertMetricsPrinted(t, expectedMetrics, body)
+}
+
+// TestAppCollector_WarnsOnDestinationResolutionFailure pins the per scrape warning for an
+// Application whose destination does not resolve. The filter reports the failure, the collector
+// logs it, and the Application is still exported.
+func TestAppCollector_WarnsOnDestinationResolutionFailure(t *testing.T) {
+	cancel, appLister := newFakeLister(t.Context(), fakeApp)
+	defer cancel()
+
+	hook := logtest.NewGlobal()
+	defer hook.Reset()
+
+	resolutionErr := stderrors.New("there are no clusters with this name: missing-cluster")
+	failingFilter := AppFilter(func(_ any) (bool, string, error) {
+		return true, "", resolutionErr
+	})
+
+	registry := NewAppRegistry(appLister, failingFilter, []string{}, []string{})
+	families, err := registry.Gather()
+	require.NoError(t, err)
+
+	var exported bool
+	for _, f := range families {
+		if f.GetName() == "argocd_app_info" && len(f.GetMetric()) > 0 {
+			exported = true
+		}
+	}
+	assert.True(t, exported, "an unresolvable destination must still be exported")
+
+	var warned bool
+	for _, entry := range hook.AllEntries() {
+		if entry.Level == logrus.WarnLevel &&
+			strings.Contains(entry.Message, "Failed to get destination cluster for application") &&
+			strings.Contains(entry.Message, resolutionErr.Error()) {
+			warned = true
+		}
+	}
+	assert.True(t, warned, "collector must warn once per scrape when the destination fails to resolve")
 }

--- a/controller/sharding/cache.go
+++ b/controller/sharding/cache.go
@@ -21,6 +21,7 @@ type ClusterShardingCache interface {
 	DeleteApp(a *v1alpha1.Application)
 	UpdateApp(a *v1alpha1.Application)
 	IsManagedCluster(c *v1alpha1.Cluster) bool
+	IsManagedClusterByServer(server string) (managed bool, known bool)
 	GetDistribution() map[string]int
 	GetAppDistribution() map[string]int
 	UpdateShard(shard int) bool
@@ -63,17 +64,35 @@ func (sharding *ClusterSharding) IsManagedCluster(c *v1alpha1.Cluster) bool {
 	if c == nil { // nil cluster (in-cluster) is always managed by current clusterShard
 		return true
 	}
-	if skipReconcile, err := strconv.ParseBool(c.Annotations[common.AnnotationKeyAppSkipReconcile]); err == nil && skipReconcile {
-		log.Debugf("Cluster %s has %s annotation set, skipping", c.Server, common.AnnotationKeyAppSkipReconcile)
+	return sharding.isManagedShard(c.Server, c.Annotations)
+}
+
+// IsManagedClusterByServer is IsManagedCluster by server URL. known reports whether the cache
+// holds a cluster for that server; when it doesn't, managed is true, mirroring IsManagedCluster(nil).
+func (sharding *ClusterSharding) IsManagedClusterByServer(server string) (bool, bool) {
+	sharding.lock.RLock()
+	defer sharding.lock.RUnlock()
+	c, ok := sharding.Clusters[server]
+	if !ok {
+		return true, false
+	}
+	return sharding.isManagedShard(server, c.Annotations), true
+}
+
+// isManagedShard reports whether the cluster identified by the given server URL and annotations
+// belongs to this shard. Callers must hold at least the read lock.
+func (sharding *ClusterSharding) isManagedShard(server string, annotations map[string]string) bool {
+	if skipReconcile, err := strconv.ParseBool(annotations[common.AnnotationKeyAppSkipReconcile]); err == nil && skipReconcile {
+		log.Debugf("Cluster %s has %s annotation set, skipping", server, common.AnnotationKeyAppSkipReconcile)
 		return false
 	}
 	clusterShard := 0
-	if shard, ok := sharding.Shards[c.Server]; ok {
+	if shard, ok := sharding.Shards[server]; ok {
 		clusterShard = shard
 	} else {
-		log.Warnf("The cluster %s has no assigned shard.", c.Server)
+		log.Warnf("The cluster %s has no assigned shard.", server)
 	}
-	log.Debugf("Checking if cluster %s with clusterShard %d should be processed by shard %d", c.Server, clusterShard, sharding.Shard)
+	log.Debugf("Checking if cluster %s with clusterShard %d should be processed by shard %d", server, clusterShard, sharding.Shard)
 	return clusterShard == sharding.Shard
 }
 

--- a/controller/sharding/cache_test.go
+++ b/controller/sharding/cache_test.go
@@ -353,6 +353,60 @@ func TestIsManagedCluster_SkipReconcileAnnotation(t *testing.T) {
 	assert.True(t, sharding.IsManagedCluster(nil))
 }
 
+func TestClusterSharding_IsManagedClusterByServer(t *testing.T) {
+	t.Parallel()
+	replicas := 2
+	shard0, shard1 := int64(0), int64(1)
+	clusters := &v1alpha1.ClusterList{
+		Items: []v1alpha1.Cluster{
+			{ID: "1", Server: "https://kubernetes.default.svc", Shard: &shard0},
+			{ID: "2", Server: "https://127.0.0.1:6443", Shard: &shard1},
+			{ID: "3", Server: "https://skipped", Shard: &shard0, Annotations: map[string]string{common.AnnotationKeyAppSkipReconcile: "true"}},
+			{ID: "4", Server: "https://not-skipped", Shard: &shard0, Annotations: map[string]string{common.AnnotationKeyAppSkipReconcile: "false"}},
+		},
+	}
+	apps := &v1alpha1.ApplicationList{
+		Items: []v1alpha1.Application{
+			createApp("app1", "https://kubernetes.default.svc"),
+			createApp("app2", "https://127.0.0.1:6443"),
+		},
+	}
+
+	sharding0 := setupTestSharding(0, replicas)
+	sharding0.Init(clusters, apps)
+	sharding1 := setupTestSharding(1, replicas)
+	sharding1.Init(clusters, apps)
+
+	tests := []struct {
+		name       string
+		server     string
+		wantShard0 bool
+		wantShard1 bool
+		wantKnown  bool
+	}{
+		{"cluster assigned to shard 0", "https://kubernetes.default.svc", true, false, true},
+		{"cluster assigned to shard 1", "https://127.0.0.1:6443", false, true, true},
+		{"cluster with skip-reconcile annotation", "https://skipped", false, false, true},
+		{"cluster with skip-reconcile annotation set to false", "https://not-skipped", true, false, true},
+		// An unknown server reports managed, matching IsManagedCluster(nil), with known=false so
+		// callers can fall back to the full lookup.
+		{"server the cache holds no cluster for", "https://unknown", true, true, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			managed, known := sharding0.IsManagedClusterByServer(tt.server)
+			assert.Equal(t, tt.wantShard0, managed, "shard 0 managed")
+			assert.Equal(t, tt.wantKnown, known, "shard 0 known")
+
+			managed, known = sharding1.IsManagedClusterByServer(tt.server)
+			assert.Equal(t, tt.wantShard1, managed, "shard 1 managed")
+			assert.Equal(t, tt.wantKnown, known, "shard 1 known")
+		})
+	}
+}
+
 func TestClusterSharding_ClusterShardOfResourceShouldNotBeChanged(t *testing.T) {
 	t.Parallel()
 	shard := 1


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

`canProcessApp` is the Application filter for the app informer and for the metrics collector, so it runs on every Application event and once per app on every Prometheus scrape. It resolved the whole destination `Cluster` through `GetDestinationCluster`, which is an index lookup for the server plus a second index lookup and a `Cluster.DeepCopy` for the object, and then handed that to `IsManagedCluster`, which reads the server URL and the skip reconcile annotation and nothing else.

`appCollector.Collect` made it worse, it filtered every Application and then called `GetDestinationCluster` a second time for each one that passed, only to read `destCluster.Server` for the `dest_server` label.

| | | time | bytes | allocs |
|---|---|---|---|---|
| one filter call | before | 2026ns | 5328B | 11 |
| one filter call | after | 371ns | 96B | 4 |
| destination resolution over 35k apps, one scrape | before | 127ms | 370.7MB | 700,000 |
| destination resolution over 35k apps, one scrape | after | 12.1ms | 3.4MB | 140,000 |

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
