### PR TITLE
docs: fix 'allows to display' grammar in status badge revisionLength

### DIFF
--- a/docs/user-guide/status-badge.md
+++ b/docs/user-guide/status-badge.md
@@ -48,7 +48,7 @@ Example: `&revision=true`
 
 By default, displayed revision is truncated to 7 characters.
 
-This parameter allows to display it fully if it exceeds that length.
+This parameter allows you to display it fully if it exceeds that length.
 
 It will also extend the badge width to 400px.
 


### PR DESCRIPTION
Fixes #29695

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

### Description

Fix non-idiomatic grammar in the status badge `revisionLength=-1` note:

- before: "This parameter allows to display it fully"
- after: "This parameter allows you to display it fully"

Docs-only, one-line change. No release notes needed.