### PR TITLE
fix(controller): keep spec.sources overrides on child Applications (#25855)

### DIFF
--- a/controller/app_sources.go
+++ b/controller/app_sources.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"bytes"
 	"encoding/json"
+	"maps"
 	"reflect"
 
 	jsonpatch "github.com/evanphx/json-patch"
@@ -40,7 +41,7 @@ func mergeLiveApplicationSources(target, live *unstructured.Unstructured) *unstr
 			merged[i] = targetSource
 			continue
 		}
-		mergedSource, err := mergeJSON(liveSources[i], targetSource)
+		mergedSource, err := mergeJSON(withoutOtherSourceTypes(liveSources[i], targetSource), targetSource)
 		if err != nil {
 			mergedSource = targetSource
 		}
@@ -58,14 +59,19 @@ func isApplication(obj *unstructured.Unstructured) bool {
 	return gvk.Group == application.Group && gvk.Kind == application.ApplicationKind
 }
 
-// sameSource leaves out targetRevision so a chart or branch bump in git keeps the overrides.
+// sourceIdentityKeys leave out targetRevision so a chart or branch bump in git keeps the overrides.
+var sourceIdentityKeys = []string{"repoURL", "chart", "path", "ref", "name"}
+
+// sourceTypeKeys are the blocks of which a source may declare at most one.
+var sourceTypeKeys = []string{"helm", "kustomize", "directory", "plugin"}
+
 func sameSource(a, b any) bool {
 	am, aok := a.(map[string]any)
 	bm, bok := b.(map[string]any)
 	if !aok || !bok {
 		return false
 	}
-	for _, key := range []string{"repoURL", "chart", "path", "ref", "name"} {
+	for _, key := range sourceIdentityKeys {
 		av, aIsString := am[key].(string)
 		bv, bIsString := bm[key].(string)
 		if (am[key] != nil && !aIsString) || (bm[key] != nil && !bIsString) || av != bv {
@@ -73,6 +79,52 @@ func sameSource(a, b any) bool {
 		}
 	}
 	return true
+}
+
+// sourceIdentity returns the identity keys joined, or "" when the element carries none of them.
+func sourceIdentity(m map[string]any) string {
+	var buf bytes.Buffer
+	found := false
+	for _, key := range sourceIdentityKeys {
+		v, _ := m[key].(string)
+		if v != "" {
+			found = true
+		}
+		buf.WriteString(v)
+		buf.WriteByte(0)
+	}
+	if !found {
+		return ""
+	}
+	return buf.String()
+}
+
+// withoutOtherSourceTypes drops live type blocks git no longer declares when git declares another
+// type, so a helm to kustomize switch does not leave two types on the merged source. A source with
+// no type block in git keeps the live one: that is the override this option exists for.
+func withoutOtherSourceTypes(live, target any) any {
+	lm, lok := live.(map[string]any)
+	tm, tok := target.(map[string]any)
+	if !lok || !tok {
+		return live
+	}
+	targetHasType := false
+	for _, key := range sourceTypeKeys {
+		if _, ok := tm[key]; ok {
+			targetHasType = true
+			break
+		}
+	}
+	if !targetHasType {
+		return live
+	}
+	res := maps.Clone(lm)
+	for _, key := range sourceTypeKeys {
+		if _, ok := tm[key]; !ok {
+			delete(res, key)
+		}
+	}
+	return res
 }
 
 // mergeJSON applies patch to base as an RFC 7396 merge patch: patch keys win, base-only keys stay.

--- a/controller/app_sources.go
+++ b/controller/app_sources.go
@@ -1,0 +1,121 @@
+package controller
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/argoproj/argo-cd/v3/pkg/apis/application"
+)
+
+// preserveSourceOverridesOption is a sync option of the parent app or an annotation option on the child.
+const preserveSourceOverridesOption = "PreserveSourceOverrides=true"
+
+// mergeLiveApplicationSources lays each git spec.sources[i] of a child Application over the live one.
+// kubectl applies CRDs with a JSON merge patch that replaces lists whole, so unlike spec.source the
+// list loses keys git does not declare, such as helm.parameters set by "argocd app set". No
+// last-applied baseline: the parent applies the merged object, so it would record carried keys as
+// git's own and the next reconcile would delete them.
+func mergeLiveApplicationSources(target, live *unstructured.Unstructured) *unstructured.Unstructured {
+	if target == nil || live == nil || !isApplication(target) || !isApplication(live) {
+		return target
+	}
+	targetSources, ok, err := unstructured.NestedSlice(target.Object, "spec", "sources")
+	if err != nil || !ok || len(targetSources) == 0 {
+		return target
+	}
+	liveSources, ok, err := unstructured.NestedSlice(live.Object, "spec", "sources")
+	if err != nil || !ok || len(liveSources) != len(targetSources) || reflect.DeepEqual(liveSources, targetSources) {
+		return target
+	}
+
+	merged := make([]any, len(targetSources))
+	for i, targetSource := range targetSources {
+		// A slot only merges when git and the cluster still describe the same source. A reorder in
+		// git falls back to the plain target so an override can never land on another source.
+		if !sameSource(targetSource, liveSources[i]) {
+			merged[i] = targetSource
+			continue
+		}
+		mergedSource, err := mergeJSON(liveSources[i], targetSource)
+		if err != nil {
+			mergedSource = targetSource
+		}
+		merged[i] = mergedSource
+	}
+	res := target.DeepCopy()
+	if err := unstructured.SetNestedSlice(res.Object, merged, "spec", "sources"); err != nil {
+		return target
+	}
+	return res
+}
+
+func isApplication(obj *unstructured.Unstructured) bool {
+	gvk := obj.GroupVersionKind()
+	return gvk.Group == application.Group && gvk.Kind == application.ApplicationKind
+}
+
+// sameSource leaves out targetRevision so a chart or branch bump in git keeps the overrides.
+func sameSource(a, b any) bool {
+	am, aok := a.(map[string]any)
+	bm, bok := b.(map[string]any)
+	if !aok || !bok {
+		return false
+	}
+	for _, key := range []string{"repoURL", "chart", "path", "ref", "name"} {
+		av, aIsString := am[key].(string)
+		bv, bIsString := bm[key].(string)
+		if (am[key] != nil && !aIsString) || (bm[key] != nil && !bIsString) || av != bv {
+			return false
+		}
+	}
+	return true
+}
+
+// mergeJSON applies patch to base as an RFC 7396 merge patch: patch keys win, base-only keys stay.
+func mergeJSON(base, patch any) (any, error) {
+	baseJSON, err := json.Marshal(base)
+	if err != nil {
+		return nil, err
+	}
+	patchJSON, err := json.Marshal(patch)
+	if err != nil {
+		return nil, err
+	}
+	mergedJSON, err := jsonpatch.MergePatch(baseJSON, patchJSON)
+	if err != nil {
+		return nil, err
+	}
+	dec := json.NewDecoder(bytes.NewReader(mergedJSON))
+	dec.UseNumber()
+	var merged any
+	if err := dec.Decode(&merged); err != nil {
+		return nil, err
+	}
+	return toUnstructuredValue(merged), nil
+}
+
+// toUnstructuredValue turns json.Number into int64 or float64 so whole numbers match the int64 the
+// live object carries.
+func toUnstructuredValue(v any) any {
+	switch t := v.(type) {
+	case json.Number:
+		if i, err := t.Int64(); err == nil {
+			return i
+		}
+		f, _ := t.Float64()
+		return f
+	case map[string]any:
+		for k, e := range t {
+			t[k] = toUnstructuredValue(e)
+		}
+	case []any:
+		for i, e := range t {
+			t[i] = toUnstructuredValue(e)
+		}
+	}
+	return v
+}

--- a/controller/app_sources_test.go
+++ b/controller/app_sources_test.go
@@ -1,0 +1,220 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+)
+
+func appWithSources(t *testing.T, sources string) *unstructured.Unstructured {
+	t.Helper()
+	manifest := `
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: child
+  namespace: argocd
+spec:
+  project: default
+  sources:
+` + sources
+	obj := &unstructured.Unstructured{}
+	require.NoError(t, yaml.Unmarshal([]byte(manifest), obj))
+	return obj
+}
+
+const parentSources = `
+  - repoURL: https://charts.example.com
+    chart: app
+    targetRevision: 1.0.0
+    helm:
+      valuesObject:
+        image:
+          tag: v1
+  - repoURL: https://git.example.com/manifests.git
+    targetRevision: main
+    path: manifests
+`
+
+const liveSourcesWithOverride = `
+  - repoURL: https://charts.example.com
+    chart: app
+    targetRevision: 1.0.0
+    helm:
+      valuesObject:
+        image:
+          tag: v1
+      parameters:
+        - name: image.tag
+          value: v2
+  - repoURL: https://git.example.com/manifests.git
+    targetRevision: main
+    path: manifests
+`
+
+func sourcesOf(t *testing.T, obj *unstructured.Unstructured) []any {
+	t.Helper()
+	sources, ok, err := unstructured.NestedSlice(obj.Object, "spec", "sources")
+	require.NoError(t, err)
+	require.True(t, ok)
+	return sources
+}
+
+func helmParamsOf(t *testing.T, obj *unstructured.Unstructured) ([]any, bool) {
+	t.Helper()
+	src, ok := sourcesOf(t, obj)[0].(map[string]any)
+	require.True(t, ok)
+	params, found, err := unstructured.NestedSlice(src, "helm", "parameters")
+	require.NoError(t, err)
+	return params, found
+}
+
+func TestMergeLiveApplicationSources(t *testing.T) {
+	t.Parallel()
+
+	wantParams := []any{map[string]any{"name": "image.tag", "value": "v2"}}
+
+	t.Run("keeps live-only helm parameters", func(t *testing.T) {
+		t.Parallel()
+		target := appWithSources(t, parentSources)
+		before := target.DeepCopy()
+		live := appWithSources(t, liveSourcesWithOverride)
+
+		got := mergeLiveApplicationSources(target, live)
+
+		params, _ := helmParamsOf(t, got)
+		assert.Equal(t, wantParams, params)
+		assert.Equal(t, before, target, "target must not be mutated")
+		tag, _, err := unstructured.NestedString(sourcesOf(t, got)[0].(map[string]any), "helm", "valuesObject", "image", "tag")
+		require.NoError(t, err)
+		assert.Equal(t, "v1", tag)
+	})
+
+	t.Run("target values win over live", func(t *testing.T) {
+		t.Parallel()
+		target := appWithSources(t, parentSources)
+		sources := sourcesOf(t, target)
+		require.NoError(t, unstructured.SetNestedField(sources[0].(map[string]any), "v3", "helm", "valuesObject", "image", "tag"))
+		require.NoError(t, unstructured.SetNestedSlice(target.Object, sources, "spec", "sources"))
+		live := appWithSources(t, liveSourcesWithOverride)
+
+		got := mergeLiveApplicationSources(target, live)
+
+		tag, _, err := unstructured.NestedString(sourcesOf(t, got)[0].(map[string]any), "helm", "valuesObject", "image", "tag")
+		require.NoError(t, err)
+		assert.Equal(t, "v3", tag)
+		params, _ := helmParamsOf(t, got)
+		assert.Equal(t, wantParams, params)
+	})
+
+	t.Run("git declaring the key wins", func(t *testing.T) {
+		t.Parallel()
+		target := appWithSources(t, parentSources)
+		sources := sourcesOf(t, target)
+		require.NoError(t, unstructured.SetNestedSlice(sources[0].(map[string]any), []any{}, "helm", "parameters"))
+		require.NoError(t, unstructured.SetNestedSlice(target.Object, sources, "spec", "sources"))
+		live := appWithSources(t, liveSourcesWithOverride)
+
+		got := mergeLiveApplicationSources(target, live)
+
+		params, found := helmParamsOf(t, got)
+		assert.True(t, found)
+		assert.Empty(t, params)
+	})
+
+	t.Run("second reconcile after a sync keeps the override", func(t *testing.T) {
+		t.Parallel()
+		// After the parent applied the merged object the live one equals the merged result.
+		target := appWithSources(t, parentSources)
+		live := mergeLiveApplicationSources(target, appWithSources(t, liveSourcesWithOverride))
+
+		got := mergeLiveApplicationSources(target, live)
+
+		params, _ := helmParamsOf(t, got)
+		assert.Equal(t, wantParams, params)
+	})
+
+	t.Run("source count changed uses target as is", func(t *testing.T) {
+		t.Parallel()
+		target := appWithSources(t, parentSources)
+		live := appWithSources(t, liveSourcesWithOverride+`
+  - repoURL: https://git.example.com/extra.git
+    path: extra
+`)
+
+		assert.Same(t, target, mergeLiveApplicationSources(target, live))
+	})
+
+	t.Run("identical sources use target as is", func(t *testing.T) {
+		t.Parallel()
+		target := appWithSources(t, parentSources)
+		assert.Same(t, target, mergeLiveApplicationSources(target, appWithSources(t, parentSources)))
+	})
+
+	t.Run("reordered sources use target as is", func(t *testing.T) {
+		t.Parallel()
+		reordered := `
+  - repoURL: https://git.example.com/manifests.git
+    targetRevision: main
+    path: manifests
+  - repoURL: https://charts.example.com
+    chart: app
+    targetRevision: 1.0.0
+    helm:
+      valuesObject:
+        image:
+          tag: v1
+`
+		target := appWithSources(t, reordered)
+		got := mergeLiveApplicationSources(target, appWithSources(t, liveSourcesWithOverride))
+		assert.Equal(t, target.Object["spec"], got.Object["spec"])
+	})
+
+	t.Run("whole numbers stay int64", func(t *testing.T) {
+		t.Parallel()
+		withReplicas := `
+  - repoURL: https://git.example.com/manifests.git
+    targetRevision: main
+    path: manifests
+    kustomize:
+      replicas:
+        - name: web
+          count: 3
+`
+		target := appWithSources(t, withReplicas)
+		live := appWithSources(t, withReplicas+`
+    helm:
+      parameters: []
+`)
+
+		got := mergeLiveApplicationSources(target, live)
+
+		replicas, _, err := unstructured.NestedSlice(sourcesOf(t, got)[0].(map[string]any), "kustomize", "replicas")
+		require.NoError(t, err)
+		assert.Equal(t, int64(3), replicas[0].(map[string]any)["count"])
+	})
+
+	t.Run("ignores non application objects and nil live", func(t *testing.T) {
+		t.Parallel()
+		target := appWithSources(t, parentSources)
+		assert.Same(t, target, mergeLiveApplicationSources(target, nil))
+
+		pod := &unstructured.Unstructured{}
+		require.NoError(t, yaml.Unmarshal([]byte("apiVersion: v1\nkind: Pod\nmetadata:\n  name: p\nspec:\n  sources: [{a: b}]\n"), pod))
+		assert.Same(t, pod, mergeLiveApplicationSources(pod, pod.DeepCopy()))
+	})
+}
+
+func TestSameSource(t *testing.T) {
+	t.Parallel()
+	assert.True(t, sameSource(map[string]any{"repoURL": "r", "path": "p"}, map[string]any{"repoURL": "r", "path": "p", "targetRevision": "v2"}))
+	assert.False(t, sameSource(map[string]any{"repoURL": "r", "path": "p"}, map[string]any{"repoURL": "r", "path": "q"}))
+	assert.False(t, sameSource(map[string]any{"repoURL": "r", "ref": "values"}, map[string]any{"repoURL": "r", "ref": "other"}))
+	assert.False(t, sameSource("not a map", map[string]any{}))
+	// Non-string identity values never match and must not panic, even when both sides carry the same type.
+	assert.False(t, sameSource(map[string]any{"repoURL": []any{"a"}}, map[string]any{"repoURL": []any{"a"}}))
+	assert.False(t, sameSource(map[string]any{"repoURL": []any{"a"}}, map[string]any{"repoURL": []any{"b"}}))
+}

--- a/controller/app_sources_test.go
+++ b/controller/app_sources_test.go
@@ -197,6 +197,52 @@ func TestMergeLiveApplicationSources(t *testing.T) {
 		assert.Equal(t, int64(3), replicas[0].(map[string]any)["count"])
 	})
 
+	t.Run("git changing the source type drops the live type block", func(t *testing.T) {
+		t.Parallel()
+		for typeKey, block := range map[string]string{"kustomize": "namePrefix: x-", "directory": "recurse: true", "plugin": "name: cmp"} {
+			target := appWithSources(t, `
+  - repoURL: https://git.example.com/manifests.git
+    targetRevision: main
+    path: manifests
+    `+typeKey+`:
+      `+block+`
+`)
+			live := appWithSources(t, `
+  - repoURL: https://git.example.com/manifests.git
+    targetRevision: main
+    path: manifests
+    helm:
+      parameters:
+        - name: image.tag
+          value: v2
+`)
+			src, ok := sourcesOf(t, mergeLiveApplicationSources(target, live))[0].(map[string]any)
+			require.True(t, ok)
+			_, hasHelm := src["helm"]
+			assert.False(t, hasHelm, typeKey)
+			assert.Contains(t, src, typeKey)
+		}
+	})
+
+	t.Run("git dropping the type block keeps the live one", func(t *testing.T) {
+		t.Parallel()
+		target := appWithSources(t, `
+  - repoURL: https://git.example.com/manifests.git
+    targetRevision: main
+    path: manifests
+`)
+		live := appWithSources(t, `
+  - repoURL: https://git.example.com/manifests.git
+    targetRevision: main
+    path: manifests
+    helm:
+      releaseName: keep
+`)
+		src, ok := sourcesOf(t, mergeLiveApplicationSources(target, live))[0].(map[string]any)
+		require.True(t, ok)
+		assert.Contains(t, src, "helm")
+	})
+
 	t.Run("ignores non application objects and nil live", func(t *testing.T) {
 		t.Parallel()
 		target := appWithSources(t, parentSources)

--- a/controller/state.go
+++ b/controller/state.go
@@ -911,6 +911,15 @@ func (m *appStateManager) CompareAppState(ctx context.Context, app *v1alpha1.App
 	targetObjsForSync, hasPreDeleteHooks, hasPostDeleteHooks := partitionTargetObjsForSync(targetObjs)
 
 	reconciliation := sync.Reconcile(targetObjsForSync, liveObjByKey, app.Spec.Destination.Namespace, infoProvider)
+	preserveOverrides := app.Spec.SyncPolicy != nil && app.Spec.SyncPolicy.SyncOptions.HasOption(preserveSourceOverridesOption)
+	for i, targetObj := range reconciliation.Target {
+		if targetObj == nil {
+			continue
+		}
+		if preserveOverrides || resourceutil.HasAnnotationOption(targetObj, synccommon.AnnotationSyncOptions, preserveSourceOverridesOption) {
+			reconciliation.Target[i] = mergeLiveApplicationSources(targetObj, reconciliation.Live[i])
+		}
+	}
 	ts.AddCheckpoint("live_ms")
 
 	compareOptions, err := m.settingsMgr.GetResourceCompareOptions()

--- a/controller/state_test.go
+++ b/controller/state_test.go
@@ -2870,3 +2870,57 @@ func TestShouldUseServerSideDiff(t *testing.T) {
 		})
 	}
 }
+
+// TestCompareAppStateChildSourceOverrides covers argoproj/argo-cd#25855: with PreserveSourceOverrides the
+// target a parent app syncs keeps helm parameters that "argocd app set" added to a child multi-source
+// Application. The diff already ignores such live-only keys, so the child is Synced either way.
+func TestCompareAppStateChildSourceOverrides(t *testing.T) {
+	wantParams := []any{map[string]any{"name": "image.tag", "value": "v2"}}
+	tests := []struct {
+		name         string
+		parentOption bool
+		childOption  bool
+		wantParams   []any
+	}{
+		{name: "off by default"},
+		{name: "parent sync option", parentOption: true, wantParams: wantParams},
+		{name: "child annotation", childOption: true, wantParams: wantParams},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			target := appWithSources(t, parentSources)
+			target.SetNamespace(test.FakeDestNamespace)
+			if tc.childOption {
+				target.SetAnnotations(map[string]string{synccommon.AnnotationSyncOptions: "PreserveSourceOverrides=true"})
+			}
+			live := appWithSources(t, liveSourcesWithOverride)
+			live.SetNamespace(test.FakeDestNamespace)
+			live.SetAnnotations(target.GetAnnotations())
+
+			app := newFakeApp()
+			if tc.parentOption {
+				app.Spec.SyncPolicy.SyncOptions = append(app.Spec.SyncPolicy.SyncOptions, "PreserveSourceOverrides=true")
+			}
+			data := fakeData{
+				manifestResponse: &apiclient.ManifestResponse{
+					Manifests: []string{toJSON(t, target)},
+					Namespace: test.FakeDestNamespace,
+					Server:    test.FakeClusterURL,
+					Revision:  "abc123",
+				},
+				managedLiveObjs: map[kube.ResourceKey]*unstructured.Unstructured{
+					kube.GetResourceKey(live): live,
+				},
+			}
+			ctrl := newFakeController(t.Context(), &data, nil)
+			compRes, err := ctrl.appStateManager.CompareAppState(t.Context(), app, &defaultProj, []string{""}, []v1alpha1.ApplicationSource{app.Spec.GetSource()}, false, false, nil, false)
+			require.NoError(t, err)
+
+			assert.Equal(t, v1alpha1.SyncStatusCodeSynced, compRes.syncStatus.Status)
+			require.Len(t, compRes.reconciliationResult.Target, 1)
+			params, _ := helmParamsOf(t, compRes.reconciliationResult.Target[0])
+			assert.Equal(t, tc.wantParams, params)
+			assert.Empty(t, app.Status.Conditions)
+		})
+	}
+}

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -698,8 +698,9 @@ func restoreNonIgnoredFields(patched, original, normalizedTarget, normalizedLive
 }
 
 // restoreNonIgnoredListElements returns false, so the caller treats the field as a leaf, unless every
-// list is a list of maps with one length and elements that carry a name pair up by name. Pairing is
-// by index, so a reordered live list would otherwise mix two elements into one.
+// list is a list of maps with one length and each element pairs up by identity (name, or the
+// Application source keys) with a unique identity in the list. Pairing is by index, so a reordered
+// live list or elements without identity would otherwise mix two elements into one.
 func restoreNonIgnoredListElements(patched, original, normalized, normalizedLive any) bool {
 	patchedList, ok1 := patched.([]any)
 	originalList, ok2 := original.([]any)
@@ -713,6 +714,7 @@ func restoreNonIgnoredListElements(patched, original, normalized, normalizedLive
 	}
 	n := len(originalList)
 	patchedMaps, originalMaps, normalizedMaps, normalizedLiveMaps := make([]map[string]any, n), make([]map[string]any, n), make([]map[string]any, n), make([]map[string]any, n)
+	seen := make(map[string]bool, n)
 	for i := range originalList {
 		patchedMaps[i], ok1 = patchedList[i].(map[string]any)
 		originalMaps[i], ok2 = originalList[i].(map[string]any)
@@ -723,11 +725,11 @@ func restoreNonIgnoredListElements(patched, original, normalized, normalizedLive
 		if normalizedLiveList != nil {
 			normalizedLiveMaps[i], _ = normalizedLiveList[i].(map[string]any)
 		}
-		patchedName, _ := patchedMaps[i]["name"].(string)
-		originalName, _ := originalMaps[i]["name"].(string)
-		if patchedName != originalName {
+		id := sourceIdentity(originalMaps[i])
+		if id == "" || seen[id] || !sameSource(patchedMaps[i], originalMaps[i]) {
 			return false
 		}
+		seen[id] = true
 	}
 	for i := range originalList {
 		restoreNonIgnoredFields(patchedMaps[i], originalMaps[i], normalizedMaps[i], normalizedLiveMaps[i])

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -667,6 +667,13 @@ func restoreNonIgnoredFields(patched, original, normalizedTarget, normalizedLive
 			continue
 		}
 
+		// Lists of equal length are walked element by element. Judging the list as one leaf
+		// would restore it whole from git and drop an ignored key that only live carries,
+		// such as spec.sources[0].helm.parameters on an Application.
+		if inPatched && restoreNonIgnoredListElements(patchedVal, originalVal, normalizedVal, normalizedLive[key]) {
+			continue
+		}
+
 		// Leaf, type-changed, or missing field.
 		// If normalized == original, the normalizer did not touch this field,
 		// so it is not ignored and should keep the original (target) value.
@@ -688,6 +695,44 @@ func restoreNonIgnoredFields(patched, original, normalizedTarget, normalizedLive
 			delete(patched, key)
 		}
 	}
+}
+
+// restoreNonIgnoredListElements returns false, so the caller treats the field as a leaf, unless every
+// list is a list of maps with one length and elements that carry a name pair up by name. Pairing is
+// by index, so a reordered live list would otherwise mix two elements into one.
+func restoreNonIgnoredListElements(patched, original, normalized, normalizedLive any) bool {
+	patchedList, ok1 := patched.([]any)
+	originalList, ok2 := original.([]any)
+	normalizedList, ok3 := normalized.([]any)
+	if !ok1 || !ok2 || !ok3 || len(patchedList) != len(originalList) || len(originalList) != len(normalizedList) {
+		return false
+	}
+	normalizedLiveList, ok := normalizedLive.([]any)
+	if normalizedLive != nil && (!ok || len(normalizedLiveList) != len(patchedList)) {
+		return false
+	}
+	n := len(originalList)
+	patchedMaps, originalMaps, normalizedMaps, normalizedLiveMaps := make([]map[string]any, n), make([]map[string]any, n), make([]map[string]any, n), make([]map[string]any, n)
+	for i := range originalList {
+		patchedMaps[i], ok1 = patchedList[i].(map[string]any)
+		originalMaps[i], ok2 = originalList[i].(map[string]any)
+		normalizedMaps[i], ok3 = normalizedList[i].(map[string]any)
+		if !ok1 || !ok2 || !ok3 {
+			return false
+		}
+		if normalizedLiveList != nil {
+			normalizedLiveMaps[i], _ = normalizedLiveList[i].(map[string]any)
+		}
+		patchedName, _ := patchedMaps[i]["name"].(string)
+		originalName, _ := originalMaps[i]["name"].(string)
+		if patchedName != originalName {
+			return false
+		}
+	}
+	for i := range originalList {
+		restoreNonIgnoredFields(patchedMaps[i], originalMaps[i], normalizedMaps[i], normalizedLiveMaps[i])
+	}
+	return true
 }
 
 // hasSharedResourceCondition will check if the Application has any resource that has already

--- a/controller/sync_test.go
+++ b/controller/sync_test.go
@@ -1040,6 +1040,41 @@ func TestRestoreNonIgnoredListElements(t *testing.T) {
 		assert.Equal(t, "live-b", patched[0].(map[string]any)["image"], "must not touch elements before bailing out")
 	})
 
+	t.Run("unnamed sources pair by repoURL and path", func(t *testing.T) {
+		t.Parallel()
+		patched := items(map[string]any{"repoURL": "r", "path": "a", "helm": "live"}, map[string]any{"repoURL": "r", "path": "b"})
+		original := items(map[string]any{"repoURL": "r", "path": "a"}, map[string]any{"repoURL": "r", "path": "b"})
+
+		assert.True(t, restoreNonIgnoredListElements(patched, original, original, original))
+		assert.Equal(t, "live", patched[0].(map[string]any)["helm"])
+	})
+
+	t.Run("reordered unnamed sources fall back to leaf", func(t *testing.T) {
+		t.Parallel()
+		patched := items(map[string]any{"repoURL": "r", "path": "b", "image": "live-b"}, map[string]any{"repoURL": "r", "path": "a", "image": "live-a"})
+		original := items(map[string]any{"repoURL": "r", "path": "a", "image": "git-a"}, map[string]any{"repoURL": "r", "path": "b", "image": "git-b"})
+
+		assert.False(t, restoreNonIgnoredListElements(patched, original, original, patched))
+		assert.Equal(t, "live-b", patched[0].(map[string]any)["image"])
+	})
+
+	t.Run("elements without identity fall back to leaf", func(t *testing.T) {
+		t.Parallel()
+		patched := items(map[string]any{"image": "live-a"}, map[string]any{"image": "live-b"})
+		original := items(map[string]any{"image": "git-a"}, map[string]any{"image": "git-b"})
+
+		assert.False(t, restoreNonIgnoredListElements(patched, original, original, patched))
+		assert.Equal(t, "live-a", patched[0].(map[string]any)["image"])
+	})
+
+	t.Run("duplicate names fall back to leaf", func(t *testing.T) {
+		t.Parallel()
+		patched := items(map[string]any{"name": "a", "image": "live-1"}, map[string]any{"name": "a", "image": "live-2"})
+		original := items(map[string]any{"name": "a", "image": "git-1"}, map[string]any{"name": "a", "image": "git-2"})
+
+		assert.False(t, restoreNonIgnoredListElements(patched, original, original, patched))
+	})
+
 	t.Run("normalized live of another length falls back to leaf", func(t *testing.T) {
 		t.Parallel()
 		patched := items(map[string]any{"name": "a"}, map[string]any{"name": "b", "liveOnly": 1})

--- a/controller/sync_test.go
+++ b/controller/sync_test.go
@@ -957,6 +957,107 @@ func TestNormalizeTargetResourcesCRDs(t *testing.T) {
 	})
 }
 
+// TestNormalizeTargetResourcesChildApplicationSources covers argoproj/argo-cd#25855: with
+// RespectIgnoreDifferences an ignored key inside spec.sources[i] of a child Application must come
+// from live while the rest of the list stays as git declares it.
+func TestNormalizeTargetResourcesChildApplicationSources(t *testing.T) {
+	doc := loadCRDSchema(t, "testdata/schemas/application-openapi-v2.yaml")
+	oapiResources, err := openapi.NewOpenAPIParser(openapi.NewOpenAPIGetter(&fakeDiscovery{schema: doc})).Parse()
+	require.NoError(t, err)
+
+	for _, expr := range []string{".spec.sources[0].helm.parameters", ".spec.sources[].helm.parameters"} {
+		t.Run(expr, func(t *testing.T) {
+			ignores := []v1alpha1.ResourceIgnoreDifferences{{Group: "argoproj.io", Kind: "Application", JQPathExpressions: []string{expr}}}
+			dc, err := diff.NewDiffConfigBuilder().
+				WithDiffSettings(ignores, nil, true, normalizers.IgnoreNormalizerOpts{}).
+				WithNoCache().
+				Build()
+			require.NoError(t, err)
+
+			target := appWithSources(t, parentSources)
+			targetSources := sourcesOf(t, target)
+			require.NoError(t, unstructured.SetNestedField(targetSources[0].(map[string]any), "v3", "helm", "valuesObject", "image", "tag"))
+			require.NoError(t, unstructured.SetNestedSlice(target.Object, targetSources, "spec", "sources"))
+
+			// Live carries the ignored parameters plus two non-ignored drifts that must not leak.
+			live := appWithSources(t, liveSourcesWithOverride)
+			liveSources := sourcesOf(t, live)
+			require.NoError(t, unstructured.SetNestedField(liveSources[0].(map[string]any), "drifted", "helm", "releaseName"))
+			require.NoError(t, unstructured.SetNestedField(liveSources[1].(map[string]any), "dev", "targetRevision"))
+			require.NoError(t, unstructured.SetNestedSlice(live.Object, liveSources, "spec", "sources"))
+
+			cr := &comparisonResult{
+				reconciliationResult: sync.ReconciliationResult{
+					Live:   []*unstructured.Unstructured{live},
+					Target: []*unstructured.Unstructured{target},
+				},
+				diffConfig: dc,
+			}
+			patched, err := normalizeTargetResources(oapiResources, cr)
+			require.NoError(t, err)
+			require.Len(t, patched, 1)
+
+			params, _ := helmParamsOf(t, patched[0])
+			assert.Equal(t, []any{map[string]any{"name": "image.tag", "value": "v2"}}, params)
+			sources := sourcesOf(t, patched[0])
+			require.Len(t, sources, 2)
+			assert.Equal(t, "v3", dig(patched[0].Object, "spec", "sources", 0, "helm", "valuesObject", "image", "tag"))
+			_, hasRelease, err := unstructured.NestedString(sources[0].(map[string]any), "helm", "releaseName")
+			require.NoError(t, err)
+			assert.False(t, hasRelease)
+			assert.Equal(t, "main", dig(patched[0].Object, "spec", "sources", 1, "targetRevision"))
+		})
+	}
+}
+
+func TestRestoreNonIgnoredListElements(t *testing.T) {
+	t.Parallel()
+	items := func(elems ...map[string]any) []any {
+		out := make([]any, 0, len(elems))
+		for _, e := range elems {
+			out = append(out, e)
+		}
+		return out
+	}
+
+	t.Run("pairs elements by index and keeps the ignored key", func(t *testing.T) {
+		t.Parallel()
+		patched := items(map[string]any{"name": "a", "image": "live-a", "ignored": "live"})
+		original := items(map[string]any{"name": "a", "image": "git-a"})
+		normalized := items(map[string]any{"name": "a", "image": "git-a"})
+		normalizedLive := items(map[string]any{"name": "a", "image": "live-a"})
+
+		assert.True(t, restoreNonIgnoredListElements(patched, original, normalized, normalizedLive))
+		assert.Equal(t, items(map[string]any{"name": "a", "image": "git-a", "ignored": "live"}), patched)
+	})
+
+	t.Run("reordered live list falls back to leaf", func(t *testing.T) {
+		t.Parallel()
+		patched := items(map[string]any{"name": "b", "image": "live-b"}, map[string]any{"name": "a", "image": "live-a"})
+		original := items(map[string]any{"name": "a", "image": "git-a"}, map[string]any{"name": "b", "image": "git-b"})
+
+		assert.False(t, restoreNonIgnoredListElements(patched, original, original, patched))
+		assert.Equal(t, "live-b", patched[0].(map[string]any)["image"], "must not touch elements before bailing out")
+	})
+
+	t.Run("normalized live of another length falls back to leaf", func(t *testing.T) {
+		t.Parallel()
+		patched := items(map[string]any{"name": "a"}, map[string]any{"name": "b", "liveOnly": 1})
+		original := items(map[string]any{"name": "a"}, map[string]any{"name": "b"})
+
+		assert.False(t, restoreNonIgnoredListElements(patched, original, original, items(map[string]any{"name": "a"})))
+	})
+
+	t.Run("non map element falls back to leaf without partial restore", func(t *testing.T) {
+		t.Parallel()
+		patched := []any{map[string]any{"name": "a", "image": "live-a"}, "scalar"}
+		original := []any{map[string]any{"name": "a", "image": "git-a"}, "scalar"}
+
+		assert.False(t, restoreNonIgnoredListElements(patched, original, original, nil))
+		assert.Equal(t, "live-a", patched[0].(map[string]any)["image"])
+	})
+}
+
 // TestNormalizeTargetResourcesPDBSelector reproduces https://github.com/argoproj/argo-cd/issues/18232
 // When a PDB (policy/v1) has an ignoreDifferences rule for a matchLabels sub-field and
 // RespectIgnoreDifferences=true is set, normalizeTargetResources should only patch the

--- a/docs/user-guide/multiple_sources.md
+++ b/docs/user-guide/multiple_sources.md
@@ -43,6 +43,8 @@ If multiple sources produce the same resource (same `group`, `kind`, `name`, and
 produce the resource will take precedence. Argo CD will produce a `RepeatedResourceWarning` in this case, but it will 
 sync the resources. This provides a convenient way to override a resource from a chart with a resource from a Git repo.
 
+When a parent Application manages a multi-source Application, values set with `argocd app set --source-position N` are removed on the next parent sync. See the [PreserveSourceOverrides](sync-options.md#preserve-source-overrides-on-child-applications) sync option.
+
 ## Helm value files from external Git repository
 
 One of the most common scenarios for using multiple sources is the following

--- a/docs/user-guide/sync-options.md
+++ b/docs/user-guide/sync-options.md
@@ -431,6 +431,37 @@ spec:
 
 The example above shows how an Argo CD Application can be configured so it will ignore the `spec.replicas` field from the desired state (git) during the sync stage. This is achieved by calculating and pre-patching the desired state before applying it in the cluster. Note that the `RespectIgnoreDifferences` sync option is only effective when the resource is already created in the cluster. If the Application is being created and no live state exists, the desired state is applied as-is.
 
+## Preserve source overrides on child Applications
+
+In the app-of-apps pattern a parent Application applies child Applications. kubectl applies custom resources with a JSON merge patch, which merges `spec.source` field by field but replaces the `spec.sources` list as a whole. A value that `argocd app set --source-position N -p ...` added to a multi-source child therefore survives a parent sync on `spec.source` but is removed from `spec.sources`, and the child's own resources go `OutOfSync`.
+
+Set `PreserveSourceOverrides=true` on the parent to lay each `spec.sources[i]` from git over the live one before the sync. Keys that git does not declare stay, keys that git declares win. The merged object is also what the parent stores and shows as the desired manifest of the child.
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+spec:
+  syncPolicy:
+    syncOptions:
+      - PreserveSourceOverrides=true
+```
+
+To enable it for one child only, put the option in the child's manifest instead:
+
+```yaml
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: PreserveSourceOverrides=true
+```
+
+> [!WARNING]
+> With this option, anyone who can edit the live child Application can keep any key git does not declare, including `plugin.env`, across parent syncs. This matches what `spec.source` already allows. Enable it only where write access to child Applications is as trusted as write access to the git repository.
+
+> [!NOTE]
+> A source is matched by `repoURL`, `chart`, `path`, `ref`, and `name` at the same index. When git reorders sources, the indexes that no longer match are applied as declared in git and lose their overrides. When git adds or removes a source, the whole list is applied as declared in git. To remove an override from git, declare the key (for example `parameters: []`) or run `argocd app unset` on the child.
+
+To keep only named fields instead, list them in `spec.ignoreDifferences` on the parent (for example `jqPathExpressions: ['.spec.sources[0].helm.parameters']` for `group: argoproj.io`, `kind: Application`) and set [`RespectIgnoreDifferences=true`](#respect-ignore-differences-configs).
+
 ## Create Namespace
 
 ```yaml

--- a/docs/user-guide/sync-options.md
+++ b/docs/user-guide/sync-options.md
@@ -458,7 +458,7 @@ metadata:
 > With this option, anyone who can edit the live child Application can keep any key git does not declare, including `plugin.env`, across parent syncs. This matches what `spec.source` already allows. Enable it only where write access to child Applications is as trusted as write access to the git repository.
 
 > [!NOTE]
-> A source is matched by `repoURL`, `chart`, `path`, `ref`, and `name` at the same index. When git reorders sources, the indexes that no longer match are applied as declared in git and lose their overrides. When git adds or removes a source, the whole list is applied as declared in git. To remove an override from git, declare the key (for example `parameters: []`) or run `argocd app unset` on the child.
+> A source is matched by `repoURL`, `chart`, `path`, `ref`, and `name` at the same index. When git reorders sources, the indexes that no longer match are applied as declared in git and lose their overrides. When git switches a source from one type to another (for example `helm` to `kustomize`), the live block of the old type is dropped. When git adds or removes a source, the whole list is applied as declared in git. To remove an override from git, declare the key (for example `parameters: []`) or run `argocd app unset` on the child.
 
 To keep only named fields instead, list them in `spec.ignoreDifferences` on the parent (for example `jqPathExpressions: ['.spec.sources[0].helm.parameters']` for `group: argoproj.io`, `kind: Application`) and set [`RespectIgnoreDifferences=true`](#respect-ignore-differences-configs).
 


### PR DESCRIPTION
Fixes #25855

## Problem

In the app-of-apps pattern a parent Application applies child Applications with `kubectl apply`. For custom resources kubectl builds a JSON merge patch (RFC 7396). `spec.source` is an object and merges key by key, so `helm.parameters` set with `argocd app set` survive a parent sync. `spec.sources` is a list and is replaced whole, so the same override on a multi-source child is dropped on the next parent sync and the child's resources go OutOfSync.

The parent never shows a diff for this, because gitops-engine strips live-only keys per list index before comparing (`jsonutil.RemoveListFields`). Only the sync drops them.

## Changes

Two ways to keep the overrides, both opt-in:

1. **Fix `RespectIgnoreDifferences=true` for keys inside list elements.** `restoreNonIgnoredFields` treated a list as one leaf, so with `ignoreDifferences: jqPathExpressions: ['.spec.sources[0].helm.parameters']` the whole `spec.sources` list was restored from git and the ignored key was lost. This is the exact repro from the issue thread. It now walks lists of equal length element by element and falls back to the old behaviour when elements are not maps, when the normalized live list has another length, or when elements do not pair up by identity (name or the source keys) or an identity repeats.

2. **New sync option `PreserveSourceOverrides=true`**, on the parent or in the child's `argocd.argoproj.io/sync-options` annotation. Before the sync, each git `spec.sources[i]` is laid over the live one as a merge patch: git keys win, live-only keys stay. A slot merges only when `repoURL`, `chart`, `path`, `ref`, and `name` match at that index, so a reorder in git cannot move an override to another source. The last-applied annotation is deliberately not used as a baseline: the parent applies the merged object, so the annotation would record the carried keys as git's own and the next reconcile would delete them.

## Limitations

- When git already declares `helm.parameters`, an entry added with `argocd app set` is still replaced by git's list. Keeping it needs per-entry merging by name. Same behaviour as `spec.source` today.
- Anyone who can edit the live child Application can keep any key git does not declare, including `plugin.env`, across parent syncs. Same as `spec.source` today. The docs carry a warning.
- The option is read from the parent's `spec.syncPolicy.syncOptions` and the child annotation, not from `argocd app sync --sync-option`, and is not exposed in the UI yet.

## Tests

- `controller/app_sources_test.go`: merge semantics, idempotence across reconciles, git declaring a key wins, reorder and count changes, int64 round trip, source identity.
- `controller/state_test.go`: `CompareAppState` with the option off, on the parent, and on the child.
- `controller/sync_test.go`: `RespectIgnoreDifferences` with the Application CRD schema keeps the ignored key and drops non-ignored drift; guards of the list walk.
- `go test -race ./controller/`, `go vet`, `golangci-lint`, `go build ./...` green. No API changes, `make codegen` not needed. No e2e test yet, it needs a running cluster.

## Docs

- `docs/user-guide/sync-options.md`: new section "Preserve source overrides on child Applications".
- `docs/user-guide/multiple_sources.md`: pointer to it.

Cherry-pick candidates: `release-3.1`, `release-3.2` (the issue is on 3.1.9).

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

## Checklist

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
