### PR TITLE
test: add benchmarks for the application refresh path and matrix generator

### DIFF
--- a/applicationset/generators/matrix_bench_test.go
+++ b/applicationset/generators/matrix_bench_test.go
@@ -1,0 +1,91 @@
+package generators
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+)
+
+// benchClusterSecrets returns count cluster secrets shaped like a registered cluster, with a bearer
+// token and CA data so the cost of copying them out of the cache is realistic.
+func benchClusterSecrets(namespace string, count int) []client.Object {
+	config := fmt.Sprintf(`{"bearerToken":%q,"tlsClientConfig":{"insecure":false,"caData":%q}}`,
+		strings.Repeat("t", 800), strings.Repeat("c", 1400))
+
+	clusters := make([]client.Object, count)
+	for i := range clusters {
+		name := fmt.Sprintf("cluster-%03d", i)
+		clusters[i] = &corev1.Secret{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"argocd.argoproj.io/secret-type": "cluster",
+				"environment":                    "production",
+			},
+			Data: map[string][]byte{
+				"name":   []byte(name),
+				"server": []byte(fmt.Sprintf("https://%s.example.com", name)),
+				"config": []byte(config),
+			},
+			Type: corev1.SecretType("Opaque"),
+		}
+	}
+	return clusters
+}
+
+func benchListElements(count int) []apiextensionsv1.JSON {
+	elements := make([]apiextensionsv1.JSON, count)
+	for i := range elements {
+		raw, err := json.Marshal(map[string]string{"path": fmt.Sprintf("apps/app-%03d", i)})
+		if err != nil {
+			panic(err)
+		}
+		elements[i] = apiextensionsv1.JSON{Raw: raw}
+	}
+	return elements
+}
+
+// BenchmarkMatrixGenerate_ListByClusters measures a matrix whose second generator does not reference
+// the first, the shape that lists every cluster secret once per outer parameter set.
+func BenchmarkMatrixGenerate_ListByClusters(b *testing.B) {
+	const namespace = "namespace"
+
+	fakeClient := fake.NewClientBuilder().WithObjects(benchClusterSecrets(namespace, 500)...).Build()
+	matrixGenerator := NewMatrixGenerator(map[string]Generator{
+		"List":     &ListGenerator{},
+		"Clusters": NewClusterGenerator(fakeClient, namespace),
+	})
+
+	appSetGenerator := &v1alpha1.ApplicationSetGenerator{
+		Matrix: &v1alpha1.MatrixGenerator{
+			Generators: []v1alpha1.ApplicationSetNestedGenerator{
+				{List: &v1alpha1.ListGenerator{Elements: benchListElements(200)}},
+				{Clusters: &v1alpha1.ClusterGenerator{}},
+			},
+		},
+	}
+	appSet := &v1alpha1.ApplicationSet{
+		Name:      "set",
+		Namespace: namespace,
+		Spec:      v1alpha1.ApplicationSetSpec{GoTemplate: true},
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		params, err := matrixGenerator.GenerateParams(appSetGenerator, appSet, fakeClient)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(params) != 200*501 {
+			b.Fatalf("unexpected parameter count %d", len(params))
+		}
+	}
+}

--- a/controller/appcontroller_bench_test.go
+++ b/controller/appcontroller_bench_test.go
@@ -1,0 +1,82 @@
+package controller
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/argoproj/argo-cd/gitops-engine/v3/pkg/health"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubetesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	appclientset "github.com/argoproj/argo-cd/v3/pkg/client/clientset/versioned/fake"
+)
+
+// newSyncedFakeApp returns an app that needs no refresh, with resourceCount entries
+// in status.resources.
+func newSyncedFakeApp(resourceCount int) *v1alpha1.Application {
+	app := newFakeApp()
+	app.Status.ReconciledAt = &metav1.Time{Time: time.Now()}
+	app.Status.Sync.Status = v1alpha1.SyncStatusCodeSynced
+	app.Status.Sync.ComparedTo.Source = app.Spec.GetSource()
+	app.Status.Sync.ComparedTo.Destination = app.Spec.Destination
+	app.Status.Sync.ComparedTo.IgnoreDifferences = app.Spec.IgnoreDifferences
+
+	resources := make([]v1alpha1.ResourceStatus, resourceCount)
+	for i := range resources {
+		resources[i] = v1alpha1.ResourceStatus{
+			Version:   "v1",
+			Kind:      "ConfigMap",
+			Namespace: "default",
+			Name:      fmt.Sprintf("cm-%d", i),
+			Status:    v1alpha1.SyncStatusCodeSynced,
+			Health:    &v1alpha1.HealthStatus{Status: health.HealthStatusHealthy},
+		}
+	}
+	app.Status.Resources = resources
+	return app
+}
+
+func BenchmarkProcessAppRefreshQueueItem_NoRefresh(b *testing.B) {
+	app := newSyncedFakeApp(500)
+	proj := defaultProj.DeepCopy()
+	ctrl := newFakeController(b.Context(), &fakeData{apps: []runtime.Object{app, proj}}, nil)
+	key, err := cache.MetaNamespaceKeyFunc(app)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		ctrl.appRefreshQueue.Add(key)
+		ctrl.processAppRefreshQueueItem()
+	}
+}
+
+func BenchmarkNormalizeApplication(b *testing.B) {
+	app := newSyncedFakeApp(500)
+	proj := defaultProj.DeepCopy()
+	ctrl := newFakeController(b.Context(), &fakeData{apps: []runtime.Object{app, proj}}, nil)
+
+	patches := 0
+	fakeAppCs := ctrl.applicationClientset.(*appclientset.Clientset)
+	fakeAppCs.ReactionChain = nil
+	fakeAppCs.AddReactor("patch", "*", func(_ kubetesting.Action) (bool, runtime.Object, error) {
+		patches++
+		return true, &v1alpha1.Application{}, nil
+	})
+
+	b.ReportAllocs()
+	for b.Loop() {
+		ctrl.normalizeApplication(app)
+	}
+	b.StopTimer()
+
+	// The spec is already normalized, so the benchmark measures the comparison rather than the patch.
+	if patches > 0 {
+		b.Fatalf("expected no patches, got %d", patches)
+	}
+}


### PR DESCRIPTION
Closing this. The benchmarks belong in the PRs that change the code they measure, where the before and after numbers sit next to the change, rather than on their own with nothing to evaluate them against. Reopening as two PRs that each carry their own benchmark.