### PR TITLE
fix: clarify credential template status instead of a bare dash (#12273)

### DIFF
--- a/ui/src/app/settings/components/repos-list/__snapshots__/repos-list.test.tsx.snap
+++ b/ui/src/app/settings/components/repos-list/__snapshots__/repos-list.test.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CredentialTemplateStatus renders a key icon and a clear label instead of a bare dash 1`] = `"<span><i class="fa fa-key"></i> Credential template</span>"`;

--- a/ui/src/app/settings/components/repos-list/repos-list.test.tsx
+++ b/ui/src/app/settings/components/repos-list/repos-list.test.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import {renderToStaticMarkup} from 'react-dom/server.node';
+import {CredentialTemplateStatus} from './repos-list';
+
+test('CredentialTemplateStatus renders a key icon and a clear label instead of a bare dash', () => {
+    const markup = renderToStaticMarkup(<CredentialTemplateStatus />);
+
+    expect(markup).toContain('fa-key');
+    expect(markup).toContain('Credential template');
+    expect(markup).not.toContain('>-<');
+    expect(markup).toMatchSnapshot();
+});

--- a/ui/src/app/settings/components/repos-list/repos-list.test.tsx
+++ b/ui/src/app/settings/components/repos-list/repos-list.test.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import {renderToStaticMarkup} from 'react-dom/server.node';
-import {CredentialTemplateStatus} from './repos-list';
+import {ConnectionStatusCell, CredentialTemplateStatus} from './repos-list';
+import {UnifiedRepo} from './repos-filter';
+import * as models from '../../../shared/models';
 
 test('CredentialTemplateStatus renders a key icon and a clear label instead of a bare dash', () => {
     const markup = renderToStaticMarkup(<CredentialTemplateStatus />);
@@ -9,4 +11,36 @@ test('CredentialTemplateStatus renders a key icon and a clear label instead of a
     expect(markup).toContain('Credential template');
     expect(markup).not.toContain('>-<');
     expect(markup).toMatchSnapshot();
+});
+
+describe('ConnectionStatusCell (the CONNECTION STATUS cell rendered by each ReposList row)', () => {
+    test('a credential template with no connection state shows the key icon and label, not a bare dash', () => {
+        const templateRepo: UnifiedRepo = {readCred: {url: 'https://github.com/example/repo.git'} as models.RepoCreds};
+
+        const markup = renderToStaticMarkup(<ConnectionStatusCell connectionState={undefined} repo={templateRepo} />);
+
+        expect(markup).toContain('fa-key');
+        expect(markup).toContain('Credential template');
+        expect(markup).not.toContain('>-<');
+    });
+
+    test('a real repository with no connection state yet still shows the bare dash', () => {
+        const uncheckedRepo: UnifiedRepo = {readRepo: {repo: 'https://github.com/example/repo.git'} as models.Repository};
+
+        const markup = renderToStaticMarkup(<ConnectionStatusCell connectionState={undefined} repo={uncheckedRepo} />);
+
+        expect(markup).toContain('>-<');
+        expect(markup).not.toContain('Credential template');
+    });
+
+    test('a repository with a known connection state keeps showing that state, unaffected by the template case', () => {
+        const connectedRepo: UnifiedRepo = {readRepo: {repo: 'https://github.com/example/repo.git'} as models.Repository};
+        const connectionState = {status: models.ConnectionStatuses.Successful, message: ''} as models.ConnectionState;
+
+        const markup = renderToStaticMarkup(<ConnectionStatusCell connectionState={connectionState} repo={connectedRepo} />);
+
+        expect(markup).toContain(models.ConnectionStatuses.Successful);
+        expect(markup).not.toContain('Credential template');
+        expect(markup).not.toContain('>-<');
+    });
 });

--- a/ui/src/app/settings/components/repos-list/repos-list.tsx
+++ b/ui/src/app/settings/components/repos-list/repos-list.tsx
@@ -56,6 +56,22 @@ export const CredentialTemplateStatus = () => (
     </span>
 );
 
+// Extracted so a test can exercise the exact branch the table row renders,
+// rather than a copy of it: a repo with a connection state shows it, a
+// credential template with none shows CredentialTemplateStatus instead of
+// manufacturing a state it doesn't have, and any other repo keeps the
+// existing "not checked yet" dash.
+export const ConnectionStatusCell = ({connectionState, repo}: {connectionState: models.ConnectionState | undefined; repo: UnifiedRepo}) =>
+    connectionState ? (
+        <>
+            <ConnectionStateIcon state={connectionState} /> {connectionState.status}
+        </>
+    ) : isTemplate(repo) ? (
+        <CredentialTemplateStatus />
+    ) : (
+        <span>-</span>
+    );
+
 interface NewSSHRepoParams {
     type: string;
     name: string;
@@ -952,15 +968,7 @@ export const ReposList = ({match, location}: RouteComponentProps) => {
                                                                             <span>{isWrite(repo) ? 'Write' : 'Read'}</span>
                                                                         </div>
                                                                         <div className='columns small-2'>
-                                                                            {connectionState ? (
-                                                                                <>
-                                                                                    <ConnectionStateIcon state={connectionState} /> {connectionState.status}
-                                                                                </>
-                                                                            ) : isTemplate(repo) ? (
-                                                                                <CredentialTemplateStatus />
-                                                                            ) : (
-                                                                                <span>-</span>
-                                                                            )}
+                                                                            <ConnectionStatusCell connectionState={connectionState} repo={repo} />
                                                                             {!isTemplate(repo) && (
                                                                                 <ActionMenu
                                                                                     items={[

--- a/ui/src/app/settings/components/repos-list/repos-list.tsx
+++ b/ui/src/app/settings/components/repos-list/repos-list.tsx
@@ -47,6 +47,15 @@ const repoToUnified = (repo: models.Repository, isWriteFlag: boolean): UnifiedRe
 
 const credToUnified = (cred: models.RepoCreds, isWriteFlag: boolean): UnifiedRepo => (isWriteFlag ? {writeCred: cred} : {readCred: cred});
 
+// A credential template has no connection state at all - it's not a repo that
+// can be reachable or not, so showing the bare '-' used for a real repo's
+// not-yet-checked status reads as broken/missing information instead.
+export const CredentialTemplateStatus = () => (
+    <span>
+        <i className='fa fa-key' /> Credential template
+    </span>
+);
+
 interface NewSSHRepoParams {
     type: string;
     name: string;
@@ -947,6 +956,8 @@ export const ReposList = ({match, location}: RouteComponentProps) => {
                                                                                 <>
                                                                                     <ConnectionStateIcon state={connectionState} /> {connectionState.status}
                                                                                 </>
+                                                                            ) : isTemplate(repo) ? (
+                                                                                <CredentialTemplateStatus />
                                                                             ) : (
                                                                                 <span>-</span>
                                                                             )}


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] This is a bug fix.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the Title of the PR guide.
* [x] I've included "Closes #12273" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. (N/A - UI-only display fix, no CLI surface)
* [x] Does this PR require documentation updates? No.
* [x] I have signed off all my commits as required by DCO.
* [x] I have written unit and/or e2e tests for my change.
* [x] My build is green.
* [x] My new feature complies with the feature status guidelines. (N/A - bug fix, not a feature)
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into.

## Why

Repositories and credential templates share one table in **Settings > Repositories**. `getConnectionState()` only reads `connectionState` off `readRepo`/`writeRepo`, so a credential template (`isTemplate(repo) === true`) never has one - the CONNECTION STATUS column falls through to a bare `-` for every template row. That reads as missing/broken data rather than "not applicable to this row type."

The original 2023 report also flagged an abbreviated `CREDS` column header and cramped spacing on a separate, credentials-only table. That table doesn't exist anymore - repos and templates were merged into today's single unified list, and the header already reads out in full (`TYPE` / `NAME` / `REPOSITORY` / `PROJECT` / `PERMISSION` / `CONNECTION STATUS`). Only the ambiguous status placeholder is still reproducible on current `master` - verified by reading `repos-filter.tsx` and `repos-list.tsx` directly before writing this fix.

## What changed

Renders a small `CredentialTemplateStatus` indicator (key icon + "Credential template" label, reusing the `fa-key` icon already used for this concept in the GPG keys list) whenever `isTemplate(repo)` is true, instead of falling through to the dash. Real repos with no connection state yet keep the existing `-` - that's a different, legitimate "not checked yet" case.

The conditional itself is extracted into an exported `ConnectionStatusCell`, so the test below exercises the exact branch the table row renders instead of a copy of it - covering all three cases: a template with no state, a real repo with no state, and a real repo with a known state.

## Superseding note

Exception: stale/abandoned. This replaces a prior attempt at PR number 27415 (opened against the pre-redesign, credentials-only table that no longer exists in this codebase - `CREDENTIALS TEMPLATE URL` / `CREDS` header). I checked its timeline before starting: it was closed unmerged by its own author last May with no maintainer review comment on it, so I'm treating it as abandoned rather than actively rejected. Its author is welcome to pick this scope back up if they'd rather continue there instead.

Closes #12273.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
