### PR TITLE
chore: add build constraint so workloadidentity tests compile on darwin without cgo

### DIFF
--- a/util/workloadidentity/workloadidentity_test.go
+++ b/util/workloadidentity/workloadidentity_test.go
@@ -1,3 +1,5 @@
+//go:build !darwin || (cgo && darwin)
+
 package workloadidentity
 
 import (


### PR DESCRIPTION
`util/workloadidentity/workloadidentity_test.go` constructs `WorkloadIdentityTokenProvider{tokenCredential: ...}`, but that field only exists in the cgo implementation (`workloadidentity_cgo.go`, built with `!darwin || (cgo && darwin)`). On darwin with `CGO_ENABLED=0`, the no-op stub from `workloadidentity_no_cgo.go` is compiled instead and the test package fails to build:

```
$ CGO_ENABLED=0 GOOS=darwin go vet ./util/workloadidentity/
vet: util/workloadidentity/workloadidentity_test.go:27:44: unknown field tokenCredential in struct literal of type WorkloadIdentityTokenProvider
```

This PR gives the test file the same build constraint as the implementation it tests, so it is only compiled where the fields it references exist. No behaviour change; on linux and on darwin with cgo the tests run exactly as before.

Verified locally:
- `CGO_ENABLED=0 GOOS=darwin go vet ./util/workloadidentity/` now passes
- `go test ./util/workloadidentity/...` passes with `CGO_ENABLED=0` and `CGO_ENABLED=1` on linux

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates? (No)
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged. (Test-only change)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).


