### PR TITLE
fix(sync): do not pass --force to server-side apply (#29624)

### DIFF
--- a/docs/user-guide/sync-options.md
+++ b/docs/user-guide/sync-options.md
@@ -276,6 +276,11 @@ metadata:
     argocd.argoproj.io/sync-options: Force=true,Replace=true
 ```
 
+> [!NOTE]
+> `Force=true` only takes effect together with `Replace=true`, or when the resource is applied client-side.
+> With `ServerSideApply=true`, `kubectl apply --server-side` does not support `--force`, so `Force=true` on its own
+> is ignored and the resource is applied with `--force-conflicts` as usual.
+
 ## Server-Side Apply
 
 This option enables Kubernetes

--- a/gitops-engine/pkg/utils/kube/resource_ops.go
+++ b/gitops-engine/pkg/utils/kube/resource_ops.go
@@ -482,7 +482,9 @@ func (k *kubectlResourceOperations) newApplyOptions(ioStreams genericiooptions.I
 
 	o.Namespace = obj.GetNamespace()
 	o.DeleteOptions.Filenames = []string{fileName}
-	o.DeleteOptions.ForceDeletion = force
+	// kubectl rejects --force together with --server-side; conflicts are already
+	// forced via --force-conflicts, so the force flag has no meaning under SSA.
+	o.DeleteOptions.ForceDeletion = force && !serverSideApply
 	o.ForceConflicts = serverSideApply
 
 	o.ToPrinter = func(operation string) (printers.ResourcePrinter, error) {

--- a/gitops-engine/pkg/utils/kube/resource_ops_test.go
+++ b/gitops-engine/pkg/utils/kube/resource_ops_test.go
@@ -415,6 +415,24 @@ func TestApplyOptionsConfiguration(t *testing.T) {
 		}
 	})
 
+	t.Run("force=true with serverSideApply=true does not set DeleteOptions.ForceDeletion", func(t *testing.T) {
+		t.Parallel()
+		k, cmdMocks := newTestKubectlResourceOperations(t)
+
+		var capturedOpts *apply.ApplyOptions
+		cmdMocks.On("Apply", mock.Anything).Run(func(args mock.Arguments) {
+			capturedOpts = args[0].(*apply.ApplyOptions)
+		}).Return(nil)
+
+		obj := testingutils.NewPod()
+		_, err := k.ApplyResource(t.Context(), obj, cmdutil.DryRunNone, true, false, true, "test-manager")
+		require.NoError(t, err)
+
+		assert.True(t, capturedOpts.ServerSideApply)
+		assert.True(t, capturedOpts.ForceConflicts)
+		assert.False(t, capturedOpts.DeleteOptions.ForceDeletion)
+	})
+
 	t.Run("outputModeJSON returns JSONPrinter", func(t *testing.T) {
 		t.Parallel()
 		k, cmdMocks := newTestKubectlResourceOperations(t)

--- a/test/e2e/sync_options_test.go
+++ b/test/e2e/sync_options_test.go
@@ -229,6 +229,45 @@ func TestSyncWithForceReplace(t *testing.T) {
 		Expect(HealthIs(health.HealthStatusHealthy))
 }
 
+// TestSyncWithForceAndServerSideApply verifies that a force sync of an application
+// that uses ServerSideApply=true succeeds. kubectl rejects --force together with
+// --server-side, so before the fix every resource failed in the apply phase with
+// "error validating options: --force cannot be used with --server-side".
+func TestSyncWithForceAndServerSideApply(t *testing.T) {
+	ctx := Given(t)
+
+	ctx.
+		Path(guestbookPath).
+		Force().
+		When().
+		CreateApp("--sync-option", "ServerSideApply=true").
+		Sync().
+		Then().
+		Expect(OperationPhaseIs(OperationSucceeded)).
+		Expect(SyncStatusIs(SyncStatusCodeSynced)).
+		Expect(HealthIs(health.HealthStatusHealthy)).
+		Expect(ResourceSyncStatusIs("Deployment", "guestbook-ui", SyncStatusCodeSynced)).
+		Expect(ResourceSyncStatusIs("Service", "guestbook-ui", SyncStatusCodeSynced)).
+		And(func(_ *Application) {
+			// the resources were applied server-side, not client-side
+			deploy, err := KubeClientset.AppsV1().Deployments(ctx.DeploymentNamespace()).Get(t.Context(), "guestbook-ui", metav1.GetOptions{})
+			require.NoError(t, err)
+			assert.NotContains(t, deploy.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
+		}).
+		// a force sync of an already existing resource must succeed as well
+		When().
+		PatchFile("guestbook-ui-deployment.yaml", `[{ "op": "replace", "path": "/spec/replicas", "value": 2 }]`).
+		Refresh(RefreshTypeNormal).
+		Then().
+		Expect(SyncStatusIs(SyncStatusCodeOutOfSync)).
+		When().
+		Sync().
+		Then().
+		Expect(OperationPhaseIs(OperationSucceeded)).
+		Expect(SyncStatusIs(SyncStatusCodeSynced)).
+		Expect(HealthIs(health.HealthStatusHealthy))
+}
+
 // Given application is set with --sync-option CreateNamespace=true and --sync-option ServerSideApply=true
 //
 //		application --dest-namespace exists


### PR DESCRIPTION
Closes #29624

## Problem

`argocd app sync <app> --force` (or `Force=true` via the sync panel, `syncStrategy.apply.force`, or the `Force=true` sync-option annotation) on an Application that uses `ServerSideApply=true` passes dry-run and then fails every resource in the apply phase with kubectl's own flag-validation message:

```
error validating options: --force cannot be used with --server-side
```

`Replace=true` is not involved; that path uses `kubectl replace` and works.

## Root cause

`gitops-engine/pkg/utils/kube/resource_ops.go:485` sets `o.DeleteOptions.ForceDeletion = force` unconditionally, and `o.ForceConflicts = serverSideApply` on the next line. `kubectl` (`k8s.io/kubectl@v0.36.1/pkg/cmd/apply/apply.go:399-400`) rejects that combination in `ApplyOptions.Validate()`, which `newApplyOptions` calls right after. The dry-run pass never trips it because `shouldUseServerSideApply` returns `false` for dry runs, so the operation gets past validation and fails for real.

`kubectl apply --force` only has a meaning for client-side apply (delete and recreate when the patch fails). Under server-side apply the equivalent is `--force-conflicts`, which Argo CD already always sets.

## Fix

Only set `DeleteOptions.ForceDeletion` when the resource is not server-side applied:

```go
o.DeleteOptions.ForceDeletion = force && !serverSideApply
```

Behaviour is unchanged for client-side apply and for `Replace=true`. Under SSA, `Force=true` is now a no-op instead of failing the resource, and `docs/user-guide/sync-options.md` (Force Sync section) says so.

## How tested

New subtest `force=true with serverSideApply=true does not set DeleteOptions.ForceDeletion` in `TestApplyOptionsConfiguration` (`gitops-engine/pkg/utils/kube/resource_ops_test.go`).

New e2e test `TestSyncWithForceAndServerSideApply` (`test/e2e/sync_options_test.go`): creates the guestbook app with `--sync-option ServerSideApply=true`, runs `argocd app sync --force` twice (initial create, then after a replicas change) and asserts the operation succeeds, the app is Synced/Healthy, and the Deployment carries no `last-applied-configuration` annotation (i.e. it really was applied server-side).

Before the fix (master `eb15eb4`):

```
--- FAIL: TestApplyOptionsConfiguration (0.00s)
    --- FAIL: TestApplyOptionsConfiguration/force=true_with_serverSideApply=true_does_not_set_DeleteOptions.ForceDeletion (0.00s)
        resource_ops_test.go:429:
                Error:          Received unexpected error:
                                error validating options: --force cannot be used with --server-side
FAIL	github.com/argoproj/argo-cd/gitops-engine/v3/pkg/utils/kube	0.045s
```

After the fix:

```
ok  	github.com/argoproj/argo-cd/gitops-engine/v3/pkg/utils/kube	0.059s
ok  	github.com/argoproj/argo-cd/gitops-engine/v3/pkg/sync	0.127s
```

`gofmt`, `go vet` and `go build ./...` in `gitops-engine/` are clean; `golangci-lint run --new-from-rev upstream/master` reports nothing for the changed lines.

## Links

- https://github.com/argoproj/argo-cd/issues/29624
- Related (not a duplicate): https://github.com/argoproj/argo-cd/issues/29332
- Force Sync docs: https://argo-cd.readthedocs.io/en/latest/user-guide/sync-options/#force-sync

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity). Cherry-pick candidates: release-3.5, release-3.4, release-3.3 (same code path).

This change was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.


