### PR TITLE
fix(cli): honor HTTP_PROXY/HTTPS_PROXY/NO_PROXY for gRPC-web connections

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -370,7 +370,6 @@ Currently, the following organizations are **officially** using Argo CD:
 1. [Softway Medical](https://www.softwaymedical.fr/)
 1. [Sophotech](https://sopho.tech)
 1. [South China Morning Post (SCMP)](https://www.scmp.com/)
-1. [Spare](https://spare.com/)
 1. [Speee](https://speee.jp/)
 1. [Spendesk](https://spendesk.com/)
 1. [Splunk](https://splunk.com/)

--- a/USERS.md
+++ b/USERS.md
@@ -370,6 +370,7 @@ Currently, the following organizations are **officially** using Argo CD:
 1. [Softway Medical](https://www.softwaymedical.fr/)
 1. [Sophotech](https://sopho.tech)
 1. [South China Morning Post (SCMP)](https://www.scmp.com/)
+1. [Spare](https://spare.com/)
 1. [Speee](https://speee.jp/)
 1. [Spendesk](https://spendesk.com/)
 1. [Splunk](https://splunk.com/)

--- a/docs/user-guide/environment-variables.md
+++ b/docs/user-guide/environment-variables.md
@@ -16,3 +16,15 @@ The following environment variables can be used with `argocd` CLI:
 | `ARGOCD_REDIS_KEY_PREFIX`            | the Argo CD Redis keys prefix (default "")
 |
 | `ARGOCD_GRPC_KEEP_ALIVE_MIN`         | defines the GRPCKeepAliveEnforcementMinimum, used in the grpc.KeepaliveEnforcementPolicy. Expects a "Duration" format (default `10s`).                                                                    |
+
+## Proxy environment variables
+
+For gRPC-web connections, the `argocd` CLI honors the standard `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` environment
+variables (and their lowercase equivalents), following Go's
+[`http.ProxyFromEnvironment`](https://pkg.go.dev/net/http#ProxyFromEnvironment) rules. Connections to the API server
+use HTTPS unless `--plaintext` is given, so `HTTPS_PROXY` is normally the variable that applies. Requests to
+`localhost` and loopback addresses are never proxied, and hosts matched by `NO_PROXY` bypass the proxy.
+
+Plain gRPC connections, i.e. those made without `--grpc-web`, do not use `HTTP_PROXY`/`HTTPS_PROXY`. They only support
+a SOCKS5 proxy configured through `ALL_PROXY`. If your environment provides an HTTP proxy only, pass `--grpc-web` or
+set `ARGOCD_OPTS="--grpc-web"`.

--- a/pkg/apiclient/apiclient.go
+++ b/pkg/apiclient/apiclient.go
@@ -309,6 +309,9 @@ func NewClientWithContext(ctx context.Context, opts *ClientOptions) (Client, err
 		}
 		c.httpClient.Transport = &http.Transport{
 			TLSClientConfig: tlsConfig,
+			// Honor HTTP_PROXY/HTTPS_PROXY/NO_PROXY, like http.DefaultTransport
+			// (which is used in the --plaintext case) and HTTPClient() already do.
+			Proxy: http.ProxyFromEnvironment,
 		}
 	}
 	if !c.GRPCWeb {

--- a/pkg/apiclient/apiclient_test.go
+++ b/pkg/apiclient/apiclient_test.go
@@ -49,6 +49,25 @@ func Test_parseGRPCHeaders(t *testing.T) {
 	})
 }
 
+func TestNewClient_GRPCWebTransportUsesProxyFromEnvironment(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewClientWithContext(t.Context(), &ClientOptions{
+		ServerAddr: "argocd.example.com:443",
+		Insecure:   true, // TLS client which does not require a real CA
+		GRPCWeb:    true, // skip the plain gRPC probe, which would try to reach the server
+	})
+	require.NoError(t, err)
+
+	cl, ok := c.(*client)
+	require.True(t, ok)
+	transport, ok := cl.httpClient.Transport.(*http.Transport)
+	require.True(t, ok, "expected *http.Transport, got %T", cl.httpClient.Transport)
+
+	assert.NotNil(t, transport.Proxy, "gRPC-web transport must honor HTTP_PROXY/HTTPS_PROXY/NO_PROXY")
+	require.NotNil(t, transport.TLSClientConfig)
+}
+
 func TestExecuteRequest_ClosesBodyOnHTTPError(t *testing.T) {
 	t.Parallel()
 	bodyClosed := &atomic.Bool{}


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

## What

Set `Proxy: http.ProxyFromEnvironment` on the `http.Transport` that `NewClientWithContext` builds for gRPC-web
requests in `pkg/apiclient/apiclient.go`.

## Why

That transport sets only `TLSClientConfig`, so its `Proxy` field is nil. A nil `Proxy` means "never proxy", not
"read the environment", so `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` are silently ignored for every gRPC-web
request. It is the client used for all gRPC-web traffic (`pkg/apiclient/grpcproxy.go`, `executeRequest` →
`c.httpClient.Do`), so an Argo CD server that is only reachable through an HTTP forward proxy cannot be reached at
all.

Two neighbouring code paths already do this correctly, which is what makes this look like an oversight rather than a
deliberate choice:

- with `--plaintext` the `Transport` is left nil, `http.DefaultTransport` applies, and proxies **are** honored;
- `HTTPClient()`, used for the OIDC/login leg, sets `Proxy: http.ProxyFromEnvironment` explicitly.

The visible symptom of that split is a login where OIDC discovery goes through the proxy and the gRPC call that
follows does not.

This addresses the `HTTPS_PROXY`/`HTTP_PROXY` half of #23933, which is the one-line change its reporter proposed. It
does not touch the `ALL_PROXY`/unix-socket half of that issue, so I have not marked the issue as closed.

Related, for reviewer context:

- #22854 was closed by #24177, but #24177 changed only the plain-gRPC dialer in `util/grpc/grpc.go`, which resolves
  proxies through `golang.org/x/net/proxy` and so reads only `ALL_PROXY`. It never touched the gRPC-web HTTP client,
  and a later comment on #22854 reports the CLI still ignoring the proxy variables.
- #23992 targets the same issue with a `golang.org/x/net/proxy` `DialContext`. That package reads only `ALL_PROXY`
  and supports only the `socks5`/`socks5h` schemes, so it covers a different case than this PR. The two are
  complementary rather than competing.
- #29189 restructures this same block to fix `--http-retry-max` on TLS. This change is deliberately a single field
  added to the existing literal so that it composes with that PR whichever lands first.

## Testing

Added `TestNewClient_GRPCWebTransportUsesProxyFromEnvironment`, which asserts the transport `NewClient` builds for a
non-plaintext gRPC-web client has a non-nil `Proxy` alongside its `TLSClientConfig`. Against the unfixed code it
fails with `Expected value not to be nil`.

Verified end to end against a stub proxy, using a binary built from this branch:

```
HTTPS_PROXY=http://127.0.0.1:3128 NO_PROXY= argocd version --grpc-web --insecure --server argocd.example.com
```

The stub proxy receives:

```
CONNECT argocd.example.com:443 HTTP/1.1
Host: argocd.example.com:443
User-Agent: Go-http-client/1.1
```

The same command with a binary built from unmodified `master` sends nothing to the proxy and fails with
`dial tcp: lookup argocd.example.com: no such host`, i.e. it connects directly and ignores `HTTPS_PROXY`.

Also ran `golangci-lint run ./pkg/apiclient/...` (v2.13.2, the version CI pins) with 0 issues,
`go test ./pkg/apiclient/... -race`, and a repo-wide `go build`.

## Documentation

Added a "Proxy environment variables" section to `docs/user-guide/environment-variables.md`. It documents the
variables the CLI honors for gRPC-web and notes that plain gRPC connections support only a SOCKS5 `ALL_PROXY`, which
is the distinction users hit in #23933 and #22854.

## Cherry-picks

Please consider `cherry-pick/3.5` and `cherry-pick/3.4`. The changed block is identical on `release-3.3`,
`release-3.4` and `release-3.5`, so the code hunk applies cleanly; `apiclient_test.go` has minor drift on those
branches and may need a trivial manual resolution.
