### PR TITLE
fix(helm): use configured proxy for Azure ACR workload identity auth

### DIFF
--- a/util/helm/creds.go
+++ b/util/helm/creds.go
@@ -18,6 +18,7 @@ import (
 
 	argoutils "github.com/argoproj/argo-cd/v3/util"
 	"github.com/argoproj/argo-cd/v3/util/env"
+	"github.com/argoproj/argo-cd/v3/util/proxy"
 	"github.com/argoproj/argo-cd/v3/util/workloadidentity"
 )
 
@@ -192,12 +193,8 @@ func (creds AzureWorkloadIdentityCreds) getAccessTokenAfterChallenge(ctx context
 	refreshTokenURL := parsedURL.String()
 
 	client := &http.Client{
-		Timeout: 10 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: creds.GetInsecureSkipVerify(),
-			},
-		},
+		Timeout:   10 * time.Second,
+		Transport: creds.azureRegistryHTTPTransport(),
 	}
 
 	formValues := url.Values{}
@@ -240,16 +237,21 @@ func (creds AzureWorkloadIdentityCreds) getAccessTokenAfterChallenge(ctx context
 	return res.RefreshToken, nil
 }
 
+func (creds AzureWorkloadIdentityCreds) azureRegistryHTTPTransport() *http.Transport {
+	return &http.Transport{
+		Proxy: proxy.GetCallback("", ""),
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: creds.GetInsecureSkipVerify(),
+		},
+	}
+}
+
 func (creds AzureWorkloadIdentityCreds) challengeAzureContainerRegistry(ctx context.Context, azureContainerRegistry string) (map[string]string, error) {
 	requestURL := fmt.Sprintf("https://%s/v2/", azureContainerRegistry)
 
 	client := &http.Client{
-		Timeout: 10 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: creds.GetInsecureSkipVerify(),
-			},
-		},
+		Timeout:   10 * time.Second,
+		Transport: creds.azureRegistryHTTPTransport(),
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, http.NoBody)

--- a/util/helm/creds_test.go
+++ b/util/helm/creds_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	argoutils "github.com/argoproj/argo-cd/v3/util"
+	"github.com/argoproj/argo-cd/v3/util/proxy"
 	"github.com/argoproj/argo-cd/v3/util/workloadidentity"
 	"github.com/argoproj/argo-cd/v3/util/workloadidentity/mocks"
 )
@@ -92,6 +93,26 @@ func TestGetPasswordShouldGenerateTokenIfNotPresentInCache(t *testing.T) {
 	token, err := creds.GetPassword()
 	require.NoError(t, err)
 	assert.Equal(t, "newRefreshToken", token, "The retrieved token should match the stored token")
+}
+
+func TestAzureWorkloadIdentityCredsHTTPTransportUsesProxy(t *testing.T) {
+	proxy.UseTestingProxyCallback()
+	t.Setenv("http_proxy", "http://proxy-from-env:7878")
+	t.Setenv("https_proxy", "http://proxy-from-env:7878")
+	t.Setenv("ALL_PROXY", "")
+
+	workloadIdentityMock := &mocks.TokenProvider{}
+	creds := NewAzureWorkloadIdentityCreds("contoso.azurecr.io/charts", "", nil, nil, false, workloadIdentityMock)
+
+	transport := creds.azureRegistryHTTPTransport()
+	require.NotNil(t, transport.Proxy)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://proxy-from-env:7878", http.NoBody)
+	require.NoError(t, err)
+	proxyURL, err := transport.Proxy(req)
+	require.NoError(t, err)
+	require.NotNil(t, proxyURL)
+	assert.Equal(t, "http://proxy-from-env:7878", proxyURL.String())
 }
 
 func TestChallengeAzureContainerRegistry(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fixes Azure workload identity ACR authentication HTTP clients that bypass configured `HTTP_PROXY`/`HTTPS_PROXY` on repo-server
- `challengeAzureContainerRegistry()` and `getAccessTokenAfterChallenge()` in `util/helm/creds.go` now use `proxy.GetCallback("", "")`, consistent with other Helm HTTP clients
- Adds unit test verifying the Azure ACR transport respects proxy environment variables

## Problem

When repo-server is configured with an HTTP proxy, Helm OCI repository connectivity to Azure Container Registry using workload identity fails with `context deadline exceeded`. The ACR challenge and token exchange requests create `http.Transport` without a `Proxy` callback, so they attempt direct connections and time out behind the proxy.

Related: [GITOPS-11286](https://redhat.atlassian.net/browse/GITOPS-11286)

## Test plan

- [x] `go test ./util/helm/ -run TestAzureWorkloadIdentityCredsHTTPTransportUsesProxy -v`
- [x] `go test ./util/helm/ -run 'TestChallengeAzureContainerRegistry|TestGetPasswordShouldGenerateTokenIfNotPresentInCache' -v`


Made with [Cursor](https://cursor.com)