### PR TITLE
chore(release): fix update-supported-version.sh script to handle k3s 1.37-rc3 tag

### DIFF
--- a/hack/update-supported-versions.sh
+++ b/hack/update-supported-versions.sh
@@ -16,7 +16,7 @@ for _ in {1..3}; do
     (.["k3s-version"] // (.k3s | map(.version))) |
     .[]' .github/workflows/ci-build.yaml | \
     jq --arg argocd_version "$argocd_version" --raw-input --slurp --raw-output \
-    'split("\n")[:-1] | map(sub("\\.[0-9]+$"; "")) | join(", ") | "| \($argocd_version) | \(.) |"')
+    'split("\n")[:-1] | map(sub("\\.[0-9]+(-.+)?$"; "")) | join(", ") | "| \($argocd_version) | \(.) |"')
   out+="$line\n"
 
 


### PR DESCRIPTION
This PR fixes the script which is currently producing a bogus kubernetes version "v1.37.0-rc3" for kubernetes 1.37. Now it strips any version string extension (like -rcN) which
related to k3s and not to k8s.

The script changes only one was tested on my development workstation.

Fixes: #29690


<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
