### PR TITLE
fix: remove empty annotations map after stripping last-applied-configuration

### DIFF
--- a/gitops-engine/pkg/diff/diff.go
+++ b/gitops-engine/pkg/diff/diff.go
@@ -189,12 +189,12 @@ func serverSideDiff(ctx context.Context, config, live *unstructured.Unstructured
 	Normalize(predictedLive, opts...)
 	unstructured.RemoveNestedField(predictedLive.Object, "metadata", "managedFields")
 	unstructured.RemoveNestedField(predictedLive.Object, "metadata", "resourceVersion")
-	unstructured.RemoveNestedField(predictedLive.Object, "metadata", "annotations", AnnotationLastAppliedConfig)
+	removeLastAppliedConfigAnnotation(predictedLive)
 
 	Normalize(live, opts...)
 	unstructured.RemoveNestedField(live.Object, "metadata", "managedFields")
 	unstructured.RemoveNestedField(live.Object, "metadata", "resourceVersion")
-	unstructured.RemoveNestedField(live.Object, "metadata", "annotations", AnnotationLastAppliedConfig)
+	removeLastAppliedConfigAnnotation(live)
 
 	predictedLiveBytes, err := json.Marshal(predictedLive)
 	if err != nil {
@@ -521,7 +521,7 @@ func normalizeTypedValue(tv *typed.TypedValue) ([]byte, error) {
 		return nil, fmt.Errorf("error converting result typedValue: expected map got %T", ru)
 	}
 	resultUn := &unstructured.Unstructured{Object: r}
-	unstructured.RemoveNestedField(resultUn.Object, "metadata", "annotations", AnnotationLastAppliedConfig)
+	removeLastAppliedConfigAnnotation(resultUn)
 
 	resultBytes, err := json.Marshal(resultUn)
 	if err != nil {
@@ -761,6 +761,42 @@ func ThreeWayDiff(orig, config, live *unstructured.Unstructured) (*DiffResult, e
 	}
 
 	return buildDiffResult(predictedLiveBytes, liveBytes), nil
+}
+
+// removeLastAppliedConfigAnnotation removes the last-applied-configuration
+// annotation from the object, along with the enclosing annotations map if that
+// was the only annotation present.
+//
+// Removing just the key is not enough: it leaves "annotations": {} behind, and
+// an empty map is not equal to an absent one during the byte-level comparison
+// performed by buildDiffResult. A resource whose only annotation is stripped on
+// one side of a diff but was never present on the other would therefore be
+// reported as modified, with a diff containing nothing but the empty map.
+//
+// The object is modified in place.
+func removeLastAppliedConfigAnnotation(un *unstructured.Unstructured) {
+	if un == nil {
+		return
+	}
+	metadata, ok := un.Object["metadata"].(map[string]any)
+	if !ok {
+		return
+	}
+	annotationsIf, ok := metadata["annotations"]
+	if !ok {
+		return
+	}
+	annotations, ok := annotationsIf.(map[string]any)
+	if !ok {
+		// A nil or otherwise unusable annotations map carries no annotations,
+		// so drop it to keep both sides of a comparison symmetric.
+		delete(metadata, "annotations")
+		return
+	}
+	delete(annotations, AnnotationLastAppliedConfig)
+	if len(annotations) == 0 {
+		delete(metadata, "annotations")
+	}
 }
 
 // removeNamespaceAnnotation remove the namespace and an empty annotation map from the metadata.

--- a/gitops-engine/pkg/diff/diff_test.go
+++ b/gitops-engine/pkg/diff/diff_test.go
@@ -2557,11 +2557,6 @@ spec:
 // TestLastAppliedConfigDoesNotCauseSpuriousDiff asserts that the
 // kubectl.kubernetes.io/last-applied-configuration annotation never contributes
 // to a diff, whichever strategy calculates it.
-//
-// It runs one fixture — identical desired and live state, with the annotation
-// present only on live — through all three strategies and asserts that none of
-// them reports a difference. The same fixture covers the other server-populated
-// metadata that only ever appears on live: resourceVersion, uid and managedFields.
 func TestLastAppliedConfigDoesNotCauseSpuriousDiff(t *testing.T) {
 	t.Parallel()
 

--- a/gitops-engine/pkg/diff/diff_test.go
+++ b/gitops-engine/pkg/diff/diff_test.go
@@ -2553,3 +2553,170 @@ spec:
 	assert.NotNil(t, result)
 	assert.True(t, result.Modified, "different config and live should show as modified")
 }
+
+// TestLastAppliedConfigDoesNotCauseSpuriousDiff asserts that the
+// kubectl.kubernetes.io/last-applied-configuration annotation never contributes
+// to a diff, whichever strategy calculates it.
+//
+// It runs one fixture — identical desired and live state, with the annotation
+// present only on live — through all three strategies and asserts that none of
+// them reports a difference. The same fixture covers the other server-populated
+// metadata that only ever appears on live: resourceVersion, uid and managedFields.
+func TestLastAppliedConfigDoesNotCauseSpuriousDiff(t *testing.T) {
+	t.Parallel()
+
+	t.Run("client-side three-way diff", func(t *testing.T) {
+		t.Parallel()
+		config := StrToUnstructured(testdata.LastAppliedConfigMapConfigYAML)
+		live := StrToUnstructured(testdata.LastAppliedConfigMapLiveYAML)
+
+		result := diff(t, config, live, diffOptionsForTest()...)
+
+		require.NotNil(t, result)
+		if !assert.False(t, result.Modified, "client-side three-way diff reported a difference") {
+			ascii, err := printDiff(t.Context(), result)
+			require.NoError(t, err)
+			t.Log(ascii)
+		}
+	})
+
+	t.Run("server-side diff, annotation retained by dry-run", func(t *testing.T) {
+		t.Parallel()
+		config := StrToUnstructured(testdata.LastAppliedConfigMapConfigYAML)
+		live := StrToUnstructured(testdata.LastAppliedConfigMapLiveYAML)
+		opts := lastAppliedServerSideDiffOpts(t, testdata.LastAppliedConfigMapPredictedLiveWithAnnotationJSON)
+
+		result, err := serverSideDiff(t.Context(), config, live, opts...)
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		if !assert.False(t, result.Modified, "server-side diff reported a difference") {
+			ascii, err := printDiff(t.Context(), result)
+			require.NoError(t, err)
+			t.Log(ascii)
+		}
+	})
+
+	// serverSideDiff strips the annotation from both sides with
+	// RemoveNestedField (diff.go:186-195), which deletes the key but leaves the
+	// enclosing map behind. live therefore ends up with "annotations": {} while
+	// predictedLive, which never had an annotations map at all, ends up with no
+	// annotations key. {} != absent, so the byte comparison reports a
+	// difference and the resource would be reported OutOfSync with an empty diff
+	// hunk. removeLastAppliedConfigAnnotation drops the emptied map so both sides stay equal.
+	t.Run("server-side diff, annotation dropped by dry-run", func(t *testing.T) {
+		t.Parallel()
+		config := StrToUnstructured(testdata.LastAppliedConfigMapConfigYAML)
+		live := StrToUnstructured(testdata.LastAppliedConfigMapLiveYAML)
+		opts := lastAppliedServerSideDiffOpts(t, testdata.LastAppliedConfigMapPredictedLiveWithoutAnnotationJSON)
+
+		result, err := serverSideDiff(t.Context(), config, live, opts...)
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		if !assert.False(t, result.Modified, "server-side diff reported a difference") {
+			ascii, err := printDiff(t.Context(), result)
+			require.NoError(t, err)
+			t.Log(ascii)
+		}
+	})
+
+	t.Run("structured merge diff", func(t *testing.T) {
+		t.Parallel()
+		config := StrToUnstructured(testdata.LastAppliedConfigMapConfigYAML)
+		live := StrToUnstructured(testdata.LastAppliedConfigMapLiveYAML)
+
+		result, err := StructuredMergeDiff(config, live, buildGVKParser(t), "argocd-controller")
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		if !assert.False(t, result.Modified, "structured merge diff reported a difference") {
+			ascii, err := printDiff(t.Context(), result)
+			require.NoError(t, err)
+			t.Log(ascii)
+		}
+	})
+}
+
+func lastAppliedServerSideDiffOpts(t *testing.T, predictedLive string) []Option {
+	t.Helper()
+	manager := "argocd-controller"
+	dryRunner := mocks.NewServerSideDryRunner(t)
+	dryRunner.EXPECT().Run(mock.Anything, mock.AnythingOfType("*unstructured.Unstructured"), manager).
+		Return(predictedLive, nil)
+	return []Option{
+		WithGVKParser(buildGVKParser(t)),
+		WithManager(manager),
+		WithServerSideDryRunner(dryRunner),
+		WithLogr(textlogger.NewLogger(textlogger.NewConfig())),
+	}
+}
+
+func TestRemoveLastAppliedConfigAnnotation(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		metadata map[string]any
+		expected map[string]any
+	}{
+		{
+			name: "removes the annotation and keeps siblings",
+			metadata: map[string]any{"annotations": map[string]any{
+				AnnotationLastAppliedConfig: "{}",
+				"keep":                      "me",
+			}},
+			expected: map[string]any{"annotations": map[string]any{"keep": "me"}},
+		},
+		{
+			name: "removes the annotations map when it becomes empty",
+			metadata: map[string]any{"annotations": map[string]any{
+				AnnotationLastAppliedConfig: "{}",
+			}},
+			expected: map[string]any{},
+		},
+		{
+			name:     "removes an already empty annotations map",
+			metadata: map[string]any{"annotations": map[string]any{}},
+			expected: map[string]any{},
+		},
+		{
+			name:     "removes a nil annotations map",
+			metadata: map[string]any{"annotations": nil},
+			expected: map[string]any{},
+		},
+		{
+			name:     "leaves an object without annotations untouched",
+			metadata: map[string]any{"name": "cm"},
+			expected: map[string]any{"name": "cm"},
+		},
+		{
+			name:     "leaves other annotations untouched when the key is absent",
+			metadata: map[string]any{"annotations": map[string]any{"keep": "me"}},
+			expected: map[string]any{"annotations": map[string]any{"keep": "me"}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			un := &unstructured.Unstructured{Object: map[string]any{"metadata": tc.metadata}}
+
+			removeLastAppliedConfigAnnotation(un)
+
+			assert.Equal(t, tc.expected, un.Object["metadata"])
+		})
+	}
+
+	t.Run("tolerates an object with no metadata", func(t *testing.T) {
+		t.Parallel()
+		un := &unstructured.Unstructured{Object: map[string]any{"kind": "ConfigMap"}}
+		removeLastAppliedConfigAnnotation(un)
+		assert.Equal(t, map[string]any{"kind": "ConfigMap"}, un.Object)
+	})
+
+	t.Run("tolerates a nil object", func(t *testing.T) {
+		t.Parallel()
+		assert.NotPanics(t, func() { removeLastAppliedConfigAnnotation(nil) })
+	})
+}

--- a/gitops-engine/pkg/diff/testdata/data.go
+++ b/gitops-engine/pkg/diff/testdata/data.go
@@ -95,4 +95,16 @@ var (
 
 	//go:embed ssd-configmap-predicted-live.json
 	ConfigMapPredictedLiveJSONSSD string
+
+	//go:embed lac-configmap-config.yaml
+	LastAppliedConfigMapConfigYAML string
+
+	//go:embed lac-configmap-live.yaml
+	LastAppliedConfigMapLiveYAML string
+
+	//go:embed lac-configmap-predicted-live-with-annotation.json
+	LastAppliedConfigMapPredictedLiveWithAnnotationJSON string
+
+	//go:embed lac-configmap-predicted-live-without-annotation.json
+	LastAppliedConfigMapPredictedLiveWithoutAnnotationJSON string
 )

--- a/gitops-engine/pkg/diff/testdata/lac-configmap-config.yaml
+++ b/gitops-engine/pkg/diff/testdata/lac-configmap-config.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: probe-cm
+  namespace: default
+  labels:
+    app: probe
+data:
+  key: value

--- a/gitops-engine/pkg/diff/testdata/lac-configmap-live.yaml
+++ b/gitops-engine/pkg/diff/testdata/lac-configmap-live.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: probe-cm
+  namespace: default
+  uid: 6f1f9f4e-2c9a-4d55-9b0e-9d0f0c1a2b3c
+  resourceVersion: "12345"
+  creationTimestamp: "2026-02-25T00:20:45Z"
+  labels:
+    app: probe
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: '{"apiVersion":"v1","data":{"key":"value"},"kind":"ConfigMap","metadata":{"annotations":{},"labels":{"app":"probe"},"name":"probe-cm","namespace":"default"}}'
+  managedFields:
+    - apiVersion: v1
+      fieldsType: FieldsV1
+      fieldsV1:
+        f:data:
+          .: {}
+          f:key: {}
+        f:metadata:
+          f:labels:
+            .: {}
+            f:app: {}
+      manager: argocd-controller
+      operation: Apply
+      time: "2026-02-25T00:20:45Z"
+    - apiVersion: v1
+      fieldsType: FieldsV1
+      fieldsV1:
+        f:metadata:
+          f:annotations:
+            f:kubectl.kubernetes.io/last-applied-configuration: {}
+      manager: kubectl-client-side-apply
+      operation: Update
+      time: "2026-02-25T00:25:11Z"
+data:
+  key: value

--- a/gitops-engine/pkg/diff/testdata/lac-configmap-predicted-live-with-annotation.json
+++ b/gitops-engine/pkg/diff/testdata/lac-configmap-predicted-live-with-annotation.json
@@ -1,0 +1,26 @@
+{
+  "apiVersion": "v1",
+  "kind": "ConfigMap",
+  "metadata": {
+    "name": "probe-cm",
+    "namespace": "default",
+    "uid": "6f1f9f4e-2c9a-4d55-9b0e-9d0f0c1a2b3c",
+    "resourceVersion": "12345",
+    "creationTimestamp": "2026-02-25T00:20:45Z",
+    "labels": { "app": "probe" },
+    "annotations": {
+      "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"key\":\"value\"},\"kind\":\"ConfigMap\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"probe\"},\"name\":\"probe-cm\",\"namespace\":\"default\"}}"
+    },
+    "managedFields": [
+      {
+        "apiVersion": "v1",
+        "fieldsType": "FieldsV1",
+        "fieldsV1": { "f:data": { ".": {}, "f:key": {} } },
+        "manager": "argocd-controller",
+        "operation": "Apply",
+        "time": "2026-02-25T00:30:00Z"
+      }
+    ]
+  },
+  "data": { "key": "value" }
+}

--- a/gitops-engine/pkg/diff/testdata/lac-configmap-predicted-live-without-annotation.json
+++ b/gitops-engine/pkg/diff/testdata/lac-configmap-predicted-live-without-annotation.json
@@ -1,0 +1,23 @@
+{
+  "apiVersion": "v1",
+  "kind": "ConfigMap",
+  "metadata": {
+    "name": "probe-cm",
+    "namespace": "default",
+    "uid": "6f1f9f4e-2c9a-4d55-9b0e-9d0f0c1a2b3c",
+    "resourceVersion": "12345",
+    "creationTimestamp": "2026-02-25T00:20:45Z",
+    "labels": { "app": "probe" },
+    "managedFields": [
+      {
+        "apiVersion": "v1",
+        "fieldsType": "FieldsV1",
+        "fieldsV1": { "f:data": { ".": {}, "f:key": {} } },
+        "manager": "argocd-controller",
+        "operation": "Apply",
+        "time": "2026-02-25T00:30:00Z"
+      }
+    ]
+  },
+  "data": { "key": "value" }
+}


### PR DESCRIPTION
While working on https://github.com/argoproj/argo-cd/issues/27933, I realised that stripping the `kubectl.kubernetes.io/last-applied-configuration` annotation in Argo CD leaves an empty "annotations": {} map behind. Since the diff compares both sides byte-for-byte, an empty map isn't equal to an absent one so a resource that was actually in sync could be reported as OutOfSync, with a diff showing nothing but the empty map.