### PR TITLE
fix(ui): tree view spacing with group nodes

### DIFF
--- a/ui/src/app/applications/components/application-resource-tree/application-resource-tree.scss
+++ b/ui/src/app/applications/components/application-resource-tree/application-resource-tree.scss
@@ -58,6 +58,8 @@
         }
     }
 
+    // Keep in sync with `NODE_HEIGHT` in `application-resource-tree.tsx`.
+    $node-height: 52px;
     $pod-size: 25px;
     $gutter: 3px;
     // Keep in sync with `POD_GROUP_PODS_PER_ROW` in `application-resource-tree.tsx`.
@@ -437,6 +439,9 @@
         line-height: 0.95;
         display: flex;
         flex-direction: column;
+        justify-content: center;
+        height: 100%;
+        box-sizing: border-box;
     }
 
     &__node-title {

--- a/ui/src/app/applications/components/application-resource-tree/application-resource-tree.scss
+++ b/ui/src/app/applications/components/application-resource-tree/application-resource-tree.scss
@@ -357,12 +357,6 @@
         top: 7px;
     }
 
-    &__node-content {
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-    }
-
     &__node-kind-icon {
         text-align: center;
         position: absolute;
@@ -435,6 +429,9 @@
     }
 
     &__node-content {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
         padding: 10px 20px 10px 10px;
         line-height: 0.95;
         display: flex;

--- a/ui/src/app/applications/components/application-resource-tree/application-resource-tree.tsx
+++ b/ui/src/app/applications/components/application-resource-tree/application-resource-tree.tsx
@@ -485,10 +485,12 @@ function renderPodGroup(
         }
     }
 
-    // Use Dagre's measured height directly to avoid duplicating sizing logic in the render path.
-    // Dagre assigns node.y as the node center; convert to DOM top-left for rendering.
+    // Dagre assigns node.y as the box center. Every other node renderer draws at `top: node.y`,
+    // i.e. a constant `NODE_HEIGHT / 2` offset below the box's true top. Pod-group nodes are taller,
+    // so we must apply that same constant offset (rather than the height-dependent `node.height / 2`)
+    // to keep grouped/compact cards aligned with equal gaps and avoid overlaps.
     const podGroupHeight = node.height;
-    const podGroupTop = node.y - podGroupHeight / 2;
+    const podGroupTop = node.y - podGroupHeight / 2 + NODE_HEIGHT / 2;
 
     return (
         <div


### PR DESCRIPTION
When the UI renders grouped nodes, their height will depends on the number of pods in it. We must account for an offset to prevent them from rendering on top of other nodes. 

Also, center the node name when there are no sync/health indicators

| Before | After | 
| --- | --- |
| <img width="1028" height="606" alt="image" src="https://github.com/user-attachments/assets/d8eec482-c780-40ad-9f0e-a810b8926c12" /> | <img width="726" height="589" alt="image" src="https://github.com/user-attachments/assets/c5feacda-9351-481e-b14f-20a67eae882f" /> |
| <img width="484" height="398" alt="image" src="https://github.com/user-attachments/assets/1fa10bbd-9e07-4637-86b2-46992211f0ce" /> | <img width="511" height="313" alt="image" src="https://github.com/user-attachments/assets/dd62a33a-6e36-4975-a085-7b45a521b124" /> |