### PR TITLE
fix(hydrator): de-dupe hydration against the whole app group

### DIFF
--- a/controller/hydrator/hydrator.go
+++ b/controller/hydrator/hydrator.go
@@ -454,9 +454,20 @@ func (h *Hydrator) hydrate(ctx context.Context, logCtx *log.Entry, apps []*appv1
 	paths := []*commitclient.PathDetails{pathDetails}
 	logCtx = logCtx.WithFields(log.Fields{"drySha": targetRevision})
 	// De-dupe, if the drySha was already hydrated log a debug and return using the data from the last successful hydration run.
-	// We only inspect one app. If apps have been added/removed, that will be handled on the next DRY commit.
-	if apps[0].Status.SourceHydrator.LastSuccessfulOperation != nil && targetRevision == apps[0].Status.SourceHydrator.LastSuccessfulOperation.DrySHA {
-		logCtx.Debug("Skipping hydration since the DRY commit was already hydrated")
+	// Every app in the group must have hydrated at this revision. Inspecting only apps[0] skips the commit
+	// for a group an app has just joined: an ApplicationSet can create an Application after the batch for
+	// this revision has already run, and that app would then be marked Hydrated against a commit that does
+	// not contain its path, with nothing to retry it.
+	alreadyHydrated := true
+	for _, app := range apps {
+		lastSuccessful := app.Status.SourceHydrator.LastSuccessfulOperation
+		if lastSuccessful == nil || lastSuccessful.DrySHA != targetRevision {
+			alreadyHydrated = false
+			break
+		}
+	}
+	if alreadyHydrated {
+		logCtx.Debug("Skipping hydration since the DRY commit was already hydrated for every app in the group")
 		return targetRevision, apps[0].Status.SourceHydrator.LastSuccessfulOperation.HydratedSHA, nil, nil
 	}
 

--- a/controller/hydrator/hydrator_test.go
+++ b/controller/hydrator/hydrator_test.go
@@ -1549,6 +1549,10 @@ func TestHydrator_hydrate_DeDupe_Success(t *testing.T) {
 	app1.Status.SourceHydrator = v1alpha1.SourceHydratorStatus{
 		LastSuccessfulOperation: lastSuccessfulOperation,
 	}
+	// Every app in the group must already be hydrated at this revision for the de-dupe to apply.
+	app2.Status.SourceHydrator = v1alpha1.SourceHydratorStatus{
+		LastSuccessfulOperation: lastSuccessfulOperation,
+	}
 
 	apps := []*v1alpha1.Application{app1, app2}
 	proj := newTestProject()
@@ -1565,6 +1569,43 @@ func TestHydrator_hydrate_DeDupe_Success(t *testing.T) {
 	assert.Equal(t, "sha123", sha)
 	assert.Equal(t, "hydrated123", hydratedSha)
 	assert.Empty(t, errs)
+}
+
+// An app that joined the group after the batch for this revision ran has no LastSuccessfulOperation.
+// The de-dupe must not fire for it, or it is marked Hydrated against a commit lacking its path and
+// nothing retries it. https://github.com/argoproj/argo-cd/issues/25190
+func TestHydrator_hydrate_DeDupe_SkippedForAppThatHasNotHydrated(t *testing.T) {
+	t.Parallel()
+
+	d := mocks.NewDependencies(t)
+	h := &Hydrator{dependencies: d}
+
+	app1 := newTestApp("app1")
+	app2 := newTestApp("app2")
+	app1.Status.SourceHydrator = v1alpha1.SourceHydratorStatus{
+		LastSuccessfulOperation: &v1alpha1.SuccessfulHydrateOperation{
+			DrySHA:      "sha123",
+			HydratedSHA: "hydrated123",
+		},
+	}
+	// app2 deliberately has no LastSuccessfulOperation.
+
+	apps := []*v1alpha1.Application{app1, app2}
+	proj := newTestProject()
+	projects := map[string]*v1alpha1.AppProject{app1.Spec.Project: proj}
+
+	d.On("GetRepoObjs", mock.Anything, app1, app1.Spec.SourceHydrator.GetDrySource(), "main", proj).Return(nil, &repoclient.ManifestResponse{Revision: "sha123"}, nil).Once()
+	// Reaching this call at all proves we did not quit early. Failing it keeps the test from
+	// needing the whole commit path mocked.
+	d.On("GetRepoObjs", mock.Anything, app2, app2.Spec.SourceHydrator.GetDrySource(), "sha123", proj).Return(nil, nil, errors.New("boom")).Once()
+	logCtx := log.NewEntry(log.StandardLogger())
+
+	sha, hydratedSha, errs, err := h.hydrate(t.Context(), logCtx, apps, projects)
+
+	require.NoError(t, err)
+	assert.Equal(t, "sha123", sha)
+	assert.Empty(t, hydratedSha, "no commit should be reported when hydration did not complete")
+	assert.Contains(t, errs, app2.QualifiedName())
 }
 
 func Test_newRevisionHasChanges(t *testing.T) {


### PR DESCRIPTION
Fixes the "missing newly added applications" case described in #25190.

## Problem

`hydrate()` decides a dry revision was already hydrated by inspecting `apps[0]` alone:

```go
// We only inspect one app. If apps have been added/removed, that will be handled on the next DRY commit.
if apps[0].Status.SourceHydrator.LastSuccessfulOperation != nil && targetRevision == apps[0].Status.SourceHydrator.LastSuccessfulOperation.DrySHA {
```

Every app sharing the hydration key is then marked `Hydrated` from that one app's `LastSuccessfulOperation`, so an app that joined the group *after* the batch for that revision ran is recorded as hydrated against a commit that does not contain its path.

## How it is reached

`ProcessHydrationQueueItem` snapshots the group in `getAppsForHydrationKey` at the start of the batch. An ApplicationSet that creates Applications shortly after a commit lands produces apps that miss that snapshot. They are enqueued again (`appNeedsHydration` returns `"no previous hydrate operation"`), reach `hydrate()`, and hit the `apps[0]` short-circuit. The commit server is never called for them.

Afterwards `appNeedsHydration` finds a `Hydrated` phase, an unchanged `spec.sourceHydrator` and an unchanged dry revision, so it returns `"hydration not needed"`. The apps sit permanently on:

```
Failed to load target state: failed to generate manifest for source 1 of 1:
rpc error: code = Unknown desc = <path>: app path does not exist
```

Nothing retries. Recovery needs an unrelated commit to the dry branch, or `argocd.argoproj.io/hydrate: hard` per app. Nothing is reported as failed — the hydration operation itself says it succeeded, and the only symptom is on the sync side, where it reads like a misconfigured path.

Observed on v3.5.2 with a git `files` generator creating one Application per component per tenant:

```
04:41:12  dry commit lands
04:41:53  batch assembled — the new tenant's apps do not exist yet
04:41:57  commit server: "Successfully handled commit request"
04:42:02  ApplicationSet creates the Applications
04:42:30  marked Hydrated, HydratedSHA = the tip from an older dry commit
```

## Change

Require every app in the group to have hydrated at the revision before skipping. The de-dupe still short-circuits the repeated passes it was added for, since those groups are unchanged. It is a loop over an in-memory slice — no extra API or repo-server calls.

## Scope

This does not cover removals: when an app leaves the group the remaining apps still carry the revision, so the de-dupe fires and the departed app's path survives on the branch until the next dry commit. Tracking the hydrated app set in `LastSuccessfulOperation`, as #25190 proposes, covers both cases. This is the smaller fix for the case that loses manifests.

A cheap follow-up worth considering separately: verify the app's own `syncSource.path` exists in `hydratedSHA` before writing `Phase: Hydrated`. That makes the terminal state checkable rather than remembered, and would catch any future variant of this.

## Tests

`TestHydrator_hydrate_DeDupe_Success` asserted the old behaviour — it gave `LastSuccessfulOperation` to `app1` only, which is exactly the broken case. Updated so both apps carry it, and added `TestHydrator_hydrate_DeDupe_SkippedForAppThatHasNotHydrated` covering an app that has never hydrated.