### PR TITLE
fix(ui): manifest editor jumpiness (#29691)

### DIFF
--- a/ui/src/app/shared/components/monaco-apply-input.test.ts
+++ b/ui/src/app/shared/components/monaco-apply-input.test.ts
@@ -1,0 +1,109 @@
+import type * as monacoEditor from 'monaco-editor';
+import {applyEditorInput, EditorInput, MonacoModelFactory} from './monaco-apply-input';
+
+function createFakeModel(initialText: string, languageId = 'yaml') {
+    const model = {
+        text: initialText,
+        languageId,
+        setValue: jest.fn((value: string) => {
+            model.text = value;
+        }),
+        getLanguageId: jest.fn(() => model.languageId),
+        getLineCount: jest.fn(() => model.text.split('\n').length),
+        dispose: jest.fn()
+    };
+    return model;
+}
+
+function createFakeEditor(model: ReturnType<typeof createFakeModel> | null) {
+    const viewState = {scroll: 42};
+    let currentModel = model as unknown as monacoEditor.editor.ITextModel | null;
+    const editor = {
+        saveViewState: jest.fn(() => viewState as unknown as monacoEditor.editor.ICodeEditorViewState),
+        restoreViewState: jest.fn(),
+        getModel: jest.fn(() => currentModel),
+        setModel: jest.fn((next: monacoEditor.editor.ITextModel | null) => {
+            currentModel = next;
+        })
+    };
+    return {editor: editor as unknown as monacoEditor.editor.IStandaloneCodeEditor, mocks: editor, viewState};
+}
+
+function createFakeMonaco(created: ReturnType<typeof createFakeModel>[]) {
+    const monaco: MonacoModelFactory = {
+        editor: {
+            createModel: jest.fn((value: string, language?: string) => {
+                const model = createFakeModel(value, language);
+                created.push(model);
+                return model as unknown as monacoEditor.editor.ITextModel;
+            })
+        }
+    };
+    return monaco;
+}
+
+describe('applyEditorInput', () => {
+    const prev: EditorInput = {text: 'apiVersion: v1\nkind: ConfigMap\n', language: 'yaml'};
+
+    test('text change updates the same model and restores view state without setModel', () => {
+        const model = createFakeModel(prev.text, 'yaml');
+        const {editor, mocks, viewState} = createFakeEditor(model);
+        const created: ReturnType<typeof createFakeModel>[] = [];
+        const monaco = createFakeMonaco(created);
+        const next: EditorInput = {text: 'apiVersion: v1\nkind: ConfigMap\nmetadata:\n  annotations:\n    tick: "1"\n', language: 'yaml'};
+
+        applyEditorInput(monaco, editor, prev, next);
+
+        expect(model.setValue).toHaveBeenCalledWith(next.text);
+        expect(mocks.setModel).not.toHaveBeenCalled();
+        expect(monaco.editor.createModel).not.toHaveBeenCalled();
+        expect(mocks.saveViewState).toHaveBeenCalled();
+        expect(mocks.restoreViewState).toHaveBeenCalledWith(viewState);
+        expect(model.dispose).not.toHaveBeenCalled();
+        expect(mocks.saveViewState.mock.invocationCallOrder[0]).toBeLessThan(model.setValue.mock.invocationCallOrder[0]);
+        expect(model.setValue.mock.invocationCallOrder[0]).toBeLessThan(mocks.restoreViewState.mock.invocationCallOrder[0]);
+    });
+
+    test('unchanged input is a no-op', () => {
+        const model = createFakeModel(prev.text, 'yaml');
+        const {editor, mocks} = createFakeEditor(model);
+        const monaco = createFakeMonaco([]);
+
+        applyEditorInput(monaco, editor, prev, {...prev});
+
+        expect(model.setValue).not.toHaveBeenCalled();
+        expect(mocks.setModel).not.toHaveBeenCalled();
+        expect(mocks.saveViewState).not.toHaveBeenCalled();
+        expect(mocks.restoreViewState).not.toHaveBeenCalled();
+    });
+
+    test('language change replaces the model, disposes the old one, and restores view state', () => {
+        const model = createFakeModel(prev.text, 'yaml');
+        const {editor, mocks, viewState} = createFakeEditor(model);
+        const created: ReturnType<typeof createFakeModel>[] = [];
+        const monaco = createFakeMonaco(created);
+        const next: EditorInput = {text: '{"kind":"ConfigMap"}', language: 'json'};
+
+        applyEditorInput(monaco, editor, prev, next);
+
+        expect(model.setValue).not.toHaveBeenCalled();
+        expect(monaco.editor.createModel).toHaveBeenCalledWith(next.text, 'json');
+        expect(mocks.setModel).toHaveBeenCalledWith(created[0]);
+        expect(model.dispose).toHaveBeenCalled();
+        expect(mocks.restoreViewState).toHaveBeenCalledWith(viewState);
+        expect(mocks.saveViewState.mock.invocationCallOrder[0]).toBeLessThan(mocks.setModel.mock.invocationCallOrder[0]);
+        expect(mocks.setModel.mock.invocationCallOrder[0]).toBeLessThan(mocks.restoreViewState.mock.invocationCallOrder[0]);
+    });
+
+    test('discards in-progress buffer text in favor of the incoming cluster YAML', () => {
+        const model = createFakeModel('user was typing this and has not saved');
+        const {editor} = createFakeEditor(model);
+        const monaco = createFakeMonaco([]);
+        const next: EditorInput = {text: 'kind: ConfigMap\n', language: 'yaml'};
+
+        applyEditorInput(monaco, editor, prev, next);
+
+        expect(model.setValue).toHaveBeenCalledWith(next.text);
+        expect(model.text).toBe(next.text);
+    });
+});

--- a/ui/src/app/shared/components/monaco-apply-input.test.ts
+++ b/ui/src/app/shared/components/monaco-apply-input.test.ts
@@ -1,12 +1,19 @@
 import type * as monacoEditor from 'monaco-editor';
 import {applyEditorInput, EditorInput, MonacoModelFactory} from './monaco-apply-input';
 
+const FULL_RANGE = {startLineNumber: 1, startColumn: 1, endLineNumber: 99, endColumn: 1};
+
 function createFakeModel(initialText: string, languageId = 'yaml') {
     const model = {
         text: initialText,
         languageId,
         setValue: jest.fn((value: string) => {
             model.text = value;
+        }),
+        getFullModelRange: jest.fn(() => FULL_RANGE as unknown as monacoEditor.Range),
+        pushEditOperations: jest.fn((_before: unknown, edits: {text: string}[]) => {
+            model.text = edits[0].text;
+            return null;
         }),
         getLanguageId: jest.fn(() => model.languageId),
         getLineCount: jest.fn(() => model.text.split('\n').length),
@@ -24,7 +31,9 @@ function createFakeEditor(model: ReturnType<typeof createFakeModel> | null) {
         getModel: jest.fn(() => currentModel),
         setModel: jest.fn((next: monacoEditor.editor.ITextModel | null) => {
             currentModel = next;
-        })
+        }),
+        // Monaco refuses editor-level edits while readOnly is set, so this must never be used.
+        executeEdits: jest.fn(() => false)
     };
     return {editor: editor as unknown as monacoEditor.editor.IStandaloneCodeEditor, mocks: editor, viewState};
 }
@@ -45,7 +54,7 @@ function createFakeMonaco(created: ReturnType<typeof createFakeModel>[]) {
 describe('applyEditorInput', () => {
     const prev: EditorInput = {text: 'apiVersion: v1\nkind: ConfigMap\n', language: 'yaml'};
 
-    test('text change updates the same model and restores view state without setModel', () => {
+    test('text change edits the same model in place and restores view state', () => {
         const model = createFakeModel(prev.text, 'yaml');
         const {editor, mocks, viewState} = createFakeEditor(model);
         const created: ReturnType<typeof createFakeModel>[] = [];
@@ -54,14 +63,28 @@ describe('applyEditorInput', () => {
 
         applyEditorInput(monaco, editor, prev, next);
 
-        expect(model.setValue).toHaveBeenCalledWith(next.text);
+        expect(model.pushEditOperations).toHaveBeenCalledWith([], [{range: FULL_RANGE, text: next.text}], expect.any(Function));
+        expect(model.text).toBe(next.text);
         expect(mocks.setModel).not.toHaveBeenCalled();
         expect(monaco.editor.createModel).not.toHaveBeenCalled();
         expect(mocks.saveViewState).toHaveBeenCalled();
         expect(mocks.restoreViewState).toHaveBeenCalledWith(viewState);
         expect(model.dispose).not.toHaveBeenCalled();
-        expect(mocks.saveViewState.mock.invocationCallOrder[0]).toBeLessThan(model.setValue.mock.invocationCallOrder[0]);
-        expect(model.setValue.mock.invocationCallOrder[0]).toBeLessThan(mocks.restoreViewState.mock.invocationCallOrder[0]);
+        expect(mocks.saveViewState.mock.invocationCallOrder[0]).toBeLessThan(model.pushEditOperations.mock.invocationCallOrder[0]);
+        expect(model.pushEditOperations.mock.invocationCallOrder[0]).toBeLessThan(mocks.restoreViewState.mock.invocationCallOrder[0]);
+    });
+
+    test('updates the document without setValue or editor-level edits, which readOnly would block', () => {
+        const model = createFakeModel(prev.text, 'yaml');
+        const {editor, mocks} = createFakeEditor(model);
+        const monaco = createFakeMonaco([]);
+        const next: EditorInput = {text: 'kind: Secret\n', language: 'yaml'};
+
+        applyEditorInput(monaco, editor, prev, next);
+
+        expect(model.setValue).not.toHaveBeenCalled();
+        expect(mocks.executeEdits).not.toHaveBeenCalled();
+        expect(model.text).toBe(next.text);
     });
 
     test('unchanged input is a no-op', () => {
@@ -71,7 +94,7 @@ describe('applyEditorInput', () => {
 
         applyEditorInput(monaco, editor, prev, {...prev});
 
-        expect(model.setValue).not.toHaveBeenCalled();
+        expect(model.pushEditOperations).not.toHaveBeenCalled();
         expect(mocks.setModel).not.toHaveBeenCalled();
         expect(mocks.saveViewState).not.toHaveBeenCalled();
         expect(mocks.restoreViewState).not.toHaveBeenCalled();
@@ -86,7 +109,7 @@ describe('applyEditorInput', () => {
 
         applyEditorInput(monaco, editor, prev, next);
 
-        expect(model.setValue).not.toHaveBeenCalled();
+        expect(model.pushEditOperations).not.toHaveBeenCalled();
         expect(monaco.editor.createModel).toHaveBeenCalledWith(next.text, 'json');
         expect(mocks.setModel).toHaveBeenCalledWith(created[0]);
         expect(model.dispose).toHaveBeenCalled();
@@ -103,7 +126,7 @@ describe('applyEditorInput', () => {
 
         applyEditorInput(monaco, editor, prev, next);
 
-        expect(model.setValue).toHaveBeenCalledWith(next.text);
+        expect(model.pushEditOperations).toHaveBeenCalledWith([], [{range: FULL_RANGE, text: next.text}], expect.any(Function));
         expect(model.text).toBe(next.text);
     });
 });

--- a/ui/src/app/shared/components/monaco-apply-input.test.ts
+++ b/ui/src/app/shared/components/monaco-apply-input.test.ts
@@ -54,7 +54,7 @@ function createFakeMonaco(created: ReturnType<typeof createFakeModel>[]) {
 describe('applyEditorInput', () => {
     const prev: EditorInput = {text: 'apiVersion: v1\nkind: ConfigMap\n', language: 'yaml'};
 
-    test('text change edits the same model in place and restores view state', () => {
+    test('text change replaces the same model and restores view state', () => {
         const model = createFakeModel(prev.text, 'yaml');
         const {editor, mocks, viewState} = createFakeEditor(model);
         const created: ReturnType<typeof createFakeModel>[] = [];
@@ -63,18 +63,18 @@ describe('applyEditorInput', () => {
 
         applyEditorInput(monaco, editor, prev, next);
 
-        expect(model.pushEditOperations).toHaveBeenCalledWith([], [{range: FULL_RANGE, text: next.text}], expect.any(Function));
+        expect(model.setValue).toHaveBeenCalledWith(next.text);
         expect(model.text).toBe(next.text);
         expect(mocks.setModel).not.toHaveBeenCalled();
         expect(monaco.editor.createModel).not.toHaveBeenCalled();
         expect(mocks.saveViewState).toHaveBeenCalled();
         expect(mocks.restoreViewState).toHaveBeenCalledWith(viewState);
         expect(model.dispose).not.toHaveBeenCalled();
-        expect(mocks.saveViewState.mock.invocationCallOrder[0]).toBeLessThan(model.pushEditOperations.mock.invocationCallOrder[0]);
-        expect(model.pushEditOperations.mock.invocationCallOrder[0]).toBeLessThan(mocks.restoreViewState.mock.invocationCallOrder[0]);
+        expect(mocks.saveViewState.mock.invocationCallOrder[0]).toBeLessThan(model.setValue.mock.invocationCallOrder[0]);
+        expect(model.setValue.mock.invocationCallOrder[0]).toBeLessThan(mocks.restoreViewState.mock.invocationCallOrder[0]);
     });
 
-    test('updates the document without setValue or editor-level edits, which readOnly would block', () => {
+    test('refreshes cannot be undone back into the buffer and saved over the cluster', () => {
         const model = createFakeModel(prev.text, 'yaml');
         const {editor, mocks} = createFakeEditor(model);
         const monaco = createFakeMonaco([]);
@@ -82,7 +82,10 @@ describe('applyEditorInput', () => {
 
         applyEditorInput(monaco, editor, prev, next);
 
-        expect(model.setValue).not.toHaveBeenCalled();
+        // Only setValue drops the model's edit history. An edit operation would leave every stale
+        // refresh on the undo stack, reachable with a ctrl-z once the user enters edit mode.
+        expect(model.pushEditOperations).not.toHaveBeenCalled();
+        // executeEdits would also be a no-op, because the manifest view is readOnly until edited.
         expect(mocks.executeEdits).not.toHaveBeenCalled();
         expect(model.text).toBe(next.text);
     });
@@ -94,7 +97,7 @@ describe('applyEditorInput', () => {
 
         applyEditorInput(monaco, editor, prev, {...prev});
 
-        expect(model.pushEditOperations).not.toHaveBeenCalled();
+        expect(model.setValue).not.toHaveBeenCalled();
         expect(mocks.setModel).not.toHaveBeenCalled();
         expect(mocks.saveViewState).not.toHaveBeenCalled();
         expect(mocks.restoreViewState).not.toHaveBeenCalled();
@@ -109,7 +112,7 @@ describe('applyEditorInput', () => {
 
         applyEditorInput(monaco, editor, prev, next);
 
-        expect(model.pushEditOperations).not.toHaveBeenCalled();
+        expect(model.setValue).not.toHaveBeenCalled();
         expect(monaco.editor.createModel).toHaveBeenCalledWith(next.text, 'json');
         expect(mocks.setModel).toHaveBeenCalledWith(created[0]);
         expect(model.dispose).toHaveBeenCalled();
@@ -126,7 +129,7 @@ describe('applyEditorInput', () => {
 
         applyEditorInput(monaco, editor, prev, next);
 
-        expect(model.pushEditOperations).toHaveBeenCalledWith([], [{range: FULL_RANGE, text: next.text}], expect.any(Function));
+        expect(model.setValue).toHaveBeenCalledWith(next.text);
         expect(model.text).toBe(next.text);
     });
 });

--- a/ui/src/app/shared/components/monaco-apply-input.ts
+++ b/ui/src/app/shared/components/monaco-apply-input.ts
@@ -15,8 +15,14 @@ export function isEqualInput(first?: EditorInput, second?: EditorInput) {
     return first && second && first.text === second.text && (first.language || '') === (second.language || '');
 }
 
+// Replace a document's contents in place. setValue would reset the view and scroll the editor back to
+// the top, and editor.executeEdits is a no-op while the editor is readOnly, so edit the model itself.
+export function replaceModelText(model: monacoEditor.editor.ITextModel, text: string): void {
+    model.pushEditOperations([], [{range: model.getFullModelRange(), text}], () => null);
+}
+
 // Update an existing Monaco editor's document without treating a live-text refresh as a new file.
-// Replacing the model via setModel resets scroll; setValue + restoreViewState keeps the view put.
+// Only the incoming props are compared, never the buffer, so text the user is still typing survives.
 export function applyEditorInput(monaco: MonacoModelFactory, editor: monacoEditor.editor.IStandaloneCodeEditor, prev: EditorInput | undefined, next: EditorInput): void {
     if (isEqualInput(prev, next)) {
         return;
@@ -27,7 +33,7 @@ export function applyEditorInput(monaco: MonacoModelFactory, editor: monacoEdito
     const languageChanged = (prev?.language || '') !== (next.language || '');
 
     if (model && !languageChanged) {
-        model.setValue(next.text);
+        replaceModelText(model, next.text);
     } else {
         const newModel = monaco.editor.createModel(next.text, next.language);
         editor.setModel(newModel);

--- a/ui/src/app/shared/components/monaco-apply-input.ts
+++ b/ui/src/app/shared/components/monaco-apply-input.ts
@@ -1,0 +1,40 @@
+import type * as monacoEditor from 'monaco-editor';
+
+export interface EditorInput {
+    text: string;
+    language?: string;
+}
+
+export interface MonacoModelFactory {
+    editor: {
+        createModel(value: string, language?: string): monacoEditor.editor.ITextModel;
+    };
+}
+
+export function isEqualInput(first?: EditorInput, second?: EditorInput) {
+    return first && second && first.text === second.text && (first.language || '') === (second.language || '');
+}
+
+// Update an existing Monaco editor's document without treating a live-text refresh as a new file.
+// Replacing the model via setModel resets scroll; setValue + restoreViewState keeps the view put.
+export function applyEditorInput(monaco: MonacoModelFactory, editor: monacoEditor.editor.IStandaloneCodeEditor, prev: EditorInput | undefined, next: EditorInput): void {
+    if (isEqualInput(prev, next)) {
+        return;
+    }
+
+    const viewState = editor.saveViewState();
+    const model = editor.getModel();
+    const languageChanged = (prev?.language || '') !== (next.language || '');
+
+    if (model && !languageChanged) {
+        model.setValue(next.text);
+    } else {
+        const newModel = monaco.editor.createModel(next.text, next.language);
+        editor.setModel(newModel);
+        model?.dispose();
+    }
+
+    if (viewState) {
+        editor.restoreViewState(viewState);
+    }
+}

--- a/ui/src/app/shared/components/monaco-apply-input.ts
+++ b/ui/src/app/shared/components/monaco-apply-input.ts
@@ -15,10 +15,15 @@ export function isEqualInput(first?: EditorInput, second?: EditorInput) {
     return first && second && first.text === second.text && (first.language || '') === (second.language || '');
 }
 
-// Replace a document's contents in place. setValue would reset the view and scroll the editor back to
-// the top, and editor.executeEdits is a no-op while the editor is readOnly, so edit the model itself.
+// Replace a document's contents with text the user must not be able to get back. setValue discards
+// the model's edit history, so undo cannot resurrect a stale refresh or an abandoned edit and save it
+// over the cluster. An edit operation would keep both on the undo stack. Callers are expected to
+// restore the view state afterwards, since setValue resets it.
+//
+// This deliberately does not go through editor.executeEdits, which does nothing while the editor is
+// readOnly, and the manifest view is readOnly whenever it is not being edited.
 export function replaceModelText(model: monacoEditor.editor.ITextModel, text: string): void {
-    model.pushEditOperations([], [{range: model.getFullModelRange(), text}], () => null);
+    model.setValue(text);
 }
 
 // Update an existing Monaco editor's document without treating a live-text refresh as a new file.

--- a/ui/src/app/shared/components/monaco-editor.tsx
+++ b/ui/src/app/shared/components/monaco-editor.tsx
@@ -1,13 +1,11 @@
 import * as React from 'react';
 
 import type * as monacoEditor from 'monaco-editor';
+import {applyEditorInput, EditorInput} from './monaco-apply-input';
 import {services} from '../services';
 import {getTheme, createSystemThemeListener} from '../utils';
 
-export interface EditorInput {
-    text: string;
-    language?: string;
-}
+export type {EditorInput};
 
 export interface MonacoProps {
     minHeight?: number;
@@ -19,18 +17,19 @@ export interface MonacoProps {
     };
 }
 
-function IsEqualInput(first?: EditorInput, second?: EditorInput) {
-    return first && second && first.text === second.text && (first.language || '') === (second.language || '');
-}
-
 const DEFAULT_LINE_HEIGHT = 18;
+
+function heightForLineCount(lineCount: number, minHeight?: number) {
+    const newHeight = lineCount * DEFAULT_LINE_HEIGHT + 50;
+    return Math.max(minHeight || 0, newHeight > window.innerHeight * 0.95 ? window.innerHeight * 0.95 : newHeight);
+}
 
 const MonacoEditorLazy = React.lazy(() =>
     import('monaco-editor').then(monaco => {
         const Component = (props: MonacoProps) => {
             const [height, setHeight] = React.useState(0);
             const [theme, setTheme] = React.useState('dark');
-            const editorApiRef = React.useRef<monacoEditor.editor.IEditor | null>(null);
+            const editorApiRef = React.useRef<monacoEditor.editor.IStandaloneCodeEditor | null>(null);
             const containerRef = React.useRef<HTMLElement | null>(null);
 
             React.useEffect(() => {
@@ -91,13 +90,15 @@ const MonacoEditorLazy = React.lazy(() =>
                         if (el) {
                             containerRef.current = el;
                             const container = el as {
-                                editorApi?: monacoEditor.editor.IEditor;
+                                editorApi?: monacoEditor.editor.IStandaloneCodeEditor;
                                 prevEditorInput?: EditorInput;
                             };
                             if (props.editor) {
                                 if (!container.editorApi) {
                                     const editor = monaco.editor.create(el, {
                                         ...props.editor.options,
+                                        value: props.editor.input.text,
+                                        language: props.editor.input.language,
                                         scrollBeyondLastLine: props.vScrollBar,
                                         scrollbar: {
                                             alwaysConsumeMouseWheel: false,
@@ -106,18 +107,15 @@ const MonacoEditorLazy = React.lazy(() =>
                                     });
 
                                     container.editorApi = editor;
-                                    editorApiRef.current = editor;
-                                }
-
-                                const model = monaco.editor.createModel(props.editor.input.text, props.editor.input.language);
-                                const lineCount = model.getLineCount();
-                                const newHeight = lineCount * DEFAULT_LINE_HEIGHT + 50;
-                                setHeight(newHeight > window.innerHeight * 0.95 ? window.innerHeight * 0.95 : newHeight);
-
-                                if (!IsEqualInput(container.prevEditorInput, props.editor.input)) {
                                     container.prevEditorInput = props.editor.input;
-                                    container.editorApi.setModel(model);
+                                    editorApiRef.current = editor;
+                                } else {
+                                    applyEditorInput(monaco, container.editorApi, container.prevEditorInput, props.editor.input);
+                                    container.prevEditorInput = props.editor.input;
                                 }
+
+                                const lineCount = container.editorApi.getModel()?.getLineCount() ?? 0;
+                                setHeight(heightForLineCount(lineCount, props.minHeight));
                                 container.editorApi.updateOptions(props.editor.options);
                                 container.editorApi.layout();
                                 if (props.editor.getApi) {

--- a/ui/src/app/shared/components/yaml-editor/resource-version.test.ts
+++ b/ui/src/app/shared/components/yaml-editor/resource-version.test.ts
@@ -1,0 +1,52 @@
+import {hasReachedResourceVersion, resourceVersionOf} from './resource-version';
+
+describe('resourceVersionOf', () => {
+    test('reads the resource version from a Kubernetes object', () => {
+        expect(resourceVersionOf({metadata: {resourceVersion: '42'}})).toBe('42');
+    });
+
+    test('returns null when there is nothing usable to compare against', () => {
+        expect(resourceVersionOf(undefined)).toBeNull();
+        expect(resourceVersionOf(null)).toBeNull();
+        expect(resourceVersionOf(true)).toBeNull();
+        expect(resourceVersionOf({})).toBeNull();
+        expect(resourceVersionOf({metadata: {}})).toBeNull();
+        expect(resourceVersionOf({metadata: {resourceVersion: ''}})).toBeNull();
+        expect(resourceVersionOf({spec: {replicas: 3}})).toBeNull();
+    });
+});
+
+describe('hasReachedResourceVersion', () => {
+    test('is reached at the exact version and at any later one', () => {
+        expect(hasReachedResourceVersion({metadata: {resourceVersion: '250'}}, '250')).toBe(true);
+        expect(hasReachedResourceVersion({metadata: {resourceVersion: '251'}}, '250')).toBe(true);
+        expect(hasReachedResourceVersion({metadata: {resourceVersion: '1000'}}, '250')).toBe(true);
+    });
+
+    test('is not reached while the live resource is older', () => {
+        expect(hasReachedResourceVersion({metadata: {resourceVersion: '249'}}, '250')).toBe(false);
+    });
+
+    test('orders by magnitude rather than by plain string order', () => {
+        expect(hasReachedResourceVersion({metadata: {resourceVersion: '1000'}}, '999')).toBe(true);
+        expect(hasReachedResourceVersion({metadata: {resourceVersion: '999'}}, '1000')).toBe(false);
+    });
+
+    test('stays exact for versions too large to be held by a JS number', () => {
+        // Both of these collapse to the same float, so parsing them as numbers would call the older
+        // live resource caught up.
+        expect(hasReachedResourceVersion({metadata: {resourceVersion: '9007199254740992'}}, '9007199254740993')).toBe(false);
+        expect(hasReachedResourceVersion({metadata: {resourceVersion: '9007199254740993'}}, '9007199254740992')).toBe(true);
+        expect(hasReachedResourceVersion({metadata: {resourceVersion: '2345678901234567890123456789012345678901'}}, '345678901234567890123456789012345678901')).toBe(true);
+        expect(hasReachedResourceVersion({metadata: {resourceVersion: '345678901234567890123456789012345678900'}}, '345678901234567890123456789012345678901')).toBe(false);
+    });
+
+    test('falls back to equality when a version is not an orderable integer', () => {
+        // Extension API servers may serve versions that cannot be ordered at all.
+        expect(hasReachedResourceVersion({metadata: {resourceVersion: 'opaque'}}, 'opaque')).toBe(true);
+        expect(hasReachedResourceVersion({metadata: {resourceVersion: 'opaque'}}, '250')).toBe(false);
+        expect(hasReachedResourceVersion({metadata: {resourceVersion: '250'}}, 'opaque')).toBe(false);
+        expect(hasReachedResourceVersion({metadata: {resourceVersion: '0250'}}, '250')).toBe(false);
+        expect(hasReachedResourceVersion({}, '250')).toBe(false);
+    });
+});

--- a/ui/src/app/shared/components/yaml-editor/resource-version.ts
+++ b/ui/src/app/shared/components/yaml-editor/resource-version.ts
@@ -1,0 +1,32 @@
+// A resource version that can be ordered: a decimal integer with no leading zero.
+const COMPARABLE_RESOURCE_VERSION = /^[1-9][0-9]*$/;
+
+export function resourceVersionOf(value: unknown): string | null {
+    const resourceVersion = (value as {metadata?: {resourceVersion?: string}})?.metadata?.resourceVersion;
+    return typeof resourceVersion === 'string' && resourceVersion !== '' ? resourceVersion : null;
+}
+
+// Whether the live resource is at least as new as the version a save returned.
+//
+// Kubernetes guarantees resource versions of a given resource type increase monotonically, so they
+// can be ordered. They are arbitrary bitsize integers though, so they are compared as strings by
+// length and then lexicographically, as the API concepts documentation prescribes. Parsing them as
+// numbers would silently lose precision past 2^53. Extension API servers may serve versions that are
+// not decimal integers at all; those can only be compared for equality, and the caller is expected to
+// stop waiting on its own rather than wait forever.
+export function hasReachedResourceVersion(live: unknown, target: string): boolean {
+    const current = resourceVersionOf(live);
+    if (!current) {
+        return false;
+    }
+    if (current === target) {
+        return true;
+    }
+    if (!COMPARABLE_RESOURCE_VERSION.test(current) || !COMPARABLE_RESOURCE_VERSION.test(target)) {
+        return false;
+    }
+    if (current.length !== target.length) {
+        return current.length > target.length;
+    }
+    return current > target;
+}

--- a/ui/src/app/shared/components/yaml-editor/yaml-editor.test.tsx
+++ b/ui/src/app/shared/components/yaml-editor/yaml-editor.test.tsx
@@ -1,0 +1,222 @@
+import * as React from 'react';
+import {act} from 'react';
+import {render as rtlRender, screen, fireEvent} from '@testing-library/react';
+import * as jsYaml from 'js-yaml';
+
+import {Context} from '../../context';
+import {dumpYaml} from './yaml-merge-patch';
+
+let lastMonacoText = '';
+const fakeModel = {
+    lines: '',
+    setValue: jest.fn((value: string) => {
+        fakeModel.lines = value;
+    }),
+    getFullModelRange: jest.fn(() => ({startLineNumber: 1, startColumn: 1, endLineNumber: 99, endColumn: 1})),
+    pushEditOperations: jest.fn((_before: unknown, edits: {text: string}[]) => {
+        fakeModel.lines = edits[0].text;
+        return null;
+    }),
+    getLinesContent: jest.fn(() => fakeModel.lines.split('\n'))
+};
+
+jest.mock('../monaco-editor', () => ({
+    MonacoEditor: (props: {editor?: {input: {text: string}; getApi?: (api: any) => void}}) => {
+        lastMonacoText = props.editor?.input.text ?? '';
+        props.editor?.getApi?.({getModel: () => fakeModel});
+        return React.createElement('div', {'data-testid': 'monaco'});
+    }
+}));
+
+import {YamlEditor} from './yaml-editor';
+
+const mockContext = {
+    history: {} as any,
+    popup: {} as any,
+    navigation: {} as any,
+    baseHref: '/',
+    notifications: {show: jest.fn()} as any
+};
+
+function renderEditor(element: React.ReactElement) {
+    return rtlRender(React.createElement(Context.Provider, {value: mockContext}, element));
+}
+
+const liveA = {
+    apiVersion: 'apps/v1',
+    kind: 'Deployment',
+    metadata: {name: 'guestbook-ui', resourceVersion: '100', annotations: {tick: '1'}},
+    spec: {replicas: 1}
+};
+
+const liveB = {
+    ...liveA,
+    metadata: {...liveA.metadata, resourceVersion: '200', annotations: {tick: '2'}}
+};
+
+const liveC = {
+    ...liveA,
+    metadata: {...liveA.metadata, resourceVersion: '300', annotations: {tick: '3'}}
+};
+
+describe('YamlEditor live freeze', () => {
+    beforeEach(() => {
+        lastMonacoText = '';
+        fakeModel.lines = '';
+        fakeModel.setValue.mockClear();
+        fakeModel.pushEditOperations.mockClear();
+        fakeModel.getLinesContent.mockClear();
+    });
+
+    test('keeps snapshot YAML while editing even if live input changes', () => {
+        const {rerender} = renderEditor(React.createElement(YamlEditor, {input: liveA, onSave: jest.fn()}));
+        expect(lastMonacoText).toBe(dumpYaml(liveA));
+
+        act(() => {
+            fireEvent.click(screen.getByRole('button', {name: /Edit/i}));
+        });
+        fakeModel.lines = dumpYaml(liveA) + '# user was typing\n';
+
+        rerender(React.createElement(Context.Provider, {value: mockContext}, React.createElement(YamlEditor, {input: liveB, onSave: jest.fn()})));
+
+        expect(lastMonacoText).toBe(dumpYaml(liveA));
+        expect(fakeModel.pushEditOperations).not.toHaveBeenCalled();
+        expect(fakeModel.lines).toContain('# user was typing');
+    });
+
+    test('Cancel discards buffered edits and later refreshes reach Monaco', () => {
+        const {rerender} = renderEditor(React.createElement(YamlEditor, {input: liveA, onSave: jest.fn()}));
+        act(() => {
+            fireEvent.click(screen.getByRole('button', {name: /Edit/i}));
+        });
+        fakeModel.lines = dumpYaml(liveA) + '# user was typing\n';
+        rerender(React.createElement(Context.Provider, {value: mockContext}, React.createElement(YamlEditor, {input: liveB, onSave: jest.fn()})));
+
+        act(() => {
+            fireEvent.click(screen.getByRole('button', {name: /Cancel/i}));
+        });
+
+        // The typed text only lives in the buffer, so Cancel has to clear it explicitly.
+        expect(fakeModel.lines).toBe(dumpYaml(liveB));
+        expect(fakeModel.setValue).not.toHaveBeenCalled();
+        expect(lastMonacoText).toBe(dumpYaml(liveB));
+
+        rerender(React.createElement(Context.Provider, {value: mockContext}, React.createElement(YamlEditor, {input: liveC, onSave: jest.fn()})));
+        expect(lastMonacoText).toBe(dumpYaml(liveC));
+    });
+
+    test('holds the saved text until the live state reaches the saved resource version', async () => {
+        const savedText = jsYaml.dump({...liveA, spec: {replicas: 3}});
+        const onSave = jest.fn().mockResolvedValue({...liveA, metadata: {...liveA.metadata, resourceVersion: '250'}, spec: {replicas: 3}});
+        const {rerender} = renderEditor(React.createElement(YamlEditor, {input: liveA, onSave}));
+
+        act(() => {
+            fireEvent.click(screen.getByRole('button', {name: /Edit/i}));
+        });
+        fakeModel.lines = savedText;
+
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button', {name: /Save/i}));
+        });
+
+        expect(onSave).toHaveBeenCalled();
+        const [patch] = onSave.mock.calls[0];
+        expect(patch).not.toContain('resourceVersion');
+
+        // Live state is still older than the save. Handing Monaco new text would wipe what was just
+        // saved, so input.text has to stay put and leave the saved buffer on screen.
+        rerender(React.createElement(Context.Provider, {value: mockContext}, React.createElement(YamlEditor, {input: liveB, onSave})));
+        expect(lastMonacoText).not.toBe(dumpYaml(liveB));
+        expect(lastMonacoText).toBe(dumpYaml(liveA));
+        expect(fakeModel.lines).toBe(savedText);
+    });
+
+    test('resumes live refresh once the live state reaches the saved resource version', async () => {
+        const onSave = jest.fn().mockResolvedValue({...liveA, metadata: {...liveA.metadata, resourceVersion: '250'}, spec: {replicas: 3}});
+        const {rerender} = renderEditor(React.createElement(YamlEditor, {input: liveA, onSave}));
+
+        act(() => {
+            fireEvent.click(screen.getByRole('button', {name: /Edit/i}));
+        });
+        fakeModel.lines = jsYaml.dump({...liveA, spec: {replicas: 3}});
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button', {name: /Save/i}));
+        });
+
+        // Resource version 300 is past the saved 250, so this live state includes the save.
+        const settled = {...liveC, spec: {replicas: 3}};
+        rerender(React.createElement(Context.Provider, {value: mockContext}, React.createElement(YamlEditor, {input: settled, onSave})));
+        expect(lastMonacoText).toBe(dumpYaml(settled));
+
+        // Whatever the cluster says now is shown as-is, including a later change to the same field.
+        const changedElsewhere = {...liveC, metadata: {...liveC.metadata, resourceVersion: '400'}, spec: {replicas: 7}};
+        rerender(React.createElement(Context.Provider, {value: mockContext}, React.createElement(YamlEditor, {input: changedElsewhere, onSave})));
+        expect(lastMonacoText).toBe(dumpYaml(changedElsewhere));
+    });
+
+    test('shows whatever the cluster reports if a rejected value never reaches the saved version', async () => {
+        const onSave = jest.fn().mockResolvedValue({...liveA, metadata: {...liveA.metadata, resourceVersion: '250'}, spec: {replicas: 3}});
+        const {rerender} = renderEditor(React.createElement(YamlEditor, {input: liveA, onSave}));
+
+        act(() => {
+            fireEvent.click(screen.getByRole('button', {name: /Edit/i}));
+        });
+        fakeModel.lines = jsYaml.dump({...liveA, spec: {replicas: 3}});
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button', {name: /Save/i}));
+        });
+
+        // A controller rewrote the value, so the live state at the saved version disagrees with the
+        // edit. The cluster's answer wins rather than the edit being kept on screen.
+        const rewritten = {...liveC, spec: {replicas: 1}};
+        rerender(React.createElement(Context.Provider, {value: mockContext}, React.createElement(YamlEditor, {input: rewritten, onSave})));
+        expect(lastMonacoText).toBe(dumpYaml(rewritten));
+    });
+
+    test('stops waiting if the live state never reaches the saved resource version', async () => {
+        jest.useFakeTimers();
+        try {
+            const onSave = jest.fn().mockResolvedValue({...liveA, metadata: {...liveA.metadata, resourceVersion: '999'}, spec: {replicas: 3}});
+            const {rerender} = renderEditor(React.createElement(YamlEditor, {input: liveA, onSave}));
+
+            act(() => {
+                fireEvent.click(screen.getByRole('button', {name: /Edit/i}));
+            });
+            fakeModel.lines = jsYaml.dump({...liveA, spec: {replicas: 3}});
+            await act(async () => {
+                fireEvent.click(screen.getByRole('button', {name: /Save/i}));
+            });
+
+            act(() => {
+                jest.advanceTimersByTime(4999);
+            });
+            rerender(React.createElement(Context.Provider, {value: mockContext}, React.createElement(YamlEditor, {input: liveB, onSave})));
+            expect(lastMonacoText).toBe(dumpYaml(liveA));
+
+            act(() => {
+                jest.advanceTimersByTime(1);
+            });
+            rerender(React.createElement(Context.Provider, {value: mockContext}, React.createElement(YamlEditor, {input: liveC, onSave})));
+
+            expect(lastMonacoText).toBe(dumpYaml(liveC));
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+
+    test('resumes immediately when the save response carries no resource version', async () => {
+        const onSave = jest.fn().mockResolvedValue({replicas: 3});
+        const {rerender} = renderEditor(React.createElement(YamlEditor, {input: liveA, onSave}));
+
+        act(() => {
+            fireEvent.click(screen.getByRole('button', {name: /Edit/i}));
+        });
+        fakeModel.lines = jsYaml.dump({...liveA, spec: {replicas: 3}});
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button', {name: /Save/i}));
+        });
+
+        rerender(React.createElement(Context.Provider, {value: mockContext}, React.createElement(YamlEditor, {input: liveC, onSave})));
+        expect(lastMonacoText).toBe(dumpYaml(liveC));
+    });
+});

--- a/ui/src/app/shared/components/yaml-editor/yaml-editor.test.tsx
+++ b/ui/src/app/shared/components/yaml-editor/yaml-editor.test.tsx
@@ -80,7 +80,7 @@ describe('YamlEditor live freeze', () => {
         rerender(React.createElement(Context.Provider, {value: mockContext}, React.createElement(YamlEditor, {input: liveB, onSave: jest.fn()})));
 
         expect(lastMonacoText).toBe(dumpYaml(liveA));
-        expect(fakeModel.pushEditOperations).not.toHaveBeenCalled();
+        expect(fakeModel.setValue).not.toHaveBeenCalled();
         expect(fakeModel.lines).toContain('# user was typing');
     });
 
@@ -96,9 +96,11 @@ describe('YamlEditor live freeze', () => {
             fireEvent.click(screen.getByRole('button', {name: /Cancel/i}));
         });
 
-        // The typed text only lives in the buffer, so Cancel has to clear it explicitly.
+        // The typed text only lives in the buffer, so Cancel has to clear it explicitly, and via
+        // setValue so that undo cannot bring the abandoned edits back.
         expect(fakeModel.lines).toBe(dumpYaml(liveB));
-        expect(fakeModel.setValue).not.toHaveBeenCalled();
+        expect(fakeModel.setValue).toHaveBeenCalledWith(dumpYaml(liveB));
+        expect(fakeModel.pushEditOperations).not.toHaveBeenCalled();
         expect(lastMonacoText).toBe(dumpYaml(liveB));
 
         rerender(React.createElement(Context.Provider, {value: mockContext}, React.createElement(YamlEditor, {input: liveC, onSave: jest.fn()})));

--- a/ui/src/app/shared/components/yaml-editor/yaml-editor.tsx
+++ b/ui/src/app/shared/components/yaml-editor/yaml-editor.tsx
@@ -1,13 +1,19 @@
 import {ErrorNotification, NotificationType} from 'argo-ui';
-import * as jsYaml from 'js-yaml';
 import type * as monacoEditor from 'monaco-editor';
 import * as React from 'react';
-import {useContext, useState, useRef} from 'react';
+import {useContext, useEffect, useState, useRef} from 'react';
 
 import {Context} from '../../context';
 import {MonacoEditor} from '../monaco-editor';
+import {replaceModelText} from '../monaco-apply-input';
+import {buildYamlMergePatch, cloneAndDumpYaml, dumpYaml, isEmptyPatch} from './yaml-merge-patch';
+import {hasReachedResourceVersion, resourceVersionOf} from './resource-version';
 
-const jsonMergePatch = require('json-merge-patch');
+// How long the document stays held after a save before live refreshes resume regardless. Bounded so
+// a resource that never reports the saved version, because it was deleted or the watch stalled,
+// cannot leave the editor stuck on stale text.
+const PENDING_SAVE_TIMEOUT_MS = 5000;
+
 require('./yaml-editor.scss');
 
 interface YamlEditorProps<T> {
@@ -23,19 +29,74 @@ interface YamlEditorProps<T> {
 
 export function YamlEditor<T>(props: YamlEditorProps<T>) {
     const ctx = useContext(Context);
+    const initialSnapshot = props.initialEditMode && props.input ? cloneAndDumpYaml(props.input) : null;
     const [editing, setEditing] = useState(!!props.initialEditMode);
+    const [frozenYaml, setFrozenYaml] = useState<string | null>(initialSnapshot?.yaml ?? null);
+    const [pendingResourceVersion, setPendingResourceVersion] = useState<string | null>(null);
     const modelRef = useRef<monacoEditor.editor.ITextModel | null>(null);
+    const snapshotRef = useRef<T | null>(initialSnapshot?.snapshot ?? null);
 
-    const yamlText = props.input ? jsYaml.dump(props.input) : '';
+    // A save is not visible in the live state until the cluster reports it back. Redrawing before
+    // then would replace what was just saved with a resource that predates it, so hold the document
+    // still instead. Nothing is invented: the text on screen is what was saved, and it is replaced
+    // by the cluster's own answer as soon as the live resource reaches the saved version.
+    const waitingForSave = pendingResourceVersion != null;
+    if (waitingForSave && !editing && hasReachedResourceVersion(props.input, pendingResourceVersion)) {
+        setPendingResourceVersion(null);
+        setFrozenYaml(null);
+    }
+
+    const yamlText = frozenYaml != null ? frozenYaml : dumpYaml(props.input);
+
+    useEffect(() => {
+        if (!waitingForSave) {
+            return;
+        }
+        const timeout = setTimeout(() => {
+            setPendingResourceVersion(null);
+            setFrozenYaml(frozen => (editing ? frozen : null));
+        }, PENDING_SAVE_TIMEOUT_MS);
+        return () => clearTimeout(timeout);
+    }, [waitingForSave, editing]);
+
+    const beginEdit = () => {
+        // Already frozen means a save is still in flight, so keep that document and its base rather
+        // than recapturing from a live state that does not have the saved change yet.
+        if (frozenYaml == null && props.input) {
+            const captured = cloneAndDumpYaml(props.input);
+            snapshotRef.current = captured.snapshot;
+            setFrozenYaml(captured.yaml);
+        }
+        setEditing(true);
+    };
+
+    const endEdit = () => {
+        snapshotRef.current = null;
+        setPendingResourceVersion(null);
+        setFrozenYaml(null);
+        setEditing(false);
+    };
 
     const handleSave = async () => {
         try {
-            const updated = jsYaml.load(modelRef.current!.getLinesContent().join('\n'));
-            const patch = jsonMergePatch.generate(props.input, updated);
+            const yaml = modelRef.current!.getLinesContent().join('\n');
+            const base = snapshotRef.current ?? props.input;
+            const patch = buildYamlMergePatch(base, yaml);
             try {
-                const unmounted = await props.onSave?.(JSON.stringify(patch || {}), 'application/merge-patch+json');
-                if (unmounted !== true) {
+                const saved = await props.onSave?.(JSON.stringify(patch || {}), 'application/merge-patch+json');
+                if (saved === true) {
+                    // The caller unmounted us, so there is nothing left to update.
+                    return;
+                }
+                const savedResourceVersion = isEmptyPatch(patch) ? null : resourceVersionOf(saved);
+                if (savedResourceVersion) {
+                    // Leave the saved text in place until the live state catches up to this version.
+                    // The snapshot stays too, so reopening Edit before then still diffs against the
+                    // state the buffer was built from instead of reverting fields to stale values.
+                    setPendingResourceVersion(savedResourceVersion);
                     setEditing(false);
+                } else {
+                    endEdit();
                 }
             } catch (e) {
                 ctx.notifications.show({
@@ -56,8 +117,11 @@ export function YamlEditor<T>(props: YamlEditorProps<T>) {
     };
 
     const handleCancel = () => {
-        modelRef.current?.setValue(jsYaml.dump(props.input));
-        setEditing(false);
+        // The abandoned edits only exist in the buffer, so the props-level refresh cannot clear them.
+        if (modelRef.current) {
+            replaceModelText(modelRef.current, dumpYaml(props.input));
+        }
+        endEdit();
         props.onCancel?.();
     };
 
@@ -75,7 +139,7 @@ export function YamlEditor<T>(props: YamlEditorProps<T>) {
                             </button>
                         </>
                     ) : (
-                        <button onClick={() => setEditing(true)} className='argo-button argo-button--base'>
+                        <button onClick={beginEdit} className='argo-button argo-button--base'>
                             Edit
                         </button>
                     )}

--- a/ui/src/app/shared/components/yaml-editor/yaml-merge-patch.test.ts
+++ b/ui/src/app/shared/components/yaml-editor/yaml-merge-patch.test.ts
@@ -1,0 +1,70 @@
+import {buildYamlMergePatch} from './yaml-merge-patch';
+
+describe('buildYamlMergePatch', () => {
+    const snapshot = {
+        apiVersion: 'apps/v1',
+        kind: 'Deployment',
+        metadata: {
+            name: 'guestbook-ui',
+            resourceVersion: '100',
+            annotations: {tick: '1'}
+        },
+        spec: {replicas: 1},
+        status: {readyReplicas: 1}
+    };
+
+    test('replica-only edit omits resourceVersion and status', () => {
+        const yaml = [
+            'apiVersion: apps/v1',
+            'kind: Deployment',
+            'metadata:',
+            '  name: guestbook-ui',
+            '  resourceVersion: "100"',
+            '  annotations:',
+            '    tick: "1"',
+            'spec:',
+            '  replicas: 3',
+            'status:',
+            '  readyReplicas: 1',
+            ''
+        ].join('\n');
+
+        const patch = buildYamlMergePatch(snapshot, yaml) as any;
+
+        expect(patch.spec).toEqual({replicas: 3});
+        expect(patch.metadata).toBeUndefined();
+        expect(patch.status).toBeUndefined();
+        expect(JSON.stringify(patch)).not.toContain('resourceVersion');
+    });
+
+    test('uses the snapshot even if live object has moved on', () => {
+        const live = {
+            ...snapshot,
+            metadata: {...snapshot.metadata, resourceVersion: '200', annotations: {tick: '9'}},
+            status: {readyReplicas: 2}
+        };
+        const yaml = [
+            'apiVersion: apps/v1',
+            'kind: Deployment',
+            'metadata:',
+            '  name: guestbook-ui',
+            '  resourceVersion: "100"',
+            '  annotations:',
+            '    tick: "1"',
+            'spec:',
+            '  replicas: 3',
+            'status:',
+            '  readyReplicas: 1',
+            ''
+        ].join('\n');
+
+        const fromSnapshot = buildYamlMergePatch(snapshot, yaml) as any;
+        const fromLive = buildYamlMergePatch(live, yaml) as any;
+
+        expect(fromSnapshot.spec).toEqual({replicas: 3});
+        expect(fromSnapshot.metadata).toBeUndefined();
+        expect(fromSnapshot.status).toBeUndefined();
+        expect(fromLive.metadata?.resourceVersion).toBe('100');
+        expect(fromLive.status?.readyReplicas).toBe(1);
+    });
+});

--- a/ui/src/app/shared/components/yaml-editor/yaml-merge-patch.ts
+++ b/ui/src/app/shared/components/yaml-editor/yaml-merge-patch.ts
@@ -1,0 +1,25 @@
+import * as jsYaml from 'js-yaml';
+
+const jsonMergePatch = require('json-merge-patch');
+
+function deepClone<T>(input: T): T {
+    return JSON.parse(JSON.stringify(input)) as T;
+}
+
+export function cloneAndDumpYaml<T>(input: T): {snapshot: T; yaml: string} {
+    const snapshot = deepClone(input);
+    return {snapshot, yaml: jsYaml.dump(snapshot)};
+}
+
+export function dumpYaml(input: unknown): string {
+    return input ? jsYaml.dump(input) : '';
+}
+
+export function buildYamlMergePatch(base: unknown, yamlText: string): object {
+    const updated = jsYaml.load(yamlText);
+    return jsonMergePatch.generate(base, updated) || {};
+}
+
+export function isEmptyPatch(patch: object | null): boolean {
+    return !patch || Object.keys(patch).length === 0;
+}


### PR DESCRIPTION
Follow up to https://github.com/argoproj/argo-cd/pull/29692 to keep the editor from discarding changes when a resource update arrives.

The UI constructs a patch based on the state being edited. If the field being patched is modified while the editor state is frozen, the saved state will overwrite whatever happened cluster-side.

On clicking Save, the editor will wait until the watch observes the manifest at the patched resource version or later before resuming live updates. If the expected resourceVersion doesn't arrive within 5s, it simply resumes the live watch. This keeps the old state from momentarily "blipping" in the editor before the newly-patched state arrives via the watcher.

Before:


https://github.com/user-attachments/assets/8d006e22-31d9-42ce-affd-d93b1a021b9a



After:


https://github.com/user-attachments/assets/454d12b5-4f52-455a-98e4-8477133caa86

