### PR TITLE
fix(repo-server): sweep orphaned temp packfiles before fetching

### DIFF
--- a/util/git/client.go
+++ b/util/git/client.go
@@ -327,13 +327,29 @@ func NewClientExt(rawRepoURL string, root string, creds Creds, insecure bool, en
 
 var gitClientTimeout = env.ParseDurationFromEnv("ARGOCD_GIT_REQUEST_TIMEOUT", 15*time.Second, 0, math.MaxInt64)
 
+// gitCleanupNoTimeoutGracePeriod is the grace period used when ARGOCD_EXEC_TIMEOUT
+// is 0 and git commands therefore run without a deadline.
+const gitCleanupNoTimeoutGracePeriod = 24 * time.Hour
+
 // gitCleanupGracePeriod is the minimum age a temporary pack file must reach
-// before cleanupOrphanedTempPackfiles will remove it. A fetch is killed at
-// ARGOCD_EXEC_TIMEOUT (plus the fatal-timeout grace), so twice that comfortably
-// exceeds the longest a fetch can be in flight; anything older cannot belong to
-// a live fetch (for example a concurrent fetch from another repo-server replica
-// sharing an RWX cache volume).
-var gitCleanupGracePeriod = 2 * env.ParseDurationFromEnv("ARGOCD_EXEC_TIMEOUT", 90*time.Second, 0, math.MaxInt64)
+// before cleanupOrphanedTempPackfiles will remove it. git is signalled at
+// ARGOCD_EXEC_TIMEOUT and SIGKILLed ARGOCD_EXEC_FATAL_TIMEOUT after that, so
+// twice the sum comfortably exceeds the longest a fetch can be in flight;
+// anything older cannot belong to a live fetch (for example a concurrent fetch
+// from another repo-server replica sharing an RWX cache volume).
+//
+// ARGOCD_EXEC_TIMEOUT=0 disables the timeout, so a fetch may run for arbitrarily
+// long and no age proves a file was orphaned. Hold on to temp files for a day in
+// that case; leaking one is cheaper than unlinking it from under a live git.
+func gitCleanupGracePeriod() time.Duration {
+	// The quartered ceilings keep the doubled sum inside math.MaxInt64.
+	execTimeout := env.ParseDurationFromEnv("ARGOCD_EXEC_TIMEOUT", 90*time.Second, 0, math.MaxInt64/4)
+	if execTimeout == 0 {
+		return gitCleanupNoTimeoutGracePeriod
+	}
+	fatalTimeout := env.ParseDurationFromEnv("ARGOCD_EXEC_FATAL_TIMEOUT", 10*time.Second, 0, math.MaxInt64/4)
+	return 2 * (execTimeout + fatalTimeout)
+}
 
 // Returns a HTTP client object suitable for go-git to use using the following
 // pattern:
@@ -651,6 +667,8 @@ func (m *nativeGitClient) cleanupOrphanedTempPackfiles() {
 		return
 	}
 
+	grace := gitCleanupGracePeriod()
+
 	var removed int
 	var reclaimed int64
 	for _, entry := range entries {
@@ -676,7 +694,7 @@ func (m *nativeGitClient) cleanupOrphanedTempPackfiles() {
 			// Can't determine the age, so don't risk deleting a live temp file.
 			continue
 		}
-		if time.Since(info.ModTime()) < gitCleanupGracePeriod {
+		if time.Since(info.ModTime()) < grace {
 			// Still within the grace window: a concurrent fetch may be writing
 			// it. Leave it; a later sweep reclaims it once it is stale.
 			continue

--- a/util/git/client.go
+++ b/util/git/client.go
@@ -622,11 +622,12 @@ func (m *nativeGitClient) IsRevisionPresent(ctx context.Context, revision string
 }
 
 // cleanupOrphanedTempPackfiles removes leftover objects/pack/tmp_{pack,idx,rev,mtimes}_* files
-// produced by a git fetch/index-pack that was killed (for example by the exec
-// timeout) before it could finalize the pack. Git treats these as garbage and
-// never prunes them itself, so without this cleanup they accumulate on every
-// failed fetch into the reused cache directory and can grow the repo-server
-// volume without bound. This is best-effort: failures are logged, not returned.
+// produced by a git fetch/index-pack that was killed (by the exec timeout, or by
+// SIGKILL on an OOMKill) before it could finalize the pack. Git treats these as
+// garbage and never prunes them itself, so without this cleanup they accumulate
+// on every failed fetch into the reused cache directory and can grow the
+// repo-server volume without bound. This is best-effort: failures are logged,
+// not returned.
 //
 // Within a single repo-server the per-repository lock (reposerver/repository/
 // lock.go) already serializes fetch/checkout per cache directory, so no
@@ -700,6 +701,9 @@ func (m *nativeGitClient) Fetch(ctx context.Context, revision string, depth int6
 		done := m.OnFetch(m.repoURL)
 		defer done()
 	}
+
+	// An OOMKilled fetch never reaches the error path below, so sweep on the way in too.
+	m.cleanupOrphanedTempPackfiles()
 
 	err := m.fetch(ctx, revision, depth)
 	if err != nil {

--- a/util/git/client_test.go
+++ b/util/git/client_test.go
@@ -247,7 +247,7 @@ func Test_nativeGitClient_cleanupOrphanedTempPackfiles(t *testing.T) {
 	root := t.TempDir()
 	packDir := filepath.Join(root, ".git", "objects", "pack")
 	require.NoError(t, os.MkdirAll(packDir, 0o755))
-	// gitCleanupGracePeriod defaults to 2 * 90s = 3m, so an hour-old file is
+	// gitCleanupGracePeriod defaults to 2 * (90s + 10s), so an hour-old file is
 	// safely stale and a just-written one is safely fresh.
 	old := time.Now().Add(-time.Hour)
 
@@ -298,6 +298,85 @@ func Test_nativeGitClient_cleanupOrphanedTempPackfiles_noPackDir(t *testing.T) {
 	// A repository whose pack directory does not exist yet must not panic or error.
 	client := &nativeGitClient{root: t.TempDir(), repoURL: "https://example.com/repo.git"}
 	assert.NotPanics(t, client.cleanupOrphanedTempPackfiles)
+}
+
+func Test_gitCleanupGracePeriod(t *testing.T) {
+	t.Run("defaults", func(t *testing.T) {
+		t.Setenv("ARGOCD_EXEC_TIMEOUT", "")
+		t.Setenv("ARGOCD_EXEC_FATAL_TIMEOUT", "")
+		assert.Equal(t, 200*time.Second, gitCleanupGracePeriod())
+	})
+
+	t.Run("both timeouts are accounted for", func(t *testing.T) {
+		t.Setenv("ARGOCD_EXEC_TIMEOUT", "5s")
+		t.Setenv("ARGOCD_EXEC_FATAL_TIMEOUT", "60s")
+		// git is SIGKILLed at 65s here, which 2 * ARGOCD_EXEC_TIMEOUT alone would
+		// have undershot.
+		assert.Equal(t, 130*time.Second, gitCleanupGracePeriod())
+	})
+
+	t.Run("fatal timeout falls back to its default", func(t *testing.T) {
+		t.Setenv("ARGOCD_EXEC_TIMEOUT", "30s")
+		t.Setenv("ARGOCD_EXEC_FATAL_TIMEOUT", "")
+		assert.Equal(t, 80*time.Second, gitCleanupGracePeriod())
+	})
+
+	t.Run("disabled exec timeout does not collapse the grace period", func(t *testing.T) {
+		t.Setenv("ARGOCD_EXEC_TIMEOUT", "0s")
+		assert.Equal(t, gitCleanupNoTimeoutGracePeriod, gitCleanupGracePeriod())
+	})
+
+	t.Run("unparseable values fall back to defaults", func(t *testing.T) {
+		t.Setenv("ARGOCD_EXEC_TIMEOUT", "nonsense")
+		t.Setenv("ARGOCD_EXEC_FATAL_TIMEOUT", "nonsense")
+		assert.Equal(t, 200*time.Second, gitCleanupGracePeriod())
+	})
+}
+
+func Test_nativeGitClient_cleanupOrphanedTempPackfiles_customTimeouts(t *testing.T) {
+	t.Setenv("ARGOCD_EXEC_TIMEOUT", "5s")
+	t.Setenv("ARGOCD_EXEC_FATAL_TIMEOUT", "60s")
+
+	root := t.TempDir()
+	packDir := filepath.Join(root, ".git", "objects", "pack")
+	require.NoError(t, os.MkdirAll(packDir, 0o755))
+
+	// git is not SIGKILLed until 65s in, so a 30s-old file can still belong to a
+	// live fetch even though it is past 2 * ARGOCD_EXEC_TIMEOUT.
+	inflight := filepath.Join(packDir, "tmp_pack_inflight")
+	require.NoError(t, os.WriteFile(inflight, []byte("partial data"), 0o644))
+	age := time.Now().Add(-30 * time.Second)
+	require.NoError(t, os.Chtimes(inflight, age, age))
+
+	client := &nativeGitClient{root: root, repoURL: "https://example.com/repo.git"}
+	client.cleanupOrphanedTempPackfiles()
+
+	assert.FileExists(t, inflight, "a temp file younger than exec timeout + fatal timeout must be preserved")
+}
+
+func Test_nativeGitClient_cleanupOrphanedTempPackfiles_timeoutDisabled(t *testing.T) {
+	t.Setenv("ARGOCD_EXEC_TIMEOUT", "0s")
+
+	root := t.TempDir()
+	packDir := filepath.Join(root, ".git", "objects", "pack")
+	require.NoError(t, os.MkdirAll(packDir, 0o755))
+
+	// Without a deadline a fetch can still be running an hour later.
+	recent := filepath.Join(packDir, "tmp_pack_recent")
+	require.NoError(t, os.WriteFile(recent, []byte("partial data"), 0o644))
+	hourOld := time.Now().Add(-time.Hour)
+	require.NoError(t, os.Chtimes(recent, hourOld, hourOld))
+
+	ancient := filepath.Join(packDir, "tmp_pack_ancient")
+	require.NoError(t, os.WriteFile(ancient, []byte("partial data"), 0o644))
+	twoDaysOld := time.Now().Add(-48 * time.Hour)
+	require.NoError(t, os.Chtimes(ancient, twoDaysOld, twoDaysOld))
+
+	client := &nativeGitClient{root: root, repoURL: "https://example.com/repo.git"}
+	client.cleanupOrphanedTempPackfiles()
+
+	assert.FileExists(t, recent, "with no exec timeout a git process may still be running, so recent temp files must be preserved")
+	assert.NoFileExists(t, ancient, "cleanup is delayed when the timeout is disabled, not disabled itself")
 }
 
 func Test_nativeGitClient_Fetch_cleansOrphanedTempPacksOnError(t *testing.T) {

--- a/util/git/client_test.go
+++ b/util/git/client_test.go
@@ -331,6 +331,27 @@ func Test_nativeGitClient_Fetch_cleansOrphanedTempPacksOnError(t *testing.T) {
 	assert.NoFileExists(t, orphanIdx, "orphaned temp index should be cleaned up after a failed fetch")
 }
 
+func Test_nativeGitClient_Fetch_sweepsOrphanedTempPacksBeforeFetching(t *testing.T) {
+	ctx := t.Context()
+	tempDir, err := _createEmptyGitRepo(ctx)
+	require.NoError(t, err)
+
+	client, err := NewClient("file://"+tempDir, NopCreds{}, true, false, "", "")
+	require.NoError(t, err)
+	require.NoError(t, client.Init())
+
+	packDir := filepath.Join(client.Root(), ".git", "objects", "pack")
+	require.NoError(t, os.MkdirAll(packDir, 0o755))
+	old := time.Now().Add(-time.Hour)
+	orphan := filepath.Join(packDir, "tmp_pack_from_previous_run")
+	require.NoError(t, os.WriteFile(orphan, []byte("partial data"), 0o644))
+	require.NoError(t, os.Chtimes(orphan, old, old))
+
+	// Fetch succeeds here, so nothing but the sweep on the way in can remove this.
+	require.NoError(t, client.Fetch(ctx, "", 0))
+	assert.NoFileExists(t, orphan, "orphan from a previous run should be cleaned up before fetching")
+}
+
 func Test_nativeGitClient_Fetch(t *testing.T) {
 	tempDir, err := _createEmptyGitRepo(t.Context())
 	require.NoError(t, err)


### PR DESCRIPTION
`cleanupOrphanedTempPackfiles` only runs when `fetch` returns an error. When the repo-server is OOMKilled mid-fetch the process takes a SIGKILL, so that path never runs — the `tmp_pack_*` files stay on the volume and only get reclaimed whenever some later fetch happens to fail. On a PVC-backed `/tmp` they just accumulate.

This calls the same sweep on the way into `Fetch`, so anything a previous process stranded is gone before the next fetch runs. The existing grace window (2 × `ARGOCD_EXEC_TIMEOUT`) still applies, so a temp file belonging to a fetch that really is in flight somewhere else won't be touched.

The existing test only covers the error path, so I added one that puts an orphan in place and then does a fetch that succeeds.

Closes #29639

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).