### PR TITLE
fix(repo-server): allow disabling TLS without overriding client-ca-path (#29661)

### DIFF
--- a/cmd/argocd-repo-server/commands/argocd_repo_server.go
+++ b/cmd/argocd-repo-server/commands/argocd_repo_server.go
@@ -143,7 +143,11 @@ func NewCommand() *cobra.Command {
 			askPassServer := askpass.NewServer(askpass.SocketPath)
 			metricsServer := metrics.NewMetricsServer()
 			cacheutil.CollectMetrics(redisClient, metricsServer, nil)
-			clientCAPath, err = resolveClientCAPath(clientCAPath, disableTLS)
+			// Flags().Changed is true when --client-ca-path was passed on the CLI. A
+			// non-empty value is also explicit because env.StringFromEnv applied
+			// ARGOCD_REPO_SERVER_CLIENT_CA_PATH as the flag default (not Changed).
+			explicit := c.Flags().Changed("client-ca-path") || clientCAPath != ""
+			clientCAPath, err = resolveClientCAPath(clientCAPath, disableTLS, explicit)
 			if err != nil {
 				return err
 			}
@@ -304,19 +308,23 @@ func buildHealthCheckTLSConfig(healthCheckClientCert *ctls.Certificate, disableT
 	return cfg
 }
 
-// resolveClientCAPath derives the effective client CA path from the flag value and the
-// disable-tls flag. A non-empty client CA path is meaningless (and thus an error) when TLS
-// is disabled, because mTLS requires TLS. When TLS is enabled and no path was provided, the
-// auto-mounted Secret path is used so mTLS is enabled whenever a client CA is present.
-func resolveClientCAPath(clientCAPath string, disableTLS bool) (string, error) {
+// resolveClientCAPath derives the effective client CA path from the flag value, whether
+// the flag was explicitly set, and the disable-tls flag.
+//
+// When TLS is disabled, a non-empty client CA path is an error because mTLS requires TLS;
+// an empty path is returned unchanged. When TLS is enabled and the flag was explicitly set
+// (CLI or environment), the provided value is used as-is, including "" which disables mTLS.
+// When TLS is enabled and the flag was not set, the auto-mounted Secret path is used so
+// mTLS is enabled whenever a client CA is present.
+func resolveClientCAPath(clientCAPath string, disableTLS bool, explicit bool) (string, error) {
 	if disableTLS {
 		if clientCAPath != "" {
 			return "", stderrors.New("--client-ca-path cannot be used when --disable-tls is enabled")
 		}
 		return "", nil
 	}
-	if clientCAPath == "" {
-		return defaultClientCAPath, nil
+	if explicit {
+		return clientCAPath, nil
 	}
-	return clientCAPath, nil
+	return defaultClientCAPath, nil
 }

--- a/cmd/argocd-repo-server/commands/argocd_repo_server.go
+++ b/cmd/argocd-repo-server/commands/argocd_repo_server.go
@@ -50,6 +50,10 @@ var (
 	helmUserAgent                                = env.StringFromEnv(common.EnvHelmUserAgent, "")
 )
 
+// defaultClientCAPath is the auto-mounted Secret path used when mTLS is enabled and no
+// explicit client CA path was configured.
+const defaultClientCAPath = "/app/config/reposerver/mtls/client-ca.crt"
+
 func NewCommand() *cobra.Command {
 	var (
 		parallelismLimit                   int64
@@ -139,8 +143,9 @@ func NewCommand() *cobra.Command {
 			askPassServer := askpass.NewServer(askpass.SocketPath)
 			metricsServer := metrics.NewMetricsServer()
 			cacheutil.CollectMetrics(redisClient, metricsServer, nil)
-			if disableTLS && clientCAPath != "" {
-				return stderrors.New("--client-ca-path cannot be used when --disable-tls is enabled")
+			clientCAPath, err = resolveClientCAPath(clientCAPath, disableTLS)
+			if err != nil {
+				return err
 			}
 
 			server, err := reposerver.NewServer(metricsServer, cache, tlsConfigCustomizer, repository.RepoServerInitConstants{
@@ -275,7 +280,7 @@ func NewCommand() *cobra.Command {
 	command.Flags().StringSliceVar(&ociMediaTypes, "oci-layer-media-types", env.StringsFromEnv("ARGOCD_REPO_SERVER_OCI_LAYER_MEDIA_TYPES", []string{"application/vnd.oci.image.layer.v1.tar", "application/vnd.oci.image.layer.v1.tar+gzip", "application/vnd.cncf.helm.chart.content.v1.tar+gzip"}, ","), "Comma separated list of allowed media types for OCI media types. This only accounts for media types within layers.")
 	command.Flags().BoolVar(&enableBuiltinGitConfig, "enable-builtin-git-config", env.ParseBoolFromEnv("ARGOCD_REPO_SERVER_ENABLE_BUILTIN_GIT_CONFIG", true), "Enable builtin git configuration options that are required for correct argocd-repo-server operation.")
 	command.Flags().BoolVar(&disableTLS, "disable-tls", env.ParseBoolFromEnv("ARGOCD_REPO_SERVER_DISABLE_TLS", false), "Disable TLS for the repo-server gRPC endpoint")
-	command.Flags().StringVar(&clientCAPath, "client-ca-path", env.StringFromEnv("ARGOCD_REPO_SERVER_CLIENT_CA_PATH", "/app/config/reposerver/mtls/client-ca.crt"), "Path to the client CA certificate file for mTLS. Defaults to the auto-mounted Secret path; mTLS is skipped if the file does not exist.")
+	command.Flags().StringVar(&clientCAPath, "client-ca-path", env.StringFromEnv("ARGOCD_REPO_SERVER_CLIENT_CA_PATH", ""), "Path to the client CA certificate file for mTLS. When TLS is enabled and this is unset, the auto-mounted Secret path is used; mTLS is skipped if the file does not exist.")
 
 	tlsConfigCustomizerSrc = tls.AddTLSFlagsToCmd(&command)
 	cacheSrc = reposervercache.AddCacheFlagsToCmd(&command, cacheutil.Options{
@@ -297,4 +302,21 @@ func buildHealthCheckTLSConfig(healthCheckClientCert *ctls.Certificate, disableT
 		cfg.ClientCertificates = []ctls.Certificate{*healthCheckClientCert}
 	}
 	return cfg
+}
+
+// resolveClientCAPath derives the effective client CA path from the flag value and the
+// disable-tls flag. A non-empty client CA path is meaningless (and thus an error) when TLS
+// is disabled, because mTLS requires TLS. When TLS is enabled and no path was provided, the
+// auto-mounted Secret path is used so mTLS is enabled whenever a client CA is present.
+func resolveClientCAPath(clientCAPath string, disableTLS bool) (string, error) {
+	if disableTLS {
+		if clientCAPath != "" {
+			return "", stderrors.New("--client-ca-path cannot be used when --disable-tls is enabled")
+		}
+		return "", nil
+	}
+	if clientCAPath == "" {
+		return defaultClientCAPath, nil
+	}
+	return clientCAPath, nil
 }

--- a/cmd/argocd-repo-server/commands/argocd_repo_server_test.go
+++ b/cmd/argocd-repo-server/commands/argocd_repo_server_test.go
@@ -34,6 +34,32 @@ func TestNewCommand_DisableTLSAndClientCAPathAreMutuallyExclusive(t *testing.T) 
 	assert.Contains(t, err.Error(), "--client-ca-path cannot be used when --disable-tls is enabled")
 }
 
+func TestResolveClientCAPath(t *testing.T) {
+	t.Run("disable-tls with no client CA path resolves empty without error", func(t *testing.T) {
+		got, err := resolveClientCAPath("", true)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("disable-tls with a client CA path is an error", func(t *testing.T) {
+		got, err := resolveClientCAPath("/tmp/client-ca.crt", true)
+		require.Error(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("TLS enabled with no client CA path defaults to the auto-mounted Secret path", func(t *testing.T) {
+		got, err := resolveClientCAPath("", false)
+		require.NoError(t, err)
+		assert.Equal(t, defaultClientCAPath, got)
+	})
+
+	t.Run("TLS enabled with an explicit client CA path is preserved", func(t *testing.T) {
+		got, err := resolveClientCAPath("/custom/client-ca.crt", false)
+		require.NoError(t, err)
+		assert.Equal(t, "/custom/client-ca.crt", got)
+	})
+}
+
 func TestBuildHealthCheckTLSConfig_NilCert(t *testing.T) {
 	cfg := buildHealthCheckTLSConfig(nil, false)
 

--- a/cmd/argocd-repo-server/commands/argocd_repo_server_test.go
+++ b/cmd/argocd-repo-server/commands/argocd_repo_server_test.go
@@ -36,25 +36,36 @@ func TestNewCommand_DisableTLSAndClientCAPathAreMutuallyExclusive(t *testing.T) 
 
 func TestResolveClientCAPath(t *testing.T) {
 	t.Run("disable-tls with no client CA path resolves empty without error", func(t *testing.T) {
-		got, err := resolveClientCAPath("", true)
-		require.NoError(t, err)
-		assert.Empty(t, got)
+		for _, explicit := range []bool{false, true} {
+			got, err := resolveClientCAPath("", true, explicit)
+			require.NoError(t, err)
+			assert.Empty(t, got)
+		}
 	})
 
 	t.Run("disable-tls with a client CA path is an error", func(t *testing.T) {
-		got, err := resolveClientCAPath("/tmp/client-ca.crt", true)
-		require.Error(t, err)
-		assert.Empty(t, got)
+		for _, explicit := range []bool{false, true} {
+			got, err := resolveClientCAPath("/tmp/client-ca.crt", true, explicit)
+			require.Error(t, err)
+			assert.Empty(t, got)
+			assert.Contains(t, err.Error(), "--client-ca-path cannot be used when --disable-tls is enabled")
+		}
 	})
 
-	t.Run("TLS enabled with no client CA path defaults to the auto-mounted Secret path", func(t *testing.T) {
-		got, err := resolveClientCAPath("", false)
+	t.Run("TLS enabled with unset client CA path defaults to the auto-mounted Secret path", func(t *testing.T) {
+		got, err := resolveClientCAPath("", false, false)
 		require.NoError(t, err)
 		assert.Equal(t, defaultClientCAPath, got)
 	})
 
+	t.Run("TLS enabled with an explicit empty client CA path disables mTLS", func(t *testing.T) {
+		got, err := resolveClientCAPath("", false, true)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
 	t.Run("TLS enabled with an explicit client CA path is preserved", func(t *testing.T) {
-		got, err := resolveClientCAPath("/custom/client-ca.crt", false)
+		got, err := resolveClientCAPath("/custom/client-ca.crt", false, true)
 		require.NoError(t, err)
 		assert.Equal(t, "/custom/client-ca.crt", got)
 	})

--- a/docs/operator-manual/server-commands/argocd-repo-server.md
+++ b/docs/operator-manual/server-commands/argocd-repo-server.md
@@ -17,7 +17,7 @@ argocd-repo-server [flags]
 ```
       --address string                                 Listen on given address for incoming connections (default "0.0.0.0")
       --allow-oob-symlinks                             Allow out-of-bounds symlinks in repositories (not recommended)
-      --client-ca-path string                          Path to the client CA certificate file for mTLS. Defaults to the auto-mounted Secret path; mTLS is skipped if the file does not exist. (default "/app/config/reposerver/mtls/client-ca.crt")
+      --client-ca-path string                          Path to the client CA certificate file for mTLS. When TLS is enabled and this is unset, the auto-mounted Secret path is used; mTLS is skipped if the file does not exist.
       --default-cache-expiration duration              Cache expiration default (default 24h0m0s)
       --disable-helm-manifest-max-extracted-size       Disable maximum size of helm manifest archives when extracted
       --disable-oci-manifest-max-extracted-size        Disable maximum size of oci manifest archives when extracted


### PR DESCRIPTION
Fixes #29661

## What this PR does

Since 3.5.0, disabling TLS on the repo-server requires manually overriding `--client-ca-path`, because the flag defaults to the auto-mounted Secret path (`/app/config/reposerver/mtls/client-ca.crt`). When TLS is disabled, that non-empty default trips the `--client-ca-path cannot be used when --disable-tls is enabled` validation, so the repo-server crashloops.

This change makes the flag default empty and resolves the auto-mounted Secret path only when TLS is enabled. An explicitly configured `--client-ca-path` combined with `--disable-tls` is still rejected, so mTLS cannot be silently dropped by accident.

## Why

The documented configuration (`reposerver.disable.tls: "true"` with no client CA) should start the repo-server with TLS disabled and mTLS off, without requiring a command-arg override.

## Changes

- Default `--client-ca-path` to empty and resolve the auto-mounted Secret path at use time when TLS is enabled.
- Keep rejecting an explicit client CA path when TLS is disabled.

## Testing

- Added `TestResolveClientCAPath` covering all four combinations (TLS on/off, path set/unset).
- `go test ./cmd/argocd-repo-server/commands/` passes.

Checklist:

- [x] Either (a) I've created an enhancement proposal and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes. (This is a bug fix.)
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [x] The title of the PR conforms to the Title of the PR guidelines.
- [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
- [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. (N/A: bug fix with no UI change.)
- [x] Does this PR require documentation updates? Yes, and the generated CLI reference has been regenerated.
- [x] I've updated documentation as required by this PR.
- [x] I have signed off all my commits as required by DCO.
- [x] I have written unit and/or e2e tests for my change.
- [x] My build is green.
- [x] My new feature complies with the feature status guidelines. (N/A.)
- [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
- [ ] Optional. My organization is added to USERS.md.
- [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into.
