### PR TITLE
fix(ui): don't write the URL when filters report unchanged state (#13156)

### DIFF
--- a/ui/src/app/applications/components/applications-list/application-sets-list.tsx
+++ b/ui/src/app/applications/components/applications-list/application-sets-list.tsx
@@ -11,7 +11,7 @@ import * as models from '../../../shared/models';
 import {AppsListPreferences, AppsListViewKey, AppsListViewType, AppSetsListPreferences, HealthStatusBarPreferences, services, ViewPreferences} from '../../../shared/services';
 import {useSidebarTarget} from '../../../sidebar/sidebar';
 import {useObservableQuery} from '../../../shared/hooks/query';
-import {isInvalidRegex} from '../../../shared/utils';
+import {gotoIfQueryChanged, isInvalidRegex} from '../../../shared/utils';
 import * as AppUtils from '../utils';
 import {AppSetsFilter, ApplicationSetFilteredApp, getAppSetFilterResults} from './applications-filter';
 import {createMatcher} from './applications-list-search';
@@ -372,15 +372,12 @@ export const ApplicationSetsList = (props: RouteComponentProps<any>) => {
 
     function onAppSetFilterPrefChanged(ctx: ContextApis, newPref: AppSetsListPreferences) {
         services.viewPreferences.updatePreferences({appList: newPref as AppsListPreferences});
-        ctx.navigation.goto(
-            '.',
-            {
-                health: newPref.healthFilter.join(','),
-                labels: newPref.labelsFilter.map(encodeURIComponent).join(','),
-                showFavorites: newPref.showFavorites ? 'true' : null
-            },
-            {replace: true}
-        );
+        const params = {
+            health: newPref.healthFilter.join(','),
+            labels: newPref.labelsFilter.map(encodeURIComponent).join(','),
+            showFavorites: newPref.showFavorites ? 'true' : null
+        };
+        gotoIfQueryChanged(ctx.navigation, params);
     }
 
     function getPageTitle(view: string) {

--- a/ui/src/app/applications/components/applications-list/applications-list.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-list.tsx
@@ -24,7 +24,7 @@ import {FlexTopBar} from '../../../shared/components';
 import {ViewTypeSwitcher} from './view-type-switcher';
 import {useSidebarTarget} from '../../../sidebar/sidebar';
 import {useQuery, useObservableQuery} from '../../../shared/hooks/query';
-import {isInvalidRegex} from '../../../shared/utils';
+import {gotoIfQueryChanged, isInvalidRegex} from '../../../shared/utils';
 
 import './applications-list.scss';
 
@@ -351,25 +351,22 @@ export const ApplicationsList = (props: RouteComponentProps<any>) => {
 
     function onAppFilterPrefChanged(ctx: ContextApis, newPref: AppsListPreferences) {
         services.viewPreferences.updatePreferences({appList: newPref});
-        ctx.navigation.goto(
-            '.',
-            {
-                proj: newPref.projectsFilter.join(','),
-                sync: newPref.syncFilter.join(','),
-                autoSync: newPref.autoSyncFilter.join(','),
-                health: newPref.healthFilter.join(','),
-                namespace: newPref.namespacesFilter.join(','),
-                targetRevision: newPref.targetRevisionFilter.map(encodeURIComponent).join(','),
-                repo: newPref.reposFilter.map(encodeURIComponent).join(','),
-                cluster: newPref.clustersFilter.join(','),
-                labels: newPref.labelsFilter.map(encodeURIComponent).join(','),
-                annotations: newPref.annotationsFilter.map(encodeURIComponent).join(','),
-                operation: newPref.operationFilter.join(','),
-                // Keep URL and preferences consistent. When false, remove the param entirely.
-                showFavorites: newPref.showFavorites ? 'true' : null
-            },
-            {replace: true}
-        );
+        const params = {
+            proj: newPref.projectsFilter.join(','),
+            sync: newPref.syncFilter.join(','),
+            autoSync: newPref.autoSyncFilter.join(','),
+            health: newPref.healthFilter.join(','),
+            namespace: newPref.namespacesFilter.join(','),
+            targetRevision: newPref.targetRevisionFilter.map(encodeURIComponent).join(','),
+            repo: newPref.reposFilter.map(encodeURIComponent).join(','),
+            cluster: newPref.clustersFilter.join(','),
+            labels: newPref.labelsFilter.map(encodeURIComponent).join(','),
+            annotations: newPref.annotationsFilter.map(encodeURIComponent).join(','),
+            operation: newPref.operationFilter.join(','),
+            // Keep URL and preferences consistent. When false, remove the param entirely.
+            showFavorites: newPref.showFavorites ? 'true' : null
+        };
+        gotoIfQueryChanged(ctx.navigation, params);
     }
 
     function getPageTitle(view: string) {

--- a/ui/src/app/shared/utils.test.ts
+++ b/ui/src/app/shared/utils.test.ts
@@ -3,7 +3,7 @@ declare const test: any;
 declare const expect: any;
 declare const describe: any;
 import {concatMaps} from './utils';
-import {isValidManagedByURL, isValidURL} from './utils';
+import {gotoIfQueryChanged, isValidManagedByURL, isValidURL} from './utils';
 
 test('map concatenation', () => {
     const map1 = {
@@ -56,5 +56,48 @@ describe('isValidManagedByURL', () => {
     test('rejects invalid URL strings', () => {
         expect(isValidManagedByURL('not-a-url')).toBe(false);
         expect(isValidManagedByURL('')).toBe(false);
+    });
+});
+
+describe('gotoIfQueryChanged', () => {
+    const navigateFrom = (search: string, params: {[name: string]: any}) => {
+        window.history.replaceState({}, '', '/applications' + search);
+        const goto = jest.fn();
+        gotoIfQueryChanged({goto} as any, params);
+        return goto;
+    };
+
+    test('replaces the URL when a value changes', () => {
+        const goto = navigateFrom('?proj=default', {proj: 'other'});
+        expect(goto).toHaveBeenCalledWith('.', {proj: 'other'}, {replace: true});
+    });
+
+    test('replaces the URL when a parameter is added', () => {
+        expect(navigateFrom('?proj=default', {proj: 'default', showFavorites: 'true'})).toHaveBeenCalled();
+    });
+
+    test('does not navigate when every parameter already has that value', () => {
+        expect(navigateFrom('?proj=default&health=Healthy', {proj: 'default', health: 'Healthy'})).not.toHaveBeenCalled();
+    });
+
+    test('does not navigate for parameters it was not given', () => {
+        expect(navigateFrom('?proj=default&view=tiles', {proj: 'default'})).not.toHaveBeenCalled();
+    });
+
+    test('treats null and undefined as removing a parameter', () => {
+        expect(navigateFrom('?showFavorites=true', {showFavorites: null})).toHaveBeenCalled();
+        expect(navigateFrom('?proj=default', {showFavorites: null})).not.toHaveBeenCalled();
+        expect(navigateFrom('?proj=default', {showFavorites: undefined})).not.toHaveBeenCalled();
+    });
+
+    test('compares every entry of an array parameter', () => {
+        expect(navigateFrom('?type=git&type=helm', {type: ['git', 'helm']})).not.toHaveBeenCalled();
+        expect(navigateFrom('?type=git&type=helm', {type: ['git']})).toHaveBeenCalled();
+        expect(navigateFrom('?type=git', {type: ['git', 'helm']})).toHaveBeenCalled();
+    });
+
+    test('navigates when the URL has no query string yet', () => {
+        expect(navigateFrom('', {proj: ''})).toHaveBeenCalled();
+        expect(navigateFrom('', {proj: null})).not.toHaveBeenCalled();
     });
 });

--- a/ui/src/app/shared/utils.ts
+++ b/ui/src/app/shared/utils.ts
@@ -1,3 +1,4 @@
+import {NavigationApi} from 'argo-ui';
 import {useCallback, useSyncExternalStore} from 'react';
 import type {CSSProperties} from 'react';
 import {AuthSettings, Cluster, UserInfo} from './models';
@@ -208,4 +209,44 @@ export function isSSOConfigured(userInfo: UserInfo | null | undefined, authSetti
     const hasDexConnectors = (authSettings.dexConfig?.connectors?.length ?? 0) > 0;
     const hasOidcConfig = !!authSettings.oidcConfig;
     return isExternalIssuer && (hasDexConnectors || hasOidcConfig);
+}
+
+/**
+ * Checks whether merging the given query parameters into a search string would change it, following
+ * how NavigationApi.goto merges them.
+ */
+function queryParamsChanged(search: string, params: {[name: string]: any}): boolean {
+    const current = new URLSearchParams(search);
+    const next = new URLSearchParams(search);
+    for (const [name, value] of Object.entries(params)) {
+        next.delete(name);
+        if (value === undefined || value === null) {
+            continue;
+        }
+        if (value instanceof Array) {
+            for (const item of value) {
+                next.append(name, item);
+            }
+        } else {
+            next.set(name, value);
+        }
+    }
+    // goto moves the parameters it sets to the end, which is not a real change.
+    current.sort();
+    next.sort();
+    return next.toString() !== current.toString();
+}
+
+/**
+ * Replaces the current URL with the given query parameters, unless they leave it unchanged. Filters
+ * report their state up when they mount, so a remount would otherwise write the same query string
+ * once per filter. Browsers rate limit history updates and throw once the cap is hit.
+ * @param navigation - The navigation API to replace the URL with
+ * @param params - The query parameters to merge into the current URL
+ */
+export function gotoIfQueryChanged(navigation: NavigationApi, params: {[name: string]: any}): void {
+    if (!queryParamsChanged(window.location.search, params)) {
+        return;
+    }
+    navigation.goto('.', params, {replace: true});
 }


### PR DESCRIPTION
While fixing a bug for #29242 I ran into the UI crashing with a SecurityError after toggling a filter a few times. It turned out to be a pre-existing bug with an open issue, so I am submitting it separately: a pre-follow-up to #29242 and a fix for #13156.

Every filter in the sidebar reports its selection up when it mounts, and each report writes the query string. A remount therefore produced identical history.replaceState calls, and WebKit throws once the cap is hit.

Any repeated remount of the list crosses the limit within seconds and replaces the UI with the error screen. With this change only real filter changes write the URL.

Fixes #13156

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [X] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [X] Does this PR require documentation updates?
* [X] I've updated documentation as required by this PR.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [X] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [X] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [X] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [X] Optional. My organization is added to USERS.md.
* [X] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).
