### PR TITLE
test: fix flaky TestWatchClusters_CreateRemoveCluster and TestWatchCuusters_LocalClusterModifications

### DIFF
--- a/util/db/cluster_norace_test.go
+++ b/util/db/cluster_norace_test.go
@@ -41,8 +41,9 @@ func TestWatchClusters_CreateRemoveCluster(t *testing.T) {
 	}
 	kubeclientset := fake.NewClientset(emptyArgoCDConfigMap, argoCDSecret)
 	settingsManager := settings.NewSettingsManager(t.Context(), kubeclientset, fakeNamespace)
-	db := NewDB(fakeNamespace, settingsManager, kubeclientset)
-	completed := runWatchTest(t, db, []func(old *v1alpha1.Cluster, new *v1alpha1.Cluster){
+	watchClientSet := newWatchNotifyingClientSet(kubeclientset)
+	db := NewDB(fakeNamespace, settingsManager, watchClientSet)
+	completed := runWatchTest(t, watchClientSet, db, []func(old *v1alpha1.Cluster, new *v1alpha1.Cluster){
 		func(old *v1alpha1.Cluster, new *v1alpha1.Cluster) {
 			assert.Nil(t, old)
 			assert.Equal(t, v1alpha1.KubernetesInternalAPIServerAddr, new.Server)
@@ -93,8 +94,9 @@ func TestWatchClusters_LocalClusterModifications(t *testing.T) {
 	}
 	kubeclientset := fake.NewClientset(emptyArgoCDConfigMap, argoCDSecret)
 	settingsManager := settings.NewSettingsManager(t.Context(), kubeclientset, fakeNamespace)
-	db := NewDB(fakeNamespace, settingsManager, kubeclientset)
-	completed := runWatchTest(t, db, []func(old *v1alpha1.Cluster, new *v1alpha1.Cluster){
+	watchClientSet := newWatchNotifyingClientSet(kubeclientset)
+	db := NewDB(fakeNamespace, settingsManager, watchClientSet)
+	completed := runWatchTest(t, watchClientSet, db, []func(old *v1alpha1.Cluster, new *v1alpha1.Cluster){
 		func(old *v1alpha1.Cluster, new *v1alpha1.Cluster) {
 			assert.Nil(t, old)
 			assert.Equal(t, v1alpha1.KubernetesInternalAPIServerAddr, new.Server)
@@ -144,8 +146,9 @@ func TestWatchClusters_MissingServerSecretKey(t *testing.T) {
 	}
 	kubeclientset := fake.NewClientset(emptyArgoCDConfigMap, argoCDSecretWithoutSecretKey)
 	settingsManager := settings.NewSettingsManager(t.Context(), kubeclientset, fakeNamespace)
-	db := NewDB(fakeNamespace, settingsManager, kubeclientset)
-	completed := runWatchTest(t, db, []func(old *v1alpha1.Cluster, new *v1alpha1.Cluster){
+	watchClientSet := newWatchNotifyingClientSet(kubeclientset)
+	db := NewDB(fakeNamespace, settingsManager, watchClientSet)
+	completed := runWatchTest(t, watchClientSet, db, []func(old *v1alpha1.Cluster, new *v1alpha1.Cluster){
 		func(old *v1alpha1.Cluster, new *v1alpha1.Cluster) {
 			assert.Nil(t, old)
 			assert.Equal(t, v1alpha1.KubernetesInternalAPIServerAddr, new.Server)
@@ -179,8 +182,9 @@ func TestWatchClusters_LocalClusterModificationsWhenDisabled(t *testing.T) {
 	}
 	kubeclientset := fake.NewClientset(argoCDConfigMapWithInClusterServerAddressDisabled, argoCDSecret)
 	settingsManager := settings.NewSettingsManager(t.Context(), kubeclientset, fakeNamespace)
-	db := NewDB(fakeNamespace, settingsManager, kubeclientset)
-	completed := runWatchTest(t, db, []func(_ *v1alpha1.Cluster, _ *v1alpha1.Cluster){
+	watchClientSet := newWatchNotifyingClientSet(kubeclientset)
+	db := NewDB(fakeNamespace, settingsManager, watchClientSet)
+	completed := runWatchTest(t, watchClientSet, db, []func(_ *v1alpha1.Cluster, _ *v1alpha1.Cluster){
 		func(_ *v1alpha1.Cluster, _ *v1alpha1.Cluster) {
 			assert.Fail(t, "The in-cluster should not be added when disabled")
 		},

--- a/util/db/cluster_test.go
+++ b/util/db/cluster_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -11,7 +12,10 @@ import (
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	"github.com/argoproj/argo-cd/v3/common"
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
@@ -237,7 +241,51 @@ func TestRejectCreationForInClusterWhenDisabled(t *testing.T) {
 	require.Error(t, err)
 }
 
-func runWatchTest(t *testing.T, db ArgoDB, actions []func(old *v1alpha1.Cluster, new *v1alpha1.Cluster)) (completed bool) {
+type watchNotifyingClientSet struct {
+	kubernetes.Interface
+	watchStarted chan struct{}
+	once         sync.Once
+}
+
+func newWatchNotifyingClientSet(clientSet kubernetes.Interface) *watchNotifyingClientSet {
+	return &watchNotifyingClientSet{Interface: clientSet, watchStarted: make(chan struct{})}
+}
+
+func (c *watchNotifyingClientSet) CoreV1() corev1client.CoreV1Interface {
+	return &watchNotifyingCoreV1{CoreV1Interface: c.Interface.CoreV1(), clientSet: c}
+}
+
+// waitForSecretWatch blocks until a secret watch has been established or the context is done.
+func (c *watchNotifyingClientSet) waitForSecretWatch(ctx context.Context) {
+	select {
+	case <-c.watchStarted:
+	case <-ctx.Done():
+	}
+}
+
+type watchNotifyingCoreV1 struct {
+	corev1client.CoreV1Interface
+	clientSet *watchNotifyingClientSet
+}
+
+func (c *watchNotifyingCoreV1) Secrets(namespace string) corev1client.SecretInterface {
+	return &watchNotifyingSecrets{SecretInterface: c.CoreV1Interface.Secrets(namespace), clientSet: c.clientSet}
+}
+
+type watchNotifyingSecrets struct {
+	corev1client.SecretInterface
+	clientSet *watchNotifyingClientSet
+}
+
+func (s *watchNotifyingSecrets) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	w, err := s.SecretInterface.Watch(ctx, opts)
+	if err == nil {
+		s.clientSet.once.Do(func() { close(s.clientSet.watchStarted) })
+	}
+	return w, err
+}
+
+func runWatchTest(t *testing.T, clientset *watchNotifyingClientSet, db ArgoDB, actions []func(old *v1alpha1.Cluster, new *v1alpha1.Cluster)) (completed bool) {
 	t.Helper()
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
@@ -246,9 +294,16 @@ func runWatchTest(t *testing.T, db ArgoDB, actions []func(old *v1alpha1.Cluster,
 
 	allDone := make(chan bool, 1)
 
+	firstEvent := true
 	doNext := func(old *v1alpha1.Cluster, new *v1alpha1.Cluster) {
 		if len(actions) == 0 {
 			assert.Fail(t, "Unexpected event")
+			return
+		}
+		if firstEvent {
+			firstEvent = false
+		} else {
+			clientset.waitForSecretWatch(ctx)
 		}
 		next := actions[0]
 		next(old, new)

--- a/util/db/cluster_test.go
+++ b/util/db/cluster_test.go
@@ -255,11 +255,13 @@ func (c *watchNotifyingClientSet) CoreV1() corev1client.CoreV1Interface {
 	return &watchNotifyingCoreV1{CoreV1Interface: c.Interface.CoreV1(), clientSet: c}
 }
 
-// waitForSecretWatch blocks until a secret watch has been established or the context is done.
-func (c *watchNotifyingClientSet) waitForSecretWatch(ctx context.Context) {
+// waitForSecretWatch reports whether a secret watch was established before the context was done.
+func (c *watchNotifyingClientSet) waitForSecretWatch(ctx context.Context) bool {
 	select {
 	case <-c.watchStarted:
+		return true
 	case <-ctx.Done():
+		return false
 	}
 }
 
@@ -302,8 +304,8 @@ func runWatchTest(t *testing.T, clientset *watchNotifyingClientSet, db ArgoDB, a
 		}
 		if firstEvent {
 			firstEvent = false
-		} else {
-			clientset.waitForSecretWatch(ctx)
+		} else if !clientset.waitForSecretWatch(ctx) {
+			return
 		}
 		next := actions[0]
 		next(old, new)


### PR DESCRIPTION
Both tests time out on several CI runs 

The fix wraps the `clientset` passed to `NewDB` so the test knows when the secret informer has already created the  watch, and holds back the actions that mutate secrets until then. The first event is exempt because `WatchClusters`
emits the in-cluster add itself, before the informer exists.

The other two tests in the file were never affected - they don't mutate anything from a handler - I changed them because `runWatchTest` now has a new  parameter.

Reproduced on master by running the compiled test binary in a loop
Before the fix there were 
10 failures in 600 runs for `CreateRemoveCluster`, 
2 in 400 for `LocalClusterModifications`. 

With the fix, 1200+ runs with no failures.

Closes #5566.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
