### PR TITLE
fix(ui): manifest viewer jumpiness (#29691)

### DIFF
--- a/ui/src/app/shared/components/monaco-apply-input.test.ts
+++ b/ui/src/app/shared/components/monaco-apply-input.test.ts
@@ -1,0 +1,109 @@
+import type * as monacoEditor from 'monaco-editor';
+import {applyEditorInput, EditorInput, MonacoModelFactory} from './monaco-apply-input';
+
+function createFakeModel(initialText: string, languageId = 'yaml') {
+    const model = {
+        text: initialText,
+        languageId,
+        setValue: jest.fn((value: string) => {
+            model.text = value;
+        }),
+        getLanguageId: jest.fn(() => model.languageId),
+        getLineCount: jest.fn(() => model.text.split('\n').length),
+        dispose: jest.fn()
+    };
+    return model;
+}
+
+function createFakeEditor(model: ReturnType<typeof createFakeModel> | null) {
+    const viewState = {scroll: 42};
+    let currentModel = model as unknown as monacoEditor.editor.ITextModel | null;
+    const editor = {
+        saveViewState: jest.fn(() => viewState as unknown as monacoEditor.editor.ICodeEditorViewState),
+        restoreViewState: jest.fn(),
+        getModel: jest.fn(() => currentModel),
+        setModel: jest.fn((next: monacoEditor.editor.ITextModel | null) => {
+            currentModel = next;
+        })
+    };
+    return {editor: editor as unknown as monacoEditor.editor.IStandaloneCodeEditor, mocks: editor, viewState};
+}
+
+function createFakeMonaco(created: ReturnType<typeof createFakeModel>[]) {
+    const monaco: MonacoModelFactory = {
+        editor: {
+            createModel: jest.fn((value: string, language?: string) => {
+                const model = createFakeModel(value, language);
+                created.push(model);
+                return model as unknown as monacoEditor.editor.ITextModel;
+            })
+        }
+    };
+    return monaco;
+}
+
+describe('applyEditorInput', () => {
+    const prev: EditorInput = {text: 'apiVersion: v1\nkind: ConfigMap\n', language: 'yaml'};
+
+    test('text change updates the same model and restores view state without setModel', () => {
+        const model = createFakeModel(prev.text, 'yaml');
+        const {editor, mocks, viewState} = createFakeEditor(model);
+        const created: ReturnType<typeof createFakeModel>[] = [];
+        const monaco = createFakeMonaco(created);
+        const next: EditorInput = {text: 'apiVersion: v1\nkind: ConfigMap\nmetadata:\n  annotations:\n    tick: "1"\n', language: 'yaml'};
+
+        applyEditorInput(monaco, editor, prev, next);
+
+        expect(model.setValue).toHaveBeenCalledWith(next.text);
+        expect(mocks.setModel).not.toHaveBeenCalled();
+        expect(monaco.editor.createModel).not.toHaveBeenCalled();
+        expect(mocks.saveViewState).toHaveBeenCalled();
+        expect(mocks.restoreViewState).toHaveBeenCalledWith(viewState);
+        expect(model.dispose).not.toHaveBeenCalled();
+        expect(mocks.saveViewState.mock.invocationCallOrder[0]).toBeLessThan(model.setValue.mock.invocationCallOrder[0]);
+        expect(model.setValue.mock.invocationCallOrder[0]).toBeLessThan(mocks.restoreViewState.mock.invocationCallOrder[0]);
+    });
+
+    test('unchanged input is a no-op', () => {
+        const model = createFakeModel(prev.text, 'yaml');
+        const {editor, mocks} = createFakeEditor(model);
+        const monaco = createFakeMonaco([]);
+
+        applyEditorInput(monaco, editor, prev, {...prev});
+
+        expect(model.setValue).not.toHaveBeenCalled();
+        expect(mocks.setModel).not.toHaveBeenCalled();
+        expect(mocks.saveViewState).not.toHaveBeenCalled();
+        expect(mocks.restoreViewState).not.toHaveBeenCalled();
+    });
+
+    test('language change replaces the model, disposes the old one, and restores view state', () => {
+        const model = createFakeModel(prev.text, 'yaml');
+        const {editor, mocks, viewState} = createFakeEditor(model);
+        const created: ReturnType<typeof createFakeModel>[] = [];
+        const monaco = createFakeMonaco(created);
+        const next: EditorInput = {text: '{"kind":"ConfigMap"}', language: 'json'};
+
+        applyEditorInput(monaco, editor, prev, next);
+
+        expect(model.setValue).not.toHaveBeenCalled();
+        expect(monaco.editor.createModel).toHaveBeenCalledWith(next.text, 'json');
+        expect(mocks.setModel).toHaveBeenCalledWith(created[0]);
+        expect(model.dispose).toHaveBeenCalled();
+        expect(mocks.restoreViewState).toHaveBeenCalledWith(viewState);
+        expect(mocks.saveViewState.mock.invocationCallOrder[0]).toBeLessThan(mocks.setModel.mock.invocationCallOrder[0]);
+        expect(mocks.setModel.mock.invocationCallOrder[0]).toBeLessThan(mocks.restoreViewState.mock.invocationCallOrder[0]);
+    });
+
+    test('discards in-progress buffer text in favor of the incoming cluster YAML', () => {
+        const model = createFakeModel('user was typing this and has not saved');
+        const {editor} = createFakeEditor(model);
+        const monaco = createFakeMonaco([]);
+        const next: EditorInput = {text: 'kind: ConfigMap\n', language: 'yaml'};
+
+        applyEditorInput(monaco, editor, prev, next);
+
+        expect(model.setValue).toHaveBeenCalledWith(next.text);
+        expect(model.text).toBe(next.text);
+    });
+});

--- a/ui/src/app/shared/components/monaco-apply-input.ts
+++ b/ui/src/app/shared/components/monaco-apply-input.ts
@@ -1,0 +1,40 @@
+import type * as monacoEditor from 'monaco-editor';
+
+export interface EditorInput {
+    text: string;
+    language?: string;
+}
+
+export interface MonacoModelFactory {
+    editor: {
+        createModel(value: string, language?: string): monacoEditor.editor.ITextModel;
+    };
+}
+
+export function isEqualInput(first?: EditorInput, second?: EditorInput) {
+    return first && second && first.text === second.text && (first.language || '') === (second.language || '');
+}
+
+// Update an existing Monaco editor's document without treating a live-text refresh as a new file.
+// Replacing the model via setModel resets scroll; setValue + restoreViewState keeps the view put.
+export function applyEditorInput(monaco: MonacoModelFactory, editor: monacoEditor.editor.IStandaloneCodeEditor, prev: EditorInput | undefined, next: EditorInput): void {
+    if (isEqualInput(prev, next)) {
+        return;
+    }
+
+    const viewState = editor.saveViewState();
+    const model = editor.getModel();
+    const languageChanged = (prev?.language || '') !== (next.language || '');
+
+    if (model && !languageChanged) {
+        model.setValue(next.text);
+    } else {
+        const newModel = monaco.editor.createModel(next.text, next.language);
+        editor.setModel(newModel);
+        model?.dispose();
+    }
+
+    if (viewState) {
+        editor.restoreViewState(viewState);
+    }
+}

--- a/ui/src/app/shared/components/monaco-editor.tsx
+++ b/ui/src/app/shared/components/monaco-editor.tsx
@@ -1,13 +1,11 @@
 import * as React from 'react';
 
 import type * as monacoEditor from 'monaco-editor';
+import {applyEditorInput, EditorInput} from './monaco-apply-input';
 import {services} from '../services';
 import {getTheme, createSystemThemeListener} from '../utils';
 
-export interface EditorInput {
-    text: string;
-    language?: string;
-}
+export type {EditorInput};
 
 export interface MonacoProps {
     minHeight?: number;
@@ -19,18 +17,19 @@ export interface MonacoProps {
     };
 }
 
-function IsEqualInput(first?: EditorInput, second?: EditorInput) {
-    return first && second && first.text === second.text && (first.language || '') === (second.language || '');
-}
-
 const DEFAULT_LINE_HEIGHT = 18;
+
+function heightForLineCount(lineCount: number, minHeight?: number) {
+    const newHeight = lineCount * DEFAULT_LINE_HEIGHT + 50;
+    return Math.max(minHeight || 0, newHeight > window.innerHeight * 0.95 ? window.innerHeight * 0.95 : newHeight);
+}
 
 const MonacoEditorLazy = React.lazy(() =>
     import('monaco-editor').then(monaco => {
         const Component = (props: MonacoProps) => {
             const [height, setHeight] = React.useState(0);
             const [theme, setTheme] = React.useState('dark');
-            const editorApiRef = React.useRef<monacoEditor.editor.IEditor | null>(null);
+            const editorApiRef = React.useRef<monacoEditor.editor.IStandaloneCodeEditor | null>(null);
             const containerRef = React.useRef<HTMLElement | null>(null);
 
             React.useEffect(() => {
@@ -91,13 +90,15 @@ const MonacoEditorLazy = React.lazy(() =>
                         if (el) {
                             containerRef.current = el;
                             const container = el as {
-                                editorApi?: monacoEditor.editor.IEditor;
+                                editorApi?: monacoEditor.editor.IStandaloneCodeEditor;
                                 prevEditorInput?: EditorInput;
                             };
                             if (props.editor) {
                                 if (!container.editorApi) {
                                     const editor = monaco.editor.create(el, {
                                         ...props.editor.options,
+                                        value: props.editor.input.text,
+                                        language: props.editor.input.language,
                                         scrollBeyondLastLine: props.vScrollBar,
                                         scrollbar: {
                                             alwaysConsumeMouseWheel: false,
@@ -106,18 +107,15 @@ const MonacoEditorLazy = React.lazy(() =>
                                     });
 
                                     container.editorApi = editor;
-                                    editorApiRef.current = editor;
-                                }
-
-                                const model = monaco.editor.createModel(props.editor.input.text, props.editor.input.language);
-                                const lineCount = model.getLineCount();
-                                const newHeight = lineCount * DEFAULT_LINE_HEIGHT + 50;
-                                setHeight(newHeight > window.innerHeight * 0.95 ? window.innerHeight * 0.95 : newHeight);
-
-                                if (!IsEqualInput(container.prevEditorInput, props.editor.input)) {
                                     container.prevEditorInput = props.editor.input;
-                                    container.editorApi.setModel(model);
+                                    editorApiRef.current = editor;
+                                } else {
+                                    applyEditorInput(monaco, container.editorApi, container.prevEditorInput, props.editor.input);
+                                    container.prevEditorInput = props.editor.input;
                                 }
+
+                                const lineCount = container.editorApi.getModel()?.getLineCount() ?? 0;
+                                setHeight(heightForLineCount(lineCount, props.minHeight));
                                 container.editorApi.updateOptions(props.editor.options);
                                 container.editorApi.layout();
                                 if (props.editor.getApi) {


### PR DESCRIPTION
It seems we're basically misusing Monaco. This change uses Monaco's API to update the contents and retain the scroll state instead of replacing the whole editor, which forces a scroll to the top of the document.

This PR doesn't fix the problem of edits disappearing on updates. One fix at a time.

Fixes #29691

Before:


https://github.com/user-attachments/assets/dfcc9b3b-fda6-4671-ad8b-a072792cfc67

After:


https://github.com/user-attachments/assets/93033b36-9c3b-4690-b662-bedf3af7364b

