### PR TITLE
fix(ui): remove unnecessary open app icon on list view

### DIFF
--- a/docs/operator-manual/managed-by-url.md
+++ b/docs/operator-manual/managed-by-url.md
@@ -58,7 +58,7 @@ metadata:
   name: child-app
   namespace: namespace-b
   annotations:
-    argocd.argoproj.io/managed-by-url: "http://localhost:8081" # replace with actual secondary ArgoCD URL in real setup
+    argocd.argoproj.io/managed-by-url: 'http://localhost:8081' # replace with actual secondary ArgoCD URL in real setup
 spec:
   project: default
   source:
@@ -77,6 +77,7 @@ spec:
 ### Result
 
 When viewing the parent Application in the primary instance's UI:
+
 - The parent Application syncs from Git and deploys the child Application
 - Clicking on `child-app` in the resource tree navigates to `https://secondary-argocd.example.com/applications/namespace-b/child-app`
 - The link opens the child Application in the correct Argo CD instance that actually manages it
@@ -85,12 +86,12 @@ When viewing the parent Application in the primary instance's UI:
 
 ### Annotation Format
 
-| Field | Value |
-|-------|-------|
+| Field          | Value                               |
+| -------------- | ----------------------------------- |
 | **Annotation** | `argocd.argoproj.io/managed-by-url` |
-| **Target** | Application |
-| **Value** | Valid HTTP(S) URL |
-| **Required** | No |
+| **Target**     | Application                         |
+| **Value**      | Valid HTTP(S) URL                   |
+| **Required**   | No                                  |
 
 ### URL Validation
 
@@ -107,51 +108,13 @@ Invalid URLs will prevent the Application from being created or updated.
 ### Behavior
 
 When generating application links, Argo CD:
+
 - **Without annotation**: Uses the current instance's base URL
 - **With annotation**: Uses the URL from the annotation
 - **Invalid annotation**: Falls back to the current instance's base URL and logs a warning
 
 > [!WARNING]
 > Ensure the URL in the annotation is accessible from users' browsers. For internal deployments, use internal DNS names or configure appropriate network access.
-
-## Testing Locally
-
-To test the annotation with two local Argo CD instances:
-
-```bash
-# Install primary instance
-kubectl create namespace argocd
-kubectl apply -n argocd --server-side --force-conflicts -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
-
-# Install secondary instance
-kubectl create namespace namespace-b
-kubectl apply -n namespace-b --server-side --force-conflicts -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
-
-# Port forward both instances
-kubectl port-forward -n argocd svc/argocd-server 8080:443 &
-kubectl port-forward -n namespace-b svc/argocd-server 8081:443 &
-
-# Wait for Argo CD to be ready
-kubectl wait --for=condition=available --timeout=300s deployment/argocd-server -n argocd
-
-# Get the admin password for primary instance
-kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d && echo
-
-```
-
-Then:
-1. Open `http://localhost:8080` in your browser
-2. Login with username `admin` and the password from the command above
-3. Navigate to the `parent-app` Application
-4. Click on the `child-app` in the resource tree
-5. It should redirect to `http://localhost:8081/applications/namespace-b/child-app`
-
-You will need to repeat the command to get the password for the secondary instance to login and access the child-app
-
-```bash
-# Get the admin password for secondary instance
-kubectl -n namespace-b get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d && echo
-```
 
 ## Troubleshooting
 
@@ -163,10 +126,8 @@ kubectl -n namespace-b get secret argocd-initial-admin-secret -o jsonpath="{.dat
 kubectl get application child-app -n instance-b -o jsonpath='{.metadata.annotations.argocd\.argoproj\.io/managed-by-url}'
 ```
 
-Expected output: A complete URL like `http://localhost:8081` or the url that has been set 
-i.e `https://secondary-argocd.example.com`
-
 **If the annotation is present but links still don't work:**
+
 - Verify the URL is accessible from your browser
 - Check browser console for errors
 - Ensure the URL format is correct (includes `http://` or `https://`)
@@ -179,19 +140,6 @@ If Application creation fails with "invalid managed-by URL" error:
 - ✅ URL contains no typos
 - ✅ URL uses only valid characters
 - ✅ URL is not a potentially malicious scheme (e.g., `javascript:`)
-
-### Nested Applications Not Working
-
-For app-of-apps patterns, ensure:
-1. The child Application YAML in Git includes the annotation
-2. The parent Application has synced successfully
-3. The child Application has been created in the cluster
-
-Verify the child Application exists:
-
-```bash
-kubectl get application CHILD-APP-NAME -n NAMESPACE
-```
 
 ## See Also
 

--- a/ui/src/app/applications/components/applications-list/application-table-row.tsx
+++ b/ui/src/app/applications/components/applications-list/application-table-row.tsx
@@ -1,4 +1,4 @@
-import {NotificationType, Tooltip} from 'argo-ui';
+import {Tooltip} from 'argo-ui';
 import * as React from 'react';
 import Moment from 'react-moment';
 import {ActionMenu, Cluster} from '../../../shared/components';
@@ -7,8 +7,7 @@ import * as models from '../../../shared/models';
 import {NoticeIcon} from '../application-notice/notice-icon';
 import {ApplicationURLs} from '../application-urls';
 import * as AppUtils from '../utils';
-import {getAppDefaultSource, OperationState, getApplicationLinkURL, getManagedByURL, MANAGED_BY_URL_INVALID_TEXT, MANAGED_BY_URL_INVALID_TOOLTIP} from '../utils';
-import {isValidManagedByURL} from '../../../shared/utils';
+import {getAppDefaultSource, OperationState} from '../utils';
 import {ApplicationsLabels} from './applications-labels';
 import {ApplicationsSource} from './applications-source';
 import {CellLink} from '../../../shared/components';
@@ -29,10 +28,7 @@ export const ApplicationTableRow = ({app, selected, pref, ctx, syncApplication, 
     const useAuthSettingsCtx = React.useContext(AuthSettingsCtx);
     const favList = pref.appList.favoritesAppList || [];
     const healthStatus = app.status.health.status;
-    const linkInfo = getApplicationLinkURL(app, ctx.baseHref);
     const source = getAppDefaultSource(app);
-    const managedByURL = getManagedByURL(app);
-    const managedByURLInvalid = !!managedByURL && !isValidManagedByURL(managedByURL);
 
     const view = pref.appDetails.view;
     const appLink = AppUtils.getAppListLink(ctx, app, view);
@@ -45,27 +41,6 @@ export const ApplicationTableRow = ({app, selected, pref, ctx, syncApplication, 
             favList.push(app.metadata.name);
         }
         services.viewPreferences.updatePreferences({appList: {...pref.appList, favoritesAppList: favList}});
-    };
-
-    const handleExternalLinkClick = (e: React.MouseEvent) => {
-        e.stopPropagation();
-        if (managedByURLInvalid) {
-            ctx.notifications.show({
-                content: (
-                    <div>
-                        <div style={{fontWeight: 600}}>{MANAGED_BY_URL_INVALID_TEXT}</div>
-                        <div style={{marginTop: 6}}>{MANAGED_BY_URL_INVALID_TOOLTIP}</div>
-                    </div>
-                ),
-                type: NotificationType.Warning
-            });
-            return;
-        }
-        if (linkInfo.isExternal) {
-            window.open(linkInfo.url, '_blank', 'noopener,noreferrer');
-        } else {
-            ctx.navigation.goto(appLink.path, {view});
-        }
     };
 
     return (
@@ -122,13 +97,6 @@ export const ApplicationTableRow = ({app, selected, pref, ctx, syncApplication, 
                                         </a>
                                     </Tooltip>
                                     <ApplicationURLs urls={app.status.summary?.externalURLs} />
-                                    <button
-                                        type='button'
-                                        className={`applications-list__open-app-button${managedByURLInvalid ? ' managed-by-url-invalid' : ''}`}
-                                        onClick={handleExternalLinkClick}
-                                        title={managedByURLInvalid ? MANAGED_BY_URL_INVALID_TEXT : `Link: ${linkInfo.url}\nmanaged-by-url: ${managedByURL || 'none'}`}>
-                                        <i className='fa fa-window-maximize' />
-                                    </button>
                                 </div>
                             </div>
                         </div>

--- a/ui/src/app/applications/components/applications-list/application-tile.tsx
+++ b/ui/src/app/applications/components/applications-list/application-tile.tsx
@@ -1,4 +1,4 @@
-import {NotificationType, Tooltip} from 'argo-ui';
+import {Tooltip} from 'argo-ui';
 import classNames from 'classnames';
 import * as React from 'react';
 import {Cluster} from '../../../shared/components';
@@ -7,8 +7,7 @@ import * as models from '../../../shared/models';
 import {NoticeIcon} from '../application-notice/notice-icon';
 import {ApplicationURLs} from '../application-urls';
 import * as AppUtils from '../utils';
-import {getAppDefaultSource, OperationState, getApplicationLinkURL, getManagedByURL, MANAGED_BY_URL_INVALID_TEXT, MANAGED_BY_URL_INVALID_TOOLTIP} from '../utils';
-import {isValidManagedByURL} from '../../../shared/utils';
+import {getAppDefaultSource, OperationState} from '../utils';
 import {services} from '../../../shared/services';
 import {ViewPreferences} from '../../../shared/services';
 
@@ -30,10 +29,7 @@ export const ApplicationTile = ({app, selected, pref, ctx, tileRef, syncApplicat
     const source = getAppDefaultSource(app);
     const isOci = source?.repoURL?.startsWith('oci://');
     const targetRevision = source ? source.targetRevision || 'HEAD' : 'Unknown';
-    const linkInfo = getApplicationLinkURL(app, ctx.baseHref);
     const healthStatus = app.status.health.status;
-    const managedByURL = getManagedByURL(app);
-    const managedByURLInvalid = !!managedByURL && !isValidManagedByURL(managedByURL);
 
     const view = pref.appDetails.view;
     const appLink = AppUtils.getAppListLink(ctx, app, view);
@@ -46,27 +42,6 @@ export const ApplicationTile = ({app, selected, pref, ctx, tileRef, syncApplicat
             favList.push(app.metadata.name);
         }
         services.viewPreferences.updatePreferences({appList: {...pref.appList, favoritesAppList: favList}});
-    };
-
-    const handleExternalLinkClick = (e: React.MouseEvent) => {
-        e.stopPropagation();
-        if (managedByURLInvalid) {
-            ctx.notifications.show({
-                content: (
-                    <div>
-                        <div style={{fontWeight: 600}}>{MANAGED_BY_URL_INVALID_TEXT}</div>
-                        <div style={{marginTop: 6}}>{MANAGED_BY_URL_INVALID_TOOLTIP}</div>
-                    </div>
-                ),
-                type: NotificationType.Warning
-            });
-            return;
-        }
-        if (linkInfo.isExternal) {
-            window.open(linkInfo.url, '_blank', 'noopener,noreferrer');
-        } else {
-            ctx.navigation.goto(appLink.path, {view});
-        }
     };
 
     return (
@@ -236,15 +211,6 @@ export const ApplicationTile = ({app, selected, pref, ctx, tileRef, syncApplicat
             {/* Header buttons — sibling of the anchor (not nested) so the markup stays valid. */}
             <div className='applications-tiles__header-buttons applications-list__external-link'>
                 <ApplicationURLs urls={app.status.summary?.externalURLs} />
-                {managedByURLInvalid ? (
-                    <button type='button' className='managed-by-url-invalid' onClick={handleExternalLinkClick} style={{cursor: 'not-allowed'}} title={MANAGED_BY_URL_INVALID_TEXT}>
-                        <i className='fa fa-window-maximize' />
-                    </button>
-                ) : (
-                    <button type='button' onClick={handleExternalLinkClick} title={managedByURL ? `Managed by: ${managedByURL}` : 'Open application'}>
-                        <i className='fa fa-window-maximize' />
-                    </button>
-                )}
                 <button title={favList?.includes(app.metadata.name) ? 'Remove Favorite' : 'Add Favorite'} className='large-text-height' onClick={handleFavoriteToggle}>
                     <i
                         className={favList?.includes(app.metadata.name) ? 'fas fa-star fa-lg' : 'far fa-star fa-lg'}

--- a/ui/src/app/applications/components/applications-list/applications-table.scss
+++ b/ui/src/app/applications/components/applications-list/applications-table.scss
@@ -78,15 +78,6 @@ $applications-list-xxlarge: calc(map-get($breakpoints, xxlarge) - 1px);
         }
     }
 
-    .applications-list__table-row button.managed-by-url-invalid {
-        color: #f4c030;
-        cursor: not-allowed;
-
-        &:hover {
-            color: #f4c030;
-        }
-    }
-
     .applications-list__meta-column {
         display: flex;
         align-items: flex-start;
@@ -148,30 +139,8 @@ $applications-list-xxlarge: calc(map-get($breakpoints, xxlarge) - 1px);
             margin-left: 0.5em;
         }
 
-        .application-notice-icon,
-        .applications-list__open-app-button {
+        .application-notice-icon {
             flex-shrink: 0;
-        }
-
-        .applications-list__open-app-button {
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            margin-left: 0.5em;
-            padding: 0;
-            border: 0;
-            background: none;
-            color: inherit;
-            cursor: pointer;
-            line-height: 1;
-
-            &:hover {
-                color: $argo-color-teal-5;
-            }
-
-            i {
-                font-size: 14px;
-            }
         }
     }
 

--- a/ui/src/app/applications/components/applications-list/applications-tiles.scss
+++ b/ui/src/app/applications/components/applications-list/applications-tiles.scss
@@ -177,14 +177,6 @@
                 color: $argo-color-teal-5;
             }
 
-            &.managed-by-url-invalid {
-                color: #f4c030;
-
-                &:hover {
-                    color: #f4c030;
-                }
-            }
-
             i {
                 font-size: 14px;
             }

--- a/ui/src/app/applications/components/applications-list/appset-table-row.tsx
+++ b/ui/src/app/applications/components/applications-list/appset-table-row.tsx
@@ -1,13 +1,12 @@
-import {NotificationType, Tooltip} from 'argo-ui';
+import {Tooltip} from 'argo-ui';
 import * as React from 'react';
 import Moment from 'react-moment';
 import {AuthSettingsCtx, ContextApis} from '../../../shared/context';
 import * as models from '../../../shared/models';
 import * as AppUtils from '../utils';
-import {getApplicationLinkURL, getManagedByURL, getAppSetHealthStatus, MANAGED_BY_URL_INVALID_TEXT, MANAGED_BY_URL_INVALID_TOOLTIP} from '../utils';
+import {getAppSetHealthStatus} from '../utils';
 import {services} from '../../../shared/services';
 import {ViewPreferences} from '../../../shared/services';
-import {isValidManagedByURL} from '../../../shared/utils';
 import {CellLink} from '../../../shared/components';
 
 export interface AppSetTableRowProps {
@@ -21,9 +20,6 @@ export const AppSetTableRow = ({appSet, selected, pref, ctx}: AppSetTableRowProp
     const useAuthSettingsCtx = React.useContext(AuthSettingsCtx);
     const favList = pref.appList.favoritesAppList || [];
     const healthStatus = getAppSetHealthStatus(appSet);
-    const linkInfo = getApplicationLinkURL(appSet, ctx.baseHref);
-    const managedByURL = getManagedByURL(appSet);
-    const managedByURLInvalid = !!managedByURL && !isValidManagedByURL(managedByURL);
 
     // AppSet pages don't support the Application details `view` param, so the link is view-less.
     const appSetLink = AppUtils.getAppListLink(ctx, appSet);
@@ -36,27 +32,6 @@ export const AppSetTableRow = ({appSet, selected, pref, ctx}: AppSetTableRowProp
             favList.push(appSet.metadata.name);
         }
         services.viewPreferences.updatePreferences({appList: {...pref.appList, favoritesAppList: favList}});
-    };
-
-    const handleExternalLinkClick = (e: React.MouseEvent) => {
-        e.stopPropagation();
-        if (managedByURLInvalid) {
-            ctx.notifications.show({
-                content: (
-                    <div>
-                        <div style={{fontWeight: 600}}>{MANAGED_BY_URL_INVALID_TEXT}</div>
-                        <div style={{marginTop: 6}}>{MANAGED_BY_URL_INVALID_TOOLTIP}</div>
-                    </div>
-                ),
-                type: NotificationType.Warning
-            });
-            return;
-        }
-        if (linkInfo.isExternal) {
-            window.open(linkInfo.url, '_blank', 'noopener,noreferrer');
-        } else {
-            ctx.navigation.goto(appSetLink.path);
-        }
     };
 
     return (
@@ -110,13 +85,6 @@ export const AppSetTableRow = ({appSet, selected, pref, ctx}: AppSetTableRowProp
                                             {appSet.metadata.name}
                                         </a>
                                     </Tooltip>
-                                    <button
-                                        type='button'
-                                        className={`applications-list__open-app-button${managedByURLInvalid ? ' managed-by-url-invalid' : ''}`}
-                                        onClick={handleExternalLinkClick}
-                                        title={managedByURLInvalid ? MANAGED_BY_URL_INVALID_TEXT : `Link: ${linkInfo.url}\nmanaged-by-url: ${managedByURL || 'none'}`}>
-                                        <i className='fa fa-window-maximize' />
-                                    </button>
                                 </div>
                             </div>
                         </div>

--- a/ui/src/app/applications/components/applications-list/appset-tile.tsx
+++ b/ui/src/app/applications/components/applications-list/appset-tile.tsx
@@ -1,12 +1,11 @@
-import {NotificationType, Tooltip} from 'argo-ui';
+import {Tooltip} from 'argo-ui';
 import * as React from 'react';
 import {ContextApis, AuthSettingsCtx} from '../../../shared/context';
 import * as models from '../../../shared/models';
 import * as AppUtils from '../utils';
-import {getApplicationLinkURL, getManagedByURL, getAppSetHealthStatus, MANAGED_BY_URL_INVALID_TEXT, MANAGED_BY_URL_INVALID_TOOLTIP} from '../utils';
+import {getAppSetHealthStatus} from '../utils';
 import {services} from '../../../shared/services';
 import {ViewPreferences} from '../../../shared/services';
-import {isValidManagedByURL} from '../../../shared/utils';
 
 export interface AppSetTileProps {
     appSet: models.ApplicationSet;
@@ -20,10 +19,7 @@ export const AppSetTile = ({appSet, selected, pref, ctx, tileRef}: AppSetTilePro
     const useAuthSettingsCtx = React.useContext(AuthSettingsCtx);
     const favList = pref.appList.favoritesAppList || [];
 
-    const linkInfo = getApplicationLinkURL(appSet, ctx.baseHref);
     const healthStatus = getAppSetHealthStatus(appSet);
-    const managedByURL = getManagedByURL(appSet);
-    const managedByURLInvalid = !!managedByURL && !isValidManagedByURL(managedByURL);
 
     // AppSet pages don't support the Application details `view` param, so the link is view-less.
     const appSetLink = AppUtils.getAppListLink(ctx, appSet);
@@ -36,27 +32,6 @@ export const AppSetTile = ({appSet, selected, pref, ctx, tileRef}: AppSetTilePro
             favList.push(appSet.metadata.name);
         }
         services.viewPreferences.updatePreferences({appList: {...pref.appList, favoritesAppList: favList}});
-    };
-
-    const handleExternalLinkClick = (e: React.MouseEvent) => {
-        e.stopPropagation();
-        if (managedByURLInvalid) {
-            ctx.notifications.show({
-                content: (
-                    <div>
-                        <div style={{fontWeight: 600}}>{MANAGED_BY_URL_INVALID_TEXT}</div>
-                        <div style={{marginTop: 6}}>{MANAGED_BY_URL_INVALID_TOOLTIP}</div>
-                    </div>
-                ),
-                type: NotificationType.Warning
-            });
-            return;
-        }
-        if (linkInfo.isExternal) {
-            window.open(linkInfo.url, '_blank', 'noopener,noreferrer');
-        } else {
-            ctx.navigation.goto(appSetLink.path);
-        }
     };
 
     return (
@@ -143,15 +118,6 @@ export const AppSetTile = ({appSet, selected, pref, ctx, tileRef}: AppSetTilePro
 
             {/* Header buttons — sibling of the anchor (not nested) so the markup stays valid. */}
             <div className='applications-tiles__header-buttons applications-list__external-link'>
-                {managedByURLInvalid ? (
-                    <button type='button' className='managed-by-url-invalid' onClick={handleExternalLinkClick} style={{cursor: 'not-allowed'}} title={MANAGED_BY_URL_INVALID_TEXT}>
-                        <i className='fa fa-window-maximize' />
-                    </button>
-                ) : (
-                    <button type='button' onClick={handleExternalLinkClick} title={managedByURL ? `Managed by: ${managedByURL}` : 'Open application'}>
-                        <i className='fa fa-window-maximize' />
-                    </button>
-                )}
                 <button title={favList?.includes(appSet.metadata.name) ? 'Remove Favorite' : 'Add Favorite'} className='large-text-height' onClick={handleFavoriteToggle}>
                     <i
                         className={favList?.includes(appSet.metadata.name) ? 'fas fa-star fa-lg' : 'far fa-star fa-lg'}

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -2084,41 +2084,6 @@ export function getManagedByURLFromNode(node: any): string | null {
 }
 
 /**
- * Gets the correct URL for an application link, considering managed-by-url annotation
- * @param app The application object
- * @param baseHref The current instance's base href
- * @param node Optional resource node to get managed-by-url from info field
- * @returns The URL to use for the application link
- */
-export function getApplicationLinkURL(app: any, baseHref: string, node?: any): {url: string; isExternal: boolean} {
-    // First try to get managed-by-url from the node's info field (for nested applications)
-    let managedByURL = node ? getManagedByURLFromNode(node) : null;
-
-    // If not found in node, try the application's metadata
-    if (!managedByURL) {
-        managedByURL = getManagedByURL(app);
-    }
-
-    let url, isExternal;
-    if (managedByURL) {
-        // Validate the managed-by URL using the same validation as external links
-        if (!isValidManagedByURL(managedByURL)) {
-            // If URL is invalid, fall back to local URL for security
-            console.warn(`Invalid managed-by URL for application ${app.metadata.name}: ${managedByURL}`);
-            url = baseHref + 'applications/' + app.metadata.namespace + '/' + app.metadata.name;
-            isExternal = false;
-        } else {
-            url = managedByURL + '/applications/' + app.metadata.namespace + '/' + app.metadata.name;
-            isExternal = true;
-        }
-    } else {
-        url = baseHref + 'applications/' + app.metadata.namespace + '/' + app.metadata.name;
-        isExternal = false;
-    }
-    return {url, isExternal};
-}
-
-/**
  * Gets the correct URL for an application link from a resource node, considering managed-by-url annotation
  * @param node The resource node representing an application
  * @param baseHref The current instance's base href


### PR DESCRIPTION
## Remove redundant "open application" icon from the applications/appset list

The applications and ApplicationSet lists always show resources on the current
Argo CD instance, and the tile/row is already a link that navigates to the app.
The extra `fa-window-maximize` icon next to each name was therefore redundant, so
it has been removed from both the tiles and table views.

### Unchanged
- The `managed-by-url` feature on **nested Applications** in a parent app's
  resource tree / resource list is untouched: clicking the node still selects the
  resource (open resource details), and the maximize icon still opens the child app.

### Result

The `fa-window-maximize` is now removed from this view.
<img width="768" height="783" alt="image" src="https://github.com/user-attachments/assets/92a22627-703b-4aa4-9386-1c67511cc8db" />
