### PR TITLE
feat(perf): drop two redundant application copies from the refresh path

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -2241,11 +2241,17 @@ func (ctrl *ApplicationController) refreshAppConditions(ctx context.Context, app
 
 // normalizeApplication normalizes an application.spec and additionally persists updates if it changed
 func (ctrl *ApplicationController) normalizeApplication(app *appv1.Application) {
-	orig := app.DeepCopy()
+	origSpec := app.Spec.DeepCopy()
 	app.Spec = *argo.NormalizeApplicationSpec(&app.Spec)
 	logCtx := log.WithFields(applog.GetAppLogFields(app))
 
-	patch, modified, err := diff.CreateTwoWayMergePatch(orig, app, appv1.Application{})
+	// Only the spec can differ, so the patch is built from the spec alone rather than from the
+	// whole application. status.resources and status.history would otherwise be marshaled twice
+	// on every refresh.
+	patch, modified, err := diff.CreateTwoWayMergePatch(
+		appv1.Application{Spec: *origSpec},
+		appv1.Application{Spec: app.Spec},
+		appv1.Application{})
 
 	if err != nil {
 		logCtx.WithError(err).Error("error constructing app spec patch")

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -1848,12 +1848,14 @@ func (ctrl *ApplicationController) processAppRefreshQueueItem() (processNext boo
 		log.WithField("appkey", appKey).Warn("Key in index is not an application")
 		return processNext
 	}
-	origApp = origApp.DeepCopy()
+	// needRefreshAppStatus only reads the application, so the informer's copy answers it and the
+	// queue items that need no refresh never pay for a copy.
 	needRefresh, refreshType, comparisonLevel := ctrl.needRefreshAppStatus(origApp, ctrl.statusRefreshTimeout, ctrl.statusHardRefreshTimeout)
 
 	if !needRefresh {
 		return processNext
 	}
+	origApp = origApp.DeepCopy()
 	app := origApp.DeepCopy()
 	logCtx := log.WithFields(applog.GetAppLogFields(app)).WithFields(log.Fields{
 		"comparison-level": comparisonLevel,

--- a/controller/appcontroller_bench_test.go
+++ b/controller/appcontroller_bench_test.go
@@ -8,9 +8,11 @@ import (
 	"github.com/argoproj/argo-cd/gitops-engine/v3/pkg/health"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	kubetesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	appclientset "github.com/argoproj/argo-cd/v3/pkg/client/clientset/versioned/fake"
 )
 
 // newSyncedFakeApp returns an app that needs no refresh, with resourceCount entries
@@ -54,5 +56,30 @@ func BenchmarkProcessAppRefreshQueueItem_NoRefresh(b *testing.B) {
 	for b.Loop() {
 		ctrl.appRefreshQueue.Add(key)
 		ctrl.processAppRefreshQueueItem()
+	}
+}
+
+func BenchmarkNormalizeApplication(b *testing.B) {
+	app := newSyncedFakeApp(500)
+	proj := defaultProj.DeepCopy()
+	ctrl := newFakeController(b.Context(), &fakeData{apps: []runtime.Object{app, proj}}, nil)
+
+	patches := 0
+	fakeAppCs := ctrl.applicationClientset.(*appclientset.Clientset)
+	fakeAppCs.ReactionChain = nil
+	fakeAppCs.AddReactor("patch", "*", func(_ kubetesting.Action) (bool, runtime.Object, error) {
+		patches++
+		return true, &v1alpha1.Application{}, nil
+	})
+
+	b.ReportAllocs()
+	for b.Loop() {
+		ctrl.normalizeApplication(app)
+	}
+	b.StopTimer()
+
+	// The spec is already normalized, so the benchmark measures the comparison rather than the patch.
+	if patches > 0 {
+		b.Fatalf("expected no patches, got %d", patches)
 	}
 }

--- a/controller/appcontroller_bench_test.go
+++ b/controller/appcontroller_bench_test.go
@@ -1,0 +1,58 @@
+package controller
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/argoproj/argo-cd/gitops-engine/v3/pkg/health"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+)
+
+// newSyncedFakeApp returns an app that needs no refresh, with resourceCount entries
+// in status.resources.
+func newSyncedFakeApp(resourceCount int) *v1alpha1.Application {
+	app := newFakeApp()
+	app.Status.ReconciledAt = &metav1.Time{Time: time.Now()}
+	app.Status.Sync.Status = v1alpha1.SyncStatusCodeSynced
+	app.Status.Sync.ComparedTo.Source = app.Spec.GetSource()
+	app.Status.Sync.ComparedTo.Destination = app.Spec.Destination
+	app.Status.Sync.ComparedTo.IgnoreDifferences = app.Spec.IgnoreDifferences
+
+	resources := make([]v1alpha1.ResourceStatus, resourceCount)
+	for i := range resources {
+		resources[i] = v1alpha1.ResourceStatus{
+			Version:   "v1",
+			Kind:      "ConfigMap",
+			Namespace: "default",
+			Name:      fmt.Sprintf("cm-%d", i),
+			Status:    v1alpha1.SyncStatusCodeSynced,
+			Health:    &v1alpha1.HealthStatus{Status: health.HealthStatusHealthy},
+		}
+	}
+	app.Status.Resources = resources
+	return app
+}
+
+func BenchmarkProcessAppRefreshQueueItem_NoRefresh(b *testing.B) {
+	app := newSyncedFakeApp(500)
+	proj := defaultProj.DeepCopy()
+	// A zero resync period disables expiry-based refresh, so the app stays on the no-refresh path
+	// however long the benchmark runs. The default one minute would expire under -benchtime or a
+	// profiling run and silently start measuring a full refresh instead.
+	ctrl := newFakeControllerWithResync(b.Context(), &fakeData{apps: []runtime.Object{app, proj}}, 0, nil, nil)
+	key, err := cache.MetaNamespaceKeyFunc(app)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		ctrl.appRefreshQueue.Add(key)
+		ctrl.processAppRefreshQueueItem()
+	}
+}

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -1766,6 +1766,51 @@ func TestNormalizeApplication(t *testing.T) {
 	}
 }
 
+// TestNormalizeApplicationPatchesSpecOnly covers a spec that normalizes and one that is already
+// normalized, on an application carrying a large status.
+func TestNormalizeApplicationPatchesSpecOnly(t *testing.T) {
+	testCases := []struct {
+		name          string
+		project       string
+		expectedPatch string
+	}{
+		{
+			name:          "missing project is normalized",
+			project:       "",
+			expectedPatch: `{"spec":{"project":"default"}}`,
+		},
+		{
+			name:    "normalized spec is not patched",
+			project: "default",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			app := newSyncedFakeApp(500)
+			app.Spec.Project = tc.project
+			proj := defaultProj.DeepCopy()
+			ctrl := newFakeController(t.Context(), &fakeData{apps: []runtime.Object{app, proj}}, nil)
+
+			var patches []string
+			fakeAppCs := ctrl.applicationClientset.(*appclientset.Clientset)
+			fakeAppCs.ReactionChain = nil
+			fakeAppCs.AddReactor("patch", "*", func(action kubetesting.Action) (bool, runtime.Object, error) {
+				patches = append(patches, string(action.(kubetesting.PatchAction).GetPatch()))
+				return true, &v1alpha1.Application{}, nil
+			})
+
+			ctrl.normalizeApplication(app)
+
+			if tc.expectedPatch == "" {
+				assert.Empty(t, patches)
+				return
+			}
+			assert.Equal(t, []string{tc.expectedPatch}, patches)
+		})
+	}
+}
+
 func TestHandleAppUpdated(t *testing.T) {
 	app := newFakeApp()
 	app.Spec.Destination.Namespace = test.FakeArgoCDNamespace

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -2223,6 +2223,64 @@ func TestNeedRefreshAppStatusZeroTimeout(t *testing.T) {
 	assert.False(t, needRefresh, "timeout 0 should disable automatic expiry-based refresh")
 }
 
+// TestNeedRefreshAppStatusDoesNotModifyApp covers the refresh decision across an app that is up to
+// date, one whose comparison expired, and one with the refresh annotation. processAppRefreshQueueItem
+// hands the informer's application to needRefreshAppStatus, so none of them may be modified.
+func TestNeedRefreshAppStatusDoesNotModifyApp(t *testing.T) {
+	syncedApp := newFakeApp()
+	syncedApp.Status.Sync = v1alpha1.SyncStatus{
+		Status: v1alpha1.SyncStatusCodeSynced,
+		ComparedTo: v1alpha1.ComparedTo{
+			Destination:       syncedApp.Spec.Destination,
+			IgnoreDifferences: syncedApp.Spec.IgnoreDifferences,
+			Source:            syncedApp.Spec.GetSource(),
+		},
+	}
+	now := metav1.Now()
+	syncedApp.Status.ReconciledAt = &now
+
+	expiredApp := syncedApp.DeepCopy()
+	past := metav1.NewTime(time.Now().UTC().Add(-2 * time.Hour))
+	expiredApp.Status.ReconciledAt = &past
+
+	annotatedApp := syncedApp.DeepCopy()
+	annotatedApp.Annotations = map[string]string{v1alpha1.AnnotationKeyRefresh: string(v1alpha1.RefreshTypeNormal)}
+
+	testCases := []struct {
+		name          string
+		app           *v1alpha1.Application
+		expectRefresh bool
+	}{
+		{
+			name:          "up to date app",
+			app:           syncedApp,
+			expectRefresh: false,
+		},
+		{
+			name:          "expired comparison",
+			app:           expiredApp,
+			expectRefresh: true,
+		},
+		{
+			name:          "refresh annotation",
+			app:           annotatedApp,
+			expectRefresh: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := newFakeController(t.Context(), &fakeData{apps: []runtime.Object{}}, nil)
+			before := tc.app.DeepCopy()
+
+			needRefresh, _, _ := ctrl.needRefreshAppStatus(tc.app, 1*time.Hour, 2*time.Hour)
+
+			assert.Equal(t, tc.expectRefresh, needRefresh)
+			assert.Equal(t, before, tc.app)
+		})
+	}
+}
+
 func TestRefreshAppConditions(t *testing.T) {
 	defaultProj := v1alpha1.AppProject{
 		Name:      "default",


### PR DESCRIPTION
Two allocation reductions on the refresh path, one per commit. Neither changes what the controller writes.

`processAppRefreshQueueItem` deep copied the informer's application before asking `needRefreshAppStatus` whether a refresh was needed, and then returned when it was not. Every informer event enqueues the app, so the resync period, our own status writes, and the operation state patches during a sync each paid for a copy that got thrown away. `needRefreshAppStatus` only reads, so the copy moves below the early return.

`normalizeApplication` marshaled the whole application twice, `status.resources` and `status.history` included, to find out the spec had not changed. Only the spec can differ, so the patch is built from the spec alone.

500 status resources, mean of 10 runs:

| | ns/op | B/op | allocs/op |
|---|---|---|---|
| `ProcessAppRefreshQueueItem_NoRefresh` before | 37.7 us | 91,557 | 523 |
| after | 4.3 us | 944 | 12 |
| `NormalizeApplication` before | 3.08 ms | 2,172,909 | 34,600 |
| after | 24.9 us | 16,524 | 225 |


Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).
