### PR TITLE
fix: expose tarball-relative path to CMP plugins via ARGOCD_APP_TARBALL_REL_PATH (#29655)

### DIFF
--- a/docs/user-guide/build-environment.md
+++ b/docs/user-guide/build-environment.md
@@ -13,6 +13,7 @@
 | `ARGOCD_APP_SOURCE_PATH`            | The path of the app within the source repo.                             |
 | `ARGOCD_APP_SOURCE_REPO_URL`        | The source repo URL.                                                    |
 | `ARGOCD_APP_SOURCE_TARGET_REVISION` | The target revision from the spec, e.g. `master`.                       |
+| `ARGOCD_APP_TARBALL_REL_PATH`       | The path of the app relative to the root of the tarball sent to a CMP. When the `manifest-generate-paths` annotation narrows the transmitted tree, this differs from `ARGOCD_APP_SOURCE_PATH`. |
 | `KUBE_VERSION`                      | The semantic version of Kubernetes without trailing metadata.           |
 | `KUBE_API_VERSIONS`                 | The version of the Kubernetes API.                                      |
 

--- a/util/cmp/stream.go
+++ b/util/cmp/stream.go
@@ -152,6 +152,11 @@ func GetCompressedRepoAndMetadata(rootPath string, appPath string, env []string,
 	if err != nil {
 		return nil, nil, fmt.Errorf("error building app relative path: %w", err)
 	}
+	// The tarball is rooted at rootPath, which may be narrower than the repository
+	// root when the manifest-generate-paths annotation is used. Expose the
+	// tarball-relative path so plugins can reconcile it with the repo-relative
+	// ARGOCD_APP_SOURCE_PATH. See https://github.com/argoproj/argo-cd/issues/29655.
+	env = append(env, fmt.Sprintf("ARGOCD_APP_TARBALL_REL_PATH=%s", appRelPath))
 	// send metadata first
 	mr := appMetadataRequest(filepath.Base(appPath), appRelPath, env, checksum, fi.Size())
 	return tgz, mr, err

--- a/util/cmp/stream_test.go
+++ b/util/cmp/stream_test.go
@@ -123,3 +123,28 @@ func getTestDataDir(t *testing.T) string {
 	t.Helper()
 	return filepath.Join(test.GetTestDir(t), "testdata")
 }
+
+func TestGetCompressedRepoAndMetadataExposesTarballRelPath(t *testing.T) {
+	t.Parallel()
+
+	// rootPath is the narrowed common root (as produced by the
+	// manifest-generate-paths annotation), while appPath is a subdirectory of it.
+	rootPath := t.TempDir()
+	appPath := filepath.Join(rootPath, "my-app")
+	require.NoError(t, os.MkdirAll(appPath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(appPath, "deployment.yaml"), []byte("apiVersion: v1\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(rootPath, "_values"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(rootPath, "_values", "values.yaml"), []byte("foo: bar\n"), 0o644))
+
+	tgz, mr, err := cmp.GetCompressedRepoAndMetadata(rootPath, appPath, []string{"ARGOCD_APP_SOURCE_PATH=team-a/my-app"}, nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, tgz.Close())
+
+	var tarballRelPath string
+	for _, e := range mr.GetMetadata().GetEnv() {
+		if e.GetName() == "ARGOCD_APP_TARBALL_REL_PATH" {
+			tarballRelPath = e.GetValue()
+		}
+	}
+	assert.Equal(t, "my-app", tarballRelPath)
+}


### PR DESCRIPTION
## What does this PR do?

Exposes the tarball-relative application path to CMP (config management plugin) sidecars via a new `ARGOCD_APP_TARBALL_REL_PATH` environment variable.

## Why is this needed?

When the `argocd.argoproj.io/manifest-generate-paths` annotation is set on an Application using a CMP sidecar plugin, `getApplicationRootPath` computes a common root that can be a subdirectory of the repository. The tarball sent to the CMP sidecar is rooted at that subdirectory, but `ARGOCD_APP_SOURCE_PATH` remains relative to the full repository root.

For example, with a layout like:

```
team-a/
  my-app/        ← spec.source.path: team-a/my-app
  _values/       ← shared values
```

and annotation `argocd.argoproj.io/manifest-generate-paths: ".;/team-a/_values"`, the common root resolves to `/repo/team-a/`, so the tarball contains `my-app/` and `_values/`. The plugin's CWD is `<workDir>/my-app/`, but `ARGOCD_APP_SOURCE_PATH` is still `team-a/my-app` (repo-relative). Plugins that derive the repository root by trimming `ARGOCD_APP_SOURCE_PATH` from CWD break.

## How does this PR fix it?

The tarball-relative path is already computed in `GetCompressedRepoAndMetadata` (`files.RelativePath(appPath, rootPath)`) and sent to the CMP server as `ManifestRequestMetadata.AppRelPath`. This PR additionally injects that value as the `ARGOCD_APP_TARBALL_REL_PATH` environment variable so plugins can detect the discrepancy between the repo-relative source path and the tarball root. The change is backward-compatible: when the tarball root equals the repository root, the value simply mirrors `ARGOCD_APP_SOURCE_PATH` (or is empty when the app path is the root).

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes. → **(b) bug fix**
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. → Not applicable (CMP server environment variable only).
* [x] Does this PR require documentation updates? → Yes.
* [x] I've updated documentation as required by this PR. → Added `ARGOCD_APP_TARBALL_REL_PATH` to the build environment table.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged. → Added `TestGetCompressedRepoAndMetadataExposesTarballRelPath`.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). → `go test ./util/cmp/...` passes; `go build ./reposerver/... ./cmpserver/...` passes.
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into. → Candidate for cherry-pick to active release branches if maintainers deem it low-risk.

Fixes #29655
