### PR TITLE
fix: preserve revision when manifest generation fails (#29575)

### DIFF
--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -72,6 +72,7 @@ type fakeData struct {
 	apps                            []runtime.Object
 	manifestResponse                *apiclient.ManifestResponse
 	manifestResponses               []*apiclient.ManifestResponse
+	manifestErr                     error
 	managedLiveObjs                 map[kube.ResourceKey]*unstructured.Unstructured
 	namespacedResources             map[kube.ResourceKey]namespacedResource
 	configMapData                   map[string]string
@@ -147,20 +148,25 @@ func newFakeControllerWithResync(ctx context.Context, data *fakeData, appResyncP
 		}
 	}
 
+	manifestErr := data.manifestErr
+	if manifestErr == nil {
+		manifestErr = repoErr
+	}
+
 	if len(data.manifestResponses) > 0 {
 		for _, response := range data.manifestResponses {
-			if repoErr != nil {
-				mockRepoClient.EXPECT().GenerateManifest(mock.Anything, mock.Anything).Run(captureRun).Return(response, repoErr).Once()
-			} else {
-				mockRepoClient.EXPECT().GenerateManifest(mock.Anything, mock.Anything).Run(captureRun).Return(response, nil).Once()
-			}
+			mockRepoClient.EXPECT().
+				GenerateManifest(mock.Anything, mock.Anything).
+				Run(captureRun).
+				Return(response, manifestErr).
+				Once()
 		}
-	} else {
-		if repoErr != nil {
-			mockRepoClient.EXPECT().GenerateManifest(mock.Anything, mock.Anything).Run(captureRun).Return(data.manifestResponse, repoErr).Once()
-		} else if data.manifestResponse != nil {
-			mockRepoClient.EXPECT().GenerateManifest(mock.Anything, mock.Anything).Run(captureRun).Return(data.manifestResponse, nil).Once()
-		}
+	} else if data.manifestResponse != nil || manifestErr != nil {
+		mockRepoClient.EXPECT().
+			GenerateManifest(mock.Anything, mock.Anything).
+			Run(captureRun).
+			Return(data.manifestResponse, manifestErr).
+			Once()
 	}
 
 	if len(data.updateRevisionForPathsResponses) > 0 {
@@ -182,12 +188,27 @@ func newFakeControllerWithResync(ctx context.Context, data *fakeData, appResyncP
 	if len(data.resolveRevisionResponses) > 0 {
 		for _, response := range data.resolveRevisionResponses {
 			if repoErr != nil {
-				mockRepoClient.EXPECT().ResolveRevision(mock.Anything, mock.Anything).Return(response, repoErr)
+				mockRepoClient.EXPECT().
+					ResolveRevision(mock.Anything, mock.Anything).
+					Return(response, repoErr).
+					Once()
 			} else {
-				mockRepoClient.EXPECT().ResolveRevision(mock.Anything, mock.Anything).Return(response, nil)
+				mockRepoClient.EXPECT().
+					ResolveRevision(mock.Anything, mock.Anything).
+					Return(response, nil).
+					Once()
 			}
 		}
 	}
+
+	mockRepoClient.EXPECT().
+		ResolveRevision(mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, req *apiclient.ResolveRevisionRequest, _ ...grpc.CallOption) (*apiclient.ResolveRevisionResponse, error) {
+			return &apiclient.ResolveRevisionResponse{
+				Revision: req.AmbiguousRevision,
+			}, nil
+		}).
+		Maybe()
 
 	mockRepoClientset := &mockrepoclient.Clientset{RepoServerServiceClient: mockRepoClient}
 

--- a/controller/state.go
+++ b/controller/state.go
@@ -334,12 +334,76 @@ func (m *appStateManager) GetRepoObjs(ctx context.Context, app *v1alpha1.Applica
 		syncedRefSources = argo.GetSyncedRefSources(refSources, sources, app.Status.Sync.Revisions)
 	}
 
+	resolvedRevisions := make([]string, len(sources))
+	sourceRepos := make([]*v1alpha1.Repository, len(sources))
 	revisionsMayHaveChanges := false
+
+	// Resolve all revisions before generating manifests.
 	for i, source := range sources {
 		if len(revisions) < len(sources) || revisions[i] == "" {
 			revisions[i] = source.TargetRevision
 		}
+
 		revision := revisions[i]
+
+		resolvedRevision, hasChanges, err := m.evaluateRevisionChanges(
+			ctx,
+			app,
+			source,
+			i,
+			revision,
+			refSources,
+			syncedRefSources,
+			noRevisionCache,
+			trackingMethod,
+			appLabelKey,
+			installationID,
+			serverVersion,
+			apiVersions,
+			proj,
+			repoClient,
+			sourceIntegrity,
+		)
+		if err != nil {
+			return nil, nil, false, fmt.Errorf("failed to evaluate revision changes for source %d of %d: %w", i+1, len(sources), err)
+		}
+
+		if hasChanges {
+			revisionsMayHaveChanges = true
+		}
+
+		repo, err := m.db.GetRepository(ctx, source.RepoURL, proj.Name)
+		if err != nil {
+			return nil, nil, false, fmt.Errorf("failed to get repo %q: %w", git.SanitizeRepoURL(source.RepoURL), err)
+		}
+		sourceRepos[i] = repo
+
+		if revision != "" && resolvedRevision == revision && !source.IsRef() {
+			resp, resolveErr := repoClient.ResolveRevision(ctx, &apiclient.ResolveRevisionRequest{
+				Repo:              repo,
+				App:               app,
+				AmbiguousRevision: revision,
+				SourceIndex:       int64(i),
+				NoRevisionCache:   noRevisionCache,
+			})
+			if resolveErr != nil {
+				return nil, nil, false, fmt.Errorf("failed to resolve revision for source %d of %d: %w", i+1, len(sources), resolveErr)
+			}
+			if resp == nil || resp.Revision == "" {
+				return nil, nil, false, fmt.Errorf("failed to resolve revision for source %d of %d: empty resolved revision", i+1, len(sources))
+			}
+
+			resolvedRevision = resp.Revision
+		}
+
+		resolvedRevisions[i] = resolvedRevision
+		revisions[i] = resolvedRevision
+	}
+
+	// Generate manifests using the already-resolved revisions.
+	for i, source := range sources {
+		revision := resolvedRevisions[i]
+		revisions[i] = revision
 
 		// Per-source span so the repo-server hop is attributed: a multi-source app otherwise
 		// produces one parent span plus N anonymous GenerateManifest RPC spans with nothing
@@ -357,21 +421,6 @@ func (m *appStateManager) GetRepoObjs(ctx context.Context, app *v1alpha1.Applica
 		if err := func() (retErr error) {
 			defer func() { traceutil.EndSpan(srcSpan, retErr) }()
 
-			// Use evaluateRevisionChanges to check for changes and get resolved revision
-			resolvedRevision, hasChanges, err := m.evaluateRevisionChanges(srcCtx, app, source, i, revision, refSources, syncedRefSources, noRevisionCache, trackingMethod, appLabelKey, installationID, serverVersion, apiVersions, proj, repoClient, sourceIntegrity)
-			if err != nil {
-				return fmt.Errorf("failed to evaluate revision changes for source %d of %d: %w", i+1, len(sources), err)
-			}
-
-			if hasChanges {
-				revisionsMayHaveChanges = true
-			}
-
-			// Use the resolved revision from evaluateRevisionChanges
-			revision = resolvedRevision
-			revisions[i] = resolvedRevision
-			srcSpan.SetAttributes(attribute.String("argocd.resolved_revision", revision))
-
 			appNamespace := app.Spec.Destination.Namespace
 
 			repos := permittedHelmRepos
@@ -386,10 +435,11 @@ func (m *appStateManager) GetRepoObjs(ctx context.Context, app *v1alpha1.Applica
 				helmRepoCreds = append(helmRepoCreds, permittedOCICredentials...)
 			}
 
-			repo, err := m.db.GetRepository(srcCtx, source.RepoURL, proj.Name)
-			if err != nil {
-				return fmt.Errorf("failed to get repo %q: %w", git.SanitizeRepoURL(source.RepoURL), err)
-			}
+			repo := sourceRepos[i]
+
+			revision = resolvedRevisions[i]
+			revisions[i] = revision
+			srcSpan.SetAttributes(attribute.String("argocd.resolved_revision", revision))
 
 			log.Debugf("Generating Manifest for source %s revision %s", source, revision)
 			manifestInfo, err := repoClient.GenerateManifest(srcCtx, &apiclient.ManifestRequest{
@@ -747,6 +797,11 @@ func (m *appStateManager) CompareAppState(ctx context.Context, app *v1alpha1.App
 		targetObjs, manifestInfos, revisionsMayHaveChanges, err = m.GetRepoObjs(ctx, app, sources, appLabelKey, revisions, noCache, noRevisionCache, project.EffectiveSourceIntegrity(), project, true)
 		if err != nil {
 			targetObjs = make([]*unstructured.Unstructured, 0)
+			if hasMultipleSources {
+				syncStatus.Revisions = revisions
+			} else if len(revisions) > 0 {
+				syncStatus.Revision = revisions[0]
+			}
 			msg := "Failed to load target state: " + err.Error()
 			conditions = append(conditions, v1alpha1.ApplicationCondition{Type: v1alpha1.ApplicationConditionComparisonError, Message: msg, LastTransitionTime: &now})
 			if firstSeen, ok := m.repoErrorCache.Load(app.Name); ok {
@@ -1111,10 +1166,12 @@ func (m *appStateManager) CompareAppState(ctx context.Context, app *v1alpha1.App
 	syncStatus.Status = syncCode
 
 	// Update the initial revision to the resolved manifest SHA
-	if hasMultipleSources {
-		syncStatus.Revisions = manifestRevisions
-	} else if len(manifestRevisions) > 0 {
-		syncStatus.Revision = manifestRevisions[0]
+	if !failedToLoadObjs {
+		if hasMultipleSources {
+			syncStatus.Revisions = manifestRevisions
+		} else if len(manifestRevisions) > 0 {
+			syncStatus.Revision = manifestRevisions[0]
+		}
 	}
 
 	ts.AddCheckpoint("sync_ms")

--- a/controller/state_test.go
+++ b/controller/state_test.go
@@ -262,10 +262,118 @@ func TestCompareAppStateEmpty(t *testing.T) {
 	assert.Empty(t, app.Status.Conditions)
 }
 
+func TestCompareAppStateManifestGenerationErrorPreservesRevision(t *testing.T) {
+	t.Parallel()
+
+	app := newFakeApp()
+	app.Status.Sync = v1alpha1.SyncStatus{
+		Revision: "old-sha",
+		Status:   v1alpha1.SyncStatusCodeSynced,
+	}
+
+	data := fakeData{
+		manifestResponse: &apiclient.ManifestResponse{},
+		manifestErr:      errors.New("manifest generation failed"),
+		resolveRevisionResponses: []*apiclient.ResolveRevisionResponse{
+			{
+				Revision: "resolved-sha",
+			},
+		},
+		onGenerateManifest: func(req *apiclient.ManifestRequest) {
+			assert.Equal(t, "resolved-sha", req.Revision)
+		},
+	}
+
+	ctrl := newFakeController(t.Context(), &data, nil)
+
+	sources := []v1alpha1.ApplicationSource{app.Spec.GetSource()}
+	revisions := []string{"HEAD"}
+
+	compRes, err := ctrl.appStateManager.CompareAppState(
+		t.Context(),
+		app,
+		&defaultProj,
+		revisions,
+		sources,
+		false,
+		true,
+		nil,
+		false,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, compRes)
+	require.NotNil(t, compRes.syncStatus)
+	assert.Equal(t, "resolved-sha", compRes.syncStatus.Revision)
+}
+
+func TestCompareAppStateManifestGenerationErrorPreservesRevisions(t *testing.T) {
+	t.Parallel()
+
+	app := newFakeApp()
+	app.Status.Sync = v1alpha1.SyncStatus{
+		Revisions: []string{"old-sha-1", "old-sha-2"},
+		Status:    v1alpha1.SyncStatusCodeSynced,
+	}
+
+	app.Spec.Sources = v1alpha1.ApplicationSources{
+		{
+			RepoURL:        "https://github.com/example/repo1.git",
+			TargetRevision: "HEAD",
+			Path:           "path1",
+		},
+		{
+			RepoURL:        "https://github.com/example/repo2.git",
+			TargetRevision: "HEAD",
+			Path:           "path2",
+		},
+	}
+
+	data := fakeData{
+		manifestResponse: &apiclient.ManifestResponse{},
+		manifestErr:      errors.New("manifest generation failed"),
+		resolveRevisionResponses: []*apiclient.ResolveRevisionResponse{
+			{
+				Revision: "resolved-sha-1",
+			},
+			{
+				Revision: "resolved-sha-2",
+			},
+		},
+	}
+
+	ctrl := newFakeController(t.Context(), &data, nil)
+
+	revisions := []string{"HEAD", "HEAD"}
+
+	compRes, err := ctrl.appStateManager.CompareAppState(
+		t.Context(),
+		app,
+		&defaultProj,
+		revisions,
+		app.Spec.Sources,
+		false,
+		true,
+		nil,
+		true,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, compRes)
+	require.NotNil(t, compRes.syncStatus)
+	assert.Equal(t, []string{"resolved-sha-1", "resolved-sha-2"}, compRes.syncStatus.Revisions)
+}
+
 // TestCompareAppStateRepoError tests the case when CompareAppState notices a repo error
 func TestCompareAppStateRepoError(t *testing.T) {
 	app := newFakeApp()
-	ctrl := newFakeController(t.Context(), &fakeData{manifestResponses: make([]*apiclient.ManifestResponse, 3)}, errors.New("test repo error"))
+	data := fakeData{
+		manifestResponses: make([]*apiclient.ManifestResponse, 3),
+		resolveRevisionResponses: []*apiclient.ResolveRevisionResponse{
+			{},
+		},
+	}
+	ctrl := newFakeController(t.Context(), &data, errors.New("test repo error"))
 	sources := make([]v1alpha1.ApplicationSource, 0)
 	sources = append(sources, app.Spec.GetSource())
 	revisions := make([]string, 0)


### PR DESCRIPTION
## Description

When manifest generation fails during sync, `GetRepoObjs` may already have resolved the requested revision to a concrete commit SHA. Previously, that resolved revision was lost when `GetRepoObjs` returned an error, leaving `SyncResult.Revision` as the original ambiguous revision.

Preserve the resolved revision(s) in `syncStatus` when `GetRepoObjs` fails so that the sync operation retains the concrete revision and GitHub commit-status notifications can use it.

Fixes #29575

## Testing

- `go test ./controller/... -count=1`
- `git diff --check`

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Fixes #29575" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).