### PR TITLE
feat(perf): reuse matrix child params when the generator is unchanged

### DIFF
--- a/applicationset/generators/matrix.go
+++ b/applicationset/generators/matrix.go
@@ -1,8 +1,13 @@
 package generators
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
+	"reflect"
+	"slices"
 	"time"
 
 	"dario.cat/mergo"
@@ -51,10 +56,35 @@ func (m *MatrixGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.App
 	if err != nil {
 		return nil, fmt.Errorf("error failed to get params for first generator in matrix generator: %w", err)
 	}
-	for _, a := range g0 {
-		g1, err := m.getParams(appSetGenerator.Matrix.Generators[1], appSet, a, client)
+
+	// The second generator runs once per parameter set of the first. When its spec holds no
+	// template placeholders the outer parameters cannot change what it produces, so it runs once
+	// and the rest of the iterations reuse the result. An error here is left for getParams to
+	// report inside the loop, with the wrapping it already has.
+	reusable := false
+	if childSpec, specErr := nestedGeneratorSpec(appSetGenerator.Matrix.Generators[1]); specErr == nil {
+		reusable = !specUsesTemplates(childSpec)
+	}
+
+	var reusedParams []map[string]any
+	if reusable && len(g0) > 0 {
+		reusedParams, err = m.getParams(appSetGenerator.Matrix.Generators[1], appSet, g0[0], client)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get params for second generator in the matrix generator: %w", err)
+		}
+	}
+
+	for _, a := range g0 {
+		var g1 []map[string]any
+		if reusable {
+			// The merge below writes into the parameters it is given, so each iteration gets a
+			// copy rather than the parameters themselves.
+			g1 = deepCopyParams(reusedParams)
+		} else {
+			g1, err = m.getParams(appSetGenerator.Matrix.Generators[1], appSet, a, client)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get params for second generator in the matrix generator: %w", err)
+			}
 		}
 		for _, b := range g1 {
 			if appSet.Spec.GoTemplate {
@@ -80,29 +110,13 @@ func (m *MatrixGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.App
 }
 
 func (m *MatrixGenerator) getParams(appSetBaseGenerator argoprojiov1alpha1.ApplicationSetNestedGenerator, appSet *argoprojiov1alpha1.ApplicationSet, params map[string]any, client client.Client) ([]map[string]any, error) {
-	matrixGen, err := getMatrixGenerator(appSetBaseGenerator)
+	requestedGenerator, err := nestedGeneratorSpec(appSetBaseGenerator)
 	if err != nil {
 		return nil, err
 	}
-	mergeGen, err := getMergeGenerator(appSetBaseGenerator)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving merge generator: %w", err)
-	}
 
 	t, err := Transform(
-		argoprojiov1alpha1.ApplicationSetGenerator{
-			List:                    appSetBaseGenerator.List,
-			Clusters:                appSetBaseGenerator.Clusters,
-			Git:                     appSetBaseGenerator.Git,
-			SCMProvider:             appSetBaseGenerator.SCMProvider,
-			ClusterDecisionResource: appSetBaseGenerator.ClusterDecisionResource,
-			PullRequest:             appSetBaseGenerator.PullRequest,
-			Plugin:                  appSetBaseGenerator.Plugin,
-			Oci:                     appSetBaseGenerator.Oci,
-			Matrix:                  matrixGen,
-			Merge:                   mergeGen,
-			Selector:                appSetBaseGenerator.Selector,
-		},
+		requestedGenerator,
 		m.supportedGenerators,
 		argoprojiov1alpha1.ApplicationSetTemplate{},
 		appSet,
@@ -121,6 +135,136 @@ func (m *MatrixGenerator) getParams(appSetBaseGenerator argoprojiov1alpha1.Appli
 	}
 
 	return t[0].Params, nil
+}
+
+// nestedGeneratorSpec builds the generator that a nested matrix entry describes.
+func nestedGeneratorSpec(appSetBaseGenerator argoprojiov1alpha1.ApplicationSetNestedGenerator) (argoprojiov1alpha1.ApplicationSetGenerator, error) {
+	matrixGen, err := getMatrixGenerator(appSetBaseGenerator)
+	if err != nil {
+		return argoprojiov1alpha1.ApplicationSetGenerator{}, err
+	}
+	mergeGen, err := getMergeGenerator(appSetBaseGenerator)
+	if err != nil {
+		return argoprojiov1alpha1.ApplicationSetGenerator{}, fmt.Errorf("error retrieving merge generator: %w", err)
+	}
+
+	return argoprojiov1alpha1.ApplicationSetGenerator{
+		List:                    appSetBaseGenerator.List,
+		Clusters:                appSetBaseGenerator.Clusters,
+		Git:                     appSetBaseGenerator.Git,
+		SCMProvider:             appSetBaseGenerator.SCMProvider,
+		ClusterDecisionResource: appSetBaseGenerator.ClusterDecisionResource,
+		PullRequest:             appSetBaseGenerator.PullRequest,
+		Plugin:                  appSetBaseGenerator.Plugin,
+		Oci:                     appSetBaseGenerator.Oci,
+		Matrix:                  matrixGen,
+		Merge:                   mergeGen,
+		Selector:                appSetBaseGenerator.Selector,
+	}, nil
+}
+
+// specUsesTemplates reports whether interpolating the generator with parameters could change it.
+// Interpolation only substitutes template placeholders, so a spec holding none is left untouched.
+func specUsesTemplates(generator argoprojiov1alpha1.ApplicationSetGenerator) bool {
+	raw, err := json.Marshal(generator)
+	if err != nil {
+		// Cannot tell, so assume the parameters matter.
+		return true
+	}
+	return bytes.Contains(raw, []byte("{{"))
+}
+
+func deepCopyParams(params []map[string]any) []map[string]any {
+	if params == nil {
+		return nil
+	}
+	out := make([]map[string]any, len(params))
+	for i, param := range params {
+		out[i] = deepCopyParamMap(param)
+	}
+	return out
+}
+
+func deepCopyParamMap(params map[string]any) map[string]any {
+	if params == nil {
+		return nil
+	}
+	out := make(map[string]any, len(params))
+	for key, value := range params {
+		out[key] = deepCopyParamValue(value)
+	}
+	return out
+}
+
+func deepCopyParamValue(value any) any {
+	switch v := value.(type) {
+	case map[string]any:
+		return deepCopyParamMap(v)
+	case map[string]string:
+		return maps.Clone(v)
+	case []any:
+		// Clone rather than allocate, so a nil list stays nil. A nil list and an empty one
+		// serialize differently, and one parameter set must not disagree with the next.
+		out := slices.Clone(v)
+		for i, item := range out {
+			out[i] = deepCopyParamValue(item)
+		}
+		return out
+	case []map[string]any:
+		// The cluster generator's flat list mode puts every cluster under one key in this shape,
+		// and hands back a nil list when it matched none.
+		out := slices.Clone(v)
+		for i, item := range out {
+			out[i] = deepCopyParamMap(item)
+		}
+		return out
+	case []string:
+		return slices.Clone(v)
+	default:
+		return deepCopyReflected(value)
+	}
+}
+
+// deepCopyReflected copies maps and slices whose concrete type is not handled above, so that a
+// generator producing an unanticipated shape does not end up sharing it between parameter sets.
+// Anything else is returned as it is, which is what a scalar needs.
+func deepCopyReflected(value any) any {
+	original := reflect.ValueOf(value)
+	switch original.Kind() {
+	case reflect.Map, reflect.Slice:
+		// Same reason as the explicit branches above: nil is not the same value as empty, and a
+		// nil map or slice has nothing to share anyway.
+		if original.IsNil() {
+			return value
+		}
+	}
+
+	switch original.Kind() {
+	case reflect.Map:
+		out := reflect.MakeMapWithSize(original.Type(), original.Len())
+		for iter := original.MapRange(); iter.Next(); {
+			out.SetMapIndex(iter.Key(), copiedOrOriginal(iter.Value(), original.Type().Elem()))
+		}
+		return out.Interface()
+	case reflect.Slice:
+		out := reflect.MakeSlice(original.Type(), original.Len(), original.Len())
+		for i := range original.Len() {
+			out.Index(i).Set(copiedOrOriginal(original.Index(i), original.Type().Elem()))
+		}
+		return out.Interface()
+	default:
+		return value
+	}
+}
+
+// copiedOrOriginal deep copies an element, falling back to the element itself when the copy cannot
+// be assigned back, which is what a nil interface element gives.
+func copiedOrOriginal(element reflect.Value, elementType reflect.Type) reflect.Value {
+	copied := reflect.ValueOf(deepCopyParamValue(element.Interface()))
+	if !copied.IsValid() || !copied.Type().AssignableTo(elementType) {
+		return element
+	}
+	return copied
 }
 
 const maxDuration time.Duration = 1<<63 - 1

--- a/applicationset/generators/matrix_bench_test.go
+++ b/applicationset/generators/matrix_bench_test.go
@@ -1,0 +1,136 @@
+package generators
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+)
+
+// benchClusterSecrets returns count cluster secrets shaped like a registered cluster, with a bearer
+// token and CA data so the cost of copying them out of the cache is realistic.
+func benchClusterSecrets(namespace string, count int) []client.Object {
+	config := fmt.Sprintf(`{"bearerToken":%q,"tlsClientConfig":{"insecure":false,"caData":%q}}`,
+		strings.Repeat("t", 800), strings.Repeat("c", 1400))
+
+	clusters := make([]client.Object, count)
+	for i := range clusters {
+		name := fmt.Sprintf("cluster-%03d", i)
+		clusters[i] = &corev1.Secret{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"argocd.argoproj.io/secret-type": "cluster",
+				"environment":                    "production",
+			},
+			Data: map[string][]byte{
+				"name":   []byte(name),
+				"server": []byte(fmt.Sprintf("https://%s.example.com", name)),
+				"config": []byte(config),
+			},
+			Type: corev1.SecretType("Opaque"),
+		}
+	}
+	return clusters
+}
+
+func benchListElements(count int) []apiextensionsv1.JSON {
+	elements := make([]apiextensionsv1.JSON, count)
+	for i := range elements {
+		raw, err := json.Marshal(map[string]string{"path": fmt.Sprintf("apps/app-%03d", i)})
+		if err != nil {
+			panic(err)
+		}
+		elements[i] = apiextensionsv1.JSON{Raw: raw}
+	}
+	return elements
+}
+
+// BenchmarkMatrixGenerate_ListByClusters measures a matrix whose second generator does not reference
+// the first, the shape that lists every cluster secret once per outer parameter set.
+func BenchmarkMatrixGenerate_ListByClusters(b *testing.B) {
+	const namespace = "namespace"
+
+	fakeClient := fake.NewClientBuilder().WithObjects(benchClusterSecrets(namespace, 500)...).Build()
+	matrixGenerator := NewMatrixGenerator(map[string]Generator{
+		"List":     &ListGenerator{},
+		"Clusters": NewClusterGenerator(fakeClient, namespace),
+	})
+
+	appSetGenerator := &v1alpha1.ApplicationSetGenerator{
+		Matrix: &v1alpha1.MatrixGenerator{
+			Generators: []v1alpha1.ApplicationSetNestedGenerator{
+				{List: &v1alpha1.ListGenerator{Elements: benchListElements(200)}},
+				{Clusters: &v1alpha1.ClusterGenerator{}},
+			},
+		},
+	}
+	appSet := &v1alpha1.ApplicationSet{
+		Name:      "set",
+		Namespace: namespace,
+		Spec:      v1alpha1.ApplicationSetSpec{GoTemplate: true},
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		params, err := matrixGenerator.GenerateParams(appSetGenerator, appSet, fakeClient)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(params) != 200*501 {
+			b.Fatalf("unexpected parameter count %d", len(params))
+		}
+	}
+}
+
+// BenchmarkMatrixGenerate_ListByClustersPerRow measures a matrix whose second generator selects on
+// the first, so it is generated once per outer parameter set and none of the work is reusable.
+func BenchmarkMatrixGenerate_ListByClustersPerRow(b *testing.B) {
+	const namespace = "namespace"
+
+	fakeClient := fake.NewClientBuilder().WithObjects(benchClusterSecrets(namespace, 500)...).Build()
+	matrixGenerator := NewMatrixGenerator(map[string]Generator{
+		"List":     &ListGenerator{},
+		"Clusters": NewClusterGenerator(fakeClient, namespace),
+	})
+
+	elements := make([]apiextensionsv1.JSON, 50)
+	for i := range elements {
+		elements[i] = apiextensionsv1.JSON{Raw: []byte(`{"env":"production"}`)}
+	}
+
+	appSetGenerator := &v1alpha1.ApplicationSetGenerator{
+		Matrix: &v1alpha1.MatrixGenerator{
+			Generators: []v1alpha1.ApplicationSetNestedGenerator{
+				{List: &v1alpha1.ListGenerator{Elements: elements}},
+				{Clusters: &v1alpha1.ClusterGenerator{
+					Selector: metav1.LabelSelector{MatchLabels: map[string]string{"environment": "{{.env}}"}},
+				}},
+			},
+		},
+	}
+	appSet := &v1alpha1.ApplicationSet{
+		Name:      "set",
+		Namespace: namespace,
+		Spec:      v1alpha1.ApplicationSetSpec{GoTemplate: true},
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		params, err := matrixGenerator.GenerateParams(appSetGenerator, appSet, fakeClient)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(params) != 50*500 {
+			b.Fatalf("unexpected parameter count %d", len(params))
+		}
+	}
+}

--- a/applicationset/generators/matrix_test.go
+++ b/applicationset/generators/matrix_test.go
@@ -1,6 +1,7 @@
 package generators
 
 import (
+	"maps"
 	"testing"
 	"time"
 
@@ -1333,4 +1334,360 @@ func getGenerators() (*v1alpha1.GitGenerator, *generatorsMock.Generator, *v1alph
 		},
 	}
 	return gitGeneratorSpec, genMock, clusterGeneratorSpec
+}
+
+// TestMatrixGenerateReusesSecondGeneratorParams covers a second generator that ignores the outer
+// parameters, one that selects on them, and an outer parameter set that merges into a nested map the
+// second generator produced.
+func TestMatrixGenerateReusesSecondGeneratorParams(t *testing.T) {
+	const namespace = "namespace"
+
+	clusters := []client.Object{
+		&corev1.Secret{
+			Name:      "staging-01",
+			Namespace: namespace,
+			Labels: map[string]string{
+				"argocd.argoproj.io/secret-type": "cluster",
+				"environment":                    "staging",
+			},
+			Data: map[string][]byte{
+				"name":   []byte("staging-01"),
+				"server": []byte("https://staging-01.example.com"),
+				"config": []byte("{}"),
+			},
+			Type: corev1.SecretType("Opaque"),
+		},
+		&corev1.Secret{
+			Name:      "production-01",
+			Namespace: namespace,
+			Labels: map[string]string{
+				"argocd.argoproj.io/secret-type": "cluster",
+				"environment":                    "production",
+			},
+			Data: map[string][]byte{
+				"name":   []byte("production-01"),
+				"server": []byte("https://production-01.example.com"),
+				"config": []byte("{}"),
+			},
+			Type: corev1.SecretType("Opaque"),
+		},
+	}
+
+	stagingLabels := func(extra map[string]string) map[string]string {
+		labels := map[string]string{
+			"argocd.argoproj.io/secret-type": "cluster",
+			"environment":                    "staging",
+		}
+		maps.Copy(labels, extra)
+		return labels
+	}
+
+	testCases := []struct {
+		name     string
+		elements []apiextensionsv1.JSON
+		selector metav1.LabelSelector
+		expected []map[string]any
+	}{
+		{
+			name: "second generator ignores the outer parameters",
+			elements: []apiextensionsv1.JSON{
+				{Raw: []byte(`{"path":"apps/one"}`)},
+				{Raw: []byte(`{"path":"apps/two"}`)},
+			},
+			selector: metav1.LabelSelector{MatchLabels: map[string]string{"environment": "staging"}},
+			expected: []map[string]any{
+				{
+					"path":           "apps/one",
+					"name":           "staging-01",
+					"nameNormalized": "staging-01",
+					"server":         "https://staging-01.example.com",
+					"project":        "",
+					"metadata":       map[string]any{"labels": stagingLabels(nil)},
+				},
+				{
+					"path":           "apps/two",
+					"name":           "staging-01",
+					"nameNormalized": "staging-01",
+					"server":         "https://staging-01.example.com",
+					"project":        "",
+					"metadata":       map[string]any{"labels": stagingLabels(nil)},
+				},
+			},
+		},
+		{
+			name: "second generator selects on the outer parameters",
+			elements: []apiextensionsv1.JSON{
+				{Raw: []byte(`{"env":"staging"}`)},
+				{Raw: []byte(`{"env":"production"}`)},
+			},
+			selector: metav1.LabelSelector{MatchLabels: map[string]string{"environment": "{{.env}}"}},
+			expected: []map[string]any{
+				{
+					"env":            "staging",
+					"name":           "staging-01",
+					"nameNormalized": "staging-01",
+					"server":         "https://staging-01.example.com",
+					"project":        "",
+					"metadata":       map[string]any{"labels": stagingLabels(nil)},
+				},
+				{
+					"env":            "production",
+					"name":           "production-01",
+					"nameNormalized": "production-01",
+					"server":         "https://production-01.example.com",
+					"project":        "",
+					"metadata": map[string]any{"labels": map[string]string{
+						"argocd.argoproj.io/secret-type": "cluster",
+						"environment":                    "production",
+					}},
+				},
+			},
+		},
+		{
+			name: "outer parameters merge into the nested map of the second generator",
+			elements: []apiextensionsv1.JSON{
+				{Raw: []byte(`{"metadata":{"only-in-first":"yes"}}`)},
+				{Raw: []byte(`{"metadata":{"only-in-second":"yes"}}`)},
+				{Raw: []byte(`{"hint":"third"}`)},
+			},
+			selector: metav1.LabelSelector{MatchLabels: map[string]string{"environment": "staging"}},
+			expected: []map[string]any{
+				{
+					"name":           "staging-01",
+					"nameNormalized": "staging-01",
+					"server":         "https://staging-01.example.com",
+					"project":        "",
+					"metadata": map[string]any{
+						"labels":        stagingLabels(nil),
+						"only-in-first": "yes",
+					},
+				},
+				{
+					"name":           "staging-01",
+					"nameNormalized": "staging-01",
+					"server":         "https://staging-01.example.com",
+					"project":        "",
+					"metadata": map[string]any{
+						"labels":         stagingLabels(nil),
+						"only-in-second": "yes",
+					},
+				},
+				{
+					"hint":           "third",
+					"name":           "staging-01",
+					"nameNormalized": "staging-01",
+					"server":         "https://staging-01.example.com",
+					"project":        "",
+					"metadata":       map[string]any{"labels": stagingLabels(nil)},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().WithObjects(clusters...).Build()
+			matrixGenerator := NewMatrixGenerator(map[string]Generator{
+				"List":     &ListGenerator{},
+				"Clusters": NewClusterGenerator(fakeClient, namespace),
+			})
+
+			got, err := matrixGenerator.GenerateParams(&v1alpha1.ApplicationSetGenerator{
+				Matrix: &v1alpha1.MatrixGenerator{
+					Generators: []v1alpha1.ApplicationSetNestedGenerator{
+						{List: &v1alpha1.ListGenerator{Elements: tc.elements}},
+						{Clusters: &v1alpha1.ClusterGenerator{Selector: tc.selector}},
+					},
+				},
+			}, &v1alpha1.ApplicationSet{
+				Name:      "set",
+				Namespace: namespace,
+				Spec:      v1alpha1.ApplicationSetSpec{GoTemplate: true},
+			}, fakeClient)
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+// countingGenerator records how many times the matrix asked its child for parameters.
+type countingGenerator struct {
+	Generator
+	calls int
+}
+
+func (c *countingGenerator) GenerateParams(appSetGenerator *v1alpha1.ApplicationSetGenerator, appSet *v1alpha1.ApplicationSet, client client.Client) ([]map[string]any, error) {
+	c.calls++
+	return c.Generator.GenerateParams(appSetGenerator, appSet, client)
+}
+
+func stagingClusterSecret(namespace string) []client.Object {
+	return []client.Object{
+		&corev1.Secret{
+			Name:      "staging-01",
+			Namespace: namespace,
+			Labels: map[string]string{
+				"argocd.argoproj.io/secret-type": "cluster",
+				"environment":                    "staging",
+			},
+			Data: map[string][]byte{
+				"name":   []byte("staging-01"),
+				"server": []byte("https://staging-01.example.com"),
+				"config": []byte("{}"),
+			},
+			Type: corev1.SecretType("Opaque"),
+		},
+	}
+}
+
+// TestMatrixGenerateSecondGeneratorInvocations covers a second generator whose spec holds no
+// template placeholders and one whose selector references the outer parameters.
+func TestMatrixGenerateSecondGeneratorInvocations(t *testing.T) {
+	const namespace = "namespace"
+
+	testCases := []struct {
+		name              string
+		selector          metav1.LabelSelector
+		generatorSelector *metav1.LabelSelector
+		expectCalls       int
+	}{
+		{
+			name:        "spec without placeholders is generated once",
+			selector:    metav1.LabelSelector{MatchLabels: map[string]string{"environment": "staging"}},
+			expectCalls: 1,
+		},
+		{
+			name:        "spec referencing outer params is generated per parameter set",
+			selector:    metav1.LabelSelector{MatchLabels: map[string]string{"environment": "{{.env}}"}},
+			expectCalls: 3,
+		},
+		{
+			name:              "spec whose parameters are all filtered out is generated once",
+			selector:          metav1.LabelSelector{MatchLabels: map[string]string{"environment": "staging"}},
+			generatorSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"name": "no-such-cluster"}},
+			expectCalls:       1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().WithObjects(stagingClusterSecret(namespace)...).Build()
+			counted := &countingGenerator{Generator: NewClusterGenerator(fakeClient, namespace)}
+			matrixGenerator := NewMatrixGenerator(map[string]Generator{
+				"List":     &ListGenerator{},
+				"Clusters": counted,
+			})
+
+			_, err := matrixGenerator.GenerateParams(&v1alpha1.ApplicationSetGenerator{
+				Matrix: &v1alpha1.MatrixGenerator{
+					Generators: []v1alpha1.ApplicationSetNestedGenerator{
+						{List: &v1alpha1.ListGenerator{Elements: []apiextensionsv1.JSON{
+							{Raw: []byte(`{"env":"staging"}`)},
+							{Raw: []byte(`{"env":"staging"}`)},
+							{Raw: []byte(`{"env":"staging"}`)},
+						}}},
+						{
+							Clusters: &v1alpha1.ClusterGenerator{Selector: tc.selector},
+							Selector: tc.generatorSelector,
+						},
+					},
+				},
+			}, &v1alpha1.ApplicationSet{
+				Name:      "set",
+				Namespace: namespace,
+				Spec:      v1alpha1.ApplicationSetSpec{GoTemplate: true},
+			}, fakeClient)
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectCalls, counted.calls)
+		})
+	}
+}
+
+// TestMatrixGenerateFlatListIsolation covers the cluster generator's flat list mode, where every
+// cluster arrives under one key as a slice of maps that the parameter sets must not share.
+func TestMatrixGenerateFlatListIsolation(t *testing.T) {
+	const namespace = "namespace"
+
+	fakeClient := fake.NewClientBuilder().WithObjects(stagingClusterSecret(namespace)...).Build()
+	matrixGenerator := NewMatrixGenerator(map[string]Generator{
+		"List":     &ListGenerator{},
+		"Clusters": NewClusterGenerator(fakeClient, namespace),
+	})
+
+	got, err := matrixGenerator.GenerateParams(&v1alpha1.ApplicationSetGenerator{
+		Matrix: &v1alpha1.MatrixGenerator{
+			Generators: []v1alpha1.ApplicationSetNestedGenerator{
+				{List: &v1alpha1.ListGenerator{Elements: []apiextensionsv1.JSON{
+					{Raw: []byte(`{"path":"apps/one"}`)},
+					{Raw: []byte(`{"path":"apps/two"}`)},
+					{Raw: []byte(`{"path":"apps/three"}`)},
+				}}},
+				{Clusters: &v1alpha1.ClusterGenerator{
+					FlatList: true,
+					Selector: metav1.LabelSelector{MatchLabels: map[string]string{"environment": "staging"}},
+				}},
+			},
+		},
+	}, &v1alpha1.ApplicationSet{
+		Name:      "set",
+		Namespace: namespace,
+		Spec:      v1alpha1.ApplicationSetSpec{GoTemplate: true},
+	}, fakeClient)
+
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+
+	clustersOf := func(params map[string]any) []map[string]any {
+		clusters, ok := params["clusters"].([]map[string]any)
+		require.True(t, ok, "expected clusters to be a slice of maps")
+		return clusters
+	}
+
+	clustersOf(got[0])[0]["name"] = "mutated"
+
+	for _, params := range got[1:] {
+		assert.Equal(t, "staging-01", clustersOf(params)[0]["name"])
+	}
+}
+
+// TestMatrixGenerateFlatListNoMatches covers flat list mode when the selector matches no clusters,
+// where the generator hands back a nil slice that every parameter set has to keep.
+func TestMatrixGenerateFlatListNoMatches(t *testing.T) {
+	const namespace = "namespace"
+
+	fakeClient := fake.NewClientBuilder().WithObjects(stagingClusterSecret(namespace)...).Build()
+	matrixGenerator := NewMatrixGenerator(map[string]Generator{
+		"List":     &ListGenerator{},
+		"Clusters": NewClusterGenerator(fakeClient, namespace),
+	})
+
+	got, err := matrixGenerator.GenerateParams(&v1alpha1.ApplicationSetGenerator{
+		Matrix: &v1alpha1.MatrixGenerator{
+			Generators: []v1alpha1.ApplicationSetNestedGenerator{
+				{List: &v1alpha1.ListGenerator{Elements: []apiextensionsv1.JSON{
+					{Raw: []byte(`{"path":"apps/one"}`)},
+					{Raw: []byte(`{"path":"apps/two"}`)},
+					{Raw: []byte(`{"path":"apps/three"}`)},
+				}}},
+				{Clusters: &v1alpha1.ClusterGenerator{
+					FlatList: true,
+					Selector: metav1.LabelSelector{MatchLabels: map[string]string{"environment": "nothing-matches"}},
+				}},
+			},
+		},
+	}, &v1alpha1.ApplicationSet{
+		Name:      "set",
+		Namespace: namespace,
+		Spec:      v1alpha1.ApplicationSetSpec{GoTemplate: true},
+	}, fakeClient)
+
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+
+	// A nil list and an empty list serialize differently, so every parameter set has to agree.
+	for i, params := range got {
+		assert.Nil(t, params["clusters"], "parameter set %d", i)
+	}
 }


### PR DESCRIPTION
The second generator of a matrix runs once per parameter set of the first, so a child that does not reference the outer parameters redoes the same work every iteration. For a cluster generator that is listing and copying every cluster secret out of the cache again, 200 times for a directories-by-clusters matrix with 200 directories.

Interpolation only substitutes template placeholders, so a child whose spec holds none cannot be changed by the outer parameters. `GenerateParams` checks that once, and when it holds, generates the child once and reuses the result.

Mean of 10 runs, 500 cluster secrets:

| | ns/op | B/op | allocs/op |
|---|---|---|---|
| 200 elements, child ignores outer params, before | 3.12 s | 2,614,600,000 | 12,724,557 |
| after | 211 ms | 206,100,000 | 2,761,056 |
| 50 elements, child selects on outer params, before | 825 ms | 773,700,000 | 3,186,007 |
| after | 823 ms | 799,700,000 | 3,186,188 |

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).
