### PR TITLE
fix(ui): correct Pod kind filter count in resource filter sidebar (#29684)

### DIFF
--- a/ui/src/app/applications/components/application-details/application-resource-filter.test.ts
+++ b/ui/src/app/applications/components/application-details/application-resource-filter.test.ts
@@ -1,4 +1,5 @@
-import {getEffectiveResourceFilter} from './application-resource-filter';
+import * as models from '../../../shared/models';
+import {getEffectiveResourceFilter, getKindResourceCount} from './application-resource-filter';
 
 test('ApplicationSet ignores kind filters when applying resource filters', () => {
     expect(getEffectiveResourceFilter(false, ['kind:Deployment', 'sync:OutOfSync'])).toEqual(['sync:OutOfSync']);
@@ -6,4 +7,15 @@ test('ApplicationSet ignores kind filters when applying resource filters', () =>
 
 test('Application still applies kind filters', () => {
     expect(getEffectiveResourceFilter(true, ['kind:Deployment', 'sync:OutOfSync'])).toEqual(['kind:Deployment', 'sync:OutOfSync']);
+});
+
+test('Kind filter count matches the number of resources of that kind', () => {
+    const nodes: models.ResourceStatus[] = [
+        {kind: 'Pod', group: '', version: 'v1', namespace: 'default', name: 'pod-1', status: 'Synced', health: {status: 'Healthy', message: ''}},
+        {kind: 'Deployment', group: 'apps', version: 'v1', namespace: 'default', name: 'deploy-1', status: 'Synced', health: {status: 'Healthy', message: ''}}
+    ];
+
+    expect(getKindResourceCount(nodes, 'Pod')).toBe(1);
+    expect(getKindResourceCount(nodes, 'Deployment')).toBe(1);
+    expect(getKindResourceCount(nodes, 'Service')).toBe(0);
 });

--- a/ui/src/app/applications/components/application-details/application-resource-filter.tsx
+++ b/ui/src/app/applications/components/application-details/application-resource-filter.tsx
@@ -22,6 +22,10 @@ export function getEffectiveResourceFilter(isApplication: boolean, resourceFilte
     return isApplication ? resourceFilter || [] : withoutKindResourceFilters(resourceFilter);
 }
 
+export function getKindResourceCount(resourceNodes: models.ResourceStatus[], kind: string): number {
+    return resourceNodes.filter(res => res.kind === kind).length;
+}
+
 export interface FiltersProps {
     children?: React.ReactNode;
     pref: AppDetailsPreferences;
@@ -127,7 +131,7 @@ export const Filters = (props: FiltersProps) => {
             case 'Health':
                 return props.resourceNodes.filter(res => res.health?.status === HealthStatuses[label]).length;
             case 'Kind':
-                return props.resourceNodes.reduce((count, res) => (res.group && label === 'Pod' ? res.group.length : res.kind === label ? count + 1 : count), 0);
+                return getKindResourceCount(props.resourceNodes, label);
             default:
                 return 0;
         }


### PR DESCRIPTION
## What does this PR do?

Fixes the resource filter sidebar badge count for the `Pod` kind, which shows an incorrect number (e.g. "Pod 4" when only one Pod resource exists).

Fixes #29684

## Why is this needed?

The `Kind` filter count in the resource filter sidebar used a broken reducer that treated a resource's API `group` string as if it were a collection of pods. For any resource with a non-empty API group (e.g. a `Deployment` with group `apps`), selecting `Pod` replaced the running count with the length of that group string (`"apps".length === 4`), producing an arbitrary badge count unrelated to the number of Pods.

## How does this PR fix it?

Replaces the broken reducer with a simple count of resources whose `kind` matches the selected kind, consistent with how every other kind is counted. The counting logic is extracted into an exported `getKindResourceCount` helper so it can be unit tested.

## Notes for reviewers

- Added a unit test covering `Pod`, `Deployment`, and an absent kind. The `Pod` assertion fails before this change (returns `4` instead of `1`) and passes after.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes. (b) this is a bug fix.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. (UI-only change)
* [x] Does this PR require documentation updates? No.
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).
