### PR TITLE
feat(sync): add SkipHealthCheck sync option for sync waves (#22940)

### DIFF
--- a/docs/operator-manual/health.md
+++ b/docs/operator-manual/health.md
@@ -335,3 +335,7 @@ metadata:
 ```
 
 By doing this, the health status of the Deployment will not affect the health of its parent Application.
+
+This annotation only affects the health of the Application. It does not change how [sync waves](../user-guide/sync-waves.md)
+wait for the resource to become healthy. To let later waves proceed without waiting for the resource, use the
+[`SkipHealthCheck=true` sync option](../user-guide/sync-options.md#skip-health-check-during-sync).

--- a/docs/user-guide/sync-options.md
+++ b/docs/user-guide/sync-options.md
@@ -431,6 +431,28 @@ spec:
 
 The example above shows how an Argo CD Application can be configured so it will ignore the `spec.replicas` field from the desired state (git) during the sync stage. This is achieved by calculating and pre-patching the desired state before applying it in the cluster. Note that the `RespectIgnoreDifferences` sync option is only effective when the resource is already created in the cluster. If the Application is being created and no live state exists, the desired state is applied as-is.
 
+## Skip Health Check During Sync
+
+When an application uses [sync phases or waves](sync-waves.md), Argo CD waits for every resource in a wave to become
+`Healthy` before it applies the next wave. A resource that never becomes healthy (for example a `DaemonSet` that cannot be
+scheduled on every node) blocks all later waves, and the sync operation stays `Running`.
+
+To consider a resource successfully synced as soon as it has been applied, without waiting for it to become healthy,
+use the following annotation:
+
+```yaml
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipHealthCheck=true
+```
+
+The health of the resource is still assessed and displayed, and it still contributes to the health of the application.
+To also exclude the resource from the application health, use the
+[`argocd.argoproj.io/ignore-healthcheck`](../operator-manual/health.md#ignoring-child-resource-health-check-in-applications)
+annotation.
+
+This option has no effect on [resource hooks](resource_hooks.md), whose completion is derived from their health.
+
 ## Create Namespace
 
 ```yaml

--- a/docs/user-guide/sync-waves.md
+++ b/docs/user-guide/sync-waves.md
@@ -137,6 +137,8 @@ Once the order is defined:
 3. It repeats this process until all phases and waves are in-sync and healthy.
 
 Because an application can have resources that are unhealthy in the first wave, it may be that the app can never get to healthy.
+A resource annotated with `argocd.argoproj.io/sync-options: SkipHealthCheck=true` is considered synced as soon as it has been
+applied, so later waves do not wait for it to become healthy. See [Skip Health Check During Sync](sync-options.md#skip-health-check-during-sync).
 
 ## How Do I Configure Phases?
 

--- a/gitops-engine/pkg/sync/common/types.go
+++ b/gitops-engine/pkg/sync/common/types.go
@@ -53,6 +53,8 @@ const (
 	SyncOptionClientSideApplyMigration = "ClientSideApplyMigration=true"
 	// Sync option that disables client-side apply migration
 	SyncOptionDisableClientSideApplyMigration = "ClientSideApplyMigration=false"
+	// Sync option that marks a resource as synced once it is applied, without waiting for it to become healthy
+	SyncOptionSkipHealthCheck = "SkipHealthCheck=true"
 
 	// Default field manager for client-side apply migration
 	DefaultClientSideApplyMigrationManager = "kubectl-client-side-apply"

--- a/gitops-engine/pkg/sync/doc.go
+++ b/gitops-engine/pkg/sync/doc.go
@@ -82,6 +82,7 @@ The sync options allows customizing the synchronization of selected resources. T
 annotation 'argocd.argoproj.io/sync-options'. Following sync options are supported:
 
 - SkipDryRunOnMissingResource=true - disables dry run in resource is missing in the cluster
+- SkipHealthCheck=true - considers the resource synced once applied, without waiting for it to become healthy
 - Prune=false - disables resource pruning
 - Validate=false - disables resource validation (equivalent to 'kubectl apply --validate=false')
 

--- a/gitops-engine/pkg/sync/sync_context.go
+++ b/gitops-engine/pkg/sync/sync_context.go
@@ -568,6 +568,9 @@ func (sc *syncContext) Sync(ctx context.Context) {
 			} else {
 				sc.setResourceResult(task, task.syncStatus, operationState, message)
 			}
+		} else if task.skipHealthCheck() {
+			// the resource opted out of the health check during sync, it is considered synced once applied
+			sc.setResourceResult(task, task.syncStatus, common.OperationSucceeded, task.message)
 		} else {
 			// this must be calculated on the live object
 			healthStatus, err := health.GetResourceHealth(task.liveObj, sc.healthOverride)

--- a/gitops-engine/pkg/sync/sync_context_test.go
+++ b/gitops-engine/pkg/sync/sync_context_test.go
@@ -360,6 +360,69 @@ func TestSyncSuccessfully_Multistep(t *testing.T) {
 	assert.Len(t, resources, 2)
 }
 
+func TestSyncSuccessfully_MultistepSkipHealthCheck(t *testing.T) {
+	newTest := func(t *testing.T, skipHealthCheck bool) *syncContext {
+		t.Helper()
+		newSvc := testingutils.NewService()
+		newSvc.SetNamespace(testingutils.FakeArgoCDNamespace)
+		testingutils.Annotate(newSvc, synccommon.AnnotationSyncWave, "0")
+		if skipHealthCheck {
+			testingutils.Annotate(newSvc, synccommon.AnnotationSyncOptions, synccommon.SyncOptionSkipHealthCheck)
+		}
+
+		newSvc2 := testingutils.NewService()
+		newSvc2.SetNamespace(testingutils.FakeArgoCDNamespace)
+		newSvc2.SetName("new-svc-2")
+		testingutils.Annotate(newSvc2, synccommon.AnnotationSyncWave, "5")
+
+		// The wave 0 resource never becomes healthy.
+		syncCtx := newTestSyncCtx(nil, WithOperationSettings(false, true, false, false),
+			WithHealthOverride(resourceNameHealthOverride(map[string]health.HealthStatusCode{
+				newSvc.GetName(): health.HealthStatusProgressing,
+			})))
+
+		syncCtx.resources = groupResources(ReconciliationResult{
+			Live:   []*unstructured.Unstructured{nil, nil},
+			Target: []*unstructured.Unstructured{newSvc, newSvc2},
+		})
+
+		syncCtx.Sync(context.Background())
+		phase, message, resources := syncCtx.GetState()
+		require.Equal(t, synccommon.OperationRunning, phase)
+		require.Equal(t, "waiting for healthy state of /Service/my-service", message)
+		require.Len(t, resources, 1)
+
+		// Update the live resources for the next sync
+		syncCtx.resources = groupResources(ReconciliationResult{
+			Live:   []*unstructured.Unstructured{newSvc, nil},
+			Target: []*unstructured.Unstructured{newSvc, newSvc2},
+		})
+		return syncCtx
+	}
+
+	t.Run("without SkipHealthCheck the next wave waits for healthy", func(t *testing.T) {
+		syncCtx := newTest(t, false)
+		syncCtx.Sync(context.Background())
+		phase, message, resources := syncCtx.GetState()
+		assert.Equal(t, synccommon.OperationRunning, phase)
+		assert.Equal(t, "waiting for healthy state of /Service/my-service", message)
+		assert.Len(t, resources, 1)
+	})
+
+	t.Run("with SkipHealthCheck the next wave proceeds", func(t *testing.T) {
+		syncCtx := newTest(t, true)
+		syncCtx.Sync(context.Background())
+		phase, message, resources := syncCtx.GetState()
+		assert.Equal(t, synccommon.OperationSucceeded, phase)
+		assert.Equal(t, "successfully synced (all tasks run)", message)
+		assert.Len(t, resources, 2)
+		result := getResourceResult(resources, kube.NewResourceKey("", "Service", testingutils.FakeArgoCDNamespace, "my-service"))
+		require.NotNil(t, result)
+		assert.Equal(t, synccommon.ResultCodeSynced, result.Status)
+		assert.Equal(t, synccommon.OperationSucceeded, result.HookPhase)
+	})
+}
+
 func TestSync_MultistepResourceDeletionMidstep(t *testing.T) {
 	pod1 := testingutils.NewPod()
 	pod1.SetName("pod-1")

--- a/gitops-engine/pkg/sync/sync_context_test.go
+++ b/gitops-engine/pkg/sync/sync_context_test.go
@@ -361,13 +361,18 @@ func TestSyncSuccessfully_Multistep(t *testing.T) {
 }
 
 func TestSyncSuccessfully_MultistepSkipHealthCheck(t *testing.T) {
-	newTest := func(t *testing.T, skipHealthCheck bool) *syncContext {
+	// targetSkip and liveSkip control whether the desired and the live wave-0 Service carry the option.
+	newTest := func(t *testing.T, targetSkip, liveSkip bool) *syncContext {
 		t.Helper()
 		newSvc := testingutils.NewService()
 		newSvc.SetNamespace(testingutils.FakeArgoCDNamespace)
 		testingutils.Annotate(newSvc, synccommon.AnnotationSyncWave, "0")
-		if skipHealthCheck {
+		liveSvc := newSvc.DeepCopy()
+		if targetSkip {
 			testingutils.Annotate(newSvc, synccommon.AnnotationSyncOptions, synccommon.SyncOptionSkipHealthCheck)
+		}
+		if liveSkip {
+			testingutils.Annotate(liveSvc, synccommon.AnnotationSyncOptions, synccommon.SyncOptionSkipHealthCheck)
 		}
 
 		newSvc2 := testingutils.NewService()
@@ -386,7 +391,7 @@ func TestSyncSuccessfully_MultistepSkipHealthCheck(t *testing.T) {
 			Target: []*unstructured.Unstructured{newSvc, newSvc2},
 		})
 
-		syncCtx.Sync(context.Background())
+		syncCtx.Sync(t.Context())
 		phase, message, resources := syncCtx.GetState()
 		require.Equal(t, synccommon.OperationRunning, phase)
 		require.Equal(t, "waiting for healthy state of /Service/my-service", message)
@@ -394,15 +399,24 @@ func TestSyncSuccessfully_MultistepSkipHealthCheck(t *testing.T) {
 
 		// Update the live resources for the next sync
 		syncCtx.resources = groupResources(ReconciliationResult{
-			Live:   []*unstructured.Unstructured{newSvc, nil},
+			Live:   []*unstructured.Unstructured{liveSvc, nil},
 			Target: []*unstructured.Unstructured{newSvc, newSvc2},
 		})
 		return syncCtx
 	}
 
 	t.Run("without SkipHealthCheck the next wave waits for healthy", func(t *testing.T) {
-		syncCtx := newTest(t, false)
-		syncCtx.Sync(context.Background())
+		syncCtx := newTest(t, false, false)
+		syncCtx.Sync(t.Context())
+		phase, message, resources := syncCtx.GetState()
+		assert.Equal(t, synccommon.OperationRunning, phase)
+		assert.Equal(t, "waiting for healthy state of /Service/my-service", message)
+		assert.Len(t, resources, 1)
+	})
+
+	t.Run("SkipHealthCheck removed from the desired state takes effect in the same sync", func(t *testing.T) {
+		syncCtx := newTest(t, false, true)
+		syncCtx.Sync(t.Context())
 		phase, message, resources := syncCtx.GetState()
 		assert.Equal(t, synccommon.OperationRunning, phase)
 		assert.Equal(t, "waiting for healthy state of /Service/my-service", message)
@@ -410,8 +424,8 @@ func TestSyncSuccessfully_MultistepSkipHealthCheck(t *testing.T) {
 	})
 
 	t.Run("with SkipHealthCheck the next wave proceeds", func(t *testing.T) {
-		syncCtx := newTest(t, true)
-		syncCtx.Sync(context.Background())
+		syncCtx := newTest(t, true, false)
+		syncCtx.Sync(t.Context())
 		phase, message, resources := syncCtx.GetState()
 		assert.Equal(t, synccommon.OperationSucceeded, phase)
 		assert.Equal(t, "successfully synced (all tasks run)", message)

--- a/gitops-engine/pkg/sync/sync_task.go
+++ b/gitops-engine/pkg/sync/sync_task.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/argoproj/argo-cd/gitops-engine/v3/pkg/sync/common"
 	"github.com/argoproj/argo-cd/gitops-engine/v3/pkg/sync/hook"
+	resourceutil "github.com/argoproj/argo-cd/gitops-engine/v3/pkg/sync/resource"
 	"github.com/argoproj/argo-cd/gitops-engine/v3/pkg/sync/syncwaves"
 	"github.com/argoproj/argo-cd/gitops-engine/v3/pkg/utils/kube"
 )
@@ -62,6 +63,13 @@ func (t *syncTask) wave() int {
 		return *t.waveOverride
 	}
 	return syncwaves.Wave(t.obj())
+}
+
+// skipHealthCheck returns true if the resource is considered synced as soon as it is applied,
+// without waiting for it to become healthy
+func (t *syncTask) skipHealthCheck() bool {
+	return (t.targetObj != nil && resourceutil.HasAnnotationOption(t.targetObj, common.AnnotationSyncOptions, common.SyncOptionSkipHealthCheck)) ||
+		(t.liveObj != nil && resourceutil.HasAnnotationOption(t.liveObj, common.AnnotationSyncOptions, common.SyncOptionSkipHealthCheck))
 }
 
 func (t *syncTask) isHook() bool {

--- a/gitops-engine/pkg/sync/sync_task.go
+++ b/gitops-engine/pkg/sync/sync_task.go
@@ -66,10 +66,10 @@ func (t *syncTask) wave() int {
 }
 
 // skipHealthCheck returns true if the resource is considered synced as soon as it is applied,
-// without waiting for it to become healthy
+// without waiting for it to become healthy. Only the desired state is consulted, so removing
+// the option from the manifest takes effect in the same sync.
 func (t *syncTask) skipHealthCheck() bool {
-	return (t.targetObj != nil && resourceutil.HasAnnotationOption(t.targetObj, common.AnnotationSyncOptions, common.SyncOptionSkipHealthCheck)) ||
-		(t.liveObj != nil && resourceutil.HasAnnotationOption(t.liveObj, common.AnnotationSyncOptions, common.SyncOptionSkipHealthCheck))
+	return t.targetObj != nil && resourceutil.HasAnnotationOption(t.targetObj, common.AnnotationSyncOptions, common.SyncOptionSkipHealthCheck)
 }
 
 func (t *syncTask) isHook() bool {


### PR DESCRIPTION
## Problem

When an Application uses sync phases or waves, `gitops-engine` marks a non-hook resource as synced only once its health is `Healthy` (or the resource has no health check). A resource that never becomes healthy blocks every later wave and the operation stays `Running`. The `argocd.argoproj.io/ignore-healthcheck` annotation does not help here: `controller/health.go` only consults it when aggregating Application health, and the sync loop never reads it (#22940).

## Fix

Adds a resource-level sync option, as suggested in #22940 by the maintainer, instead of changing what `ignore-healthcheck` means:

```yaml
metadata:
  annotations:
    argocd.argoproj.io/sync-options: SkipHealthCheck=true
```

- `gitops-engine/pkg/sync/common/types.go`: new `SyncOptionSkipHealthCheck` constant.
- `gitops-engine/pkg/sync/sync_task.go`: `syncTask.skipHealthCheck()` reads the option from the desired (target) object only, so removing it from the manifest takes effect in the same sync.
- `gitops-engine/pkg/sync/sync_context.go`: in the running-task loop, a task with the option is marked `OperationSucceeded` once applied, the same path a resource without a health check takes today. Hooks are unaffected; their completion still comes from their health.
- `controller/health.go` is untouched, so the real health of the resource is still computed, shown in the UI and aggregated into the Application health. Users who also want to exclude it from the Application health combine it with `ignore-healthcheck`.
- Docs: new "Skip Health Check During Sync" section in `docs/user-guide/sync-options.md`, a pointer in `docs/user-guide/sync-waves.md`, and a note in `docs/operator-manual/health.md` that `ignore-healthcheck` does not affect waves.

## How tested

New `TestSyncSuccessfully_MultistepSkipHealthCheck` in `gitops-engine/pkg/sync/sync_context_test.go`: two waves, the wave-0 Service is forced to `Progressing`. Without the option the second sync still reports `waiting for healthy state of /Service/my-service`; with the option the operation reaches `Succeeded` with both resources synced; with the option only on the live object (removed from the manifest) the second sync still waits. The test fails on `master` without the `sync_context.go` change.

```
cd gitops-engine && go test ./pkg/sync/... -run 'TestSyncSuccessfully_Multistep' -count=1
ok      github.com/argoproj/argo-cd/gitops-engine/v3/pkg/sync
```

`go build`, `go vet` and the full `./pkg/sync/...` suite pass in the `gitops-engine` module.

Closes #22940

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

This change was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.


