### PR TITLE
fix: ARGOCD_OPTS repeated --header flags now accumulate as comma-separated

### DIFF
--- a/util/config/env.go
+++ b/util/config/env.go
@@ -37,7 +37,11 @@ func LoadFlags() error {
 			}
 			key = strings.TrimPrefix(opt, "--")
 		case key != "":
-			flags[key] = opt
+			if existing, ok := flags[key]; ok {
+				flags[key] = existing + "," + opt
+			} else {
+				flags[key] = opt
+			}
 			key = ""
 		default:
 			return errors.New("ARGOCD_OPTS invalid at '" + opt + "'")

--- a/util/config/env_test.go
+++ b/util/config/env_test.go
@@ -148,3 +148,9 @@ func TestFlagWithEqualSign(t *testing.T) {
 
 	assert.Equal(t, "bar", GetFlag("foo", ""))
 }
+
+func TestRepeatedFlagCommaSeparated(t *testing.T) {
+	loadOpts(t, "--header 'CF-Access-Client-Id: foo' --header 'CF-Access-Client-Secret: bar'")
+
+	assert.Equal(t, "CF-Access-Client-Id: foo,CF-Access-Client-Secret: bar", GetFlag("header", ""))
+}


### PR DESCRIPTION
Previously, passing --header multiple times via ARGOCD_OPTS would only keep the last value. Now repeated flags are joined with commas, matching the behavior of the CLI flag parser. GetStringSliceFlag already splits on comma, so the existing --header flag works correctly with both repeated flags and comma-separated values.