### PR TITLE
fix: recover auto-sync from orphaned operation state (#29636)

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -2684,6 +2684,13 @@ func alreadyAttemptedSync(app *appv1.Application, desiredRevisions []string, new
 		return false, []string{}, ""
 	}
 	if app.Status.OperationState.SyncResult == nil {
+		if app.Status.OperationState.FinishedAt == nil {
+			// The operation was orphaned (e.g. the controller restarted while an
+			// operation was in progress) and never actually finished. Treat it as
+			// not-yet-attempted so that auto-sync can proceed instead of being
+			// permanently suppressed by a stale terminal phase.
+			return false, []string{}, app.Status.OperationState.Phase
+		}
 		// If the sync has completed without result, it is very likely that an error happened
 		// We don't want to resync with auto-sync indefinitely. We should have retried the configured amount of time already
 		// In this case, a manual action to restore the app may be required

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -3971,6 +3971,18 @@ func TestAlreadyAttemptSync(t *testing.T) {
 		assert.True(t, attempted)
 	})
 
+	t.Run("no sync result for orphaned sync", func(t *testing.T) {
+		// A terminal phase with no sync result and no finishedAt indicates an
+		// operation orphaned by a controller restart. It should not be treated as
+		// already attempted, otherwise auto-sync is permanently suppressed.
+		app := app.DeepCopy()
+		app.Status.OperationState.SyncResult = nil
+		app.Status.OperationState.Phase = synccommon.OperationSucceeded
+		app.Status.OperationState.FinishedAt = nil
+		attempted, _, _ := alreadyAttemptedSync(app, []string{defaultRevision}, true)
+		assert.False(t, attempted)
+	})
+
 	t.Run("single source", func(t *testing.T) {
 		t.Run("no revision", func(t *testing.T) {
 			attempted, _, _ := alreadyAttemptedSync(app, []string{}, true)


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where an Argo CD Application can become permanently unable to auto-sync when `status.operationState` is left in an inconsistent terminal state after an `argocd-application-controller` restart.

## Why is this needed?

When the controller restarts while an operation is in progress, the Application can be left with a terminal `phase` (e.g. `Succeeded`) but a `nil` `syncResult` and `nil` `finishedAt`. In `alreadyAttemptedSync`, the `SyncResult == nil` branch treated any completed phase as "already attempted", which permanently suppressed auto-sync:

```
Already attempted sync: sync does not have any results
Skipping auto-sync: already attempted sync to [] with timeout 0s
```

This left the Application `OutOfSync` but `Healthy`, with no condition raised and no timeout or reconciliation path to recover it.

## How does this PR fix it?

When `SyncResult` is `nil`, additionally check `FinishedAt`. A `nil` `FinishedAt` means the operation never actually completed (it was orphaned), so it is treated as not-yet-attempted and auto-sync can proceed. Operations that genuinely completed without a result (the existing error case, where `FinishedAt` is set) keep the current behavior of avoiding an indefinite resync loop.

## Checklist

* [x] Either (a) I've created an enhancement proposal and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes. → **(b) bug fix**
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr).
* [x] I've included "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. → Not applicable (controller-only bug fix).
* [x] Does this PR require documentation updates? → No.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal).
* [x] I have written unit and/or e2e tests for my change. → Added `TestAlreadyAttemptSync/no_sync_result_for_orphaned_sync`.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into. → Candidate for cherry-pick to active release branches if maintainers deem it low-risk.

Fixes #29636
